### PR TITLE
[SPIR-V] Coalesce chains of spv_gep into a single access chain

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCombine.td
+++ b/llvm/lib/Target/SPIRV/SPIRVCombine.td
@@ -34,10 +34,18 @@ def matrix_multiply_lowering
                         [{ return Helper.matchMatrixMultiply(*${root}); }]),
                     (apply [{ Helper.applyMatrixMultiply(*${root}); }])>;
 
+def access_chain_coalescing : GICombineRule <
+  (defs root:$root),
+  (match (wip_match_opcode G_INTRINSIC, G_INTRINSIC_W_SIDE_EFFECTS):$root,
+          [{ return Helper.matchCoalesceAccessChain(*${root}); }]),
+  (apply [{ Helper.applyCoalesceAccessChain(*${root}); }])
+>;
+
 def SPIRVPreLegalizerCombiner
     : GICombiner<"SPIRVPreLegalizerCombinerImpl",
                  [vector_length_sub_to_distance_lowering,
                   vector_select_to_faceforward_lowering,
-                  matrix_transpose_lowering, matrix_multiply_lowering]> {
+                  matrix_transpose_lowering, matrix_multiply_lowering,
+                  access_chain_coalescing]> {
   let CombineAllMethodName = "tryCombineAllImpl";
 }

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -400,3 +400,86 @@ void SPIRVCombinerHelper::applyMatrixMultiply(MachineInstr &MI) const {
   Builder.buildBuildVector(ResReg, ResultScalars);
   MI.eraseFromParent();
 }
+
+static bool isSpvGep(const MachineInstr &MI) {
+  unsigned Op = MI.getOpcode();
+  if (Op != TargetOpcode::G_INTRINSIC &&
+      Op != TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS)
+    return false;
+  return cast<GIntrinsic>(MI).getIntrinsicID() == Intrinsic::spv_gep;
+}
+
+bool SPIRVCombinerHelper::matchCoalesceAccessChain(MachineInstr &MI) const {
+  if (!isSpvGep(MI) || MI.getNumExplicitOperands() < 5)
+    return false;
+
+  MachineInstr *Inner = MRI.getVRegDef(MI.getOperand(3).getReg());
+  if (!Inner || !isSpvGep(*Inner) || Inner->getParent() != MI.getParent() ||
+      Inner->getNumExplicitOperands() < 5)
+    return false;
+
+  Register InnerDef = Inner->getOperand(0).getReg();
+  for (MachineInstr &Use : MRI.use_nodbg_instructions(InnerDef)) {
+    if (&Use == &MI)
+      continue;
+    if (Use.getOpcode() == TargetOpcode::G_INTRINSIC ||
+        Use.getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS) {
+      Intrinsic::ID IID = cast<GIntrinsic>(Use).getIntrinsicID();
+      if (IID == Intrinsic::spv_assign_ptr_type ||
+          IID == Intrinsic::spv_assign_type)
+        continue;
+    }
+    return false;
+  }
+
+  if (!getImm(MI.getOperand(4), &MRI) || foldImm(MI.getOperand(4), &MRI) != 0)
+    return false;
+
+  for (unsigned I = 4, E = Inner->getNumExplicitOperands(); I != E; ++I)
+    if (!getImm(Inner->getOperand(I), &MRI))
+      return false;
+  for (unsigned I = 5, E = MI.getNumExplicitOperands(); I != E; ++I)
+    if (!getImm(MI.getOperand(I), &MRI))
+      return false;
+
+  return true;
+}
+
+void SPIRVCombinerHelper::applyCoalesceAccessChain(MachineInstr &MI) const {
+  Register Result = MI.getOperand(0).getReg();
+  int64_t OuterInBounds = MI.getOperand(2).getImm();
+
+  MachineInstr *Inner = MRI.getVRegDef(MI.getOperand(3).getReg());
+  Register InnerBase = Inner->getOperand(3).getReg();
+  int64_t InnerInBounds = Inner->getOperand(2).getImm();
+
+  SmallVector<Register, 8> InnerIdxs;
+  for (unsigned I = 4, E = Inner->getNumExplicitOperands(); I != E; ++I)
+    InnerIdxs.push_back(Inner->getOperand(I).getReg());
+  SmallVector<Register, 8> OuterIdxs;
+  for (unsigned I = 5, E = MI.getNumExplicitOperands(); I != E; ++I)
+    OuterIdxs.push_back(MI.getOperand(I).getReg());
+
+  Builder.setInstrAndDebugLoc(MI);
+  auto MIB =
+      Builder.buildIntrinsic(Intrinsic::spv_gep, ArrayRef<Register>{Result})
+          .addImm(InnerInBounds & OuterInBounds)
+          .addUse(InnerBase);
+  for (Register R : InnerIdxs)
+    MIB.addUse(R);
+  for (Register R : OuterIdxs)
+    MIB.addUse(R);
+
+  Register InnerDef = Inner->getOperand(0).getReg();
+  SmallVector<MachineInstr *, 4> MarkersToErase;
+  for (MachineInstr &Use : MRI.use_nodbg_instructions(InnerDef)) {
+    if (&Use == &MI || &Use == Inner)
+      continue;
+    MarkersToErase.push_back(&Use);
+  }
+  for (MachineInstr *M : MarkersToErase)
+    M->eraseFromParent();
+
+  MI.eraseFromParent();
+  Inner->eraseFromParent();
+}

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
@@ -37,6 +37,8 @@ public:
   void applyMatrixTranspose(MachineInstr &MI) const;
   bool matchMatrixMultiply(MachineInstr &MI) const;
   void applyMatrixMultiply(MachineInstr &MI) const;
