### PR TITLE
[DAGcombine] Recognize fneg on RHS for partial_reduce_fmla

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -13540,7 +13540,7 @@ SDValue DAGCombiner::foldPartialReduceMLAMulOp(SDNode *N) {
 
   // Handle negation (sub-reduction).
   bool IsMLS = false;
-  if (sd_match(Op1, m_AnyOf(m_Neg(m_Value(Tmp)), m_FNeg(m_Value(Tmp))))) {
+  if (sd_match(Op1, m_Neg(m_Value(Tmp)))) {
     Op1 = Tmp;
     Opc = Op1->getOpcode();
     IsMLS = true;
@@ -13551,6 +13551,14 @@ SDValue DAGCombiner::foldPartialReduceMLAMulOp(SDNode *N) {
 
   SDValue LHS = Op1->getOperand(0);
   SDValue RHS = Op1->getOperand(1);
+
+  // After instcombine, negation for FP operations is on the RHS, so implement:
+  //   fmul(fpext(a), fneg(fpext(b)))
+  //-> fmul(fpext(a), fpext(fneg(b)))
+  if (sd_match(RHS, m_FNeg(m_Value(Tmp)))) {
+    RHS = Tmp;
+    IsMLS = true;
+  }
 
   // Try to treat (shl %a, %c) as (mul %a, (1 << %c)) for constant %c.
   if (Opc == ISD::SHL) {

--- a/llvm/test/CodeGen/AArch64/partial-reduction-sub-fp.ll
+++ b/llvm/test/CodeGen/AArch64/partial-reduction-sub-fp.ll
@@ -11,9 +11,9 @@ define <vscale x 4 x float> @fmlslbt_bf16_f32(<vscale x 4 x float> %acc, <vscale
 ; CHECK-NEXT:    ret
   %a.fpext = fpext <vscale x 8 x bfloat> %a to <vscale x 8 x float>
   %b.fpext = fpext <vscale x 8 x bfloat> %b to <vscale x 8 x float>
-  %mul = fmul fast <vscale x 8 x float> %a.fpext, %b.fpext
-  %mul.neg = fneg <vscale x 8 x float> %mul
-  %res = call fast <vscale x 4 x float> @llvm.vector.partial.reduce.fadd(<vscale x 4 x float> %acc, <vscale x 8 x float> %mul.neg)
+  %b.fpext.neg = fneg <vscale x 8 x float> %b.fpext
+  %mul = fmul fast <vscale x 8 x float> %a.fpext, %b.fpext.neg
+  %res = call fast <vscale x 4 x float> @llvm.vector.partial.reduce.fadd(<vscale x 4 x float> %acc, <vscale x 8 x float> %mul)
   ret <vscale x 4 x float> %res
 }
 
@@ -25,9 +25,9 @@ define <vscale x 4 x float> @fmlslbt_f16_f32(<vscale x 4 x float> %acc, <vscale 
 ; CHECK-NEXT:    ret
   %a.fpext = fpext <vscale x 8 x half> %a to <vscale x 8 x float>
   %b.fpext = fpext <vscale x 8 x half> %b to <vscale x 8 x float>
-  %mul = fmul fast <vscale x 8 x float> %a.fpext, %b.fpext
-  %mul.neg = fneg <vscale x 8 x float> %mul
-  %res = call fast <vscale x 4 x float> @llvm.vector.partial.reduce.fadd(<vscale x 4 x float> %acc, <vscale x 8 x float> %mul.neg)
+  %b.fpext.neg = fneg <vscale x 8 x float> %b.fpext
+  %mul = fmul fast <vscale x 8 x float> %a.fpext, %b.fpext.neg
+  %res = call fast <vscale x 4 x float> @llvm.vector.partial.reduce.fadd(<vscale x 4 x float> %acc, <vscale x 8 x float> %mul)
   ret <vscale x 4 x float> %res
 }
 
@@ -59,9 +59,9 @@ define <4 x float> @fixed_fmlslbt_bf16_f32(<4 x float> %acc, <8 x bfloat> %a, <8
 ; CHECK-NEXT:    ret
   %a.fpext = fpext <8 x bfloat> %a to <8 x float>
   %b.fpext = fpext <8 x bfloat> %b to <8 x float>
-  %mul = fmul fast <8 x float> %a.fpext, %b.fpext
-  %mul.neg = fneg <8 x float> %mul
-  %res = call fast <4 x float> @llvm.vector.partial.reduce.fadd(<4 x float> %acc, <8 x float> %mul.neg)
+  %b.fpext.neg = fneg <8 x float> %b.fpext
+  %mul = fmul fast <8 x float> %a.fpext, %b.fpext.neg
+  %res = call fast <4 x float> @llvm.vector.partial.reduce.fadd(<4 x float> %acc, <8 x float> %mul)
   ret <4 x float> %res
 }
 
@@ -77,9 +77,9 @@ define <4 x float> @fixed_fmlslbt_f16_f32(<4 x float> %acc, <8 x half> %a, <8 x 
 ; CHECK-NEXT:    ret
   %a.fpext = fpext <8 x half> %a to <8 x float>
   %b.fpext = fpext <8 x half> %b to <8 x float>
-  %mul = fmul fast <8 x float> %a.fpext, %b.fpext
-  %mul.neg = fneg <8 x float> %mul
-  %res = call fast <4 x float> @llvm.vector.partial.reduce.fadd(<4 x float> %acc, <8 x float> %mul.neg)
+  %b.fpext.neg = fneg <8 x float> %b.fpext
+  %mul = fmul fast <8 x float> %a.fpext, %b.fpext.neg
+  %res = call fast <4 x float> @llvm.vector.partial.reduce.fadd(<4 x float> %acc, <8 x float> %mul)
   ret <4 x float> %res
 }
 


### PR DESCRIPTION
PR #186809 recognized the negation on the fmul() expression, but after instcombine the fneg is moved to the RHS operand, so with #186809 the negation would not be recognized by the combine.

https://godbolt.org/z/YfoYshz78