### PR TITLE
[AMDGPU][MIRFormatter] Printer & parser for S_WAITCNT human-readable mask

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
@@ -30,6 +30,10 @@ StringLiteral SaSdstName = "SaSdst";
 
 StringLiteral AllOff = "AllOff";
 
+StringLiteral VmcntName = "Vmcnt";
+StringLiteral ExpcntName = "Expcnt";
+StringLiteral LgkmcntName = "Lgkmcnt";
+
 void AMDGPUMIRFormatter::printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const {
   bool NonePrinted = true;
   ListSeparator Delim(SWaitAluDelim);
@@ -61,10 +65,34 @@ void AMDGPUMIRFormatter::printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const {
     OS << AllOff;
 }
 
+void AMDGPUMIRFormatter::printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const {
+  const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
+  bool NonePrinted = true;
+  ListSeparator Delim(SWaitAluDelim);
+  auto PrintFieldIfNotMax = [&](StringRef Descr, uint64_t Num, unsigned Max) {
+    if (Num != Max) {
+      OS << Delim << Descr << SWaitAluDelim << Num;
+      NonePrinted = false;
+    }
+  };
+  OS << SWaitAluImmPrefix;
+  PrintFieldIfNotMax(VmcntName, AMDGPU::decodeVmcnt(Version, Imm),
+                     AMDGPU::getVmcntBitMask(Version));
+  PrintFieldIfNotMax(ExpcntName, AMDGPU::decodeExpcnt(Version, Imm),
+                     AMDGPU::getExpcntBitMask(Version));
+  PrintFieldIfNotMax(LgkmcntName, AMDGPU::decodeLgkmcnt(Version, Imm),
+                     AMDGPU::getLgkmcntBitMask(Version));
+  if (NonePrinted)
+    OS << AllOff;
+}
+
 void AMDGPUMIRFormatter::printImm(raw_ostream &OS, const MachineInstr &MI,
                       std::optional<unsigned int> OpIdx, int64_t Imm) const {
 
   switch (MI.getOpcode()) {
+  case AMDGPU::S_WAITCNT:
+    printSWaitcntImm(Imm, OS);
+    break;
   case AMDGPU::S_WAITCNT_DEPCTR:
     printSWaitAluImm(Imm, OS);
     break;
@@ -87,6 +115,8 @@ bool AMDGPUMIRFormatter::parseImmMnemonic(const unsigned OpCode,
 {
 
   switch (OpCode) {
+  case AMDGPU::S_WAITCNT:
+    return parseSWaitcntImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
   case AMDGPU::S_WAITCNT_DEPCTR:
     return parseSWaitAluImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
   case AMDGPU::S_DELAY_ALU:
@@ -138,6 +168,72 @@ void AMDGPUMIRFormatter::printSDelayAluImm(int64_t Imm,
 
   OS << "_id1_";
   Outdep(Id1);
+}
+
+bool AMDGPUMIRFormatter::parseSWaitcntImmMnemonic(
+    const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
+    MIRFormatter::ErrorCallbackType &ErrorCallback) const {
+  const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
+
+  // Accept integer masks for compatibility with old MIR.
+  if (!Src.consumeInteger(10, Imm))
+    return false;
+
+  // Initialize with all counters at max (no wait).
+  unsigned Vmcnt = AMDGPU::getVmcntBitMask(Version);
+  unsigned Expcnt = AMDGPU::getExpcntBitMask(Version);
+  unsigned Lgkmcnt = AMDGPU::getLgkmcntBitMask(Version);
+
+  // The input is in the form: .Name1_Num1_Name2_Num2
+  // Drop the '.' prefix.
+  if (!Src.consume_front(SWaitAluImmPrefix))
+    return ErrorCallback(Src.begin(), "expected prefix");
+  if (Src.empty())
+    return ErrorCallback(Src.begin(), "expected <CounterName>_<CounterNum>");
+
+  // Special case for all off (all counters at max).
+  if (Src == AllOff) {
+    Imm = AMDGPU::encodeWaitcnt(Version, Vmcnt, Expcnt, Lgkmcnt);
+    return false;
+  }
+
+  // Parse counter name, number pairs.
+  while (!Src.empty()) {
+    size_t DelimIdx = Src.find(SWaitAluDelim);
+    if (DelimIdx == StringRef::npos)
+      return ErrorCallback(Src.begin(), "expected <CounterName>_<CounterNum>");
+    StringRef Name = Src.substr(0, DelimIdx);
+    StringRef::iterator NamePos = Src.begin();
+    Src.consume_front(Name);
+    Src.consume_front(SWaitAluDelim);
+
+    int64_t Num;
+    StringRef::iterator NumPos = Src.begin();
+    if (Src.consumeInteger(10, Num) || Num < 0)
+      return ErrorCallback(NumPos,
+                           "expected non-negative integer counter number");
+
+    unsigned Max;
+    if (Name == VmcntName) {
+      Max = AMDGPU::getVmcntBitMask(Version);
+      Vmcnt = Num;
+    } else if (Name == ExpcntName) {
+      Max = AMDGPU::getExpcntBitMask(Version);
+      Expcnt = Num;
+    } else if (Name == LgkmcntName) {
+      Max = AMDGPU::getLgkmcntBitMask(Version);
+      Lgkmcnt = Num;
+    } else {
+      return ErrorCallback(NamePos, "invalid counter name");
+    }
+    if (Num >= Max)
+      return ErrorCallback(NumPos, "counter value too large");
+
+    Src.consume_front(SWaitAluDelim);
+  }
+
+  Imm = AMDGPU::encodeWaitcnt(Version, Vmcnt, Expcnt, Lgkmcnt);
+  return false;
 }
 
 bool AMDGPUMIRFormatter::parseSWaitAluImmMnemonic(

--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
@@ -52,11 +52,18 @@ private:
   const MCSubtargetInfo &STI;
   /// Prints the string to represent s_wait_alu immediate value.
   void printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const;
+  /// Prints the string to represent s_waitcnt immediate value.
+  void printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const;
   /// Print the string to represent s_delay_alu immediate value
   void printSDelayAluImm(int64_t Imm, llvm::raw_ostream &OS) const;
 
   /// Parse the immediate pseudo literal for s_wait_alu
   bool parseSWaitAluImmMnemonic(
+      const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
+      MIRFormatter::ErrorCallbackType &ErrorCallback) const;
+
+  /// Parse the immediate pseudo literal for s_waitcnt
+  bool parseSWaitcntImmMnemonic(
       const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
       MIRFormatter::ErrorCallbackType &ErrorCallback) const;
 

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-waitcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-waitcnt.mir
@@ -16,7 +16,7 @@ body:             |
     ; CHECK-LABEL: name: asyncmark_preexisting_waitcnt
     ; CHECK: liveins: $vgpr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: S_WAITCNT 0
+    ; CHECK-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: ASYNCMARK
     ; CHECK-NEXT: S_ENDPGM 0
     S_WAITCNT_soft 0

--- a/llvm/test/CodeGen/AMDGPU/branch-relax-indirect-branch.mir
+++ b/llvm/test/CodeGen/AMDGPU/branch-relax-indirect-branch.mir
@@ -16,7 +16,7 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x50000000), %bb.5(0x30000000)
   ; CHECK-NEXT:   liveins: $sgpr12, $sgpr30, $sgpr31, $sgpr33, $sgpr34, $sgpr35, $sgpr36, $sgpr37, $sgpr38, $sgpr39, $sgpr40, $sgpr41, $sgpr42, $sgpr43, $sgpr44, $sgpr45, $sgpr46, $sgpr47, $sgpr48, $sgpr49, $sgpr50, $sgpr51, $sgpr52, $sgpr53, $sgpr54, $sgpr55, $sgpr56, $sgpr57, $sgpr58, $sgpr59, $sgpr60, $sgpr61, $sgpr62, $sgpr63, $sgpr64, $sgpr65, $sgpr66, $sgpr67, $sgpr68, $sgpr69, $sgpr70, $sgpr71, $sgpr72, $sgpr73, $sgpr74, $sgpr75, $sgpr76, $sgpr77, $sgpr78, $sgpr79, $sgpr80, $sgpr81, $sgpr82, $sgpr83, $sgpr84, $sgpr85, $sgpr86, $sgpr87, $sgpr88, $sgpr89, $sgpr90, $sgpr91, $sgpr92, $sgpr93, $sgpr94, $sgpr95, $sgpr96, $sgpr97, $sgpr98, $sgpr99, $sgpr100, $sgpr101, $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   $sgpr4_sgpr5 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFSET $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 0, 0, 0, implicit $exec
   ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFSET $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 4, 0, 0, implicit $exec
@@ -115,7 +115,7 @@ body:             |
   ; CHECK-NEXT:   $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 0, 0, 0, implicit $exec
   ; CHECK-NEXT:   $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 4, 0, 0, implicit $exec
   ; CHECK-NEXT:   $exec = S_MOV_B64 killed $sgpr4_sgpr5
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   S_SETPC_B64_return undef $sgpr30_sgpr31
   bb.0.entry:
     successors: %bb.1(0x50000000), %bb.4(0x30000000)

--- a/llvm/test/CodeGen/AMDGPU/branch-relax-no-terminators.mir
+++ b/llvm/test/CodeGen/AMDGPU/branch-relax-no-terminators.mir
@@ -17,7 +17,7 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x50000000), %bb.5(0x30000000)
   ; CHECK-NEXT:   liveins: $sgpr12, $sgpr30, $sgpr31, $sgpr33, $sgpr34, $sgpr35, $sgpr36, $sgpr37, $sgpr38, $sgpr39, $sgpr40, $sgpr41, $sgpr42, $sgpr43, $sgpr44, $sgpr45, $sgpr46, $sgpr47, $sgpr48, $sgpr49, $sgpr50, $sgpr51, $sgpr52, $sgpr53, $sgpr54, $sgpr55, $sgpr56, $sgpr57, $sgpr58, $sgpr59, $sgpr60, $sgpr61, $sgpr62, $sgpr63, $sgpr64, $sgpr65, $sgpr66, $sgpr67, $sgpr68, $sgpr69, $sgpr70, $sgpr71, $sgpr72, $sgpr73, $sgpr74, $sgpr75, $sgpr76, $sgpr77, $sgpr78, $sgpr79, $sgpr80, $sgpr81, $sgpr82, $sgpr83, $sgpr84, $sgpr85, $sgpr86, $sgpr87, $sgpr88, $sgpr89, $sgpr90, $sgpr91, $sgpr92, $sgpr93, $sgpr94, $sgpr95, $sgpr96, $sgpr97, $sgpr98, $sgpr99, $sgpr100, $sgpr101, $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   $sgpr4_sgpr5 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFSET $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 0, 0, 0, implicit $exec
   ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFSET $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 4, 0, 0, implicit $exec
@@ -117,7 +117,7 @@ body:             |
   ; CHECK-NEXT:   $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 0, 0, 0, implicit $exec
   ; CHECK-NEXT:   $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 4, 0, 0, implicit $exec
   ; CHECK-NEXT:   $exec = S_MOV_B64 killed $sgpr4_sgpr5
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   S_SETPC_B64_return undef $sgpr30_sgpr31
   bb.0.entry:
     successors: %bb.1(0x50000000), %bb.4(0x30000000)

--- a/llvm/test/CodeGen/AMDGPU/call-waw-waitcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/call-waw-waitcnt.mir
@@ -26,7 +26,7 @@ body:             |
     ; GCN-LABEL: name: call_waw_waitcnt
     ; GCN: liveins: $sgpr4_sgpr5, $sgpr7, $sgpr0_sgpr1_sgpr2_sgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $sgpr30_sgpr31 = S_LOAD_DWORDX2_IMM $sgpr4_sgpr5, 0, 0
     ; GCN-NEXT: $sgpr33 = S_MOV_B32 killed $sgpr7
     ; GCN-NEXT: $flat_scr_lo = S_ADD_U32 killed $sgpr4, $sgpr33, implicit-def $scc
@@ -37,7 +37,7 @@ body:             |
     ; GCN-NEXT:   $sgpr5 = S_ADDC_U32 internal $sgpr5, target-flags(amdgpu-rel32-hi) @func + 4, implicit-def $scc, implicit internal $scc
     ; GCN-NEXT: }
     ; GCN-NEXT: $sgpr32 = S_MOV_B32 $sgpr33
-    ; GCN-NEXT: S_WAITCNT 49279
+    ; GCN-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GCN-NEXT: dead $sgpr30_sgpr31 = SI_CALL killed renamable $sgpr4_sgpr5, @func, csr_amdgpu, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit-def dead $vgpr0
     ; GCN-NEXT: S_ENDPGM 0
     $sgpr30_sgpr31 = S_LOAD_DWORDX2_IMM $sgpr4_sgpr5, 0, 0

--- a/llvm/test/CodeGen/AMDGPU/force-wait-after-always-gds.mir
+++ b/llvm/test/CodeGen/AMDGPU/force-wait-after-always-gds.mir
@@ -5,11 +5,11 @@
 # GCN:       bb.0
 # GCN:       DS_ADD_U32
 # GCN:       DS_SUB_U32
-# GCN-NEXT:  S_WAITCNT 64535
+# GCN-NEXT:  S_WAITCNT .Lgkmcnt_1
 # GCN-NEXT:  $vgpr3 = DS_ORDERED_COUNT
-# GCN-NEXT:  S_WAITCNT 64519
+# GCN-NEXT:  S_WAITCNT .Lgkmcnt_0
 # GCN-NEXT:  $vgpr4_vgpr5 = DS_ADD_GS_REG_RTN
-# GCN-NEXT:  S_WAITCNT 64519
+# GCN-NEXT:  S_WAITCNT .Lgkmcnt_0
 # GCN-NEXT:  S_NOP 0
 
 name:   test_ordered_count

--- a/llvm/test/CodeGen/AMDGPU/gcn-reg-pressure-true16-integer-overflow.mir
+++ b/llvm/test/CodeGen/AMDGPU/gcn-reg-pressure-true16-integer-overflow.mir
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:vreg_64 = COPY [[S_LOAD_DWORDX2_IMM]]
     ; CHECK-NEXT: [[V_PK_LSHLREV_B16_:%[0-9]+]]:vgpr_32 = V_PK_LSHLREV_B16 0, 8, 8, [[V_LSHLREV_B32_e64_]], 0, 0, 0, 0, 0, implicit $exec
     ; CHECK-NEXT: FLAT_STORE_DWORD [[COPY3]], [[V_PK_LSHLREV_B16_]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s32))
-    ; CHECK-NEXT: S_WAITCNT 0
+    ; CHECK-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: S_ENDPGM 0
     %0:sgpr_64(p4) = COPY killed $sgpr4_sgpr5
     %1:sreg_64_xexec = S_LOAD_DWORDX2_IMM killed %0(p4), 0, 0 :: (dereferenceable invariant load (s64), align 16, addrspace 4)

--- a/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
+++ b/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
@@ -77,15 +77,15 @@ body:             |
   ; GFX11-NEXT:     renamable $vgpr14 = BUFFER_LOAD_USHORT_IDXEN killed renamable $vgpr14, renamable $sgpr4_sgpr5_sgpr6_sgpr7, 0, 0, 0, 0, implicit $exec :: (dereferenceable invariant load (s16), align 1, addrspace 8)
   ; GFX11-NEXT:     renamable $vgpr7 = BUFFER_LOAD_USHORT_IDXEN killed renamable $vgpr7, renamable $sgpr4_sgpr5_sgpr6_sgpr7, 0, 0, 0, 0, implicit $exec :: (dereferenceable invariant load (s16), align 1, addrspace 8)
   ; GFX11-NEXT:   }
-  ; GFX11-NEXT:   S_WAITCNT 9207
+  ; GFX11-NEXT:   S_WAITCNT .Vmcnt_8
   ; GFX11-NEXT:   renamable $vgpr5 = V_PERM_B32_e64 killed $vgpr6, killed $vgpr5, 84148480, implicit $exec
-  ; GFX11-NEXT:   S_WAITCNT 4087
+  ; GFX11-NEXT:   S_WAITCNT .Vmcnt_3
   ; GFX11-NEXT:   renamable $vgpr6 = V_PERM_B32_e64 killed $vgpr12, killed $vgpr9, 84148480, implicit $exec
-  ; GFX11-NEXT:   S_WAITCNT 3063
+  ; GFX11-NEXT:   S_WAITCNT .Vmcnt_2
   ; GFX11-NEXT:   renamable $vgpr9 = V_PERM_B32_e64 killed $vgpr13, killed $vgpr10, 84148480, implicit $exec
-  ; GFX11-NEXT:   S_WAITCNT 2039
+  ; GFX11-NEXT:   S_WAITCNT .Vmcnt_1
   ; GFX11-NEXT:   renamable $vgpr10 = V_PERM_B32_e64 killed $vgpr14, killed $vgpr11, 84148480, implicit $exec
-  ; GFX11-NEXT:   S_WAITCNT 1015
+  ; GFX11-NEXT:   S_WAITCNT .Vmcnt_0
   ; GFX11-NEXT:   renamable $vgpr7 = V_PERM_B32_e64 killed $vgpr7, killed $vgpr8, 84148480, implicit $exec
   ; GFX11-NEXT:   renamable $vgpr1 = nofpexcept V_DOT2_F32_F16 8, $vgpr5, 8, killed $vgpr6, 8, killed $vgpr1, -1, 0, 0, 0, 0, implicit $mode, implicit $exec
   ; GFX11-NEXT:   renamable $vgpr2 = nofpexcept V_DOT2_F32_F16 8, $vgpr5, 8, killed $vgpr9, 8, killed $vgpr2, -1, 0, 0, 0, 0, implicit $mode, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/hazard-shift64.mir
+++ b/llvm/test/CodeGen/AMDGPU/hazard-shift64.mir
@@ -12,7 +12,7 @@ body:             |
     ; GCN-LABEL: name: highest_reg_shift_amt_v7
     ; GCN: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr2_vgpr3 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr0, implicit $exec
     ; GCN-NEXT: renamable $vgpr2_vgpr3 = V_LSHRREV_B64_e64 undef $vgpr0, killed $vgpr2_vgpr3, implicit $exec
     ; GCN-NEXT: $vgpr7, $vgpr0 = V_SWAP_B32 $vgpr0, $vgpr7, implicit $exec
@@ -30,7 +30,7 @@ body:             |
     ; GCN-LABEL: name: highest_reg_shift_amt_v15
     ; GCN: $vgpr15 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr2_vgpr3 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr15 = V_SWAP_B32 undef $vgpr15, undef $vgpr0, implicit $exec
     ; GCN-NEXT: renamable $vgpr2_vgpr3 = V_LSHRREV_B64_e64 undef $vgpr0, killed $vgpr2_vgpr3, implicit $exec
     ; GCN-NEXT: $vgpr15, $vgpr0 = V_SWAP_B32 $vgpr0, $vgpr15, implicit $exec
@@ -48,7 +48,7 @@ body:             |
     ; GCN-LABEL: name: highest_reg_shift_amt_v255
     ; GCN: $vgpr255 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr2_vgpr3 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr255 = V_SWAP_B32 undef $vgpr255, undef $vgpr0, implicit $exec
     ; GCN-NEXT: renamable $vgpr2_vgpr3 = V_LSHRREV_B64_e64 undef $vgpr0, killed $vgpr2_vgpr3, implicit $exec
     ; GCN-NEXT: $vgpr255, $vgpr0 = V_SWAP_B32 $vgpr0, $vgpr255, implicit $exec
@@ -98,7 +98,7 @@ body:             |
     ; GCN-LABEL: name: highest_reg_shift_amt_used_v0_both
     ; GCN: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr0_vgpr1 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr2, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0_vgpr1 = V_LSHRREV_B64_e64 undef $vgpr2, killed $vgpr0_vgpr1, implicit $exec
     ; GCN-NEXT: $vgpr7, $vgpr2 = V_SWAP_B32 $vgpr2, $vgpr7, implicit $exec
@@ -148,7 +148,7 @@ body:             |
     ; GCN-LABEL: name: highest_reg_shift_amt_overlapped_both
     ; GCN: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr6_vgpr7 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr6 = V_SWAP_B32 undef $vgpr6, undef $vgpr0, implicit $exec
     ; GCN-NEXT: $vgpr1, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr1, implicit $exec
     ; GCN-NEXT: $vgpr0_vgpr1 = V_LSHRREV_B64_e64 undef $vgpr1, undef $vgpr0_vgpr1, implicit $exec
@@ -188,7 +188,7 @@ body:             |
     ; GCN-NEXT: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr6_vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr1 = V_DOT4C_I32_I8_e32 $vgpr7, $vgpr7, $vgpr1, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr6 = V_SWAP_B32 undef $vgpr6, undef $vgpr0, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: $vgpr1, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr1, implicit $exec
@@ -212,7 +212,7 @@ body:             |
     ; GCN: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr2_vgpr3 = IMPLICIT_DEF
     ; GCN-NEXT: BUNDLE implicit-def $vgpr2_vgpr3, implicit-def $vgpr7 {
-    ; GCN-NEXT:   S_WAITCNT 0
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT:   $vgpr0, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr0, implicit $exec
     ; GCN-NEXT:   renamable $vgpr2_vgpr3 = V_LSHRREV_B64_e64 undef $vgpr0, killed $vgpr2_vgpr3, implicit $exec
     ; GCN-NEXT: }
@@ -239,7 +239,7 @@ body:             |
     ; GCN-NEXT:   $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT:   $vgpr6_vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT:   $vgpr1 = V_DOT4C_I32_I8_e32 $vgpr7, $vgpr7, $vgpr1, implicit $exec
-    ; GCN-NEXT:   S_WAITCNT 0
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT:   $vgpr0, $vgpr6 = V_SWAP_B32 undef $vgpr6, undef $vgpr0, implicit $exec
     ; GCN-NEXT:   S_NOP 0
     ; GCN-NEXT:   $vgpr1, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr1, implicit $exec
@@ -269,7 +269,7 @@ body:             |
     ; GCN: $vgpr0 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr2_vgpr3 = IMPLICIT_DEF
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr0, implicit $exec
     ; GCN-NEXT: renamable $vgpr2_vgpr3 = V_LSHRREV_B64_e64 undef $vgpr0, killed $vgpr2_vgpr3, implicit $exec
     ; GCN-NEXT: $vgpr7, $vgpr0 = V_SWAP_B32 $vgpr0, $vgpr7, implicit $exec
@@ -291,7 +291,7 @@ body:             |
     ; GCN-NEXT: $vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr6_vgpr7 = IMPLICIT_DEF
     ; GCN-NEXT: $vgpr1 = V_DOT4C_I32_I8_e32 $vgpr7, $vgpr7, $vgpr1, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0, $vgpr6 = V_SWAP_B32 undef $vgpr6, undef $vgpr0, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: $vgpr1, $vgpr7 = V_SWAP_B32 undef $vgpr7, undef $vgpr1, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/hazard.mir
+++ b/llvm/test/CodeGen/AMDGPU/hazard.mir
@@ -126,7 +126,7 @@ body: |
     S_ENDPGM 0
 ...
 # GCN-LABEL: name: hazard-lookahead-wave-barrier
-# GCN: S_WAITCNT 0
+# GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # GCN-NEXT: S_NOP 0
 # GCN-NEXT: V_ADD_F16_dpp
 ---

--- a/llvm/test/CodeGen/AMDGPU/hazards-gfx950.mir
+++ b/llvm/test/CodeGen/AMDGPU/hazards-gfx950.mir
@@ -303,7 +303,7 @@ body:             |
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: renamable $vgpr5 = GLOBAL_LOAD_DWORD renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr5 = V_CVT_SCALEF32_SR_FP8_BF16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr5, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: GLOBAL_STORE_DWORD killed renamable $vgpr0_vgpr1, killed renamable $vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
@@ -323,7 +323,7 @@ body:             |
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: renamable $vgpr5 = GLOBAL_LOAD_DWORD renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr5 = V_CVT_SCALEF32_SR_FP8_F16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr5, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: GLOBAL_STORE_DWORD killed renamable $vgpr0_vgpr1, killed renamable $vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
@@ -343,7 +343,7 @@ body:             |
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: renamable $vgpr5 = GLOBAL_LOAD_DWORD renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr5 = V_CVT_SCALEF32_SR_FP8_F32_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr5, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr2 = V_ADD_U32_e32 4, killed $vgpr5, implicit $exec
@@ -365,7 +365,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp8_f32_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP8_F32_e64 8, killed $vgpr1, 0, killed $vgpr2, 0, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -388,7 +388,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp8_f16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP8_F16_e64 8, killed $vgpr1, 0, killed $vgpr2, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_PK_ADD_U16 8, killed $vgpr0, 8, $vgpr0, 0, 0, 0, 0, 0, implicit $exec
@@ -407,9 +407,9 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp8_bf16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_SR_BF8_BF16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
@@ -430,9 +430,9 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_sr_bf8_f16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_SR_BF8_F16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
@@ -453,9 +453,9 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_sr_bf8_f32_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_SR_BF8_F32_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
@@ -476,7 +476,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_bf8_f32_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_BF8_F32_e64 8, killed $vgpr1, 0, killed $vgpr2, 0, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -499,7 +499,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_bf8_f16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_BF8_F16_e64 8, killed $vgpr1, 0, killed $vgpr2, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_PK_ADD_U16 8, killed $vgpr0, 8, $vgpr0, 0, 0, 0, 0, 0, implicit $exec
@@ -518,7 +518,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_bf8_bf16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_BF8_BF16_e64 8, killed $vgpr1, 0, killed $vgpr2, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_PK_ADD_U16 8, killed $vgpr0, 8, $vgpr0, 0, 0, 0, 0, 0, implicit $exec
@@ -537,7 +537,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f32_neg_hazard_opsel0
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP4_F32_e64 0, killed $vgpr1, 0, killed $vgpr2, 0, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -559,7 +559,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f32_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP4_F32_e64 8, killed $vgpr1, 0, killed $vgpr2, 4, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -582,7 +582,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f32_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP4_F32_e64 0, killed $vgpr1, 0, killed $vgpr2, 0, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -604,7 +604,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f32_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr1 = V_AND_B32_e32 2147483647, killed $vgpr1, implicit $exec
     ; GCN-NEXT: renamable $vgpr2 = V_XOR_B32_e32 -2147483648, killed $vgpr2, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_FP4_F32_e64 8, killed $vgpr1, 0, killed $vgpr2, 4, killed $vgpr3, killed $vgpr0, 0, implicit $mode, implicit $exec
@@ -626,9 +626,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_f16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
@@ -649,9 +649,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_bf16_opsel0_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_BF16_e64 0, killed $vgpr2, 0, killed $vgpr3, 0, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
@@ -672,9 +672,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_bf16_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_BF16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
@@ -695,9 +695,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_bf16_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_BF16_e64 0, killed $vgpr2, 0, killed $vgpr3, 0, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -717,9 +717,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_bf16_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_BF16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -739,9 +739,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_f32_opsel0_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_F32_e64 0, killed $vgpr2_vgpr3, 0, killed $vgpr4, 0, killed $vgpr5, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
@@ -762,9 +762,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_f32_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_F32_e64 8, killed $vgpr2_vgpr3, 0, killed $vgpr4, 4, killed $vgpr5, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
@@ -785,9 +785,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_f32_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_F32_e64 0, killed $vgpr2_vgpr3, 0, killed $vgpr4, 0, killed $vgpr5, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -807,9 +807,9 @@ body:             |
     ; GCN-LABEL: name: test_scalef32_sr_pk_fp4_f32_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: early-clobber renamable $vgpr1 = V_CVT_SCALEF32_SR_PK_FP4_F32_e64 8, killed $vgpr2_vgpr3, 0, killed $vgpr4, 4, killed $vgpr5, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -829,7 +829,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f16_neg_opsel0_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 0, killed $vgpr0, 0, killed $vgpr1, 0, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr2, $vgpr2, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -847,7 +847,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f16_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr2, $vgpr2, implicit $exec
@@ -866,7 +866,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f16_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 0, killed $vgpr0, 0, killed $vgpr1, 0, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -884,7 +884,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_f16_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr1, $vgpr1, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -902,7 +902,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_bf16_neg_opsel0_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_BF16_e64 0, killed $vgpr0, 0, killed $vgpr1, 0, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr2, $vgpr2, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -920,7 +920,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_bf16_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_BF16_e64 8, killed $vgpr0, 0, killed $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr2, $vgpr2, implicit $exec
@@ -939,7 +939,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_bf16_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_BF16_e64 0, killed $vgpr0, 0, killed $vgpr1, 0, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -957,7 +957,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_fp4_bf16_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_BF16_e64 8, killed $vgpr0, 0, killed $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -975,9 +975,9 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_hazard_skipping_over_meta_instr
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_SR_BF8_F16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: $vgpr4 = KILL
     ; GCN-NEXT: S_NOP 0
@@ -1000,7 +1000,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_f16_to_fp4_to_f16_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, killed $vgpr0, 0, $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_F16_FP4_e64 4, killed $vgpr2, 0, killed $vgpr1, 0, implicit $mode, implicit $exec
@@ -1019,7 +1019,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_f16_fp4_opsel0_neg_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_F16_FP4_e64 0, killed $vgpr2, 0, killed $vgpr1, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -1038,7 +1038,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_pk_f16_fp4_opsel3_neg_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_PK_F16_FP4_e64 4, killed $vgpr2, 4, killed $vgpr1, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: renamable $vgpr0 = V_ADD_U32_e32 killed $vgpr0, $vgpr0, implicit $exec
     ; GCN-NEXT: S_SETPC_B64_return undef $sgpr30_sgpr31, implicit killed $vgpr0
@@ -1056,9 +1056,9 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_hazard_pseudo
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: renamable $vgpr0 = V_CVT_SCALEF32_SR_BF8_F16_e64 8, killed $vgpr2, 0, killed $vgpr3, 4, killed $vgpr4, killed $vgpr0, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: WAVE_BARRIER
     ; GCN-NEXT: S_NOP 0
@@ -1109,7 +1109,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scalef32_inlineasm_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: INLINEASM &"; use $0", sideeffect attdialect, reguse:VGPR_32, killed renamable $vgpr2
@@ -1128,7 +1128,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scale_cvt_scalef32_sr_pk_fp4_f16_opsel0_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, $vgpr0, 0, $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: early-clobber renamable $vgpr4 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 0, killed $vgpr0, 0, killed $vgpr3, 0, killed $vgpr1, killed $vgpr2, 0, implicit $mode, implicit $exec
@@ -1150,7 +1150,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scale_cvt_scalef32_sr_pk_fp4_f16_opsel3_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, $vgpr0, 0, $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: early-clobber renamable $vgpr4 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr3, 4, killed $vgpr1, killed $vgpr2, 0, implicit $mode, implicit $exec
@@ -1172,7 +1172,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scale_cvt_scalef32_sr_pk_fp4_f16_opsel0_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 0, $vgpr0, 0, $vgpr1, 0, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: early-clobber renamable $vgpr4 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr3, 4, killed $vgpr1, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: $vgpr0 = V_MOV_B32_e32 killed $vgpr1, implicit $exec, implicit $exec
@@ -1192,7 +1192,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scale_cvt_scalef32_sr_pk_fp4_f16_opsel3_neg_fp4_as_src_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, $vgpr0, 0, $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: early-clobber renamable $vgpr4 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr3, 4, killed $vgpr1, killed $vgpr2, 0, implicit $mode, implicit $exec
@@ -1213,7 +1213,7 @@ body:             |
     ; GCN-LABEL: name: test_cvt_scale_cvt_scale_waw_hazard
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: renamable $vgpr2 = V_CVT_SCALEF32_PK_FP4_F16_e64 8, $vgpr0, 0, $vgpr1, 4, killed $vgpr2, 0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_NOP 0
     ; GCN-NEXT: early-clobber renamable $vgpr2 = V_CVT_SCALEF32_SR_PK_FP4_F16_e64 8, killed $vgpr0, 0, killed $vgpr3, 4, killed $vgpr1, killed $vgpr1, 0, implicit $mode, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-callee.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-callee.mir
@@ -9,7 +9,7 @@
 ---
 # CHECK-LABEL: name: entry_callee_wait{{$}}
 # CHECK: bb.0:
-# CHECK-NEXT: S_WAITCNT 0{{$}}
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0{{$}}
 # CHECK-NEXT: V_ADD_F32
 # CHECK-NEXT: S_SETPC_B64
 liveins:

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-crash.ll
@@ -9,7 +9,7 @@ define fastcc i32 @foo() {
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $sgpr12, $sgpr13, $sgpr14, $sgpr15, $sgpr30, $sgpr31, $vgpr31, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9, $sgpr10_sgpr11
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   $sgpr16 = S_MOV_B32 $sgpr33
   ; CHECK-NEXT:   $sgpr33 = S_MOV_B32 $sgpr32
   ; CHECK-NEXT:   $sgpr17 = S_OR_SAVEEXEC_B32 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
@@ -28,7 +28,7 @@ define fastcc i32 @foo() {
   ; CHECK-NEXT:   renamable $sgpr16_sgpr17 = S_LOAD_DWORDX2_IMM killed renamable $sgpr16_sgpr17, 0, 0 :: (dereferenceable invariant load (s64) from got, addrspace 4)
   ; CHECK-NEXT:   $vgpr40 = V_WRITELANE_B32 killed $sgpr30, 0, $vgpr40
   ; CHECK-NEXT:   $vgpr40 = V_WRITELANE_B32 killed $sgpr31, 1, $vgpr40
-  ; CHECK-NEXT:   S_WAITCNT 49279
+  ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   dead $sgpr30_sgpr31 = SI_CALL killed renamable $sgpr16_sgpr17, @bar, csr_amdgpu, implicit killed $sgpr4_sgpr5, implicit killed $sgpr6_sgpr7, implicit killed $sgpr8_sgpr9, implicit killed $sgpr10_sgpr11, implicit killed $sgpr12, implicit killed $sgpr13, implicit killed $sgpr14, implicit killed $sgpr15, implicit killed $vgpr31, implicit $sgpr0_sgpr1_sgpr2_sgpr3
   ; CHECK-NEXT:   $vcc_lo = S_MOV_B32 $exec_lo
   ; CHECK-NEXT: {{  $}}
@@ -47,7 +47,7 @@ define fastcc i32 @foo() {
   ; CHECK-NEXT:   $vgpr40 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr33, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" load (s32) from %stack.2, addrspace 5)
   ; CHECK-NEXT:   $exec_lo = S_MOV_B32 killed $sgpr5
   ; CHECK-NEXT:   $sgpr33 = S_MOV_B32 killed $sgpr4
-  ; CHECK-NEXT:   S_WAITCNT 16240
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   S_SETPC_B64_return undef $sgpr30_sgpr31, implicit undef $vgpr0
   fence acquire
   call fastcc void @bar()

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-exp.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-exp.mir
@@ -19,7 +19,7 @@
 
 # CHECK-LABEL: name: exp_done_waitcnt{{$}}
 # CHECK: EXP_DONE
-# CHECK-NEXT: S_WAITCNT 3855
+# CHECK-NEXT: S_WAITCNT .Expcnt_0
 # CHECK: $vgpr0 = V_MOV_B32
 # CHECK: $vgpr1 = V_MOV_B32
 # CHECK: $vgpr2 = V_MOV_B32

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-fence-soft.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-fence-soft.mir
@@ -8,10 +8,10 @@ name: dma_then_fence
 body:             |
   bb.0:
     ; GCN-LABEL: name: dma_then_fence
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
     ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
@@ -29,11 +29,11 @@ name: dma_then_global_load
 body:             |
   bb.0:
     ; GCN-LABEL: name: dma_then_global_load
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
     ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3953
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_1
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
@@ -52,7 +52,7 @@ name: no_dma_just_fence
 body:             |
   bb.0:
     ; GCN-LABEL: name: no_dma_just_fence
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
@@ -70,10 +70,10 @@ name: dma_then_system_fence
 body:             |
   bb.0:
     ; GCN-LABEL: name: dma_then_system_fence
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3953
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_1
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
@@ -91,11 +91,11 @@ name: merge_with_prev_wait
 body:             |
   bb.0:
     ; GCN-LABEL: name: merge_with_prev_wait
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
     ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
@@ -115,11 +115,11 @@ name: merge_with_next_wait
 body:             |
   bb.0:
     ; GCN-LABEL: name: merge_with_next_wait
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
     ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 3952
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-hang.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-hang.mir
@@ -17,7 +17,7 @@ body: |
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $sgpr12, $sgpr13, $sgpr14, $sgpr15, $sgpr30, $sgpr31, $sgpr34, $sgpr35, $sgpr36, $sgpr37, $sgpr38, $sgpr39, $sgpr40, $sgpr41, $sgpr42, $sgpr43, $sgpr44, $sgpr45, $sgpr46, $sgpr47, $vgpr0, $vgpr1, $vgpr31, $vgpr40, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9, $sgpr10_sgpr11
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   SCRATCH_STORE_DWORDX4_SADDR killed undef $vgpr8_vgpr9_vgpr10_vgpr11, $sgpr33, 4, 0, implicit $exec, implicit $flat_scr, implicit-def $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17 :: (store (s128) into %stack.0, align 4, addrspace 5)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-merge.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-merge.ll
@@ -20,7 +20,7 @@ define amdgpu_kernel void @widget(ptr addrspace(1) %arg, i1 %arg1) {
   ; CHECK-NEXT:   $sgpr20 = S_ADD_U32 $sgpr20, killed $sgpr17, implicit-def $scc, implicit-def $sgpr20_sgpr21_sgpr22_sgpr23
   ; CHECK-NEXT:   $sgpr21 = S_ADDC_U32 $sgpr21, 0, implicit-def dead $scc, implicit killed $scc, implicit-def $sgpr20_sgpr21_sgpr22_sgpr23
   ; CHECK-NEXT:   renamable $vgpr1 = V_MOV_B32_e32 0, implicit $exec
-  ; CHECK-NEXT:   S_WAITCNT 49279
+  ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   S_BITCMP1_B32 killed renamable $sgpr2, 0, implicit-def $scc
   ; CHECK-NEXT:   renamable $sgpr4_sgpr5 = S_MOV_B64 0
   ; CHECK-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec, implicit $exec
@@ -42,12 +42,12 @@ define amdgpu_kernel void @widget(ptr addrspace(1) %arg, i1 %arg1) {
   ; CHECK-NEXT:   successors: %bb.12(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT:   liveins: $vgpr0, $sgpr0_sgpr1, $sgpr2_sgpr3, $sgpr4_sgpr5, $sgpr6_sgpr7, $vgpr0_vgpr1:0x000000000000000C, $vgpr2_vgpr3, $sgpr20_sgpr21_sgpr22_sgpr23
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   renamable $vgpr0 = V_XOR_B32_e32 1, killed $vgpr0, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr4_vgpr5 = V_LSHLREV_B64_e64 4, $vgpr0_vgpr1, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr0 = GLOBAL_LOAD_DWORD killed renamable $vgpr4_vgpr5, 0, 0, implicit $exec :: (load (s32) from %ir.getelementptr, align 16, addrspace 1)
   ; CHECK-NEXT:   renamable $sgpr6_sgpr7 = S_OR_B64 killed renamable $sgpr6_sgpr7, $exec, implicit-def dead $scc
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   V_CMP_GT_I32_e32 1, killed $vgpr0, implicit-def $vcc, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr0 = IMPLICIT_DEF
   ; CHECK-NEXT:   $sgpr8_sgpr9 = S_AND_SAVEEXEC_B64 killed $vcc, implicit-def $exec, implicit-def $scc, implicit $exec
@@ -90,7 +90,7 @@ define amdgpu_kernel void @widget(ptr addrspace(1) %arg, i1 %arg1) {
   ; CHECK-NEXT:   successors: %bb.6(0x40000000), %bb.5(0x40000000)
   ; CHECK-NEXT:   liveins: $vgpr0, $vgpr4, $sgpr0_sgpr1, $sgpr2_sgpr3, $vgpr0_vgpr1:0x000000000000000C, $vgpr2_vgpr3, $sgpr20_sgpr21_sgpr22_sgpr23
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   renamable $sgpr6_sgpr7 = V_CMP_EQ_U32_e64 0, killed $vgpr4, implicit $exec
   ; CHECK-NEXT:   renamable $vcc = S_AND_B64 $exec, renamable $sgpr6_sgpr7, implicit-def dead $scc
   ; CHECK-NEXT:   S_CBRANCH_VCCNZ %bb.5, implicit killed $vcc

--- a/llvm/test/CodeGen/AMDGPU/lds-direct-hazards-gfx11.mir
+++ b/llvm/test/CodeGen/AMDGPU/lds-direct-hazards-gfx11.mir
@@ -342,7 +342,7 @@ body:            |
   bb.0:
     ; GCN-LABEL: name: lds_param_load_vmem_war_waitcnt
     ; GCN: $vgpr0 = IMAGE_LOAD_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 2, -1, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s32))
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr1 = LDS_PARAM_LOAD 0, 0, 15, implicit $m0, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0 = IMAGE_LOAD_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 2, -1, 0, 0, 0, 0, 0, 0, implicit $exec :: (load 4)

--- a/llvm/test/CodeGen/AMDGPU/lds-dma-waitcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/lds-dma-waitcnt.mir
@@ -2,7 +2,7 @@
 
 # GCN-LABEL: name: buffer_load_dword_lds_ds_read
 # GCN:      BUFFER_LOAD_DWORD_LDS_IDXEN
-# GCN-NEXT: S_WAITCNT 3952
+# GCN-NEXT: S_WAITCNT .Vmcnt_0
 #                     vmcnt(0)
 # GCN-NEXT: DS_READ_B32_gfx9
 ---
@@ -19,7 +19,7 @@ body:             |
 # GCN-LABEL: name: buffer_load_dword_lds_vmcnt_1
 # GCN:      BUFFER_LOAD_DWORD_LDS_IDXEN
 # GCN-NEXT: BUFFER_LOAD_DWORD_IDXEN
-# GCN-NEXT: S_WAITCNT 3953
+# GCN-NEXT: S_WAITCNT .Vmcnt_1
 #                     vmcnt(1)
 # GCN-NEXT: DS_READ_B32_gfx9
 ---
@@ -36,7 +36,7 @@ body:             |
 
 # GCN-LABEL: name: buffer_load_dword_lds_flat_read
 # GCN:      BUFFER_LOAD_DWORD_LDS_IDXEN
-# GCN-NEXT: S_WAITCNT 3952
+# GCN-NEXT: S_WAITCNT .Vmcnt_0
 #                     vmcnt(0)
 # GCN-NEXT: FLAT_LOAD_DWORD
 ---
@@ -53,7 +53,7 @@ body:             |
 
 # GCN-LABEL: name: global_load_lds_dword_ds_read
 # GCN:      GLOBAL_LOAD_LDS_DWORD
-# GCN-NEXT: S_WAITCNT 3952
+# GCN-NEXT: S_WAITCNT .Vmcnt_0
 #                     vmcnt(0)
 # GCN-NEXT: DS_READ_B32_gfx9
 ---
@@ -71,7 +71,7 @@ body:             |
 # GCN-LABEL: name: ds_read_global_load_lds_use_ds_data
 # GCN:      DS_READ_B32_gfx9
 # GCN-NEXT: GLOBAL_LOAD_LDS_DWORD
-# GCN-NEXT: S_WAITCNT 49279
+# GCN-NEXT: S_WAITCNT .Lgkmcnt_0
 #                     lgkmcnt(0)
 # GCN-NEXT: V_ADD_U32_e32
 ---
@@ -91,7 +91,7 @@ body:             |
 # GCN-LABEL: name: ds_read_buffer_load_lds_use_ds_data
 # GCN:      DS_READ_B32_gfx9
 # GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN
-# GCN-NEXT: S_WAITCNT 49279
+# GCN-NEXT: S_WAITCNT .Lgkmcnt_0
 #                     lgkmcnt(0)
 # GCN-NEXT: V_ADD_U32_e32
 ---
@@ -108,7 +108,7 @@ body:             |
 
 # GCN-LABEL: name: scratch_load_lds_dword_ds_read
 # GCN:      SCRATCH_LOAD_LDS_DWORD
-# GCN-NEXT: S_WAITCNT 3952
+# GCN-NEXT: S_WAITCNT .Vmcnt_0
 #                     vmcnt(0)
 # GCN-NEXT: DS_READ_B32_gfx9
 ---
@@ -141,7 +141,7 @@ body:             |
 # GCN:      BUFFER_LOAD_DWORD_LDS_IDXEN
 # GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN
 # GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN
-# GCN-NEXT: S_WAITCNT 3952
+# GCN-NEXT: S_WAITCNT .Vmcnt_0
 #                     vmcnt(0)
 # GCN-NEXT: DS_READ_B32_gfx9
 ---

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.gws.barrier-bundle.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.gws.barrier-bundle.ll
@@ -23,7 +23,7 @@ define amdgpu_kernel void @gws_barrier_offset0(i32 %val) #0 {
   ; GFX6-SDAG-NEXT:   S_SETREG_IMM32_B32 0, 515, implicit-def $mode, implicit $mode
   ; GFX6-SDAG-NEXT:   BUNDLE implicit renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX6-SDAG-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX6-SDAG-NEXT:     S_WAITCNT 0
+  ; GFX6-SDAG-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX6-SDAG-NEXT:   }
   ; GFX6-SDAG-NEXT:   renamable $sgpr0 = S_GETREG_B32 515, implicit $mode
   ; GFX6-SDAG-NEXT:   S_CMP_LG_U32 killed renamable $sgpr0, 0, implicit-def $scc
@@ -48,7 +48,7 @@ define amdgpu_kernel void @gws_barrier_offset0(i32 %val) #0 {
   ; GFX6-GISEL-NEXT:   S_SETREG_IMM32_B32 0, 515, implicit-def $mode, implicit $mode
   ; GFX6-GISEL-NEXT:   BUNDLE implicit renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX6-GISEL-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX6-GISEL-NEXT:     S_WAITCNT 0
+  ; GFX6-GISEL-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX6-GISEL-NEXT:   }
   ; GFX6-GISEL-NEXT:   renamable $sgpr0 = S_GETREG_B32 515, implicit $mode
   ; GFX6-GISEL-NEXT:   S_CMP_LG_U32 killed renamable $sgpr0, 0, implicit-def $scc
@@ -66,7 +66,7 @@ define amdgpu_kernel void @gws_barrier_offset0(i32 %val) #0 {
   ; GFX9-SDAG-NEXT:   $m0 = S_MOV_B32 0
   ; GFX9-SDAG-NEXT:   BUNDLE implicit killed renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX9-SDAG-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX9-SDAG-NEXT:     S_WAITCNT 0
+  ; GFX9-SDAG-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX9-SDAG-NEXT:   }
   ; GFX9-SDAG-NEXT:   S_ENDPGM 0
   ;
@@ -79,7 +79,7 @@ define amdgpu_kernel void @gws_barrier_offset0(i32 %val) #0 {
   ; GFX9-GISEL-NEXT:   $m0 = S_MOV_B32 0
   ; GFX9-GISEL-NEXT:   BUNDLE implicit killed renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX9-GISEL-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX9-GISEL-NEXT:     S_WAITCNT 0
+  ; GFX9-GISEL-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX9-GISEL-NEXT:   }
   ; GFX9-GISEL-NEXT:   S_ENDPGM 0
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 0)
@@ -103,7 +103,7 @@ define amdgpu_kernel void @gws_barrier_offset63(i32 %val) #0 {
   ; GFX6-SDAG-NEXT:   S_SETREG_IMM32_B32 0, 515, implicit-def $mode, implicit $mode
   ; GFX6-SDAG-NEXT:   BUNDLE implicit renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX6-SDAG-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 63, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX6-SDAG-NEXT:     S_WAITCNT 0
+  ; GFX6-SDAG-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX6-SDAG-NEXT:   }
   ; GFX6-SDAG-NEXT:   renamable $sgpr0 = S_GETREG_B32 515, implicit $mode
   ; GFX6-SDAG-NEXT:   S_CMP_LG_U32 killed renamable $sgpr0, 0, implicit-def $scc
@@ -128,7 +128,7 @@ define amdgpu_kernel void @gws_barrier_offset63(i32 %val) #0 {
   ; GFX6-GISEL-NEXT:   S_SETREG_IMM32_B32 0, 515, implicit-def $mode, implicit $mode
   ; GFX6-GISEL-NEXT:   BUNDLE implicit renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX6-GISEL-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 63, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX6-GISEL-NEXT:     S_WAITCNT 0
+  ; GFX6-GISEL-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX6-GISEL-NEXT:   }
   ; GFX6-GISEL-NEXT:   renamable $sgpr0 = S_GETREG_B32 515, implicit $mode
   ; GFX6-GISEL-NEXT:   S_CMP_LG_U32 killed renamable $sgpr0, 0, implicit-def $scc
