### PR TITLE
[Flang][OpenMP] Fix crash lowering parallel do with nested tile construct

### DIFF
--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -702,9 +702,13 @@ pft::Evaluation *getNestedDoConstruct(pft::Evaluation &eval) {
     //     <<DoConstruct>> -> 7
     if (nested.getIf<parser::NonLabelDoStmt>())
       continue;
-    assert(nested.getIf<parser::DoConstruct>() &&
-           "Unexpected construct in the nested evaluations");
-    return &nested;
+    if (nested.getIf<parser::DoConstruct>())
+      return &nested;
+    // Loop transformations can introduce nested OpenMP
+    // constructs between the directive and the actual do-loop nest.
+    if (nested.getIf<parser::OpenMPConstruct>())
+      return getNestedDoConstruct(nested);
+    assert(false && "Unexpected construct in the nested evaluations");
   }
   llvm_unreachable("Expected do loop to be in the nested evaluations");
 }

--- a/flang/test/Lower/OpenMP/tile-parallel-do.f90
+++ b/flang/test/Lower/OpenMP/tile-parallel-do.f90
@@ -1,0 +1,22 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=51 -o - %s | FileCheck %s
+
+subroutine func7(a)
+  implicit none
+  double precision :: a(100, 100)
+  integer :: i, j
+
+  !$omp parallel do
+  !$omp tile sizes(4, 16)
+  do i = 1, 100
+    do j = 1, 100
+      a(j, i) = a(j, i) + 1.0d0
+    end do
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPfunc7(
+! CHECK: omp.parallel
+! CHECK: omp.wsloop
+! CHECK: omp.loop_nest
+! CHECK-SAME: tiles(4, 16)
+


### PR DESCRIPTION
This fixes a crash in OpenMP lowering for cases like `!$omp parallel do with nested !$omp tile sizes(...)` .
The loop-walk logic now correctly steps through intermediate OpenMP transformation wrappers to find the actual do construct, instead of assuming it is directly nested.

Fixes :  [https://github.com/llvm/llvm-project/issues/193256](https://github.com/llvm/llvm-project/issues/193256) 
sample reproducer : [https://godbolt.org/z/b7zecYEMT](https://godbolt.org/z/b7zecYEMT)