### PR TITLE
Reland "[lldb][Linux] Read memory protection keys for memory regions (#193934)"

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1443,6 +1443,8 @@ tuples to return are:
   listed (`dirty-pages:;`) indicates no dirty pages in
   this memory region.  The *absence* of this key means
   that this stub cannot determine dirty pages.
+* `protection-key:<key>` - where `<key>` is an unsigned integer memory
+  protection key.
 
 If the address requested is not in a mapped region (e.g. we've jumped through
 a NULL pointer and are at 0x0) currently lldb expects to get back the size

--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -51,6 +51,8 @@ public:
 
   LazyBool IsShadowStack() const { return m_is_shadow_stack; }
 
+  std::optional<unsigned> GetProtectionKey() const { return m_protection_key; }
+
   void SetReadable(LazyBool val) { m_read = val; }
 
   void SetWritable(LazyBool val) { m_write = val; }
@@ -78,6 +80,11 @@ public:
 
   MemoryRegionInfo &SetIsShadowStack(LazyBool val) {
     m_is_shadow_stack = val;
+    return *this;
+  }
+
+  MemoryRegionInfo &SetProtectionKey(std::optional<unsigned> key) {
+    m_protection_key = key;
     return *this;
   }
 
@@ -114,7 +121,8 @@ public:
            m_memory_tagged == rhs.m_memory_tagged &&
            m_pagesize == rhs.m_pagesize &&
            m_is_stack_memory == rhs.m_is_stack_memory &&
-           m_is_shadow_stack == rhs.m_is_shadow_stack;
+           m_is_shadow_stack == rhs.m_is_shadow_stack &&
+           m_protection_key == rhs.m_protection_key;
   }
 
   bool operator!=(const MemoryRegionInfo &rhs) const { return !(*this == rhs); }
@@ -157,6 +165,7 @@ protected:
   LazyBool m_memory_tagged = eLazyBoolDontKnow;
   LazyBool m_is_stack_memory = eLazyBoolDontKnow;
   LazyBool m_is_shadow_stack = eLazyBoolDontKnow;
+  std::optional<unsigned> m_protection_key = std::nullopt;
   int m_pagesize = 0;
   std::optional<std::vector<lldb::addr_t>> m_dirty_pages;
 };

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -775,6 +775,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
                     "error",
                     "dirty-pages",
                     "type",
+                    "protection-key",
                 ],
             )
             self.assertIsNotNone(val)

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1689,6 +1689,8 @@ protected:
     LazyBool is_shadow_stack = range_info.IsShadowStack();
     if (is_shadow_stack == eLazyBoolYes)
       result.AppendMessage("shadow stack: yes");
+    if (std::optional<unsigned> protection_key = range_info.GetProtectionKey())
+      result.AppendMessageWithFormatv("protection key: {0}", *protection_key);
 
     const std::optional<std::vector<addr_t>> &dirty_page_list =
         range_info.GetDirtyPageList();

--- a/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
@@ -174,6 +174,10 @@ void lldb_private::ParseLinuxSMapRegions(llvm::StringRef linux_smap,
               region->SetMemoryTagged(eLazyBoolYes);
             else if (flag == "ss")
               region->SetIsShadowStack(eLazyBoolYes);
+        } else if (name == "ProtectionKey") {
+          unsigned key = 0;
+          if (!value.ltrim().getAsInteger(10, key))
+            region->SetProtectionKey(key);
         }
       } else {
         // Orphaned settings line

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1677,6 +1677,10 @@ Status GDBRemoteCommunicationClient::GetMemoryRegionInfo(
               dirty_page_list.push_back(page);
           }
           region_info.SetDirtyPageList(dirty_page_list);
+        } else if (name == "protection-key") {
+          unsigned protection_key = 0;
+          if (!value.getAsInteger(10, protection_key))
+            region_info.SetProtectionKey(protection_key);
         }
       }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2895,6 +2895,9 @@ GDBRemoteCommunicationServerLLGS::Handle_qMemoryRegionInfo(
       response.PutStringAsRawHex8(name.GetStringRef());
       response.PutChar(';');
     }
+
+    if (std::optional<unsigned> protection_key = region_info.GetProtectionKey())
+      response.Printf("protection-key:%" PRIu32 ";", *protection_key);
   }
 
   return SendPacketNoLock(response.GetString());