@@ -146,7 +146,7 @@ define amdgpu_kernel void @gws_barrier_offset63(i32 %val) #0 {
   ; GFX9-SDAG-NEXT:   $m0 = S_MOV_B32 0
   ; GFX9-SDAG-NEXT:   BUNDLE implicit killed renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX9-SDAG-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 63, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX9-SDAG-NEXT:     S_WAITCNT 0
+  ; GFX9-SDAG-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX9-SDAG-NEXT:   }
   ; GFX9-SDAG-NEXT:   S_ENDPGM 0
   ;
@@ -159,7 +159,7 @@ define amdgpu_kernel void @gws_barrier_offset63(i32 %val) #0 {
   ; GFX9-GISEL-NEXT:   $m0 = S_MOV_B32 0
   ; GFX9-GISEL-NEXT:   BUNDLE implicit killed renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; GFX9-GISEL-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 63, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; GFX9-GISEL-NEXT:     S_WAITCNT 0
+  ; GFX9-GISEL-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GFX9-GISEL-NEXT:   }
   ; GFX9-GISEL-NEXT:   S_ENDPGM 0
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 63)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.gws.barrier-fastregalloc.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.gws.barrier-fastregalloc.ll
@@ -13,7 +13,7 @@ define amdgpu_kernel void @gws_barrier_offset0(i32 %val) #0 {
   ; MIR-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr4, implicit $exec, implicit $exec
   ; MIR-NEXT:   BUNDLE implicit killed renamable $vgpr0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource") {
   ; MIR-NEXT:     DS_GWS_BARRIER renamable $vgpr0, 0, implicit $m0, implicit $exec :: (load (s32) from custom "GWSResource")
