### PR TITLE
[SystemZ] z/OS only accept C initialization

### DIFF
--- a/clang/test/AST/ByteCode/cxx17.cpp
+++ b/clang/test/AST/ByteCode/cxx17.cpp
@@ -174,5 +174,7 @@ template <int I> struct std::tuple_element<I, const C> {
 
 namespace ZeroInCheckInvoke {
   constexpr C foo(const C &) { return C{}; }
+#ifndef __MVS__
   thread_local const auto &[s, t, u] = foo(C{}); // both-warning {{thread_local}}
+#endif
 }

--- a/clang/test/SemaCXX/cxx17-compat.cpp
+++ b/clang/test/SemaCXX/cxx17-compat.cpp
@@ -81,6 +81,7 @@ static auto [cx, cy, cz] = C();
     // expected-warning@-4 {{structured binding declaration declared 'static' is incompatible with C++ standards before C++20}}
 #endif
 void f() {
+#ifndef __MVS__
   static thread_local auto [cx, cy, cz] = C();
 #if __cplusplus <= 201703L
     // expected-warning@-2 {{structured binding declaration declared 'static' is a C++20 extension}}
@@ -88,6 +89,7 @@ void f() {
 #else
     // expected-warning@-5 {{structured binding declaration declared 'static' is incompatible with C++ standards before C++20}}
     // expected-warning@-6 {{structured binding declaration declared 'thread_local' is incompatible with C++ standards before C++20}}
+#endif
 #endif
 }
 


### PR DESCRIPTION
The TLS support only accept compile constant expressions (both C and C++) on z/OS.  Add #if to skip these tests on z/OS.