### PR TITLE
[llvm-objcopy] Mark compression options unsupported except on ELF

### DIFF
--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -33,7 +33,9 @@ Expected<const COFFConfig &> ConfigManager::getCOFFConfig() const {
       Common.DiscardMode == DiscardType::Locals ||
       !Common.SymbolsToAdd.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
-      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty())
+      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty())
     return createStringError(llvm::errc::invalid_argument,
                              "option is not supported for COFF");
 
@@ -54,7 +56,9 @@ Expected<const MachOConfig &> ConfigManager::getMachOConfig() const {
       Common.DiscardMode == DiscardType::Locals ||
       !Common.SymbolsToAdd.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
-      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty())
+      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty())
     return createStringError(llvm::errc::invalid_argument,
                              "option is not supported for MachO");
 
@@ -75,7 +79,9 @@ Expected<const WasmConfig &> ConfigManager::getWasmConfig() const {
       !Common.SetSectionFlags.empty() || !Common.SetSectionType.empty() ||
       !Common.SymbolsToRename.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
-      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty())
+      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty())
     return createStringError(llvm::errc::invalid_argument,
                              "only flags for section dumping, removal, and "
                              "addition are supported");
@@ -105,7 +111,9 @@ Expected<const XCOFFConfig &> ConfigManager::getXCOFFConfig() const {
       Common.Weaken || Common.StripUnneeded || Common.DecompressDebugSections ||
       Common.GapFill != 0 || Common.PadTo != 0 ||
       Common.ChangeSectionLMAValAll != 0 ||
-      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty()) {
+      !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty()) {
     return createStringError(
         llvm::errc::invalid_argument,
         "no flags are supported yet, only basic copying is allowed");
@@ -129,7 +137,9 @@ ConfigManager::getDXContainerConfig() const {
       Common.StripUnneeded || Common.DecompressDebugSections ||
       Common.GapFill != 0 || Common.PadTo != 0 ||
       Common.ChangeSectionLMAValAll != 0 ||
-      !Common.ChangeSectionAddress.empty()) {
+      !Common.ChangeSectionAddress.empty() ||
+      Common.CompressionType != DebugCompressionType::None ||
+      !Common.compressSections.empty()) {
     return createStringError(llvm::errc::invalid_argument,
                              "option is not supported for DXContainer");
   }

--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -80,6 +80,7 @@ Expected<const WasmConfig &> ConfigManager::getWasmConfig() const {
       !Common.SymbolsToRename.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||
       !Common.ChangeSectionAddress.empty() || !Common.ExtractSection.empty() ||
+      Common.DecompressDebugSections ||
       Common.CompressionType != DebugCompressionType::None ||
       !Common.compressSections.empty())
     return createStringError(llvm::errc::invalid_argument,


### PR DESCRIPTION
These options are implemented only for the ELF target; make the tool error out accordingly.

We don't seem to have any preexisting tests for the unsupported options.

This fixes one aspect of https://github.com/llvm/llvm-project/issues/190574 by properly indicating that the options aren't supported/implemented yet.