+  bool matchCoalesceAccessChain(MachineInstr &MI) const;
+  void applyCoalesceAccessChain(MachineInstr &MI) const;
 
 private:
   SPIRVTypeInst getDotProductVectorType(Register ResReg, uint32_t K,

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-struct.ll
@@ -8,7 +8,6 @@
 ; CHECK-DAG: %[[ZERO:[0-9]+]] = OpConstant %[[INT]] 0{{$}}
 
 ; CHECK-DAG: %[[STRUCT_MATRIX:[0-9]+]] = OpTypeStruct %[[VEC4]] %[[VEC4]] %[[VEC4]] %[[VEC4]]
-; CHECK-DAG: %[[PTR_MATRIX:[0-9]+]] = OpTypePointer Uniform %[[STRUCT_MATRIX]]
 ; CHECK-DAG: %[[PTR_FLOAT:[0-9]+]] = OpTypePointer Uniform %[[FLOAT]]
 
 ; CHECK-DAG: %[[STRUCT_MYSTRUCT:[0-9]+]] = OpTypeStruct %[[STRUCT_MATRIX]] %[[STRUCT_MATRIX]] %[[STRUCT_MATRIX]]
@@ -87,8 +86,7 @@ entry:
   %mul3.i20.i = fmul reassoc nnan ninf nsz arcp afn <4 x float> %splat.splat2.i19.i, %5
   %8 = tail call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.fmuladd.v4f32(<4 x float> %splat.splat.i18.i, <4 x float> nofpclass(nan inf) %4, <4 x float> %mul3.i20.i)
   %9 = fadd reassoc nnan ninf nsz arcp afn <4 x float> %8, %6
-; CHECK: %[[PTR_M1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_MATRIX]] %[[PTR_STRUCT]] %[[ONE_64]]
-; CHECK: %[[PTR_M1_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_M1]] %[[ZERO]]
+; CHECK: %[[PTR_M1_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ONE_64]] %[[ZERO]]
 ; CHECK: %[[VAL_M1_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V0]]
   %10 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 64), align 16
 ; CHECK: %[[PTR_M1_V1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ONE_64]] %[[ONE_64]]
