### PR TITLE
[mlir][linalg] Generalize 1D convolution/pooling vectorization

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -1891,38 +1891,7 @@ static LogicalResult reductionPreconditions(LinalgOp op) {
 
 static LogicalResult
 vectorizeDynamicConvOpPrecondition(linalg::LinalgOp conv,
-                                   bool flatten1DDepthwiseConv) {
-  if (flatten1DDepthwiseConv) {
-    LDBG() << "Vectorization of flattened convs with dynamic shapes is not "
-              "supported";
-    return failure();
-  }
-
-  // Dynamic shapes are supported only for 1D depthwise convolutions on the
-  // canonical NWC / WC layouts (i.e. the channel dim is already trailing on
-  // LHS/RES; no pre-transpose is needed). Non-canonical layouts (NCW/CW)
-  // reach the depthwise vectorizer through a pre-transpose that cannot
-  // carry a `vector.mask`, so they require fully-static shapes.
-  FailureOr<Conv1DConfig> maybeConfig = classifyAs1DConv(conv);
-  if (failed(maybeConfig) || !maybeConfig->isDepthwise) {
-    LDBG() << "Not a 1D depthwise conv; dynamic shapes are not supported";
-    return failure();
-  }
-
-  // Only the trailing dim (channel for canonical layouts) may be dynamic.
-  // This rejects non-canonical layouts with a dynamic channel in the middle
-  // as a byproduct, since the middle dim shows up in `drop_back(1)`.
-  Value lhs = conv.getDpsInputOperand(0)->get();
-  ArrayRef<int64_t> lhsShape = cast<ShapedType>(lhs.getType()).getShape();
-  auto shapeWithoutCh = lhsShape.drop_back(1);
-  if (ShapedType::isDynamicShape(shapeWithoutCh)) {
-    LDBG() << "Dynamically-shaped op vectorization precondition failed: only "
-              "the trailing (channel) dim can be dynamic";
-    return failure();
-  }
-
-  return success();
-}
+                                   bool flatten1DDepthwiseConv);
 
 static LogicalResult
 vectorizeDynamicLinalgOpPrecondition(linalg::LinalgOp op,
@@ -2401,6 +2370,41 @@ static LogicalResult vectorizeConvOpPrecondition(linalg::LinalgOp convOp) {
   } else {
     if (rhsRank != 1 && rhsRank != 2 && rhsRank != 3)
       return failure();
+  }
+
+  return success();
+}
+
+static LogicalResult
+vectorizeDynamicConvOpPrecondition(linalg::LinalgOp conv,
+                                   bool flatten1DDepthwiseConv) {
+  if (flatten1DDepthwiseConv) {
+    LDBG() << "Vectorization of flattened convs with dynamic shapes is not "
+              "supported";
+    return failure();
+  }
+
+  // Dynamic shapes are supported only for 1D depthwise convolutions on the
+  // canonical NWC / WC layouts (i.e. the channel dim is already trailing on
+  // LHS/RES; no pre-transpose is needed). Non-canonical layouts (NCW/CW)
+  // reach the depthwise vectorizer through a pre-transpose that cannot
+  // carry a `vector.mask`, so they require fully-static shapes.
+  FailureOr<Conv1DConfig> maybeConfig = classifyAs1DConv(conv);
+  if (failed(maybeConfig) || !maybeConfig->isDepthwise) {
+    LDBG() << "Not a 1D depthwise conv; dynamic shapes are not supported";
+    return failure();
+  }
+
+  // Only the trailing dim (channel for canonical layouts) may be dynamic.
+  // This rejects non-canonical layouts with a dynamic channel in the middle
+  // as a byproduct, since the middle dim shows up in `drop_back(1)`.
+  Value lhs = conv.getDpsInputOperand(0)->get();
+  ArrayRef<int64_t> lhsShape = cast<ShapedType>(lhs.getType()).getShape();
+  auto shapeWithoutCh = lhsShape.drop_back(1);
+  if (ShapedType::isDynamicShape(shapeWithoutCh)) {
+    LDBG() << "Dynamically-shaped op vectorization precondition failed: only "
+              "the trailing (channel) dim can be dynamic";
+    return failure();
   }
 
   return success();

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -1898,19 +1898,26 @@ vectorizeDynamicConvOpPrecondition(linalg::LinalgOp conv,
     return failure();
   }
 
-  if (!isaConvolutionOpOfType<linalg::DepthwiseConv1DNwcWcOp>(conv)) {
-    LDBG() << "Not a 1D depth-wise WC conv, dynamic shapes are not supported";
+  // Dynamic shapes are supported only for 1D depthwise convolutions on the
+  // canonical NWC / WC layouts (i.e. the channel dim is already trailing on
+  // LHS/RES; no pre-transpose is needed). Non-canonical layouts (NCW/CW)
+  // reach the depthwise vectorizer through a pre-transpose that cannot
+  // carry a `vector.mask`, so they require fully-static shapes.
+  FailureOr<Conv1DConfig> maybeConfig = classifyAs1DConv(conv);
+  if (failed(maybeConfig) || !maybeConfig->isDepthwise) {
+    LDBG() << "Not a 1D depthwise conv; dynamic shapes are not supported";
     return failure();
   }
 
-  // Support dynamic shapes in 1D depthwise convolution, but only in the
-  // _channel_ dimension.
+  // Only the trailing dim (channel for canonical layouts) may be dynamic.
+  // This rejects non-canonical layouts with a dynamic channel in the middle
+  // as a byproduct, since the middle dim shows up in `drop_back(1)`.
   Value lhs = conv.getDpsInputOperand(0)->get();
   ArrayRef<int64_t> lhsShape = cast<ShapedType>(lhs.getType()).getShape();
   auto shapeWithoutCh = lhsShape.drop_back(1);
   if (ShapedType::isDynamicShape(shapeWithoutCh)) {
     LDBG() << "Dynamically-shaped op vectorization precondition failed: only "
-              "channel dim can be dynamic";
+              "the trailing (channel) dim can be dynamic";
     return failure();
   }
 
@@ -3718,127 +3725,122 @@ public:
         ->getResult(0);
   }
 
-  /// Generate a vector implementation for:
-  /// ```
-  ///   Op def: (     n,     w,     c,    kw)
-  ///    Iters: ({Par(), Par(), Par(), Red()})
-  ///   Layout: {{n, strideW * w + dilationW * kw, c}, {kw, c}, {n, w, c}}
-  /// ```
+  /// Unified depthwise 1D convolution vectorizer.
+  ///
+  /// Handles all classified depthwise layouts:
+  ///   * canonical batched     <N, W, C> / <Kw, C> / <N, W, C>
+  ///   * non-canonical batched (e.g. NCW_CW)
+  ///   * canonical batchless   <W, C> / <Kw, C> / <W, C>
+  ///   * non-canonical batchless (e.g. CW/CW)
+  ///
+  /// Pipeline (with steps 2, 3, and 6 skipped when not required by the
+  /// layout):
+  ///   1. Read operands in their tensor-native layout (optionally masked).
+  ///   2. `vector.transpose` each operand to canonical NWC (if
+  ///      `perms` is non-identity).
+  ///   3. `vector.shape_cast` lhs/res to a unit leading dim (if the layout
+  ///      is batchless), so the kernel always sees 3D NWC vectors.
+  ///   4. Run `depthwise1DKernel`.
+  ///   5. Inverse-`shape_cast` / inverse-`transpose` the result.
+  ///   6. `vector.transfer_write` (optionally masked) back into the result.
+  ///
+  /// Masking and scalable vectors require the channel dim to be the trailing
+  /// vector dim of the read/write, which rules out layouts that need a
+  /// `vector.transpose` to reach canonical NWC (e.g. NCW). Batchless
+  /// canonical layouts (e.g. WC) already have the channel trailing, and the
+  /// unit-N `vector.shape_cast` wrapping the kernel preserves the
+  /// scalable-dim count, so they are supported. Layouts that need a
+  /// pre-transpose require fully-static shapes.
+  ///
   /// kw is always unrolled.
   /// TODO: w (resp. kw) is unrolled when the strideW ( resp. dilationW) is
   /// > 1.
   FailureOr<Operation *> depthwiseConv(uint64_t channelDimVecSize,
                                        bool channelDimScalableFlag,
                                        bool flatten) {
-    bool scalableChDim = false;
-    bool useMasking = false;
-    int64_t nSize, wSize, cSize, kwSize;
-    // kernel{kw, c}
-    bindShapeDims(rhsShapedType, kwSize, cSize);
-    if (ShapedType::isDynamic(cSize)) {
+    LinalgOp linalgOp = cast<LinalgOp>(op);
+    Conv1DPerms perms = computeCanonicalPerms(linalgOp, config);
+    const bool hasPerms = !perms.allIdentity();
+    const bool isBatchless = config.layout == ConvLayoutKind::Batchless;
+
+    // Decide on masking / scalable up-front so we can gate the other
+    // preconditions on the canonical-batched-layout invariant.
+    const bool useMasking =
+        ShapedType::isDynamic(rhsShapedType.getShape().back());
+    // Scalable vectors require both a dynamic channel dim and the caller-
+    // supplied scalable flag.
+    const bool scalableChDim = useMasking && channelDimScalableFlag;
+    if (useMasking) {
       assert(channelDimVecSize != 0 && "Channel dim vec size must be > 0");
-      cSize = channelDimVecSize;
-      // Scalable vectors are only used when both conditions are met:
-      //  1. channel dim is dynamic
-      //  2. channelDimScalableFlag is set
-      scalableChDim = channelDimScalableFlag;
-      useMasking = true;
+      assert(!flatten && "Unsupported flattened conv with dynamic shapes");
     }
 
-    assert(!(useMasking && flatten) &&
-           "Unsupported flattened conv with dynamic shapes");
+    // Masking / scalable put the scalable flag on the trailing vector dim, so
+    // they only apply when the channel is already trailing (canonical
+    // batched NWC or batchless canonical WC). Layouts that need a
+    // pre-transpose put a different dim in the trailing position, breaking
+    // that assumption.
+    if (useMasking && hasPerms)
+      return rewriter.notifyMatchFailure(
+          op, "masking/scalable depthwise conv requires the channel dim to "
+              "be the trailing vector dim (no pre-transpose)");
 
-    // out{n, w, c}
-    bindShapeDims(resShapedType, nSize, wSize);
+    // Pre-transpose layouts build their vector types from the static tensor
+    // shape.
+    if (hasPerms &&
+        (!lhsShapedType.hasStaticShape() || !rhsShapedType.hasStaticShape() ||
+         !resShapedType.hasStaticShape()))
+      return rewriter.notifyMatchFailure(
+          op, "depthwise conv with a pre-transpose requires static shapes");
 
+    // Canonical loop sizes. For the masked path `sizes.c` is dynamic (`?`);
+    // override with the caller-supplied vector size.
+    Conv1DSizes sizes = computeConvSizes(linalgOp);
+    if (useMasking)
+      sizes.c = channelDimVecSize;
+    Conv1DShapes canon = computeCanonicalShapes(sizes);
+    Conv1DShapes read = computeReadShapes(canon, perms);
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
 
-    // w is unrolled (i.e. wSizeStep == 1) iff strideW > 1.
-    // When strideW == 1, we can batch the contiguous loads and avoid
-    // unrolling
-    int64_t wSizeStep = strideW == 1 ? wSize : 1;
+    // Step 1: read each operand in its tensor-native layout, optionally
+    // wrapped in a channel-dim `vector.mask` on the canonical batched path.
+    Value lhsVec = readOperand(lhsShaped, lhsShapedType, read.lhs, zero,
+                               scalableChDim, useMasking);
+    Value rhsVec = readOperand(rhsShaped, rhsShapedType, read.rhs, zero,
+                               scalableChDim, useMasking);
+    Value resVec = readOperand(resShaped, resShapedType, read.res, zero,
+                               scalableChDim, useMasking);
 
-    Type lhsEltType = lhsShapedType.getElementType();
-    Type rhsEltType = rhsShapedType.getElementType();
-    Type resEltType = resShapedType.getElementType();
-    VectorType lhsType = VectorType::get(
-        {nSize,
-         // iw = ow * sw + kw *  dw - 1
-         //   (i.e. 16 convolved with 3 (@stride 1 dilation 1) -> 14)
-         ((wSize - 1) * strideW + 1) + ((kwSize - 1) * dilationW + 1) - 1,
-         cSize},
-        lhsEltType, /*scalableDims=*/{false, false, scalableChDim});
-    VectorType rhsType =
-        VectorType::get({kwSize, cSize}, rhsEltType,
-                        /*scalableDims=*/{false, scalableChDim});
-    VectorType resType =
-        VectorType::get({nSize, wSize, cSize}, resEltType,
-                        /*scalableDims=*/{false, false, scalableChDim});
+    // Step 2: pre-transpose to canonical NWC / <Kw, C> / NWC form. No-op on
+    // identity perms.
+    lhsVec = transposeToCanonical(lhsVec, perms.lhs);
+    rhsVec = transposeToCanonical(rhsVec, perms.rhs);
+    resVec = transposeToCanonical(resVec, perms.res);
 
-    // Masks the input xfer Op along the channel dim, iff the corresponding
-    // scalable flag is set.
-    auto maybeMaskXferOp = [&](ArrayRef<int64_t> maskShape,
-                               ArrayRef<bool> scalableDims,
-                               Operation *opToMask) {
-      if (!useMasking)
-        return opToMask;
-      auto maskType =
-          VectorType::get(maskShape, rewriter.getI1Type(), scalableDims);
-
-      SmallVector<bool> inBounds(maskShape.size(), true);
-      auto xferOp = cast<VectorTransferOpInterface>(opToMask);
-      xferOp->setAttr(xferOp.getInBoundsAttrName(),
-                      rewriter.getBoolArrayAttr(inBounds));
-
-      SmallVector<OpFoldResult> mixedDims = vector::getMixedSizesXfer(
-          cast<LinalgOp>(op).hasPureTensorSemantics(), opToMask, rewriter);
-
-      Value maskOp =
-          vector::CreateMaskOp::create(rewriter, loc, maskType, mixedDims);
-
-      return mlir::vector::maskOperation(rewriter, opToMask, maskOp);
-    };
-
-    // Read lhs slice of size {n, w * strideW + kw * dilationW, c} @ [0, 0,
-    // 0].
-    Value lhs = vector::TransferReadOp::create(
-        rewriter, loc, lhsType, lhsShaped, ValueRange{zero, zero, zero},
-        /*padding=*/arith::getZeroConstant(rewriter, loc, lhsEltType));
-    auto *maybeMaskedLhs = maybeMaskXferOp(
-        lhsType.getShape(), lhsType.getScalableDims(), lhs.getDefiningOp());
-
-    // Read rhs slice of size {kw, c} @ [0, 0].
-    Value rhs = vector::TransferReadOp::create(
-        rewriter, loc, rhsType, rhsShaped, ValueRange{zero, zero},
-        /*padding=*/arith::getZeroConstant(rewriter, loc, rhsEltType));
-    auto *maybeMaskedRhs = maybeMaskXferOp(
-        rhsType.getShape(), rhsType.getScalableDims(), rhs.getDefiningOp());
-
-    // Read res slice of size {n, w, c} @ [0, 0, 0].
-    Value res = vector::TransferReadOp::create(
-        rewriter, loc, resType, resShaped, ValueRange{zero, zero, zero},
-        /*padding=*/arith::getZeroConstant(rewriter, loc, resEltType));
-    auto *maybeMaskedRes = maybeMaskXferOp(
-        resType.getShape(), resType.getScalableDims(), res.getDefiningOp());
-
-    FailureOr<Value> kernelRes = depthwise1DKernel(
-        maybeMaskedLhs->getResult(0), maybeMaskedRhs->getResult(0),
-        maybeMaskedRes->getResult(0), nSize, wSize, cSize, kwSize, wSizeStep,
-        flatten);
-    if (failed(kernelRes)) {
-      // Best-effort: erase the original transfer_reads we created above.
-      // (Mask wrapper ops, if any, will be handled by the failed-pattern
-      // rollback in the parent rewrite driver.)
-      for (Value v : {res, rhs, lhs, zero})
-        if (v)
-          rewriter.eraseOp(v.getDefiningOp());
-      return failure();
+    // Step 3: batchless layouts shape-cast a unit leading dim so operands
+    // satisfy the kernel's 3D-vector contract.
+    if (isBatchless) {
+      lhsVec = expandUnitLeadingDim(lhsVec);
+      resVec = expandUnitLeadingDim(resVec);
     }
 
-    Operation *resOut = vector::TransferWriteOp::create(
-        rewriter, loc, *kernelRes, resShaped, ValueRange{zero, zero, zero});
-    return maybeMaskXferOp(resType.getShape(), resType.getScalableDims(),
-                           resOut);
+    // Step 4: core depthwise compute on canonical 3D NWC vectors.
+    int64_t leadingN = isBatchless ? 1 : sizes.n;
+    int64_t wSizeStep = strideW == 1 ? sizes.w : 1;
+    FailureOr<Value> kernelRes =
+        depthwise1DKernel(lhsVec, rhsVec, resVec, leadingN, sizes.w, sizes.c,
+                          sizes.kw, wSizeStep, flatten);
+    if (failed(kernelRes))
+      return failure();
+
+    // Step 5: inverse shape_cast to drop the unit leading dim for batchless.
+    Value out = *kernelRes;
+    if (isBatchless)
+      out = collapseUnitLeadingDim(out);
+
+    // Step 6: inverse-transpose and write back (optionally masked).
+    return writeAndPostTranspose(out, read.res, perms.res, scalableChDim,
+                                 useMasking);
   }
 
   /// Vector-level depthwise compute kernel: extracts kw x w tiles from the
@@ -3852,7 +3854,7 @@ public:
   ///   - `nSize` equals `lhs.getShape()[0]` and `res.getShape()[0]`.
   /// Callers whose operand layout does not have a batch dim (batchless) must
   /// `vector.shape_cast` to unit `N = 1` before invoking the kernel and
-  /// collapse the result back afterwards (see `depthwiseConvViaTranspose`).
+  /// collapse the result back afterwards (see `depthwiseConv`).
   ///
   /// On MulAcc failure the kernel erases only the IR it created; the caller
   /// is responsible for cleaning up its own pre-kernel IR.
@@ -3951,83 +3953,6 @@ public:
     return out;
   }
 
-  /// Depthwise convolution for layouts not handled by the masked/scalable
-  /// `depthwiseConv()` path: read the operands in their original layout,
-  /// transpose the loaded vectors to canonical NWC, run the kernel, then
-  /// inverse-transpose the result and write it back. Also handles the
-  /// batchless canonical case (no transposes, but the kernel's 3D contract
-  /// still requires a unit-N shape_cast around the call). Static shapes only
-  /// (no masking, no scalable vectors).
-  FailureOr<Operation *> depthwiseConvViaTranspose(const Conv1DPerms &perms,
-                                                   bool flatten) {
-    LinalgOp linalgOp = cast<LinalgOp>(op);
-    Conv1DSizes sizes = computeConvSizes(linalgOp);
-    Conv1DShapes canon = computeCanonicalShapes(sizes);
-    Conv1DShapes read = computeReadShapes(canon, perms);
-
-    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-    Type lhsEltType = lhsShapedType.getElementType();
-    Type rhsEltType = rhsShapedType.getElementType();
-    Type resEltType = resShapedType.getElementType();
-    SmallVector<Value> lhsIdx(read.lhs.size(), zero);
-    SmallVector<Value> rhsIdx(read.rhs.size(), zero);
-    SmallVector<Value> resIdx(read.res.size(), zero);
-
-    Value lhs = vector::TransferReadOp::create(
-        rewriter, loc, VectorType::get(read.lhs, lhsEltType), lhsShaped, lhsIdx,
-        arith::getZeroConstant(rewriter, loc, lhsEltType));
-    Value rhs = vector::TransferReadOp::create(
-        rewriter, loc, VectorType::get(read.rhs, rhsEltType), rhsShaped, rhsIdx,
-        arith::getZeroConstant(rewriter, loc, rhsEltType));
-    Value res = vector::TransferReadOp::create(
-        rewriter, loc, VectorType::get(read.res, resEltType), resShaped, resIdx,
-        arith::getZeroConstant(rewriter, loc, resEltType));
-
-    if (!perms.lhs.empty())
-      lhs = vector::TransposeOp::create(rewriter, loc, lhs, perms.lhs);
-    if (!perms.rhs.empty())
-      rhs = vector::TransposeOp::create(rewriter, loc, rhs, perms.rhs);
-    if (!perms.res.empty())
-      res = vector::TransposeOp::create(rewriter, loc, res, perms.res);
-
-    bool batchless = config.layout == ConvLayoutKind::Batchless;
-    auto expandLeading = [&](Value v) -> Value {
-      auto vTy = cast<VectorType>(v.getType());
-      SmallVector<int64_t> shape3D = {1};
-      llvm::append_range(shape3D, vTy.getShape());
-      return vector::ShapeCastOp::create(
-          rewriter, loc, VectorType::get(shape3D, vTy.getElementType()), v);
-    };
-    auto collapseLeading = [&](Value v) -> Value {
-      auto vTy = cast<VectorType>(v.getType());
-      assert(vTy.getShape().front() == 1 &&
-             "expected unit leading dim to collapse");
-      SmallVector<int64_t> shape2D(vTy.getShape().begin() + 1,
-                                   vTy.getShape().end());
-      return vector::ShapeCastOp::create(
-          rewriter, loc, VectorType::get(shape2D, vTy.getElementType()), v);
-    };
-
-    if (batchless) {
-      lhs = expandLeading(lhs);
-      res = expandLeading(res);
-    }
-
-    int64_t leadingN = batchless ? 1 : sizes.n;
-    int64_t wSizeStep = strideW == 1 ? sizes.w : 1;
-    FailureOr<Value> kernelRes =
-        depthwise1DKernel(lhs, rhs, res, leadingN, sizes.w, sizes.c, sizes.kw,
-                          wSizeStep, flatten);
-    if (failed(kernelRes))
-      return failure();
-
-    Value kernelVec = *kernelRes;
-    if (batchless)
-      kernelVec = collapseLeading(kernelVec);
-
-    return writeAndPostTranspose(kernelVec, read.res, perms.res);
-  }
-
   /// Lower:
   ///   *  lhs{n, w, c} * rhs{c} -> res{n, w, c} (flatten = false)
   ///   *  lhs{n, w * c} * rhs{c} -> res{n, w * c} (flatten = true)
@@ -4099,52 +4024,25 @@ public:
   // generate() pipeline helpers
   //===--------------------------------------------------------------------===//
 
-  /// Handle depthwise convolution. For canonical (NWC) layout, delegate to
-  /// the existing depthwiseConv() which supports masking/scalable channel
-  /// dim. For non-canonical layouts (e.g. NcwCw), pre-transpose at the
-  /// vector boundaries and run the canonical kernel; this path requires
-  /// fully-static shapes (no masking).
+  /// Entry point for depthwise convolution. Extracts the channel-dim
+  /// vector-size hint (only meaningful on the masked canonical path) from
+  /// the caller-supplied vector sizes and hands off to the unified
+  /// `depthwiseConv`.
   FailureOr<Operation *> handleDepthwise(ArrayRef<int64_t> inputVecSizes,
                                          ArrayRef<bool> inputScalableVecDims,
                                          bool flatten1DDepthwiseConv) {
-    LinalgOp linalgOp = cast<LinalgOp>(op);
-    Conv1DPerms perms = computeCanonicalPerms(linalgOp, config);
-
-    // The masked/scalable path (`depthwiseConv()`) builds 3D <N, W, C> vector
-    // types directly from the op's loop ranges and assumes the operand
-    // vectors are already in canonical NWC with a real batch dim. It is thus
-    // only valid when the layout is Batched *and* the tensor dims already
-    // appear in canonical order (identity permutations). All other cases
-    // (non-canonical batched, batchless canonical, batchless non-canonical)
-    // go through `depthwiseConvViaTranspose`, which performs any needed
-    // canonicalization via `vector.transpose` and handles batchless layouts
-    // by shape-casting to a unit leading dim around the kernel.
-    bool canUseMaskedPath =
-        perms.allIdentity() && config.layout == ConvLayoutKind::Batched;
-
-    if (canUseMaskedPath) {
-      int64_t vecChDimSize = 0;
-      bool vecChScalableFlag = false;
-      if (!inputVecSizes.empty()) {
-        DenseMap<unsigned, unsigned> loopToRes =
-            buildLoopToTensorDimMap(linalgOp.getIndexingMapsArray()[2]);
-        unsigned chTensorDim = loopToRes[dims().depth[0]];
-        vecChDimSize = inputVecSizes[chTensorDim];
-        vecChScalableFlag = inputScalableVecDims[chTensorDim];
-      }
-      return depthwiseConv(vecChDimSize, vecChScalableFlag,
-                           flatten1DDepthwiseConv);
+    int64_t vecChDimSize = 0;
+    bool vecChScalableFlag = false;
+    if (!inputVecSizes.empty()) {
+      LinalgOp linalgOp = cast<LinalgOp>(op);
+      DenseMap<unsigned, unsigned> loopToRes =
+          buildLoopToTensorDimMap(linalgOp.getIndexingMapsArray()[2]);
+      unsigned chTensorDim = loopToRes[dims().depth[0]];
+      vecChDimSize = inputVecSizes[chTensorDim];
+      vecChScalableFlag = inputScalableVecDims[chTensorDim];
     }
-
-    // `depthwiseConvViaTranspose` builds vector types from the static tensor
-    // shapes; dynamic operands would require threading masks through the
-    // transposes/shape_casts which is not yet implemented.
-    if (!lhsShapedType.hasStaticShape() || !rhsShapedType.hasStaticShape() ||
-        !resShapedType.hasStaticShape())
-      return rewriter.notifyMatchFailure(
-          op, "depthwise conv outside the canonical batched NWC layout "
-              "requires static shapes");
-    return depthwiseConvViaTranspose(perms, flatten1DDepthwiseConv);
+    return depthwiseConv(vecChDimSize, vecChScalableFlag,
+                         flatten1DDepthwiseConv);
   }
 
   /// Extract canonical loop sizes from ConvolutionDimensions.
@@ -4232,41 +4130,106 @@ public:
                         inverseApply(canonical.res, perms.res)};
   }
 
+  /// Wrap `opToMask` (a `vector.transfer_read` or `vector.transfer_write`)
+  /// in a `vector.mask` against a channel-dim mask; no-op when `useMask` is
+  /// false. `useMask` is only meaningful on layouts where the channel dim
+  /// is the trailing vector dim (canonical batched NWC).
+  Operation *maybeMaskXferOp(ArrayRef<int64_t> maskShape,
+                             ArrayRef<bool> scalableDims, Operation *opToMask,
+                             bool useMask) {
+    if (!useMask)
+      return opToMask;
+    auto maskType =
+        VectorType::get(maskShape, rewriter.getI1Type(), scalableDims);
+    SmallVector<bool> inBounds(maskShape.size(), true);
+    auto xferOp = cast<VectorTransferOpInterface>(opToMask);
+    xferOp->setAttr(xferOp.getInBoundsAttrName(),
+                    rewriter.getBoolArrayAttr(inBounds));
+    SmallVector<OpFoldResult> mixedDims = vector::getMixedSizesXfer(
+        cast<LinalgOp>(op).hasPureTensorSemantics(), opToMask, rewriter);
+    Value maskOp =
+        vector::CreateMaskOp::create(rewriter, loc, maskType, mixedDims);
+    return mlir::vector::maskOperation(rewriter, opToMask, maskOp);
+  }
+
+  /// Read a single operand in its tensor-native layout, optionally wrapping
+  /// the `transfer_read` in a channel-dim `vector.mask`.
+  ///
+  /// `scalableTrailing` marks the trailing vector dim as scalable (only
+  /// valid with `useMask`, and only on the canonical batched layout).
+  /// `indexZero` is shared across all operands by the caller so
+  /// `transfer_read` indices fold to the same SSA value without relying
+  /// on a CSE pass.
+  Value readOperand(Value shaped, ShapedType shapedType,
+                    ArrayRef<int64_t> readShape, Value indexZero,
+                    bool scalableTrailing = false, bool useMask = false) {
+    Type eltType = shapedType.getElementType();
+    SmallVector<bool> scalableDims(readShape.size(), false);
+    if (scalableTrailing)
+      scalableDims.back() = true;
+    auto vecType = VectorType::get(readShape, eltType, scalableDims);
+    SmallVector<Value> indices(readShape.size(), indexZero);
+    auto read = vector::TransferReadOp::create(
+        rewriter, loc, vecType, shaped, indices,
+        arith::getZeroConstant(rewriter, loc, eltType));
+    Operation *maybeMasked =
+        maybeMaskXferOp(readShape, scalableDims, read.getOperation(), useMask);
+    return maybeMasked->getResult(0);
+  }
+
+  /// `vector.transpose` to canonical NWC form; no-op on identity `perm`.
+  Value transposeToCanonical(Value v, ArrayRef<int64_t> perm) {
+    if (perm.empty())
+      return v;
+    return vector::TransposeOp::create(rewriter, loc, v, perm);
+  }
+
+  /// Insert a unit leading dim via `vector.shape_cast` so batchless
+  /// operand vectors satisfy the 3D `depthwise1DKernel` contract. The
+  /// leading dim is non-scalable; trailing scalable flags are preserved.
+  Value expandUnitLeadingDim(Value v) {
+    auto vTy = cast<VectorType>(v.getType());
+    SmallVector<int64_t> shape = {1};
+    llvm::append_range(shape, vTy.getShape());
+    SmallVector<bool> scalable = {false};
+    llvm::append_range(scalable, vTy.getScalableDims());
+    return vector::ShapeCastOp::create(
+        rewriter, loc, VectorType::get(shape, vTy.getElementType(), scalable),
+        v);
+  }
+
+  /// Inverse of `expandUnitLeadingDim` for the kernel result. The leading
+  /// dim (which must be a non-scalable unit) is dropped; trailing scalable
+  /// flags are preserved.
+  Value collapseUnitLeadingDim(Value v) {
+    auto vTy = cast<VectorType>(v.getType());
+    assert(vTy.getShape().front() == 1 &&
+           "collapseUnitLeadingDim: expected unit leading dim");
+    assert(!vTy.getScalableDims().front() &&
+           "collapseUnitLeadingDim: leading dim must be non-scalable");
+    SmallVector<int64_t> shape(vTy.getShape().begin() + 1,
+                               vTy.getShape().end());
+    SmallVector<bool> scalable(vTy.getScalableDims().begin() + 1,
+                               vTy.getScalableDims().end());
+    return vector::ShapeCastOp::create(
+        rewriter, loc, VectorType::get(shape, vTy.getElementType(), scalable),
+        v);
+  }
+
   /// Read operand tensors and pre-transpose to canonical NWC form. `rhs` is
   /// nullptr for pooling.
   Conv1DOperandVecs readAndTranspose(const Conv1DShapes &readShapes,
                                      const Conv1DPerms &perms) {
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-    Type lhsEltType = lhsShapedType.getElementType();
-    Type rhsEltType = rhsShapedType.getElementType();
-    Type resEltType = resShapedType.getElementType();
-
-    SmallVector<Value> lhsIndices(readShapes.lhs.size(), zero);
-    SmallVector<Value> rhsIndices(readShapes.rhs.size(), zero);
-    SmallVector<Value> resIndices(readShapes.res.size(), zero);
-
     Conv1DOperandVecs vecs;
-    vecs.lhs = vector::TransferReadOp::create(
-        rewriter, loc, VectorType::get(readShapes.lhs, lhsEltType), lhsShaped,
-        lhsIndices, arith::getZeroConstant(rewriter, loc, lhsEltType));
+    vecs.lhs = readOperand(lhsShaped, lhsShapedType, readShapes.lhs, zero);
     if (convKind() == ConvOperationKind::Conv)
-      vecs.rhs = vector::TransferReadOp::create(
-          rewriter, loc, VectorType::get(readShapes.rhs, rhsEltType), rhsShaped,
-          rhsIndices, arith::getZeroConstant(rewriter, loc, rhsEltType));
-    vecs.res = vector::TransferReadOp::create(
-        rewriter, loc, VectorType::get(readShapes.res, resEltType), resShaped,
-        resIndices, arith::getZeroConstant(rewriter, loc, resEltType));
-
-    if (!perms.lhs.empty())
-      vecs.lhs =
-          vector::TransposeOp::create(rewriter, loc, vecs.lhs, perms.lhs);
-    if (!perms.rhs.empty() && vecs.rhs)
-      vecs.rhs =
-          vector::TransposeOp::create(rewriter, loc, vecs.rhs, perms.rhs);
-    if (!perms.res.empty())
-      vecs.res =
-          vector::TransposeOp::create(rewriter, loc, vecs.res, perms.res);
-
+      vecs.rhs = readOperand(rhsShaped, rhsShapedType, readShapes.rhs, zero);
+    vecs.res = readOperand(resShaped, resShapedType, readShapes.res, zero);
+    vecs.lhs = transposeToCanonical(vecs.lhs, perms.lhs);
+    if (vecs.rhs)
+      vecs.rhs = transposeToCanonical(vecs.rhs, perms.rhs);
+    vecs.res = transposeToCanonical(vecs.res, perms.res);
     return vecs;
   }
 
@@ -4318,19 +4281,25 @@ public:
                                   resVals, config.layout);
   }
 
