### PR TITLE
[z/OS] Modify regex in error message to match on z/OS.

### DIFF
--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -147,3 +147,5 @@ test_bin = os.path.join(os.path.dirname(__file__), "Inputs", "fake-externals")
 config.environment["PATH"] = os.path.pathsep.join(
     (test_bin, config.environment["PATH"])
 )
+if llvm_config:
+    llvm_config.add_err_msg_substitutions()

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -44,6 +44,8 @@ lit_path = os.path.abspath(lit_path)
 # Required because some tests import the lit module
 if llvm_config:
     llvm_config.with_environment("PYTHONPATH", lit_path, append_path=True)
+    config.available_features.add("llvm_config_available")
+    llvm_config.add_err_msg_substitutions()
 else:
     config.environment["PYTHONPATH"] = lit_path
 # Do not add user-site packages directory to the python search path. This avoids test failures if there's an
@@ -147,5 +149,3 @@ test_bin = os.path.join(os.path.dirname(__file__), "Inputs", "fake-externals")
 config.environment["PATH"] = os.path.pathsep.join(
     (test_bin, config.environment["PATH"])
 )
-if llvm_config:
-    llvm_config.add_err_msg_substitutions()

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -44,7 +44,7 @@ lit_path = os.path.abspath(lit_path)
 # Required because some tests import the lit module
 if llvm_config:
     llvm_config.with_environment("PYTHONPATH", lit_path, append_path=True)
-    config.available_features.add("llvm_config_available")
+    config.available_features.add("llvm-config-available")
     llvm_config.add_err_msg_substitutions()
 else:
     config.environment["PYTHONPATH"] = lit_path

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -13,7 +13,7 @@
 # CHECK: FAIL: shtest-cat :: cat-error-1.txt ({{[^)]*}})
 # CHECK: cat temp1.txt
 # CHECK: # .---command stderr{{-*}}
-# CHECK-NEXT: # | [Errno 2] No such file or directory: 'temp1.txt'
+# CHECK-NEXT: # | [Errno {{.*}}] {{.*}}No such file or directory{{.*}}: 'temp1.txt'
 # CHECK: # error: command failed with exit status: 1
 
 # CHECK: PASS: shtest-cat :: cat.txt ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -1,7 +1,7 @@
 ## Test the cat command.
 #
 # RUN: not %{lit} -v %{inputs}/shtest-cat \
-# RUN: | FileCheck -match-full-lines %s
+# RUN: | FileCheck -match-full-lines -DMSG=%errc_ENOENT %s
 # END.
 
 # CHECK: FAIL: shtest-cat :: cat-error-0.txt ({{[^)]*}})
@@ -13,7 +13,7 @@
 # CHECK: FAIL: shtest-cat :: cat-error-1.txt ({{[^)]*}})
 # CHECK: cat temp1.txt
 # CHECK: # .---command stderr{{-*}}
-# CHECK-NEXT: # | [Errno {{.*}}] {{.*}}No such file or directory{{.*}}: 'temp1.txt'
+# CHECK-NEXT: # | [Errno {{.*}}] [[MSG]]: 'temp1.txt'
 # CHECK: # error: command failed with exit status: 1
 
 # CHECK: PASS: shtest-cat :: cat.txt ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -4,7 +4,7 @@
 # REQUIRES: llvm-config-available
 #
 # RUN: not %{lit} -v %{inputs}/shtest-cat \
-# RUN: | FileCheck -match-full-lines -DMSG=%errc_ENOENT %s
+# RUN: | FileCheck -match-full-lines -DERROR_MSG=%errc_ENOENT %s
 # END.
 
 # CHECK: FAIL: shtest-cat :: cat-error-0.txt ({{[^)]*}})
@@ -16,7 +16,7 @@
 # CHECK: FAIL: shtest-cat :: cat-error-1.txt ({{[^)]*}})
 # CHECK: cat temp1.txt
 # CHECK: # .---command stderr{{-*}}
-# CHECK-NEXT: # | [Errno {{.*}}] [[MSG]]: 'temp1.txt'
+# CHECK-NEXT: # | [Errno {{[0-9]+}}] [[ERROR_MSG]]: 'temp1.txt'
 # CHECK: # error: command failed with exit status: 1
 
 # CHECK: PASS: shtest-cat :: cat.txt ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -1,4 +1,7 @@
 ## Test the cat command.
+
+# This is required for the use of %errc_ENOENT.
+# REQUIRES: llvm_config_available
 #
 # RUN: not %{lit} -v %{inputs}/shtest-cat \
 # RUN: | FileCheck -match-full-lines -DMSG=%errc_ENOENT %s

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -1,7 +1,7 @@
 ## Test the cat command.
 
 # This is required for the use of %errc_ENOENT.
