### PR TITLE
[lldb][AArch64][Linux] Rename "por" register to "por_el0"

### DIFF
--- a/lldb/docs/use/aarch64-linux.md
+++ b/lldb/docs/use/aarch64-linux.md
@@ -377,12 +377,12 @@ This involves 3 components:
   into the overlay permissions.
 * The permissions set in the page table. These are the base permissions of the
   memory.
-* Overlay permissions, stored in the `por` register. These are applied on top
+* Overlay permissions, stored in the `por_el0` register. These are applied on top
   of the page table permissions. Overlay permissions cannot enable anything
   that was not enabled in the page table. In other words, overlay permissions
   can only keep, or remove permissions.
 
-LLDB users can read and write the `por` register if they choose to, but for
+LLDB users can read and write the `por_el0` register if they choose to, but for
 purely inspecting permissions, the `memory region` command is the better choice
 as it will show you all 3 things in one place.
 
@@ -408,10 +408,10 @@ overlay 6 is read only (`r--`). `effective: r--` is the result of overlaying
 that permission set onto the base permissions. Which removes the write
 permission, which is the cause of the signal.
 
-You can also see overlay `6` by reading the `por` register:
+You can also see overlay `6` by reading the `por_el0` register:
 ```
-(lldb) register read por
-     por = 0x0000000001234567
+(lldb) register read por_el0
+     por_el0 = 0x0000000001234567
          = {
 <...>
              Perm6 = Read
@@ -423,4 +423,4 @@ for glibc).
 
 ### Expression Evaluation
 
-The `por` reigster is saved before, and restored after expression evaluation.
+The `por_el0` reigster is saved before, and restored after expression evaluation.

--- a/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
@@ -893,28 +893,29 @@ ABISysV_arm64::GetMemoryPermissions(lldb_private::RegisterContext &reg_ctx,
   // Extension.
   // See Arm Architecture Reference manual "POR_EL0, Permission Overlay Register
   // 0 (EL0)".
-  const RegisterInfo *por_info = reg_ctx.GetRegisterInfoByName("por");
-  if (!por_info)
+  const RegisterInfo *por_el0_info = reg_ctx.GetRegisterInfoByName("por_el0");
+  if (!por_el0_info)
     return std::nullopt;
 
-  uint64_t por_value =
-      reg_ctx.ReadRegisterAsUnsigned(por_info, LLDB_INVALID_ADDRESS);
-  if (por_value == LLDB_INVALID_ADDRESS)
+  uint64_t por_el0_value =
+      reg_ctx.ReadRegisterAsUnsigned(por_el0_info, LLDB_INVALID_ADDRESS);
+  if (por_el0_value == LLDB_INVALID_ADDRESS)
     return std::nullopt;
 
-  // POR contains 16, 4-bit permission sets (though Linux limits this to 8
+  // por_el0 contains 16, 4-bit permission sets (though Linux limits this to 8
   // useable sets).
   if (protection_key >= 16)
     return std::nullopt;
 
   // Bit 3 - reserved, bit 2 - write, bit 1 - execute, bit 0 - read.
-  const uint64_t por_permissions = (por_value >> (protection_key * 4)) & 0xf;
+  const uint64_t por_el0_permissions =
+      (por_el0_value >> (protection_key * 4)) & 0xf;
   uint32_t overlay = 0;
-  if (por_permissions & 4)
+  if (por_el0_permissions & 4)
     overlay |= lldb::ePermissionsWritable;
-  if (por_permissions & 2)
+  if (por_el0_permissions & 2)
     overlay |= lldb::ePermissionsExecutable;
-  if (por_permissions & 1)
+  if (por_el0_permissions & 1)
     overlay |= lldb::ePermissionsReadable;
 
   uint32_t effective = original_permissions;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -139,7 +139,7 @@ private:
   uint64_t m_fpmr_reg;
 
   struct poe_regs {
-    uint64_t por_reg;
+    uint64_t por_el0_reg;
   };
 
   struct poe_regs m_poe_regs;

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
@@ -32,35 +32,43 @@
 using namespace lldb_private;
 
 Arm64RegisterFlagsDetector::Fields
-Arm64RegisterFlagsDetector::DetectPORFields(uint64_t hwcap, uint64_t hwcap2,
-                                            uint64_t hwcap3) {
+Arm64RegisterFlagsDetector::DetectPOREL0Fields(uint64_t hwcap, uint64_t hwcap2,
+                                               uint64_t hwcap3) {
   (void)hwcap;
   (void)hwcap3;
 
   if (!(hwcap2 & HWCAP2_POE))
     return {};
 
-  static const FieldEnum por_perm_enum("por_perm_enum",
-                                       {
-                                           {0b0000, "No Access"},
-                                           {0b0001, "Read"},
-                                           {0b0010, "Execute"},
-                                           {0b0011, "Read, Execute"},
-                                           {0b0100, "Write"},
-                                           {0b0101, "Write, Read"},
-                                           {0b0110, "Write, Execute"},
-                                           {0b0111, "Read, Write, Execute"},
-                                       });
+  static const FieldEnum por_el0_perm_enum("por_el0_perm_enum",
+                                           {
+                                               {0b0000, "No Access"},
+                                               {0b0001, "Read"},
+                                               {0b0010, "Execute"},
+                                               {0b0011, "Read, Execute"},
+                                               {0b0100, "Write"},
+                                               {0b0101, "Write, Read"},
+                                               {0b0110, "Write, Execute"},
+                                               {0b0111, "Read, Write, Execute"},
+                                           });
 
   return {
-      {"Perm15", 60, 63, &por_perm_enum}, {"Perm14", 56, 59, &por_perm_enum},
-      {"Perm13", 52, 55, &por_perm_enum}, {"Perm12", 48, 51, &por_perm_enum},
-      {"Perm11", 44, 47, &por_perm_enum}, {"Perm10", 40, 43, &por_perm_enum},
-      {"Perm9", 36, 39, &por_perm_enum},  {"Perm8", 32, 35, &por_perm_enum},
-      {"Perm7", 28, 31, &por_perm_enum},  {"Perm6", 24, 27, &por_perm_enum},
-      {"Perm5", 20, 23, &por_perm_enum},  {"Perm4", 16, 19, &por_perm_enum},
-      {"Perm3", 12, 15, &por_perm_enum},  {"Perm2", 8, 11, &por_perm_enum},
-      {"Perm1", 4, 7, &por_perm_enum},    {"Perm0", 0, 3, &por_perm_enum},
+      {"Perm15", 60, 63, &por_el0_perm_enum},
+      {"Perm14", 56, 59, &por_el0_perm_enum},
+      {"Perm13", 52, 55, &por_el0_perm_enum},
+      {"Perm12", 48, 51, &por_el0_perm_enum},
+      {"Perm11", 44, 47, &por_el0_perm_enum},
+      {"Perm10", 40, 43, &por_el0_perm_enum},
+      {"Perm9", 36, 39, &por_el0_perm_enum},
+      {"Perm8", 32, 35, &por_el0_perm_enum},
+      {"Perm7", 28, 31, &por_el0_perm_enum},
+      {"Perm6", 24, 27, &por_el0_perm_enum},
+      {"Perm5", 20, 23, &por_el0_perm_enum},
+      {"Perm4", 16, 19, &por_el0_perm_enum},
+      {"Perm3", 12, 15, &por_el0_perm_enum},
+      {"Perm2", 8, 11, &por_el0_perm_enum},
+      {"Perm1", 4, 7, &por_el0_perm_enum},
+      {"Perm0", 0, 3, &por_el0_perm_enum},
   };
 }
 

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
@@ -69,8 +69,8 @@ private:
                                  uint64_t hwcap3);
   static Fields DetectGCSFeatureFields(uint64_t hwcap, uint64_t hwcap2,
                                        uint64_t hwcap3);
-  static Fields DetectPORFields(uint64_t hwcap, uint64_t hwcap2,
-                                uint64_t hwcap3);
+  static Fields DetectPOREL0Fields(uint64_t hwcap, uint64_t hwcap2,
+                                   uint64_t hwcap3);
 
   struct RegisterEntry {
     RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
@@ -89,7 +89,7 @@ private:
       RegisterEntry("fpmr", 8, DetectFPMRFields),
       RegisterEntry("gcs_features_enabled", 8, DetectGCSFeatureFields),
       RegisterEntry("gcs_features_locked", 8, DetectGCSFeatureFields),
-      RegisterEntry("por", 8, DetectPORFields),
+      RegisterEntry("por_el0", 8, DetectPOREL0Fields),
   };
 
   // Becomes true once field detection has been run for all registers.

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -102,7 +102,7 @@ static lldb_private::RegisterInfo g_register_infos_gcs[] = {
     DEFINE_EXTENSION_REG(gcs_features_locked), DEFINE_EXTENSION_REG(gcspr_el0)};
 
 static lldb_private::RegisterInfo g_register_infos_poe[] = {
-    DEFINE_EXTENSION_REG(por)};
+    DEFINE_EXTENSION_REG(por_el0)};
 
 // Number of register sets provided by this context.
 enum {

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
@@ -80,7 +80,7 @@ RegisterContextCorePOSIX_arm64::Create(Thread &thread, const ArchSpec &arch,
 
   DataExtractor poe_data = getRegset(notes, arch.GetTriple(), AARCH64_POE_Desc);
   struct poe_regs {
-    uint64_t por_reg;
+    uint64_t por_el0_reg;
   };
   if (poe_data.GetByteSize() >= sizeof(poe_regs))
     opt_regsets.Set(RegisterInfoPOSIX_arm64::eRegsetMaskPOE);

--- a/lldb/test/API/linux/aarch64/permission_overlay/TestAArch64LinuxPOE.py
+++ b/lldb/test/API/linux/aarch64/permission_overlay/TestAArch64LinuxPOE.py
@@ -12,8 +12,8 @@ from lldbsuite.test import lldbutil
 class AArch64LinuxPOE(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    EXPECTED_POR = "por = 0x0000000001234567"
-    EXPECTED_POR_FIELDS = (
+    EXPECTED_POR_EL0 = "por_el0 = 0x0000000001234567"
+    EXPECTED_POR_EL0_FIELDS = (
         "         = {\n"
         "             Perm15 = No Access\n"
         "             Perm14 = No Access\n"
@@ -65,19 +65,19 @@ class AArch64LinuxPOE(TestBase):
             "register read --all",
             substrs=[
                 "Permission Overlay Registers",
-                f"{self.EXPECTED_POR}",
+                f"{self.EXPECTED_POR_EL0}",
             ],
         )
 
         if self.hasXMLSupport():
             self.expect(
-                "register read por",
-                substrs=[f"     {self.EXPECTED_POR}\n" + self.EXPECTED_POR_FIELDS],
+                "register read por_el0",
+                substrs=[f" {self.EXPECTED_POR_EL0}\n" + self.EXPECTED_POR_EL0_FIELDS],
             )
 
-        # POR should be restored after expression evaluation.
+        # POR_EL0 should be restored after expression evaluation.
         self.expect("expression expr_function()", substrs=["$0 = 1"])
-        self.expect("register read por", substrs=[self.EXPECTED_POR])
+        self.expect("register read por_el0", substrs=[self.EXPECTED_POR_EL0])
 
         # Unmapped region has no key (not even default).
         self.expect("memory region 0", substrs=["protection key:"], matching=False)
@@ -125,7 +125,7 @@ class AArch64LinuxPOE(TestBase):
 
         # Allow writes so we can continue. This value has permission 6 changed
         # from read only (1) to write (4).
-        self.runCmd("register write por 0x4234567")
+        self.runCmd("register write por_el0 0x4234567")
 
         self.expect("continue", substrs=["exited with status = 0"])
 
@@ -141,14 +141,14 @@ class AArch64LinuxPOE(TestBase):
             "register read --all",
             substrs=[
                 "Permission Overlay Registers",
-                f"{self.EXPECTED_POR}",
+                f"{self.EXPECTED_POR_EL0}",
             ],
         )
 
         if self.hasXMLSupport():
             self.expect(
-                "register read por",
-                substrs=[f"     {self.EXPECTED_POR}\n" + self.EXPECTED_POR_FIELDS],
+                "register read por_el0",
+                substrs=[f" {self.EXPECTED_POR_EL0}\n" + self.EXPECTED_POR_EL0_FIELDS],
             )
 
         # Protection keys are listed in /proc/<pid>/smaps, which is not included

--- a/lldb/test/API/linux/aarch64/permission_overlay/main.c
+++ b/lldb/test/API/linux/aarch64/permission_overlay/main.c
@@ -13,13 +13,13 @@
 // However, POE and therefore protection keys are new to AArch64 so we need to
 // be able to build with a libc without support for it.
 
-static uint64_t por_read(void) {
+static uint64_t por_el0_read(void) {
   uint64_t por;
   __asm__ volatile("mrs %0, S3_3_C10_C2_4" /*POR_EL0*/ : "=r"(por));
   return por;
 }
 
-static void por_write(uint64_t por) {
+static void por_el0_write(uint64_t por) {
   __asm__ volatile("msr S3_3_C10_C2_4, %0\n" /*POR_EL0*/
                    "isb" ::"r"(por)
                    : "memory");
@@ -62,7 +62,7 @@ static inline uint64_t set_perm(uint64_t por, int pkey, uint8_t perm) {
 static void cause_write_fault(char *buffer) { buffer[0] = '?'; }
 
 int expr_function() {
-  por_write(set_perm(por_read(), 1, 0));
+  por_el0_write(set_perm(por_el0_read(), 1, 0));
   return 1;
 }
 
@@ -113,7 +113,7 @@ int main(void) {
     // pkey 0 is already set to read+write+execute, we will set all other
     // valid encodings. 0 is no access and 7 is read+write_execute.
     uint8_t perm = NUM_KEYS - i;
-    por_write(set_perm(por_read(), i, perm));
+    por_el0_write(set_perm(por_el0_read(), i, perm));
   }
 
   // This page should allow reads.


### PR DESCRIPTION
As agreed with my Arm colleagues working on GDB.

The suffix means we are matching the architectural name exactly, and reducing confusion if you're
debuging multiple exception levels where there could be por_el<N> as well.

In the process of updating the tests I found some
"register read" output has changed alignment so I
have fixed that too.