### PR TITLE
[libclc] Use 'LLVM_DEFAULT_TARGET_TRIPLE' instead of 'LLVM_RUNTIMES_TARGET'

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -34,7 +34,7 @@ set( LIBCLC_TARGETS_ALL
   spirv64-mesa3d-
 )
 
-set(LIBCLC_TARGET ${LLVM_RUNTIMES_TARGET})
+set(LIBCLC_TARGET ${LLVM_DEFAULT_TARGET_TRIPLE})
 
 if(NOT LIBCLC_TARGET)
   message(FATAL_ERROR "libclc target is empty\n")


### PR DESCRIPTION
Summary:
The 'LLVM_RUNTIMES_TARGET' variable is the raw value used by the LLVM
CMake. It can contain multilib arguments which will not compile when
used as a triple. The more canonical value is
`LLVM_DEFAULT_TARGET_TRIPLE`, which is used by flang-rt, libc, openmp,
etc.