-# REQUIRES: llvm_config_available
+# REQUIRES: llvm-config-available
 #
 # RUN: not %{lit} -v %{inputs}/shtest-cat \
 # RUN: | FileCheck -match-full-lines -DMSG=%errc_ENOENT %s

--- a/llvm/utils/lit/tests/shtest-cat.py
+++ b/llvm/utils/lit/tests/shtest-cat.py
@@ -1,6 +1,6 @@
 ## Test the cat command.
 
-# This is required for the use of %errc_ENOENT.
+## This is required for the use of %errc_ENOENT.
 # REQUIRES: llvm-config-available
 #
 # RUN: not %{lit} -v %{inputs}/shtest-cat \

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -12,10 +12,6 @@
 
 # END.
 
-## AIX needs the regex because alternative versions of cat generate different
-## formats of error message. %errc_ENOENT can't be used here because [[...]]
-## inside {{...}} is not supported.
-
 # CHECK: -- Testing:
 
 # CHECK: FAIL: shtest-format :: external_shell/fail.txt
@@ -27,6 +23,9 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
+## AIX needs the regex because alternative versions of cat generate different
+## formats of error message. %errc_ENOENT can't be used here because [[...]]
+## inside {{...}} is not supported.
 # AIX: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: No such file or directory)}}
 # NON-AIX: cat{{(_64)?(\.exe)?}}: {{.*does-not-exist.*}}: [[ERROR_MSG]]
 # CHECK: --

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -12,6 +12,10 @@
 
 # END.
 
+## AIX needs the regex because alternative versions of cat generate different
+## formats of error message. %errc_ENOENT can't be used here because [[...]]
+## inside {{...}} is not supported.
+
 # CHECK: -- Testing:
 
 # CHECK: FAIL: shtest-format :: external_shell/fail.txt
@@ -23,7 +27,7 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
-# AIX: cat{{(_64)?(\.exe)?}}: cannot open does-not-exist
+# AIX: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: No such file or directory)}}
 # NON-AIX: cat{{(_64)?(\.exe)?}}: {{.*does-not-exist.*}}: [[ERROR_MSG]]
 # CHECK: --
 

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -18,7 +18,7 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
-# CHECK: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: No such file or directory)}}
+# CHECK: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: .*No such file or directory)}}
 # CHECK: --
 
 # CHECK: FAIL: shtest-format :: external_shell/fail_with_bad_encoding.txt

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -1,5 +1,8 @@
 # Check the various features of the ShTest format.
 
+## This is required for the use of %errc_ENOENT.
+# REQUIRES: llvm-config-available
+
 # RUN: rm -f %t.xml
 # RUN: not %{lit} -v %{inputs}/shtest-format --xunit-xml-output %t.xml > %t.out
 # RUN: FileCheck -DERROR_MSG=%errc_ENOENT < %t.out %s \

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -3,6 +3,9 @@
 # RUN: rm -f %t.xml
 # RUN: not %{lit} -v %{inputs}/shtest-format --xunit-xml-output %t.xml > %t.out
 # RUN: FileCheck < %t.out %s
+# RUN: FileCheck -DERROR_MSG=%errc_ENOENT < %t.out %s \
+# RUN:   %if system-aix %{ --check-prefix=AIX,CHECK %} \
+# RUN:   %else  %{ --check-prefix=NON-AIX,CHECK %}
 # RUN: FileCheck --check-prefix=XUNIT < %t.xml %s
 
 # END.
@@ -18,7 +21,8 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
-# CHECK: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: .*No such file or directory)}}
+# AIX: cat{{(_64)?(\.exe)?}}: cannot open does-not-exist
+# NON-AIX: cat{{(_64)?(\.exe)?}}: {{.*does-not-exist.*}}: [[ERROR_MSG]]
 # CHECK: --
 
 # CHECK: FAIL: shtest-format :: external_shell/fail_with_bad_encoding.txt

--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -2,7 +2,6 @@
 
 # RUN: rm -f %t.xml
 # RUN: not %{lit} -v %{inputs}/shtest-format --xunit-xml-output %t.xml > %t.out
-# RUN: FileCheck < %t.out %s
 # RUN: FileCheck -DERROR_MSG=%errc_ENOENT < %t.out %s \
 # RUN:   %if system-aix %{ --check-prefix=AIX,CHECK %} \
 # RUN:   %else  %{ --check-prefix=NON-AIX,CHECK %}

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -10,6 +10,10 @@
 #
 # END.
 
+## AIX needs the regex because alternative versions of wc generate different
+## formats of error message. %errc_ENOENT can't be used here because [[...]]
+## inside {{...}} is not supported.
+
 #       CHECK: -- Testing: {{.*}}
 #       CHECK: FAIL: shtest-output-printing :: basic.txt {{.*}}
 #  CHECK-NEXT: ***{{\**}} TEST 'shtest-output-printing :: basic.txt' FAILED ***{{\**}}