-  ; MIR-NEXT:     S_WAITCNT 0
+  ; MIR-NEXT:     S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; MIR-NEXT:   }
   ; MIR-NEXT:   S_ENDPGM 0
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 0)

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-atomic-insert-end.mir
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-atomic-insert-end.mir
@@ -77,7 +77,7 @@ body:             |
   ; CHECK-NEXT:   $vgpr1_vgpr2 = V_LSHL_B64_e64 $vgpr0_vgpr1, 3, implicit $exec
   ; CHECK-NEXT:   $sgpr7 = S_MOV_B32 61440
   ; CHECK-NEXT:   $sgpr6 = S_MOV_B32 0
-  ; CHECK-NEXT:   S_WAITCNT 127
+  ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   $vgpr1_vgpr2 = BUFFER_LOAD_DWORDX2_ADDR64 killed $vgpr1_vgpr2, $sgpr4_sgpr5_sgpr6_sgpr7, 0, 0, 1, 0, implicit $exec :: (volatile load (s64) from %ir.tid.gep, addrspace 1)
   ; CHECK-NEXT:   S_WAITCNT_soft 3952
   ; CHECK-NEXT:   $vgpr0 = V_XOR_B32_e32 1, killed $vgpr0, implicit $exec
@@ -94,9 +94,9 @@ body:             |
   ; CHECK-NEXT:   dead $vgpr0 = V_MOV_B32_e32 -1, implicit $exec
   ; CHECK-NEXT:   dead $vgpr0 = V_MOV_B32_e32 61440, implicit $exec
   ; CHECK-NEXT:   $sgpr4_sgpr5 = S_MOV_B64 0
