### PR TITLE
[LifetimeSafety] Add placement new support

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -643,26 +643,16 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
-      // FIXME: This assumes the placement argument is a direct glvalue pointer
-      // expression with an origin list shaped like
-      // storage -> pointer value -> pointee object.
-      // The code below overwrites the pointee object origin. Since origin flow
-      // is one way, non-direct placement argument forms such as `storage.get()`
-      // or `&storage` need separate handling to find the actual storage object
-      // whose origins should be overwritten.
-
       // Use the placement argument before the implicit conversion to void*, so
       // inner origins are still available.
-      const Expr *PlacementArg = NE->getPlacementArg(0)->IgnoreImpCasts();
-      // If the placement argument is a glvalue (such as DeclRefExpr), skip its
-      // outer storage origin so the list starts with the pointer origin.
-      OriginList *PlacementList =
-          getRValueOrigins(PlacementArg, getOriginsList(*PlacementArg));
-      // If the placement argument only has a glvalue origin, there is no
-      // pointee object origin to overwrite.
-      if (Init && PlacementList)
-        // Placement new constructs the pointee of the placement pointer.
-        flow(PlacementList->peelOuterOrigin(), getOriginsList(*Init), true);
+      const Expr *PlacementArg = NE->getPlacementArg(0);
+      if (const CastExpr *ICE = dyn_cast<CastExpr>(PlacementArg)) {
+        PlacementArg = ICE->getSubExpr();
+      }
+      OriginList *PlacementList = getOriginsList(*PlacementArg);
+      // FIXME: General placement arguments need separate handling to overwrite
+      // the right origins.
+
       // The pointer returned by placement new comes from the placement
       // argument.
       if (PlacementList)

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -646,9 +646,10 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
       // Use the placement argument before the implicit conversion to void*, so
       // inner origins are still available.
       const Expr *PlacementArg = NE->getPlacementArg(0);
-      if (const CastExpr *ICE = dyn_cast<CastExpr>(PlacementArg)) {
+      if (const auto *ICE = dyn_cast<ImplicitCastExpr>(PlacementArg);
+          ICE && ICE->getCastKind() == CK_BitCast &&
+          PlacementArg->getType()->isVoidPointerType())
         PlacementArg = ICE->getSubExpr();
-      }
       OriginList *PlacementList = getOriginsList(*PlacementArg);
       // FIXME: General placement arguments need separate handling to overwrite
       // the right origins.

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -658,14 +658,17 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
       // outer storage origin so the list starts with the pointer origin.
       OriginList *PlacementList =
           getRValueOrigins(PlacementArg, getOriginsList(*PlacementArg));
-      // Placement new constructs the pointee of the placement pointer.
-      if (Init)
+      // If the placement argument only has a glvalue origin, there is no
+      // pointee object origin to overwrite.
+      if (Init && PlacementList)
+        // Placement new constructs the pointee of the placement pointer.
         flow(PlacementList->peelOuterOrigin(), getOriginsList(*Init), true);
       // The pointer returned by placement new comes from the placement
       // argument.
-      CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
-          NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
-          true));
+      if (PlacementList)
+        CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
+            NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
+            true));
     }
   } else {
     const Loan *L = createLoan(FactMgr, NE);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -631,16 +631,6 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
 
 void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   OriginList *NewList = getOriginsList(*NE);
-  auto FlowTo = [&](OriginList *List) {
-    if (!List || !NE->getInitializer())
-      return;
-
-    // FIXME: OriginList is null for `new[]` initializers. Remove this
-    // `Init` check once array origins are supported.
-    if (OriginList *Init = getOriginsList(*NE->getInitializer()); Init) {
-      flow(List, Init, true);
-    }
-  };
 
   // Check if we have a placement new where the second argument is void*, to
   // avoid flowing from non-pointer parameters, such as std::nothrow.
@@ -652,6 +642,10 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
+      // FIXME: Flow from constructor expr to placement arg. To also support
+      // side effect placement new has. e.g.
+      // new(&p) MyObj(...);
+      // Should flow from constrcutor to &p.
       OriginList *PlacementList = getOriginsList(*NE->getPlacementArg(0));
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
@@ -664,7 +658,14 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   }
 
   NewList = NewList->peelOuterOrigin();
