### PR TITLE
[clang][modules] Make `ExportDecl` a `std::pair`

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -562,7 +562,7 @@ public:
   ///
   /// The pointer is the module being re-exported, while the bit will be true
   /// to indicate that this is a wildcard export.
-  using ExportDecl = llvm::PointerIntPair<Module *, 1, bool>;
+  using ExportDecl = std::pair<Module *, bool>;
 
   /// The set of export declarations.
   SmallVector<ExportDecl, 2> Exports;

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -395,8 +395,8 @@ void Module::getExportedModules(SmallVectorImpl<Module *> &Exported) const {
   bool UnrestrictedWildcard = false;
   SmallVector<Module *, 4> WildcardRestrictions;
   for (unsigned I = 0, N = Exports.size(); I != N; ++I) {
-    Module *Mod = Exports[I].getPointer();
-    if (!Exports[I].getInt()) {
+    Module *Mod = Exports[I].first;
+    if (!Exports[I].second) {
       // Export a named module directly; no wildcards involved.
       Exported.push_back(Mod);
 
@@ -409,7 +409,7 @@ void Module::getExportedModules(SmallVectorImpl<Module *> &Exported) const {
     if (UnrestrictedWildcard)
       continue;
 
-    if (Module *Restriction = Exports[I].getPointer())
+    if (Module *Restriction = Exports[I].first)
       WildcardRestrictions.push_back(Restriction);
     else {
       WildcardRestrictions.clear();
@@ -570,9 +570,9 @@ void Module::print(raw_ostream &OS, unsigned Indent, bool Dump) const {
   for (unsigned I = 0, N = Exports.size(); I != N; ++I) {
     OS.indent(Indent + 2);
     OS << "export ";
-    if (Module *Restriction = Exports[I].getPointer()) {
+    if (Module *Restriction = Exports[I].first) {
       OS << Restriction->getFullModuleName(true);
-      if (Exports[I].getInt())
+      if (Exports[I].second)
         OS << ".*";
     } else {
       OS << "*";

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -707,7 +707,7 @@ void CodeGenModule::EmitCXXModuleInitFunc(Module *Primary) {
   llvm::SmallSetVector<Module *, 8> AllImports;
   // Ones that we export
   for (auto I : Primary->Exports)
-    AllImports.insert(I.getPointer());
+    AllImports.insert(I.first);
   // Ones that we only import.
   AllImports.insert_range(Primary->Imports);
   // Ones that we import in the global module fragment or the private module

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -971,7 +971,7 @@ void DumpModuleInfoAction::ExecuteAction() {
       if (!Primary->Exports.empty())
         Out << "   Exports:\n";
       for (unsigned MN = 0, N = Primary->Exports.size(); MN != N; ++MN) {
-        if (Module *M = Primary->Exports[MN].getPointer()) {
+        if (Module *M = Primary->Exports[MN].first) {
           PrintSubMapEntry(M->Name, M->Kind);
         }
       }

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1626,7 +1626,7 @@ bool ModuleMap::resolveExports(Module *Mod, bool Complain) {
   Mod->UnresolvedExports.clear();
   for (auto &UE : Unresolved) {
     Module::ExportDecl Export = resolveExport(Mod, UE, Complain);
-    if (Export.getPointer() || Export.getInt())
+    if (Export.first || Export.second)
       Mod->Exports.push_back(Export);
     else
       Mod->UnresolvedExports.push_back(UE);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5115,8 +5115,8 @@ ASTReader::ASTReadResult ASTReader::ReadAST(ModuleFileName FileName,
 
     case UnresolvedModuleRef::Export:
       if (ResolvedMod || Unresolved.IsWildcard)
-        Unresolved.Mod->Exports.push_back(
-          Module::ExportDecl(ResolvedMod, Unresolved.IsWildcard));
+        Unresolved.Mod->Exports.push_back(Module::ExportDecl(
+            ResolvedMod, static_cast<bool>(Unresolved.IsWildcard)));
       continue;
     }
   }

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -3208,8 +3208,8 @@ void ASTWriter::WriteSubmodules(Module *WritingModule, ASTContext *Context) {
       for (const auto &E : Mod->Exports) {
         // FIXME: This may fail; we don't require that all exported modules
         // are local or imported.
-        Record.push_back(getSubmoduleID(E.getPointer()));
-        Record.push_back(E.getInt());
+        Record.push_back(getSubmoduleID(E.first));
+        Record.push_back(E.second);
       }
       Stream.EmitRecord(SUBMODULE_EXPORTS, Record);
     }


### PR DESCRIPTION
This PR replaces `llvm::PointerIntPair` with `std::pair` for module exports. This is NFC that enables a future PR to use a different (larger) type to represent module references.