### PR TITLE
[NFC][lld] Avoid hex address case sensitivity in fill-trap tests

### DIFF
--- a/lld/test/ELF/fill-trap-ppc.s
+++ b/lld/test/ELF/fill-trap-ppc.s
@@ -23,8 +23,8 @@
 # CHECK-NEXT: LOAD           0x010000 0x0000000010010000 0x0000000010010000 0x010000 0x010000 R E 0x10000
 
 ## Check that executable page is filled with traps at its end.
-# LE: 01fff0 08 00 e0 7f 08 00 e0 7f 08 00 e0 7f 08 00 e0 7f
-# BE: 01fff0 7f e0 00 08 7f e0 00 08 7f e0 00 08 7f e0 00 08
+# LE: {{01fff0|01FFF0}} 08 00 e0 7f 08 00 e0 7f 08 00 e0 7f 08 00 e0 7f
+# BE: {{01fff0|01FFF0}} 7f e0 00 08 7f e0 00 08 7f e0 00 08 7f e0 00 08
 
 .globl _start
 _start:

--- a/lld/test/ELF/fill-trap.s
+++ b/lld/test/ELF/fill-trap.s
@@ -39,7 +39,7 @@
 # CHECK-NEXT:   ]
 
 ## Check that executable page is filled with traps at its end.
-# FILL: 001ff0 cccc cccc cccc cccc cccc cccc cccc cccc
+# FILL: {{001ff0|001FF0}} cccc cccc cccc cccc cccc cccc cccc cccc
 
 ## There is a single RWX segment. Test that p_memsz is not truncated to p_filesz.
 # RUN: ld.lld a.o bss.o -z separate-loadable-segments -T rwx.lds -z max-page-size=64 -o rwx


### PR DESCRIPTION
Ubuntu is switching from GNU coreutils to Rust version, and new
od util has different case in output.

https://github.com/uutils/coreutils/issues/11985
