### PR TITLE
[BOLT][AArch64] Refuse to run CMOVConversion pass

### DIFF
--- a/bolt/lib/Passes/CMOVConversion.cpp
+++ b/bolt/lib/Passes/CMOVConversion.cpp
@@ -271,6 +271,11 @@ void CMOVConversion::runOnFunction(BinaryFunction &Function) {
 }
 
 Error CMOVConversion::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   for (auto &It : BC.getBinaryFunctions()) {
     BinaryFunction &Function = It.second;
     if (!shouldOptimize(Function))

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -6,9 +6,12 @@ RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
+RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
+CHECK-CMOV-CONV: BOLT-ERROR: CMOV conversion is supported only on X86
+
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -6,11 +6,13 @@ RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
-RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
+
+// Passes specific to X86 arch
+RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
 CHECK-CMOV-CONV: BOLT-ERROR: CMOV conversion is supported only on X86
 
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT


### PR DESCRIPTION
`--cmov-conversion` is unsupported in AArch64 as convertMoveToConditionalMove() is only overriden for X86.

- Add a guard for non-X86
- Update unsupported-passes.test with expected error