-  FlowTo(NewList);
+
+  if (!NewList || !NE->getInitializer())
+    return;
+
+  // FIXME: OriginList is null for `new[]` initializers. Remove this `Init`
+  // check once array origins are supported.
+  if (OriginList *Init = getOriginsList(*NE->getInitializer()); Init)
+    flow(NewList, Init, true);
 }
 
 void FactsGenerator::VisitCXXDeleteExpr(const CXXDeleteExpr *DE) {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -672,8 +672,8 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
 
   // FIXME: OriginList is null for `new[]` initializers. Remove this `Init`
   // check once array origins are supported.
-  if (OriginList *Init = getOriginsList(*NE->getInitializer()); Init)
-    flow(NewList, Init, true);
+  if (OriginList *InitList = getOriginsList(*Init); InitList)
+    flow(NewList, InitList, true);
 }
 
 void FactsGenerator::VisitCXXDeleteExpr(const CXXDeleteExpr *DE) {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -642,11 +642,12 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
-      // FIXME: Flow from constructor expr to placement arg to also support
-      // side effect placement new has. e.g.
-      // new(&p) MyObj(...);
-      // Should flow from MyObj(...) to &p.
-      OriginList *PlacementList = getOriginsList(*NE->getPlacementArg(0));
+      const Expr *PlacementArg = NE->getPlacementArg(0)->IgnoreImpCasts();
+      OriginList *PlacementList =
+          getRValueOrigins(PlacementArg, getOriginsList(*PlacementArg));
+      if (PlacementList->peelOuterOrigin())
+        flow(PlacementList->peelOuterOrigin(),
+             getOriginsList(*NE->getInitializer()), true);
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
           true));

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -332,6 +332,12 @@ void FactsGenerator::VisitCastExpr(const CastExpr *CE) {
   case CK_BuiltinFnToFnPtr:
     // Ignore function-to-pointer decays.
     return;
+  case CK_BitCast:
+    // OriginLists for Src and Dst may differ here. For example when casting
+    // from int** to void*
+    if (Src && Dest && Dest->getLength() == Src->getLength())
+      flow(Dest, Src, /*Kill=*/true);
+    return;
   default:
     return;
   }
@@ -625,20 +631,40 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
 
 void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   OriginList *NewList = getOriginsList(*NE);
+  auto FlowTo = [&](OriginList *List) {
+    if (!List || !NE->getInitializer())
+      return;
 
-  const Loan *L = createLoan(FactMgr, NE);
-  CurrentBlockFacts.push_back(
-      FactMgr.createFact<IssueFact>(L->getID(), NewList->getOuterOriginID()));
+    // FIXME: OriginList is null for `new[]` initializers. Remove this
+    // `Init` check once array origins are supported.
+    if (OriginList *Init = getOriginsList(*NE->getInitializer()); Init) {
+      flow(List, Init, true);
+    }
+  };
+
+  // Check if we have a placement new where the second argument is void*, to
+  // avoid flowing from non-pointer parameters, such as std::nothrow.
+  // And that the placement parameter num is 1,
+  // that is to mostly limit to standard library placement new.
+  if (NE->getNumPlacementArgs() == 1) {
+    if (const auto *Arg = NE->getOperatorNew()
+                              ->getParamDecl(1)
+                              ->getType()
+                              ->getAs<PointerType>();
+        Arg && Arg->isVoidPointerType()) {
+      OriginList *PlacementList = getOriginsList(*NE->getPlacementArg(0));
+      CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
+          NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
+          true));
+    }
+  } else {
+    const Loan *L = createLoan(FactMgr, NE);
+    CurrentBlockFacts.push_back(
+        FactMgr.createFact<IssueFact>(L->getID(), NewList->getOuterOriginID()));
+  }
 
   NewList = NewList->peelOuterOrigin();