-  /// Post-transpose the result back to the original layout and write it.
+  /// Post-transpose the result back to the original layout and write it,
+  /// optionally wrapping the `transfer_write` in a channel-dim `vector.mask`.
   FailureOr<Operation *> writeAndPostTranspose(Value res,
                                                ArrayRef<int64_t> writeShape,
-                                               ArrayRef<int64_t> resPerm) {
+                                               ArrayRef<int64_t> resPerm,
+                                               bool scalableTrailing = false,
+                                               bool useMask = false) {
     if (!resPerm.empty()) {
       SmallVector<int64_t> invResPerm = invertPermutationVector(resPerm);
       res = vector::TransposeOp::create(rewriter, loc, res, invResPerm);
     }
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> resIndices(writeShape.size(), zero);
-    return vector::TransferWriteOp::create(rewriter, loc, res, resShaped,
-                                           resIndices)
-        .getOperation();
+    Operation *write = vector::TransferWriteOp::create(rewriter, loc, res,
+                                                       resShaped, resIndices);
+    SmallVector<bool> scalableDims(writeShape.size(), false);
+    if (scalableTrailing)
+      scalableDims.back() = true;
+    return maybeMaskXferOp(writeShape, scalableDims, write, useMask);
   }
 
   /// Generic entry point that handles any 1D convolution/pooling layout.

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -105,38 +105,45 @@ static OpType getSingleOpOfType(Block &block) {
   return res;
 }
 
