### PR TITLE
[clang] Don't issue permission error during header search

### DIFF
--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -460,6 +460,7 @@ OptionalFileEntryRef HeaderSearch::getFileAndSuggestModule(
     std::error_code EC = llvm::errorToErrorCode(File.takeError());
     if (EC != llvm::errc::no_such_file_or_directory &&
         EC != llvm::errc::invalid_argument &&
+        EC != llvm::errc::permission_denied &&
         EC != llvm::errc::is_a_directory && EC != llvm::errc::not_a_directory) {
       Diags.Report(IncludeLoc, diag::err_cannot_open_file)
           << FileName << EC.message();

--- a/clang/test/Lexer/search-perm.c
+++ b/clang/test/Lexer/search-perm.c
@@ -1,0 +1,11 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: chmod -r %t/no-perm/header.h
+// RUN: %clang_cc1 -fsyntax-only -I %t/no-perm -I %t/include %t/tu.c
+
+//--- no-perm/header.h
+#error "no permission"
+//--- include/header.h
+//--- tu.c
+#if __has_include("header.h")
+#include "header.h"
+#endif


### PR DESCRIPTION
When searching for headers, a permission error is currently treated
differently from a no such file or directory error. The permission error
will trigger a `cannot open file` error and stop the search process.

Even more confusingly, if the search happens inside `__has_include`,
the cannot open file error is issued on the `__has_include` statement,
which should not try to open file.

Instead, just treat a permission_denied error as a regular file error
and resume the search process. This will also make __has_include check
to return false if the only file can be found has no permission to read.

rdar://175435878
