### PR TITLE
[GVN] Propagate isMemorySSAEnabled() into ValueTable

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2806,9 +2806,8 @@ bool GVNPass::runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
   this->LI = &LI;
   VN.setMemDep(MD);
   // Propagate the MSSA-enabled flag so the value-numbering paths in
-  // lookupOrAddCall() and computeLoadStoreVN() -- which gate on
-  // IsMSSAEnabled -- are actually reachable when the MSSA backend is
-  // selected.
+  // lookupOrAddCall() and computeLoadStoreVN(), which depends on whether
+  // IsMSSAEnabled is turned on.
   VN.setMemorySSA(MSSA, isMemorySSAEnabled());
   ORE = RunORE;
   InvalidBlockRPONumbers = true;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2805,7 +2805,11 @@ bool GVNPass::runImpl(Function &F, AssumptionCache &RunAC, DominatorTree &RunDT,
   ICF = &ImplicitCFT;
   this->LI = &LI;
   VN.setMemDep(MD);
-  VN.setMemorySSA(MSSA);
+  // Propagate the MSSA-enabled flag so the value-numbering paths in
+  // lookupOrAddCall() and computeLoadStoreVN() -- which gate on
+  // IsMSSAEnabled -- are actually reachable when the MSSA backend is
+  // selected.
+  VN.setMemorySSA(MSSA, isMemorySSAEnabled());
   ORE = RunORE;
   InvalidBlockRPONumbers = true;
   MemorySSAUpdater Updater(MSSA);

--- a/llvm/test/Transforms/GVN/tbaa.ll
+++ b/llvm/test/Transforms/GVN/tbaa.ll
@@ -3,18 +3,11 @@
 ; RUN: opt -passes='gvn<memoryssa>' -S < %s | FileCheck --check-prefixes=CHECK,MSSA %s
 
 define i32 @test1(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test1(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0:![0-9]+]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test1(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0:![0-9]+]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]])
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test1(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0:![0-9]+]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !0
   %b = call i32 @foo(ptr %p)
@@ -23,18 +16,11 @@ define i32 @test1(ptr %p, ptr %q) {
 }
 
 define i32 @test2(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test2(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test2(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test2(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !0
   %b = call i32 @foo(ptr %p), !tbaa !0
@@ -43,18 +29,11 @@ define i32 @test2(ptr %p, ptr %q) {
 }
 
 define i32 @test3(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test3(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4:![0-9]+]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test3(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4:![0-9]+]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test3(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4:![0-9]+]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !3
   %b = call i32 @foo(ptr %p), !tbaa !3
@@ -63,18 +42,11 @@ define i32 @test3(ptr %p, ptr %q) {
 }
 
 define i32 @test4(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test4(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[A_TBAA6:![0-9]+]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test4(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[A_TBAA6:![0-9]+]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test4(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[A_TBAA6:![0-9]+]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !1
   %b = call i32 @foo(ptr %p), !tbaa !0
@@ -83,18 +55,11 @@ define i32 @test4(ptr %p, ptr %q) {
 }
 
 define i32 @test5(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test5(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test5(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[A_TBAA6]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test5(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !0
   %b = call i32 @foo(ptr %p), !tbaa !1
@@ -103,18 +68,11 @@ define i32 @test5(ptr %p, ptr %q) {
 }
 
 define i32 @test6(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test6(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test6(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test6(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[C_TBAA0]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !0
   %b = call i32 @foo(ptr %p), !tbaa !3
@@ -123,18 +81,11 @@ define i32 @test6(ptr %p, ptr %q) {
 }
 
 define i32 @test7(ptr %p, ptr %q) {
-; MDEP-LABEL: define i32 @test7(
-; MDEP-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MDEP-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[SCALAR_TYPE_TBAA7:![0-9]+]]
-; MDEP-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
-; MDEP-NEXT:    ret i32 [[C]]
-;
-; MSSA-LABEL: define i32 @test7(
-; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
-; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[SCALAR_TYPE_TBAA7:![0-9]+]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[B_TBAA4]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
-; MSSA-NEXT:    ret i32 [[C]]
+; CHECK-LABEL: define i32 @test7(
+; CHECK-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[SCALAR_TYPE_TBAA7:![0-9]+]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
+; CHECK-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !4
   %b = call i32 @foo(ptr %p), !tbaa !3
@@ -202,8 +153,7 @@ define i32 @test10(ptr %p, ptr %q) {
 ; MSSA-LABEL: define i32 @test10(
 ; MSSA-SAME: ptr [[P:%.*]], ptr [[Q:%.*]]) {
 ; MSSA-NEXT:    [[A:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[INT_TBAA13:![0-9]+]]
-; MSSA-NEXT:    [[B:%.*]] = call i32 @foo(ptr [[P]]), !tbaa [[INT_TBAA17:![0-9]+]]
-; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[B]]
+; MSSA-NEXT:    [[C:%.*]] = add i32 [[A]], [[A]]
 ; MSSA-NEXT:    ret i32 [[C]]
 ;
   %a = call i32 @foo(ptr %p), !tbaa !15  ; TAG_X_i
@@ -270,8 +220,4 @@ declare i32 @foo(ptr) readonly
 ; MSSA: [[META14]] = !{!"struct X", [[META15]], i64 0}
 ; MSSA: [[META15]] = !{!"int", [[META16:![0-9]+]], i64 0}
 ; MSSA: [[META16]] = !{!"char", [[META3]], i64 0}
-; MSSA: [[INT_TBAA17]] = !{[[META18:![0-9]+]], [[META15]], i64 0}
-; MSSA: [[META18]] = !{!"struct Y", [[META14]], i64 0}
 ;.
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; CHECK: {{.*}}


### PR DESCRIPTION
`GVNPass::runImpl()` calls `VN.setMemorySSA(MSSA)` with a single argument. The second parameter of `ValueTable::setMemorySSA()`, `MSSAEnabled`, defaults to `false`, so `ValueTable::IsMSSAEnabled` remains false even when the pass is configured with `-enable-gvn-memoryssa=1` or `-passes='gvn<memoryssa>'`.

The MemorySSA-backed value-numbering paths in `ValueTable::lookupOrAddCall()` and `ValueTable::computeLoadStoreVN()` are gated on `IsMSSAEnabled`, making them unreachable from runImpl() on main today.

This patch forwards isMemorySSAEnabled() as the second argument to setMemorySSA(), so selecting the MemorySSA backend actually enables MemorySSA-aware value numbering.

