### PR TITLE
[AAEval] Print ModRefInfo for atomic operations

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysisEvaluator.cpp
+++ b/llvm/lib/Analysis/AliasAnalysisEvaluator.cpp
@@ -78,10 +78,11 @@ static inline void PrintModRefResults(
   }
 }
 
-static inline void PrintModRefResults(const char *Msg, bool P, CallBase *CallA,
-                                      CallBase *CallB, Module *M) {
+static inline void PrintModRefResults(const char *Msg, bool P,
+                                      Instruction *MemOpA, Instruction *MemOpB,
+                                      Module *M) {
   if (PrintAll || P) {
-    errs() << "  " << Msg << ": " << *CallA << " <-> " << *CallB << '\n';
+    errs() << "  " << Msg << ": " << *MemOpA << " <-> " << *MemOpB << '\n';
   }
 }
 
@@ -104,7 +105,7 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
   ++FunctionCount;
 
   SetVector<std::pair<const Value *, Type *>> Pointers;
-  SmallSetVector<CallBase *, 16> Calls;
+  SmallSetVector<Instruction *, 16> OtherMemOps;
   SetVector<Value *> Loads;
   SetVector<Value *> Stores;
 
@@ -116,14 +117,16 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
       Pointers.insert({SI->getPointerOperand(),
                        SI->getValueOperand()->getType()});
       Stores.insert(SI);
-    } else if (auto *CB = dyn_cast<CallBase>(&Inst))
-      Calls.insert(CB);
+    }
+
+    if (isa<CallBase>(Inst) || Inst.isAtomic())
+      OtherMemOps.insert(&Inst);
   }
 
   if (PrintAll || PrintNoAlias || PrintMayAlias || PrintPartialAlias ||
       PrintMustAlias || PrintNoModRef || PrintMod || PrintRef || PrintModRef)
     errs() << "Function: " << F.getName() << ": " << Pointers.size()
-           << " pointers, " << Calls.size() << " call sites\n";
+           << " pointers, " << OtherMemOps.size() << " call sites\n";
 
   // iterate over the worklist, and run the full (n^2)/2 disambiguations
   for (auto I1 = Pointers.begin(), E = Pointers.end(); I1 != E; ++I1) {
@@ -208,27 +211,27 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
     }
   }
 
