### PR TITLE
[clang][bytecode] Fix `MemberExpr`s with a static member

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2608,22 +2608,16 @@ bool Compiler<Emitter>::VisitMemberExpr(const MemberExpr *E) {
   if (DiscardResult)
     return this->discard(Base);
 
-  // MemberExprs are almost always lvalues, in which case we don't need to
-  // do the load. But sometimes they aren't.
-  const auto maybeLoadValue = [&]() -> bool {
-    if (E->isGLValue())
-      return true;
-    if (OptPrimType T = classify(E))
-      return this->emitLoadPop(*T, E);
-    return false;
-  };
-
   if (const auto *VD = dyn_cast<VarDecl>(Member)) {
     // I am almost confident in saying that a var decl must be static
-    // and therefore registered as a global variable. But this will probably
-    // turn out to be wrong some time in the future, as always.
-    if (auto GlobalIndex = P.getGlobal(VD))
-      return this->emitGetPtrGlobal(*GlobalIndex, E) && maybeLoadValue();
+    // and therefore registered as a global variable.
+    if (auto GlobalIndex = P.getGlobal(VD)) {
+      if (!this->emitGetPtrGlobal(*GlobalIndex, E))
+        return false;
+      if (Member->getType()->isReferenceType())
+        return this->emitLoadPopPtr(E);
+      return true;
+    }
     return false;
   }
 
@@ -2644,6 +2638,17 @@ bool Compiler<Emitter>::VisitMemberExpr(const MemberExpr *E) {
   if (!R)
     return false;
   const Record::Field *F = R->getField(FD);
+
+  // MemberExprs are almost always lvalues, in which case we don't need to
+  // do the load. But sometimes they aren't.
+  const auto maybeLoadValue = [&]() -> bool {
+    if (E->isGLValue())
+      return true;
+    if (OptPrimType T = classify(E))
+      return this->emitLoadPop(*T, E);
+    return false;
+  };
+
   // Leave a pointer to the field on the stack.
   if (F->Decl->getType()->isReferenceType())
     return this->emitGetFieldPop(PT_Ptr, F->Offset, E) && maybeLoadValue();

--- a/clang/test/AST/ByteCode/libcxx/static-reference-load.cpp
+++ b/clang/test/AST/ByteCode/libcxx/static-reference-load.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -std=c++2c -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -std=c++2c  -verify=ref,both                                             %s
+
+// both-no-diagnostics
+
+
+template <class _Tp> struct __cw_fixed_value {
+  constexpr __cw_fixed_value(_Tp __v) : __data(__v) {}
+  _Tp __data;
+};
+
+
+template <__cw_fixed_value _Xp>
+struct constant_wrapper {
+  static constexpr auto &ref_value = _Xp.__data;
+  template <typename _Rp>
+  auto operator=(_Rp) -> constant_wrapper<(ref_value = _Rp::ref_value)>;
+};
+
+struct WithOps {
+  int value;
+  constexpr WithOps operator=(int i) const { return {i}; }
+};
+
+void test() {
+  constexpr constant_wrapper<3> cw3;
+  constant_wrapper<WithOps{}> cwOps5;
+  auto result = cwOps5 = cw3;
+  static_assert(result.ref_value.value);
+}
+

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1327,12 +1327,27 @@ namespace pr18633 {
   }
 }
 
-namespace {
+namespace MemberExprOnStatic {
   struct F {
     static constexpr int Z = 12;
   };
   F f;
   static_assert(f.Z == 12, "");
+
+  template<int I>
+  struct S {
+    static constexpr const auto &k = I;
+    int a;
+  };
+
+  S<10> s{12};
+  static_assert(s.k == 10, "");
+
+  constexpr int foo() {
+    S<100> s{12};
+    return s.k;
+  }
+  static_assert(foo() == 100, "");
 }
 
 namespace UnnamedBitFields {


### PR DESCRIPTION
We need logic to load from the reference pointer, similar to the one we have for regular `DeclRefExpr`s.