### PR TITLE
[BOLT][AArch64] Refuse to run JTFootprintReduction pass

### DIFF
--- a/bolt/lib/Passes/JTFootprintReduction.cpp
+++ b/bolt/lib/Passes/JTFootprintReduction.cpp
@@ -247,6 +247,11 @@ void JTFootprintReduction::optimizeFunction(BinaryFunction &Function,
 }
 
 Error JTFootprintReduction::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+  
   if (opts::JumpTables == JTS_BASIC && BC.HasRelocations)
     return Error::success();
 

--- a/bolt/lib/Passes/JTFootprintReduction.cpp
+++ b/bolt/lib/Passes/JTFootprintReduction.cpp
@@ -251,7 +251,7 @@ Error JTFootprintReduction::runOnFunctions(BinaryContext &BC) {
     BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
     exit(1);
   }
-  
+
   if (opts::JumpTables == JTS_BASIC && BC.HasRelocations)
     return Error::success();
 

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -5,9 +5,10 @@
 RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
+RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
-
+CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'


### PR DESCRIPTION
JTFootprintReduction results in a no-op on AArch64. This is because it emits createIJmp32Frag() which is unimplemented for AArch64 and is only overridden by x86.

- Add a guard for non-x86
- Update unsupported-passes.test with expected error message