-  // Mod/ref alias analysis: compare all pairs of calls and values
-  for (CallBase *Call : Calls) {
+  // Mod/ref alias analysis: compare all pairs of mem ops and values
+  for (Instruction *MemOp : OtherMemOps) {
     for (const auto &Pointer : Pointers) {
       LocationSize Size =
           LocationSize::precise(DL.getTypeStoreSize(Pointer.second));
-      switch (AA.getModRefInfo(Call, Pointer.first, Size)) {
+      switch (AA.getModRefInfo(MemOp, Pointer.first, Size)) {
       case ModRefInfo::NoModRef:
-        PrintModRefResults("NoModRef", PrintNoModRef, Call, Pointer,
+        PrintModRefResults("NoModRef", PrintNoModRef, MemOp, Pointer,
                            F.getParent());
         ++NoModRefCount;
         break;
       case ModRefInfo::Mod:
-        PrintModRefResults("Just Mod", PrintMod, Call, Pointer, F.getParent());
+        PrintModRefResults("Just Mod", PrintMod, MemOp, Pointer, F.getParent());
         ++ModCount;
         break;
       case ModRefInfo::Ref:
-        PrintModRefResults("Just Ref", PrintRef, Call, Pointer, F.getParent());
+        PrintModRefResults("Just Ref", PrintRef, MemOp, Pointer, F.getParent());
         ++RefCount;
         break;
       case ModRefInfo::ModRef:
-        PrintModRefResults("Both ModRef", PrintModRef, Call, Pointer,
+        PrintModRefResults("Both ModRef", PrintModRef, MemOp, Pointer,
                            F.getParent());
         ++ModRefCount;
         break;
@@ -236,27 +239,27 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
     }
   }
 
-  // Mod/ref alias analysis: compare all pairs of calls
-  for (CallBase *CallA : Calls) {
-    for (CallBase *CallB : Calls) {
-      if (CallA == CallB)
+  // Mod/ref alias analysis: compare all pairs of mem ops
+  for (Instruction *MemOpA : OtherMemOps) {
+    for (Instruction *MemOpB : OtherMemOps) {
+      if (MemOpA == MemOpB)
         continue;
-      switch (AA.getModRefInfo(CallA, CallB)) {
+      switch (AA.getModRefInfo(MemOpA, MemOpB)) {
       case ModRefInfo::NoModRef:
-        PrintModRefResults("NoModRef", PrintNoModRef, CallA, CallB,
+        PrintModRefResults("NoModRef", PrintNoModRef, MemOpA, MemOpB,
                            F.getParent());
         ++NoModRefCount;
         break;
       case ModRefInfo::Mod:
-        PrintModRefResults("Just Mod", PrintMod, CallA, CallB, F.getParent());
+        PrintModRefResults("Just Mod", PrintMod, MemOpA, MemOpB, F.getParent());
         ++ModCount;
         break;
       case ModRefInfo::Ref:
-        PrintModRefResults("Just Ref", PrintRef, CallA, CallB, F.getParent());
+        PrintModRefResults("Just Ref", PrintRef, MemOpA, MemOpB, F.getParent());
         ++RefCount;
         break;
       case ModRefInfo::ModRef:
-        PrintModRefResults("Both ModRef", PrintModRef, CallA, CallB,
+        PrintModRefResults("Both ModRef", PrintModRef, MemOpA, MemOpB,
                            F.getParent());
         ++ModRefCount;
         break;

--- a/llvm/test/Analysis/BasicAA/atomics.ll
+++ b/llvm/test/Analysis/BasicAA/atomics.ll
@@ -1,0 +1,181 @@
+; RUN: opt -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 %s | FileCheck %s
+
+declare void @escape(ptr)
+declare noalias ptr @malloc(i64)
+
+; CHECK-LABEL: Function: alloca_no_escape:
+; CHECK:  NoModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 monotonic, align 4
+; CHECK:  NoModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 monotonic monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 monotonic monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %4 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %4 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %5 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %5 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %6 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %6 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence seq_cst
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence seq_cst
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %7 = atomicrmw add ptr %x, i32 1 seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %7 = atomicrmw add ptr %x, i32 1 seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %8 = cmpxchg ptr %x, i32 0, i32 1 seq_cst seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %8 = cmpxchg ptr %x, i32 0, i32 1 seq_cst seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %9 = load atomic i32, ptr %x seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %9 = load atomic i32, ptr %x seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x seq_cst, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x seq_cst, align 4
+define void @alloca_no_escape(ptr %x) {
+  %a = alloca i32
+  store i32 0, ptr %a
+
+  atomicrmw add ptr %x, i32 1 monotonic
+  cmpxchg ptr %x, i32 0, i32 1 monotonic monotonic
+  load atomic i32, ptr %x monotonic, align 4
+  store atomic i32 0, ptr %x monotonic, align 4
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  fence seq_cst
+  atomicrmw add ptr %x, i32 1 seq_cst
+  cmpxchg ptr %x, i32 0, i32 1 seq_cst seq_cst
+  load atomic i32, ptr %x seq_cst, align 4
+  store atomic i32 0, ptr %x seq_cst, align 4
+
+  ret void
+}
+
+; CHECK-LABEL: Function: alloca_escape_after:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define void @alloca_escape_after(ptr %x) {
+  %a = alloca i32
+  store i32 0, ptr %a
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  call void @escape(ptr %a)
+
+  ret void
+}
+
+; CHECK-LABEL: Function: noalias_no_escape:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define void @noalias_no_escape(ptr noalias %a, ptr %x) {
+  store i32 0, ptr %a
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  ret void
+}
+
+; CHECK-LABEL: Function: noalias_escape_after:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define void @noalias_escape_after(ptr noalias %a, ptr %x) {
+  store i32 0, ptr %a
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  ret void
+}
+
+; CHECK-LABEL: Function: malloc_no_escape:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %a = call ptr @malloc(i64 4)
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %a = call ptr @malloc(i64 4)
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define void @malloc_no_escape(ptr %x) {
+  %a = call ptr @malloc(i64 4)
+  store i32 0, ptr %a
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  ret void
+}
+
+; CHECK-LABEL: Function: malloc_escape_after:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %a = call ptr @malloc(i64 4)
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %a = call ptr @malloc(i64 4)
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence release
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define ptr @malloc_escape_after(ptr %x) {
+  %a = call ptr @malloc(i64 4)
+  store i32 0, ptr %a
+
+  fence release
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  ret ptr %a
+}


### PR DESCRIPTION
Print ModRefInfo for fence, atomicrmw, etc. Also for atomic
load and store, as these may have additional effects beyond
what is implied by the simple alias result.