-  ; CHECK-NEXT:   S_WAITCNT 127
+  ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; CHECK-NEXT:   S_WAITCNT 3952
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   S_WAITCNT_soft 3952
   ; CHECK-NEXT:   BUFFER_ATOMIC_SMAX_ADDR64 killed $vgpr0, killed $vgpr1_vgpr2, killed $sgpr4_sgpr5_sgpr6_sgpr7, 0, 400, 0, implicit $exec :: (volatile load syncscope("one-as") seq_cst (s32) from %ir.gep, addrspace 1)
   ; CHECK-NEXT:   S_WAITCNT_soft 3952

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-multiple-mem-operands-atomics.mir
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-multiple-mem-operands-atomics.mir
@@ -20,9 +20,9 @@ body:             |
   ; GCN-NEXT:   $sgpr11 = S_MOV_B32 15204352, implicit-def $sgpr8_sgpr9_sgpr10_sgpr11
   ; GCN-NEXT:   $vgpr0 = V_MOV_B32_e32 1, implicit $exec
   ; GCN-NEXT:   BUFFER_STORE_DWORD_OFFSET killed $vgpr0, $sgpr8_sgpr9_sgpr10_sgpr11, $sgpr3, 4, 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(5) poison`, addrspace 5)
-  ; GCN-NEXT:   S_WAITCNT 127
+  ; GCN-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; GCN-NEXT:   S_CMP_LG_U32 killed $sgpr2, 0, implicit-def $scc
-  ; GCN-NEXT:   S_WAITCNT 3855
+  ; GCN-NEXT:   S_WAITCNT .Expcnt_0
   ; GCN-NEXT:   $vgpr0 = V_MOV_B32_e32 2, implicit $exec
   ; GCN-NEXT:   $vgpr1 = V_MOV_B32_e32 32772, implicit $exec
   ; GCN-NEXT:   BUFFER_STORE_DWORD_OFFEN killed $vgpr0, killed $vgpr1, $sgpr8_sgpr9_sgpr10_sgpr11, $sgpr3, 0, 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(5) poison`, addrspace 5)
@@ -33,7 +33,7 @@ body:             |
   ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $sgpr4_sgpr5, $sgpr3, $sgpr8_sgpr9_sgpr10_sgpr11
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   $sgpr0 = S_LOAD_DWORD_IMM killed $sgpr0_sgpr1, 52, 0 :: (non-temporal dereferenceable invariant load (s32) from `ptr addrspace(4) poison`, addrspace 4)
-  ; GCN-NEXT:   S_WAITCNT 3855
+  ; GCN-NEXT:   S_WAITCNT .Expcnt_0
   ; GCN-NEXT:   $vgpr0 = V_MOV_B32_e32 32772, implicit $exec
   ; GCN-NEXT:   S_BRANCH %bb.3
   ; GCN-NEXT: {{  $}}
@@ -42,13 +42,13 @@ body:             |
   ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $sgpr4_sgpr5, $sgpr3, $sgpr8_sgpr9_sgpr10_sgpr11
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   $sgpr0 = S_LOAD_DWORD_IMM killed $sgpr0_sgpr1, 48, 0 :: (non-temporal dereferenceable invariant load (s32) from `ptr addrspace(4) poison`, addrspace 4)
-  ; GCN-NEXT:   S_WAITCNT 3855
+  ; GCN-NEXT:   S_WAITCNT .Expcnt_0
   ; GCN-NEXT:   $vgpr0 = V_MOV_B32_e32 4, implicit $exec
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.3:
   ; GCN-NEXT:   liveins: $sgpr3, $sgpr4_sgpr5, $sgpr8_sgpr9_sgpr10_sgpr11, $vgpr0, $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   S_WAITCNT 127
+  ; GCN-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; GCN-NEXT:   $sgpr0 = S_LSHL_B32 killed $sgpr0, 2, implicit-def dead $scc
   ; GCN-NEXT:   $vgpr0 = V_ADD_CO_U32_e32 killed $sgpr0, killed $vgpr0, implicit-def dead $vcc, implicit $exec
   ; GCN-NEXT:   S_WAITCNT_soft 3952
@@ -57,7 +57,7 @@ body:             |
   ; GCN-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GCN-NEXT:   $vgpr1 = V_MOV_B32_e32 $sgpr4, implicit $exec, implicit-def $vgpr1_vgpr2, implicit $sgpr4_sgpr5
   ; GCN-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr5, implicit $exec, implicit $sgpr4_sgpr5, implicit $exec
-  ; GCN-NEXT:   S_WAITCNT 3952
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0
   ; GCN-NEXT:   FLAT_STORE_DWORD killed $vgpr1_vgpr2, killed $vgpr0, 0, 0, implicit $exec, implicit $flat_scr :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0.entry:

