### PR TITLE
[Clang][NEON] Use const std::string & in NeonEmitter. NFC.

### DIFF
--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -520,7 +520,7 @@ public:
 private:
   StringRef getNextModifiers(StringRef Proto, unsigned &Pos) const;
 
-  std::string mangleName(std::string Name, ClassKind CK) const;
+  std::string mangleName(const std::string &Name, ClassKind CK) const;
 
   void initVariables();
   std::string replaceParamsIn(std::string S);
@@ -1120,7 +1120,8 @@ std::string Intrinsic::getMangledName(bool ForceClassS) const {
   return mangleName(Name, ForceClassS ? ClassS : LocalCK);
 }
 
-std::string Intrinsic::mangleName(std::string Name, ClassKind LocalCK) const {
+std::string Intrinsic::mangleName(const std::string &Name,
+                                  ClassKind LocalCK) const {
   std::string typeCode = getInstTypeCode(BaseType, LocalCK);
   std::string S = Name;
 


### PR DESCRIPTION
Fixes #94375
