### PR TITLE
[libclc] Parse triples to be more permissive

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -22,27 +22,13 @@ option(
   LIBCLC_USE_SPIRV_BACKEND "Build SPIR-V targets with the SPIR-V backend." OFF
 )
 
-# List of all supported targets.
-set( LIBCLC_TARGETS_ALL
-  amdgcn-amd-amdhsa-llvm
-  clspv--
-  clspv64--
-  nvptx64--
-  nvptx64--nvidiacl
-  nvptx64-nvidia-cuda
-  spirv-mesa3d-
-  spirv64-mesa3d-
-)
-
-set(LIBCLC_TARGET ${LLVM_RUNTIMES_TARGET})
+set(LIBCLC_TARGET ${LLVM_DEFAULT_TARGET_TRIPLE})
 
 if(NOT LIBCLC_TARGET)
   message(FATAL_ERROR "libclc target is empty\n")
 endif()
-if(NOT "${LIBCLC_TARGET}" IN_LIST LIBCLC_TARGETS_ALL)
-  message(FATAL_ERROR "Unknown libclc target: ${LIBCLC_TARGET}\n"
-    "Valid targets are: ${LIBCLC_TARGETS_ALL}\n")
-endif()
+
+libclc_configure_triple(${LIBCLC_TARGET} ARCH OS)
 
 if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set( LIBCLC_STANDALONE_BUILD TRUE )
@@ -95,10 +81,6 @@ if( NOT LIBCLC_USE_SPIRV_BACKEND )
 endif()
 
 message(STATUS "libclc target '${LIBCLC_TARGET}' is enabled")
-
-string( REPLACE "-" ";" TRIPLE  ${LIBCLC_TARGET} )
-list(GET TRIPLE 0 ARCH)
-list(GET TRIPLE 2 OS)
 
 if(ARCH STREQUAL spirv OR ARCH STREQUAL spirv64)
   if(NOT LIBCLC_USE_SPIRV_BACKEND AND NOT llvm-spirv_exe)

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -6,6 +6,66 @@ macro(libclc_configure_source_list variable path)
   set(${variable} ${${variable}} PARENT_SCOPE)
 endmacro()
 
+# Validates the triple and extracts the OS and architecture components.
+macro(libclc_configure_triple triple arch os)
+  # Validate the target triple by its components.
+  string(REPLACE "-" ";" TRIPLE ${triple})
+  list(GET TRIPLE 0 ARCH)
+  list(LENGTH TRIPLE triple_len)
+
+  set(VENDOR "")
+  set(OS "")
+  set(ENV "")
+  if(triple_len GREATER 1)
+    list(GET TRIPLE 1 VENDOR)
+  endif()
+  if(triple_len GREATER 2)
+    list(GET TRIPLE 2 OS)
+  endif()
+  if(triple_len GREATER 3)
+    list(GET TRIPLE 3 ENV)
+  endif()
+
+  set(libclc_known_arches nvptx64 amdgcn spirv spirv64 clspv clspv64)
+  if(NOT ARCH IN_LIST libclc_known_arches)
+    message(FATAL_ERROR "libclc target '${LIBCLC_TARGET}' has unknown "
+      "architecture '${ARCH}'\n"
+      "Valid architectures are: ${libclc_known_arches}\n")
+  endif()
+
+  if(ARCH STREQUAL "amdgcn")
+    if(NOT OS STREQUAL "amdhsa")
+      message(FATAL_ERROR
+        "libclc target '${LIBCLC_TARGET}': amdgcn requires the 'amdhsa' OS\n")
+    endif()
+    if(VENDOR AND NOT VENDOR STREQUAL "amd")
+      message(FATAL_ERROR
+        "libclc target '${LIBCLC_TARGET}': unexpected vendor '${VENDOR}'\n")
+    endif()
+  elseif(ARCH STREQUAL "nvptx64")
+    if(VENDOR AND NOT VENDOR STREQUAL "nvidia")
+      message(FATAL_ERROR
+        "libclc target '${LIBCLC_TARGET}': unexpected vendor '${VENDOR}'\n")
+    endif()
+    if(OS AND NOT (OS STREQUAL "nvidiacl" OR OS STREQUAL "cuda"))
+      message(FATAL_ERROR
+        "libclc target '${LIBCLC_TARGET}': unexpected OS '${OS}'\n")
+    endif()
+  elseif(ARCH MATCHES "^spirv")
+    if(VENDOR AND NOT VENDOR STREQUAL "mesa3d")
+      message(FATAL_ERROR
+        "libclc target '${LIBCLC_TARGET}': unexpected vendor '${VENDOR}'\n")
+    endif()
+  endif()
+
+  if(ENV AND NOT ENV STREQUAL "llvm")
+    message(FATAL_ERROR
+      "libclc target '${LIBCLC_TARGET}': unexpected environment '${ENV}'\n")
+  endif()
+  set(${arch} ${ARCH})
+  set(${os} ${OS})
+endmacro()
+
 # Appends a compile option to the given source files. Paths are relative
 # to `path` and the property is set in the top-level libclc directory scope.
 macro(libclc_configure_source_options path option)


### PR DESCRIPTION
Summary:
Previously we used a list of exact triples, but realistically there's
only a few fields that truly matter. This change makes it more
permissive for users to pass custom triples now that `libclc` is a more
shallow wrapper around `--target=` in OpenCL

I believe we should start providing cache files as well.
