### PR TITLE
[libc][docs] Add dlfcn.h implementation status (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -45,6 +45,7 @@ if (SPHINX_FOUND)
       cpio
       ctype
       dirent
+      dlfcn
       endian
       errno
       fcntl

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -11,6 +11,7 @@ Implementation Status
    cpio
    ctype
    dirent
+   dlfcn
    endian
    errno
    fcntl

--- a/libc/utils/docgen/dlfcn.yaml
+++ b/libc/utils/docgen/dlfcn.yaml
@@ -1,0 +1,21 @@
+functions:
+  dladdr:
+    in-latest-posix: ""
+  dlclose:
+    in-latest-posix: ""
+  dlerror:
+    in-latest-posix: ""
+  dlopen:
+    in-latest-posix: ""
+  dlsym:
+    in-latest-posix: ""
+
+macros:
+  RTLD_GLOBAL:
+    in-latest-posix: ""
+  RTLD_LAZY:
+    in-latest-posix: ""
+  RTLD_LOCAL:
+    in-latest-posix: ""
+  RTLD_NOW:
+    in-latest-posix: ""


### PR DESCRIPTION
Add dlfcn.h implementation-status docs to llvm-libc.