@@ -108,8 +106,7 @@ entry:
   %15 = tail call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.fmuladd.v4f32(<4 x float> %splat.splat5.i16.i, <4 x float> nofpclass(nan inf) %12, <4 x float> %14)
   %splat.splat7.i17.i = shufflevector <4 x float> %9, <4 x float> poison, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
   %16 = tail call reassoc nnan ninf nsz arcp afn noundef <4 x float> @llvm.fmuladd.v4f32(<4 x float> %splat.splat7.i17.i, <4 x float> nofpclass(nan inf) %13, <4 x float> %15)
-; CHECK: %[[PTR_M2:[0-9]+]] = OpInBoundsAccessChain %[[PTR_MATRIX]] %[[PTR_STRUCT]] %[[TWO_64]]
-; CHECK: %[[PTR_M2_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_M2]] %[[ZERO]]
+; CHECK: %[[PTR_M2_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[TWO_64]] %[[ZERO]]
 ; CHECK: %[[VAL_M2_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V0]]
   %17 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 128), align 16
 ; CHECK: %[[PTR_M2_V1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[TWO_64]] %[[ONE_64]]

--- a/llvm/test/CodeGen/SPIRV/logical-struct-access.ll
+++ b/llvm/test/CodeGen/SPIRV/logical-struct-access.ll
@@ -21,12 +21,11 @@
 ; CHECK-DAG: [[uint_2:%[0-9]+]] = OpConstant [[uint]] 2
 
 ; CHECK-DAG: [[ptr_uint:%[0-9]+]] = OpTypePointer Function [[uint]]
-; CHECK-DAG:    [[ptr_A:%[0-9]+]] = OpTypePointer Function [[A]]
 ; CHECK-DAG:    [[ptr_B:%[0-9]+]] = OpTypePointer Function [[B]]
 
 define internal i32 @load_B_0(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
-; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_A]] [[tmp]] [[uint_0]]
+; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_0]] [[uint_0]]
   %res = getelementptr %B, ptr %base, i32 0, i32 0
   %val = load i32, ptr %res
   ret i32 %val
