### PR TITLE
[libclc] Make sure PACKAGE_VERSION is set for libclc

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -69,6 +69,11 @@ else()
     message(FATAL_ERROR "Clang is not enabled, but is required to build libclc in-tree")
   endif()
 
+  # The package version is required to find the resource directory.
+  if( LLVM_PACKAGE_VERSION AND NOT PACKAGE_VERSION )
+    set( PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}" )
+  endif()
+
   get_host_tool_path( llvm-link LLVM_LINK llvm-link_exe llvm-link_target )
   get_host_tool_path( opt OPT opt_exe opt_target )
 


### PR DESCRIPTION
Summary:
This can be unset because CMake does not expose this as a raw variable
when you use the find_package interface. If it is not set as in the case
of standalone builds the clang resource directory won't be found
