### PR TITLE
[Clang] Use const std::string & in ClangOptionDocEmitter. NFC.

### DIFF
--- a/clang/utils/TableGen/ClangOptionDocEmitter.cpp
+++ b/clang/utils/TableGen/ClangOptionDocEmitter.cpp
@@ -218,7 +218,7 @@ bool canSphinxCopeWithOption(const Record *Option) {
   return false;
 }
 
-void emitHeading(int Depth, std::string Heading, raw_ostream &OS) {
+void emitHeading(int Depth, const std::string &Heading, raw_ostream &OS) {
   assert(Depth < 8 && "groups nested too deeply");
   OS << Heading << '\n'
      << std::string(Heading.size(), "=~-_'+<>"[Depth]) << "\n";


### PR DESCRIPTION
Fixes #94373