-
-  if (!NewList || !NE->getInitializer())
-    return;
-
-  // FIXME: OriginList is null for `new[]` initializers. Remove this `Init`
-  // check once array origins are supported.
-  if (OriginList *Init = getOriginsList(*NE->getInitializer()); Init)
-    flow(NewList, Init, true);
+  FlowTo(NewList);
 }
 
 void FactsGenerator::VisitCXXDeleteExpr(const CXXDeleteExpr *DE) {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -642,10 +642,10 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
-      // FIXME: Flow from constructor expr to placement arg. To also support
+      // FIXME: Flow from constructor expr to placement arg to also support
       // side effect placement new has. e.g.
       // new(&p) MyObj(...);
-      // Should flow from constrcutor to &p.
+      // Should flow from MyObj(...) to &p.
       OriginList *PlacementList = getOriginsList(*NE->getPlacementArg(0));
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -631,6 +631,7 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
 
 void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   OriginList *NewList = getOriginsList(*NE);
+  const Expr *Init = NE->getInitializer();
 
   // Check if we have a placement new where the second argument is void*, to
   // avoid flowing from non-pointer parameters, such as std::nothrow.
@@ -645,9 +646,8 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
       const Expr *PlacementArg = NE->getPlacementArg(0)->IgnoreImpCasts();
       OriginList *PlacementList =
           getRValueOrigins(PlacementArg, getOriginsList(*PlacementArg));
-      if (PlacementList->peelOuterOrigin())
-        flow(PlacementList->peelOuterOrigin(),
-             getOriginsList(*NE->getInitializer()), true);
+      if (Init)
+        flow(PlacementList->peelOuterOrigin(), getOriginsList(*Init), true);
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
           true));
@@ -660,7 +660,7 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
 
   NewList = NewList->peelOuterOrigin();
 
-  if (!NewList || !NE->getInitializer())
+  if (!NewList || !Init)
     return;
 
   // FIXME: OriginList is null for `new[]` initializers. Remove this `Init`

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -643,11 +643,18 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
+      // Use the placement argument before the implicit conversion to void*, so
+      // inner origins are still available.
       const Expr *PlacementArg = NE->getPlacementArg(0)->IgnoreImpCasts();
+      // If the placement argument is a glvalue (such as DeclRefExpr), skip its
+      // outer storage origin so the list starts with the pointer origin.
       OriginList *PlacementList =
           getRValueOrigins(PlacementArg, getOriginsList(*PlacementArg));
+      // Placement new constructs the pointee of the placement pointer.
       if (Init)
         flow(PlacementList->peelOuterOrigin(), getOriginsList(*Init), true);
