### PR TITLE
[libc] Move mul_overflow to math_extras.h

### DIFF
--- a/libc/src/__support/math_extras.h
+++ b/libc/src/__support/math_extras.h
@@ -80,6 +80,21 @@ template <typename T>
 #endif // __builtin_sub_overflow
 }
 
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr bool mul_overflow(T a, T b, T &res) {
+#if __has_builtin(__builtin_mul_overflow)
+  return __builtin_mul_overflow(a, b, &res);
+#else
+  T max = cpp::numeric_limits<T>::max();
+  T min = cpp::numeric_limits<T>::min();
+  bool overflow = (b > 0 && (a > max / b || a < min / b)) ||
+                  (b < 0 && (a < max / b || a > min / b));
+  if (!overflow)
+    res = a * b;
+  return overflow;
+#endif
+}
+
 #define RETURN_IF(TYPE, BUILTIN)                                               \
   if constexpr (cpp::is_same_v<T, TYPE>)                                       \
     return BUILTIN(a, b, carry_in, &carry_out);

--- a/libc/src/__support/memory_size.h
+++ b/libc/src/__support/memory_size.h
@@ -15,23 +15,12 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
+#include "src/__support/math_extras.h"
 #include "src/string/memory_utils/utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
-template <class T> LIBC_INLINE bool mul_overflow(T a, T b, T *res) {
-#if __has_builtin(__builtin_mul_overflow)
-  return __builtin_mul_overflow(a, b, res);
-#else
-  T max = cpp::numeric_limits<T>::max();
-  T min = cpp::numeric_limits<T>::min();
-  bool overflow = (b > 0 && (a > max / b || a < min / b)) ||
-                  (b < 0 && (a < max / b || a > min / b));
-  if (!overflow)
-    *res = a * b;
-  return overflow;
-#endif
-}
+
 // Limit memory size to the max of ssize_t
 class SafeMemSize {
 private:
@@ -68,7 +57,7 @@ public:
     type result;
     if (LIBC_UNLIKELY((value | other.value) < 0))
       result = -1;
-    if (LIBC_UNLIKELY(mul_overflow(value, other.value, &result)))
+    if (LIBC_UNLIKELY(mul_overflow(value, other.value, result)))
       result = -1;
     return SafeMemSize{result};
   }

--- a/libc/src/search/lfind.cpp
+++ b/libc/src/search/lfind.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/CPP/cstddef.h" // cpp::byte
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/memory_size.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(void *, lfind,
@@ -21,7 +21,7 @@ LLVM_LIBC_FUNCTION(void *, lfind,
     return nullptr;
 
   size_t byte_len = 0;
-  if (internal::mul_overflow(*nmemb, size, &byte_len))
+  if (mul_overflow(*nmemb, size, byte_len))
     return nullptr;
 
   const cpp::byte *next = reinterpret_cast<const cpp::byte *>(base);

--- a/libc/src/search/lsearch.cpp
+++ b/libc/src/search/lsearch.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/CPP/cstddef.h" // cpp::byte
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/memory_size.h"
+#include "src/__support/math_extras.h"
 #include "src/string/memory_utils/inline_memcpy.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -22,7 +22,7 @@ LLVM_LIBC_FUNCTION(void *, lsearch,
     return nullptr;
 
   size_t byte_len = 0;
-  if (internal::mul_overflow(*nmemb, size, &byte_len))
+  if (mul_overflow(*nmemb, size, byte_len))
     return nullptr;
 
   const cpp::byte *next = reinterpret_cast<const cpp::byte *>(base);


### PR DESCRIPTION
This way downstream llvm-libc users could use this as part of math_extras.h.