--- a/lldb/source/Target/MemoryRegionInfo.cpp
+++ b/lldb/source/Target/MemoryRegionInfo.cpp
@@ -12,14 +12,14 @@ using namespace lldb_private;
 
 llvm::raw_ostream &lldb_private::operator<<(llvm::raw_ostream &OS,
                                             const MemoryRegionInfo &Info) {
-  return OS << llvm::formatv("MemoryRegionInfo([{0}, {1}), {2:r}{3:w}{4:x}, "
-                             "{5}, `{6}`, {7}, {8}, {9}, {10}, {11})",
-                             Info.GetRange().GetRangeBase(),
-                             Info.GetRange().GetRangeEnd(), Info.GetReadable(),
-                             Info.GetWritable(), Info.GetExecutable(),
-                             Info.GetMapped(), Info.GetName(), Info.GetFlash(),
-                             Info.GetBlocksize(), Info.GetMemoryTagged(),
-                             Info.IsStackMemory(), Info.IsShadowStack());
+  return OS << llvm::formatv(
+             "MemoryRegionInfo([{0}, {1}), {2:r}{3:w}{4:x}, "
+             "{5}, `{6}`, {7}, {8}, {9}, {10}, {11}, {12})",
+             Info.GetRange().GetRangeBase(), Info.GetRange().GetRangeEnd(),
+             Info.GetReadable(), Info.GetWritable(), Info.GetExecutable(),
+             Info.GetMapped(), Info.GetName(), Info.GetFlash(),
+             Info.GetBlocksize(), Info.GetMemoryTagged(), Info.IsStackMemory(),
+             Info.IsShadowStack(), Info.GetProtectionKey());
 }
 
 void llvm::format_provider<LazyBool>::format(const LazyBool &B, raw_ostream &OS,

--- a/lldb/test/API/linux/aarch64/permission_overlay/TestAArch64LinuxPOE.py
+++ b/lldb/test/API/linux/aarch64/permission_overlay/TestAArch64LinuxPOE.py
@@ -79,6 +79,19 @@ class AArch64LinuxPOE(TestBase):
         self.expect("expression expr_function()", substrs=["$0 = 1"])
         self.expect("register read por", substrs=[self.EXPECTED_POR])
 
+        # Unmapped region has no key (not even default).
+        self.expect("memory region 0", substrs=["protection key:"], matching=False)
+
+        # The region has base permissions rwx, which is what we see here.
+        self.expect(
+            "memory region read_only_page", substrs=["rwx", "protection key: 6"]
+        )
+        # A region not assigned to a protection key has the default key 0.
+        self.expect("memory region key_zero_page", substrs=["rwx", "protection key: 0"])
+
+        # Protection keys should be on their own line.
+        self.expect("memory region --all", patterns=["\nprotection key: [0-9]+\n"])
+
         # Not passing this to the application allows us to fix the permissions
         # using lldb, then continue to a normal exit.
         self.runCmd("process handle SIGSEGV --pass false")
@@ -127,3 +140,7 @@ class AArch64LinuxPOE(TestBase):
                 "register read por",
                 substrs=[f"     {self.EXPECTED_POR}\n" + self.EXPECTED_POR_FIELDS],
             )
+
+        # Protection keys are listed in /proc/<pid>/smaps, which is not included
+        # in core files.
+        self.expect("memory region --all", substrs=["protection key:"], matching=False)

--- a/lldb/test/API/linux/aarch64/permission_overlay/main.c
+++ b/lldb/test/API/linux/aarch64/permission_overlay/main.c
@@ -81,6 +81,11 @@ int main(void) {
   const int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
   const int flags = MAP_PRIVATE | MAP_ANONYMOUS;
 
+  // This page will have the default key 0.
+  char *key_zero_page = mmap(NULL, page_size, prot, flags, -1, 0);
+  if (key_zero_page == MAP_FAILED)
+    exit(2);
+
   // Later we will use this to cause a protection key fault.
   char *read_only_page = NULL;
 

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -269,6 +269,46 @@ INSTANTIATE_TEST_SUITE_P(
                                 .SetIsShadowStack(eLazyBoolYes)
                                 .SetMemoryTagged(eLazyBoolNo),
                         },
+                        ""),
+        // 0 is the default protection key.
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "ProtectionKey:          0",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetProtectionKey(0),
+                        },
+                        ""),
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "ProtectionKey:          99",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr))
+                                .SetProtectionKey(99),
+                        },
+                        ""),
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "ProtectionKey:      not_an_integer",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr)),
+                        },
+                        ""),
+        // Should be unsigned.
+        std::make_tuple("0-0 rw-p 00000000 00:00 0\n"
+                        "ProtectionKey:      -24",
+                        MemoryRegionInfos{
+                            MemoryRegionInfo(make_range(0, 0), eLazyBoolYes,
+                                             eLazyBoolYes, eLazyBoolNo,
+                                             eLazyBoolNo, eLazyBoolYes,
+                                             ConstString(nullptr)),
+                        },
                         "")));
 
 TEST_P(LinuxProcSMapsTestFixture, ParseSMapRegions) {

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -398,6 +398,7 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
   EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.GetMemoryTagged());
   EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.IsStackMemory());
   EXPECT_EQ(lldb_private::eLazyBoolDontKnow, region_info.IsShadowStack());
+  EXPECT_EQ(std::nullopt, region_info.GetProtectionKey());
 
   result = std::async(std::launch::async, [&] {
     return client.GetMemoryRegionInfo(addr, region_info);
@@ -429,6 +430,25 @@ TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfo) {
                "start:a000;size:2000;type:heap;");
   EXPECT_TRUE(result.get().Success());
   EXPECT_EQ(lldb_private::eLazyBoolNo, region_info.IsStackMemory());
+
+  result = std::async(std::launch::async, [&] {
+    return client.GetMemoryRegionInfo(addr, region_info);
+  });
+
+  HandlePacket(server, "qMemoryRegionInfo:a000",
+               "start:a000;size:2000;protection-key:42;");
+  EXPECT_TRUE(result.get().Success());
+  ASSERT_THAT(region_info.GetProtectionKey(),
+              ::testing::Optional(::testing::Eq(42)));
+
+  result = std::async(std::launch::async, [&] {
+    return client.GetMemoryRegionInfo(addr, region_info);
+  });
+
+  HandlePacket(server, "qMemoryRegionInfo:a000",
+               "start:a000;size:2000;protection-key:not_a_number;");
+  EXPECT_TRUE(result.get().Success());
+  ASSERT_THAT(region_info.GetProtectionKey(), std::nullopt);
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, GetMemoryRegionInfoInvalidResponse) {


### PR DESCRIPTION
This reverts commit 390a29ea833965f481a7011b07deed9612229d6e.

Two tests failed on the X86 buildbot but not in GitHub CI because the buildbot has protection keys and the CI machines do not. I ran the tests on an AArch64 host without protection keys, and only selected tests on a simulated AArch64 machine with protection keys, so I did not find this earlier.

The fix was to add "protection-key" to the list of possible qMemoryRegionInfo response keys.