+      // The pointer returned by placement new comes from the placement
+      // argument.
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
           true));

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -643,6 +643,14 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
                               ->getType()
                               ->getAs<PointerType>();
         Arg && Arg->isVoidPointerType()) {
+      // FIXME: This assumes the placement argument is a direct glvalue pointer
+      // expression with an origin list shaped like
+      // storage -> pointer value -> pointee object.
+      // The code below overwrites the pointee object origin. Since origin flow
+      // is one way, non-direct placement argument forms such as `storage.get()`
+      // or `&storage` need separate handling to find the actual storage object
+      // whose origins should be overwritten.
+
       // Use the placement argument before the implicit conversion to void*, so
       // inner origins are still available.
       const Expr *PlacementArg = NE->getPlacementArg(0)->IgnoreImpCasts();

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2936,125 +2936,6 @@ void placement_new_array_braces() {
   (void)p[0];                    // expected-note {{later used here}}
 }
 
-// FIXME: Currently `&expr` creates a brand new origin instead of reusing origins
-// from the original expression. Because of that, writes through `&expr` cannot
-// overwrite the original expression's inner storage origins. 
-// Related to https://github.com/llvm/llvm-project/issues/176291
-struct PlacementNewInMethod {
-  View V;
-
-  void bad_store_after_placement_new() {
-    {
-      MyObj obj;
-      new (&V) View(obj);
-    }
-    V.use();
-  }
-};
-
-void placement_new_member_call_from_dead_scope() {
-  View *storage = new View;
-  {
-    MyObj obj;
-    new (storage) View(obj); // expected-warning {{object whose reference is captured does not live long enough}}
-  }                          // expected-note {{destroyed here}}
-  storage->use();            // expected-note {{later used here}}
-}
-
-struct ViewPointerFieldHolder {
-  View *Ptr;
-};
-
-// FIXME: Repeated field accesses do not share stable field origins.
-void placement_new_pointer_field_from_dead_scope() {
-  ViewPointerFieldHolder h{new View};
-  {
-    MyObj obj;
-    new (h.Ptr) View(obj);
-  }
-  h.Ptr->use();
-}
-
-// FIXME: Repeated array element accesses do not share stable element origins.
-void placement_new_array_subscript_from_dead_scope() {
-  View *slots[1] = {new View};
-  {
-    MyObj obj;
-    new (slots[0]) View(obj);
-  }
-  slots[0]->use();
-}
-
-// FIXME: Writes through references do not update the referred pointer's origins.
-void placement_new_pointer_reference_from_dead_scope() {
-  View *storage = new View;
-  View *&ref = storage;
-  {
-    MyObj obj;
-    new (ref) View(obj);
-  }
-  storage->use();
-}
-
-// FIXME: Writing through a conditional glvalue is not propagated to either arm.
-void placement_new_conditional_pointer_from_dead_scope(bool flag) {
-  View *x = new View;
-  View *y = new View;
-  {
-    MyObj obj;
-    new (flag ? x : y) View(obj);
-  }
-  x->use();
-  y->use();
-}
-
-View *identity(View *p [[clang::lifetimebound]]);
-
-// FIXME: Function call results are not mapped back to the argument they expose.
-void placement_new_function_pointer_from_dead_scope() {
-  View *storage = new View;
-  {
-    MyObj obj;
-    new (identity(storage)) View(obj);
-  }
-  storage->use();
-}
-
-struct ViewStorage {
-  View Storage;
-  View *get() [[clang::lifetimebound]];
-};
-
-// FIXME: Placement-new does not write back through the lifetimebound result of `get()`.
-void placement_new_member_function_pointer_from_dead_scope() {
-  ViewStorage storage;
-  {
-    MyObj obj;
-    new (storage.get()) View(obj);
-  }
-  storage.Storage.use();
-}
-
-// FIXME: Address-of placement arguments are not resolved to the addressed object.
-void placement_new_addressof_from_dead_scope() {
-  View storage;
-  {
-    MyObj obj;
-    new (&storage) View(obj);
-  }
-  storage.use();
-}
-
-// FIXME: Explicit casts to `void *` are not ignored for placement arguments.
-void placement_new_explicit_void_cast_from_dead_scope() {
-  View *storage = new View;
-  {
-    MyObj obj;
-    new ((void *)storage) View(obj);
-  }
-  storage->use();
-}
-
 void placement_new_heap_then_delete_use_after_free() {
   int *storage = new int(7); // expected-warning {{allocated object does not live long enough}}
   int *p = new (storage) int(42);
@@ -3088,8 +2969,117 @@ void placement_new_pointer_field_use_after_scope() {
   }
   (void)p->Ptr->id;
 }
+} // namespace placement_new
 
