### PR TITLE
[offload] draft POC: verify event synchronization

### DIFF
--- a/offload/unittests/OffloadAPI/device_code/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/device_code/CMakeLists.txt
@@ -7,6 +7,7 @@ add_offload_test_device_code(byte.cpp byte)
 add_offload_test_device_code(localmem.cpp localmem)
 add_offload_test_device_code(localmem_reduction.cpp localmem_reduction)
 add_offload_test_device_code(localmem_static.cpp localmem_static)
+add_offload_test_device_code(localmem_static_wait.cpp localmem_static_wait)
 add_offload_test_device_code(global.cpp global)
 add_offload_test_device_code(global_ctor.cpp global_ctor)
 add_offload_test_device_code(global_dtor.cpp global_dtor)
@@ -21,6 +22,7 @@ add_custom_target(offload_device_binaries DEPENDS
     localmem.bin
     localmem_reduction.bin
     localmem_static.bin
+    localmem_static_wait.bin
     global.bin
     global_ctor.bin
     global_dtor.bin

--- a/offload/unittests/OffloadAPI/device_code/localmem_static_wait.cpp
+++ b/offload/unittests/OffloadAPI/device_code/localmem_static_wait.cpp
@@ -1,0 +1,34 @@
+#include <gpuintrin.h>
+#include <stdint.h>
+
+[[clang::loader_uninitialized]]
+__gpu_local uint32_t shared_mem[64];
+
+int factorial (unsigned long cur, int iter, int fin) {
+	if (iter < fin) {
+		return factorial(cur*iter, iter + 1, fin);
+	} else {
+		return cur;
+	}
+}
+
+extern "C" __gpu_kernel void localmem_static_wait(uint32_t *out) {
+  shared_mem[__gpu_thread_id(0)] = 2;
+
+  __gpu_sync_threads();
+
+    unsigned long res = 0;
+	for (unsigned long i = 0; i < 1000000000; i++) { //< 1000000000; i++) {
+		res += factorial(1, 1, 30);
+        if (res == 0) {
+            res = 1;
+        }
+	}
+
+
+  if (__gpu_thread_id(0) == 0) {
+    out[__gpu_block_id(0)] = res; //0;
+    for (uint32_t i = 0; i < __gpu_num_threads(0); i++)
+      out[__gpu_block_id(0)] += shared_mem[i];
+  }
+}

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -60,6 +60,7 @@ KERNEL_TEST(Byte, byte)
 KERNEL_TEST(LocalMem, localmem)
 KERNEL_TEST(LocalMemReduction, localmem_reduction)
 KERNEL_TEST(LocalMemStatic, localmem_static)
+KERNEL_TEST(LocalMemStaticSyncEvent, localmem_static_wait)
 KERNEL_TEST(GlobalCtor, global_ctor)
 KERNEL_TEST(GlobalDtor, global_dtor)
 
@@ -232,6 +233,38 @@ TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
       olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args), &LaunchArgs));
 
   ASSERT_SUCCESS(olSyncQueue(Queue));
+
+  uint32_t *Data = (uint32_t *)Mem;
+  for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)
+    ASSERT_EQ(Data[i], 2 * LaunchArgs.GroupSize.x);
+
+  ASSERT_SUCCESS(olMemFree(Mem));
+}
+
+TEST_P(olLaunchKernelLocalMemStaticSyncEventTest, Success) {
+  LaunchArgs.NumGroups.x = 4;
+  LaunchArgs.DynSharedMemory = 0;
+
+  void *Mem;
+  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
+                            LaunchArgs.NumGroups.x * sizeof(uint32_t), &Mem));
+  struct {
+    void *Mem;
+  } Args{Mem};
+
+  // ol_queue_handle_t Queue2 = nullptr;
+  // ASSERT_SUCCESS(olCreateQueue(Device, &Queue2));
+
+
+  ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
+                                &LaunchArgs));
+
+  ol_event_handle_t Event = nullptr;
+  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  // ASSERT_SUCCESS(olWaitEvents(Queue2, &Event, 1));
+  ASSERT_SUCCESS(olSyncEvent(Event));
+
+  // ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)


### PR DESCRIPTION
add a new kernel
add a new test in order to verify event synchronization
change olSyncQueue to olSyncEvent
the test passes on the device identified as LEVEL_ZERO_Intel_GPU_Xe_LPG_1
the test does not pass on the device identified as LEVEL_ZERO_Intel_GPU_Xe_HP_0
the test passes on both devices when olSyncQueue is used