### PR TITLE
[LLVM][CodeGen][RISCV] Avoid duplicate live-in copies and reuse existing virtual registers

### DIFF
--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -498,13 +498,26 @@ MachineRegisterInfo::EmitLiveInCopies(MachineBasicBlock *EntryMBB,
         LiveIns.erase(LiveIns.begin() + i);
         --i; --e;
       } else {
-        // Emit a copy.
-        BuildMI(*EntryMBB, EntryMBB->begin(), DebugLoc(),
-                TII.get(TargetOpcode::COPY), LiveIns[i].second)
-          .addReg(LiveIns[i].first);
-
-        // Add the register to the entry block live-in set.
-        EntryMBB->addLiveIn(LiveIns[i].first);
+        MachineInstr *CopyMI = getUniqueVRegDef(LiveIns[i].second);
+        if (!CopyMI) {
+          // Emit a copy.
+          BuildMI(*EntryMBB, EntryMBB->begin(), DebugLoc(),
+                  TII.get(TargetOpcode::COPY), LiveIns[i].second)
+              .addReg(LiveIns[i].first);
+        } else {
+          assert(CopyMI->isCopy() && "There is already instruction that's "
+                                     "emitted but it's not a COPY");
+          assert(CopyMI->getOperand(1).getReg() == LiveIns[i].first &&
+                 "The copy that has already been emitted is not copying the "
+                 "right physical register");
+          assert(CopyMI->getParent() == EntryMBB &&
+                 "The copy that has already been emitted is not in the entry "
+                 "block");
+        }
+        if (!EntryMBB->isLiveIn(LiveIns[i].first)) {
+          // Add the register to the entry block live-in set.
+          EntryMBB->addLiveIn(LiveIns[i].first);
+        }
       }
     } else {
       // Add the register to the entry block live-in set.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -24179,8 +24179,13 @@ static SDValue unpackFromRegLoc(SelectionDAG &DAG, SDValue Chain,
   EVT LocVT = VA.getLocVT();
   SDValue Val;
   const TargetRegisterClass *RC = TLI.getRegClassFor(LocVT.getSimpleVT());
-  Register VReg = RegInfo.createVirtualRegister(RC);
-  RegInfo.addLiveIn(VA.getLocReg(), VReg);
+  Register VReg;
+  if (RegInfo.isLiveIn(VA.getLocReg()))
+    VReg = RegInfo.getLiveInVirtReg(VA.getLocReg());
+  else {
+    VReg = RegInfo.createVirtualRegister(RC);
+    RegInfo.addLiveIn(VA.getLocReg(), VReg);
+  }
   Val = DAG.getCopyFromReg(Chain, DL, VReg, LocVT);
 
   // If input is sign extended from 32 bits, note it for the SExtWRemoval pass.


### PR DESCRIPTION
Original github issue: https://github.com/llvm/llvm-project/issues/168256

Prevent emitting redundant COPY instructions for live-in registers by reusing already-defined virtual registers when available.

  In MachineRegisterInfo::EmitLiveInCopies, check for an existing unique vreg definition:

-     Reuse existing COPY if present, with assertions to validate correctness.
-     Only emit a new COPY when none exists.
-     Avoid duplicating entries in the entry block live-in set.

  
  
  In RISCV lowering (unpackFromRegLoc):
-     Reuse existing live-in virtual registers via getLiveInVirtReg when available.
-     Only create new virtual register and add it as a live in if the physical register is not already live-in.

This reduces redundant instructions, ensures consistency of live-in handling, and prevents duplicate COPY emission in the entry block.