-// FIXME: Stripping implicit casts also strips array to pointer decay, leaving only the array glvalue origin and no pointee origin to overwrite. Because of that, origins are not propagated here.
+// FIXME: Currently this is not diagnosed because placement new does not overwrite the placement argument's origins.
+namespace placement_new_argument {
+struct PlacementNewInMethod {
+  View V;
+
+  void bad_store_after_placement_new() {
+    {
+      MyObj obj;
+      new (&V) View(obj);
+    }
+    V.use();
+  }
+};
+
+void placement_new_member_call_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new (storage) View(obj);
+  }
+  storage->use();
+}
+
+struct ViewPointerFieldHolder {
+  View *Ptr;
+};
+
+void placement_new_pointer_field_from_dead_scope() {
+  ViewPointerFieldHolder h{new View};
+  {
+    MyObj obj;
+    new (h.Ptr) View(obj);
+  }
+  h.Ptr->use();
+}
+
+void placement_new_array_subscript_from_dead_scope() {
+  View *slots[1] = {new View};
+  {
+    MyObj obj;
+    new (slots[0]) View(obj);
+  }
+  slots[0]->use();
+}
+
+void placement_new_pointer_reference_from_dead_scope() {
+  View *storage = new View;
+  View *&ref = storage;
+  {
+    MyObj obj;
+    new (ref) View(obj);
+  }
+  storage->use();
+}
+
+void placement_new_conditional_pointer_from_dead_scope(bool flag) {
+  View *x = new View;
+  View *y = new View;
+  {
+    MyObj obj;
+    new (flag ? x : y) View(obj);
+  }
+  x->use();
+  y->use();
+}
+
+View *identity(View *p [[clang::lifetimebound]]);
+
+void placement_new_function_pointer_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new (identity(storage)) View(obj);
+  }
+  storage->use();
+}
+
+struct ViewStorage {
+  View Storage;
+  View *get() [[clang::lifetimebound]];
+};
+
+void placement_new_member_function_pointer_from_dead_scope() {
+  ViewStorage storage;
+  {
+    MyObj obj;
+    new (storage.get()) View(obj);
+  }
+  storage.Storage.use();
+}
+
+void placement_new_addressof_from_dead_scope() {
+  View storage;
+  {
+    MyObj obj;
+    new (&storage) View(obj);
+  }
+  storage.use();
+}
+
+void placement_new_explicit_void_cast_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new ((void *)storage) View(obj);
+  }
+  storage->use();
+}
+
 void placement_new_direct_array_use_after_placement() {
   char storage[sizeof(std::string)];
   std::string* str1 = new (storage) std::string{"Old"};
@@ -3098,7 +3088,7 @@ void placement_new_direct_array_use_after_placement() {
   (void)*p1;
 }
 
-} // namespace placement_new
+} // namespace placement_new_argument
 
 namespace method_call_uses_field_origins {
 int GLOBAL_INT;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3089,6 +3089,15 @@ void placement_new_pointer_field_use_after_scope() {
   (void)p->Ptr->id;
 }
 
+// FIXME: Stripping implicit casts also strips array to pointer decay, leaving only the array glvalue origin and no pointee origin to overwrite. Because of that, origins are not propagated here.
+void placement_new_direct_array_use_after_placement() {
+  char storage[sizeof(std::string)];
+  std::string* str1 = new (storage) std::string{"Old"};
+  auto p1 = str1->c_str();
+  new (storage) std::string{"New"};
+  (void)*p1;
+}
+
 } // namespace placement_new
 
 namespace method_call_uses_field_origins {

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2860,17 +2860,6 @@ struct PointerFieldHolder {
 };
 
 // FIXME: https://github.com/llvm/llvm-project/issues/184344
-void placement_new_pointer_field_use_after_scope() {
-  PointerFieldHolder h;
-  PointerFieldHolder *p = &h;
-  {
-    MyObj obj;
-    p = new (&h) PointerFieldHolder{&obj};
-  }
-  (void)p->Ptr->id;
-}
-
-// FIXME: https://github.com/llvm/llvm-project/issues/184344
 void delete_through_pointer_field() {
   PointerFieldHolder h{new MyObj};
   delete h.Ptr;
@@ -2897,6 +2886,114 @@ void allocate_void_ptr() {
 }
 
 } // namespace new_allocation
+
+namespace placement_new {
+
+void placement_new_int_basic() {
+  int *p;
+  {
+    int storage;
+    p = new (&storage) int; // expected-warning {{object whose reference is captured does not live long enough}}
+  }                         // expected-note {{destroyed here}}
+  (void)*p;                 // expected-note {{later used here}}
+}
+
+void placement_new_view_from_dead_scope() {
+  View storage;
+  View *p = &storage;
+  {
+    MyObj obj;
+    p = new (&storage) View(obj); // expected-warning {{object whose reference is captured does not live long enough}}
+  }                               // expected-note {{destroyed here}}
+  p->use();                       // expected-note {{later used here}}
+}
+
+void placement_new_pointer_from_dead_object() {
+  MyObj *slot = nullptr;
+  MyObj **p = &slot;
+  {
+    MyObj obj;
+    p = new (&slot) MyObj *(&obj); // expected-warning {{object whose reference is captured does not live long enough}}
+  }                                // expected-note {{destroyed here}}
+  (void)**p;                       // expected-note {{later used here}}
+}
+
+void placement_new_array_basic() {
+  int *p;
+  {
+    int storage[2];
+    p = new (&storage) int[2]; // expected-warning {{object whose reference is captured does not live long enough}}
+  }                            // expected-note {{destroyed here}}
+  (void)p[0];                  // expected-note {{later used here}}
+}
+
+void placement_new_array_braces() {
+  int *p;
+  {
+    int storage[2];
+    p = new (&storage) int[2]{}; // expected-warning {{object whose reference is captured does not live long enough}}
+  }                              // expected-note {{destroyed here}}
+  (void)p[0];                    // expected-note {{later used here}}
+}
+
+struct PlacementNewInMethod {
+  View V; // expected-note {{this field dangles}}
+
+  void bad_store_after_placement_new() {
+    {
+      MyObj obj;
+      new (this) PlacementNewInMethod;
+      V = obj; // expected-warning {{address of stack memory escapes to a field}}
+    }
+    V.use();
+  }
+};
+
+// FIXME: Currently does not diagnose. We do not overwrite `storage`'s origins on placement new because we lose them on bitcast from `View*` to `void*`.
+void placement_new_member_call_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new (storage) View(obj);
+  }
+  storage->use();
+}
+
+void placement_new_heap_then_delete_use_after_free() {
+  int *storage = new int(7); // expected-warning {{allocated object does not live long enough}}
+  int *p = new (storage) int(42);
+  delete storage;            // expected-note {{freed here}}
+  (void)*p;                  // expected-note {{later used here}}
+}
+
+int* foo(int* x [[clang::lifetimebound]], int* y [[clang::lifetimebound]]);
+
+void placement_new_delete_result_of_lifetimebound_call() {
+  int *x = new int(1); // expected-warning {{allocated object does not live long enough}}
+  int *y = new int(2); // expected-warning {{allocated object does not live long enough}}
+  int *slot = nullptr;
+  int **p = new (&slot) int *(foo(x, y));
+  delete foo(x, y);    // expected-note 2 {{freed here}}
+  (void)**p;           // expected-note 2 {{later used here}}
+}
+
+
+struct PointerFieldHolder {
+  MyObj *Ptr;
+};
+
+// FIXME: https://github.com/llvm/llvm-project/issues/184344
+void placement_new_pointer_field_use_after_scope() {
+  PointerFieldHolder h;
+  PointerFieldHolder *p = &h;
+  {
+    MyObj obj;
+    p = new (&h) PointerFieldHolder{&obj};
+  }
+  (void)p->Ptr->id;
+}
+
+} // namespace placement_new
 
 namespace method_call_uses_field_origins {
 int GLOBAL_INT;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2936,7 +2936,10 @@ void placement_new_array_braces() {
   (void)p[0];                    // expected-note {{later used here}}
 }
 
-// FIXME: Currently does not diagnose. We do not overwrite `V`'s origins on placement new because we lose them on bitcast from `View*` to `void*`.
+// FIXME: Currently `&expr` creates a brand new origin instead of reusing origins
+// from the original expression. Because of that, writes through `&expr` cannot
+// overwrite the original expression's inner storage origins. 
+// Related to https://github.com/llvm/llvm-project/issues/176291
 struct PlacementNewInMethod {
   View V;
 
@@ -2949,14 +2952,13 @@ struct PlacementNewInMethod {
   }
 };
 
-// FIXME: same false-negative as above
 void placement_new_member_call_from_dead_scope() {
   View *storage = new View;
   {
     MyObj obj;
-    new (storage) View(obj);
-  }
-  storage->use();
+    new (storage) View(obj); // expected-warning {{object whose reference is captured does not live long enough}}
+  }                          // expected-note {{destroyed here}}
+  storage->use();            // expected-note {{later used here}}
 }
 
 void placement_new_heap_then_delete_use_after_free() {

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2936,20 +2936,20 @@ void placement_new_array_braces() {
   (void)p[0];                    // expected-note {{later used here}}
 }
 
+// FIXME: Currently does not diagnose. We do not overwrite `V`'s origins on placement new because we lose them on bitcast from `View*` to `void*`.
 struct PlacementNewInMethod {
-  View V; // expected-note {{this field dangles}}
+  View V;
 
   void bad_store_after_placement_new() {
     {
       MyObj obj;
-      new (this) PlacementNewInMethod;
-      V = obj; // expected-warning {{address of stack memory escapes to a field}}
+      new (&V) View(obj);
     }
     V.use();
   }
 };
 
-// FIXME: Currently does not diagnose. We do not overwrite `storage`'s origins on placement new because we lose them on bitcast from `View*` to `void*`.
+// FIXME: same false-negative as above
 void placement_new_member_call_from_dead_scope() {
   View *storage = new View;
   {

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2961,6 +2961,100 @@ void placement_new_member_call_from_dead_scope() {
   storage->use();            // expected-note {{later used here}}
 }
 
+struct ViewPointerFieldHolder {
+  View *Ptr;
+};
+
+// FIXME: Repeated field accesses do not share stable field origins.
+void placement_new_pointer_field_from_dead_scope() {
+  ViewPointerFieldHolder h{new View};
+  {
+    MyObj obj;
+    new (h.Ptr) View(obj);
+  }
+  h.Ptr->use();
+}
+
+// FIXME: Repeated array element accesses do not share stable element origins.
+void placement_new_array_subscript_from_dead_scope() {
+  View *slots[1] = {new View};
+  {
+    MyObj obj;
+    new (slots[0]) View(obj);
+  }
+  slots[0]->use();
+}
+
+// FIXME: Writes through references do not update the referred pointer's origins.
+void placement_new_pointer_reference_from_dead_scope() {
+  View *storage = new View;
+  View *&ref = storage;
+  {
+    MyObj obj;
+    new (ref) View(obj);
+  }
+  storage->use();
+}
+
+// FIXME: Writing through a conditional glvalue is not propagated to either arm.
+void placement_new_conditional_pointer_from_dead_scope(bool flag) {
+  View *x = new View;
+  View *y = new View;
+  {
+    MyObj obj;
+    new (flag ? x : y) View(obj);
+  }
+  x->use();
+  y->use();
+}
+
+View *identity(View *p [[clang::lifetimebound]]);
+
+// FIXME: Function call results are not mapped back to the argument they expose.
+void placement_new_function_pointer_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new (identity(storage)) View(obj);
+  }
+  storage->use();
+}
+
+struct ViewStorage {
+  View Storage;
+  View *get() [[clang::lifetimebound]];
+};
+
+// FIXME: Placement-new does not write back through the lifetimebound result of `get()`.
+void placement_new_member_function_pointer_from_dead_scope() {
+  ViewStorage storage;
+  {
+    MyObj obj;
+    new (storage.get()) View(obj);
+  }
+  storage.Storage.use();
+}
+
+// FIXME: Address-of placement arguments are not resolved to the addressed object.
+void placement_new_addressof_from_dead_scope() {
+  View storage;
+  {
+    MyObj obj;
+    new (&storage) View(obj);
+  }
+  storage.use();
+}
+
+// FIXME: Explicit casts to `void *` are not ignored for placement arguments.
+void placement_new_explicit_void_cast_from_dead_scope() {
+  View *storage = new View;
+  {
+    MyObj obj;
+    new ((void *)storage) View(obj);
+  }
+  storage->use();
+}
+
 void placement_new_heap_then_delete_use_after_free() {
   int *storage = new int(7); // expected-warning {{allocated object does not live long enough}}
   int *p = new (storage) int(42);


### PR DESCRIPTION
Allows flow from placement new closely resembling standard library form.

Comes as part of the completion of #164963.