### PR TITLE
[clang][modules] Always keep submodule index up-to-date

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -738,6 +738,7 @@ public:
   void setParent(Module *M) {
     assert(!Parent);
     Parent = M;
+    Parent->SubModuleIndex[M->Name] = Parent->SubModules.size();
     Parent->SubModules.push_back(this);
   }
 

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -352,7 +352,7 @@ private:
 
   /// A mapping from the submodule name to the index into the
   /// \c SubModules vector at which that submodule resides.
-  mutable llvm::StringMap<unsigned> SubModuleIndex;
+  llvm::StringMap<unsigned> SubModuleIndex;
 
   /// The AST file name and key if this is a top-level module which has a
   /// corresponding serialized AST file, or null otherwise.

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -53,6 +53,7 @@ Module::Module(ModuleConstructorTag, StringRef Name,
     NoUndeclaredIncludes = Parent->NoUndeclaredIncludes;
     ModuleMapIsPrivate = Parent->ModuleMapIsPrivate;
 
+    Parent->SubModuleIndex[Name] = Parent->SubModules.size();
     Parent->SubModules.push_back(this);
   }
 }
@@ -348,10 +349,6 @@ void Module::markUnavailable(bool Unimportable) {
 }
 
 Module *Module::findSubmodule(StringRef Name) const {
-  // Add new submodules into the index.
-  for (unsigned I = SubModuleIndex.size(), E = SubModules.size(); I != E; ++I)
-    SubModuleIndex[SubModules[I]->Name] = I;
-
   if (auto It = SubModuleIndex.find(Name); It != SubModuleIndex.end())
     return SubModules[It->second];
 


### PR DESCRIPTION
This partially reverts #113391, always keeping the submodule index up-to-date. This is important for a follow-up PR that will make deserialization of submodules lazier. Without this change, updating the index would deserialize submodules too eagerly. The original PR only showed 0.5% improvement in scan times, while the upcoming PR promises an order of magnitude larger improvement.