### PR TITLE
[MCP][NFC] Add Cost modelling for EliminateSpillageCopies

### DIFF
--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -1304,6 +1304,18 @@ void MachineCopyPropagation::backwardCopyPropagateBlock(
 // Reg is defined by a COPY, we untrack this Reg via
 // CopyTracker::clobberRegister(Reg, ...).
 void MachineCopyPropagation::eliminateSpillageCopies(MachineBasicBlock &MBB) {
+
+  // Perform some cost modelling to ensure that only MBB's with more
+  // than 6 copies are checked. To create a chain that can be optimised,
+  // 6 copies are needed.
+  unsigned CopyCount = 0;
+  for (const MachineInstr &MI : MBB) {
+    if (isCopyInstr(MI, *TII, UseCopyInstr) && ++CopyCount > 6)
+      break;
+  }
+  if (CopyCount < 6)
+    return;
+
   // ChainLeader maps MI inside a spill-reload chain to its innermost reload COPY.
   // Thus we can track if a MI belongs to an existing spill-reload chain.
   DenseMap<MachineInstr *, MachineInstr *> ChainLeader;


### PR DESCRIPTION
For EliminateSpillageCopies to be effective, a block needs to contain at least 6 copies. The block will be examined, and any blocks that contain less than 6 copies will be skipped. In testing, this has yeilded a .2% improvement in compile time when the pass is enabled on AArch64.

This was originally intended to be included in #192609 but was lost during a rebase, and not spotted until after merging.

Compile Time Results: https://llvm-compile-time-tracker.com/compare.php?from=1421c8ab77425030bfbebe1631df16b8ea011885&to=049753579a4051968e2d62f51050d09c53d4fed8&stat=instructions:u
Original Review: https://github.com/llvm/llvm-project/pull/192609