### PR TITLE
[libc][docs] Add sys/uio.h implementation status (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -71,6 +71,7 @@ if (SPHINX_FOUND)
       sys/stat
       sys/statvfs
       sys/time
+      sys/uio
       sys/utsname
       sys/wait
       termios

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -39,6 +39,7 @@ Implementation Status
    sys/stat
    sys/statvfs
    sys/time
+   sys/uio
    sys/utsname
    sys/wait
    termios

--- a/libc/utils/docgen/sys/uio.yaml
+++ b/libc/utils/docgen/sys/uio.yaml
@@ -1,0 +1,5 @@
+functions:
+  readv:
+    in-latest-posix: ""
+  writev:
+    in-latest-posix: ""


### PR DESCRIPTION
Add sys/uio.h implementation-status docs to llvm-libc.