### PR TITLE
Revert "AMDGPU: Implement getInstSizeVerifyMode"

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
@@ -456,6 +456,28 @@ void AMDGPUAsmPrinter::emitInstruction(const MachineInstr *MI) {
     MCInstLowering.lower(MI, TmpInst);
     EmitToStreamer(*OutStreamer, TmpInst);
 
+#ifdef EXPENSIVE_CHECKS
+    // Check getInstSizeInBytes on explicitly specified CPUs (it cannot
+    // work correctly for the generic CPU).
+    //
+    // The isPseudo check really shouldn't be here, but unfortunately there are
+    // some negative lit tests that depend on being able to continue through
+    // here even when pseudo instructions haven't been lowered.
+    //
+    // We also overestimate branch sizes with the offset bug.
+    if (!MI->isPseudo() && STI.isCPUStringValid(STI.getCPU()) &&
+        (!STI.hasOffset3fBug() || !MI->isBranch())) {
+      SmallVector<MCFixup, 4> Fixups;
+      SmallVector<char, 16> CodeBytes;
+
+      std::unique_ptr<MCCodeEmitter> InstEmitter(createAMDGPUMCCodeEmitter(
+          *STI.getInstrInfo(), OutContext));
+      InstEmitter->encodeInstruction(TmpInst, CodeBytes, Fixups, STI);
+
+      assert(CodeBytes.size() == STI.getInstrInfo()->getInstSizeInBytes(*MI));
+    }
+#endif
+
     if (DumpCodeInstEmitter) {
       // Disassemble instruction/operands to text
       DisasmLines.resize(DisasmLines.size() + 1);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10002,13 +10002,6 @@ unsigned SIInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   }
 }
 
-TargetInstrInfo::InstSizeVerifyMode
-SIInstrInfo::getInstSizeVerifyMode(const MachineInstr &MI) const {
-  if (MI.isBranch() && ST.hasOffset3fBug())
-    return InstSizeVerifyMode::NoVerify;
-  return InstSizeVerifyMode::ExactSize;
-}
-
 bool SIInstrInfo::mayAccessFlatAddressSpace(const MachineInstr &MI) const {
   if (!isFLAT(MI))
     return false;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1614,9 +1614,6 @@ public:
 
   unsigned getInstSizeInBytes(const MachineInstr &MI) const override;
 
-  InstSizeVerifyMode
-  getInstSizeVerifyMode(const MachineInstr &MI) const override;
-
   bool mayAccessFlatAddressSpace(const MachineInstr &MI) const;
 
   std::pair<unsigned, unsigned>


### PR DESCRIPTION
Reverts llvm/llvm-project#191461

Fails on miscomputed V_MADMK_F32 size 