### PR TITLE
[flang] Fix abort on invalid -fdo-concurrent-to-openmp value.

### DIFF
--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -176,13 +176,13 @@ static bool parseDebugArgs(Fortran::frontend::CodeGenOptions &opts,
   return true;
 }
 
-static void parseDoConcurrentMapping(Fortran::frontend::CodeGenOptions &opts,
+static bool parseDoConcurrentMapping(Fortran::frontend::CodeGenOptions &opts,
                                      llvm::opt::ArgList &args,
                                      clang::DiagnosticsEngine &diags) {
   llvm::opt::Arg *arg =
       args.getLastArg(clang::options::OPT_fdo_concurrent_to_openmp_EQ);
   if (!arg)
-    return;
+    return true;
 
   using DoConcurrentMappingKind =
       Fortran::frontend::CodeGenOptions::DoConcurrentMappingKind;
@@ -197,9 +197,11 @@ static void parseDoConcurrentMapping(Fortran::frontend::CodeGenOptions &opts,
   if (!val.has_value()) {
     diags.Report(clang::diag::err_drv_invalid_value)
         << arg->getAsString(args) << arg->getValue();
+    return false;
   }
 
   opts.setDoConcurrentMapping(val.value());
+  return true;
 }
 
 static bool parseVectorLibArg(Fortran::frontend::CodeGenOptions &opts,
@@ -505,8 +507,6 @@ static void parseCodeGenArgs(Fortran::frontend::CodeGenOptions &opts,
                    clang::options::OPT_funderscoring, false)) {
     opts.Underscoring = 0;
   }
-
-  parseDoConcurrentMapping(opts, args, diags);
 
   if (const llvm::opt::Arg *arg =
           args.getLastArg(clang::options::OPT_complex_range_EQ)) {
@@ -1686,6 +1686,7 @@ bool CompilerInvocation::createFromArgs(
   parseTargetArgs(invoc.getTargetOpts(), args);
   parsePreprocessorArgs(invoc.getPreprocessorOpts(), args);
   parseCodeGenArgs(invoc.getCodeGenOpts(), args, diags);
+  success &= parseDoConcurrentMapping(invoc.getCodeGenOpts(), args, diags);
   success &= parseDebugArgs(invoc.getCodeGenOpts(), args, diags);
 
   // Enable USE statement preservation for debug info if debug level is above

--- a/flang/test/Driver/do_concurrent_to_omp_cli.f90
+++ b/flang/test/Driver/do_concurrent_to_omp_cli.f90
@@ -16,5 +16,10 @@
 ! OPT: warning: OpenMP is required for lowering `do concurrent` loops to OpenMP.
 ! OPT-SAME:     Enable OpenMP using `-fopenmp`.
 
+! RUN: not %flang -c -fopenmp -fdo-concurrent-to-openmp=devic,e %s 2>&1 \
+! RUN: | FileCheck %s --check-prefix=BADVAL
+
+! BADVAL: error: invalid value 'devic,e' in '-fdo-concurrent-to-openmp{{.*}}'
+
 program test_cli
 end program


### PR DESCRIPTION
We observed that following command can cause an assertion fail
 `flang -fopenmp -fdo-concurrent-to-openmp=devic,e` <file>

It happened because `parseDoConcurrentMapping` reported an error but still called `val.value()` on failure, tripping std::optional assertions.

The fix is to return false on error and wire return into `createFromArgs`.