@@ -34,7 +33,7 @@ define internal i32 @load_B_0(ptr %base) {
 
 define internal i32 @load_inbounds_B_0(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
-; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_A]] [[tmp]] [[uint_0]]
+; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_0]] [[uint_0]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 0
   %val = load i32, ptr %res
   ret i32 %val
@@ -58,7 +57,7 @@ define internal i32 @load_inbounds_B_1(ptr %base) {
 
 define internal i32 @load_B_2(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
-; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
+; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_2]] [[uint_0]]
   %res = getelementptr %B, ptr %base, i32 0, i32 2
   %val = load i32, ptr %res
   ret i32 %val
@@ -66,7 +65,7 @@ define internal i32 @load_B_2(ptr %base) {
 
 define internal i32 @load_inbounds_B_2(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
-; CHECK: {{%[0-9]+}} = OpInBoundsAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
+; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_2]] [[uint_0]]
   %res = getelementptr inbounds %B, ptr %base, i32 0, i32 2
   %val = load i32, ptr %res
   ret i32 %val
@@ -90,8 +89,7 @@ define internal i32 @load_inbounds_B_2_1(ptr %base) {
 
 define internal i32 @load_B_2_A_1(ptr %base) {
 ; CHECK: [[tmp:%[0-9]+]] = OpFunctionParameter [[ptr_B]]
-; CHECK: [[x:%[0-9]+]] = OpAccessChain [[ptr_A]] [[tmp]] [[uint_2]]
-; CHECK:   {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[x]] [[uint_1]]
+; CHECK: {{%[0-9]+}} = OpAccessChain [[ptr_uint]] [[tmp]] [[uint_2]] [[uint_1]]
   %x = getelementptr %B, ptr %base, i32 0, i32 2
   %res = getelementptr %A, ptr %x, i32 0, i32 1
   %val = load i32, ptr %res

--- a/llvm/test/CodeGen/SPIRV/pointers/coalesce-access-chain.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/coalesce-access-chain.ll
@@ -1,0 +1,80 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-pc-vulkan1.3-library %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-pc-vulkan1.3-library %s -o - -filetype=obj | spirv-val %}
+
+%struct.Inner = type { i32, <4 x float> }
+%struct.Outer = type { [5 x %struct.Inner], i32 }
+
+; CHECK-DAG: %[[#float:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#vec4:]] = OpTypeVector %[[#float]] 4
+; CHECK-DAG: %[[#int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Inner:]] = OpTypeStruct %[[#int]] %[[#vec4]]
+; CHECK-DAG: %[[#idx_5:]] = OpConstant %[[#int]] 5
+; CHECK-DAG: %[[#Array:]] = OpTypeArray %[[#Inner]] %[[#idx_5]]
+; CHECK-DAG: %[[#Outer:]] = OpTypeStruct %[[#Array]] %[[#int]]
+; CHECK-DAG: %[[#ptr_Outer:]] = OpTypePointer Function %[[#Outer]]
+; CHECK-DAG: %[[#ptr_float:]] = OpTypePointer Function %[[#float]]
+; CHECK-DAG: %[[#int_0:]] = OpConstant %[[#int]] 0
+; CHECK-DAG: %[[#int_1:]] = OpConstant %[[#int]] 1
+; CHECK-DAG: %[[#int_2:]] = OpConstant %[[#int]] 2
+
+define spir_func float @two_deep(ptr %obj) convergent {
+entry:
+  %tok = call token @llvm.experimental.convergence.entry()
+  ; CHECK: %[[#obj2:]] = OpFunctionParameter %[[#ptr_Outer]]
+  ; CHECK: %[[#ptr2:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#obj2]] %[[#int_0]] %[[#int_2]] %[[#int_1]] %[[#int_1]]
+  ; CHECK-NOT: OpInBoundsAccessChain
+  ; CHECK: OpLoad %[[#float]] %[[#ptr2]]
+  %inner = getelementptr inbounds %struct.Outer, ptr %obj, i32 0, i32 0, i32 2
+  %vecp = getelementptr inbounds %struct.Inner, ptr %inner, i32 0, i32 1
+  %eltp = getelementptr inbounds <4 x float>, ptr %vecp, i32 0, i32 1
+  %val = load float, ptr %eltp, align 4
+  ret float %val
+}
+
+define spir_func float @three_deep(ptr %obj) convergent {
+entry:
+  %tok = call token @llvm.experimental.convergence.entry()
+  ; CHECK: %[[#obj3:]] = OpFunctionParameter %[[#ptr_Outer]]
+  ; CHECK: %[[#ptr3:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#obj3]] %[[#int_0]] %[[#int_2]] %[[#int_1]] %[[#int_1]]
+  ; CHECK-NOT: OpInBoundsAccessChain
+  ; CHECK: OpLoad %[[#float]] %[[#ptr3]]
+  %a = getelementptr inbounds %struct.Outer, ptr %obj, i32 0, i32 0
+  %b = getelementptr inbounds [5 x %struct.Inner], ptr %a, i32 0, i32 2
+  %c = getelementptr inbounds %struct.Inner, ptr %b, i32 0, i32 1
+  %d = getelementptr inbounds <4 x float>, ptr %c, i32 0, i32 1
+  %val = load float, ptr %d, align 4
+  ret float %val
+}
+
+; If the inner GEP has multiple uses, do NOT coalesce: emit two access chains.
+define spir_func float @inner_multi_use(ptr %obj) convergent {
+entry:
+  %tok = call token @llvm.experimental.convergence.entry()
+  ; CHECK: %[[#objm:]] = OpFunctionParameter %[[#ptr_Outer]]
+  ; CHECK: %[[#innerp:]] = OpInBoundsAccessChain {{%[0-9]+}} %[[#objm]] %[[#int_0]] %[[#int_2]] %[[#int_1]]
+  ; CHECK: %[[#eltp:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#innerp]] %[[#int_1]]
+  ; CHECK: OpStore %[[#innerp]]
+  %inner = getelementptr inbounds %struct.Outer, ptr %obj, i32 0, i32 0, i32 2, i32 1
+  %eltp = getelementptr inbounds <4 x float>, ptr %inner, i32 0, i32 1
+  store <4 x float> zeroinitializer, ptr %inner, align 16
+  %val = load float, ptr %eltp, align 4
+  ret float %val
+}
+
+; If any index is dynamic (non-constant), do NOT coalesce.
+define spir_func float @dynamic_index(ptr %obj, i32 %i) convergent {
+entry:
+  %tok = call token @llvm.experimental.convergence.entry()
+  ; CHECK: %[[#objd:]] = OpFunctionParameter %[[#ptr_Outer]]
+  ; CHECK: %[[#i:]] = OpFunctionParameter %[[#int]]
+  ; CHECK: %[[#dyn:]] = OpInBoundsAccessChain {{%[0-9]+}} %[[#objd]] %[[#int_0]] %[[#i]]
+  ; CHECK: OpInBoundsAccessChain %[[#ptr_float]] %[[#dyn]] %[[#int_1]] %[[#int_1]]
+  %inner = getelementptr inbounds %struct.Outer, ptr %obj, i32 0, i32 0, i32 %i
+  %eltp = getelementptr inbounds %struct.Inner, ptr %inner, i32 0, i32 1, i32 1
+  %val = load float, ptr %eltp, align 4
+  ret float %val
+}
+
+declare token @llvm.experimental.convergence.entry() #1
+
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
@@ -16,9 +16,10 @@
 ; CHECK-DAG:   %[[#v4_fp:]] = OpTypePointer Function %[[#v4]]
 
 define internal spir_func <3 x i32> @foo(ptr addrspace(10) %a) {
+; CHECK: %[[#foo_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#foo_a]]
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr addrspace(10) %1, align 16
@@ -30,9 +31,10 @@ define internal spir_func <3 x i32> @foo(ptr addrspace(10) %a) {
 }
 
 define internal spir_func <3 x i32> @fooDefault(ptr %a) {
+; CHECK: %[[#fooD_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#fooD_a]]
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr %1, align 16
@@ -44,9 +46,10 @@ define internal spir_func <3 x i32> @fooDefault(ptr %a) {
 }
 
 define internal spir_func <3 x i32> @fooBounds(ptr %a) {
+; CHECK: %[[#fooB_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#tmp:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
+; CHECK: %[[#tmp:]]  = OpAccessChain %[[#v4_fp]] %[[#fooB_a]]
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr %1, align 16
@@ -58,9 +61,10 @@ define internal spir_func <3 x i32> @fooBounds(ptr %a) {
 }
 
 define internal spir_func <2 x i32> @bar(ptr addrspace(10) %a) {
+; CHECK: %[[#bar_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#bar_a]]
 
   ; partial loading of a vector: v4 -> v2.
   %2 = load <2 x i32>, ptr addrspace(10) %1, align 16
@@ -72,13 +76,11 @@ define internal spir_func <2 x i32> @bar(ptr addrspace(10) %a) {
 }
 
 define internal spir_func i32 @baz(ptr addrspace(10) %a) {
+; CHECK: %[[#baz_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
-
-  ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr addrspace(10) %1, align 16
-; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_pp]] %[[#tmp]] %[[#uint_0]]
+; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_pp]] %[[#baz_a]] %[[#uint_0]]
 ; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
@@ -86,13 +88,11 @@ define internal spir_func i32 @baz(ptr addrspace(10) %a) {
 }
 
 define internal spir_func i32 @bazDefault(ptr %a) {
+; CHECK: %[[#bazD_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
-
-  ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr %1, align 16
-; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_fp]] %[[#tmp]] %[[#uint_0]]
+; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_fp]] %[[#bazD_a]] %[[#uint_0]]
 ; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
@@ -100,13 +100,11 @@ define internal spir_func i32 @bazDefault(ptr %a) {
 }
 
 define internal spir_func i32 @bazBounds(ptr %a) {
+; CHECK: %[[#bazB_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#tmp:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
-
-  ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr %1, align 16
-; CHECK: %[[#ptr:]]  = OpAccessChain %[[#uint_fp]] %[[#tmp]] %[[#uint_0]]
+; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_fp]] %[[#bazB_a]] %[[#uint_0]]
 ; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
@@ -114,9 +112,10 @@ define internal spir_func i32 @bazBounds(ptr %a) {
 }
 
 define internal spir_func void @foos(ptr addrspace(10) %a) {
+; CHECK: %[[#foos_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#foos_a]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr addrspace(10) %1, align 16
 ; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
@@ -132,9 +131,10 @@ define internal spir_func void @foos(ptr addrspace(10) %a) {
 }
 
 define internal spir_func void @foosDefault(ptr %a) {
+; CHECK: %[[#foosD_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
+; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#foosD_a]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr %1, align 16
 ; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
@@ -150,9 +150,10 @@ define internal spir_func void @foosDefault(ptr %a) {
 }
 
 define internal spir_func void @foosBounds(ptr %a) {
+; CHECK: %[[#foosB_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
+; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_fp]] %[[#foosB_a]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr %1, align 64
 ; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
@@ -168,9 +169,10 @@ define internal spir_func void @foosBounds(ptr %a) {
 }
 
 define internal spir_func void @bars(ptr addrspace(10) %a) {
+; CHECK: %[[#bars_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_pp]] %[[#]]
+; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_pp]] %[[#bars_a]]
 
   store <2 x i32> <i32 0, i32 1>, ptr addrspace(10) %1, align 16
 ; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
@@ -184,36 +186,33 @@ define internal spir_func void @bars(ptr addrspace(10) %a) {
 }
 
 define internal spir_func void @bazs(ptr addrspace(10) %a) {
+; CHECK: %[[#bazs_a:]] = OpFunctionParameter %[[#v4_pp]]
 
   %1 = getelementptr <4 x i32>, ptr addrspace(10) %a, i64 0
-; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_pp]] %[[#]]
-
   store i32 0, ptr addrspace(10) %1, align 32
-; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#ptr]] %[[#uint_0]]
+; CHECK: %[[#tmp:]] = OpAccessChain %[[#uint_pp]] %[[#bazs_a]] %[[#uint_0]]
 ; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
 
 define internal spir_func void @bazsDefault(ptr %a) {
+; CHECK: %[[#bazsD_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
-
   store i32 0, ptr %1, align 16
-; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_fp]] %[[#ptr]] %[[#uint_0]]
+; CHECK: %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_fp]] %[[#bazsD_a]] %[[#uint_0]]
 ; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
 
 define internal spir_func void @bazsBounds(ptr %a) {
+; CHECK: %[[#bazsB_a:]] = OpFunctionParameter %[[#v4_fp]]
 
   %1 = getelementptr <4 x i32>, ptr %a, i64 0
-; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
-
   store i32 0, ptr %1, align 16
-; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_fp]] %[[#ptr]] %[[#uint_0]]
+; CHECK: %[[#tmp:]] = OpAccessChain %[[#uint_fp]] %[[#bazsB_a]] %[[#uint_0]]
 ; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-array.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-array.ll
@@ -17,23 +17,22 @@
 ; CHECK-DAG:     %[[#arr_uint_5:]] = OpTypeArray %[[#uint]] %[[#uint_5]]
 ; CHECK-DAG: %[[#ptr_arr_uint_5:]] = OpTypePointer Function %[[#arr_uint_5]]
 ; CHECK-DAG:              %[[#S:]] = OpTypeStruct %[[#uint]] %[[#uint]]
-; CHECK-DAG:          %[[#ptr_S:]] = OpTypePointer Function %[[#S]]
 ; CHECK-DAG:        %[[#arr_S_5:]] = OpTypeArray %[[#S]] %[[#uint_5]]
 ; CHECK-DAG:    %[[#ptr_arr_S_5:]] = OpTypePointer Function %[[#arr_S_5]]
 ; CHECK-DAG:             %[[#S2:]] = OpTypeStruct %[[#uint]] %[[#S]] %[[#uint]]
-; CHECK-DAG:         %[[#ptr_S2:]] = OpTypePointer Function %[[#S2]]
 ; CHECK-DAG:       %[[#arr_S2_5:]] = OpTypeArray %[[#S2]] %[[#uint_5]]
 ; CHECK-DAG:   %[[#ptr_arr_S2_5:]] = OpTypePointer Function %[[#arr_S2_5]]
 
 define spir_func void @array_load_store(ptr %a) convergent {
 entry:
+; CHECK:	%[[#a1:]] = OpFunctionParameter {{%[0-9]+}}
   %0 = call token @llvm.experimental.convergence.entry()
   %tmp = alloca [5 x i32], align 4
 ; CHECK:	%[[#tmp:]] = OpVariable %[[#ptr_arr_uint_5]] Function
 
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x i32]) %a, i64 2)
   %2 = load i32, ptr %1, align 4
-; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_2]]
+; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#a1]] %[[#ulong_2]]
 ; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x i32]) %tmp, i64 3)
@@ -46,6 +45,7 @@ entry:
 
 define spir_func void @array_struct_load_store(ptr %a) convergent {
 entry:
+; CHECK:	%[[#a2:]] = OpFunctionParameter {{%[0-9]+}}
   %0 = call token @llvm.experimental.convergence.entry()
   %tmp = alloca [5 x %struct.S], align 4
 ; CHECK:	%[[#tmp:]] = OpVariable %[[#ptr_arr_S_5]] Function
@@ -53,15 +53,13 @@ entry:
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x %struct.S]) %a, i64 2)
   %2 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %1, i64 1)
   %3 = load i32, ptr %2, align 4
-; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#]] %[[#ulong_2]]
-; CHECK:	  %[[#B:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#A]] %[[#ulong_1]]
+; CHECK:	  %[[#B:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#a2]] %[[#ulong_2]] %[[#ulong_1]]
 ; CHECK:	  %[[#C:]] = OpLoad %[[#uint]] %[[#B]]
 
   %4 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S]) %tmp, i64 3)
   %5 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %4, i32 0)
   store i32 %3, ptr %5, align 4
-; CHECK:	  %[[#D:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#tmp]] %[[#ulong_3]]
-; CHECK:	  %[[#E:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#D]] %[[#uint_0]]
+; CHECK:	  %[[#E:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#tmp]] %[[#ulong_3]] %[[#uint_0]]
 ; CHECK:	             OpStore %[[#E]] %[[#C]]
 
   ret void
@@ -69,13 +67,14 @@ entry:
 
 define spir_func void @array_struct_load_store_combined(ptr %a) convergent {
 entry:
+; CHECK:	%[[#a3:]] = OpFunctionParameter {{%[0-9]+}}
   %0 = call token @llvm.experimental.convergence.entry()
   %tmp = alloca [5 x %struct.S], align 4
 ; CHECK:	%[[#tmp:]] = OpVariable %[[#ptr_arr_S_5]] Function
 
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x %struct.S]) %a, i64 2, i64 1)
   %2 = load i32, ptr %1, align 4
-; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_2]] %[[#ulong_1]]
+; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#a3]] %[[#ulong_2]] %[[#ulong_1]]
 ; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S]) %tmp, i64 3, i32 0)
@@ -88,6 +87,7 @@ entry:
 
 define spir_func void @array_nested_struct_load_store(ptr %a) convergent {
 entry:
+; CHECK:	%[[#a4:]] = OpFunctionParameter {{%[0-9]+}}
   %0 = call token @llvm.experimental.convergence.entry()
   %tmp = alloca [5 x %struct.S2], align 4
 ; CHECK:	%[[#tmp:]] = OpVariable %[[#ptr_arr_S2_5]] Function
@@ -96,18 +96,14 @@ entry:
   %2 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S2) %1, i64 1)
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %2, i64 0)
   %4 = load i32, ptr %3, align 4
-; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_S2]] %[[#]] %[[#ulong_1]]
-; CHECK:	  %[[#B:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#A]] %[[#ulong_1]]
-; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#B]] %[[#ulong_0]]
+; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#a4]] %[[#ulong_1]] %[[#ulong_1]] %[[#ulong_0]]
 ; CHECK:	  %[[#D:]] = OpLoad %[[#uint]] %[[#C]]
 
   %5 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S2]) %tmp, i64 3)
   %6 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S2) %5, i32 1)
   %7 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %6, i32 0)
   store i32 %4, ptr %7, align 4
-; CHECK:	  %[[#E:]] = OpInBoundsAccessChain %[[#ptr_S2]] %[[#tmp]] %[[#ulong_3]]
-; CHECK:	  %[[#F:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#E]] %[[#uint_1]]
-; CHECK:	  %[[#G:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#F]] %[[#uint_0]]
+; CHECK:	  %[[#G:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#tmp]] %[[#ulong_3]] %[[#uint_1]] %[[#uint_0]]
 ; CHECK:	             OpStore %[[#G]] %[[#D]]
 
   ret void
@@ -115,13 +111,14 @@ entry:
 
 define spir_func void @array_nested_struct_load_store_combined(ptr %a) convergent {
 entry:
+; CHECK:	%[[#a5:]] = OpFunctionParameter {{%[0-9]+}}
   %0 = call token @llvm.experimental.convergence.entry()
   %tmp = alloca [5 x %struct.S2], align 4
 ; CHECK:	%[[#tmp:]] = OpVariable %[[#ptr_arr_S2_5]] Function
 
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x %struct.S2]) %a, i64 1, i64 1, i64 0)
   %2 = load i32, ptr %1, align 4
-; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_1]] %[[#ulong_1]] %[[#ulong_0]]
+; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#a5]] %[[#ulong_1]] %[[#ulong_1]] %[[#ulong_0]]
 ; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S2]) %tmp, i64 3, i32 1, i32 0)

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-class.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-class.ll
@@ -9,7 +9,6 @@
 ; CHECK-DAG: %[[#Base:]] = OpTypeStruct %[[#int]]
 ; CHECK-DAG: %[[#Derived:]] = OpTypeStruct %[[#Base]] %[[#float]]
 ; CHECK-DAG: %[[#ptr_Derived:]] = OpTypePointer Function %[[#Derived]]
-; CHECK-DAG: %[[#ptr_Base:]] = OpTypePointer Function %[[#Base]]
 ; CHECK-DAG: %[[#ptr_int:]] = OpTypePointer Function %[[#int]]
 ; CHECK-DAG: %[[#idx_0:]] = OpConstant %[[#int]] 0
 
@@ -18,13 +17,9 @@ entry:
   %0 = call token @llvm.experimental.convergence.entry()
   ; CHECK: %[[#d_var:]] = OpFunctionParameter %[[#ptr_Derived]]
 
-  ; Access Base part
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%class.Derived) %d, i32 0)
-  ; CHECK: %[[#ptr_base:]] = OpInBoundsAccessChain %[[#ptr_Base]] %[[#d_var]] %[[#idx_0]]
-
-  ; Access field in Base
   %2 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%class.Base) %1, i32 0)
-  ; CHECK: %[[#ptr_field:]] = OpInBoundsAccessChain %[[#ptr_int]] %[[#ptr_base]] %[[#idx_0]]
+  ; CHECK: %[[#ptr_field:]] = OpInBoundsAccessChain %[[#ptr_int]] %[[#d_var]] %[[#idx_0]] %[[#idx_0]]
 
   store i32 42, ptr %2, align 4
   ; CHECK: OpStore %[[#ptr_field]]


### PR DESCRIPTION
Add a SPIRVPreLegalizerCombiner rule that fuses two consecutive spv_gep G_INTRINSICs (inner feeding outer) when the inner has a single use, all index operands are constant, and the outer's leading index is 0