### PR TITLE
[libc][docs][POSIX] Add sys/select.h implementation status (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -66,6 +66,7 @@ if (SPHINX_FOUND)
       strings
       sys/mman
       sys/resource
+      sys/select
       sys/socket
       sys/stat
       sys/statvfs

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -34,6 +34,7 @@ Implementation Status
    strings
    sys/mman
    sys/resource
+   sys/select
    sys/socket
    sys/stat
    sys/statvfs

--- a/libc/utils/docgen/sys/select.yaml
+++ b/libc/utils/docgen/sys/select.yaml
@@ -1,0 +1,17 @@
+functions:
+  pselect:
+    in-latest-posix: ""
+  select:
+    in-latest-posix: ""
+
+macros:
+  FD_CLR:
+    in-latest-posix: ""
+  FD_ISSET:
+    in-latest-posix: ""
+  FD_SET:
+    in-latest-posix: ""
+  FD_SETSIZE:
+    in-latest-posix: ""
+  FD_ZERO:
+    in-latest-posix: ""


### PR DESCRIPTION
Add sys/select.h implementation-status docs to llvm-libc.