### PR TITLE
[SLP] Add new test for widened strided loads of > i8 width

### DIFF
--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
@@ -427,6 +427,105 @@ define void @rt_stride_1_no_reordering(ptr %pl, i64 %stride, ptr %ps) {
   ret void
 }
 
+define void @rt_stride_1_no_reordering_i16(ptr %pl, i64 %stride, ptr %ps) {
+; CHECK-LABEL: define void @rt_stride_1_no_reordering_i16(
+; CHECK-SAME: ptr [[PL:%.*]], i64 [[STRIDE:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[STRIDE0:%.*]] = mul nsw i64 [[STRIDE]], 0
+; CHECK-NEXT:    [[GEP_L0:%.*]] = getelementptr inbounds i16, ptr [[PL]], i64 [[STRIDE0]]
+; CHECK-NEXT:    [[GEP_S0:%.*]] = getelementptr inbounds i16, ptr [[PS]], i64 0
+; CHECK-NEXT:    [[TMP1:%.*]] = mul i64 [[STRIDE]], 2
+; CHECK-NEXT:    [[TMP2:%.*]] = call <16 x i16> @llvm.experimental.vp.strided.load.v16i16.p0.i64(ptr align 1 [[GEP_L0]], i64 [[TMP1]], <16 x i1> splat (i1 true), i32 16)
+; CHECK-NEXT:    store <16 x i16> [[TMP2]], ptr [[GEP_S0]], align 1
+; CHECK-NEXT:    ret void
+;
+  %stride0  = mul nsw i64 %stride, 0
+  %stride1  = mul nsw i64 %stride, 1
+  %stride2  = mul nsw i64 %stride, 2
+  %stride3  = mul nsw i64 %stride, 3
+  %stride4  = mul nsw i64 %stride, 4
+  %stride5  = mul nsw i64 %stride, 5
+  %stride6  = mul nsw i64 %stride, 6
+  %stride7  = mul nsw i64 %stride, 7
+  %stride8  = mul nsw i64 %stride, 8
+  %stride9  = mul nsw i64 %stride, 9
+  %stride10 = mul nsw i64 %stride, 10
+  %stride11 = mul nsw i64 %stride, 11
+  %stride12 = mul nsw i64 %stride, 12
+  %stride13 = mul nsw i64 %stride, 13
+  %stride14 = mul nsw i64 %stride, 14
+  %stride15 = mul nsw i64 %stride, 15
+
+  %gep_l0 = getelementptr inbounds i16, ptr %pl, i64 %stride0
+  %gep_l1 = getelementptr inbounds i16, ptr %pl, i64 %stride1
+  %gep_l2 = getelementptr inbounds i16, ptr %pl, i64 %stride2
+  %gep_l3 = getelementptr inbounds i16, ptr %pl, i64 %stride3
+  %gep_l4 = getelementptr inbounds i16, ptr %pl, i64 %stride4
+  %gep_l5 = getelementptr inbounds i16, ptr %pl, i64 %stride5
+  %gep_l6 = getelementptr inbounds i16, ptr %pl, i64 %stride6
+  %gep_l7 = getelementptr inbounds i16, ptr %pl, i64 %stride7
+  %gep_l8 = getelementptr inbounds i16, ptr %pl, i64 %stride8
+  %gep_l9 = getelementptr inbounds i16, ptr %pl, i64 %stride9
+  %gep_l10 = getelementptr inbounds i16, ptr %pl, i64 %stride10
+  %gep_l11 = getelementptr inbounds i16, ptr %pl, i64 %stride11
+  %gep_l12 = getelementptr inbounds i16, ptr %pl, i64 %stride12
+  %gep_l13 = getelementptr inbounds i16, ptr %pl, i64 %stride13
+  %gep_l14 = getelementptr inbounds i16, ptr %pl, i64 %stride14
+  %gep_l15 = getelementptr inbounds i16, ptr %pl, i64 %stride15
+
+  %load0  = load i16, ptr %gep_l0 , align 1
+  %load1  = load i16, ptr %gep_l1 , align 1
+  %load2  = load i16, ptr %gep_l2 , align 1
+  %load3  = load i16, ptr %gep_l3 , align 1
+  %load4  = load i16, ptr %gep_l4 , align 1
+  %load5  = load i16, ptr %gep_l5 , align 1
+  %load6  = load i16, ptr %gep_l6 , align 1
+  %load7  = load i16, ptr %gep_l7 , align 1
+  %load8  = load i16, ptr %gep_l8 , align 1
+  %load9  = load i16, ptr %gep_l9 , align 1
+  %load10 = load i16, ptr %gep_l10, align 1
+  %load11 = load i16, ptr %gep_l11, align 1
+  %load12 = load i16, ptr %gep_l12, align 1
+  %load13 = load i16, ptr %gep_l13, align 1
+  %load14 = load i16, ptr %gep_l14, align 1
+  %load15 = load i16, ptr %gep_l15, align 1
+
+  %gep_s0 = getelementptr inbounds i16, ptr %ps, i64 0
+  %gep_s1 = getelementptr inbounds i16, ptr %ps, i64 1
+  %gep_s2 = getelementptr inbounds i16, ptr %ps, i64 2
+  %gep_s3 = getelementptr inbounds i16, ptr %ps, i64 3
+  %gep_s4 = getelementptr inbounds i16, ptr %ps, i64 4
+  %gep_s5 = getelementptr inbounds i16, ptr %ps, i64 5
+  %gep_s6 = getelementptr inbounds i16, ptr %ps, i64 6
+  %gep_s7 = getelementptr inbounds i16, ptr %ps, i64 7
+  %gep_s8 = getelementptr inbounds i16, ptr %ps, i64 8
+  %gep_s9 = getelementptr inbounds i16, ptr %ps, i64 9
+  %gep_s10 = getelementptr inbounds i16, ptr %ps, i64 10
+  %gep_s11 = getelementptr inbounds i16, ptr %ps, i64 11
+  %gep_s12 = getelementptr inbounds i16, ptr %ps, i64 12
+  %gep_s13 = getelementptr inbounds i16, ptr %ps, i64 13
+  %gep_s14 = getelementptr inbounds i16, ptr %ps, i64 14
+  %gep_s15 = getelementptr inbounds i16, ptr %ps, i64 15
+
+  store i16 %load0, ptr %gep_s0, align 1
+  store i16 %load1, ptr %gep_s1, align 1
+  store i16 %load2, ptr %gep_s2, align 1
+  store i16 %load3, ptr %gep_s3, align 1
+  store i16 %load4, ptr %gep_s4, align 1
+  store i16 %load5, ptr %gep_s5, align 1
+  store i16 %load6, ptr %gep_s6, align 1
+  store i16 %load7, ptr %gep_s7, align 1
+  store i16 %load8, ptr %gep_s8, align 1
+  store i16 %load9, ptr %gep_s9, align 1
+  store i16 %load10, ptr %gep_s10, align 1
+  store i16 %load11, ptr %gep_s11, align 1
+  store i16 %load12, ptr %gep_s12, align 1
+  store i16 %load13, ptr %gep_s13, align 1
+  store i16 %load14, ptr %gep_s14, align 1
+  store i16 %load15, ptr %gep_s15, align 1
+
+  ret void
+}
+
 define void @rt_stride_1_with_reordering(ptr %pl, i64 %stride, ptr %ps) {
 ; CHECK-LABEL: define void @rt_stride_1_with_reordering(
 ; CHECK-SAME: ptr [[PL:%.*]], i64 [[STRIDE:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
@@ -802,6 +901,120 @@ define void @rt_stride_widen_no_reordering(ptr %pl, i64 %stride, ptr %ps) {
   store i8 %load13, ptr %gep_s13, align 1
   store i8 %load14, ptr %gep_s14, align 1
   store i8 %load15, ptr %gep_s15, align 1
+
+  ret void
+}
+
+define void @rt_stride_widen_no_reordering_i16(ptr %pl, i64 %stride, ptr %ps) {
+; CHECK-LABEL: define void @rt_stride_widen_no_reordering_i16(
+; CHECK-SAME: ptr [[PL:%.*]], i64 [[STRIDE:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[OFFSET0:%.*]] = mul nsw i64 [[STRIDE]], 0
+; CHECK-NEXT:    [[OFFSET4:%.*]] = mul nsw i64 [[STRIDE]], 1
+; CHECK-NEXT:    [[OFFSET8:%.*]] = mul nsw i64 [[STRIDE]], 2
+; CHECK-NEXT:    [[OFFSET12:%.*]] = mul nsw i64 [[STRIDE]], 3
+; CHECK-NEXT:    [[GEP_L0:%.*]] = getelementptr inbounds i16, ptr [[PL]], i64 [[OFFSET0]]
+; CHECK-NEXT:    [[GEP_L4:%.*]] = getelementptr inbounds i16, ptr [[PL]], i64 [[OFFSET4]]
+; CHECK-NEXT:    [[GEP_L8:%.*]] = getelementptr inbounds i16, ptr [[PL]], i64 [[OFFSET8]]
+; CHECK-NEXT:    [[GEP_L12:%.*]] = getelementptr inbounds i16, ptr [[PL]], i64 [[OFFSET12]]
+; CHECK-NEXT:    [[GEP_S0:%.*]] = getelementptr inbounds i16, ptr [[PS]], i64 0
+; CHECK-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[GEP_L0]], align 1
+; CHECK-NEXT:    [[TMP2:%.*]] = load <4 x i16>, ptr [[GEP_L4]], align 1
+; CHECK-NEXT:    [[TMP3:%.*]] = load <4 x i16>, ptr [[GEP_L8]], align 1
+; CHECK-NEXT:    [[TMP4:%.*]] = load <4 x i16>, ptr [[GEP_L12]], align 1
+; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <4 x i16> [[TMP1]], <4 x i16> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP6:%.*]] = shufflevector <4 x i16> [[TMP2]], <4 x i16> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP7:%.*]] = shufflevector <4 x i16> [[TMP1]], <4 x i16> [[TMP2]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP8:%.*]] = shufflevector <4 x i16> [[TMP3]], <4 x i16> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP9:%.*]] = shufflevector <16 x i16> [[TMP7]], <16 x i16> [[TMP8]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP10:%.*]] = shufflevector <4 x i16> [[TMP4]], <4 x i16> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP11:%.*]] = shufflevector <16 x i16> [[TMP9]], <16 x i16> [[TMP10]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 16, i32 17, i32 18, i32 19>
+; CHECK-NEXT:    store <16 x i16> [[TMP11]], ptr [[GEP_S0]], align 1
+; CHECK-NEXT:    ret void
+;
+  %offset0  = mul nsw i64 %stride, 0
+  %offset1  = add nsw i64 %offset0, 1
+  %offset2  = add nsw i64 %offset0, 2
+  %offset3  = add nsw i64 %offset0, 3
+  %offset4  = mul nsw i64 %stride, 1
+  %offset5  = add nsw i64 %offset4, 1
+  %offset6  = add nsw i64 %offset4, 2
+  %offset7  = add nsw i64 %offset4, 3
+  %offset8  = mul nsw i64 %stride, 2
+  %offset9  = add nsw i64 %offset8, 1
+  %offset10  = add nsw i64 %offset8, 2
+  %offset11  = add nsw i64 %offset8, 3
+  %offset12 = mul nsw i64 %stride, 3
+  %offset13 = add nsw i64 %offset12, 1
+  %offset14 = add nsw i64 %offset12, 2
+  %offset15 = add nsw i64 %offset12, 3
+
+  %gep_l0 = getelementptr inbounds i16, ptr %pl, i64 %offset0
+  %gep_l1 = getelementptr inbounds i16, ptr %pl, i64 %offset1
+  %gep_l2 = getelementptr inbounds i16, ptr %pl, i64 %offset2
+  %gep_l3 = getelementptr inbounds i16, ptr %pl, i64 %offset3
+  %gep_l4 = getelementptr inbounds i16, ptr %pl, i64 %offset4
+  %gep_l5 = getelementptr inbounds i16, ptr %pl, i64 %offset5
+  %gep_l6 = getelementptr inbounds i16, ptr %pl, i64 %offset6
+  %gep_l7 = getelementptr inbounds i16, ptr %pl, i64 %offset7
+  %gep_l8 = getelementptr inbounds i16, ptr %pl, i64 %offset8
+  %gep_l9 = getelementptr inbounds i16, ptr %pl, i64 %offset9
+  %gep_l10 = getelementptr inbounds i16, ptr %pl, i64 %offset10
+  %gep_l11 = getelementptr inbounds i16, ptr %pl, i64 %offset11
+  %gep_l12 = getelementptr inbounds i16, ptr %pl, i64 %offset12
+  %gep_l13 = getelementptr inbounds i16, ptr %pl, i64 %offset13
+  %gep_l14 = getelementptr inbounds i16, ptr %pl, i64 %offset14
+  %gep_l15 = getelementptr inbounds i16, ptr %pl, i64 %offset15
+
+  %load0  = load i16, ptr %gep_l0 , align 1
+  %load1  = load i16, ptr %gep_l1 , align 1
+  %load2  = load i16, ptr %gep_l2 , align 1
+  %load3  = load i16, ptr %gep_l3 , align 1
+  %load4  = load i16, ptr %gep_l4 , align 1
+  %load5  = load i16, ptr %gep_l5 , align 1
+  %load6  = load i16, ptr %gep_l6 , align 1
+  %load7  = load i16, ptr %gep_l7 , align 1
+  %load8  = load i16, ptr %gep_l8 , align 1
+  %load9  = load i16, ptr %gep_l9 , align 1
+  %load10 = load i16, ptr %gep_l10, align 1
+  %load11 = load i16, ptr %gep_l11, align 1
+  %load12 = load i16, ptr %gep_l12, align 1
+  %load13 = load i16, ptr %gep_l13, align 1
+  %load14 = load i16, ptr %gep_l14, align 1
+  %load15 = load i16, ptr %gep_l15, align 1
+
+  %gep_s0 = getelementptr inbounds i16, ptr %ps, i64 0
+  %gep_s1 = getelementptr inbounds i16, ptr %ps, i64 1
+  %gep_s2 = getelementptr inbounds i16, ptr %ps, i64 2
+  %gep_s3 = getelementptr inbounds i16, ptr %ps, i64 3
+  %gep_s4 = getelementptr inbounds i16, ptr %ps, i64 4
+  %gep_s5 = getelementptr inbounds i16, ptr %ps, i64 5
+  %gep_s6 = getelementptr inbounds i16, ptr %ps, i64 6
+  %gep_s7 = getelementptr inbounds i16, ptr %ps, i64 7
+  %gep_s8 = getelementptr inbounds i16, ptr %ps, i64 8
+  %gep_s9 = getelementptr inbounds i16, ptr %ps, i64 9
+  %gep_s10 = getelementptr inbounds i16, ptr %ps, i64 10
+  %gep_s11 = getelementptr inbounds i16, ptr %ps, i64 11
+  %gep_s12 = getelementptr inbounds i16, ptr %ps, i64 12
+  %gep_s13 = getelementptr inbounds i16, ptr %ps, i64 13
+  %gep_s14 = getelementptr inbounds i16, ptr %ps, i64 14
+  %gep_s15 = getelementptr inbounds i16, ptr %ps, i64 15
+
+  store i16 %load0, ptr %gep_s0, align 1
+  store i16 %load1, ptr %gep_s1, align 1
+  store i16 %load2, ptr %gep_s2, align 1
+  store i16 %load3, ptr %gep_s3, align 1
+  store i16 %load4, ptr %gep_s4, align 1
+  store i16 %load5, ptr %gep_s5, align 1
+  store i16 %load6, ptr %gep_s6, align 1
+  store i16 %load7, ptr %gep_s7, align 1
+  store i16 %load8, ptr %gep_s8, align 1
+  store i16 %load9, ptr %gep_s9, align 1
+  store i16 %load10, ptr %gep_s10, align 1
+  store i16 %load11, ptr %gep_s11, align 1
+  store i16 %load12, ptr %gep_s12, align 1
+  store i16 %load13, ptr %gep_s13, align 1
+  store i16 %load14, ptr %gep_s14, align 1
+  store i16 %load15, ptr %gep_s15, align 1
 
   ret void
 }


### PR DESCRIPTION
Currently we don't vectorize into strided loads as expected.