### PR TITLE
[Clang][AArch64] Fix codegen for SVE vector compare operations

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2310,8 +2310,20 @@ bool Type::isSignedIntegerOrEnumerationType() const {
 bool Type::hasSignedIntegerRepresentation() const {
   if (const auto *VT = dyn_cast<VectorType>(CanonicalType))
     return VT->getElementType()->isSignedIntegerOrEnumerationType();
-  else
-    return isSignedIntegerOrEnumerationType();
+
+  if (const auto *BT = dyn_cast<BuiltinType>(CanonicalType)) {
+    switch (BT->getKind()) {
+#define SVE_VECTOR_TYPE_INT(Name, MangledName, Id, SingletonId, NumEls,        \
+                            ElBits, NF, IsSigned)                              \
+  case BuiltinType::Id:                                                        \
+    return IsSigned;
+#include "clang/Basic/AArch64ACLETypes.def"
+    default:
+      break;
+    }
+  }
+
+  return isSignedIntegerOrEnumerationType();
 }
 
 /// isUnsignedIntegerType - Return true if this is an integer type that is

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -5320,7 +5320,7 @@ Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,
 
     // If this is a vector comparison, sign extend the result to the appropriate
     // vector integer type and return it (don't convert to bool).
-    if (LHSTy->isVectorType())
+    if (LHSTy->isVectorType() || LHSTy->isSveVLSBuiltinType())
       return Builder.CreateSExt(Result, ConvertType(E->getType()), "sext");
 
   } else {

--- a/clang/test/CodeGen/AArch64/sve-vector-compare-ops.c
+++ b/clang/test/CodeGen/AArch64/sve-vector-compare-ops.c
@@ -21,8 +21,8 @@ svbool_t eq_bool(svbool_t a, svbool_t b) {
 // CHECK-LABEL: @eq_i8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t eq_i8(svint8_t a, svint8_t b) {
   return a == b;
@@ -31,8 +31,8 @@ svint8_t eq_i8(svint8_t a, svint8_t b) {
 // CHECK-LABEL: @eq_i16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t eq_i16(svint16_t a, svint16_t b) {
   return a == b;
@@ -41,8 +41,8 @@ svint16_t eq_i16(svint16_t a, svint16_t b) {
 // CHECK-LABEL: @eq_i32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t eq_i32(svint32_t a, svint32_t b) {
   return a == b;
@@ -51,8 +51,8 @@ svint32_t eq_i32(svint32_t a, svint32_t b) {
 // CHECK-LABEL: @eq_i64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t eq_i64(svint64_t a, svint64_t b) {
   return a == b;
@@ -61,8 +61,8 @@ svint64_t eq_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @eq_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t eq_u8(svuint8_t a, svuint8_t b) {
   return a == b;
@@ -71,8 +71,8 @@ svint8_t eq_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @eq_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t eq_u16(svuint16_t a, svuint16_t b) {
   return a == b;
@@ -81,8 +81,8 @@ svint16_t eq_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @eq_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t eq_u32(svuint32_t a, svuint32_t b) {
   return a == b;
@@ -91,8 +91,8 @@ svint32_t eq_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @eq_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp eq <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t eq_u64(svuint64_t a, svuint64_t b) {
   return a == b;
@@ -101,8 +101,8 @@ svint64_t eq_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @eq_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t eq_f16(svfloat16_t a, svfloat16_t b) {
   return a == b;
@@ -111,8 +111,8 @@ svint16_t eq_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @eq_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t eq_f32(svfloat32_t a, svfloat32_t b) {
   return a == b;
@@ -121,8 +121,8 @@ svint32_t eq_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @eq_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oeq <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t eq_f64(svfloat64_t a, svfloat64_t b) {
   return a == b;
@@ -142,8 +142,8 @@ svbool_t neq_bool(svbool_t a, svbool_t b) {
 // CHECK-LABEL: @neq_i8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t neq_i8(svint8_t a, svint8_t b) {
   return a != b;
@@ -152,8 +152,8 @@ svint8_t neq_i8(svint8_t a, svint8_t b) {
 // CHECK-LABEL: @neq_i16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t neq_i16(svint16_t a, svint16_t b) {
   return a != b;
@@ -162,8 +162,8 @@ svint16_t neq_i16(svint16_t a, svint16_t b) {
 // CHECK-LABEL: @neq_i32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t neq_i32(svint32_t a, svint32_t b) {
   return a != b;
@@ -172,8 +172,8 @@ svint32_t neq_i32(svint32_t a, svint32_t b) {
 // CHECK-LABEL: @neq_i64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t neq_i64(svint64_t a, svint64_t b) {
   return a != b;
@@ -182,8 +182,8 @@ svint64_t neq_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @neq_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t neq_u8(svuint8_t a, svuint8_t b) {
   return a != b;
@@ -192,8 +192,8 @@ svint8_t neq_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @neq_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t neq_u16(svuint16_t a, svuint16_t b) {
   return a != b;
@@ -202,8 +202,8 @@ svint16_t neq_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @neq_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t neq_u32(svuint32_t a, svuint32_t b) {
   return a != b;
@@ -212,8 +212,8 @@ svint32_t neq_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @neq_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ne <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t neq_u64(svuint64_t a, svuint64_t b) {
   return a != b;
@@ -222,8 +222,8 @@ svint64_t neq_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @neq_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp une <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t neq_f16(svfloat16_t a, svfloat16_t b) {
   return a != b;
@@ -232,8 +232,8 @@ svint16_t neq_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @neq_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp une <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t neq_f32(svfloat32_t a, svfloat32_t b) {
   return a != b;
@@ -242,8 +242,8 @@ svint32_t neq_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @neq_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp une <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t neq_f64(svfloat64_t a, svfloat64_t b) {
   return a != b;
@@ -262,9 +262,9 @@ svbool_t lt_bool(svbool_t a, svbool_t b) {
 
 // CHECK-LABEL: @lt_i8(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t lt_i8(svint8_t a, svint8_t b) {
   return a < b;
@@ -272,9 +272,9 @@ svint8_t lt_i8(svint8_t a, svint8_t b) {
 
 // CHECK-LABEL: @lt_i16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t lt_i16(svint16_t a, svint16_t b) {
   return a < b;
@@ -282,9 +282,9 @@ svint16_t lt_i16(svint16_t a, svint16_t b) {
 
 // CHECK-LABEL: @lt_i32(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t lt_i32(svint32_t a, svint32_t b) {
   return a < b;
@@ -292,9 +292,9 @@ svint32_t lt_i32(svint32_t a, svint32_t b) {
 
 // CHECK-LABEL: @lt_i64(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t lt_i64(svint64_t a, svint64_t b) {
   return a < b;
@@ -303,8 +303,8 @@ svint64_t lt_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @lt_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t lt_u8(svuint8_t a, svuint8_t b) {
   return a < b;
@@ -313,8 +313,8 @@ svint8_t lt_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @lt_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t lt_u16(svuint16_t a, svuint16_t b) {
   return a < b;
@@ -323,8 +323,8 @@ svint16_t lt_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @lt_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t lt_u32(svuint32_t a, svuint32_t b) {
   return a < b;
@@ -333,8 +333,8 @@ svint32_t lt_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @lt_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t lt_u64(svuint64_t a, svuint64_t b) {
   return a < b;
@@ -343,8 +343,8 @@ svint64_t lt_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @lt_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t lt_f16(svfloat16_t a, svfloat16_t b) {
   return a < b;
@@ -353,8 +353,8 @@ svint16_t lt_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @lt_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t lt_f32(svfloat32_t a, svfloat32_t b) {
   return a < b;
@@ -363,8 +363,8 @@ svint32_t lt_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @lt_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t lt_f64(svfloat64_t a, svfloat64_t b) {
   return a < b;
@@ -383,9 +383,9 @@ svbool_t leq_bool(svbool_t a, svbool_t b) {
 
 // CHECK-LABEL: @leq_i8(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sle <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t leq_i8(svint8_t a, svint8_t b) {
   return a <= b;
@@ -393,9 +393,9 @@ svint8_t leq_i8(svint8_t a, svint8_t b) {
 
 // CHECK-LABEL: @leq_i16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sle <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t leq_i16(svint16_t a, svint16_t b) {
   return a <= b;
@@ -403,9 +403,9 @@ svint16_t leq_i16(svint16_t a, svint16_t b) {
 
 // CHECK-LABEL: @leq_i32(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sle <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t leq_i32(svint32_t a, svint32_t b) {
   return a <= b;
@@ -413,9 +413,9 @@ svint32_t leq_i32(svint32_t a, svint32_t b) {
 
 // CHECK-LABEL: @leq_i64(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sle <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t leq_i64(svint64_t a, svint64_t b) {
   return a <= b;
@@ -424,8 +424,8 @@ svint64_t leq_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @leq_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t leq_u8(svuint8_t a, svuint8_t b) {
   return a <= b;
@@ -434,8 +434,8 @@ svint8_t leq_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @leq_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t leq_u16(svuint16_t a, svuint16_t b) {
   return a <= b;
@@ -444,8 +444,8 @@ svint16_t leq_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @leq_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t leq_u32(svuint32_t a, svuint32_t b) {
   return a <= b;
@@ -454,8 +454,8 @@ svint32_t leq_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @leq_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ule <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t leq_u64(svuint64_t a, svuint64_t b) {
   return a <= b;
@@ -464,8 +464,8 @@ svint64_t leq_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @leq_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ole <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t leq_f16(svfloat16_t a, svfloat16_t b) {
   return a <= b;
@@ -474,8 +474,8 @@ svint16_t leq_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @leq_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ole <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t leq_f32(svfloat32_t a, svfloat32_t b) {
   return a <= b;
@@ -484,8 +484,8 @@ svint32_t leq_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @leq_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ole <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t leq_f64(svfloat64_t a, svfloat64_t b) {
   return a <= b;
@@ -504,9 +504,9 @@ svbool_t gt_bool(svbool_t a, svbool_t b) {
 
 // CHECK-LABEL: @gt_i8(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t gt_i8(svint8_t a, svint8_t b) {
   return a > b;
@@ -514,9 +514,9 @@ svint8_t gt_i8(svint8_t a, svint8_t b) {
 
 // CHECK-LABEL: @gt_i16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t gt_i16(svint16_t a, svint16_t b) {
   return a > b;
@@ -524,9 +524,9 @@ svint16_t gt_i16(svint16_t a, svint16_t b) {
 
 // CHECK-LABEL: @gt_i32(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t gt_i32(svint32_t a, svint32_t b) {
   return a > b;
@@ -534,9 +534,9 @@ svint32_t gt_i32(svint32_t a, svint32_t b) {
 
 // CHECK-LABEL: @gt_i64(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t gt_i64(svint64_t a, svint64_t b) {
   return a > b;
@@ -545,8 +545,8 @@ svint64_t gt_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @gt_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t gt_u8(svuint8_t a, svuint8_t b) {
   return a > b;
@@ -555,8 +555,8 @@ svint8_t gt_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @gt_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t gt_u16(svuint16_t a, svuint16_t b) {
   return a > b;
@@ -565,8 +565,8 @@ svint16_t gt_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @gt_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t gt_u32(svuint32_t a, svuint32_t b) {
   return a > b;
@@ -575,8 +575,8 @@ svint32_t gt_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @gt_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t gt_u64(svuint64_t a, svuint64_t b) {
   return a > b;
@@ -585,8 +585,8 @@ svint64_t gt_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @gt_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t gt_f16(svfloat16_t a, svfloat16_t b) {
   return a > b;
@@ -595,8 +595,8 @@ svint16_t gt_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @gt_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t gt_f32(svfloat32_t a, svfloat32_t b) {
   return a > b;
@@ -605,8 +605,8 @@ svint32_t gt_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @gt_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp ogt <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t gt_f64(svfloat64_t a, svfloat64_t b) {
   return a > b;
@@ -625,9 +625,9 @@ svbool_t geq_bool(svbool_t a, svbool_t b) {
 
 // CHECK-LABEL: @geq_i8(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sge <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t geq_i8(svint8_t a, svint8_t b) {
   return a >= b;
@@ -635,9 +635,9 @@ svint8_t geq_i8(svint8_t a, svint8_t b) {
 
 // CHECK-LABEL: @geq_i16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sge <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t geq_i16(svint16_t a, svint16_t b) {
   return a >= b;
@@ -645,9 +645,9 @@ svint16_t geq_i16(svint16_t a, svint16_t b) {
 
 // CHECK-LABEL: @geq_i32(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sge <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t geq_i32(svint32_t a, svint32_t b) {
   return a >= b;
@@ -655,9 +655,9 @@ svint32_t geq_i32(svint32_t a, svint32_t b) {
 
 // CHECK-LABEL: @geq_i64(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp sge <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t geq_i64(svint64_t a, svint64_t b) {
   return a >= b;
@@ -666,8 +666,8 @@ svint64_t geq_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @geq_u8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    ret <vscale x 16 x i8> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    ret <vscale x 16 x i8> [[SEXT]]
 //
 svint8_t geq_u8(svuint8_t a, svuint8_t b) {
   return a >= b;
@@ -676,8 +676,8 @@ svint8_t geq_u8(svuint8_t a, svuint8_t b) {
 // CHECK-LABEL: @geq_u16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t geq_u16(svuint16_t a, svuint16_t b) {
   return a >= b;
@@ -686,8 +686,8 @@ svint16_t geq_u16(svuint16_t a, svuint16_t b) {
 // CHECK-LABEL: @geq_u32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t geq_u32(svuint32_t a, svuint32_t b) {
   return a >= b;
@@ -696,8 +696,8 @@ svint32_t geq_u32(svuint32_t a, svuint32_t b) {
 // CHECK-LABEL: @geq_u64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp uge <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t geq_u64(svuint64_t a, svuint64_t b) {
   return a >= b;
@@ -706,8 +706,8 @@ svint64_t geq_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @geq_f16(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oge <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    ret <vscale x 8 x i16> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    ret <vscale x 8 x i16> [[SEXT]]
 //
 svint16_t geq_f16(svfloat16_t a, svfloat16_t b) {
   return a >= b;
@@ -716,8 +716,8 @@ svint16_t geq_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @geq_f32(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oge <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    ret <vscale x 4 x i32> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    ret <vscale x 4 x i32> [[SEXT]]
 //
 svint32_t geq_f32(svfloat32_t a, svfloat32_t b) {
   return a >= b;
@@ -726,8 +726,8 @@ svint32_t geq_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @geq_f64(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp oge <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    ret <vscale x 2 x i64> [[CONV]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    ret <vscale x 2 x i64> [[SEXT]]
 //
 svint64_t geq_f64(svfloat64_t a, svfloat64_t b) {
   return a >= b;

--- a/clang/test/CodeGenCXX/aarch64-sve-vector-conditional-op.cpp
+++ b/clang/test/CodeGenCXX/aarch64-sve-vector-conditional-op.cpp
@@ -19,9 +19,9 @@ svbool_t cond_bool(svbool_t a, svbool_t b) {
 
 // CHECK-LABEL: @_Z7cond_i8u10__SVInt8_tS_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 16 x i8> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 16 x i8> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 16 x i1> [[VECTOR_COND]], <vscale x 16 x i8> [[A]], <vscale x 16 x i8> [[B]]
 // CHECK-NEXT:    ret <vscale x 16 x i8> [[VECTOR_SELECT]]
 //
@@ -32,8 +32,8 @@ svint8_t cond_i8(svint8_t a, svint8_t b) {
 // CHECK-LABEL: @_Z7cond_u8u11__SVUint8_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 16 x i8> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 16 x i8> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 16 x i8> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 16 x i1> [[VECTOR_COND]], <vscale x 16 x i8> [[A]], <vscale x 16 x i8> [[B]]
 // CHECK-NEXT:    ret <vscale x 16 x i8> [[VECTOR_SELECT]]
 //
@@ -43,9 +43,9 @@ svuint8_t cond_u8(svuint8_t a, svuint8_t b) {
 
 // CHECK-LABEL: @_Z8cond_i16u11__SVInt16_tS_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 8 x i1> [[VECTOR_COND]], <vscale x 8 x i16> [[A]], <vscale x 8 x i16> [[B]]
 // CHECK-NEXT:    ret <vscale x 8 x i16> [[VECTOR_SELECT]]
 //
@@ -56,8 +56,8 @@ svint16_t cond_i16(svint16_t a, svint16_t b) {
 // CHECK-LABEL: @_Z8cond_u16u12__SVUint16_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 8 x i16> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 8 x i1> [[VECTOR_COND]], <vscale x 8 x i16> [[A]], <vscale x 8 x i16> [[B]]
 // CHECK-NEXT:    ret <vscale x 8 x i16> [[VECTOR_SELECT]]
 //
@@ -67,9 +67,9 @@ svuint16_t cond_u16(svuint16_t a, svuint16_t b) {
 
 // CHECK-LABEL: @_Z8cond_i32u11__SVInt32_tS_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x i32> [[A]], <vscale x 4 x i32> [[B]]
 // CHECK-NEXT:    ret <vscale x 4 x i32> [[VECTOR_SELECT]]
 //
@@ -80,8 +80,8 @@ svint32_t cond_i32(svint32_t a, svint32_t b) {
 // CHECK-LABEL: @_Z8cond_u32u12__SVUint32_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x i32> [[A]], <vscale x 4 x i32> [[B]]
 // CHECK-NEXT:    ret <vscale x 4 x i32> [[VECTOR_SELECT]]
 //
@@ -91,9 +91,9 @@ svuint32_t cond_u32(svuint32_t a, svuint32_t b) {
 
 // CHECK-LABEL: @_Z8cond_i64u11__SVInt64_tS_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x i64> [[A]], <vscale x 2 x i64> [[B]]
 // CHECK-NEXT:    ret <vscale x 2 x i64> [[VECTOR_SELECT]]
 //
@@ -104,8 +104,8 @@ svint64_t cond_i64(svint64_t a, svint64_t b) {
 // CHECK-LABEL: @_Z8cond_u64u12__SVUint64_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x i64> [[A]], <vscale x 2 x i64> [[B]]
 // CHECK-NEXT:    ret <vscale x 2 x i64> [[VECTOR_SELECT]]
 //
@@ -116,8 +116,8 @@ svuint64_t cond_u64(svuint64_t a, svuint64_t b) {
 // CHECK-LABEL: @_Z8cond_f16u13__SVFloat16_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 8 x half> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 8 x i1> [[CMP]] to <vscale x 8 x i16>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 8 x i16> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 8 x i1> [[VECTOR_COND]], <vscale x 8 x half> [[A]], <vscale x 8 x half> [[B]]
 // CHECK-NEXT:    ret <vscale x 8 x half> [[VECTOR_SELECT]]
 //
@@ -128,8 +128,8 @@ svfloat16_t cond_f16(svfloat16_t a, svfloat16_t b) {
 // CHECK-LABEL: @_Z8cond_f32u13__SVFloat32_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 4 x float> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x float> [[A]], <vscale x 4 x float> [[B]]
 // CHECK-NEXT:    ret <vscale x 4 x float> [[VECTOR_SELECT]]
 //
@@ -140,8 +140,8 @@ svfloat32_t cond_f32(svfloat32_t a, svfloat32_t b) {
 // CHECK-LABEL: @_Z8cond_f64u13__SVFloat64_tS_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 2 x double> [[A:%.*]], [[B:%.*]]
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x double> [[A]], <vscale x 2 x double> [[B]]
 // CHECK-NEXT:    ret <vscale x 2 x double> [[VECTOR_SELECT]]
 //
@@ -151,9 +151,9 @@ svfloat64_t cond_f64(svfloat64_t a, svfloat64_t b) {
 
 // CHECK-LABEL: @_Z14cond_i32_splatu11__SVInt32_t(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], zeroinitializer
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 4 x i32> [[A:%.*]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x i32> [[A]], <vscale x 4 x i32> zeroinitializer
 // CHECK-NEXT:    ret <vscale x 4 x i32> [[VECTOR_SELECT]]
 //
@@ -164,8 +164,8 @@ svint32_t cond_i32_splat(svint32_t a) {
 // CHECK-LABEL: @_Z14cond_u32_splatu12__SVUint32_t(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 4 x i32> [[A:%.*]], splat (i32 1)
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x i32> [[A]], <vscale x 4 x i32> splat (i32 1)
 // CHECK-NEXT:    ret <vscale x 4 x i32> [[VECTOR_SELECT]]
 //
@@ -175,9 +175,9 @@ svuint32_t cond_u32_splat(svuint32_t a) {
 
 // CHECK-LABEL: @_Z14cond_i64_splatu11__SVInt64_t(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], zeroinitializer
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt <vscale x 2 x i64> [[A:%.*]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x i64> [[A]], <vscale x 2 x i64> zeroinitializer
 // CHECK-NEXT:    ret <vscale x 2 x i64> [[VECTOR_SELECT]]
 //
@@ -188,8 +188,8 @@ svint64_t cond_i64_splat(svint64_t a) {
 // CHECK-LABEL: @_Z14cond_u64_splatu12__SVUint64_t(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ult <vscale x 2 x i64> [[A:%.*]], splat (i64 1)
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x i64> [[A]], <vscale x 2 x i64> splat (i64 1)
 // CHECK-NEXT:    ret <vscale x 2 x i64> [[VECTOR_SELECT]]
 //
@@ -200,8 +200,8 @@ svuint64_t cond_u64_splat(svuint64_t a) {
 // CHECK-LABEL: @_Z14cond_f32_splatu13__SVFloat32_t(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 4 x float> [[A:%.*]], zeroinitializer
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 4 x i1> [[CMP]] to <vscale x 4 x i32>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 4 x i32> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 4 x i1> [[VECTOR_COND]], <vscale x 4 x float> [[A]], <vscale x 4 x float> zeroinitializer
 // CHECK-NEXT:    ret <vscale x 4 x float> [[VECTOR_SELECT]]
 //
@@ -212,8 +212,8 @@ svfloat32_t cond_f32_splat(svfloat32_t a) {
 // CHECK-LABEL: @_Z14cond_f64_splatu13__SVFloat64_t(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP:%.*]] = fcmp olt <vscale x 2 x double> [[A:%.*]], zeroinitializer
-// CHECK-NEXT:    [[CONV:%.*]] = zext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
-// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[CONV]], zeroinitializer
+// CHECK-NEXT:    [[SEXT:%.*]] = sext <vscale x 2 x i1> [[CMP]] to <vscale x 2 x i64>
+// CHECK-NEXT:    [[VECTOR_COND:%.*]] = icmp ne <vscale x 2 x i64> [[SEXT]], zeroinitializer
 // CHECK-NEXT:    [[VECTOR_SELECT:%.*]] = select <vscale x 2 x i1> [[VECTOR_COND]], <vscale x 2 x double> [[A]], <vscale x 2 x double> zeroinitializer
 // CHECK-NEXT:    ret <vscale x 2 x double> [[VECTOR_SELECT]]
 //


### PR DESCRIPTION
Overloaded operartors `<`, `>`, `<=`, `>=`, `==`, and `!=` with SVE integer vector operands emitted LLVM IR with a couple of issues:
  * The `icmp` instruction always performed unsigned comparison, even for signed operands.
  * The result of the comparison was zero-extended, whereas the intent is to follow established NEON conventions and sign-extend it.

This patches fixes these issues.