-/// Helper function to extract the input slices after filter is unrolled along
-/// kw.
+/// Layout of the canonical 1D conv/pool form:
+///   - Scalar:    no batch, no channels (e.g. 1D non-channeled conv).
+///   - Batched:   [n, w, c] / [n, w, f] (e.g. NWC conv).
+///   - Batchless: [w, c]    / [w, f]    (no batch dim).
+enum class ConvLayoutKind { Scalar, Batched, Batchless };
+
+/// Extract input slices after unrolling the filter along kw.
+///
+/// Per-tile shape and offset depend on `layout`:
+///   Scalar:    {wSizeStep}            @ [w + kw]
+///   Batched:   {n, wSizeStep, c}      @ [0, sw*w + dw*kw, 0]
+///   Batchless: {wSizeStep, c}         @ [sw*w + dw*kw, 0]
 static SmallVector<Value>
 extractConvInputSlices(RewriterBase &rewriter, Location loc, Value input,
                        int64_t nSize, int64_t wSize, int64_t cSize,
                        int64_t kwSize, int strideW, int dilationW,
-                       int64_t wSizeStep, bool isSingleChanneled) {
+                       int64_t wSizeStep, ConvLayoutKind layout) {
   SmallVector<Value> result;
-  if (isSingleChanneled) {
-    // Extract input slice of size {wSizeStep} @ [w + kw] for non-channeled
-    // convolution.
-    SmallVector<int64_t> sizes = {wSizeStep};
-    SmallVector<int64_t> strides = {1};
-    for (int64_t kw = 0; kw < kwSize; ++kw) {
-      for (int64_t w = 0; w < wSize; w += wSizeStep) {
-        result.push_back(vector::ExtractStridedSliceOp::create(
-            rewriter, loc, input, /*offsets=*/ArrayRef<int64_t>{w + kw}, sizes,
-            strides));
+  for (int64_t kw = 0; kw < kwSize; ++kw) {
+    for (int64_t w = 0; w < wSize; w += wSizeStep) {
+      int64_t offset = w * strideW + kw * dilationW;
+      SmallVector<int64_t> sizes, offsets;
+      switch (layout) {
+      case ConvLayoutKind::Scalar:
+        sizes = {wSizeStep};
+        offsets = {w + kw};
+        break;
+      case ConvLayoutKind::Batched:
+        sizes = {nSize, wSizeStep, cSize};
+        offsets = {0, offset, 0};
+        break;
+      case ConvLayoutKind::Batchless:
+        sizes = {wSizeStep, cSize};
+        offsets = {offset, 0};
+        break;
       }
-    }
-  } else {
-    // Extract lhs slice of size {n, wSizeStep, c} @ [0, sw * w + dw * kw, 0]
-    // for channeled convolution.
-    SmallVector<int64_t> sizes = {nSize, wSizeStep, cSize};
-    SmallVector<int64_t> strides = {1, 1, 1};
-    for (int64_t kw = 0; kw < kwSize; ++kw) {
-      for (int64_t w = 0; w < wSize; w += wSizeStep) {
-        result.push_back(vector::ExtractStridedSliceOp::create(
-            rewriter, loc, input,
-            /*offsets=*/ArrayRef<int64_t>{0, w * strideW + kw * dilationW, 0},
-            sizes, strides));
-      }
+      SmallVector<int64_t> strides(sizes.size(), 1);
+      result.push_back(vector::ExtractStridedSliceOp::create(
+          rewriter, loc, input, offsets, sizes, strides));
     }
   }
   return result;
@@ -157,60 +164,66 @@ static SmallVector<Value> extractConvFilterSlices(RewriterBase &rewriter,
   return result;
 }
 
-/// Helper function to extract the result slices after filter is unrolled along
-/// kw.
+/// Extract result slices, one per output spatial tile.
+///
+/// Per-tile shape and offset depend on `layout`:
+///   Scalar:    {wSizeStep}            @ [w]
+///   Batched:   {n, wSizeStep, f}      @ [0, w, 0]
+///   Batchless: {wSizeStep, f}         @ [w, 0]
 static SmallVector<Value>
 extractConvResultSlices(RewriterBase &rewriter, Location loc, Value res,
                         int64_t nSize, int64_t wSize, int64_t fSize,
-                        int64_t wSizeStep, bool isSingleChanneled) {
+                        int64_t wSizeStep, ConvLayoutKind layout) {
   SmallVector<Value> result;
-  if (isSingleChanneled) {
-    // Extract res slice: {wSizeStep} @ [w] for non-channeled convolution.
-    SmallVector<int64_t> sizes = {wSizeStep};
-    SmallVector<int64_t> strides = {1};
-    for (int64_t w = 0; w < wSize; w += wSizeStep) {
-      result.push_back(vector::ExtractStridedSliceOp::create(
-          rewriter, loc, res, /*offsets=*/ArrayRef<int64_t>{w}, sizes,
-          strides));
+  for (int64_t w = 0; w < wSize; w += wSizeStep) {
+    SmallVector<int64_t> sizes, offsets;
+    switch (layout) {
+    case ConvLayoutKind::Scalar:
+      sizes = {wSizeStep};
+      offsets = {w};
+      break;
+    case ConvLayoutKind::Batched:
+      sizes = {nSize, wSizeStep, fSize};
+      offsets = {0, w, 0};
+      break;
+    case ConvLayoutKind::Batchless:
+      sizes = {wSizeStep, fSize};
+      offsets = {w, 0};
+      break;
     }
-  } else {
-    // Extract res slice: {n, wSizeStep, f} @ [0, w, 0] for channeled
-    // convolution.
-    SmallVector<int64_t> sizes = {nSize, wSizeStep, fSize};
-    SmallVector<int64_t> strides = {1, 1, 1};
-    for (int64_t w = 0; w < wSize; w += wSizeStep) {
-      result.push_back(vector::ExtractStridedSliceOp::create(
-          rewriter, loc, res, /*offsets=*/ArrayRef<int64_t>{0, w, 0}, sizes,
-          strides));
-    }
+    SmallVector<int64_t> strides(sizes.size(), 1);
+    result.push_back(vector::ExtractStridedSliceOp::create(
+        rewriter, loc, res, offsets, sizes, strides));
   }
   return result;
 }
 
-/// Helper function to insert the computed result slices.
+/// Insert computed result slices back into the result vector.
+///
+/// Per-tile offset depends on `layout`:
+///   Scalar:    @ [w]
+///   Batched:   @ [0, w, 0]
+///   Batchless: @ [w, 0]
 static Value insertConvResultSlices(RewriterBase &rewriter, Location loc,
                                     Value res, int64_t wSize, int64_t wSizeStep,
                                     SmallVectorImpl<Value> &resVals,
-                                    bool isSingleChanneled) {
-
-  if (isSingleChanneled) {
-    // Write back res slice: {wSizeStep} @ [w] for non-channeled convolution.
-    // This does not depend on kw.
-    SmallVector<int64_t> strides = {1};
-    for (int64_t w = 0; w < wSize; w += wSizeStep) {
-      res = vector::InsertStridedSliceOp::create(
-          rewriter, loc, resVals[w], res, /*offsets=*/ArrayRef<int64_t>{w},
-          strides);
+                                    ConvLayoutKind layout) {
+  for (int64_t w = 0; w < wSize; w += wSizeStep) {
+    SmallVector<int64_t> offsets;
+    switch (layout) {
+    case ConvLayoutKind::Scalar:
+      offsets = {w};
+      break;
+    case ConvLayoutKind::Batched:
+      offsets = {0, w, 0};
+      break;
+    case ConvLayoutKind::Batchless:
+      offsets = {w, 0};
+      break;
     }
-  } else {
-    // Write back res slice: {n, wSizeStep, f} @ [0, w, 0] for channeled
-    // convolution. This does not depend on kw.
-    SmallVector<int64_t> strides = {1, 1, 1};
-    for (int64_t w = 0; w < wSize; w += wSizeStep) {
-      res = vector::InsertStridedSliceOp::create(
-          rewriter, loc, resVals[w], res,
-          /*offsets=*/ArrayRef<int64_t>{0, w, 0}, strides);
-    }
+    SmallVector<int64_t> strides(offsets.size(), 1);
+    res = vector::InsertStridedSliceOp::create(
+        rewriter, loc, resVals[w / wSizeStep], res, offsets, strides);
   }
   return res;
 }
@@ -603,13 +616,6 @@ static AffineMap reindexIndexingMap(AffineMap map) {
          "expected reindexed map with same number of dims and results");
   return res;
 }
-
-/// Helper enum to represent conv1d input traversal order.
-enum class Conv1DOpOrder {
-  W,   // Corresponds to non-channeled 1D convolution operation.
-  Ncw, // Corresponds to operation that traverses the input in (n, c, w) order.
-  Nwc  // Corresponds to operation that traverses the input in (n, w, c) order.
-};
 
 /// Helper data structure to represent the result of vectorization for a single
 /// operation. In certain specific cases, like terminators, we do not want to
@@ -2164,41 +2170,225 @@ static bool isSupportedPoolKind(vector::CombiningKind kind) {
   }
 }
 
-static LogicalResult vectorizeConvOpPrecondition(linalg::LinalgOp convOp) {
-  auto getOperandType = [&](auto operand) {
-    return dyn_cast<ShapedType>((operand->get()).getType());
+namespace {
+/// Classification of a 1D convolution/pooling derived from
+/// ConvolutionDimensions. Cached state used by every step of the rewrite
+/// pipeline.
+struct Conv1DConfig {
+  ConvolutionDimensions dims;
+  ConvOperationKind convKind = ConvOperationKind::Conv;
+  ConvLayoutKind layout = ConvLayoutKind::Scalar;
+  bool isDepthwise = false;
+  bool isPooling = false;
+  /// Subset of `dims.batch` treated as outer (N-like) batch dims.
+  SmallVector<unsigned> nLikeBatch;
+  /// Subset of `dims.batch` treated as the channel-like dim for pooling.
+  /// Derived from the LHS indexing map (innermost LHS position) by
+  /// `splitPoolBatchByLhsInnermost`, not from the order of `dims.batch`.
+  SmallVector<unsigned> cLikeBatch;
+};
+
+/// Sizes extracted from the canonical 1D conv/pool form.
+struct Conv1DSizes {
+  int64_t kw = 0;
+  int64_t w = 0;
+  int64_t n = 0;
+  int64_t c = 0;
+  int64_t f = 0;
+};
+
+/// Permutations from the original operand layouts to the canonical NWC form.
+/// An empty vector means the permutation is identity (no transpose needed).
+struct Conv1DPerms {
+  SmallVector<int64_t> lhs;
+  SmallVector<int64_t> rhs;
+  SmallVector<int64_t> res;
+
+  bool allIdentity() const { return lhs.empty() && rhs.empty() && res.empty(); }
+};
+
+/// Pre-permutation (i.e. as-stored-in-tensor) shapes used for transfer_read.
+struct Conv1DShapes {
+  SmallVector<int64_t> lhs;
+  SmallVector<int64_t> rhs;
+  SmallVector<int64_t> res;
+};
+
+/// Triple of operand vector values (in canonical NWC form). `rhs` is null
+/// for pooling.
+struct Conv1DOperandVecs {
+  Value lhs;
+  Value rhs;
+  Value res;
+};
+} // namespace
+
+/// Build a map from loop-dim position to tensor-dim position for the dims of
+/// `map` that are plain `AffineDimExpr`s. Non-plain results (e.g. strided
+/// access expressions) are skipped.
+static DenseMap<unsigned, unsigned> buildLoopToTensorDimMap(AffineMap map) {
+  DenseMap<unsigned, unsigned> result;
+  for (unsigned i = 0; i < map.getNumResults(); ++i) {
+    if (auto dimExpr = dyn_cast<AffineDimExpr>(map.getResult(i)))
+      result[dimExpr.getPosition()] = i;
+  }
+  return result;
+}
+
+/// For a pool-like op (no inputChannel/outputChannel dims), split `batch`
+/// into (outer, channel-like) based on the LHS indexing map: the batch loop
+/// that appears at the innermost LHS tensor position plays the channel-like
+/// role in the canonical NWC vector form; all other batch loops are outer
+/// (N-like) batch dims. This derivation is independent of the order in
+/// which `inferConvolutionDims` returns `batch`, so equivalent pools written
+/// with different iterator orderings classify the same way.
+///
+/// Returns failure when:
+///   - any batch loop is missing from the LHS indexing map (malformed pool);
+///   - two batch loops tie at the innermost LHS position (ambiguous).
+static FailureOr<std::pair<SmallVector<unsigned>, SmallVector<unsigned>>>
+splitPoolBatchByLhsInnermost(LinalgOp linalgOp, ArrayRef<unsigned> batch) {
+  DenseMap<unsigned, unsigned> loopToLhs =
+      buildLoopToTensorDimMap(linalgOp.getIndexingMapsArray()[0]);
+
+  std::optional<unsigned> cLike;
+  unsigned maxPos = 0;
+  for (unsigned d : batch) {
+    auto it = loopToLhs.find(d);
+    if (it == loopToLhs.end())
+      return failure();
+    unsigned p = it->second;
+    if (!cLike || p > maxPos) {
+      cLike = d;
+      maxPos = p;
+    } else if (p == maxPos) {
+      return failure();
+    }
+  }
+
+  SmallVector<unsigned> nLike, cLikeOut;
+  for (unsigned d : batch) {
+    if (d == *cLike)
+      cLikeOut.push_back(d);
+    else
+      nLike.push_back(d);
+  }
+  return std::make_pair(std::move(nLike), std::move(cLikeOut));
+}
+
+/// Classify `op` as a vectorizable 1D convolution/pooling. On failure,
+/// optionally writes a human-readable reason into `*reason`.
+static FailureOr<Conv1DConfig> classifyAs1DConv(LinalgOp op,
+                                                std::string *reason = nullptr) {
+  auto fail = [&](StringRef msg) -> FailureOr<Conv1DConfig> {
+    if (reason)
+      *reason = msg.str();
+    return failure();
   };
-  ShapedType lhsShapedType = getOperandType(convOp.getDpsInputOperand(0));
-  ShapedType rhsShapedType = getOperandType(convOp.getDpsInputOperand(1));
-  ShapedType resShapedType = getOperandType(convOp.getDpsInitOperand(0));
-  // (LHS has dimension NCW/NWC and RES has dimension NFW/NCW/NWF/NWC) OR
-  // (non-channeled convolution -> LHS and RHS both have single dimensions).
-  // Note that this also ensures 2D and 3D convolutions are rejected.
-  if ((lhsShapedType.getRank() != 3 || resShapedType.getRank() != 3) &&
-      (lhsShapedType.getRank() != 1 || resShapedType.getRank() != 1))
+
+  FailureOr<ConvolutionDimensions> maybeDims = inferConvolutionDims(op);
+  if (failed(maybeDims))
+    return fail("op is not a convolution (inferConvolutionDims failed)");
+
+  // Restrict to 1D: exactly one filter-loop dim and one output-image dim.
+  if (maybeDims->filterLoop.size() != 1 || maybeDims->outputImage.size() != 1)
+    return fail("only 1D convolutions are supported");
+  if (maybeDims->strides.empty() || maybeDims->dilations.empty())
+    return fail("strides and dilations must be statically known");
+
+  // Channel symmetry: either both channel kinds present or both folded away.
+  if (maybeDims->inputChannel.empty() != maybeDims->outputChannel.empty())
+    return fail("asymmetric inputChannel/outputChannel dims");
+
+  // Multiplicity restrictions: every category we index later assumes <= 1.
+  if (maybeDims->inputChannel.size() > 1 || maybeDims->outputChannel.size() > 1)
+    return fail("multiple inputChannel/outputChannel dims are not supported");
+  if (maybeDims->depth.size() > 1)
+    return fail("multiple depth dims are not supported");
+
+  // Inspect the reduce body to know whether this is a conv or a pool.
+  Operation *reduceOp = matchLinalgReduction(op.getDpsInitOperand(0));
+  if (!reduceOp)
+    return fail("could not match the reduction in the op body");
+  std::optional<ConvOperationKind> maybeKind = getConvOperationKind(reduceOp);
+  if (!maybeKind)
+    return fail("unsupported reduction body (not a conv or pool kind)");
+
+  Conv1DConfig config;
+  config.dims = std::move(*maybeDims);
+  config.convKind = *maybeKind;
+  config.isDepthwise = !config.dims.depth.empty();
+
+  bool bothChannelsEmpty =
+      config.dims.inputChannel.empty() && config.dims.outputChannel.empty();
+  bool noBatchOrChannels =
+      bothChannelsEmpty && config.dims.batch.empty() && !config.isDepthwise;
+
+  // Pure non-channeled 1D convolution: lhs=[iw], rhs=[kw], res=[w].
+  if (noBatchOrChannels) {
+    config.layout = ConvLayoutKind::Scalar;
+    return config;
+  }
+
+  // Both channel dims folded away with a batch dim => structurally pooling.
+  // Reject if the body is actually a multiply-add convolution (it would need
+  // channel dims that do not exist).
+  if (bothChannelsEmpty && !config.isDepthwise &&
+      config.convKind != ConvOperationKind::Pool)
+    return fail("convolution body but no channel dims (use a pooling body or "
+                "add channel dims)");
+  config.isPooling = bothChannelsEmpty && !config.isDepthwise;
+
+  // Batch-dim splitting.
+  //
+  // For pooling, the op body alone cannot distinguish "N" from "C": both are
+  // parallel loops on LHS and result that do not appear on RHS, so
+  // `inferConvolutionDims` groups them together in `dims.batch`. We derive
+  // which one plays the channel-like role from the LHS tensor layout
+  // (innermost LHS position) via `splitPoolBatchByLhsInnermost`, so that the
+  // classification does not depend on the order of `dims.batch`.
+  if (config.isPooling && !config.dims.batch.empty()) {
+    auto split = splitPoolBatchByLhsInnermost(op, config.dims.batch);
+    if (failed(split))
+      return fail("cannot determine channel-like batch dim for pooling op "
+                  "(ambiguous LHS layout or batch dim missing from LHS)");
+    std::tie(config.nLikeBatch, config.cLikeBatch) = std::move(*split);
+  } else if (!config.isPooling) {
+    config.nLikeBatch.assign(config.dims.batch.begin(),
+                             config.dims.batch.end());
+  }
+
+  // Multi-batch is not supported by the current canonical shapes.
+  if (config.nLikeBatch.size() > 1)
+    return fail("more than one N-like batch dim is not supported");
+
+  config.layout = config.nLikeBatch.empty() ? ConvLayoutKind::Batchless
+                                            : ConvLayoutKind::Batched;
+  return config;
+}
+
+static LogicalResult vectorizeConvOpPrecondition(linalg::LinalgOp convOp) {
+  // Single shared classifier ensures the precondition and the matcher in
+  // Conv1DGenerator::create cannot drift apart.
+  FailureOr<Conv1DConfig> maybeConfig = classifyAs1DConv(convOp);
+  if (failed(maybeConfig))
     return failure();
 
   Operation *reduceOp = matchLinalgReduction(convOp.getDpsInitOperand(0));
-  if (!reduceOp)
-    return failure();
-
-  auto maybeOper = getConvOperationKind(reduceOp);
-  if (!maybeOper.has_value())
-    return failure();
-
-  auto maybeKind = getCombinerOpKind(reduceOp);
+  std::optional<vector::CombiningKind> maybeKind = getCombinerOpKind(reduceOp);
   // Typically convolution will have a `Add` CombiningKind but for i1 type it
   // can get strength reduced to `OR` which is also supported. This strength
   // reduction logic is in `buildBinaryFn` helper in the Linalg dialect.
   if (!maybeKind || ((*maybeKind != vector::CombiningKind::ADD &&
                       *maybeKind != vector::CombiningKind::OR) &&
-                     (*maybeOper != ConvOperationKind::Pool ||
-                      !isSupportedPoolKind(*maybeKind)))) {
+                     (maybeConfig->convKind != ConvOperationKind::Pool ||
+                      !isSupportedPoolKind(*maybeKind))))
     return failure();
-  }
 
-  auto rhsRank = rhsShapedType.getRank();
-  if (*maybeOper == ConvOperationKind::Pool) {
+  ShapedType rhsShapedType =
+      cast<ShapedType>(convOp.getDpsInputOperand(1)->get().getType());
+  int64_t rhsRank = rhsShapedType.getRank();
+  if (maybeConfig->convKind == ConvOperationKind::Pool) {
     if (rhsRank != 1)
       return failure();
   } else {
@@ -3308,35 +3498,83 @@ static void bindShapeDims(ShapedType shapedType, IntTy &...vals) {
   bindShapeDims<0>(shapedType, vals...);
 }
 
-/// Match 1D convolution or pooling operations and return their dilations and
-/// strides. Returns std::nullopt for unrecognized ops.
-static std::optional<DilationsAndStrides> match1DConvPoolOp(LinalgOp op) {
-#define MATCH_1D_CONV_POOL_OP(ConvOpTy)                                        \
-  if (auto convParams = matchConvolutionOpOfType<ConvOpTy>(op))                \
-    return convParams;
+/// Compute permutations to transpose each operand from its current layout to
+/// the canonical NWC form:
+///   lhs = [N?, iw, inputChannel?, depth?, C_like_batch?]
+///   rhs = [kw, inputChannel?, outputChannel?, depth?]
+///   res = [N?, w,  outputChannel?, depth?, C_like_batch?]
+/// An empty result vector means the permutation is identity.
+static Conv1DPerms computeCanonicalPerms(LinalgOp linalgOp,
+                                         const Conv1DConfig &config) {
+  const ConvolutionDimensions &dims = config.dims;
+  ArrayRef<unsigned> nLikeBatch = config.nLikeBatch;
+  ArrayRef<unsigned> cLikeBatch = config.cLikeBatch;
+  AffineMap lhsMap = linalgOp.getIndexingMapsArray()[0];
+  AffineMap rhsMap = linalgOp.getIndexingMapsArray()[1];
+  AffineMap resMap = linalgOp.getIndexingMapsArray()[2];
 
-  // 1D Convolution ops.
-  MATCH_1D_CONV_POOL_OP(linalg::Conv1DOp);
-  MATCH_1D_CONV_POOL_OP(linalg::Conv1DNwcWcfOp);
-  MATCH_1D_CONV_POOL_OP(linalg::Conv1DNcwFcwOp);
-  // Depthwise 1D Convolution ops.
-  // Note: Only NWC layout without channel multiplier is supported.
-  // DepthwiseConv1DNcwCwOp (NCW) and DepthwiseConv1DNwcWcmOp (with multiplier)
-  // are not supported.
-  MATCH_1D_CONV_POOL_OP(linalg::DepthwiseConv1DNwcWcOp);
-  // 1D Pooling ops (NWC layout).
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNwcSumOp);
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNwcMaxOp);
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNwcMaxUnsignedOp);
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNwcMinOp);
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNwcMinUnsignedOp);
-  // 1D Pooling ops (NCW layout).
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNcwSumOp);
-  MATCH_1D_CONV_POOL_OP(linalg::PoolingNcwMaxOp);
+  DenseMap<unsigned, unsigned> loopToLhs = buildLoopToTensorDimMap(lhsMap);
+  DenseMap<unsigned, unsigned> loopToRhs = buildLoopToTensorDimMap(rhsMap);
+  DenseMap<unsigned, unsigned> loopToRes = buildLoopToTensorDimMap(resMap);
 
-#undef MATCH_1D_CONV_POOL_OP
+  // The spatial (outputImage) tensor dim in LHS is the result that is NOT a
+  // plain AffineDimExpr: its expression is `strideW*ow + dilationW*kw`.
+  std::optional<unsigned> lhsSpatialTensorDim;
+  for (unsigned i = 0; i < lhsMap.getNumResults(); ++i) {
+    if (!isa<AffineDimExpr>(lhsMap.getResult(i))) {
+      lhsSpatialTensorDim = i;
+      break;
+    }
+  }
+  assert((dims.outputImage.empty() || lhsSpatialTensorDim) &&
+         "expected a non-plain LHS dim expr for the spatial dim");
 
-  return std::nullopt;
+  Conv1DPerms perms;
+
+  // Result: [N_like_batch, outputImage, outputChannel, depth, C_like_batch].
+  for (unsigned d : nLikeBatch)
+    perms.res.push_back(loopToRes[d]);
+  for (unsigned d : dims.outputImage)
+    perms.res.push_back(loopToRes[d]);
+  for (unsigned d : dims.outputChannel)
+    perms.res.push_back(loopToRes[d]);
+  for (unsigned d : dims.depth)
+    perms.res.push_back(loopToRes[d]);
+  for (unsigned d : cLikeBatch)
+    perms.res.push_back(loopToRes[d]);
+
+  // LHS: [N_like_batch, outputImage->spatial, inputChannel, depth,
+  //       C_like_batch]. The spatial position is the non-plain dim expr.
+  for (unsigned d : nLikeBatch)
+    perms.lhs.push_back(loopToLhs[d]);
+  if (lhsSpatialTensorDim)
+    perms.lhs.push_back(*lhsSpatialTensorDim);
+  for (unsigned d : dims.inputChannel)
+    perms.lhs.push_back(loopToLhs[d]);
+  for (unsigned d : dims.depth)
+    perms.lhs.push_back(loopToLhs[d]);
+  for (unsigned d : cLikeBatch)
+    perms.lhs.push_back(loopToLhs[d]);
+
+  // RHS: [filterLoop, inputChannel, outputChannel, depth]. For pooling RHS
+  // only has filterLoop.
+  for (unsigned d : dims.filterLoop)
+    perms.rhs.push_back(loopToRhs[d]);
+  for (unsigned d : dims.inputChannel)
+    perms.rhs.push_back(loopToRhs[d]);
+  for (unsigned d : dims.outputChannel)
+    perms.rhs.push_back(loopToRhs[d]);
+  for (unsigned d : dims.depth)
+    perms.rhs.push_back(loopToRhs[d]);
+
+  if (isIdentityPermutation(perms.lhs))
+    perms.lhs.clear();
+  if (isIdentityPermutation(perms.rhs))
+    perms.rhs.clear();
+  if (isIdentityPermutation(perms.res))
+    perms.res.clear();
+
+  return perms;
 }
 
 namespace {
@@ -3376,26 +3614,25 @@ namespace {
 /// kw is unrolled, w is unrolled iff dilationW > 1.
 struct Conv1DGenerator
     : public StructuredGenerator<LinalgOp, utils::IteratorType> {
-  /// Factory method to create a Conv1DGenerator. Returns failure if the
-  /// operation doesn't have valid strides/dilations.
+  /// Factory method to create a Conv1DGenerator. Uses the shared
+  /// `classifyAs1DConv` so the precondition and the matcher cannot drift
+  /// apart. Returns failure if the op is not a supported 1D conv/pool op.
   static FailureOr<Conv1DGenerator> create(RewriterBase &rewriter,
                                            LinalgOp linalgOp) {
-    // Try to match a 1D conv/pool op using matchConvolutionOpOfType. This
-    // works for both named ops and generic ops that match their semantics.
-    std::optional<DilationsAndStrides> convParams = match1DConvPoolOp(linalgOp);
-    if (!convParams)
-      return failure();
-
-    int strideW = static_cast<int>(convParams->strides.front());
-    int dilationW = static_cast<int>(convParams->dilations.front());
-    return Conv1DGenerator(rewriter, linalgOp, strideW, dilationW);
+    std::string reason;
+    FailureOr<Conv1DConfig> maybeConfig = classifyAs1DConv(linalgOp, &reason);
+    if (failed(maybeConfig))
+      return rewriter.notifyMatchFailure(linalgOp, reason);
+    return Conv1DGenerator(rewriter, linalgOp, std::move(*maybeConfig));
   }
 
 private:
-  Conv1DGenerator(RewriterBase &rewriter, LinalgOp linalgOp, int strideW,
-                  int dilationW)
+  Conv1DGenerator(RewriterBase &rewriter, LinalgOp linalgOp,
+                  Conv1DConfig config)
       : StructuredGenerator<LinalgOp, utils::IteratorType>(rewriter, linalgOp),
-        strideW(strideW), dilationW(dilationW) {
+        config(std::move(config)) {
+    strideW = static_cast<int>(this->config.dims.strides.front());
+    dilationW = static_cast<int>(this->config.dims.dilations.front());
 
     lhsShaped = linalgOp.getDpsInputOperand(0)->get();
     rhsShaped = linalgOp.getDpsInputOperand(1)->get();
@@ -3406,242 +3643,11 @@ private:
 
     Operation *reduceOp = matchLinalgReduction(linalgOp.getDpsInitOperand(0));
     redOp = reduceOp->getName().getIdentifier();
-
-    setConvOperationKind(reduceOp);
-
-    auto maybeKind = getCombinerOpKind(reduceOp);
-    reductionKind = maybeKind.value();
+    setPoolExtFromReduce(reduceOp);
+    reductionKind = getCombinerOpKind(reduceOp).value();
   }
 
 public:
-  /// Generate a vector implementation for:
-  /// ```
-  ///   Op def: (     w,     kw  )
-  ///    Iters: ({Par(), Red()})
-  ///   Layout: {{w + kw}, {kw}, {w}}
-  /// ```
-  /// kw is always unrolled.
-  ///
-  /// or
-  ///
-  /// ```
-  ///   Op def: (     n,     w,     c,    kw,    f  )
-  ///    Iters: ({Par(), Par(), Par(), Red(), Red()})
-  ///   Layout: {{n, strideW * w + dilationW * kw, c}, {kw, c, f}, {n, w, f}}
-  /// ```
-  /// kw is always unrolled.
-  /// TODO: w (resp. kw) is unrolled when the strideW ( resp. dilationW) is
-  /// > 1.
-  FailureOr<Operation *> conv(Conv1DOpOrder conv1DOpOrder) {
-    int64_t nSize, wSize, cSize, kwSize, fSize;
-    SmallVector<int64_t, 3> lhsShape, rhsShape, resShape;
-    bool isSingleChanneled = (conv1DOpOrder == Conv1DOpOrder::W);
-    switch (conv1DOpOrder) {
-    case Conv1DOpOrder::W:
-      // Initialize unused dimensions
-      nSize = fSize = cSize = 0;
-      // out{W}
-      bindShapeDims(resShapedType, wSize);
-      // kernel{kw}
-      bindShapeDims(rhsShapedType, kwSize);
-      lhsShape = {// iw = ow + kw - 1
-                  //   (i.e. 16 convolved with 3 -> 14)
-                  (wSize + kwSize - 1)};
-      rhsShape = {kwSize};
-      resShape = {wSize};
-      break;
-    case Conv1DOpOrder::Nwc:
-      // out{n, w, f}
-      bindShapeDims(resShapedType, nSize, wSize, fSize);
-      switch (oper) {
-      case ConvOperationKind::Conv:
-        // kernel{kw, c, f}
-        bindShapeDims(rhsShapedType, kwSize, cSize);
-        break;
-      case ConvOperationKind::Pool:
-        // kernel{kw}
-        bindShapeDims(rhsShapedType, kwSize);
-        cSize = fSize;
-        break;
-      }
-      lhsShape = {nSize,
-                  // iw = ow * sw + kw *  dw - 1
-                  //   (i.e. 16 convolved with 3 (@stride 1 dilation 1) -> 14)
-                  // Perform the proper inclusive -> exclusive -> inclusive.
-                  ((wSize - 1) * strideW + 1) + ((kwSize - 1) * dilationW + 1) -
-                      1,
-                  cSize};
-      switch (oper) {
-      case ConvOperationKind::Conv:
-        rhsShape = {kwSize, cSize, fSize};
-        break;
-      case ConvOperationKind::Pool:
-        rhsShape = {kwSize};
-        break;
-      }
-      resShape = {nSize, wSize, fSize};
-      break;
-    case Conv1DOpOrder::Ncw:
-      // out{n, f, w}
-      bindShapeDims(resShapedType, nSize, fSize, wSize);
-      switch (oper) {
-      case ConvOperationKind::Conv:
-        // kernel{f, c, kw}
-        bindShapeDims(rhsShapedType, fSize, cSize, kwSize);
-        break;
-      case ConvOperationKind::Pool:
-        // kernel{kw}
-        bindShapeDims(rhsShapedType, kwSize);
-        cSize = fSize;
-        break;
-      }
-      lhsShape = {nSize, cSize,
-                  // iw = ow * sw + kw *  dw - 1
-                  //   (i.e. 16 convolved with 3 (@stride 1 dilation 1) -> 14)
-                  // Perform the proper inclusive -> exclusive -> inclusive.
-                  ((wSize - 1) * strideW + 1) + ((kwSize - 1) * dilationW + 1) -
-                      1};
-      switch (oper) {
-      case ConvOperationKind::Conv:
-        rhsShape = {fSize, cSize, kwSize};
-        break;
-      case ConvOperationKind::Pool:
-        rhsShape = {kwSize};
-        break;
-      }
-      resShape = {nSize, fSize, wSize};
-      break;
-    }
-
-    vector::TransferWriteOp write;
-    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-
-    // w is unrolled (i.e. wSizeStep == 1) iff strideW > 1.
-    // When strideW == 1, we can batch the contiguous loads and avoid
-    // unrolling
-    int64_t wSizeStep = strideW == 1 ? wSize : 1;
-
-    Type lhsEltType = lhsShapedType.getElementType();
-    Type rhsEltType = rhsShapedType.getElementType();
-    Type resEltType = resShapedType.getElementType();
-    auto lhsType = VectorType::get(lhsShape, lhsEltType);
-    auto rhsType = VectorType::get(rhsShape, rhsEltType);
-    auto resType = VectorType::get(resShape, resEltType);
-    // Zero padding with the corresponding dimensions for lhs, rhs and res.
-    SmallVector<Value> lhsPadding(lhsShape.size(), zero);
-    SmallVector<Value> rhsPadding(rhsShape.size(), zero);
-    SmallVector<Value> resPadding(resShape.size(), zero);
-
-    // Read the whole lhs, rhs and res in one shot (with zero padding).
-    Value lhs = vector::TransferReadOp::create(
-        rewriter, loc, lhsType, lhsShaped, lhsPadding,
-        /*padding=*/arith::getZeroConstant(rewriter, loc, lhsEltType));
-    // This is needed only for Conv.
-    Value rhs = nullptr;
-    if (oper == ConvOperationKind::Conv)
-      rhs = vector::TransferReadOp::create(
-          rewriter, loc, rhsType, rhsShaped, rhsPadding,
-          /*padding=*/arith::getZeroConstant(rewriter, loc, rhsEltType));
-    Value res = vector::TransferReadOp::create(
-        rewriter, loc, resType, resShaped, resPadding,
-        /*padding=*/arith::getZeroConstant(rewriter, loc, resEltType));
-
-    // The base vectorization case for channeled convolution is input:
-    // {n,w,c}, weight: {kw,c,f}, output: {n,w,f}. To reuse the base pattern
-    // vectorization case, we do pre transpose on input, weight, and output.
-    switch (conv1DOpOrder) {
-    case Conv1DOpOrder::W:
-    case Conv1DOpOrder::Nwc:
-      // Base case, so no transposes necessary.
-      break;
-    case Conv1DOpOrder::Ncw: {
-      // To match base vectorization case, we pre-transpose current case.
-      // ncw -> nwc
-      static constexpr std::array<int64_t, 3> permLhs = {0, 2, 1};
-      lhs = vector::TransposeOp::create(rewriter, loc, lhs, permLhs);
-      // fcw -> wcf
-      static constexpr std::array<int64_t, 3> permRhs = {2, 1, 0};
-
-      // This is needed only for Conv.
-      if (oper == ConvOperationKind::Conv)
-        rhs = vector::TransposeOp::create(rewriter, loc, rhs, permRhs);
-      // nfw -> nwf
-      static constexpr std::array<int64_t, 3> permRes = {0, 2, 1};
-      res = vector::TransposeOp::create(rewriter, loc, res, permRes);
-      break;
-    }
-    }
-
-    //===------------------------------------------------------------------===//
-    // Begin vector-only rewrite part
-    //===------------------------------------------------------------------===//
-    // Unroll along kw and read slices of lhs and rhs.
-    SmallVector<Value> lhsVals, rhsVals, resVals;
-    lhsVals = extractConvInputSlices(rewriter, loc, lhs, nSize, wSize, cSize,
-                                     kwSize, strideW, dilationW, wSizeStep,
-                                     isSingleChanneled);
-    // Do not do for pooling.
-    if (oper == ConvOperationKind::Conv)
-      rhsVals = extractConvFilterSlices(rewriter, loc, rhs, kwSize);
-    resVals = extractConvResultSlices(rewriter, loc, res, nSize, wSize, fSize,
-                                      wSizeStep, isSingleChanneled);
-
-    auto linearIndex = [&](int64_t kw, int64_t w) {
-      return kw * (wSize / wSizeStep) + w;
-    };
-
-    // Compute contraction: O{n, w, f} += I{n, sw * w + dw * kw, c} * F{c, f}
-    // or perform outerproduct for non-channeled convolution or perform simple
-    // arith operation for pooling
-    for (int64_t kw = 0; kw < kwSize; ++kw) {
-      for (int64_t w = 0; w < wSize; w += wSizeStep) {
-        switch (oper) {
-        case ConvOperationKind::Conv:
-          if (isSingleChanneled) {
-            resVals[w] = conv1dSliceAsOuterProduct(rewriter, loc,
-                                                   lhsVals[linearIndex(kw, w)],
-                                                   rhsVals[kw], resVals[w]);
-          } else {
-            resVals[w] = conv1dSliceAsContraction(rewriter, loc,
-                                                  lhsVals[linearIndex(kw, w)],
-                                                  rhsVals[kw], resVals[w]);
-          }
-          break;
-        case ConvOperationKind::Pool:
-          resVals[w] = pool1dSlice(rewriter, loc, lhsVals[linearIndex(kw, w)],
-                                   resVals[w]);
-          break;
-        }
-      }
-    }
-
-    res = insertConvResultSlices(rewriter, loc, res, wSize, wSizeStep, resVals,
-                                 isSingleChanneled);
-    //===------------------------------------------------------------------===//
-    // End vector-only rewrite part
-    //===------------------------------------------------------------------===//
-
-    // The base vectorization case for channeled convolution is output:
-    // {n,w,f} To reuse the result from base pattern vectorization case, we
-    // post transpose the base case result.
-    switch (conv1DOpOrder) {
-    case Conv1DOpOrder::W:
-    case Conv1DOpOrder::Nwc:
-      // Base case, so no transposes necessary.
-      break;
-    case Conv1DOpOrder::Ncw: {
-      // nwf -> nfw
-      static constexpr std::array<int64_t, 3> perm = {0, 2, 1};
-      res = vector::TransposeOp::create(rewriter, loc, res, perm);
-      break;
-    }
-    }
-
-    return vector::TransferWriteOp::create(rewriter, loc, res, resShaped,
-                                           resPadding)
-        .getOperation();
-  }
-
   // Take a value and widen to have the same element type as `ty`.
   Value promote(RewriterBase &rewriter, Location loc, Value val, Type ty) {
     const Type srcElementType = getElementTypeOrSelf(val.getType());
@@ -3745,7 +3751,6 @@ public:
     // out{n, w, c}
     bindShapeDims(resShapedType, nSize, wSize);
 
-    vector::TransferWriteOp write;
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
 
     // w is unrolled (i.e. wSizeStep == 1) iff strideW > 1.
@@ -3816,34 +3821,59 @@ public:
     auto *maybeMaskedRes = maybeMaskXferOp(
         resType.getShape(), resType.getScalableDims(), res.getDefiningOp());
 
-    //===------------------------------------------------------------------===//
-    // Begin vector-only rewrite part
-    //===------------------------------------------------------------------===//
-    // Unroll along kw and read slices of lhs and rhs.
-    SmallVector<Value> lhsVals, rhsVals, resVals;
+    FailureOr<Value> kernelRes = depthwise1DKernel(
+        maybeMaskedLhs->getResult(0), maybeMaskedRhs->getResult(0),
+        maybeMaskedRes->getResult(0), nSize, wSize, cSize, kwSize, wSizeStep,
+        flatten);
+    if (failed(kernelRes)) {
+      // Best-effort: erase the original transfer_reads we created above.
+      // (Mask wrapper ops, if any, will be handled by the failed-pattern
+      // rollback in the parent rewrite driver.)
+      for (Value v : {res, rhs, lhs, zero})
+        if (v)
+          rewriter.eraseOp(v.getDefiningOp());
+      return failure();
+    }
+
+    Operation *resOut = vector::TransferWriteOp::create(
+        rewriter, loc, *kernelRes, resShaped, ValueRange{zero, zero, zero});
+    return maybeMaskXferOp(resType.getShape(), resType.getScalableDims(),
+                           resOut);
+  }
+
+  /// Vector-level depthwise compute kernel: extracts kw x w tiles from the
+  /// canonical NWC operand vectors, runs MulAcc, and re-inserts the tiles
+  /// back into the result vector. All inputs must be in canonical NWC form
+  /// (lhs=[n,iw,c], rhs=[kw,c], res=[n,w,c]).
+  ///
+  /// On MulAcc failure the kernel erases only the IR it created; the caller
+  /// is responsible for cleaning up its own pre-kernel IR.
+  FailureOr<Value> depthwise1DKernel(Value lhs, Value rhs, Value res,
+                                     int64_t nSize, int64_t wSize,
+                                     int64_t cSize, int64_t kwSize,
+                                     int64_t wSizeStep, bool flatten) {
+    Type lhsEltType = cast<VectorType>(lhs.getType()).getElementType();
+    Type resEltType = cast<VectorType>(res.getType()).getElementType();
+
     SmallVector<int64_t> inOutSliceSizes = {nSize, wSizeStep, cSize};
     SmallVector<int64_t> inOutStrides = {1, 1, 1};
 
-    // Extract lhs slice of size {n, wSizeStep, c}
-    //   @ [0, sw * w + dw * kw, 0].
+    SmallVector<Value> lhsVals, rhsVals, resVals;
     for (int64_t kw = 0; kw < kwSize; ++kw) {
       for (int64_t w = 0; w < wSize; w += wSizeStep) {
         lhsVals.push_back(vector::ExtractStridedSliceOp::create(
-            rewriter, loc, maybeMaskedLhs->getResult(0),
+            rewriter, loc, lhs,
             /*offsets=*/ArrayRef<int64_t>{0, w * strideW + kw * dilationW, 0},
             inOutSliceSizes, inOutStrides));
       }
     }
-    // Extract rhs slice of size {c} @ [kw].
     for (int64_t kw = 0; kw < kwSize; ++kw) {
-      rhsVals.push_back(
-          vector::ExtractOp::create(rewriter, loc, maybeMaskedRhs->getResult(0),
-                                    /*offsets=*/ArrayRef<int64_t>{kw}));
+      rhsVals.push_back(vector::ExtractOp::create(
+          rewriter, loc, rhs, /*offsets=*/ArrayRef<int64_t>{kw}));
     }
-    // Extract res slice: {n, wSizeStep, c} @ [0, w, 0].
     for (int64_t w = 0; w < wSize; w += wSizeStep) {
       resVals.push_back(vector::ExtractStridedSliceOp::create(
-          rewriter, loc, maybeMaskedRes->getResult(0),
+          rewriter, loc, res,
           /*offsets=*/ArrayRef<int64_t>{0, w, 0}, inOutSliceSizes,
           inOutStrides));
     }
@@ -3852,7 +3882,7 @@ public:
       return kw * (wSize / wSizeStep) + w;
     };
 
-    // Note - the scalable flags are ignored as flattening combined with
+    // Note: the scalable flags are ignored because flattening combined with
     // scalable vectorization is not supported.
     SmallVector<int64_t> inOutFlattenSliceSizes = {nSize, wSizeStep * cSize};
     auto lhsTypeAfterFlattening =
@@ -3860,24 +3890,19 @@ public:
     auto resTypeAfterFlattening =
         VectorType::get(inOutFlattenSliceSizes, resEltType);
 
-    // Compute contraction: O{n, w, c} += I{n, sw * w + dw * kw, c} * F{c}
     for (int64_t kw = 0; kw < kwSize; ++kw) {
       for (int64_t w = 0; w < wSize; w += wSizeStep) {
         Value lhsVal = lhsVals[linearIndex(kw, w)];
         Value resVal = resVals[w];
         if (flatten) {
-          // Flatten the input and output vectors (collapse the channel
-          // dimension)
-          lhsVal =
-              vector::ShapeCastOp::create(rewriter, loc, lhsTypeAfterFlattening,
-                                          lhsVals[linearIndex(kw, w)]);
-          resVal = vector::ShapeCastOp::create(
-              rewriter, loc, resTypeAfterFlattening, resVals[w]);
+          lhsVal = vector::ShapeCastOp::create(rewriter, loc,
+                                               lhsTypeAfterFlattening, lhsVal);
+          resVal = vector::ShapeCastOp::create(rewriter, loc,
+                                               resTypeAfterFlattening, resVal);
         }
         resVals[w] = depthwiseConv1dSliceAsMulAcc(rewriter, loc, lhsVal,
                                                   rhsVals[kw], resVal, flatten);
         if (flatten) {
-          // Un-flatten the output vector (restore the channel dimension)
           resVals[w] = vector::ShapeCastOp::create(
               rewriter, loc, VectorType::get(inOutSliceSizes, resEltType),
               resVals[w]);
@@ -3885,34 +3910,86 @@ public:
       }
     }
 
-    // Its possible we failed to create the Fma.
     if (!llvm::all_of(resVals, [](Value v) { return v; })) {
-      // Manually revert (in reverse order) to avoid leaving a bad IR state.
-      for (auto &collection :
-           {resVals, rhsVals, lhsVals, {res, rhs, lhs, zero}})
+      for (auto &collection : {resVals, rhsVals, lhsVals})
         for (Value v : collection)
-          rewriter.eraseOp(v.getDefiningOp());
+          if (v)
+            rewriter.eraseOp(v.getDefiningOp());
       return rewriter.notifyMatchFailure(op, "failed to create FMA");
     }
 
-    // Write back res slice: {n, wSizeStep, c} @ [0, w, 0].
-    // This does not depend on kw.
+    Value out = res;
     for (int64_t w = 0; w < wSize; w += wSizeStep) {
-      maybeMaskedRes = vector::InsertStridedSliceOp::create(
-          rewriter, loc, resVals[w], maybeMaskedRes->getResult(0),
+      out = vector::InsertStridedSliceOp::create(
+          rewriter, loc, resVals[w], out,
           /*offsets=*/ArrayRef<int64_t>{0, w, 0},
           /*strides=*/ArrayRef<int64_t>{1, 1, 1});
     }
-    //===------------------------------------------------------------------===//
-    // End vector-only rewrite part
-    //===------------------------------------------------------------------===//
+    return out;
+  }
 
-    // Write back res slice of size {n, w, c} @ [0, 0, 0].
-    Operation *resOut = vector::TransferWriteOp::create(
-        rewriter, loc, maybeMaskedRes->getResult(0), resShaped,
-        ValueRange{zero, zero, zero});
-    return maybeMaskXferOp(resType.getShape(), resType.getScalableDims(),
-                           resOut);
+  /// Depthwise convolution for non-canonical layouts: read the operands in
+  /// their original layout, transpose the loaded vectors to canonical NWC,
+  /// run the kernel, inverse-transpose the result, and write it back.
+  /// Static shapes only (no masking).
+  FailureOr<Operation *> depthwiseConvViaTranspose(const Conv1DPerms &perms,
+                                                   bool flatten) {
+    // Canonical sizes: kernel is [kw, c], result is [n, w, c].
+    int64_t kwSize = 0, cSize = 0, nSize = 0, wSize = 0;
+    {
+      DenseMap<unsigned, unsigned> loopToRhs =
+          buildLoopToTensorDimMap(cast<LinalgOp>(op).getIndexingMapsArray()[1]);
+      DenseMap<unsigned, unsigned> loopToRes =
+          buildLoopToTensorDimMap(cast<LinalgOp>(op).getIndexingMapsArray()[2]);
+      kwSize = rhsShapedType.getShape()[loopToRhs[dims().filterLoop[0]]];
+      cSize = rhsShapedType.getShape()[loopToRhs[dims().depth[0]]];
+      nSize = config.nLikeBatch.empty()
+                  ? 1
+                  : resShapedType.getShape()[loopToRes[config.nLikeBatch[0]]];
+      wSize = resShapedType.getShape()[loopToRes[dims().outputImage[0]]];
+    }
+    int64_t iwSize =
+        ((wSize - 1) * strideW + 1) + ((kwSize - 1) * dilationW + 1) - 1;
+
+    Conv1DShapes canon{
+        /*lhs=*/{nSize, iwSize, cSize},
+        /*rhs=*/{kwSize, cSize},
+        /*res=*/{nSize, wSize, cSize},
+    };
+    Conv1DShapes read = computeReadShapes(canon, perms);
+
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Type lhsEltType = lhsShapedType.getElementType();
+    Type rhsEltType = rhsShapedType.getElementType();
+    Type resEltType = resShapedType.getElementType();
+    SmallVector<Value> lhsIdx(read.lhs.size(), zero);
+    SmallVector<Value> rhsIdx(read.rhs.size(), zero);
+    SmallVector<Value> resIdx(read.res.size(), zero);
+
+    Value lhs = vector::TransferReadOp::create(
+        rewriter, loc, VectorType::get(read.lhs, lhsEltType), lhsShaped, lhsIdx,
+        arith::getZeroConstant(rewriter, loc, lhsEltType));
+    Value rhs = vector::TransferReadOp::create(
+        rewriter, loc, VectorType::get(read.rhs, rhsEltType), rhsShaped, rhsIdx,
+        arith::getZeroConstant(rewriter, loc, rhsEltType));
+    Value res = vector::TransferReadOp::create(
+        rewriter, loc, VectorType::get(read.res, resEltType), resShaped, resIdx,
+        arith::getZeroConstant(rewriter, loc, resEltType));
+
+    if (!perms.lhs.empty())
+      lhs = vector::TransposeOp::create(rewriter, loc, lhs, perms.lhs);
+    if (!perms.rhs.empty())
+      rhs = vector::TransposeOp::create(rewriter, loc, rhs, perms.rhs);
+    if (!perms.res.empty())
+      res = vector::TransposeOp::create(rewriter, loc, res, perms.res);
+
+    int64_t wSizeStep = strideW == 1 ? wSize : 1;
+    FailureOr<Value> kernelRes = depthwise1DKernel(
+        lhs, rhs, res, nSize, wSize, cSize, kwSize, wSizeStep, flatten);
+    if (failed(kernelRes))
+      return failure();
+
+    return writeAndPostTranspose(*kernelRes, read.res, perms.res);
   }
 
   /// Lower:
@@ -3964,148 +4041,284 @@ public:
     return arith::AddIOp::create(rewriter, loc, mul, res);
   }
 
-  /// Entry point for non-channeled convolution:
-  ///   {{w + kw}, {kw}, {w}}
-  FailureOr<Operation *> generateNonChanneledConv() {
-    AffineExpr w, kw;
-    bindDims(ctx, w, kw);
-    if (!iters({Par(), Red()}))
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to match conv::W 1-par 1-red");
-
-    // No transposition needed.
-    if (layout({/*lhsIndex*/ {w + kw},
-                /*rhsIndex*/ {kw},
-                /*resIndex*/ {w}}))
-      return conv(Conv1DOpOrder::W);
-
-    return rewriter.notifyMatchFailure(op, "not a conv::W layout");
+  /// Create a contraction: lhs{w, c} * rhs{c, f} -> res{w, f}.
+  /// Used for batchless channeled convolution.
+  Value conv1dBatchlessSliceAsContraction(RewriterBase &rewriter, Location loc,
+                                          Value lhs, Value rhs, Value res) {
+    vector::IteratorType par = vector::IteratorType::parallel;
+    vector::IteratorType red = vector::IteratorType::reduction;
+    AffineExpr w, f, c;
+    bindDims(ctx, w, f, c);
+    lhs = promote(rewriter, loc, lhs, res.getType());
+    rhs = promote(rewriter, loc, rhs, res.getType());
+    auto contractionOp = vector::ContractionOp::create(
+        rewriter, loc, lhs, rhs, res,
+        /*indexingMaps=*/MapList{{w, c}, {c, f}, {w, f}},
+        /*iteratorTypes=*/ArrayRef<vector::IteratorType>{par, par, red});
+    contractionOp.setKind(reductionKind);
+    return contractionOp;
   }
 
-  /// Entry point that transposes into the common form:
-  ///   {{n, strideW * w + dilationW * kw, c}, {kw, c, f}, {n, w, f}}
-  FailureOr<Operation *> generateNwcConv() {
-    AffineExpr n, w, f, kw, c;
-    bindDims(ctx, n, w, f, kw, c);
-    if (!iters({Par(), Par(), Par(), Red(), Red()}))
+  //===--------------------------------------------------------------------===//
+  // generate() pipeline helpers
+  //===--------------------------------------------------------------------===//
+
+  /// Handle depthwise convolution. For canonical (NWC) layout, delegate to
+  /// the existing depthwiseConv() which supports masking/scalable channel
+  /// dim. For non-canonical layouts (e.g. NcwCw), pre-transpose at the
+  /// vector boundaries and run the canonical kernel; this path requires
+  /// fully-static shapes (no masking).
+  FailureOr<Operation *> handleDepthwise(ArrayRef<int64_t> inputVecSizes,
+                                         ArrayRef<bool> inputScalableVecDims,
+                                         bool flatten1DDepthwiseConv) {
+    LinalgOp linalgOp = cast<LinalgOp>(op);
+    Conv1DPerms perms = computeCanonicalPerms(linalgOp, config);
+
+    if (perms.allIdentity()) {
+      // Canonical NWC: existing path handles masking + scalable dims.
+      int64_t vecChDimSize = 0;
+      bool vecChScalableFlag = false;
+      if (!inputVecSizes.empty()) {
+        DenseMap<unsigned, unsigned> loopToRes =
+            buildLoopToTensorDimMap(linalgOp.getIndexingMapsArray()[2]);
+        unsigned chTensorDim = loopToRes[dims().depth[0]];
+        vecChDimSize = inputVecSizes[chTensorDim];
+        vecChScalableFlag = inputScalableVecDims[chTensorDim];
+      }
+      return depthwiseConv(vecChDimSize, vecChScalableFlag,
+                           flatten1DDepthwiseConv);
+    }
+
+    // Non-canonical depthwise: only static shapes are supported because
+    // boundary masking interacts with the post-transpose layout in ways we
+    // don't yet handle.
+    if (!lhsShapedType.hasStaticShape() || !rhsShapedType.hasStaticShape() ||
+        !resShapedType.hasStaticShape())
       return rewriter.notifyMatchFailure(
-          op, "failed to match conv::Nwc 3-par 2-red");
-
-    // No transposition needed.
-    if (layout({/*lhsIndex*/ {n, strideW * w + dilationW * kw, c},
-                /*rhsIndex*/ {kw, c, f},
-                /*resIndex*/ {n, w, f}}))
-      return conv(Conv1DOpOrder::Nwc);
-
-    return rewriter.notifyMatchFailure(op, "not a conv::Nwc layout");
+          op,
+          "depthwise conv with non-canonical layout requires static shapes");
+    return depthwiseConvViaTranspose(perms, flatten1DDepthwiseConv);
   }
 
-  /// Entry point that transposes into the common form:
-  ///   {{n, c, strideW * w + dilationW * kw}, {f, c, kw}, {n, f, w}}
-  FailureOr<Operation *> generateNcwConv() {
-    AffineExpr n, w, f, kw, c;
-    bindDims(ctx, n, f, w, c, kw);
-    if (!iters({Par(), Par(), Par(), Red(), Red()}))
-      return rewriter.notifyMatchFailure(
-          op, "failed to match conv::Ncw 3-par 2-red");
-
-    if (layout({/*lhsIndex*/ {n, c, strideW * w + dilationW * kw},
-                /*rhsIndex*/ {f, c, kw},
-                /*resIndex*/ {n, f, w}}))
-      return conv(Conv1DOpOrder::Ncw);
-
-    return rewriter.notifyMatchFailure(op, "not a conv::Ncw layout");
+  /// Extract canonical loop sizes from ConvolutionDimensions.
+  Conv1DSizes computeConvSizes(LinalgOp linalgOp) const {
+    SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
+    Conv1DSizes sizes;
+    sizes.kw = loopRanges[dims().filterLoop[0]];
+    sizes.w = loopRanges[dims().outputImage[0]];
+    if (!config.nLikeBatch.empty())
+      sizes.n = loopRanges[config.nLikeBatch[0]];
+    if (config.isPooling) {
+      // Pooling has no separate filter channel: the C-like batch dim doubles
+      // as both input and output channel size.
+      if (!config.cLikeBatch.empty())
+        sizes.c = sizes.f = loopRanges[config.cLikeBatch[0]];
+    } else if (config.layout != ConvLayoutKind::Scalar) {
+      sizes.c = loopRanges[dims().inputChannel[0]];
+      sizes.f = loopRanges[dims().outputChannel[0]];
+    }
+    return sizes;
   }
 
-  /// Entry point that transposes into the common form:
-  ///   {{n, strideW * w + dilationW * kw, c}, {kw}, {n, w, c}} for pooling
-  FailureOr<Operation *> generateNwcPooling() {
-    AffineExpr n, w, c, kw;
-    bindDims(ctx, n, w, c, kw);
-    if (!iters({Par(), Par(), Par(), Red()}))
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to match pooling 3-par 1-red");
-
-    // No transposition needed.
-    if (layout({/*lhsIndex*/ {n, strideW * w + dilationW * kw, c},
-                /*rhsIndex*/ {kw},
-                /*resIndex*/ {n, w, c}}))
-      return conv(Conv1DOpOrder::Nwc);
-
-    return rewriter.notifyMatchFailure(op, "not a pooling::Nwc layout");
+  /// Build the canonical (post-transpose) NWC operand shapes.
+  Conv1DShapes computeCanonicalShapes(const Conv1DSizes &sizes) const {
+    int64_t iwSize = config.layout == ConvLayoutKind::Scalar
+                         ? (sizes.w + sizes.kw - 1)
+                         : ((sizes.w - 1) * strideW + 1) +
+                               ((sizes.kw - 1) * dilationW + 1) - 1;
+    Conv1DShapes shapes;
+    switch (config.layout) {
+    case ConvLayoutKind::Scalar:
+      shapes.lhs = {iwSize};
+      shapes.rhs = {sizes.kw};
+      shapes.res = {sizes.w};
+      break;
+    case ConvLayoutKind::Batched:
+      shapes.lhs = {sizes.n, iwSize, sizes.c};
+      shapes.rhs = config.isPooling
+                       ? SmallVector<int64_t>{sizes.kw}
+                       : SmallVector<int64_t>{sizes.kw, sizes.c, sizes.f};
+      shapes.res = {sizes.n, sizes.w, sizes.f};
+      break;
+    case ConvLayoutKind::Batchless:
+      shapes.lhs = {iwSize, sizes.c};
+      shapes.rhs = config.isPooling
+                       ? SmallVector<int64_t>{sizes.kw}
+                       : SmallVector<int64_t>{sizes.kw, sizes.c, sizes.f};
+      shapes.res = {sizes.w, sizes.f};
+      break;
+    }
+    return shapes;
   }
 
-  /// Entry point that transposes into the common form:
-  ///   {{n, c, strideW * w + dilationW * kw}, {kw}, {n, c, w}} for pooling
-  FailureOr<Operation *> generateNcwPooling() {
-    AffineExpr n, w, c, kw;
-    bindDims(ctx, n, c, w, kw);
-    if (!iters({Par(), Par(), Par(), Red()}))
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to match pooling 3-par 1-red");
-
-    if (layout({/*lhsIndex*/ {n, c, strideW * w + dilationW * kw},
-                /*rhsIndex*/ {kw},
-                /*resIndex*/ {n, c, w}}))
-      return conv(Conv1DOpOrder::Ncw);
-
-    return rewriter.notifyMatchFailure(op, "not a pooling::Ncw layout");
+  /// Compute the pre-read (transfer_read) shapes by inverting the
+  /// permutations on the canonical shapes. If a permutation is identity, the
+  /// canonical shape is returned unchanged.
+  Conv1DShapes computeReadShapes(const Conv1DShapes &canonical,
+                                 const Conv1DPerms &perms) const {
+    auto inverseApply = [](ArrayRef<int64_t> canonShape,
+                           ArrayRef<int64_t> perm) -> SmallVector<int64_t> {
+      if (perm.empty())
+        return SmallVector<int64_t>(canonShape);
+      return applyPermutation(canonShape, invertPermutationVector(perm));
+    };
+    return Conv1DShapes{inverseApply(canonical.lhs, perms.lhs),
+                        inverseApply(canonical.rhs, perms.rhs),
+                        inverseApply(canonical.res, perms.res)};
   }
 
-  /// Entry point that transposes into the common form:
-  ///   {{n, strideW * w + dilationW * kw, c}, {kw, c}, {n, w, c}}
-  FailureOr<Operation *> generateDilatedConv(uint64_t vecChDimSize = 0,
-                                             bool vecChDimScalableFlag = false,
-                                             bool flatten = false) {
-    AffineExpr n, w, c, kw;
-    bindDims(ctx, n, w, c, kw);
-    if (!iters({Par(), Par(), Par(), Red()}))
-      return rewriter.notifyMatchFailure(
-          op, "failed to match depthwise::Nwc conv 3-par 1-red");
+  /// Read operand tensors and pre-transpose to canonical NWC form. `rhs` is
+  /// nullptr for pooling.
+  Conv1DOperandVecs readAndTranspose(const Conv1DShapes &readShapes,
+                                     const Conv1DPerms &perms) {
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Type lhsEltType = lhsShapedType.getElementType();
+    Type rhsEltType = rhsShapedType.getElementType();
+    Type resEltType = resShapedType.getElementType();
 
-    // No transposition needed.
-    if (layout({/*lhsIndex*/ {n, strideW * w + dilationW * kw, c},
-                /*rhsIndex*/ {kw, c},
-                /*resIndex*/ {n, w, c}}))
-      return depthwiseConv(vecChDimSize, vecChDimScalableFlag, flatten);
+    SmallVector<Value> lhsIndices(readShapes.lhs.size(), zero);
+    SmallVector<Value> rhsIndices(readShapes.rhs.size(), zero);
+    SmallVector<Value> resIndices(readShapes.res.size(), zero);
 
-    return rewriter.notifyMatchFailure(op, "not a depthwise::Nwc layout");
+    Conv1DOperandVecs vecs;
+    vecs.lhs = vector::TransferReadOp::create(
+        rewriter, loc, VectorType::get(readShapes.lhs, lhsEltType), lhsShaped,
+        lhsIndices, arith::getZeroConstant(rewriter, loc, lhsEltType));
+    if (convKind() == ConvOperationKind::Conv)
+      vecs.rhs = vector::TransferReadOp::create(
+          rewriter, loc, VectorType::get(readShapes.rhs, rhsEltType), rhsShaped,
+          rhsIndices, arith::getZeroConstant(rewriter, loc, rhsEltType));
+    vecs.res = vector::TransferReadOp::create(
+        rewriter, loc, VectorType::get(readShapes.res, resEltType), resShaped,
+        resIndices, arith::getZeroConstant(rewriter, loc, resEltType));
+
+    if (!perms.lhs.empty())
+      vecs.lhs =
+          vector::TransposeOp::create(rewriter, loc, vecs.lhs, perms.lhs);
+    if (!perms.rhs.empty() && vecs.rhs)
+      vecs.rhs =
+          vector::TransposeOp::create(rewriter, loc, vecs.rhs, perms.rhs);
+    if (!perms.res.empty())
+      vecs.res =
+          vector::TransposeOp::create(rewriter, loc, vecs.res, perms.res);
+
+    return vecs;
+  }
+
+  /// Extract slices, perform the contraction/pooling, and re-insert slices.
+  /// All operands must already be in canonical NWC form.
+  Value computeConv1D(const Conv1DOperandVecs &vecs, const Conv1DSizes &sizes,
+                      int64_t wSizeStep) {
+    auto linearIndex = [&](int64_t kw, int64_t w) {
+      return kw * (sizes.w / wSizeStep) + w / wSizeStep;
+    };
+
+    SmallVector<Value> lhsVals = extractConvInputSlices(
+        rewriter, loc, vecs.lhs, sizes.n, sizes.w, sizes.c, sizes.kw, strideW,
+        dilationW, wSizeStep, config.layout);
+    SmallVector<Value> rhsVals;
+    if (convKind() == ConvOperationKind::Conv)
+      rhsVals = extractConvFilterSlices(rewriter, loc, vecs.rhs, sizes.kw);
+    SmallVector<Value> resVals =
+        extractConvResultSlices(rewriter, loc, vecs.res, sizes.n, sizes.w,
+                                sizes.f, wSizeStep, config.layout);
+
+    for (int64_t kw = 0; kw < sizes.kw; ++kw) {
+      for (int64_t w = 0; w < sizes.w; w += wSizeStep) {
+        int64_t idx = linearIndex(kw, w);
+        int64_t wIdx = w / wSizeStep;
+        if (convKind() == ConvOperationKind::Pool) {
+          resVals[wIdx] =
+              pool1dSlice(rewriter, loc, lhsVals[idx], resVals[wIdx]);
+          continue;
+        }
+        switch (config.layout) {
+        case ConvLayoutKind::Scalar:
+          resVals[wIdx] = conv1dSliceAsOuterProduct(rewriter, loc, lhsVals[idx],
+                                                    rhsVals[kw], resVals[wIdx]);
+          break;
+        case ConvLayoutKind::Batched:
+          resVals[wIdx] = conv1dSliceAsContraction(rewriter, loc, lhsVals[idx],
+                                                   rhsVals[kw], resVals[wIdx]);
+          break;
+        case ConvLayoutKind::Batchless:
+          resVals[wIdx] = conv1dBatchlessSliceAsContraction(
+              rewriter, loc, lhsVals[idx], rhsVals[kw], resVals[wIdx]);
+          break;
+        }
+      }
+    }
+
+    return insertConvResultSlices(rewriter, loc, vecs.res, sizes.w, wSizeStep,
+                                  resVals, config.layout);
+  }
+
+  /// Post-transpose the result back to the original layout and write it.
+  FailureOr<Operation *> writeAndPostTranspose(Value res,
+                                               ArrayRef<int64_t> writeShape,
+                                               ArrayRef<int64_t> resPerm) {
+    if (!resPerm.empty()) {
+      SmallVector<int64_t> invResPerm = invertPermutationVector(resPerm);
+      res = vector::TransposeOp::create(rewriter, loc, res, invResPerm);
+    }
+    Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    SmallVector<Value> resIndices(writeShape.size(), zero);
+    return vector::TransferWriteOp::create(rewriter, loc, res, resShaped,
+                                           resIndices)
+        .getOperation();
+  }
+
+  /// Generic entry point that handles any 1D convolution/pooling layout.
+  FailureOr<Operation *> generate(ArrayRef<int64_t> inputVecSizes = {},
+                                  ArrayRef<bool> inputScalableVecDims = {},
+                                  bool flatten1DDepthwiseConv = false) {
+    if (config.isDepthwise)
+      return handleDepthwise(inputVecSizes, inputScalableVecDims,
+                             flatten1DDepthwiseConv);
+
+    LinalgOp linalgOp = cast<LinalgOp>(op);
+    Conv1DSizes sizes = computeConvSizes(linalgOp);
+    Conv1DPerms perms = computeCanonicalPerms(linalgOp, config);
+    Conv1DShapes canonShapes = computeCanonicalShapes(sizes);
+    Conv1DShapes readShapes = computeReadShapes(canonShapes, perms);
+
+    Conv1DOperandVecs vecs = readAndTranspose(readShapes, perms);
+
+    int64_t wSizeStep = strideW == 1 ? sizes.w : 1;
+    Value res = computeConv1D(vecs, sizes, wSizeStep);
+
+    return writeAndPostTranspose(res, readShapes.res, perms.res);
   }
 
 private:
-  ConvOperationKind oper = ConvOperationKind::Conv;
+  Conv1DConfig config;
   StringAttr redOp;
   StringAttr poolExtOp;
   bool isPoolExt = false;
-  int strideW, dilationW;
+  int strideW = 0;
+  int dilationW = 0;
   Value lhsShaped, rhsShaped, resShaped;
   ShapedType lhsShapedType, rhsShapedType, resShapedType;
   vector::CombiningKind reductionKind;
 
-  // Sets oper, poolExtOp and isPoolExt for valid conv/pooling ops.
-  void setConvOperationKind(Operation *reduceOp) {
+  /// Convenience accessors.
+  const ConvolutionDimensions &dims() const { return config.dims; }
+  ConvOperationKind convKind() const { return config.convKind; }
+
+  /// Inspect the reduce op body and set `isPoolExt`/`poolExtOp` if this is a
+  /// pooling op whose value is fed by a cast of a block argument.
+  void setPoolExtFromReduce(Operation *reduceOp) {
     int numBlockArguments =
         llvm::count_if(reduceOp->getOperands(), llvm::IsaPred<BlockArgument>);
-    if (numBlockArguments == 1) {
-      // Will be convolution if feeder is a MulOp.
-      // A strength reduced version of MulOp for i1 type is AndOp which is also
-      // supported. Otherwise, it can be pooling. This strength reduction logic
-      // is in `buildBinaryFn` helper in the Linalg dialect.
-      auto feedValIt = llvm::find_if_not(reduceOp->getOperands(),
-                                         llvm::IsaPred<BlockArgument>);
-      Operation *feedOp = (*feedValIt).getDefiningOp();
-      if (isCastOfBlockArgument(feedOp)) {
-        oper = ConvOperationKind::Pool;
-        isPoolExt = true;
-        poolExtOp = feedOp->getName().getIdentifier();
-        return;
-      }
-      oper = ConvOperationKind::Conv;
+    if (numBlockArguments != 1)
       return;
+    auto feedValIt = llvm::find_if_not(reduceOp->getOperands(),
+                                       llvm::IsaPred<BlockArgument>);
+    Operation *feedOp = (*feedValIt).getDefiningOp();
+    if (isCastOfBlockArgument(feedOp)) {
+      isPoolExt = true;
+      poolExtOp = feedOp->getName().getIdentifier();
     }
-    // numBlockArugments == 2 and this is a pooling op.
-    oper = ConvOperationKind::Pool;
-    isPoolExt = false;
   }
 };
 } // namespace
@@ -4118,44 +4331,8 @@ static FailureOr<Operation *> vectorizeConvolution(
   FailureOr<Conv1DGenerator> conv1dGen = Conv1DGenerator::create(rewriter, op);
   if (failed(conv1dGen))
     return failure();
-  auto res = conv1dGen->generateNonChanneledConv();
-  if (succeeded(res))
-    return res;
-  res = conv1dGen->generateNwcConv();
-  if (succeeded(res))
-    return res;
-  res = conv1dGen->generateNcwConv();
-  if (succeeded(res))
-    return res;
-  res = conv1dGen->generateNwcPooling();
-  if (succeeded(res))
-    return res;
-  res = conv1dGen->generateNcwPooling();
-  if (succeeded(res))
-    return res;
-
-  // Only depthwise 1D NWC convs are left - these can be vectorized using masks
-  // and scalable vectors. Note that ATM the only dim that can be dynamic (i.e.
-  // masked/scalable) is the channel dim (i.e. the trailing dim).
-  uint64_t vecChDimSize = ShapedType::kDynamic;
-  bool vecChDimScalableFlag = false;
-  if (!inputVecSizes.empty()) {
-    // Only use the input vector size corresponding to the channel dim. Other
-    // vector dims will be inferred from the Ops.
-    assert((isaConvolutionOpOfType<linalg::DepthwiseConv1DNwcWcOp>(op) ||
-            isaConvolutionOpOfType<linalg::DepthwiseConv1DNcwCwOp>(op)) &&
-           "Not a 1D depthwise conv!");
-    size_t chDimIdx = 0;
-    if (isaConvolutionOpOfType<linalg::DepthwiseConv1DNwcWcOp>(op))
-      chDimIdx = 2;
-    if (isaConvolutionOpOfType<linalg::DepthwiseConv1DNcwCwOp>(op))
-      chDimIdx = 1;
-
-    vecChDimSize = inputVecSizes[chDimIdx];
-    vecChDimScalableFlag = inputScalableVecDims[chDimIdx];
-  }
-  return conv1dGen->generateDilatedConv(vecChDimSize, vecChDimScalableFlag,
-                                        flatten1DDepthwiseConv);
+  return conv1dGen->generate(inputVecSizes, inputScalableVecDims,
+                             flatten1DDepthwiseConv);
 }
 
 struct VectorizeConvolution : public OpInterfaceRewritePattern<LinalgOp> {

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -3843,8 +3843,16 @@ public:
 
   /// Vector-level depthwise compute kernel: extracts kw x w tiles from the
   /// canonical NWC operand vectors, runs MulAcc, and re-inserts the tiles
-  /// back into the result vector. All inputs must be in canonical NWC form
-  /// (lhs=[n,iw,c], rhs=[kw,c], res=[n,w,c]).
+  /// back into the result vector.
+  ///
+  /// Rank/shape contract (enforced by `assert`):
+  ///   - `lhs` is a 3D vector <nSize, iwSize, cSize>
+  ///   - `res` is a 3D vector <nSize, wSize,  cSize>
+  ///   - `rhs` is a 2D vector <kwSize, cSize>
+  ///   - `nSize` equals `lhs.getShape()[0]` and `res.getShape()[0]`.
+  /// Callers whose operand layout does not have a batch dim (batchless) must
+  /// `vector.shape_cast` to unit `N = 1` before invoking the kernel and
+  /// collapse the result back afterwards (see `depthwiseConvViaTranspose`).
   ///
   /// On MulAcc failure the kernel erases only the IR it created; the caller
   /// is responsible for cleaning up its own pre-kernel IR.
@@ -3852,6 +3860,21 @@ public:
                                      int64_t nSize, int64_t wSize,
                                      int64_t cSize, int64_t kwSize,
                                      int64_t wSizeStep, bool flatten) {
+    auto lhsVecTy = cast<VectorType>(lhs.getType());
+    auto rhsVecTy = cast<VectorType>(rhs.getType());
+    auto resVecTy = cast<VectorType>(res.getType());
+    assert(lhsVecTy.getRank() == 3 && resVecTy.getRank() == 3 &&
+           rhsVecTy.getRank() == 2 &&
+           "depthwise1DKernel expects 3D lhs/res and 2D rhs in canonical NWC");
+    assert(lhsVecTy.getShape()[0] == nSize && resVecTy.getShape()[0] == nSize &&
+           "depthwise1DKernel: nSize must match the leading dim of lhs/res");
+    assert(lhsVecTy.getShape()[2] == cSize && resVecTy.getShape()[2] == cSize &&
+           rhsVecTy.getShape()[1] == cSize &&
+           "depthwise1DKernel: cSize must match the trailing dim of each "
+           "operand");
+    (void)lhsVecTy;
+    (void)rhsVecTy;
+    (void)resVecTy;
     Type lhsEltType = cast<VectorType>(lhs.getType()).getElementType();
     Type resEltType = cast<VectorType>(res.getType()).getElementType();
 
@@ -3928,34 +3951,18 @@ public:
     return out;
   }
 
-  /// Depthwise convolution for non-canonical layouts: read the operands in
-  /// their original layout, transpose the loaded vectors to canonical NWC,
-  /// run the kernel, inverse-transpose the result, and write it back.
-  /// Static shapes only (no masking).
+  /// Depthwise convolution for layouts not handled by the masked/scalable
+  /// `depthwiseConv()` path: read the operands in their original layout,
+  /// transpose the loaded vectors to canonical NWC, run the kernel, then
+  /// inverse-transpose the result and write it back. Also handles the
+  /// batchless canonical case (no transposes, but the kernel's 3D contract
+  /// still requires a unit-N shape_cast around the call). Static shapes only
+  /// (no masking, no scalable vectors).
   FailureOr<Operation *> depthwiseConvViaTranspose(const Conv1DPerms &perms,
                                                    bool flatten) {
-    // Canonical sizes: kernel is [kw, c], result is [n, w, c].
-    int64_t kwSize = 0, cSize = 0, nSize = 0, wSize = 0;
-    {
-      DenseMap<unsigned, unsigned> loopToRhs =
-          buildLoopToTensorDimMap(cast<LinalgOp>(op).getIndexingMapsArray()[1]);
-      DenseMap<unsigned, unsigned> loopToRes =
-          buildLoopToTensorDimMap(cast<LinalgOp>(op).getIndexingMapsArray()[2]);
-      kwSize = rhsShapedType.getShape()[loopToRhs[dims().filterLoop[0]]];
-      cSize = rhsShapedType.getShape()[loopToRhs[dims().depth[0]]];
-      nSize = config.nLikeBatch.empty()
-                  ? 1
-                  : resShapedType.getShape()[loopToRes[config.nLikeBatch[0]]];
-      wSize = resShapedType.getShape()[loopToRes[dims().outputImage[0]]];
-    }
-    int64_t iwSize =
-        ((wSize - 1) * strideW + 1) + ((kwSize - 1) * dilationW + 1) - 1;
-
-    Conv1DShapes canon{
-        /*lhs=*/{nSize, iwSize, cSize},
-        /*rhs=*/{kwSize, cSize},
-        /*res=*/{nSize, wSize, cSize},
-    };
+    LinalgOp linalgOp = cast<LinalgOp>(op);
+    Conv1DSizes sizes = computeConvSizes(linalgOp);
+    Conv1DShapes canon = computeCanonicalShapes(sizes);
     Conv1DShapes read = computeReadShapes(canon, perms);
 
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
@@ -3983,13 +3990,42 @@ public:
     if (!perms.res.empty())
       res = vector::TransposeOp::create(rewriter, loc, res, perms.res);
 
-    int64_t wSizeStep = strideW == 1 ? wSize : 1;
-    FailureOr<Value> kernelRes = depthwise1DKernel(
-        lhs, rhs, res, nSize, wSize, cSize, kwSize, wSizeStep, flatten);
+    bool batchless = config.layout == ConvLayoutKind::Batchless;
+    auto expandLeading = [&](Value v) -> Value {
+      auto vTy = cast<VectorType>(v.getType());
+      SmallVector<int64_t> shape3D = {1};
+      llvm::append_range(shape3D, vTy.getShape());
+      return vector::ShapeCastOp::create(
+          rewriter, loc, VectorType::get(shape3D, vTy.getElementType()), v);
+    };
+    auto collapseLeading = [&](Value v) -> Value {
+      auto vTy = cast<VectorType>(v.getType());
+      assert(vTy.getShape().front() == 1 &&
+             "expected unit leading dim to collapse");
+      SmallVector<int64_t> shape2D(vTy.getShape().begin() + 1,
+                                   vTy.getShape().end());
+      return vector::ShapeCastOp::create(
+          rewriter, loc, VectorType::get(shape2D, vTy.getElementType()), v);
+    };
+
+    if (batchless) {
+      lhs = expandLeading(lhs);
+      res = expandLeading(res);
+    }
+
+    int64_t leadingN = batchless ? 1 : sizes.n;
+    int64_t wSizeStep = strideW == 1 ? sizes.w : 1;
+    FailureOr<Value> kernelRes =
+        depthwise1DKernel(lhs, rhs, res, leadingN, sizes.w, sizes.c, sizes.kw,
+                          wSizeStep, flatten);
     if (failed(kernelRes))
       return failure();
 
-    return writeAndPostTranspose(*kernelRes, read.res, perms.res);
+    Value kernelVec = *kernelRes;
+    if (batchless)
+      kernelVec = collapseLeading(kernelVec);
+
+    return writeAndPostTranspose(kernelVec, read.res, perms.res);
   }
 
   /// Lower:
@@ -4074,8 +4110,19 @@ public:
     LinalgOp linalgOp = cast<LinalgOp>(op);
     Conv1DPerms perms = computeCanonicalPerms(linalgOp, config);
 
-    if (perms.allIdentity()) {
-      // Canonical NWC: existing path handles masking + scalable dims.
+    // The masked/scalable path (`depthwiseConv()`) builds 3D <N, W, C> vector
+    // types directly from the op's loop ranges and assumes the operand
+    // vectors are already in canonical NWC with a real batch dim. It is thus
+    // only valid when the layout is Batched *and* the tensor dims already
+    // appear in canonical order (identity permutations). All other cases
+    // (non-canonical batched, batchless canonical, batchless non-canonical)
+    // go through `depthwiseConvViaTranspose`, which performs any needed
+    // canonicalization via `vector.transpose` and handles batchless layouts
+    // by shape-casting to a unit leading dim around the kernel.
+    bool canUseMaskedPath =
+        perms.allIdentity() && config.layout == ConvLayoutKind::Batched;
+
+    if (canUseMaskedPath) {
       int64_t vecChDimSize = 0;
       bool vecChScalableFlag = false;
       if (!inputVecSizes.empty()) {
@@ -4089,14 +4136,14 @@ public:
                            flatten1DDepthwiseConv);
     }
 
-    // Non-canonical depthwise: only static shapes are supported because
-    // boundary masking interacts with the post-transpose layout in ways we
-    // don't yet handle.
+    // `depthwiseConvViaTranspose` builds vector types from the static tensor
+    // shapes; dynamic operands would require threading masks through the
+    // transposes/shape_casts which is not yet implemented.
     if (!lhsShapedType.hasStaticShape() || !rhsShapedType.hasStaticShape() ||
         !resShapedType.hasStaticShape())
       return rewriter.notifyMatchFailure(
-          op,
-          "depthwise conv with non-canonical layout requires static shapes");
+          op, "depthwise conv outside the canonical batched NWC layout "
+              "requires static shapes");
     return depthwiseConvViaTranspose(perms, flatten1DDepthwiseConv);
   }
 
@@ -4113,6 +4160,10 @@ public:
       // as both input and output channel size.
       if (!config.cLikeBatch.empty())
         sizes.c = sizes.f = loopRanges[config.cLikeBatch[0]];
+    } else if (config.isDepthwise) {
+      // Depthwise shares a single channel dim across LHS/RHS/RES; sizes.f is
+      // unused on this path.
+      sizes.c = loopRanges[dims().depth[0]];
     } else if (config.layout != ConvLayoutKind::Scalar) {
       sizes.c = loopRanges[dims().inputChannel[0]];
       sizes.f = loopRanges[dims().outputChannel[0]];
@@ -4120,12 +4171,30 @@ public:
     return sizes;
   }
 
-  /// Build the canonical (post-transpose) NWC operand shapes.
+  /// Build the canonical (post-transpose) NWC operand shapes. RHS and RES
+  /// shapes vary by op kind:
+  ///   - pooling:   RHS=<kw>,            RES channel=sizes.c (C-like batch)
+  ///   - depthwise: RHS=<kw, c>,         RES channel=sizes.c
+  ///   - conv:      RHS=<kw, c, f>,      RES channel=sizes.f
   Conv1DShapes computeCanonicalShapes(const Conv1DSizes &sizes) const {
     int64_t iwSize = config.layout == ConvLayoutKind::Scalar
                          ? (sizes.w + sizes.kw - 1)
                          : ((sizes.w - 1) * strideW + 1) +
                                ((sizes.kw - 1) * dilationW + 1) - 1;
+
+    SmallVector<int64_t> rhsShape;
+    int64_t resChannel = 0;
+    if (config.isPooling) {
+      rhsShape = {sizes.kw};
+      resChannel = sizes.c;
+    } else if (config.isDepthwise) {
+      rhsShape = {sizes.kw, sizes.c};
+      resChannel = sizes.c;
+    } else {
+      rhsShape = {sizes.kw, sizes.c, sizes.f};
+      resChannel = sizes.f;
+    }
+
     Conv1DShapes shapes;
     switch (config.layout) {
     case ConvLayoutKind::Scalar:
@@ -4135,17 +4204,13 @@ public:
       break;
     case ConvLayoutKind::Batched:
       shapes.lhs = {sizes.n, iwSize, sizes.c};
-      shapes.rhs = config.isPooling
-                       ? SmallVector<int64_t>{sizes.kw}
-                       : SmallVector<int64_t>{sizes.kw, sizes.c, sizes.f};
-      shapes.res = {sizes.n, sizes.w, sizes.f};
+      shapes.rhs = std::move(rhsShape);
+      shapes.res = {sizes.n, sizes.w, resChannel};
       break;
     case ConvLayoutKind::Batchless:
       shapes.lhs = {iwSize, sizes.c};
-      shapes.rhs = config.isPooling
-                       ? SmallVector<int64_t>{sizes.kw}
-                       : SmallVector<int64_t>{sizes.kw, sizes.c, sizes.f};
-      shapes.res = {sizes.w, sizes.f};
+      shapes.rhs = std::move(rhsShape);
+      shapes.res = {sizes.w, resChannel};
       break;
     }
     return shapes;

--- a/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
@@ -835,6 +835,56 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// Non-canonical depthwise 1D conv (NCW_CW): input (n, c, iw), filter (c, kw),
+// output (n, c, w). The vectorizer reads in the original layout, transposes
+// to canonical NWC for the depthwise compute kernel, and post-transposes the
+// result back to NCW. Static shapes only (masked path stays on the canonical
+// layout).
+func.func @depthwise_conv1d_ncw_cw_tensor(%input: tensor<2x3x6xf32>,
+                                          %filter: tensor<3x2xf32>,
+                                          %output: tensor<2x3x5xf32>) -> tensor<2x3x5xf32> {
+  %0 = linalg.depthwise_conv_1d_ncw_cw
+    {dilations = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}
+    ins(%input, %filter : tensor<2x3x6xf32>, tensor<3x2xf32>)
+    outs(%output : tensor<2x3x5xf32>) -> tensor<2x3x5xf32>
+  return %0 : tensor<2x3x5xf32>
+}
+
+// CHECK-LABEL: func.func @depthwise_conv1d_ncw_cw_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<2x3x6xf32>, %[[FILTER:.+]]: tensor<3x2xf32>, %[[OUTPUT:.+]]: tensor<2x3x5xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[V_INPUT_R:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : tensor<2x3x6xf32>, vector<2x3x6xf32>
+// CHECK-DAG:   %[[V_FILTER_R:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]]]{{.*}} : tensor<3x2xf32>, vector<3x2xf32>
+// CHECK-DAG:   %[[V_OUTPUT_R:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : tensor<2x3x5xf32>, vector<2x3x5xf32>
+/// Pre-transpose operands to canonical NWC/KC/NWC form.
+// CHECK:       %[[V_INPUT:.+]] = vector.transpose %[[V_INPUT_R]], [0, 2, 1] : vector<2x3x6xf32> to vector<2x6x3xf32>
+// CHECK:       %[[V_FILTER:.+]] = vector.transpose %[[V_FILTER_R]], [1, 0] : vector<3x2xf32> to vector<2x3xf32>
+// CHECK:       %[[V_OUTPUT:.+]] = vector.transpose %[[V_OUTPUT_R]], [0, 2, 1] : vector<2x3x5xf32> to vector<2x5x3xf32>
+/// kw = 0, 1 input slices (dilation = 1).
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0, 0], sizes = [2, 5, 3], strides = [1, 1, 1]} : vector<2x6x3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 1, 0], sizes = [2, 5, 3], strides = [1, 1, 1]} : vector<2x6x3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[FLT_KW0:.+]] = vector.extract %[[V_FILTER]][0] : vector<3xf32> from vector<2x3xf32>
+// CHECK:       %[[FLT_KW1:.+]] = vector.extract %[[V_FILTER]][1] : vector<3xf32> from vector<2x3xf32>
+/// Canonical depthwise kernel: broadcast+FMA per kw.
+// CHECK:       %[[B0:.+]] = vector.broadcast %[[FLT_KW0]] : vector<3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[FMA0:.+]] = vector.fma %[[IN_KW0]], %[[B0]], %[[V_OUTPUT]] : vector<2x5x3xf32>
+// CHECK:       %[[B1:.+]] = vector.broadcast %[[FLT_KW1]] : vector<3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[FMA1:.+]] = vector.fma %[[IN_KW1]], %[[B1]], %[[FMA0]] : vector<2x5x3xf32>
+/// Post-transpose the result back to NCW and write.
+// CHECK:       %[[V_RES:.+]] = vector.transpose %[[FMA1]], [0, 2, 1] : vector<2x5x3xf32> to vector<2x3x5xf32>
+// CHECK:       vector.transfer_write %[[V_RES]], %[[OUTPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : vector<2x3x5xf32>, tensor<2x3x5xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.depthwise_conv_1d_ncw_cw", "linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
 func.func @conv_1d_nwc_wcf_mixed_type_memref(%input: memref<1x2x3xf16>, %filter: memref<1x3x2xf16>, %output: memref<1x2x2xf32>) {
   linalg.conv_1d_nwc_wcf
   {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>}
@@ -1266,6 +1316,352 @@ func.func @pooling_ncw_sum_memref_2_3_2_1(%input: memref<4x2x5xf32>, %filter: me
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.pooling_ncw_sum", "linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless 1D conv (linalg.generic): input (iw, c), filter (kw, c, f),
+// output (w, f). Input is already in canonical WC form so no transposes
+// are required at the vector boundaries.
+func.func @conv1d_wc_wcf_tensor(%input: tensor<6x3xf32>,
+                                %filter: tensor<3x3x8xf32>,
+                                %output: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0 + d2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<6x3xf32>, tensor<3x3x8xf32>)
+    outs(%output : tensor<4x8xf32>) {
+    ^bb0(%in: f32, %filt: f32, %out: f32):
+      %mul = arith.mulf %in, %filt : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> tensor<4x8xf32>
+  return %res : tensor<4x8xf32>
+}
+
+// CHECK: #[[LHS_MAP_NWC:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[RHS_MAP_NWC:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[RES_MAP_NWC:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+//      CHECK: func.func @conv1d_wc_wcf_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<6x3xf32>, %[[FILTER:.+]]: tensor<3x3x8xf32>, %[[OUTPUT:.+]]: tensor<4x8xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[F0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:   %[[V_INPUT:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<6x3xf32>, vector<6x3xf32>
+// CHECK-DAG:   %[[V_FILTER:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true, true]} : tensor<3x3x8xf32>, vector<3x3x8xf32>
+// CHECK-DAG:   %[[V_OUTPUT:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<4x8xf32>, vector<4x8xf32>
+/// Input slices at offsets kw=0,1,2 (stride=1, dilation=1)
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [1, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW2:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+/// Filter slices at kw=0,1,2
+// CHECK:       %[[FLT_KW0:.+]] = vector.extract %[[V_FILTER]][0] : vector<3x8xf32> from vector<3x3x8xf32>
+// CHECK:       %[[FLT_KW1:.+]] = vector.extract %[[V_FILTER]][1] : vector<3x8xf32> from vector<3x3x8xf32>
+// CHECK:       %[[FLT_KW2:.+]] = vector.extract %[[V_FILTER]][2] : vector<3x8xf32> from vector<3x3x8xf32>
+/// Batchless contractions: {w,c} x {c,f} -> {w,f}
+// CHECK:       %[[CON0:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_NWC]], #[[RHS_MAP_NWC]], #[[RES_MAP_NWC]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW0]], %[[FLT_KW0]], %[[V_OUTPUT]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+// CHECK:       %[[CON1:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_NWC]], #[[RHS_MAP_NWC]], #[[RES_MAP_NWC]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW1]], %[[FLT_KW1]], %[[CON0]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+// CHECK:       %[[CON2:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_NWC]], #[[RHS_MAP_NWC]], #[[RES_MAP_NWC]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW2]], %[[FLT_KW2]], %[[CON1]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+// CHECK:       vector.transfer_write %[[CON2]], %[[OUTPUT]][%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<4x8xf32>, tensor<4x8xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless 1D conv (linalg.generic): input (c, iw), filter (f, c, kw),
+// output (f, w). All three operands are stored in non-canonical layouts;
+// the vectorizer pre-transposes to canonical WC/KCF/WF for the compute and
+// post-transposes the result back to FW.
+func.func @conv1d_cw_fcw_tensor(%input: tensor<3x6xf32>,
+                                %filter: tensor<8x3x3xf32>,
+                                %output: tensor<8x4xf32>) -> tensor<8x4xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d3, d0 + d2)>,
+      affine_map<(d0, d1, d2, d3) -> (d1, d3, d2)>,
+      affine_map<(d0, d1, d2, d3) -> (d1, d0)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<3x6xf32>, tensor<8x3x3xf32>)
+    outs(%output : tensor<8x4xf32>) {
+    ^bb0(%in: f32, %filt: f32, %out: f32):
+      %mul = arith.mulf %in, %filt : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> tensor<8x4xf32>
+  return %res : tensor<8x4xf32>
+}
+
+// CHECK: #[[LHS_MAP_CW:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[RHS_MAP_CW:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[RES_MAP_CW:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+//      CHECK: func.func @conv1d_cw_fcw_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<3x6xf32>, %[[FILTER:.+]]: tensor<8x3x3xf32>, %[[OUTPUT:.+]]: tensor<8x4xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[F0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:   %[[V_INPUT_R:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<3x6xf32>, vector<3x6xf32>
+// CHECK-DAG:   %[[V_FILTER_R:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true, true]} : tensor<8x3x3xf32>, vector<8x3x3xf32>
+// CHECK-DAG:   %[[V_OUTPUT_R:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<8x4xf32>, vector<8x4xf32>
+/// Pre-transpose to canonical WC/KWCF/WF form
+// CHECK:       %[[V_INPUT:.+]] = vector.transpose %[[V_INPUT_R]], [1, 0] : vector<3x6xf32> to vector<6x3xf32>
+// CHECK:       %[[V_FILTER:.+]] = vector.transpose %[[V_FILTER_R]], [2, 1, 0] : vector<8x3x3xf32> to vector<3x3x8xf32>
+// CHECK:       %[[V_OUTPUT:.+]] = vector.transpose %[[V_OUTPUT_R]], [1, 0] : vector<8x4xf32> to vector<4x8xf32>
+/// Input slices at offsets kw=0,1,2 (stride=1, dilation=1)
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [1, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW2:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+/// Filter slices at kw=0,1,2
+// CHECK:       %[[FLT_KW0:.+]] = vector.extract %[[V_FILTER]][0] : vector<3x8xf32> from vector<3x3x8xf32>
+// CHECK:       %[[FLT_KW1:.+]] = vector.extract %[[V_FILTER]][1] : vector<3x8xf32> from vector<3x3x8xf32>
+// CHECK:       %[[FLT_KW2:.+]] = vector.extract %[[V_FILTER]][2] : vector<3x8xf32> from vector<3x3x8xf32>
+/// Batchless contractions: {w,c} x {c,f} -> {w,f}
+// CHECK:       %[[CON0:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_CW]], #[[RHS_MAP_CW]], #[[RES_MAP_CW]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW0]], %[[FLT_KW0]], %[[V_OUTPUT]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+// CHECK:       %[[CON1:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_CW]], #[[RHS_MAP_CW]], #[[RES_MAP_CW]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW1]], %[[FLT_KW1]], %[[CON0]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+// CHECK:       %[[CON2:.+]] = vector.contract {indexing_maps = [#[[LHS_MAP_CW]], #[[RHS_MAP_CW]], #[[RES_MAP_CW]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %[[IN_KW2]], %[[FLT_KW2]], %[[CON1]] : vector<4x3xf32>, vector<3x8xf32> into vector<4x8xf32>
+/// Post-transpose result back to FW
+// CHECK:       %[[V_RES:.+]] = vector.transpose %[[CON2]], [1, 0] : vector<4x8xf32> to vector<8x4xf32>
+// CHECK:       vector.transfer_write %[[V_RES]], %[[OUTPUT]][%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<8x4xf32>, tensor<8x4xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless 1D max pooling (linalg.generic): input (iw, c), kernel (kw),
+// output (w, c). Input is already in canonical WC form so no transposes
+// are required.
+func.func @pooling_wc_max_tensor(%input: tensor<6x3xf32>,
+                                 %kernel: tensor<3xf32>,
+                                 %output: tensor<4x3xf32>) -> tensor<4x3xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0 + d2, d1)>,
+      affine_map<(d0, d1, d2) -> (d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %kernel : tensor<6x3xf32>, tensor<3xf32>)
+    outs(%output : tensor<4x3xf32>) {
+    ^bb0(%in: f32, %k: f32, %out: f32):
+      %max = arith.maximumf %out, %in : f32
+      linalg.yield %max : f32
+  } -> tensor<4x3xf32>
+  return %res : tensor<4x3xf32>
+}
+
+// CHECK-LABEL: func.func @pooling_wc_max_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<6x3xf32>, %[[KERNEL:.+]]: tensor<3xf32>, %[[OUTPUT:.+]]: tensor<4x3xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[F0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:   %[[V_INPUT:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<6x3xf32>, vector<6x3xf32>
+// CHECK-DAG:   %[[V_OUTPUT:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<4x3xf32>, vector<4x3xf32>
+/// Input slices at offsets kw=0,1,2 (stride=1, dilation=1)
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [1, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW2:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+/// Batchless max pooling: element-wise maximumf accumulation
+// CHECK:       %[[MAX0:.+]] = arith.maximumf %[[IN_KW0]], %[[V_OUTPUT]] : vector<4x3xf32>
+// CHECK:       %[[MAX1:.+]] = arith.maximumf %[[IN_KW1]], %[[MAX0]] : vector<4x3xf32>
+// CHECK:       %[[MAX2:.+]] = arith.maximumf %[[IN_KW2]], %[[MAX1]] : vector<4x3xf32>
+// CHECK:       vector.transfer_write %[[MAX2]], %[[OUTPUT]][%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<4x3xf32>, tensor<4x3xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless 1D max pooling (linalg.generic): input (c, iw), kernel (kw),
+// output (c, w). Input/output are stored in non-canonical CW form; the
+// vectorizer pre-transposes to canonical WC for the compute and
+// post-transposes the result back to CW.
+func.func @pooling_cw_max_tensor(%input: tensor<3x6xf32>,
+                                 %kernel: tensor<3xf32>,
+                                 %output: tensor<3x4xf32>) -> tensor<3x4xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d1, d0 + d2)>,
+      affine_map<(d0, d1, d2) -> (d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d0)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %kernel : tensor<3x6xf32>, tensor<3xf32>)
+    outs(%output : tensor<3x4xf32>) {
+    ^bb0(%in: f32, %k: f32, %out: f32):
+      %max = arith.maximumf %out, %in : f32
+      linalg.yield %max : f32
+  } -> tensor<3x4xf32>
+  return %res : tensor<3x4xf32>
+}
+
+// CHECK-LABEL: func.func @pooling_cw_max_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<3x6xf32>, %[[KERNEL:.+]]: tensor<3xf32>, %[[OUTPUT:.+]]: tensor<3x4xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[F0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:   %[[V_INPUT_R:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<3x6xf32>, vector<3x6xf32>
+// CHECK-DAG:   %[[V_OUTPUT_R:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]], %[[F0]] {in_bounds = [true, true]} : tensor<3x4xf32>, vector<3x4xf32>
+/// Pre-transpose to canonical WC form
+// CHECK:       %[[V_INPUT:.+]] = vector.transpose %[[V_INPUT_R]], [1, 0] : vector<3x6xf32> to vector<6x3xf32>
+// CHECK:       %[[V_OUTPUT:.+]] = vector.transpose %[[V_OUTPUT_R]], [1, 0] : vector<3x4xf32> to vector<4x3xf32>
+/// Input slices at offsets kw=0,1,2 (stride=1, dilation=1)
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [1, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+// CHECK:       %[[IN_KW2:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [4, 3], strides = [1, 1]} : vector<6x3xf32> to vector<4x3xf32>
+/// Batchless max pooling in WC canonical form, then post-transpose back to CW
+// CHECK:       %[[MAX0:.+]] = arith.maximumf %[[IN_KW0]], %[[V_OUTPUT]] : vector<4x3xf32>
+// CHECK:       %[[MAX1:.+]] = arith.maximumf %[[IN_KW1]], %[[MAX0]] : vector<4x3xf32>
+// CHECK:       %[[MAX2:.+]] = arith.maximumf %[[IN_KW2]], %[[MAX1]] : vector<4x3xf32>
+/// Post-transpose result back to CW
+// CHECK:       %[[V_RES:.+]] = vector.transpose %[[MAX2]], [1, 0] : vector<4x3xf32> to vector<3x4xf32>
+// CHECK:       vector.transfer_write %[[V_RES]], %[[OUTPUT]][%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<3x4xf32>, tensor<3x4xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// 1D NWC max-pool whose loops are declared as (c, n, w, kw) instead of the
+// usual (n, w, c, kw). The LHS/result tensor layout is still NWC, so the
+// vectorizer should produce the canonical vector<NxWxC> shape and no
+// transposes. This exercises the `splitPoolBatchByLhsInnermost` derivation:
+// `inferConvolutionDims` returns `batch = [0, 1]` (sorted by loop index),
+// but `d0` is at the innermost LHS position (2), so it must be picked as
+// the channel-like batch regardless of the `dims.batch` ordering. An
+// ordering-based heuristic (pick `dims.batch.back()`) would instead select
+// `d1` (the N-like loop) and miscompile.
+func.func @pooling_nwc_max_reordered_loops_tensor(%input: tensor<2x6x3xf32>,
+                                                  %filter: tensor<2xf32>,
+                                                  %output: tensor<2x5x3xf32>) -> tensor<2x5x3xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d1, d2 + d3, d0)>,
+      affine_map<(d0, d1, d2, d3) -> (d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d1, d2, d0)>
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  } ins(%input, %filter : tensor<2x6x3xf32>, tensor<2xf32>)
+    outs(%output : tensor<2x5x3xf32>) {
+    ^bb0(%in: f32, %w: f32, %out: f32):
+      %m = arith.maximumf %in, %out : f32
+      linalg.yield %m : f32
+  } -> tensor<2x5x3xf32>
+  return %res : tensor<2x5x3xf32>
+}
+
+// CHECK-LABEL: func.func @pooling_nwc_max_reordered_loops_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<2x6x3xf32>, %{{.+}}: tensor<2xf32>, %[[OUTPUT:.+]]: tensor<2x5x3xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[V_INPUT:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : tensor<2x6x3xf32>, vector<2x6x3xf32>
+// CHECK-DAG:   %[[V_OUTPUT:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : tensor<2x5x3xf32>, vector<2x5x3xf32>
+/// Already in canonical NWC: no pre-transposes.
+// CHECK-NOT:   vector.transpose
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0, 0], sizes = [2, 5, 3], strides = [1, 1, 1]} : vector<2x6x3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 1, 0], sizes = [2, 5, 3], strides = [1, 1, 1]} : vector<2x6x3xf32> to vector<2x5x3xf32>
+// CHECK:       %[[MAX0:.+]] = arith.maximumf %[[IN_KW0]], %[[V_OUTPUT]] : vector<2x5x3xf32>
+// CHECK:       %[[MAX1:.+]] = arith.maximumf %[[IN_KW1]], %[[MAX0]] : vector<2x5x3xf32>
+// CHECK-NOT:   vector.transpose
+// CHECK:       vector.transfer_write %[[MAX1]], %[[OUTPUT]][%[[C0]], %[[C0]], %[[C0]]]{{.*}} : vector<2x5x3xf32>, tensor<2x5x3xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless 1D conv (linalg.generic) in canonical WC form with strideW = 2
+// and dilationW = 2. With stride > 1 the W loop is unrolled (one extract per
+// w step, wSizeStep = 1) and the kw loop is unrolled with offsets spaced by
+// dilation. iw = (w - 1) * stride + 1 + (kw - 1) * dilation + 1 - 1 = 11.
+func.func @conv1d_wc_wcf_strided_dilated_tensor(%input: tensor<11x3xf32>,
+                                                %filter: tensor<3x3x8xf32>,
+                                                %output: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %res = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0 * 2 + d2 * 2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<11x3xf32>, tensor<3x3x8xf32>)
+    outs(%output : tensor<4x8xf32>) {
+    ^bb0(%in: f32, %filt: f32, %out: f32):
+      %mul = arith.mulf %in, %filt : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> tensor<4x8xf32>
+  return %res : tensor<4x8xf32>
+}
+
+// CHECK-LABEL: func.func @conv1d_wc_wcf_strided_dilated_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<11x3xf32>, %[[FILTER:.+]]: tensor<3x3x8xf32>, %[[OUTPUT:.+]]: tensor<4x8xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[V_INPUT:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]]
+// CHECK-DAG:   %[[V_FILTER:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]], %[[C0]]]
+// CHECK-DAG:   %[[V_OUTPUT:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]]
+/// kw=0: input slices at offsets 0, 2, 4, 6 (w*strideW with stride=2)
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [0, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [4, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [6, 0], sizes = [1, 3], strides = [1, 1]}
+/// kw=1: same w-offsets shifted by dilationW=2
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [2, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [4, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [6, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [8, 0], sizes = [1, 3], strides = [1, 1]}
+/// kw=2: w-offsets shifted by 2*dilationW=4 from kw=0
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [4, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [6, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [8, 0], sizes = [1, 3], strides = [1, 1]}
+// CHECK:       vector.extract_strided_slice %[[V_INPUT]] {offsets = [10, 0], sizes = [1, 3], strides = [1, 1]}
+/// Filter slices at kw=0,1,2 and per-w output slices
+// CHECK:       vector.extract %[[V_FILTER]][0]
+// CHECK:       vector.extract %[[V_FILTER]][1]
+// CHECK:       vector.extract %[[V_FILTER]][2]
+// CHECK-COUNT-4: vector.extract_strided_slice %[[V_OUTPUT]]
+/// 12 contractions (4 w * 3 kw); the last 4 produce the per-w results.
+// CHECK-COUNT-12: vector.contract
+// CHECK-COUNT-4: vector.insert_strided_slice
+// CHECK:       vector.transfer_write {{.*}}, %[[OUTPUT]][%[[C0]], %[[C0]]]
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
     %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
     transform.yield

--- a/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/convolution-with-patterns.mlir
@@ -885,6 +885,124 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// Batchless canonical depthwise 1D: operands are already in <W, C> / <Kw, C>
+// form, so no vector.transpose is needed. The 3D `depthwise1DKernel` contract
+// is satisfied by shape-casting the LHS/RES vectors to a unit leading dim
+// before the kernel and collapsing it back afterwards.
+#bl_canon_lhs = affine_map<(w, c, kw) -> (w + kw, c)>
+#bl_canon_rhs = affine_map<(w, c, kw) -> (kw, c)>
+#bl_canon_res = affine_map<(w, c, kw) -> (w, c)>
+func.func @depthwise_conv1d_wc_wc_tensor(%input: tensor<6x3xf32>,
+                                          %filter: tensor<2x3xf32>,
+                                          %output: tensor<5x3xf32>) -> tensor<5x3xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#bl_canon_lhs, #bl_canon_rhs, #bl_canon_res],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %filter : tensor<6x3xf32>, tensor<2x3xf32>)
+    outs(%output : tensor<5x3xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %c, %m : f32
+    linalg.yield %r : f32
+  } -> tensor<5x3xf32>
+  return %0 : tensor<5x3xf32>
+}
+
+// CHECK-LABEL: func.func @depthwise_conv1d_wc_wc_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<6x3xf32>, %[[FILTER:.+]]: tensor<2x3xf32>, %[[OUTPUT:.+]]: tensor<5x3xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[V_INPUT:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]]{{.*}} : tensor<6x3xf32>, vector<6x3xf32>
+// CHECK-DAG:   %[[V_FILTER:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]]]{{.*}} : tensor<2x3xf32>, vector<2x3xf32>
+// CHECK-DAG:   %[[V_OUTPUT:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]]{{.*}} : tensor<5x3xf32>, vector<5x3xf32>
+/// Canonical layout: no pre-transposes.
+// CHECK-NOT:   vector.transpose
+/// Expand to <1, W, C> for the depthwise kernel.
+// CHECK:       %[[V_INPUT_3D:.+]] = vector.shape_cast %[[V_INPUT]] : vector<6x3xf32> to vector<1x6x3xf32>
+// CHECK:       %[[V_OUTPUT_3D:.+]] = vector.shape_cast %[[V_OUTPUT]] : vector<5x3xf32> to vector<1x5x3xf32>
+/// kw = 0, 1 input slices carry the unit leading dim.
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT_3D]] {offsets = [0, 0, 0], sizes = [1, 5, 3], strides = [1, 1, 1]} : vector<1x6x3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT_3D]] {offsets = [0, 1, 0], sizes = [1, 5, 3], strides = [1, 1, 1]} : vector<1x6x3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FLT_KW0:.+]] = vector.extract %[[V_FILTER]][0] : vector<3xf32> from vector<2x3xf32>
+// CHECK:       %[[FLT_KW1:.+]] = vector.extract %[[V_FILTER]][1] : vector<3xf32> from vector<2x3xf32>
+// CHECK:       %[[B0:.+]] = vector.broadcast %[[FLT_KW0]] : vector<3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FMA0:.+]] = vector.fma %[[IN_KW0]], %[[B0]], %[[V_OUTPUT_3D]] : vector<1x5x3xf32>
+// CHECK:       %[[B1:.+]] = vector.broadcast %[[FLT_KW1]] : vector<3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FMA1:.+]] = vector.fma %[[IN_KW1]], %[[B1]], %[[FMA0]] : vector<1x5x3xf32>
+/// Collapse the unit leading dim back to batchless <W, C> and write.
+// CHECK:       %[[V_RES:.+]] = vector.shape_cast %[[FMA1]] : vector<1x5x3xf32> to vector<5x3xf32>
+// CHECK:       vector.transfer_write %[[V_RES]], %[[OUTPUT]][%[[C0]], %[[C0]]]{{.*}} : vector<5x3xf32>, tensor<5x3xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Batchless non-canonical depthwise 1D: input/output are laid out as <C, W>
+// and the filter as <C, Kw>. The vectorizer pre-transposes the read vectors
+// to canonical NWC, shape-casts in a unit leading dim for the depthwise
+// kernel, collapses it back, and post-transposes the result into <C, W>.
+#bl_cw_lhs = affine_map<(w, c, kw) -> (c, w + kw)>
+#bl_cw_rhs = affine_map<(w, c, kw) -> (c, kw)>
+#bl_cw_res = affine_map<(w, c, kw) -> (c, w)>
+func.func @depthwise_conv1d_cw_cw_tensor(%input: tensor<3x6xf32>,
+                                          %filter: tensor<3x2xf32>,
+                                          %output: tensor<3x5xf32>) -> tensor<3x5xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#bl_cw_lhs, #bl_cw_rhs, #bl_cw_res],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %filter : tensor<3x6xf32>, tensor<3x2xf32>)
+    outs(%output : tensor<3x5xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %c, %m : f32
+    linalg.yield %r : f32
+  } -> tensor<3x5xf32>
+  return %0 : tensor<3x5xf32>
+}
+
+// CHECK-LABEL: func.func @depthwise_conv1d_cw_cw_tensor(
+// CHECK-SAME:    %[[INPUT:.+]]: tensor<3x6xf32>, %[[FILTER:.+]]: tensor<3x2xf32>, %[[OUTPUT:.+]]: tensor<3x5xf32>
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[V_INPUT_R:.+]] = vector.transfer_read %[[INPUT]][%[[C0]], %[[C0]]]{{.*}} : tensor<3x6xf32>, vector<3x6xf32>
+// CHECK-DAG:   %[[V_FILTER_R:.+]] = vector.transfer_read %[[FILTER]][%[[C0]], %[[C0]]]{{.*}} : tensor<3x2xf32>, vector<3x2xf32>
+// CHECK-DAG:   %[[V_OUTPUT_R:.+]] = vector.transfer_read %[[OUTPUT]][%[[C0]], %[[C0]]]{{.*}} : tensor<3x5xf32>, vector<3x5xf32>
+/// Pre-transpose to canonical WC/KwC/WC.
+// CHECK:       %[[V_INPUT:.+]] = vector.transpose %[[V_INPUT_R]], [1, 0] : vector<3x6xf32> to vector<6x3xf32>
+// CHECK:       %[[V_FILTER:.+]] = vector.transpose %[[V_FILTER_R]], [1, 0] : vector<3x2xf32> to vector<2x3xf32>
+// CHECK:       %[[V_OUTPUT:.+]] = vector.transpose %[[V_OUTPUT_R]], [1, 0] : vector<3x5xf32> to vector<5x3xf32>
+/// Expand to <1, W, C> for the depthwise kernel.
+// CHECK:       %[[V_INPUT_3D:.+]] = vector.shape_cast %[[V_INPUT]] : vector<6x3xf32> to vector<1x6x3xf32>
+// CHECK:       %[[V_OUTPUT_3D:.+]] = vector.shape_cast %[[V_OUTPUT]] : vector<5x3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[IN_KW0:.+]] = vector.extract_strided_slice %[[V_INPUT_3D]] {offsets = [0, 0, 0], sizes = [1, 5, 3], strides = [1, 1, 1]} : vector<1x6x3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[IN_KW1:.+]] = vector.extract_strided_slice %[[V_INPUT_3D]] {offsets = [0, 1, 0], sizes = [1, 5, 3], strides = [1, 1, 1]} : vector<1x6x3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FLT_KW0:.+]] = vector.extract %[[V_FILTER]][0] : vector<3xf32> from vector<2x3xf32>
+// CHECK:       %[[FLT_KW1:.+]] = vector.extract %[[V_FILTER]][1] : vector<3xf32> from vector<2x3xf32>
+// CHECK:       %[[B0:.+]] = vector.broadcast %[[FLT_KW0]] : vector<3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FMA0:.+]] = vector.fma %[[IN_KW0]], %[[B0]], %[[V_OUTPUT_3D]] : vector<1x5x3xf32>
+// CHECK:       %[[B1:.+]] = vector.broadcast %[[FLT_KW1]] : vector<3xf32> to vector<1x5x3xf32>
+// CHECK:       %[[FMA1:.+]] = vector.fma %[[IN_KW1]], %[[B1]], %[[FMA0]] : vector<1x5x3xf32>
+/// Collapse the unit leading dim and post-transpose back to <C, W>.
+// CHECK:       %[[V_RES_2D:.+]] = vector.shape_cast %[[FMA1]] : vector<1x5x3xf32> to vector<5x3xf32>
+// CHECK:       %[[V_RES:.+]] = vector.transpose %[[V_RES_2D]], [1, 0] : vector<5x3xf32> to vector<3x5xf32>
+// CHECK:       vector.transfer_write %[[V_RES]], %[[OUTPUT]][%[[C0]], %[[C0]]]{{.*}} : vector<3x5xf32>, tensor<3x5xf32>
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1 = transform.get_parent_op %0 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %2 = transform.structured.vectorize_children_and_apply_patterns %1 : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
 func.func @conv_1d_nwc_wcf_mixed_type_memref(%input: memref<1x2x3xf16>, %filter: memref<1x3x2xf16>, %output: memref<1x2x2xf32>) {
   linalg.conv_1d_nwc_wcf
   {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>}

--- a/mlir/test/Dialect/Linalg/vectorization/convolution.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/convolution.mlir
@@ -196,3 +196,162 @@ module attributes {transform.with_named_sequence} {
 // CHECK:           %[[FMA_2:.*]] = vector.fma %[[IN_2]], %[[FLT_2_B]], %[[FMA_1]] : vector<3x2x[4]xf32>
 // CHECK:           %[[OUT_INS:.*]] = vector.insert_strided_slice %[[FMA_2]], %[[VEC_OUT]] {offsets = [0, 0, 0], strides = [1, 1, 1]} : vector<3x2x[4]xf32> into vector<3x2x[4]xf32>
 // CHECK:           vector.mask %[[MASK_OUT]] { vector.transfer_write %[[OUT_INS]], %[[OUTPUT]]{{\[}}%[[C0]], %[[C0]], %[[C0]]] {in_bounds = [true, true, true]} : vector<3x2x[4]xf32>, memref<3x2x?xf32> } : vector<3x2x[4]xi1>
+
+// -----
+
+// Batchless canonical depthwise (WC / <Kw, C> / WC) with a dynamic channel dim.
+
+#bl_canon_lhs = affine_map<(w, c, kw) -> (w + kw, c)>
+#bl_canon_rhs = affine_map<(w, c, kw) -> (kw, c)>
+#bl_canon_res = affine_map<(w, c, kw) -> (w, c)>
+
+func.func @depthwise_conv1d_wc_wc_8x3xi8_tensor(%input: tensor<8x?xi8>,
+                                                %filter: tensor<1x?xi8>,
+                                                %output: tensor<8x?xi8>) -> tensor<8x?xi8> {
+  %0 = linalg.generic {
+    indexing_maps = [#bl_canon_lhs, #bl_canon_rhs, #bl_canon_res],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %filter : tensor<8x?xi8>, tensor<1x?xi8>)
+    outs(%output : tensor<8x?xi8>) {
+  ^bb0(%a: i8, %b: i8, %c: i8):
+    %m = arith.muli %a, %b : i8
+    %r = arith.addi %c, %m : i8
+    linalg.yield %r : i8
+  } -> tensor<8x?xi8>
+  return %0 : tensor<8x?xi8>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 vector_sizes [8, 4, 1] : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL:   func.func @depthwise_conv1d_wc_wc_8x3xi8_tensor(
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<8x?xi8>,
+// CHECK-SAME:      %[[FILTER:.*]]: tensor<1x?xi8>,
+// CHECK-SAME:      %[[OUTPUT:.*]]: tensor<8x?xi8>) -> tensor<8x?xi8> {
+
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[PAD:.*]] = arith.constant 0 : i8
+
+/// Create a mask for the input tensor (2D: W x C).
+// CHECK:           %[[CH_DIM_IN:.*]] = tensor.dim %[[INPUT]], %[[C1]] : tensor<8x?xi8>
+// CHECK:           %[[C8:.*]] = arith.constant 8 : index
+// CHECK:           %[[MASK_IN:.*]] = vector.create_mask %[[C8]], %[[CH_DIM_IN]] : vector<8x4xi1>
+/// Read the input tensor.
+// CHECK:           %[[VEC_IN:.*]] = vector.mask %[[MASK_IN]] { vector.transfer_read %[[INPUT]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<8x?xi8>, vector<8x4xi8> } : vector<8x4xi1> -> vector<8x4xi8>
+
+/// Create a mask for the filter tensor.
+// CHECK:           %[[CH_DIM_FLT:.*]] = tensor.dim %[[FILTER]], %[[C1]] : tensor<1x?xi8>
+// CHECK:           %[[MASK_FLT:.*]] = vector.create_mask %[[C1]], %[[CH_DIM_FLT]] : vector<1x4xi1>
+/// Read the filter tensor.
+// CHECK:           %[[VEC_FLT:.*]] = vector.mask %[[MASK_FLT]] { vector.transfer_read %[[FILTER]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<1x?xi8>, vector<1x4xi8> } : vector<1x4xi1> -> vector<1x4xi8>
+
+/// Create a mask for the output tensor.
+// CHECK:           %[[CH_DIM_OUT:.*]] = tensor.dim %[[OUTPUT]], %[[C1]] : tensor<8x?xi8>
+// CHECK:           %[[MASK_OUT:.*]] = vector.create_mask %[[C8]], %[[CH_DIM_OUT]] : vector<8x4xi1>
+/// Read the output tensor.
+// CHECK:           %[[VEC_OUT:.*]] = vector.mask %[[MASK_OUT]] { vector.transfer_read %[[OUTPUT]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<8x?xi8>, vector<8x4xi8> } : vector<8x4xi1> -> vector<8x4xi8>
+
+/// Batchless layout: expand the 2D operand vectors to 3D <1, W, C> for the
+/// depthwise kernel; collapse back before the masked write.
+// CHECK:           %[[VEC_IN_3D:.*]] = vector.shape_cast %[[VEC_IN]] : vector<8x4xi8> to vector<1x8x4xi8>
+// CHECK:           %[[VEC_OUT_3D:.*]] = vector.shape_cast %[[VEC_OUT]] : vector<8x4xi8> to vector<1x8x4xi8>
+
+/// Convolution (on 3D NWC vectors).
+// CHECK:           %[[IN_1:.*]] = vector.extract_strided_slice %[[VEC_IN_3D]] {offsets = [0, 0, 0], sizes = [1, 8, 4], strides = [1, 1, 1]} : vector<1x8x4xi8> to vector<1x8x4xi8>
+// CHECK:           %[[FLT_1:.*]] = vector.extract %[[VEC_FLT]][0] : vector<4xi8> from vector<1x4xi8>
+// CHECK:           %[[OUT_1:.*]] = vector.extract_strided_slice %[[VEC_OUT_3D]] {offsets = [0, 0, 0], sizes = [1, 8, 4], strides = [1, 1, 1]} : vector<1x8x4xi8> to vector<1x8x4xi8>
+// CHECK:           %[[FLT_1_B:.*]] = vector.broadcast %[[FLT_1]] : vector<4xi8> to vector<1x8x4xi8>
+// CHECK:           %[[MULI:.*]] = arith.muli %[[IN_1]], %[[FLT_1_B]] : vector<1x8x4xi8>
+// CHECK:           %[[ADDI:.*]] = arith.addi %[[MULI]], %[[OUT_1]] : vector<1x8x4xi8>
+// CHECK:           %[[OUT_INS:.*]] = vector.insert_strided_slice %[[ADDI]], %[[VEC_OUT_3D]] {offsets = [0, 0, 0], strides = [1, 1, 1]} : vector<1x8x4xi8> into vector<1x8x4xi8>
+
+/// Collapse back to 2D and masked-write.
+// CHECK:           %[[OUT_2D:.*]] = vector.shape_cast %[[OUT_INS]] : vector<1x8x4xi8> to vector<8x4xi8>
+// CHECK:           %[[OUT:.*]] = vector.mask %[[MASK_OUT]] { vector.transfer_write %[[OUT_2D]], %[[OUTPUT]]{{\[}}%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<8x4xi8>, tensor<8x?xi8> } : vector<8x4xi1> -> tensor<8x?xi8>
+// CHECK:           return %[[OUT]] : tensor<8x?xi8>
+
+// -----
+
+#bl_canon_lhs = affine_map<(w, c, kw) -> (w + kw, c)>
+#bl_canon_rhs = affine_map<(w, c, kw) -> (kw, c)>
+#bl_canon_res = affine_map<(w, c, kw) -> (w, c)>
+
+func.func @depthwise_conv1d_wc_wc_8x3xi8_tensor_scalable(
+      %input: tensor<8x?xi8>,
+      %filter: tensor<1x?xi8>,
+      %output: tensor<8x?xi8>) -> tensor<8x?xi8> {
+  %0 = linalg.generic {
+    indexing_maps = [#bl_canon_lhs, #bl_canon_rhs, #bl_canon_res],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%input, %filter : tensor<8x?xi8>, tensor<1x?xi8>)
+    outs(%output : tensor<8x?xi8>) {
+  ^bb0(%a: i8, %b: i8, %c: i8):
+    %m = arith.muli %a, %b : i8
+    %r = arith.addi %c, %m : i8
+    linalg.yield %r : i8
+  } -> tensor<8x?xi8>
+  return %0 : tensor<8x?xi8>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 vector_sizes [8, [4], 1] : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL:   func.func @depthwise_conv1d_wc_wc_8x3xi8_tensor_scalable(
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<8x?xi8>,
+// CHECK-SAME:      %[[FILTER:.*]]: tensor<1x?xi8>,
+// CHECK-SAME:      %[[OUTPUT:.*]]: tensor<8x?xi8>) -> tensor<8x?xi8> {
+
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[PAD:.*]] = arith.constant 0 : i8
+
+/// Create a mask for the input tensor (2D: W x C); the trailing dim is
+/// scalable `[4]`.
+// CHECK:           %[[CH_DIM_IN:.*]] = tensor.dim %[[INPUT]], %[[C1]] : tensor<8x?xi8>
+// CHECK:           %[[C8:.*]] = arith.constant 8 : index
+// CHECK:           %[[MASK_IN:.*]] = vector.create_mask %[[C8]], %[[CH_DIM_IN]] : vector<8x[4]xi1>
+/// Read the input tensor.
+// CHECK:           %[[VEC_IN:.*]] = vector.mask %[[MASK_IN]] { vector.transfer_read %[[INPUT]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<8x?xi8>, vector<8x[4]xi8> } : vector<8x[4]xi1> -> vector<8x[4]xi8>
+
+/// Create a mask for the filter tensor.
+// CHECK:           %[[CH_DIM_FLT:.*]] = tensor.dim %[[FILTER]], %[[C1]] : tensor<1x?xi8>
+// CHECK:           %[[MASK_FLT:.*]] = vector.create_mask %[[C1]], %[[CH_DIM_FLT]] : vector<1x[4]xi1>
+/// Read the filter tensor.
+// CHECK:           %[[VEC_FLT:.*]] = vector.mask %[[MASK_FLT]] { vector.transfer_read %[[FILTER]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<1x?xi8>, vector<1x[4]xi8> } : vector<1x[4]xi1> -> vector<1x[4]xi8>
+
+/// Create a mask for the output tensor.
+// CHECK:           %[[CH_DIM_OUT:.*]] = tensor.dim %[[OUTPUT]], %[[C1]] : tensor<8x?xi8>
+// CHECK:           %[[MASK_OUT:.*]] = vector.create_mask %[[C8]], %[[CH_DIM_OUT]] : vector<8x[4]xi1>
+/// Read the output tensor.
+// CHECK:           %[[VEC_OUT:.*]] = vector.mask %[[MASK_OUT]] { vector.transfer_read %[[OUTPUT]]{{\[}}%[[C0]], %[[C0]]], %[[PAD]] {in_bounds = [true, true]} : tensor<8x?xi8>, vector<8x[4]xi8> } : vector<8x[4]xi1> -> vector<8x[4]xi8>
+
+/// Batchless layout: expand the 2D operand vectors to 3D <1, W, C> for the
+/// depthwise kernel; the shape_cast preserves the scalable flag on the
+/// trailing dim.
+// CHECK:           %[[VEC_IN_3D:.*]] = vector.shape_cast %[[VEC_IN]] : vector<8x[4]xi8> to vector<1x8x[4]xi8>
+// CHECK:           %[[VEC_OUT_3D:.*]] = vector.shape_cast %[[VEC_OUT]] : vector<8x[4]xi8> to vector<1x8x[4]xi8>
+
+/// Convolution (on 3D NWC vectors).
+// CHECK:           %[[IN_1:.*]] = vector.extract_strided_slice %[[VEC_IN_3D]] {offsets = [0, 0, 0], sizes = [1, 8, 4], strides = [1, 1, 1]} : vector<1x8x[4]xi8> to vector<1x8x[4]xi8>
+// CHECK:           %[[FLT_1:.*]] = vector.extract %[[VEC_FLT]][0] : vector<[4]xi8> from vector<1x[4]xi8>
+// CHECK:           %[[OUT_1:.*]] = vector.extract_strided_slice %[[VEC_OUT_3D]] {offsets = [0, 0, 0], sizes = [1, 8, 4], strides = [1, 1, 1]} : vector<1x8x[4]xi8> to vector<1x8x[4]xi8>
+// CHECK:           %[[FLT_1_B:.*]] = vector.broadcast %[[FLT_1]] : vector<[4]xi8> to vector<1x8x[4]xi8>
+// CHECK:           %[[MULI:.*]] = arith.muli %[[IN_1]], %[[FLT_1_B]] : vector<1x8x[4]xi8>
+// CHECK:           %[[ADDI:.*]] = arith.addi %[[MULI]], %[[OUT_1]] : vector<1x8x[4]xi8>
+// CHECK:           %[[OUT_INS:.*]] = vector.insert_strided_slice %[[ADDI]], %[[VEC_OUT_3D]] {offsets = [0, 0, 0], strides = [1, 1, 1]} : vector<1x8x[4]xi8> into vector<1x8x[4]xi8>
+
+/// Collapse back to 2D and masked-write.
+// CHECK:           %[[OUT_2D:.*]] = vector.shape_cast %[[OUT_INS]] : vector<1x8x[4]xi8> to vector<8x[4]xi8>
+// CHECK:           %[[OUT:.*]] = vector.mask %[[MASK_OUT]] { vector.transfer_write %[[OUT_2D]], %[[OUTPUT]]{{\[}}%[[C0]], %[[C0]]] {in_bounds = [true, true]} : vector<8x[4]xi8>, tensor<8x?xi8> } : vector<8x[4]xi1> -> tensor<8x?xi8>
+// CHECK:           return %[[OUT]] : tensor<8x?xi8>

--- a/mlir/test/Dialect/Linalg/vectorization/unsupported.mlir
+++ b/mlir/test/Dialect/Linalg/vectorization/unsupported.mlir
@@ -411,3 +411,104 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// Convolution-like generic where inputChannel was folded away (size-1) but
+// outputChannel survived, producing asymmetric channel dims. Conv1DGenerator
+// cannot handle this and should gracefully reject it.
+
+func.func @conv1d_asymmetric_channel_folded(%filter: tensor<3xf32>,
+                                            %image: tensor<1x3xf32>,
+                                            %output: tensor<1x1xf32>) -> tensor<1x1xf32> {
+  // expected-error @+1 {{Attempted to vectorize, but failed}}
+  %res = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d1 + d2)>,
+                     affine_map<(d0, d1, d2) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%filter, %image : tensor<3xf32>, tensor<1x3xf32>)
+    outs(%output : tensor<1x1xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %mul = arith.mulf %in, %in_1 : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<1x1xf32>
+  return %res : tensor<1x1xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Convolution where both inputChannel and outputChannel had size 1 and were
+// folded away. After decomposition to 1D the structural classification marks
+// the op as "pooling" (no channels) but the body is a multiply+add
+// convolution. Conv1DGenerator should reject this mismatch instead of
+// producing an invalid vector.contract with scalar operands.
+
+func.func @conv1d_both_channels_folded(%lhs: tensor<2x4x7xf32>,
+                                       %rhs: tensor<3xf32>,
+                                       %out: tensor<2x4x5xf32>) -> tensor<2x4x5xf32> {
+  // expected-error @+1 {{Attempted to vectorize, but failed}}
+  %res = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2 + d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  } ins(%lhs, %rhs : tensor<2x4x7xf32>, tensor<3xf32>)
+    outs(%out : tensor<2x4x5xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %acc: f32):
+    %mul = arith.mulf %in, %in_1 : f32
+    %add = arith.addf %acc, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<2x4x5xf32>
+  return %res : tensor<2x4x5xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Channel-wise sliding-window reduction (e.g. from LRN) where the batch
+// dimensions [N, H, W] produce more than one N-like batch dim after
+// classification. The canonical shapes in Conv1DGenerator only support a
+// single N-like batch dim, so this must be rejected.
+
+func.func @pooling_multi_batch_reject(%lhs: tensor<5x5x5x5xf32>,
+                                      %rhs: tensor<3xf32>,
+                                      %out: tensor<5x5x5x3xf32>) -> tensor<5x5x5x3xf32> {
+  // expected-error @+1 {{Attempted to vectorize, but failed}}
+  %res = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3 + d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+  } ins(%lhs, %rhs : tensor<5x5x5x5xf32>, tensor<3xf32>)
+    outs(%out : tensor<5x5x5x3xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %acc: f32):
+    %add = arith.addf %acc, %in : f32
+    linalg.yield %add : f32
+  } -> tensor<5x5x5x3xf32>
+  return %res : tensor<5x5x5x3xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.structured.vectorize %0 : !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
## Summary

Today the 1D conv/pool vectorizer dispatches on specific Linalg named-op types
(`linalg.conv_1d_*`, `linalg.pooling_*`, `linalg.depthwise_conv_1d_*`). Any op
that is structurally a 1D conv/pool — either a `linalg.generic` or a named op
with a layout the dispatcher doesn't enumerate — silently bails out. The two
consequences that motivated this patch:

1. Batchless layouts (e.g. `linalg.conv_1d_ncw_cw` on `WC` / `CW` tensors) and
   other non-canonical layouts fall off the vectorization path even though
   their semantics are identical to layouts that do vectorize.
2. `linalg.depthwise_conv_1d_ncw_cw` is currently not vectorized at all.

This patch replaces the op-type dispatch with semantic classification via
`inferConvolutionDims`, giving a single pipeline that handles canonical and
non-canonical layouts, batched and batchless inputs, and the previously
unsupported `NCW` depthwise layout — all while preserving the existing IR for
layouts that were already supported.

## What changes

### Classification
- New `classifyAs1DConv` helper: a single source of truth that validates a
  `LinalgOp` is a vectorizable 1D conv/pool, extracts its semantic dimensions,
  and reports specific failure reasons via `notifyMatchFailure` / `LDBG()`.
- Preconditions and the rewrite matcher now share this classifier, so any op
  accepted by the precondition is guaranteed to be handled by the rewrite (no
  silent "precondition passes, rewrite bails" drift).

### Pipeline
- `Conv1DConfig` caches the classified state (dimensions, conv kind, layout,
  batch split) for the lifetime of a rewrite.
- `Conv1DPerms` / `Conv1DShapes` / `Conv1DOperandVecs` split what used to be a
  monolithic switch into explicit data flowing between named steps.
- A single `depthwiseConv` entry point now handles every depthwise layout.
  Previously there were two near-duplicate paths (`depthwiseConv`,
  `depthwiseConvViaTranspose`), each with their own bugs around `nSize` and
  batchless reads. Unified into one six-step pipeline:

  1. Read each operand in its tensor-native layout (optionally masked).
  2. `vector.transpose` to canonical NWC — only when the perm is non-identity.
  3. `vector.shape_cast` to add a unit leading dim — only for batchless layouts.
  4. `depthwise1DKernel` — always operates on 3D NWC vectors.
  5. Inverse `shape_cast` / inverse `transpose`.
  6. Write (optionally masked).

### New layout support
- **Batchless canonical depthwise** (`linalg.depthwise_conv_1d_wc_wc`) —
  including with dynamic channel dim and scalable vectors.
- **Non-canonical depthwise** (`linalg.depthwise_conv_1d_ncw_cw`).
- **Generic-op forms** of the above, classified by `isaConvolutionOpInterface`.
- Batch as well as batchless versions of the Conv ops are now handled gracefully.

### Pooling batch-splitting
- The old ordering-based heuristic that decided which batch loop played the
  N-like vs C-like role was incorrect for generic pool ops where the batch
  loops aren't in a fixed order. Replaced by `splitPoolBatchByLhsInnermost`,
  which derives the C-like batch from the LHS indexing map (innermost LHS
  position wins) with an explicit failure on ambiguity.

NOTE: The PR contains a few stale comment/code and I'm trying to address that.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>