@@ -30,7 +34,7 @@
 #  CHECK-NEXT: not not wc missing-file &> [[FILE:.*]] || true
 #  CHECK-NEXT: # executed command: not not wc missing-file
 #  CHECK-NEXT: # .---redirected output from '[[FILE]]'
-#  AIX-NEXT:   # | {{.*}}wc: cannot open missing-file
+#  AIX-NEXT:   # | {{.*}}wc: {{cannot open missing-file|missing-file.* No such file or directory}}
 #  NON-AIX-NEXT: # | {{.*}}wc: {{.*missing-file.*}}: [[ERROR_MSG]]
 #  CHECK-NEXT: # `-----------------------------
 #  CHECK-NEXT: # note: command had no output on stdout or stderr

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -10,10 +10,6 @@
 #
 # END.
 
-## AIX needs the regex because alternative versions of wc generate different
-## formats of error message. %errc_ENOENT can't be used here because [[...]]
-## inside {{...}} is not supported.
-
 #       CHECK: -- Testing: {{.*}}
 #       CHECK: FAIL: shtest-output-printing :: basic.txt {{.*}}
 #  CHECK-NEXT: ***{{\**}} TEST 'shtest-output-printing :: basic.txt' FAILED ***{{\**}}
@@ -34,6 +30,9 @@
 #  CHECK-NEXT: not not wc missing-file &> [[FILE:.*]] || true
 #  CHECK-NEXT: # executed command: not not wc missing-file
 #  CHECK-NEXT: # .---redirected output from '[[FILE]]'
+## AIX needs the regex because alternative versions of wc generate different
+## formats of error message. %errc_ENOENT can't be used here because [[...]]
+## inside {{...}} is not supported.
 #  AIX-NEXT:   # | {{.*}}wc: {{cannot open missing-file|missing-file.* No such file or directory}}
 #  NON-AIX-NEXT: # | {{.*}}wc: {{.*missing-file.*}}: [[ERROR_MSG]]
 #  CHECK-NEXT: # `-----------------------------

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -25,7 +25,7 @@
 #  CHECK-NEXT: not not wc missing-file &> [[FILE:.*]] || true
 #  CHECK-NEXT: # executed command: not not wc missing-file
 #  CHECK-NEXT: # .---redirected output from '[[FILE]]'
-#  CHECK-NEXT: # | {{.*}}wc: {{cannot open missing-file|missing-file.* No such file or directory}}
+#  CHECK-NEXT: # | {{.*}}wc: {{cannot open missing-file|.*missing-file.*: .*No such file or directory}}
 #  CHECK-NEXT: # `-----------------------------
 #  CHECK-NEXT: # note: command had no output on stdout or stderr
 #  CHECK-NEXT: # error: command failed with exit status: 1

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -1,7 +1,12 @@
-# Check the various features of the ShTest format.
+## Check the various features of the ShTest format.
+#
+## This is required for the use of %errc_ENOENT.
+# REQUIRES: llvm-config-available
 #
 # RUN: not %{lit} -v %{inputs}/shtest-output-printing > %t.out
-# RUN: FileCheck --input-file %t.out --match-full-lines %s
+# RUN: FileCheck --input-file %t.out --match-full-lines -DERROR_MSG=%errc_ENOENT %s \
+# RUN:   %if system-aix %{ --check-prefix=AIX,CHECK %} \
+# RUN:   %else  %{ --check-prefix=NON-AIX,CHECK %}
 #
 # END.
 
@@ -25,7 +30,8 @@
 #  CHECK-NEXT: not not wc missing-file &> [[FILE:.*]] || true
 #  CHECK-NEXT: # executed command: not not wc missing-file
 #  CHECK-NEXT: # .---redirected output from '[[FILE]]'
-#  CHECK-NEXT: # | {{.*}}wc: {{cannot open missing-file|.*missing-file.*: .*No such file or directory}}
+#  AIX-NEXT:   # | {{.*}}wc: cannot open missing-file
+#  NON-AIX-NEXT: # | {{.*}}wc: {{.*missing-file.*}}: [[ERROR_MSG]]
 #  CHECK-NEXT: # `-----------------------------
 #  CHECK-NEXT: # note: command had no output on stdout or stderr
 #  CHECK-NEXT: # error: command failed with exit status: 1


### PR DESCRIPTION
This PR modifies regex in error message to match on z/OS:
```
[Errno 129] EDC5129I No such file or directory.: 'temp1.txt'
wc: file "missing-file": EDC5129I No such file or directory.
cat: does-not-exist: EDC5129I No such file or directory.
```