--- a/llvm/test/CodeGen/AMDGPU/post-ra-sched-kill-bundle-use-inst.mir
+++ b/llvm/test/CodeGen/AMDGPU/post-ra-sched-kill-bundle-use-inst.mir
@@ -23,11 +23,11 @@ body:             |
     ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
     ; CHECK-NEXT: BUNDLE implicit $vgpr0, implicit $m0, implicit $exec {
     ; CHECK-NEXT:   DS_GWS_INIT $vgpr0, 8, implicit $m0, implicit $exec
-    ; CHECK-NEXT:   S_WAITCNT 0
+    ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit killed $vgpr0, implicit $m0, implicit $exec {
     ; CHECK-NEXT:   DS_GWS_BARRIER killed $vgpr0, 8, implicit $m0, implicit $exec
-    ; CHECK-NEXT:   S_WAITCNT 0
+    ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: }
     renamable $sgpr0 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 0, 0
     $m0 = S_MOV_B32 -1

--- a/llvm/test/CodeGen/AMDGPU/release-vgprs.mir
+++ b/llvm/test/CodeGen/AMDGPU/release-vgprs.mir
@@ -182,7 +182,7 @@ body:             |
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 1015
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
   ; CHECK-NEXT:   $vgpr1 = V_ADD_U32_e32 $vgpr0, $vgpr2, implicit $exec
   ; CHECK-NEXT:   S_CMP_LG_U32 killed renamable $sgpr3, renamable $sgpr4, implicit-def $scc
   ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit killed $scc
@@ -457,7 +457,7 @@ body:             |
   ; OPT-NEXT: bb.1:
   ; OPT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT:   S_WAITCNT 1015
+  ; OPT-NEXT:   S_WAITCNT .Vmcnt_0
   ; OPT-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, killed renamable $vgpr4, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 115, 0, 0, implicit $exec :: (volatile store (s32), addrspace 1)
   ; OPT-NEXT:   S_CMP_LG_U32 killed renamable $sgpr3, renamable $sgpr4, implicit-def $scc
   ; OPT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit killed $scc
@@ -478,7 +478,7 @@ body:             |
   ; NOOPT-NEXT: bb.1:
   ; NOOPT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT:   S_WAITCNT 1015
+  ; NOOPT-NEXT:   S_WAITCNT .Vmcnt_0
   ; NOOPT-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, killed renamable $vgpr4, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 115, 0, 0, implicit $exec :: (volatile store (s32), addrspace 1)
   ; NOOPT-NEXT:   S_CMP_LG_U32 killed renamable $sgpr3, renamable $sgpr4, implicit-def $scc
   ; NOOPT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit killed $scc
@@ -621,7 +621,7 @@ frameInfo:
 body:             |
   bb.0:
     ; CHECK-LABEL: name: with_calls
-    ; CHECK: S_WAITCNT 0
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr1, 0, 4, implicit $exec
     ; CHECK-NEXT: $sgpr30_sgpr31 = SI_CALL undef renamable $sgpr4_sgpr5, 0, csr_amdgpu
     ; CHECK-NEXT: S_ENDPGM 0, implicit $vgpr97
@@ -639,7 +639,7 @@ frameInfo:
 body:             |
   bb.0:
     ; CHECK-LABEL: name: with_tail_calls
-    ; CHECK: S_WAITCNT 0
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr97, 0, 4, implicit $exec
     ; CHECK-NEXT: SI_TCRETURN undef renamable $sgpr4_sgpr5, @with_tail_calls, 0, csr_amdgpu
     GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr97, 0, 4, implicit $exec
@@ -656,7 +656,7 @@ frameInfo:
 body:             |
   bb.0:
     ; CHECK-LABEL: name: waveslot_limited
-    ; CHECK: S_WAITCNT 0
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr96, 0, 4, implicit $exec
     ; CHECK-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr96, 0, 4, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/scheduler-handle-move-bundle.mir
+++ b/llvm/test/CodeGen/AMDGPU/scheduler-handle-move-bundle.mir
@@ -30,7 +30,7 @@ body:             |
     ; GCN-NEXT: $m0 = S_MOV_B32 0
     ; GCN-NEXT: BUNDLE implicit $vgpr0, implicit $m0, implicit $exec {
     ; GCN-NEXT:   DS_GWS_INIT $vgpr0, 11, implicit $m0, implicit $exec :: (store (s32))
-    ; GCN-NEXT:   S_WAITCNT 0
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: }
     ; GCN-NEXT: DS_WRITE_B32_gfx9 [[V_MOV_B32_e32_1]], [[V_MOV_B32_e32_2]], 0, 0, implicit $exec :: (store (s32), addrspace 3)
     ; GCN-NEXT: S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/skip-branch-taildup-ret.mir
+++ b/llvm/test/CodeGen/AMDGPU/skip-branch-taildup-ret.mir
@@ -13,13 +13,13 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM renamable $sgpr4_sgpr5, 4, 0 :: (dereferenceable invariant load (s64), align 16, addrspace 4)
   ; CHECK-NEXT:   renamable $vgpr0 = V_LSHLREV_B32_e32 2, killed $vgpr0, implicit $exec
-  ; CHECK-NEXT:   S_WAITCNT 127
+  ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   $vgpr1 = V_MOV_B32_e32 $sgpr1, implicit $exec, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr0 = V_ADD_CO_U32_e32 $sgpr0, killed $vgpr0, implicit-def $vcc, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr1 = V_ADDC_U32_e32 0, killed $vgpr1, implicit-def $vcc, implicit killed $vcc, implicit $exec
   ; CHECK-NEXT:   renamable $vgpr0 = FLAT_LOAD_DWORD renamable $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr :: (load (s32), addrspace 1)
   ; CHECK-NEXT:   renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM killed renamable $sgpr4_sgpr5, 0, 0 :: (dereferenceable invariant load (s64), align 16, addrspace 4)
-  ; CHECK-NEXT:   S_WAITCNT 112
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   V_CMP_NE_U32_e32 0, killed $vgpr0, implicit-def $vcc, implicit $exec
   ; CHECK-NEXT:   $sgpr2_sgpr3 = S_AND_SAVEEXEC_B64 $vcc, implicit-def $exec, implicit-def $scc, implicit $exec
   ; CHECK-NEXT:   renamable $sgpr2_sgpr3 = S_XOR_B64 $exec, killed renamable $sgpr2_sgpr3, implicit-def dead $scc
@@ -130,7 +130,7 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT:   liveins: $vgpr0, $sgpr30_sgpr31, $vgpr1_vgpr2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   V_CMP_NE_U32_e32 0, killed $vgpr0, implicit-def $vcc, implicit $exec
   ; CHECK-NEXT:   $sgpr6_sgpr7 = S_AND_SAVEEXEC_B64 $vcc, implicit-def $exec, implicit-def $scc, implicit $exec
   ; CHECK-NEXT:   renamable $sgpr6_sgpr7 = S_XOR_B64 $exec, killed renamable $sgpr6_sgpr7, implicit-def dead $scc

--- a/llvm/test/CodeGen/AMDGPU/smem-war-hazard.mir
+++ b/llvm/test/CodeGen/AMDGPU/smem-war-hazard.mir
@@ -1,5 +1,5 @@
 # RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -verify-machineinstrs -run-pass post-RA-hazard-rec -o - %s | FileCheck -check-prefixes=GCN,GFX10 %s
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -verify-machineinstrs -run-pass post-RA-hazard-rec -o - %s | FileCheck -check-prefixes=GCN %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -verify-machineinstrs -run-pass post-RA-hazard-rec -o - %s | FileCheck -check-prefixes=GCN,GFX11 %s
 
 # GCN-LABEL: name: hazard_smem_war
 # GCN:        S_LOAD_DWORD_IMM
@@ -97,8 +97,9 @@ body: |
 
 # GCN-LABEL: name: hazard_smem_war_only_vmcnt_0
 # GCN:        S_LOAD_DWORD_IMM
-# GCN-NEXT:   S_WAITCNT 3952{{$}}
+# GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_15
 # GFX10-NEXT: $sgpr_null = S_MOV_B32 0
+# GFX11-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
 # GCN-NEXT:   V_CMP_EQ_F32
 ---
 name: hazard_smem_war_only_vmcnt_0
@@ -113,8 +114,9 @@ body: |
 
 # GCN-LABEL: name: hazard_smem_war_only_expcnt_0
 # GCN:        S_LOAD_DWORD_IMM
-# GCN-NEXT:   S_WAITCNT 53007{{$}}
+# GFX10-NEXT: S_WAITCNT .Expcnt_0_Lgkmcnt_15
 # GFX10-NEXT: $sgpr_null = S_MOV_B32 0
+# GFX11-NEXT: S_WAITCNT .Vmcnt_51_Lgkmcnt_48
 # GCN-NEXT:   V_CMP_EQ_F32
 ---
 name: hazard_smem_war_only_expcnt_0
@@ -128,8 +130,9 @@ body: |
 ...
 
 # GCN-LABEL: name: hazard_smem_war_only_lgkmcnt_0
-# GCN:      S_LOAD_DWORD_IMM
-# GCN-NEXT: S_WAITCNT 49279{{$}}
+# GCN:       S_LOAD_DWORD_IMM
+# GFX10-NEXT: S_WAITCNT .Lgkmcnt_0
+# GFX11-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
 # GCN-NEXT: V_CMP_EQ_F32
 ---
 name: hazard_smem_war_only_lgkmcnt_0

--- a/llvm/test/CodeGen/AMDGPU/spill-wait.mir
+++ b/llvm/test/CodeGen/AMDGPU/spill-wait.mir
@@ -14,7 +14,7 @@ body: |
     ; GFX9-LABEL: name: spill_vgpr_tuple
     ; GFX9: liveins: $vgpr0_vgpr1, $sgpr76_sgpr77_sgpr78_sgpr79
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr64_vgpr65 = V_MOV_B64_e32 $vgpr0_vgpr1, implicit $exec
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr64, $sgpr76_sgpr77_sgpr78_sgpr79, 0, 672, 0, 0, implicit $exec, implicit-def $vgpr64_vgpr65, implicit $vgpr64_vgpr65
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET $vgpr65, $sgpr76_sgpr77_sgpr78_sgpr79, 0, 676, 0, 0, implicit $exec, implicit $vgpr64_vgpr65
@@ -50,9 +50,9 @@ body: |
     ; GFX9-LABEL: name: load_vcc_wait
     ; GFX9: liveins: $vgpr0, $sgpr10_sgpr11
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vcc_lo = S_LOAD_DWORD_IMM $sgpr10_sgpr11, 0, 0
-    ; GFX9-NEXT: S_WAITCNT 49279
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX9-NEXT: $vgpr1 = V_ADDC_U32_e32 0, $vgpr0, implicit-def $vcc, implicit $vcc, implicit $exec
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -85,9 +85,9 @@ body: |
     ; GFX9-LABEL: name: load_flat_scr_lo_flat_load_wait
     ; GFX9: liveins: $sgpr10_sgpr11, $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $flat_scr_lo = S_LOAD_DWORD_IMM $sgpr10_sgpr11, 0, 0
-    ; GFX9-NEXT: S_WAITCNT 49279
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -118,9 +118,9 @@ body: |
     ; GFX9-LABEL: name: load_flat_scr_lo_scratch_store_wait
     ; GFX9: liveins: $sgpr10_sgpr11, $vgpr0, $sgpr32
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $flat_scr_hi = S_LOAD_DWORD_IMM $sgpr10_sgpr11, 0, 0
-    ; GFX9-NEXT: S_WAITCNT 49279
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX9-NEXT: SCRATCH_STORE_DWORD_SADDR $vgpr0, $sgpr32, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -153,18 +153,18 @@ body: |
     ; GFX9-LABEL: name: spill_load_store
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 8, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 12, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 16, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr3 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 20, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: S_WAITCNT 3955
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_3
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 40, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $vgpr0_vgpr1_vgpr2_vgpr3
-    ; GFX9-NEXT: S_WAITCNT 3955
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_3
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 44, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 3955
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_3
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 48, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 3955
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_3
     ; GFX9-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 52, 0, 0, implicit $exec, implicit killed $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -211,7 +211,7 @@ body:             |
     ; GFX9-LABEL: name: scratch_load_waw
     ; GFX9: liveins: $vgpr0, $sgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = SCRATCH_LOAD_DWORD $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: $vgpr2 = SCRATCH_LOAD_SHORT_D16_HI_SADDR $sgpr0, 0, 0, $vgpr2, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/statepoint-insert-waitcnts.mir
+++ b/llvm/test/CodeGen/AMDGPU/statepoint-insert-waitcnts.mir
@@ -36,7 +36,7 @@ body:             |
     ; CHECK-LABEL: name: test_wait_statepoint_callee
     ; CHECK: liveins: $sgpr12, $sgpr13, $sgpr14, $sgpr15, $sgpr30, $sgpr31, $vgpr31, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9, $sgpr10_sgpr11, $sgpr12_sgpr13
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: S_WAITCNT 0
+    ; CHECK-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: $sgpr16 = S_MOV_B32 $sgpr33
     ; CHECK-NEXT: $sgpr33 = S_MOV_B32 $sgpr32
     ; CHECK-NEXT: $sgpr18_sgpr19 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
@@ -47,7 +47,7 @@ body:             |
     ; CHECK-NEXT: $sgpr32 = frame-setup S_ADDK_I32 $sgpr32, 1024, implicit-def dead $scc
     ; CHECK-NEXT: $vgpr40 = V_WRITELANE_B32 $sgpr31, 1, $vgpr40
     ; CHECK-NEXT: $sgpr14_sgpr15 = S_LOAD_DWORDX2_IMM $sgpr12_sgpr13, 0, 0
-    ; CHECK-NEXT: S_WAITCNT 49279
+    ; CHECK-NEXT: S_WAITCNT .Lgkmcnt_0
     ; CHECK-NEXT: STATEPOINT 2882400015, 0, 11, renamable $sgpr14_sgpr15, 0, killed $sgpr4_sgpr5, killed $sgpr6_sgpr7, killed $sgpr8_sgpr9, killed $sgpr10_sgpr11, killed $sgpr12, killed $sgpr13, killed $sgpr14, killed $sgpr15, killed $vgpr31, $sgpr0_sgpr1_sgpr2_sgpr3, 2, 0, 2, 0, 2, 1, 2, 0, 2, 0, 2, 0, 2, 0, csr_amdgpu
     $sgpr16 = S_MOV_B32 $sgpr33
     $sgpr33 = S_MOV_B32 $sgpr32

--- a/llvm/test/CodeGen/AMDGPU/transform-block-with-return-to-epilog.ll
+++ b/llvm/test/CodeGen/AMDGPU/transform-block-with-return-to-epilog.ll
@@ -32,7 +32,7 @@ define amdgpu_ps float @test_return_to_epilog_into_end_block(i32 inreg %a, float
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
-  ; GCN-NEXT:   S_WAITCNT 3952
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.3:
 entry:
@@ -79,7 +79,7 @@ define amdgpu_ps float @test_unify_return_to_epilog_into_end_block(i32 inreg %a,
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
-  ; GCN-NEXT:   S_WAITCNT 3952
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.5:
 entry:

--- a/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
+++ b/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
@@ -18,12 +18,12 @@ body:             |
     ; GFX950-NEXT: {{  $}}
     ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -40,12 +40,12 @@ body:             |
     ; GFX942-NEXT: {{  $}}
     ; GFX942-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX942-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX942-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX942-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX942-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -62,12 +62,12 @@ body:             |
     ; GFX90A-NEXT: {{  $}}
     ; GFX90A-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX90A-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX90A-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX90A-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX90A-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -111,12 +111,12 @@ body:             |
     ; GFX950-NEXT: {{  $}}
     ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -133,12 +133,12 @@ body:             |
     ; GFX942-NEXT: {{  $}}
     ; GFX942-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX942-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX942-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX942-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX942-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -155,12 +155,12 @@ body:             |
     ; GFX90A-NEXT: {{  $}}
     ; GFX90A-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX90A-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX90A-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX90A-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX90A-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -204,12 +204,12 @@ body:             |
     ; GFX950-NEXT: {{  $}}
     ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -226,12 +226,12 @@ body:             |
     ; GFX942-NEXT: {{  $}}
     ; GFX942-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX942-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX942-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX942-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX942-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -248,12 +248,12 @@ body:             |
     ; GFX90A-NEXT: {{  $}}
     ; GFX90A-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX90A-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX90A-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX90A-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX90A-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -998,12 +998,12 @@ body:             |
     ; GFX950-NEXT: {{  $}}
     ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -1020,12 +1020,12 @@ body:             |
     ; GFX942-NEXT: {{  $}}
     ; GFX942-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX942-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX942-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX942-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX942-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -1042,12 +1042,12 @@ body:             |
     ; GFX90A-NEXT: {{  $}}
     ; GFX90A-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX90A-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX90A-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX90A-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX90A-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -1091,12 +1091,12 @@ body:             |
     ; GFX950-NEXT: {{  $}}
     ; GFX950-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX950-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX950-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX950-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX950-NEXT: S_WAITCNT 49279
+    ; GFX950-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX950-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX950-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX950-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -1113,12 +1113,12 @@ body:             |
     ; GFX942-NEXT: {{  $}}
     ; GFX942-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX942-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX942-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX942-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX942-NEXT: S_WAITCNT 49279
+    ; GFX942-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX942-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX942-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX942-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51
@@ -1135,12 +1135,12 @@ body:             |
     ; GFX90A-NEXT: {{  $}}
     ; GFX90A-NEXT: early-clobber renamable $sgpr36_sgpr37_sgpr38_sgpr39_sgpr40_sgpr41_sgpr42_sgpr43 = S_LOAD_DWORDX8_IMM_ec killed renamable $sgpr4_sgpr5, 0, 0
     ; GFX90A-NEXT: renamable $vgpr18 = V_MOV_B32_e32 0, implicit $exec
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: renamable $sgpr44_sgpr45_sgpr46_sgpr47 = S_LOAD_DWORDX4_IMM renamable $sgpr40_sgpr41, 0, 0
     ; GFX90A-NEXT: renamable $sgpr48_sgpr49_sgpr50_sgpr51 = S_LOAD_DWORDX4_IMM renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11_sgpr12_sgpr13_sgpr14_sgpr15 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr42_sgpr43, 0, 0
     ; GFX90A-NEXT: early-clobber renamable $sgpr16_sgpr17_sgpr18_sgpr19_sgpr20_sgpr21_sgpr22_sgpr23_sgpr24_sgpr25_sgpr26_sgpr27_sgpr28_sgpr29_sgpr30_sgpr31 = S_LOAD_DWORDX16_IMM_ec killed renamable $sgpr40_sgpr41, 0, 0
-    ; GFX90A-NEXT: S_WAITCNT 49279
+    ; GFX90A-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX90A-NEXT: $vgpr0_vgpr1 = V_MOV_B64_e32 $sgpr44_sgpr45, implicit $exec, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit $sgpr44_sgpr45_sgpr46_sgpr47
     ; GFX90A-NEXT: $vgpr2_vgpr3 = V_MOV_B64_e32 killed $sgpr46_sgpr47, implicit $exec, implicit $sgpr44_sgpr45_sgpr46_sgpr47, implicit $exec
     ; GFX90A-NEXT: $vgpr4_vgpr5 = V_MOV_B64_e32 $sgpr48_sgpr49, implicit $exec, implicit-def $vgpr4_vgpr5_vgpr6_vgpr7, implicit $sgpr48_sgpr49_sgpr50_sgpr51

--- a/llvm/test/CodeGen/AMDGPU/valu-mask-write-hazard.mir
+++ b/llvm/test/CodeGen/AMDGPU/valu-mask-write-hazard.mir
@@ -562,7 +562,7 @@ body:            |
   bb.0:
     ; GCN-LABEL: name: mask_hazard_waitcnt
     ; GCN: $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr0_sgpr1, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $sgpr0_sgpr1 = S_GETPC_B64
     ; GCN-NEXT: S_WAITCNT_DEPCTR .SaSdst_0
     ; GCN-NEXT: $sgpr0 = S_ADD_U32 $sgpr0, 0, implicit-def $scc

--- a/llvm/test/CodeGen/AMDGPU/vccz-corrupt-bug-workaround.mir
+++ b/llvm/test/CodeGen/AMDGPU/vccz-corrupt-bug-workaround.mir
@@ -7,7 +7,7 @@
 ---
 # CHECK-LABEL: name: vccz_corrupt_workaround
 # CHECK: $vcc = V_CMP_EQ_F32
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # CHECK-NEXT: S_CBRANCH_VCCZ %bb.2, implicit killed $vcc
 
@@ -50,7 +50,7 @@ body: |
 ---
 # CHECK-LABEL: name: vccz_corrupt_undef_vcc
 # CHECK: BUFFER_STORE_DWORD_OFFSET
-# SI-NEXT: S_WAITCNT 3855
+# SI-NEXT: S_WAITCNT .Expcnt_0
 # CHECK-NEXT: $vgpr0 = V_MOV_B32_e32
 
 name: vccz_corrupt_undef_vcc
@@ -190,9 +190,9 @@ body: |
 
 ---
 # CHECK-LABEL: name: load_wait_def_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 0
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
 name: load_wait_def_use
@@ -207,9 +207,9 @@ body: |
 
 ---
 # CHECK-LABEL: name: load_wait_nop_def_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: S_NOP 0
 # SI-NEXT: $vcc = S_MOV_B64 0
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
@@ -226,10 +226,10 @@ body: |
 
 ---
 # CHECK-LABEL: name: load_def_wait_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
 # SI-NEXT: $vcc = S_MOV_B64 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
 name: load_def_wait_use
@@ -243,10 +243,10 @@ body: |
 ...
 
 # CHECK-LABEL: name: load_def_wait_nop_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
 # SI-NEXT: $vcc = S_MOV_B64 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: S_NOP 0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
@@ -263,10 +263,10 @@ body: |
 
 ---
 # CHECK-LABEL: name: load_def_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
 # SI-NEXT: $vcc = S_MOV_B64 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
 name: load_def_use
@@ -280,10 +280,10 @@ body: |
 
 ---
 # CHECK-LABEL: name: def_load_wait_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
 name: def_load_wait_use
@@ -298,10 +298,10 @@ body: |
 
 ---
 # CHECK-LABEL: name: def_load_wait_nop_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: S_NOP 0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
@@ -318,10 +318,10 @@ body: |
 
 ---
 # CHECK-LABEL: name: def_load_use
-# SI: S_WAITCNT 0
+# SI: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 0
 # SI-NEXT: $sgpr0 = S_LOAD_DWORD_IMM $sgpr0_sgpr1, 0, 0
-# SI-NEXT: S_WAITCNT 127
+# SI-NEXT: S_WAITCNT .Lgkmcnt_0
 # SI-NEXT: $vcc = S_MOV_B64 $vcc
 # SI-NEXT: S_CBRANCH_VCCZ %bb.1, implicit $vcc
 name: def_load_use

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-agpr.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-agpr.mir
@@ -63,10 +63,10 @@ body: |
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   S_WAITCNT 0
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr :: (load (s32) from %ir.global4, addrspace 1)
   ; GCN-NEXT:   $agpr4_agpr5_agpr6_agpr7 = FLAT_LOAD_DWORDX4 $vgpr8_vgpr9, 0, 0, implicit $exec, implicit $flat_scr :: (load (s128) from %ir.global16, addrspace 1)
-  ; GCN-NEXT:   S_WAITCNT 3953
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_1
   ; GCN-NEXT:   $agpr0 = V_ACCVGPR_MOV_B32 $agpr1, implicit $exec
   ; GCN-NEXT:   S_BRANCH %bb.1
   ; GCN-NEXT: {{  $}}
@@ -74,15 +74,15 @@ body: |
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
-  ; GCN-NEXT:   S_WAITCNT 3952
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0
   ; GCN-NEXT:   $agpr4_agpr5_agpr6_agpr7 = FLAT_LOAD_DWORDX4 $vgpr8_vgpr9, 0, 0, implicit $exec, implicit $flat_scr :: (load (s128) from %ir.global16, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = V_ACCVGPR_READ_B32_e64 $agpr1, implicit $exec
   ; GCN-NEXT:   S_BRANCH %bb.2
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_WAITCNT 49279
+  ; GCN-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr :: (load (s32) from %ir.flat4)
-  ; GCN-NEXT:   S_WAITCNT 3952
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0
   ; GCN-NEXT:   $agpr4_agpr5_agpr6_agpr7 = FLAT_LOAD_DWORDX4 $vgpr8_vgpr9, 0, 0, implicit $exec, implicit $flat_scr :: (load (s128) from %ir.flat16)
   ; GCN-NEXT:   $vgpr0 = V_ACCVGPR_READ_B32_e64 $agpr1, implicit $exec
   ; GCN-NEXT:   S_ENDPGM 0
@@ -118,12 +118,12 @@ body: |
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   S_WAITCNT 0
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.1:
   ; GCN-NEXT:   $vgpr4_vgpr5 = V_LSHLREV_B64_e64 4, $vgpr8_vgpr9, implicit $exec
-  ; GCN-NEXT:   S_WAITCNT 112
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Lgkmcnt_0
   ; GCN-NEXT:   FLAT_STORE_DWORD $vgpr4_vgpr5, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
@@ -149,7 +149,7 @@ body: |
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.2(0x80000000)
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   S_WAITCNT 0
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
   ; GCN-NEXT:   S_BRANCH %bb.2
   ; GCN-NEXT: {{  $}}
@@ -159,7 +159,7 @@ body: |
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   $vgpr4_vgpr5 = V_LSHLREV_B64_e64 4, $vgpr8_vgpr9, implicit $exec
-  ; GCN-NEXT:   S_WAITCNT 112
+  ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Lgkmcnt_0
   ; GCN-NEXT:   FLAT_STORE_DWORD $vgpr4_vgpr5, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
@@ -179,7 +179,7 @@ body: |
 
 # GCN-LABEL: name: preexisting_waitcnt{{$}}
 # GCN: FLAT_LOAD_DWORD
-# GCN-NEXT: S_WAITCNT 0
+# GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # GCN-NOT: S_WAITCNT
 name: preexisting_waitcnt
 tracksRegLiveness: true
@@ -211,7 +211,7 @@ body: |
     ; GCN-NEXT:   S_NOP 0
     ; GCN-NEXT:   S_NOP 0
     ; GCN-NEXT: }
-    ; GCN-NEXT: S_WAITCNT 112
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GCN-NEXT: FLAT_STORE_DWORD $vgpr2_vgpr3, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
     $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     BUNDLE {
@@ -238,7 +238,7 @@ body: |
     ; GCN-NEXT: $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: BUNDLE {
     ; GCN-NEXT:   S_NOP 0
-    ; GCN-NEXT:   S_WAITCNT 0
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: }
     ; GCN-NEXT: FLAT_STORE_DWORD $vgpr2_vgpr3, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
     $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
@@ -266,7 +266,7 @@ body: |
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: BUNDLE implicit-def $agpr0, implicit $vgpr2_vgpr3 {
     ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
-    ; GCN-NEXT:   S_WAITCNT 112
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GCN-NEXT:   FLAT_STORE_DWORD $vgpr2_vgpr3, internal $agpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: }
     BUNDLE implicit-def $agpr0, implicit $vgpr2_vgpr3 {
@@ -293,7 +293,7 @@ body: |
     ; GCN-NEXT: BUNDLE implicit-def $agpr0, implicit $vgpr2_vgpr3 {
     ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: }
-    ; GCN-NEXT: S_WAITCNT 112
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GCN-NEXT: FLAT_STORE_DWORD $vgpr2_vgpr3, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
     BUNDLE implicit-def $agpr0, implicit $vgpr2_vgpr3 {
     $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
@@ -322,7 +322,7 @@ body: |
     ; GCN-NEXT:   $agpr0 = FLAT_LOAD_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: }
     ; GCN-NEXT: BUNDLE implicit $agpr0, implicit $vgpr2_vgpr3 {
-    ; GCN-NEXT:   S_WAITCNT 112
+    ; GCN-NEXT:   S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GCN-NEXT:   FLAT_STORE_DWORD $vgpr2_vgpr3, $agpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: }
     BUNDLE implicit-def $agpr0, implicit $vgpr2_vgpr3 {
@@ -341,7 +341,7 @@ name: high_register_collision
 body: |
   bb.0:
     ; GCN-LABEL: name: high_register_collision
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $agpr0 = V_ACCVGPR_MOV_B32 $agpr1, implicit $exec
     ; GCN-NEXT: $vgpr226 = FLAT_LOAD_DWORD $vgpr6_vgpr7, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: $vgpr4_vgpr5 = V_LSHLREV_B64_e64 4, $vgpr8_vgpr9, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-back-edge-loop.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-back-edge-loop.mir
@@ -2,7 +2,7 @@
 
 # GCN-LABEL: waitcnt-back-edge-loop
 # GCN: bb.2
-# GCN: S_WAITCNT 3952
+# GCN: S_WAITCNT .Vmcnt_0
 # GCN: $vgpr5 = V_CVT_I32_F32_e32 killed $vgpr5, implicit $mode, implicit $exec
 
 ---
@@ -61,7 +61,7 @@ body:             |
 
 # GCN-LABEL: name: waitcnt-multiple-back-edges{{$}}
 # GCN: bb.0:
-# GCN: S_WAITCNT 0
+# GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # GCN-NEXT: S_BRANCH %bb.2
 
 name: waitcnt-multiple-back-edges

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-bvh.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-bvh.mir
@@ -6,7 +6,7 @@ name: waitcnt-check-inorder
 body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-check-inorder
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_ENDPGM 0
@@ -19,9 +19,9 @@ name: waitcnt-check-vs-vmem
 body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-check-vs-vmem
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
-    ; GCN-NEXT: S_WAITCNT 16240
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr16, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
@@ -33,9 +33,9 @@ name: waitcnt-check-vs-mimg-samp
 body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-check-vs-mimg-samp
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
-    ; GCN-NEXT: S_WAITCNT 16240
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
@@ -47,9 +47,9 @@ name: waitcnt-check-vs-vmem-reverse
 body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-check-vs-vmem-reverse
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr20, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
-    ; GCN-NEXT: S_WAITCNT 16240
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr20, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
@@ -61,9 +61,9 @@ name: waitcnt-check-vs-mimg-samp-reverse
 body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-check-vs-mimg-samp-reverse
-    ; GCN: S_WAITCNT 0
+    ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr16_vgpr17, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
-    ; GCN-NEXT: S_WAITCNT 16240
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr16_vgpr17, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-debug-non-first-terminators.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-debug-non-first-terminators.mir
@@ -17,11 +17,11 @@ body:             |
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   S_NOP 0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
-  ; CHECK-NEXT:   S_WAITCNT 0
+  ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
   ; CHECK-NEXT:   S_NOP 0
   bb.0:
     S_CBRANCH_SCC1 %bb.1, implicit $scc

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-debug.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-debug.mir
@@ -8,27 +8,27 @@
 
 ...
 # GCN-LABEL: name: waitcnt-debug
-# LGKM: S_WAITCNT 127
+# LGKM: S_WAITCNT .Lgkmcnt_0
 # LGKM-NEXT: S_NOP 0
 # LGKM-NEXT: S_NOP 0
 
-# EXP: S_WAITCNT 3855
+# EXP: S_WAITCNT .Expcnt_0
 # EXP-NEXT: S_NOP 0
-# EXP-NEXT: S_WAITCNT 3855
+# EXP-NEXT: S_WAITCNT .Expcnt_0
 # EXP-NEXT: S_NOP 0
 
-# VM: S_WAITCNT 3952
+# VM: S_WAITCNT .Vmcnt_0
 # VM-NEXT: S_NOP 0
-# VM-NEXT: S_WAITCNT 3952
+# VM-NEXT: S_WAITCNT .Vmcnt_0
 # VM-NEXT: S_NOP 0
-# VM-NEXT: S_WAITCNT 3952
+# VM-NEXT: S_WAITCNT .Vmcnt_0
 # VM-NEXT: S_NOP 0
 
-# ZERO: S_WAITCNT 0
+# ZERO: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # ZERO-NEXT: S_NOP 0
-# ZERO-NEXT: S_WAITCNT 0
+# ZERO-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # ZERO-NEXT: S_NOP 0
-# ZERO-NEXT: S_WAITCNT 0
+# ZERO-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # ZERO-NEXT: S_NOP 0
 
 name:            waitcnt-debug

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-loop-irreducible.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-loop-irreducible.mir
@@ -15,11 +15,11 @@
 
 # GCN-LABEL: name: irreducible_loop{{$}}
 # GCN: S_LOAD_DWORDX4_IMM
-# GFX8: S_WAITCNT 127{{$}}
-# GFX9: S_WAITCNT 49279{{$}}
+# GFX8: S_WAITCNT .Lgkmcnt_0{{$}}
+# GFX9: S_WAITCNT .Lgkmcnt_0{{$}}
 # GCN: S_BUFFER_LOAD_DWORD_IMM
-# GFX8: S_WAITCNT 127{{$}}
-# GFX9: S_WAITCNT 49279{{$}}
+# GFX8: S_WAITCNT .Lgkmcnt_0{{$}}
+# GFX9: S_WAITCNT .Lgkmcnt_0{{$}}
 # GCN: S_CMP_GE_I32
 name:            irreducible_loop
 body:             |
@@ -55,17 +55,17 @@ body:             |
 # GCN-LABEL: name: irreducible_loop_extended
 
 # GCN: S_LOAD_DWORDX4_IMM
-# GFX8: S_WAITCNT 127{{$}}
-# GFX9: S_WAITCNT 49279{{$}}
+# GFX8: S_WAITCNT .Lgkmcnt_0{{$}}
+# GFX9: S_WAITCNT .Lgkmcnt_0{{$}}
 # GCN: BUFFER_STORE_DWORD_OFFEN_exact
-# GFX8: S_WAITCNT 127{{$}}
-# GFX9: S_WAITCNT 49279{{$}}
+# GFX8: S_WAITCNT .Lgkmcnt_0{{$}}
+# GFX9: S_WAITCNT .Lgkmcnt_0{{$}}
 # GCN: BUFFER_STORE_DWORD_OFFEN_exact
 # GCN: S_LOAD_DWORDX4_IMM
-# GFX8: S_WAITCNT 127{{$}}
-# GFX9: S_WAITCNT 49279{{$}}
+# GFX8: S_WAITCNT .Lgkmcnt_0{{$}}
+# GFX9: S_WAITCNT .Lgkmcnt_0{{$}}
 # GCN: BUFFER_ATOMIC_ADD_OFFSET_RTN
-# GCN: S_WAITCNT 3952
+# GCN: S_WAITCNT .Vmcnt_0
 # GCN: FLAT_STORE_DWORD
 # GCN: S_ENDPGM 0
 name: irreducible_loop_extended

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-loop-single-basic-block.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-loop-single-basic-block.mir
@@ -4,9 +4,9 @@
 
 # GCN-LABEL: waitcnt-loop-single-basic-block
 # GCN: bb.0
-# GCN: S_WAITCNT 3952
+# GCN: S_WAITCNT .Vmcnt_0{{$}}
 # GCN-NEXT: GLOBAL_STORE_DWORD
-# GCN: S_WAITCNT 3953
+# GCN: S_WAITCNT .Vmcnt_1
 # GCN-NEXT: GLOBAL_STORE_DWORD
 
 ...

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-meta-instructions.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-meta-instructions.mir
@@ -13,7 +13,7 @@ body:             |
     ; GCN-LABEL: name: waitcnt_kill
     ; GCN: liveins: $vgpr0_vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GCN-NEXT: KILL $vgpr0
     $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
@@ -30,7 +30,7 @@ body:             |
     ; GCN-LABEL: name: waitcnt_implicit_def
     ; GCN: liveins: $vgpr0_vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GCN-NEXT: $vgpr0 = IMPLICIT_DEF
     $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
@@ -47,7 +47,7 @@ body:             |
     ; GCN-LABEL: name: waitcnt_eh_label
     ; GCN: liveins: $vgpr0_vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GCN-NEXT: EH_LABEL <mcsymbol Ltmp0>, implicit $vgpr0
     $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
@@ -65,7 +65,7 @@ body:             |
     ; GCN-LABEL: name: waitcnt_cfi
     ; GCN: liveins: $vgpr0_vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT 0
+    ; GCN-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GCN-NEXT: CFI_INSTRUCTION offset $vgpr0, 16
     $vgpr0 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-no-redundant.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-no-redundant.mir
@@ -6,7 +6,7 @@
 ...
 # CHECK-LABEL: name: waitcnt-no-redundant
 # CHECK: FLAT_ATOMIC_CMPSWAP
-# CHECK-NEXT: S_WAITCNT 3952
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0
 # CHECK-NEXT: BUFFER_WBINVL1
 
 name: waitcnt-no-redundant
@@ -27,7 +27,7 @@ body: |
 # WAR hazard does not apply here, because S_BUFFER_LOAD accesses invariant memory.
 ...
 # CHECK-LABEL: name: waitcnt-no-war-wait
-# CHECK: S_WAITCNT 0
+# CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # CHECK-NEXT: S_BUFFER_LOAD_DWORD_IMM
 # CHECK-NEXT: TBUFFER_STORE_FORMAT_X_OFFEN_exact
 name: waitcnt-no-war-wait

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-overflow.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-overflow.mir
@@ -25,7 +25,7 @@ body:             |
     ; GFX9-LABEL: name: max-counter-lgkmcnt
     ; GFX9: liveins: $vgpr99
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = DS_READ2_B32_gfx9 renamable $vgpr99, 0, 1, 0, implicit $exec
     ; GFX9-NEXT: $vgpr2_vgpr3 = DS_READ2_B32_gfx9 renamable $vgpr99, 2, 3, 0, implicit $exec
     ; GFX9-NEXT: $vgpr4_vgpr5 = DS_READ2_B32_gfx9 renamable $vgpr99, 4, 5, 0, implicit $exec
@@ -44,7 +44,7 @@ body:             |
     ; GFX9-NEXT: $vgpr30_vgpr31 = DS_READ2_B32_gfx9 renamable $vgpr99, 30, 31, 0, implicit $exec
     ; GFX9-NEXT: $vgpr32_vgpr33 = DS_READ2_B32_gfx9 renamable $vgpr99, 32, 33, 0, implicit $exec
     ; GFX9-NEXT: $vgpr34_vgpr35 = DS_READ2_B32_gfx9 renamable $vgpr99, 34, 35, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 52863
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_14
     ; GFX9-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
     ; GFX9-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
     ; GFX9-NEXT: $vgpr4 = V_MAC_F32_e32 0, $vgpr5, $vgpr4, implicit $mode, implicit $exec
@@ -54,7 +54,7 @@ body:             |
     ; GFX10-LABEL: name: max-counter-lgkmcnt
     ; GFX10: liveins: $vgpr99
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: $vgpr0_vgpr1 = DS_READ2_B32_gfx9 renamable $vgpr99, 0, 1, 0, implicit $exec
     ; GFX10-NEXT: $vgpr2_vgpr3 = DS_READ2_B32_gfx9 renamable $vgpr99, 2, 3, 0, implicit $exec
     ; GFX10-NEXT: $vgpr4_vgpr5 = DS_READ2_B32_gfx9 renamable $vgpr99, 4, 5, 0, implicit $exec
@@ -73,20 +73,20 @@ body:             |
     ; GFX10-NEXT: $vgpr30_vgpr31 = DS_READ2_B32_gfx9 renamable $vgpr99, 30, 31, 0, implicit $exec
     ; GFX10-NEXT: $vgpr32_vgpr33 = DS_READ2_B32_gfx9 renamable $vgpr99, 32, 33, 0, implicit $exec
     ; GFX10-NEXT: $vgpr34_vgpr35 = DS_READ2_B32_gfx9 renamable $vgpr99, 34, 35, 0, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 53631
+    ; GFX10-NEXT: S_WAITCNT .Lgkmcnt_17
     ; GFX10-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 53375
+    ; GFX10-NEXT: S_WAITCNT .Lgkmcnt_16
     ; GFX10-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 53119
+    ; GFX10-NEXT: S_WAITCNT .Lgkmcnt_15
     ; GFX10-NEXT: $vgpr4 = V_MAC_F32_e32 0, $vgpr5, $vgpr4, implicit $mode, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 52863
+    ; GFX10-NEXT: S_WAITCNT .Lgkmcnt_14
     ; GFX10-NEXT: $vgpr6 = V_MAC_F32_e32 0, $vgpr7, $vgpr6, implicit $mode, implicit $exec
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: max-counter-lgkmcnt
     ; GFX11: liveins: $vgpr99
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: $vgpr0_vgpr1 = DS_READ2_B32_gfx9 renamable $vgpr99, 0, 1, 0, implicit $exec
     ; GFX11-NEXT: $vgpr2_vgpr3 = DS_READ2_B32_gfx9 renamable $vgpr99, 2, 3, 0, implicit $exec
     ; GFX11-NEXT: $vgpr4_vgpr5 = DS_READ2_B32_gfx9 renamable $vgpr99, 4, 5, 0, implicit $exec
@@ -105,13 +105,13 @@ body:             |
     ; GFX11-NEXT: $vgpr30_vgpr31 = DS_READ2_B32_gfx9 renamable $vgpr99, 30, 31, 0, implicit $exec
     ; GFX11-NEXT: $vgpr32_vgpr33 = DS_READ2_B32_gfx9 renamable $vgpr99, 32, 33, 0, implicit $exec
     ; GFX11-NEXT: $vgpr34_vgpr35 = DS_READ2_B32_gfx9 renamable $vgpr99, 34, 35, 0, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 64791
+    ; GFX11-NEXT: S_WAITCNT .Lgkmcnt_17
     ; GFX11-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 64775
+    ; GFX11-NEXT: S_WAITCNT .Lgkmcnt_16
     ; GFX11-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 64759
+    ; GFX11-NEXT: S_WAITCNT .Lgkmcnt_15
     ; GFX11-NEXT: $vgpr4 = V_MAC_F32_e32 0, $vgpr5, $vgpr4, implicit $mode, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 64743
+    ; GFX11-NEXT: S_WAITCNT .Lgkmcnt_14
     ; GFX11-NEXT: $vgpr6 = V_MAC_F32_e32 0, $vgpr7, $vgpr6, implicit $mode, implicit $exec
     ; GFX11-NEXT: S_ENDPGM 0
     ; GFX12-LABEL: name: max-counter-lgkmcnt
@@ -184,7 +184,7 @@ body:             |
     ; GFX9-LABEL: name: max-counter-vmcnt
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 8, 0, 0, implicit $exec
@@ -252,7 +252,7 @@ body:             |
     ; GFX9-NEXT: $vgpr64 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 256, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr65 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 260, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr66 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 264, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 53118
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_62
     ; GFX9-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
     ; GFX9-NEXT: $vgpr1 = V_MAC_F32_e32 0, $vgpr2, $vgpr1, implicit $mode, implicit $exec
     ; GFX9-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
@@ -262,7 +262,7 @@ body:             |
     ; GFX10-LABEL: name: max-counter-vmcnt
     ; GFX10: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 8, 0, 0, implicit $exec
@@ -330,7 +330,7 @@ body:             |
     ; GFX10-NEXT: $vgpr64 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 256, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr65 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 260, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr66 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 264, 0, 0, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 65406
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_62
     ; GFX10-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
     ; GFX10-NEXT: $vgpr1 = V_MAC_F32_e32 0, $vgpr2, $vgpr1, implicit $mode, implicit $exec
     ; GFX10-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
@@ -340,7 +340,7 @@ body:             |
     ; GFX11-LABEL: name: max-counter-vmcnt
     ; GFX11: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 8, 0, 0, implicit $exec
@@ -408,7 +408,7 @@ body:             |
     ; GFX11-NEXT: $vgpr64 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 256, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr65 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 260, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr66 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 264, 0, 0, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 64503
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_62
     ; GFX11-NEXT: $vgpr0 = V_MAC_F32_e32 0, $vgpr1, $vgpr0, implicit $mode, implicit $exec
     ; GFX11-NEXT: $vgpr1 = V_MAC_F32_e32 0, $vgpr2, $vgpr1, implicit $mode, implicit $exec
     ; GFX11-NEXT: $vgpr2 = V_MAC_F32_e32 0, $vgpr3, $vgpr2, implicit $mode, implicit $exec
@@ -579,7 +579,7 @@ body:             |
     ; GFX9-LABEL: name: max-counter-expcnt
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0, $vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: EXP 0, $vgpr0, $vgpr0, $vgpr0, $vgpr0, -1, -1, 15, implicit $exec
     ; GFX9-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
     ; GFX9-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
@@ -594,7 +594,7 @@ body:             |
     ; GFX10-LABEL: name: max-counter-expcnt
     ; GFX10: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0, $vgpr1
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: EXP 0, $vgpr0, $vgpr0, $vgpr0, $vgpr0, -1, -1, 15, implicit $exec
     ; GFX10-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
     ; GFX10-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
@@ -609,7 +609,7 @@ body:             |
     ; GFX11-LABEL: name: max-counter-expcnt
     ; GFX11: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0, $vgpr1
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: EXP 0, $vgpr0, $vgpr0, $vgpr0, $vgpr0, -1, -1, 15, implicit $exec
     ; GFX11-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
     ; GFX11-NEXT: EXP 0, $vgpr1, $vgpr1, $vgpr1, $vgpr1, -1, -1, 15, implicit $exec
@@ -659,7 +659,7 @@ body: |
     ; GFX9-LABEL: name: max-counter-dscnt
     ; GFX9: liveins: $vgpr99
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr1 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr2 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
@@ -700,13 +700,13 @@ body: |
     ; GFX9-NEXT: $vgpr37 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr38 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr39 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 52863
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_14
     ; GFX9-NEXT: $vgpr0 = V_ADD_F32_e32 $vgpr0, $vgpr0, implicit $mode, implicit $exec
     ; GFX9-NEXT: S_ENDPGM 0
     ; GFX10-LABEL: name: max-counter-dscnt
     ; GFX10: liveins: $vgpr99
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: $vgpr0 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr1 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr2 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
@@ -747,13 +747,13 @@ body: |
     ; GFX10-NEXT: $vgpr37 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr38 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX10-NEXT: $vgpr39 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
-    ; GFX10-NEXT: S_WAITCNT 59263
+    ; GFX10-NEXT: S_WAITCNT .Lgkmcnt_39
     ; GFX10-NEXT: $vgpr0 = V_ADD_F32_e32 $vgpr0, $vgpr0, implicit $mode, implicit $exec
     ; GFX10-NEXT: S_ENDPGM 0
     ; GFX11-LABEL: name: max-counter-dscnt
     ; GFX11: liveins: $vgpr99
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: $vgpr0 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr1 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr2 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
@@ -794,7 +794,7 @@ body: |
     ; GFX11-NEXT: $vgpr37 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr38 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
     ; GFX11-NEXT: $vgpr39 = DS_READ_B32_gfx9 $vgpr99, 0, 0, implicit $exec
-    ; GFX11-NEXT: S_WAITCNT 65143
+    ; GFX11-NEXT: S_WAITCNT .Lgkmcnt_39
     ; GFX11-NEXT: $vgpr0 = V_ADD_F32_e32 $vgpr0, $vgpr0, implicit $mode, implicit $exec
     ; GFX11-NEXT: S_ENDPGM 0
     ; GFX12-LABEL: name: max-counter-dscnt

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-permute.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-permute.mir
@@ -3,7 +3,7 @@
 ...
 # CHECK-LABEL: name: waitcnt-permute{{$}}
 # CHECK: DS_BPERMUTE_B32
-# CHECK-NEXT: S_WAITCNT 127
+# CHECK-NEXT: S_WAITCNT .Lgkmcnt_0
 
 name:            waitcnt-permute
 liveins:

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting-vscnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting-vscnt.mir
@@ -11,24 +11,24 @@ body:             |
     ; GFX10-LABEL: name: test_waitcnt_preexisting_vscnt_unmodified
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX10-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX10-NEXT: S_BARRIER
     ; GFX10-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX10-NEXT: S_WAITCNT 112
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: test_waitcnt_preexisting_vscnt_unmodified
     ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX11-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX11-NEXT: S_BARRIER
     ; GFX11-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX11-NEXT: S_WAITCNT 7
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX11-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
@@ -48,24 +48,24 @@ body:             |
     ; GFX10-LABEL: name: test_waitcnt_preexisting_vscnt_needs_vscnt
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX10-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 1
     ; GFX10-NEXT: S_BARRIER
     ; GFX10-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX10-NEXT: S_WAITCNT 112
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: test_waitcnt_preexisting_vscnt_needs_vscnt
     ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX11-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 1
     ; GFX11-NEXT: S_BARRIER
     ; GFX11-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX11-NEXT: S_WAITCNT 7
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX11-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
@@ -85,24 +85,24 @@ body:             |
     ; GFX10-LABEL: name: test_waitcnt_preexisting_vscnt_with_other_waitcnt
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX10-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX10-NEXT: S_BARRIER
     ; GFX10-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX10-NEXT: S_WAITCNT 112
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: test_waitcnt_preexisting_vscnt_with_other_waitcnt
     ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX11-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX11-NEXT: S_BARRIER
     ; GFX11-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX11-NEXT: S_WAITCNT 7
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX11-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
@@ -123,24 +123,24 @@ body:             |
     ; GFX10-LABEL: name: test_waitcnt_preexisting_vscnt_combined
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX10-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX10-NEXT: S_BARRIER
     ; GFX10-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX10-NEXT: S_WAITCNT 112
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: test_waitcnt_preexisting_vscnt_combined
     ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX11-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 0
     ; GFX11-NEXT: S_BARRIER
     ; GFX11-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX11-NEXT: S_WAITCNT 7
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX11-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
@@ -162,24 +162,24 @@ body:             |
     ; GFX10-LABEL: name: test_waitcnt_preexisting_vscnt_combined_both_types
     ; GFX10: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX10-NEXT: {{  $}}
-    ; GFX10-NEXT: S_WAITCNT 0
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX10-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 1
     ; GFX10-NEXT: S_BARRIER
     ; GFX10-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX10-NEXT: S_WAITCNT 112
+    ; GFX10-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX10-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX10-NEXT: S_ENDPGM 0
     ;
     ; GFX11-LABEL: name: test_waitcnt_preexisting_vscnt_combined_both_types
     ; GFX11: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GFX11-NEXT: S_WAITCNT_VSCNT undef $sgpr_null, 1
     ; GFX11-NEXT: S_BARRIER
     ; GFX11-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX11-NEXT: S_WAITCNT 7
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX11-NEXT: S_ENDPGM 0
     GLOBAL_STORE_DWORD $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting.mir
@@ -17,11 +17,11 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_lgkmcnt_unmodified
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 49279
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -34,7 +34,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 49279
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
     ; GFX12-NEXT: S_WAIT_DSCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
@@ -56,11 +56,11 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_vmcnt_unmodified
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 3952
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -73,7 +73,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 3952
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
@@ -97,11 +97,11 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_vmcnt_needs_lgkmcnt
     ; GFX9: liveins: $vgpr0
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -114,7 +114,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 3952
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: S_WAIT_DSCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
@@ -136,11 +136,11 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_lgkmcnt_needs_vmcnt
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -153,7 +153,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 49279
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
@@ -178,13 +178,13 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_apply_all_counters
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr4_vgpr5 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr6_vgpr7 = DS_READ2_B32 $vgpr2, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr6 = V_OR_B32_e32 1, killed $vgpr6, implicit $exec
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_apply_all_counters
@@ -197,7 +197,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr4_vgpr5 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
     ; GFX12-NEXT: $vgpr6_vgpr7 = DS_READ2_B32 $vgpr2, 0, 1, 0, implicit $m0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_WAIT_DSCNT 0
     ; GFX12-NEXT: $vgpr6 = V_OR_B32_e32 1, killed $vgpr6, implicit $exec
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
@@ -221,9 +221,9 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_combine_waitcnt
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_combine_waitcnt
@@ -235,12 +235,12 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAITCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
@@ -262,9 +262,9 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_combine_waitcnt_diff_counters
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_combine_waitcnt_diff_counters
@@ -276,8 +276,8 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAITCNT 49279
-    ; GFX12-NEXT: S_WAITCNT 3952
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
@@ -298,9 +298,9 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_early_wait
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: S_NOP 0
     ; GFX9-NEXT: S_NOP 0
     ; GFX9-NEXT: S_NOP 0
@@ -316,7 +316,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAITCNT 0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_NOP 0
     ; GFX12-NEXT: S_NOP 0
     ; GFX12-NEXT: S_NOP 0
@@ -341,9 +341,9 @@ body:             |
     ; GFX9-LABEL: name: test_waitcnt_preexisting_ignore_kill
     ; GFX9: liveins: $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 3952
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX9-NEXT: KILL $vgpr0
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_ignore_kill
@@ -355,7 +355,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAITCNT 3952
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: KILL $vgpr0
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     S_WAITCNT 3952
@@ -369,7 +369,7 @@ name:            test_waitcnt_preexisting_func_start
 body:             |
   bb.0:
     ; GFX9-LABEL: name: test_waitcnt_preexisting_func_start
-    ; GFX9: S_WAITCNT 0
+    ; GFX9: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: S_ENDPGM 0
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_func_start
@@ -378,7 +378,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
-    ; GFX12-NEXT: S_WAITCNT 0
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_ENDPGM 0
     S_WAITCNT 0
     S_ENDPGM 0
@@ -391,13 +391,13 @@ name:            test_waitcnt_preexisting_buffer_inv
 body:             |
   bb.0:
     ; GFX9-LABEL: name: test_waitcnt_preexisting_buffer_inv
-    ; GFX9: S_WAITCNT 0
+    ; GFX9: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 3952
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX9-NEXT: BUFFER_INVL2 implicit $exec
     ; GFX9-NEXT: BUFFER_WBINVL1_VOL implicit $exec
     ; GFX9-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 112
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: S_ENDPGM 0
     ;
@@ -408,7 +408,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
     ; GFX12-NEXT: S_WAIT_KMCNT 0
     ; GFX12-NEXT: $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
-    ; GFX12-NEXT: S_WAITCNT 3952
+    ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: BUFFER_INVL2 implicit $exec
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: BUFFER_WBINVL1_VOL implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-sample-out-order.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-sample-out-order.mir
@@ -10,7 +10,7 @@ body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-gather-sample
     ; GCN: $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr0_vgpr1_vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
-    ; GFX1150-NEXT: S_WAITCNT 1015
+    ; GFX1150-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr0_vgpr1_vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
@@ -39,7 +39,7 @@ body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-sample-gather
     ; GCN: $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
-    ; GFX1150-NEXT: S_WAITCNT 1015
+    ; GFX1150-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr0_vgpr1_vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
     $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
@@ -54,8 +54,8 @@ body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-sample-load
     ; GCN: $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
-    ; GFX11: S_WAITCNT 1015
-    ; GFX1150-NEXT: S_WAITCNT 1015
+    ; GFX11: S_WAITCNT .Vmcnt_0
+    ; GFX1150-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: renamable $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
     $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
@@ -70,8 +70,8 @@ body: |
   bb.0:
     ; GCN-LABEL: name: waitcnt-load-sample
     ; GCN: renamable $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
-    ; GFX11: S_WAITCNT 1015
-    ; GFX1150-NEXT: S_WAITCNT 1015
+    ; GFX11: S_WAITCNT .Vmcnt_0
+    ; GFX1150-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GCN-NEXT: $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     renamable $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-sample-waw.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-sample-waw.mir
@@ -11,10 +11,10 @@ body:             |
     ; GFX11-LABEL: name: sample_load_msaa
     ; GFX11: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $sgpr8, $sgpr9, $sgpr10, $sgpr11, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V1_gfx11 killed renamable $vgpr0, renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, killed renamable $sgpr8_sgpr9_sgpr10_sgpr11, 15, 0, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
     ; GFX11-NEXT: renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_MSAA_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
-    ; GFX11-NEXT: S_WAITCNT 1015
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX11-NEXT: SI_RETURN_TO_EPILOG killed $vgpr0, killed $vgpr1, killed $vgpr2, killed $vgpr3
     renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V1_gfx11 killed renamable $vgpr0, renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, killed renamable $sgpr8_sgpr9_sgpr10_sgpr11, 15, 0, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
     renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_MSAA_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
@@ -32,11 +32,11 @@ body:             |
     ; GFX11-LABEL: name: atomic_msaa
     ; GFX11: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $sgpr8, $sgpr9, $sgpr10, $sgpr11, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4
     ; GFX11-NEXT: {{  $}}
-    ; GFX11-NEXT: S_WAITCNT 0
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX11-NEXT: dead $vgpr0 = IMAGE_ATOMIC_ADD_V1_V2_gfx11 killed $vgpr0, renamable $vgpr4_vgpr5, renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 1, 6, -1, 1, 0, -1, 0, 0, implicit $exec :: (volatile dereferenceable load store (s32), addrspace 8)
-    ; GFX11-NEXT: S_WAITCNT 1015
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX11-NEXT: renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_MSAA_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
-    ; GFX11-NEXT: S_WAITCNT 1015
+    ; GFX11-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX11-NEXT: SI_RETURN_TO_EPILOG killed $vgpr0, killed $vgpr1, killed $vgpr2, killed $vgpr3
     dead $vgpr0 = IMAGE_ATOMIC_ADD_V1_V2_gfx11 killed $vgpr0, renamable $vgpr4_vgpr5, renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 1, 6, -1, 1, 0, -1, 0, 0, implicit $exec :: (volatile dereferenceable load store (s32), addrspace 8)
     renamable $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_MSAA_LOAD_V4_V2_gfx11 killed renamable $vgpr4_vgpr5, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 4, 7, -1, 0, 0, -1, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-trailing.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-trailing.mir
@@ -4,7 +4,7 @@
 # is followed by a meta instruction.
 
 # CHECK-LABEL: name: waitcnt-no-redundant
-# CHECK: S_WAITCNT 0
+# CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # CHECK: S_MOV_B32
 # CHECK-NOT: S_WAITCNT
 

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
@@ -11,16 +11,16 @@
 
 # GFX9-LABEL: waitcnt_vm_loop
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop
@@ -56,16 +56,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_noterm
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_noterm
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_noterm
@@ -100,10 +100,10 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_noterm_wait
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
-# GFX9-NOT: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 name:            waitcnt_vm_loop_noterm_wait
 body:             |
@@ -134,16 +134,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_load
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_load
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_load
@@ -182,16 +182,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_no_store
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_no_store
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_no_store
@@ -231,16 +231,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_no_use
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_no_use
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_no_use
@@ -281,16 +281,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop2
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop2
@@ -328,16 +328,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2_store
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop2_store
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop2_store
@@ -376,16 +376,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2_use_in_loop
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop2_use_in_loop
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop2_use_in_loop
@@ -424,20 +424,20 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2_nowait
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.3:
 
 # GFX10-LABEL: waitcnt_vm_loop2_nowait
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.3:
 
 # GFX12-LABEL: waitcnt_vm_loop2_nowait
@@ -485,16 +485,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2_reginterval
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop2_reginterval
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop2_reginterval
@@ -533,16 +533,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop2_reginterval2
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop2_reginterval2
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop2_reginterval2
@@ -585,16 +585,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_zero
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 3952
+# GFX9: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_zero
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16240
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10-NOT: S_WAITCNT 16240
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_zero
@@ -635,7 +635,7 @@ body:             |
 
 # GFX10-LABEL: waitcnt_vm_necessary
 # GFX10-LABEL: bb.0:
-# GFX10: S_WAITCNT 16240
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10: $vgpr4
 # GFX10-NOT: S_WAITCNT
 # GFX10-LABEL: bb.1:
@@ -651,7 +651,7 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_necessary
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 3952
+# GFX9: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # GFX9: $vgpr4
 # GFX9-NOT: S_WAITCNT
 # GFX9-LABEL: bb.1:
@@ -679,16 +679,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_global_mem
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_global_mem
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_global_mem
@@ -727,16 +727,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_scratch_mem
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_scratch_mem
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_scratch_mem
@@ -775,16 +775,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_flat_mem
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_flat_mem
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 11
+# GFX10-NOT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 11
+# GFX10: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_flat_mem
@@ -825,16 +825,16 @@ body:             |
 
 # GFX9-LABEL: waitcnt_vm_loop_flat_load
 # GFX9-LABEL: bb.0:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.1:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT .Vmcnt_0{{$}}
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_flat_load
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 16
+# GFX10-NOT: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 16
+# GFX10: S_WAITCNT .Vmcnt_0{{$}}
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_flat_load

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmem-waw.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmem-waw.mir
@@ -11,7 +11,7 @@ body: |
     ; GFX9-LABEL: name: buffer_buffer
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $sgpr5
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = BUFFER_LOAD_DWORDX4_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr1 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr5, 0, 0, 0, implicit $exec
     $vgpr0_vgpr1_vgpr2_vgpr3 = BUFFER_LOAD_DWORDX4_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
@@ -28,7 +28,7 @@ body: |
     ; GFX9-LABEL: name: tbuffer_tbuffer
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $sgpr5
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr0_vgpr1_vgpr2 = TBUFFER_LOAD_FORMAT_XYZ_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, 0, 4, 125, 0, 0, implicit $exec
     ; GFX9-NEXT: $vgpr0 = TBUFFER_LOAD_FORMAT_X_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, 0, 16, 116, 0, 0, implicit $exec
     $vgpr0_vgpr1_vgpr2 = TBUFFER_LOAD_FORMAT_XYZ_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, 0, 4, 125, 0, 0, implicit $exec
@@ -46,7 +46,7 @@ body: |
     ; GFX9-LABEL: name: gather_gather
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, $vgpr0_vgpr1_vgpr2, $vgpr3_vgpr4_vgpr5
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr0_vgpr1_vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
     ; GFX9-NEXT: $vgpr13_vgpr14_vgpr15_vgpr16 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr3_vgpr4_vgpr5, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
     $vgpr10_vgpr11_vgpr12_vgpr13 = IMAGE_GATHER4_LZ_O_V4_V3 $vgpr0_vgpr1_vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 1, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
@@ -65,9 +65,9 @@ body: |
     ; GFX9-LABEL: name: nosampler_sampler
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, $vgpr0_vgpr1_vgpr2_vgpr3
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr4 = IMAGE_LOAD_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 2, -1, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
-    ; GFX9-NEXT: S_WAITCNT 3952
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX9-NEXT: $vgpr4 = IMAGE_SAMPLE_L_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 8, 0, 0, 0, 0, 0, -1, 0, implicit $exec :: (load (s128))
     $vgpr4 = IMAGE_LOAD_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 2, -1, 0, 0, 0, 0, 0, 0, implicit $exec :: (load (s128))
     $vgpr4 = IMAGE_SAMPLE_L_V1_V4 $vgpr0_vgpr1_vgpr2_vgpr3, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, $sgpr8_sgpr9_sgpr10_sgpr11, 8, 0, 0, 0, 0, 0, -1, 0, implicit $exec :: (load (s128))
@@ -82,7 +82,7 @@ body: |
     ; GFX9-LABEL: name: global_scratch_buffer
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: $vgpr2 = SCRATCH_LOAD_DWORD $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX9-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
@@ -101,9 +101,9 @@ body: |
     ; GFX9-LABEL: name: flat_buffer
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX9-NEXT: S_WAITCNT 49279
+    ; GFX9-NEXT: S_WAITCNT .Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     $vgpr2 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
@@ -118,9 +118,9 @@ body: |
     ; GFX9-LABEL: name: buffer_flat
     ; GFX9: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0_vgpr1
     ; GFX9-NEXT: {{  $}}
-    ; GFX9-NEXT: S_WAITCNT 0
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX9-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
-    ; GFX9-NEXT: S_WAITCNT 3952
+    ; GFX9-NEXT: S_WAITCNT .Vmcnt_0
     ; GFX9-NEXT: $vgpr2 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr2 = BUFFER_LOAD_DWORD_OFFSET $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     $vgpr2 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vscnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vscnt.mir
@@ -3,8 +3,8 @@
 
 # GCN-LABEL: waitcnt-vscnt
 # GCN: GLOBAL_ATOMIC_ADD_RTN
-# GFX10-NEXT: S_WAITCNT 49279
-# GFX11-NEXT: S_WAITCNT 64519
+# GFX10-NEXT: S_WAITCNT .Lgkmcnt_0
+# GFX11-NEXT: S_WAITCNT .Lgkmcnt_0
 ---
 name: waitcnt-vscnt
 machineFunctionInfo:

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-wcg-attributes.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-wcg-attributes.mir
@@ -65,7 +65,7 @@ name:            test-wcg-attributes-gfx900
 body:             |
   bb.0:
     ; CHECK-LABEL: name: test-wcg-attributes-gfx900
-    ; CHECK: S_WAITCNT 0
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; CHECK-NEXT: $vgpr1 = nofpexcept V_EXP_F32_e32 $vgpr0, implicit $mode, implicit $exec
     ; CHECK-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = DS_READ_B128_gfx9 renamable $vgpr36, 8224, 0, implicit $exec
     ; CHECK-NEXT: S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/waitcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt.mir
@@ -58,33 +58,33 @@
 # CHECK: FLAT_LOAD_DWORDX4
 # Global loads will return in order so we should:
 # s_waitcnt vmcnt(1)
-# CHECK-NEXT: S_WAITCNT 3953
+# CHECK-NEXT: S_WAITCNT .Vmcnt_1
 
 # CHECK-LABEL: bb.1:
 # CHECK: FLAT_LOAD_DWORD
 # s_waitcnt vmcnt(0)
-# GFX89: S_WAITCNT 3952
+# GFX89: S_WAITCNT .Vmcnt_0
 # CHECK: FLAT_LOAD_DWORDX4
 
 # CHECK-LABEL: bb.2:
 # CHECK: FLAT_LOAD_DWORD
 # s_waitcnt vmcnt(0)
-# GFX89: S_WAITCNT 3952
+# GFX89: S_WAITCNT .Vmcnt_0
 # CHECK: FLAT_LOAD_DWORDX4
 
 # CHECK-LABEL: bb.3:
 # s_waitcnt vmcnt(0)
-# GFX89: S_WAITCNT 3952
+# GFX89: S_WAITCNT .Vmcnt_0
 # CHECK: FLAT_LOAD_DWORD
 # CHECK: FLAT_LOAD_DWORD
 # s_waitcnt vmcnt(0) lgkmcnt(0)
-# GFX89: S_WAITCNT 112
+# GFX89: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 
 # CHECK-LABEL: bb.4:
 # GFX89-NOT: S_WAITCNT
 # CHECK: FLAT_LOAD_DWORD
 # s_waitcnt vmcnt(0) lgkmcnt(0)
-# GFX89: S_WAITCNT 112
+# GFX89: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 
 name: flat_zero_waitcnt
 
@@ -132,7 +132,7 @@ body: |
 
 # CHECK: bb.1:
 # CHECK-NEXT: V_LSHLREV_B64_e64
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: FLAT_STORE_DWORD
 name: single_fallthrough_successor_no_end_block_wait
 
@@ -159,7 +159,7 @@ body: |
 
 # CHECK: bb.2:
 # CHECK-NEXT: V_LSHLREV_B64_e64
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: FLAT_STORE_DWORD
 name: single_branch_successor_not_next_block
 
@@ -181,7 +181,7 @@ body: |
 
 # CHECK-LABEL: name: preexisting_waitcnt{{$}}
 # CHECK: FLAT_LOAD_DWORD
-# CHECK-NEXT: S_WAITCNT 0
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # CHECK-NOT: S_WAITCNT
 name: preexisting_waitcnt
 tracksRegLiveness: true
@@ -204,7 +204,7 @@ body: |
 # CHECK-NEXT: S_NOP
 # CHECK-NEXT: S_NOP
 # CHECK-NEXT: }
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 name: bundle_no_waitcnt
 tracksRegLiveness: true
 machineFunctionInfo:
@@ -226,7 +226,7 @@ body: |
 # See the waitcnt inside the bundle and don't insert an extra
 # CHECK-LABEL: name: preexisting_waitcnt_in_bundle{{$}}
 # CHECK: FLAT_LOAD_DWORD
-# CHECK: S_WAITCNT 0
+# CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 # CHECK-NOT: S_WAITCNT
 name: preexisting_waitcnt_in_bundle
 tracksRegLiveness: true
@@ -250,7 +250,7 @@ body: |
 # CHECK-LABEL: name: insert_in_bundle{{$}}
 # CHECK: BUNDLE implicit-def $vgpr0, implicit $vgpr1_vgpr2 {
 # CHECK-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr1_vgpr2, 0, 0, implicit $exec, implicit $flat_scr
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: FLAT_STORE_DWORD $vgpr1_vgpr2, internal $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
 # CHECK-NEXT: }
 
@@ -275,7 +275,7 @@ body: |
 # CHECK: BUNDLE implicit-def $vgpr0, implicit $vgpr1_vgpr2 {
 # CHECK-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr1_vgpr2, 0, 0, implicit $exec, implicit $flat_scr
 # CHECK-NEXT: }
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: FLAT_STORE_DWORD $vgpr1_vgpr2, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
 
 name: exit_bundle
@@ -302,7 +302,7 @@ body: |
 # CHECK-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr1_vgpr2, 0, 0, implicit $exec, implicit $flat_scr
 # CHECK-NEXT: }
 # CHECK-NEXT: BUNDLE implicit $vgpr0, implicit $vgpr1_vgpr2 {
-# CHECK-NEXT: S_WAITCNT 112
+# CHECK-NEXT: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: FLAT_STORE_DWORD $vgpr1_vgpr2, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
 # CHECK-NEXT: }
 
@@ -323,7 +323,7 @@ body: |
 
 ---
 # CHECK-LABEL: name: subregs16bit
-# CHECK: S_WAITCNT 112
+# CHECK: S_WAITCNT .Vmcnt_0_Lgkmcnt_0
 # CHECK-NEXT: V_NOP_e32
 
 name: subregs16bit

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt-errors.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt-errors.mir
@@ -1,0 +1,191 @@
+# RUN: split-file %s %t
+
+;--- bad-expression.mir
+# RUN: not llc %t/bad-expression.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/bad-expression.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected <CounterName>_<CounterNum>
+# CHECK-NEXT:    S_WAITCNT .BadExpression
+# CHECK-NEXT:               ^
+name: BadExpression
+body: |
+  bb.0:
+    S_WAITCNT .BadExpression
+...
+
+;--- vmcnt-too-large.mir
+# RUN: not llc %t/vmcnt-too-large.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/vmcnt-too-large.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_99999
+# CHECK-NEXT:                     ^
+name: VmcntTooLarge
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_99999
+...
+
+;--- expcnt-too-large.mir
+# RUN: not llc %t/expcnt-too-large.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/expcnt-too-large.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAITCNT .Expcnt_99999
+# CHECK-NEXT:                      ^
+name: ExpcntTooLarge
+body: |
+  bb.0:
+    S_WAITCNT .Expcnt_99999
+...
+
+;--- lgkmcnt-too-large.mir
+# RUN: not llc %t/lgkmcnt-too-large.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/lgkmcnt-too-large.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAITCNT .Lgkmcnt_99999
+# CHECK-NEXT:                       ^
+name: LgkmcntTooLarge
+body: |
+  bb.0:
+    S_WAITCNT .Lgkmcnt_99999
+...
+
+;--- expected-prefix.mir
+# RUN: not llc %t/expected-prefix.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/expected-prefix.mir
+---
+# CHECK: error: {{.*}}
+name: MissingDotPrefix
+body: |
+  bb.0:
+    S_WAITCNT MissingDotPrefix
+...
+
+;--- invalid-counter-name.mir
+# RUN: not llc %t/invalid-counter-name.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/invalid-counter-name.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} invalid counter name
+# CHECK-NEXT:    S_WAITCNT .InvalidCounterName_1
+# CHECK-NEXT:               ^
+name: InvalidCounterName
+body: |
+  bb.0:
+    S_WAITCNT .InvalidCounterName_1
+...
+
+;--- vmcnt-non-integer.mir
+# RUN: not llc %t/vmcnt-non-integer.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/vmcnt-non-integer.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_BadCnt
+# CHECK-NEXT:                     ^
+name: VmcntNonInteger
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_BadCnt
+...
+
+;--- expcnt-non-integer.mir
+# RUN: not llc %t/expcnt-non-integer.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/expcnt-non-integer.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Expcnt_BadCnt
+# CHECK-NEXT:                      ^
+name: ExpcntNonInteger
+body: |
+  bb.0:
+    S_WAITCNT .Expcnt_BadCnt
+...
+
+;--- lgkmcnt-non-integer.mir
+# RUN: not llc %t/lgkmcnt-non-integer.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/lgkmcnt-non-integer.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Lgkmcnt_BadCnt
+# CHECK-NEXT:                       ^
+name: LgkmcntNonInteger
+body: |
+  bb.0:
+    S_WAITCNT .Lgkmcnt_BadCnt
+...
+
+;--- vmcnt-negative.mir
+# RUN: not llc %t/vmcnt-negative.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/vmcnt-negative.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_-1
+# CHECK-NEXT:                     ^
+name: VmcntNegative
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_-1
+...
+
+;--- expcnt-negative.mir
+# RUN: not llc %t/expcnt-negative.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/expcnt-negative.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Expcnt_-1
+# CHECK-NEXT:                      ^
+name: ExpcntNegative
+body: |
+  bb.0:
+    S_WAITCNT .Expcnt_-1
+...
+
+;--- lgkmcnt-negative.mir
+# RUN: not llc %t/lgkmcnt-negative.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/lgkmcnt-negative.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Lgkmcnt_-1
+# CHECK-NEXT:                       ^
+name: LgkmcntNegative
+body: |
+  bb.0:
+    S_WAITCNT .Lgkmcnt_-1
+...
+
+;--- valid-vmcnt-invalid-expcnt.mir
+# RUN: not llc %t/valid-vmcnt-invalid-expcnt.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-vmcnt-invalid-expcnt.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_0_Expcnt_99999
+# CHECK-NEXT:                              ^
+name: ValidVmcntInvalidExpcnt
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_0_Expcnt_99999
+...
+
+;--- valid-vmcnt-expcnt-invalid-lgkmcnt.mir
+# RUN: not llc %t/valid-vmcnt-expcnt-invalid-lgkmcnt.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-vmcnt-expcnt-invalid-lgkmcnt.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_99999
+# CHECK-NEXT:                                        ^
+name: ValidVmcntExpcntInvalidLgkmcnt
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_99999
+...
+
+;--- valid-vmcnt-invalid-name.mir
+# RUN: not llc %t/valid-vmcnt-invalid-name.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-vmcnt-invalid-name.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} invalid counter name
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_0_BadName_1
+# CHECK-NEXT:                       ^
+name: ValidVmcntInvalidName
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_0_BadName_1
+...
+
+;--- valid-vmcnt-expcnt-non-integer-lgkmcnt.mir
+# RUN: not llc %t/valid-vmcnt-expcnt-non-integer-lgkmcnt.mir -mtriple=amdgcn -mcpu=gfx900 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-vmcnt-expcnt-non-integer-lgkmcnt.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_abc
+# CHECK-NEXT:                                        ^
+name: ValidVmcntExpcntNonIntegerLgkmcnt
+body: |
+  bb.0:
+    S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_abc
+...

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt.mir
@@ -1,0 +1,229 @@
+# RUN: split-file %s %t
+
+# Common tests that work on all targets
+;--- common.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx803 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+---
+name: vmcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_0
+    ; CHECK: S_WAITCNT .Vmcnt_0
+    S_WAITCNT .Vmcnt_0
+...
+---
+name: vmcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_1
+    ; CHECK: S_WAITCNT .Vmcnt_1
+    S_WAITCNT .Vmcnt_1
+...
+---
+name: expcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_0
+    ; CHECK: S_WAITCNT .Expcnt_0
+    S_WAITCNT .Expcnt_0
+...
+---
+name: expcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_1
+    ; CHECK: S_WAITCNT .Expcnt_1
+    S_WAITCNT .Expcnt_1
+...
+---
+name: expcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_max-1
+    ; CHECK: S_WAITCNT .Expcnt_6
+    S_WAITCNT .Expcnt_6
+...
+---
+name: lgkmcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_0
+    ; CHECK: S_WAITCNT .Lgkmcnt_0
+    S_WAITCNT .Lgkmcnt_0
+...
+---
+name: lgkmcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_1
+    ; CHECK: S_WAITCNT .Lgkmcnt_1
+    S_WAITCNT .Lgkmcnt_1
+...
+---
+name: vmcnt_expcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_expcnt
+    ; CHECK: S_WAITCNT .Vmcnt_1_Expcnt_2
+    S_WAITCNT .Vmcnt_1_Expcnt_2
+...
+---
+name: vmcnt_lgkmcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_lgkmcnt
+    ; CHECK: S_WAITCNT .Vmcnt_3_Lgkmcnt_5
+    S_WAITCNT .Vmcnt_3_Lgkmcnt_5
+...
+---
+name: expcnt_lgkmcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_lgkmcnt
+    ; CHECK: S_WAITCNT .Expcnt_4_Lgkmcnt_6
+    S_WAITCNT .Expcnt_4_Lgkmcnt_6
+...
+---
+name: all-zero
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-zero
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+...
+---
+name: all-off
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-off
+    ; CHECK: S_WAITCNT .AllOff
+    S_WAITCNT .AllOff
+...
+---
+name: zero-number
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: zero-number
+    ; CHECK: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    S_WAITCNT 0
+...
+
+# GFX8-specific: vmcnt max=15, lgkmcnt max=15
+;--- gfx8.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx803 -run-pass=none %t/gfx8.mir -o - | FileCheck %t/gfx8.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT .Vmcnt_14
+    S_WAITCNT .Vmcnt_14
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT .Lgkmcnt_14
+    S_WAITCNT .Lgkmcnt_14
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=15, expcnt=7, lgkmcnt=15 -> 0xF7F = 3967
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT .AllOff
+    S_WAITCNT 3967
+...
+
+# GFX9-specific: vmcnt max=63, lgkmcnt max=15
+;--- gfx9.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=none %t/gfx9.mir -o - | FileCheck %t/gfx9.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT .Vmcnt_62
+    S_WAITCNT .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT .Lgkmcnt_14
+    S_WAITCNT .Lgkmcnt_14
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=63, expcnt=7, lgkmcnt=15 -> 0xCF7F = 53119
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT .AllOff
+    S_WAITCNT 53119
+...
+
+# GFX10-specific: vmcnt max=63, lgkmcnt max=63
+;--- gfx10.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -run-pass=none %t/gfx10.mir -o - | FileCheck %t/gfx10.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT .Vmcnt_62
+    S_WAITCNT .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT .Lgkmcnt_62
+    S_WAITCNT .Lgkmcnt_62
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=63, expcnt=7, lgkmcnt=63 -> 0xFF7F = 65407
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT .AllOff
+    S_WAITCNT 65407
+...
+
+# GFX11-specific: vmcnt max=63, lgkmcnt max=63 (different encoding than GFX10)
+;--- gfx11.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -run-pass=none %t/gfx11.mir -o - | FileCheck %t/gfx11.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT .Vmcnt_62
+    S_WAITCNT .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT .Lgkmcnt_62
+    S_WAITCNT .Lgkmcnt_62
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; GFX11 encoding: expcnt[2:0]=bits[2:0], lgkmcnt[5:0]=bits[9:4], vmcnt[5:0]=bits[15:10]
+    ; vmcnt=63, expcnt=7, lgkmcnt=63 -> 0xFFF7 = 65527
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT .AllOff
+    S_WAITCNT 65527
+...

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt_missing_operand_crash.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt_missing_operand_crash.mir
@@ -1,0 +1,9 @@
+# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -filetype=null 2>&1 | FileCheck %s
+
+---
+# CHECK: Bad machine code: Too few operands
+name: missing_operand_crash
+body: |
+  bb.0:
+    S_WAITCNT
+...


### PR DESCRIPTION
This patch implements a printer and parser for the S_WAITCNT mask. It prints the mask in a human-readable format, showing the counter values like `Vmcnt_<NUM>_Expcnt_<NUM>_Lgkmcnt_<NUM>`.

The format matches the printing style of S_WAITCNT_DEPCTR. For example:
```
 S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
 S_WAITCNT .Expcnt_0
 S_WAITCNT .AllOff
```
Counters at their maximum value (meaning "don't wait") are omitted. When all counters are at max, `.AllOff` is printed.

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>