### PR TITLE
[CIR] Implement static-local-tls lowering

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3843,7 +3843,7 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
   }];
   let arguments = (ins
     FlatSymbolRefAttr : $globalName,
-    UnitAttr : $tls
+    UnitProp : $tls
   );
 
   let regions = (region

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3813,8 +3813,7 @@ def CIR_FuncOp : CIR_Op<"func", [
 //===----------------------------------------------------------------------===//
 
 def CIR_LocalInitOp : CIR_Op<"local_init", [
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>, NoRegionArguments,
-  ParentOneOf<["cir::FuncOp"]>
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>, NoRegionArguments
 ]> {
   let summary = "initialize a static or thread local object";
   let description = [{
@@ -3823,8 +3822,8 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
     variable. This will be handled during lowering-prepare to include the
     guard variables correctly for the variable.
 
-    This operation also represents static local thread local variables, which is
-    represented by the 'tls' flag.
+    This operation may also represent a static local thread local variable,
+    which would be indicated by the 'tls' flag.
 
     Example:
     ```
@@ -3869,6 +3868,7 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
 }
 }];
 
+  let hasVerifier = 1;
   let hasLLVMLowering = false;
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3814,8 +3814,7 @@ def CIR_FuncOp : CIR_Op<"func", [
 
 def CIR_LocalInitOp : CIR_Op<"local_init", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>, NoRegionArguments,
-  ParentOneOf<["cir::FuncOp"]>,
-  HasAtMostOneOfAttrs<["tls", "static_local"]>
+  ParentOneOf<["cir::FuncOp"]>
 ]> {
   let summary = "initialize a static or thread local object";
   let description = [{
@@ -3824,8 +3823,13 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
     variable. This will be handled during lowering-prepare to include the
     guard variables correctly for the variable.
 
+    This operation also represents static local thread local variables, which is
+    represented by the 'tls' flag.
+
     Example:
     ```
+    // Note: despite this always being static_local, we print it anyway to be
+    // visually consistent with get_global, and as a 'counter' to 'tls'.
     cir.local_init static_local @GlobalName ctor {
       %4 = cir.get_global static_local @GlobalName : !cir.ptr<!rec_CtorDtor>
       %5 = cir.call @_Z5get_iv() : () -> !s32i
@@ -3840,8 +3844,7 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
   }];
   let arguments = (ins
     FlatSymbolRefAttr : $globalName,
-    UnitAttr : $tls,
-    UnitAttr : $static_local
+    UnitAttr : $tls
   );
 
   let regions = (region
@@ -3850,8 +3853,7 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
   );
 
   let assemblyFormat = [{
-    (`thread_local` $tls^)?
-    (`static_local` $static_local^)?
+    (`thread_local` $tls^) : (`static_local`)?
     $globalName attr-dict
     (`ctor` $ctorRegion^)?
     (`dtor` $dtorRegion^)?

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -155,8 +155,6 @@ static void emitDeclDestroy(CIRGenFunction &cgf, const VarDecl *vd,
   // directly.
   cir::FuncOp fnOp;
   if (record && (canRegisterDestructor || cgm.getCodeGenOpts().CXAAtExit)) {
-    if (vd->getTLSKind())
-      cgm.errorNYI(vd->getSourceRange(), "TLS destructor");
     assert(!record->hasTrivialDestructor());
     assert(!cir::MissingFeatures::openCL());
     CXXDestructorDecl *dtor = record->getDestructor();
@@ -343,16 +341,11 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
 void CIRGenModule::emitCXXStaticLocalVarDeclInit(const VarDecl *varDecl,
                                                  cir::GlobalOp addr,
                                                  bool performInit) {
-  assert(varDecl->isStaticLocal() ||
-         varDecl->getTLSKind() != VarDecl::TLS_None);
+  assert(varDecl->isStaticLocal());
 
-  if (varDecl->getTLSKind() != VarDecl::TLS_None)
-    errorNYI(varDecl->getSourceRange(),
-             "TLS not implemented for static-local init");
-
-  auto initOp = cir::LocalInitOp::create(
-      builder, addr->getLoc(), addr.getSymNameAttr(),
-      varDecl->getTLSKind() != VarDecl::TLS_None, varDecl->isStaticLocal());
+  auto initOp =
+      cir::LocalInitOp::create(builder, addr->getLoc(), addr.getSymNameAttr(),
+                               varDecl->getTLSKind() != VarDecl::TLS_None);
 
   emitCXXSpecialVarDeclInit(varDecl, addr, performInit, initOp.getCtorRegion(),
                             initOp.getDtorRegion());

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -459,7 +459,7 @@ CIRGenModule::getOrCreateStaticVarDecl(const VarDecl &d,
     gv.setComdat(true);
 
   if (d.getTLSKind())
-    errorNYI(d.getSourceRange(), "getOrCreateStaticVarDecl: TLS");
+    setTLSMode(gv, d);
 
   setGVProperties(gv, &d);
 
@@ -642,7 +642,8 @@ void CIRGenFunction::emitStaticVarDecl(const VarDecl &d,
   cir::GlobalOp globalOp = cgm.getOrCreateStaticVarDecl(d, linkage);
   // TODO(cir): we should have a way to represent global ops as values without
   // having to emit a get global op. Sometimes these emissions are not used.
-  mlir::Value addr = builder.createGetGlobal(globalOp);
+  mlir::Value addr =
+      builder.createGetGlobal(globalOp, d.getTLSKind() != VarDecl::TLS_None);
   auto getAddrOp = addr.getDefiningOp<cir::GetGlobalOp>();
   assert(getAddrOp && "expected cir::GetGlobalOp");
 

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1763,11 +1763,6 @@ void CIRGenItaniumCXXABI::registerGlobalDtor(const VarDecl *vd,
   if (vd->isNoDestroy(cgm.getASTContext()))
     return;
 
-  if (vd->getTLSKind()) {
-    cgm.errorNYI(vd->getSourceRange(), "registerGlobalDtor: TLS");
-    return;
-  }
-
   // HLSL doesn't support atexit.
   if (cgm.getLangOpts().HLSL) {
     cgm.errorNYI(vd->getSourceRange(), "registerGlobalDtor: HLSL");

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -375,6 +375,12 @@ LogicalResult cir::BreakOp::verify() {
 // LocalInitOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult cir::LocalInitOp::verify() {
+  if (!getOperation()->getParentOfType<FuncOp>())
+    return emitOpError("must be inside of a 'cir.func'");
+  return success();
+}
+
 LogicalResult
 cir::LocalInitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   cir::GlobalOp global = getReferencedGlobal(symbolTable);

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -385,10 +385,7 @@ cir::LocalInitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   if (getTls() && !global.getTlsModel())
     return emitOpError("access to global not marked thread local");
 
-  bool isStaticLocal = getStaticLocal();
-  bool globalIsStaticLocal = global.getStaticLocalGuard().has_value();
-
-  if (isStaticLocal != globalIsStaticLocal)
+  if (!global.getStaticLocalGuard().has_value())
     return emitOpError("static_local attribute mismatch");
 
   return success();

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -242,8 +242,7 @@ struct LoweringPreparePass
 
   void emitGlobalGuardedDtorRegion(CIRBaseBuilderTy &builder,
                                    cir::GlobalOp global,
-                                   mlir::Region &dtorRegion,
-                                   bool tls,
+                                   mlir::Region &dtorRegion, bool tls,
                                    mlir::Block &entryBB) {
     // Create a variable that binds the atexit to this shared object.
     builder.setInsertionPointToStart(&mlirModule.getBodyRegion().front());
@@ -2168,7 +2167,6 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
     }
   }
 }
-
 
 void LoweringPreparePass::runOnOperation() {
   mlir::Operation *op = getOperation();

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -183,6 +183,7 @@ struct LoweringPreparePass
       guard.setInitialValueAttr(cir::IntAttr::get(guardTy, 0));
       guard.setDSOLocal(globalOp.getDsoLocal());
       guard.setAlignment(guardAlignment.getAsAlign().value());
+      guard.setTlsModel(globalOp.getTlsModel());
 
       // The ABI says: "It is suggested that it be emitted in the same COMDAT
       // group as the associated data object." In practice, this doesn't work
@@ -242,6 +243,7 @@ struct LoweringPreparePass
   void emitGlobalGuardedDtorRegion(CIRBaseBuilderTy &builder,
                                    cir::GlobalOp global,
                                    mlir::Region &dtorRegion,
+                                   bool tls,
                                    mlir::Block &entryBB) {
     // Create a variable that binds the atexit to this shared object.
     builder.setInsertionPointToStart(&mlirModule.getBodyRegion().front());
@@ -266,6 +268,11 @@ struct LoweringPreparePass
         builder.getVoidFnTy({voidFnPtrTy, voidPtrTy, handlePtrTy});
 
     llvm::StringLiteral nameAtExit = "__cxa_atexit";
+    if (tls)
+      nameAtExit = astCtx->getTargetInfo().getTriple().isOSDarwin()
+                       ? llvm::StringLiteral("_tlv_atexit")
+                       : llvm::StringLiteral("__cxa_thread_atexit");
+
     cir::FuncOp fnAtExit = buildRuntimeFunction(builder, nameAtExit,
                                                 global.getLoc(), fnAtExitType);
 
@@ -317,6 +324,28 @@ struct LoweringPreparePass
     // initialization so that recursive accesses during initialization do not
     // restart initialization.
 
+    auto emitBody = [&]() {
+      // Emit the initializer and add a global destructor if appropriate.
+      mlir::Block *insertBlock = builder.getInsertionBlock();
+      if (!ctorRegion.empty()) {
+        assert(ctorRegion.hasOneBlock() && "Enforced by MaxSizedRegion<1>");
+
+        mlir::Block &block = ctorRegion.front();
+        insertBlock->getOperations().splice(
+            insertBlock->end(), block.getOperations(), block.begin(),
+            std::prev(block.end()));
+      }
+
+      if (!dtorRegion.empty()) {
+        assert(dtorRegion.hasOneBlock() && "Enforced by MaxSizedRegion<1>");
+
+        emitGlobalGuardedDtorRegion(builder, globalOp, dtorRegion, !threadsafe,
+                                    *insertBlock);
+      }
+      builder.setInsertionPointToEnd(insertBlock);
+      ctorRegion.getBlocks().clear();
+    };
+
     // Variables used when coping with thread-safe statics and exceptions.
     if (threadsafe) {
       // Call __cxa_guard_acquire.
@@ -341,26 +370,7 @@ struct LoweringPreparePass
       // OG: CGF.EHStack.pushCleanup<CallGuardAbort>(EHCleanup, guard);
       assert(!cir::MissingFeatures::guardAbortOnException());
 
-      // Emit the initializer and add a global destructor if appropriate.
-      mlir::Block *insertBlock = builder.getInsertionBlock();
-      if (!ctorRegion.empty()) {
-        assert(ctorRegion.hasOneBlock() && "Enforced by MaxSizedRegion<1>");
-
-        mlir::Block &block = ctorRegion.front();
-        insertBlock->getOperations().splice(
-            insertBlock->end(), block.getOperations(), block.begin(),
-            std::prev(block.end()));
-      }
-
-      if (!dtorRegion.empty()) {
-        assert(dtorRegion.hasOneBlock() && "Enforced by MaxSizedRegion<1>");
-
-        emitGlobalGuardedDtorRegion(builder, globalOp, dtorRegion,
-                                    *insertBlock);
-      }
-
-      builder.setInsertionPointToEnd(insertBlock);
-      ctorRegion.getBlocks().clear();
+      emitBody();
 
       // Pop the guard-abort cleanup if we pushed one.
       // OG: CGF.PopCleanupBlock();
@@ -380,11 +390,13 @@ struct LoweringPreparePass
       globalOp->emitError("NYI: non-threadsafe init for non-local variables");
       return;
     } else {
+      emitBody();
       // For local variables, store 1 into the first byte of the guard variable
       // after the object initialization completes so that initialization is
       // retried if initialization is interrupted by an exception.
-      globalOp->emitError("NYI: non-threadsafe init for local variables");
-      return;
+      builder.createStore(
+          loc, builder.getConstantInt(loc, guardPtrTy.getPointee(), 1),
+          guardPtr);
     }
 
     builder.createYield(loc); // Outermost IfOp
@@ -1063,7 +1075,8 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
     assert(!cir::MissingFeatures::astVarDeclInterface());
     assert(!cir::MissingFeatures::opGlobalThreadLocal());
 
-    emitGlobalGuardedDtorRegion(builder, op, dtorRegion, *entryBB);
+    emitGlobalGuardedDtorRegion(builder, op, dtorRegion,
+                                op.getTlsModel().has_value(), *entryBB);
   }
 
   // Replace cir.yield with cir.return
@@ -1159,31 +1172,27 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
                     (varDecl.isLocalVarDecl() || nonTemplateInline) &&
                     !varDecl.getTLSKind();
 
-  // TLS variables need special handling - the guard must also be thread-local.
-  if (varDecl.getTLSKind()) {
-    globalOp->emitError("NYI: guarded initialization for thread-local statics");
-    return;
-  }
-
   // If we have a global variable with internal linkage and thread-safe statics
   // are disabled, we can just let the guard variable be of type i8.
   bool useInt8GuardVariable = !threadsafe && globalOp.hasInternalLinkage();
-  if (useInt8GuardVariable) {
-    globalOp->emitError("NYI: int8 guard variables for non-threadsafe statics");
-    return;
-  }
-
+  cir::CIRDataLayout dataLayout(mlirModule);
+  cir::IntType guardTy;
+  clang::CharUnits guardAlignment;
   // Guard variables are 64 bits in the generic ABI and size width on ARM
   // (i.e. 32-bit on AArch32, 64-bit on AArch64).
-  if (useARMGuardVarABI()) {
+  if (useInt8GuardVariable) {
+    guardTy = cir::IntType::get(&getContext(), 8, /*isSigned=*/true);
+    guardAlignment = clang::CharUnits::One();
+  } else if (useARMGuardVarABI()) {
     globalOp->emitError("NYI: ARM-style guard variables for static locals");
     return;
+  } else {
+    guardTy = cir::IntType::get(&getContext(), 64, /*isSigned=*/true);
+    guardAlignment =
+        clang::CharUnits::fromQuantity(dataLayout.getABITypeAlign(guardTy));
   }
-  cir::IntType guardTy =
-      cir::IntType::get(&getContext(), 64, /*isSigned=*/true);
-  cir::CIRDataLayout dataLayout(mlirModule);
-  clang::CharUnits guardAlignment =
-      clang::CharUnits::fromQuantity(dataLayout.getABITypeAlign(guardTy));
+  assert(guardTy && guardAlignment.getQuantity() != 0);
+
   auto guardPtrTy = cir::PointerType::get(guardTy);
 
   // Create the guard variable if we don't already have it.
@@ -1195,7 +1204,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
     return;
   }
 
-  mlir::Value guardPtr = builder.createGetGlobal(guard, /*threadLocal*/ false);
+  mlir::Value guardPtr = builder.createGetGlobal(guard, localInitOp.getTls());
 
   // Test whether the variable has completed initialization.
   //
@@ -1292,10 +1301,6 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
 
 void LoweringPreparePass::lowerLocalInitOp(
     cir::LocalInitOp initOp, mlir::SymbolTableCollection &symbolTables) {
-  if (!initOp.getStaticLocal()) {
-    initOp->emitError("NYI: Non-static-local in lower-init-local op");
-    return;
-  }
 
   // If we don't actually need to initialize anything anymore, we're done here.
   if (initOp.getCtorRegion().empty() && initOp.getDtorRegion().empty()) {
@@ -2163,6 +2168,7 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
     }
   }
 }
+
 
 void LoweringPreparePass::runOnOperation() {
   mlir::Operation *op = getOperation();

--- a/clang/test/CIR/CodeGen/thread-local-in-func.cpp
+++ b/clang/test/CIR/CodeGen/thread-local-in-func.cpp
@@ -1,0 +1,360 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2>&1 | FileCheck %s --check-prefix=CIR-BEFORE-LPP,CIR-BOTH
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s --check-prefix=CIR,CIR-BOTH
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM,LLVM-BOTH
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=OGCG,LLVM-BOTH
+
+// Guard variables.
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ13test_ctordtoriE4init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ13test_ctordtoriE4init = internal thread_local global i8 0
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ13test_ctordtoriE10const_init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ13test_ctordtoriE10const_init = internal thread_local global i8 0
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ9test_dtoriE10const_init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ9test_dtoriE10const_init = internal thread_local global i8 0
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ9test_ctoriE4init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ9test_ctoriE4init = internal thread_local global i8 0
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ9test_ctoriE10const_init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ9test_ctoriE10const_init = internal thread_local global i8 0
+// CIR-DAG: cir.global "private" internal tls_dyn dso_local @_ZGVZ8test_intiE4init = #cir.int<0> : !s8i
+// LLVM-BOTH-DAG: @_ZGVZ8test_intiE4init = internal thread_local global i8 0
+
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ13test_ctordtoriE4init"> @_ZZ13test_ctordtoriE4init = #cir.zero : !rec_CtorDtor
+// LLVM-BOTH-DAG: @_ZZ13test_ctordtoriE4init = internal thread_local global %struct.CtorDtor zeroinitializer
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ13test_ctordtoriE10const_init"> @_ZZ13test_ctordtoriE10const_init = #cir.zero : !rec_CtorDtor
+// LLVM-BOTH-DAG: @_ZZ13test_ctordtoriE10const_init = internal thread_local global %struct.CtorDtor zeroinitializer
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ9test_dtoriE10const_init"> @_ZZ9test_dtoriE10const_init = #cir.zero : !rec_Dtor
+// LLVM-BOTH-DAG: @_ZZ9test_dtoriE10const_init = internal thread_local global %struct.Dtor zeroinitializer
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ9test_ctoriE4init"> @_ZZ9test_ctoriE4init = #cir.zero : !rec_Ctor
+// LLVM-BOTH-DAG: @_ZZ9test_ctoriE4init = internal thread_local global %struct.Ctor zeroinitializer
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ9test_ctoriE10const_init"> @_ZZ9test_ctoriE10const_init = #cir.zero : !rec_Ctor
+// LLVM-BOTH-DAG: @_ZZ9test_ctoriE10const_init = internal thread_local global %struct.Ctor zeroinitializer
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local static_local_guard<"_ZGVZ8test_intiE4init"> @_ZZ8test_intiE4init = #cir.int<0> : !s32i
+// LLVM-BOTH-DAG: @_ZZ8test_intiE4init = internal thread_local global i32 0
+// CIR-BOTH-DAG: cir.global "private" internal tls_dyn dso_local @_ZZ8test_intiE10const_init = #cir.int<5> : !s32i
+// LLVM-BOTH-DAG: @_ZZ8test_intiE10const_init = internal thread_local global i32 5
+int get_i();
+
+void test_int(int param) {
+  int local;
+  thread_local int const_init = 5;
+  thread_local int init = param + local + get_i();
+
+// CIR-BOTH-LABEL: cir.func no_inline dso_local @_Z8test_inti(
+// CIR-BOTH: %[[PARAM_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["param", init]
+// CIR-BOTH: [[LOCAL_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["local"]
+// CIR-BOTH: %[[GET_CONST_TLS:.*]] = cir.get_global thread_local @_ZZ8test_intiE10const_init : !cir.ptr<!s32i>
+// CIR-BOTH: %[[GET_TLS:.*]] = cir.get_global thread_local static_local @_ZZ8test_intiE4init : !cir.ptr<!s32i>
+//
+// CIR-BEFORE-LPP: cir.local_init thread_local @_ZZ8test_intiE4init ctor {
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ8test_intiE4init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+//
+// CIR-BOTH:   %[[GET_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ8test_intiE4init : !cir.ptr<!s32i>
+// CIR-BOTH:   %[[LOAD_PARAM:.*]] = cir.load {{.*}}[[PARAM_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BOTH:   %[[LOAD_LOCAL:.*]] = cir.load {{.*}}[[LOCAL_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BOTH:   %[[ADD1:.*]] = cir.add nsw %[[LOAD_PARAM]], %[[LOAD_LOCAL]] : !s32i
+// CIR-BOTH:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {{.*}})
+// CIR-BOTH:   %[[ADD2:.*]] = cir.add nsw %[[ADD1]], %[[CALL]] : !s32i
+// CIR-BOTH:   cir.store {{.*}}%[[ADD2]], %[[GET_TLS_INIT]] : !s32i, !cir.ptr<!s32i>
+// CIR-BEFORE-LPP:   cir.yield
+
+// CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR: cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+//
+// CIR-BOTH: }
+
+// LLVM-BOTH-LABEL: define dso_local void @_Z8test_inti(
+// LLVM-BOTH: %[[PARAM_ALLOCA:.*]] = alloca i32
+// LLVM-BOTH: %[[LOCAL_ALLOCA:.*]] = alloca i32
+//
+// OG just loads this without the builtin, but I don't believe it is meaningful.
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ8test_intiE4init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ8test_intiE4init
+//
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+// 
+// OG loads the TLS after the init, just before the store, again irrelevant.
+// Also, the store to the guard variable is also without the call to
+// llvm.threadlocal.address.
+// LLVM: %[[GET_TLS_INIT:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ8test_intiE4init)
+// LLVM-BOTH: %[[LOAD_PARAM:.*]] = load i32, ptr %[[PARAM_ALLOCA]]
+// LLVM-BOTH: %[[LOAD_LOCAL:.*]] = load i32, ptr %[[LOCAL_ALLOCA]]
+// LLVM-BOTH: %[[ADD1:.*]] = add nsw i32 %[[LOAD_PARAM]], %[[LOAD_LOCAL]]
+// LLVM-BOTH: %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
+// LLVM-BOTH: %[[ADD2:.*]] = add nsw i32 %[[ADD1]], %[[CALL]]
+// OGCG: %[[GET_TLS_INIT:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@_ZZ8test_intiE4init)
+// LLVM-BOTH: store i32 %[[ADD2]], ptr %[[GET_TLS_INIT]]
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG: store i8 1, ptr @_ZGVZ8test_intiE4init
+}
+
+struct Ctor {
+  Ctor(int i);
+    int i;
+};
+
+void test_ctor(int param) {
+  int local;
+  thread_local Ctor const_init = 5;
+  thread_local Ctor init = param + local + get_i();
+// CIR-BOTH-LABEL: cir.func no_inline dso_local @_Z9test_ctori(
+// CIR-BOTH: %[[PARAM_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["param", init]
+// CIR-BOTH: [[LOCAL_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["local"]
+// CIR-BOTH: %[[GET_CONST_TLS:.*]] = cir.get_global thread_local static_local @_ZZ9test_ctoriE10const_init : !cir.ptr<!rec_Ctor>
+//
+// CIR-BEFORE-LPP: cir.local_init thread_local @_ZZ9test_ctoriE10const_init ctor {
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ9test_ctoriE10const_init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+//
+// CIR-BOTH:   %[[GET_CONST_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ9test_ctoriE10const_init : !cir.ptr<!rec_Ctor>
+// CIR-BOTH:   %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
+// CIR-BOTH:   cir.call @_ZN4CtorC1Ei(%[[GET_CONST_TLS_INIT]], %[[FIVE]]) : (!cir.ptr<!rec_Ctor> {{.*}}) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+//
+// CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR: cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+//
+// CIR-BOTH: }
+// CIR-BOTH: %[[GET_TLS:.*]] = cir.get_global thread_local static_local @_ZZ9test_ctoriE4init : !cir.ptr<!rec_Ctor>
+//
+// CIR-BEFORE-LPP: cir.local_init thread_local @_ZZ9test_ctoriE4init ctor {
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ9test_ctoriE4init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+//
+// CIR-BOTH:   %[[GET_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ9test_ctoriE4init : !cir.ptr<!rec_Ctor>
+// CIR-BOTH:   %[[LOAD_PARAM:.*]] = cir.load {{.*}}[[PARAM_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BOTH:   %[[LOAD_LOCAL:.*]] = cir.load {{.*}}[[LOCAL_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BOTH:   %[[ADD1:.*]] = cir.add nsw %[[LOAD_PARAM]], %[[LOAD_LOCAL]] : !s32i
+// CIR-BOTH:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {{.*}})
+// CIR-BOTH:   %[[ADD2:.*]] = cir.add nsw %[[ADD1]], %[[CALL]] : !s32i
+// CIR-BOTH:   cir.call @_ZN4CtorC1Ei(%[[GET_TLS_INIT]], %[[ADD2]]) : (!cir.ptr<!rec_Ctor> {{.*}}) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+//
+// CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR: cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+//
+// CIR-BOTH: }
+
+// LLVM-BOTH-LABEL: define dso_local void @_Z9test_ctori(
+// LLVM-BOTH: %[[PARAM_ALLOCA:.*]] = alloca i32
+// LLVM-BOTH: %[[LOCAL_ALLOCA:.*]] = alloca i32
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ9test_ctoriE10const_init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ9test_ctoriE10const_init
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+//
+// LLVM: %[[GET_TLS_INIT:.*]] = call ptr @llvm.threadlocal.address.p0(ptr {{.*}}@_ZZ9test_ctoriE10const_init)
+// LLVM: call void @_ZN4CtorC1Ei(ptr {{.*}}%[[GET_TLS_INIT]], i32 noundef 5)
+// OGCG: call void @_ZN4CtorC1Ei(ptr {{.*}}@_ZZ9test_ctoriE10const_init, i32 noundef 5)
+//
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG: store i8 1, ptr @_ZGVZ9test_ctoriE10const_init
+// LLVM-BOTH: br
+//
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ9test_ctoriE4init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ9test_ctoriE4init
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+//
+// LLVM: %[[GET_TLS_INIT:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ9test_ctoriE4init)
+// LLVM-BOTH: %[[LOAD_PARAM:.*]] = load i32, ptr %[[PARAM_ALLOCA]]
+// LLVM-BOTH: %[[LOAD_LOCAL:.*]] = load i32, ptr %[[LOCAL_ALLOCA]]
+// LLVM-BOTH: %[[ADD1:.*]] = add nsw i32 %[[LOAD_PARAM]], %[[LOAD_LOCAL]]
+// LLVM-BOTH: %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
+// LLVM-BOTH: %[[ADD2:.*]] = add nsw i32 %[[ADD1]], %[[CALL]]
+// LLVM: call void @_ZN4CtorC1Ei(ptr {{.*}}%[[GET_TLS_INIT]], i32 noundef %[[ADD2]])
+// OGCG: call void @_ZN4CtorC1Ei(ptr {{.*}}@_ZZ9test_ctoriE4init, i32 noundef %[[ADD2]])
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG: store i8 1, ptr @_ZGVZ9test_ctoriE4init
+
+}
+
+struct Dtor {
+  ~Dtor();
+    int i;
+};
+
+void test_dtor(int param) {
+  int local;
+  thread_local Dtor const_init;
+// CIR-BOTH-LABEL: cir.func no_inline dso_local @_Z9test_dtori(
+// CIR-BOTH: %[[PARAM_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["param", init]
+// CIR-BOTH: [[LOCAL_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["local"]
+// CIR-BOTH: %[[GET_TLS:.*]] = cir.get_global thread_local static_local @_ZZ9test_dtoriE10const_init : !cir.ptr<!rec_Dtor>
+//
+// CIR-BEFORE-LPP: cir.local_init thread_local @_ZZ9test_dtoriE10const_init dtor {
+// CIR-BEFORE-LPP:   %[[GET_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ9test_dtoriE10const_init : !cir.ptr<!rec_Dtor>
+// CIR-BEFORE-LPP:   cir.call @_ZN4DtorD1Ev(%[[GET_TLS_DEL]]) : (!cir.ptr<!rec_Dtor>) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+// CIR-BEFORE_LLP: }
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ9test_dtoriE10const_init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+//
+// CIR:   %[[GET_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ9test_dtoriE10const_init : !cir.ptr<!rec_Dtor>
+// CIR:   %[[GET_DEL_FUNC:.*]] = cir.get_global @_ZN4DtorD1Ev : !cir.ptr<!cir.func<(!cir.ptr<!rec_Dtor>)>>
+// CIR:   %[[DEL_FUNC_DECAY:.*]] = cir.cast bitcast %[[GET_DEL_FUNC]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_Dtor>)>> -> !cir.ptr<!cir.func<(!cir.ptr<!void>)>>
+// CIR:   %[[TLS_DECAY:.*]] = cir.cast bitcast %[[GET_TLS_DEL]] : !cir.ptr<!rec_Dtor> -> !cir.ptr<!void>
+// CIR:   %[[DSO_HANDLE:.*]] = cir.get_global @__dso_handle : !cir.ptr<i8>
+// CIR:   cir.call @__cxa_thread_atexit(%[[DEL_FUNC_DECAY]], %[[TLS_DECAY]], %[[DSO_HANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR:   cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+// CIR: }
+
+// LLVM-BOTH-LABEL: define dso_local void @_Z9test_dtori(
+// LLVM-BOTH: %[[PARAM_ALLOCA:.*]] = alloca i32
+// LLVM-BOTH: %[[LOCAL_ALLOCA:.*]] = alloca i32
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ9test_dtoriE10const_init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ9test_dtoriE10const_init
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+//
+// LLVM: %[[GET_TLS_DEL:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ9test_dtoriE10const_init)
+// LLVM: call void @__cxa_thread_atexit(ptr @_ZN4DtorD1Ev, ptr %[[GET_TLS_DEL]], ptr @__dso_handle)
+// OGCG: call i32 @__cxa_thread_atexit(ptr @_ZN4DtorD1Ev, ptr @_ZZ9test_dtoriE10const_init, ptr @__dso_handle)
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG:store i8 1, ptr @_ZGVZ9test_dtoriE10const_init
+}
+
+struct CtorDtor {
+  CtorDtor(int i);
+  ~CtorDtor();
+    int i;
+};
+
+void test_ctordtor(int param) {
+  int local;
+  thread_local CtorDtor const_init = 5;
+  thread_local CtorDtor init = param + local + get_i();
+// CIR-BOTH-LABEL: cir.func no_inline dso_local @_Z13test_ctordtori(
+// CIR-BOTH: %[[PARAM_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["param", init]
+// CIR-BOTH: [[LOCAL_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["local"]
+// CIR-BOTH: %[[GET_CONST_TLS:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE10const_init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LLP: cir.local_init thread_local @_ZZ13test_ctordtoriE10const_init ctor {
+// CIR-BEFORE-LPP:   %[[GET_CONST_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE10const_init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LPP:   %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
+// CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_CONST_TLS_INIT]], %[[FIVE:.*]]) : (!cir.ptr<!rec_CtorDtor> {{.*}}) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+// CIR-BEFORE-LPP: } dtor 
+// CIR-BEFORE-LPP:   %[[GET_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE10const_init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_TLS_DEL]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+// CIR-BEFORE-LPP: }
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ13test_ctordtoriE10const_init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+// CIR:   %[[GET_CONST_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE10const_init : !cir.ptr<!rec_CtorDtor>
+// CIR:   %[[FIVE:.*]] = cir.const #cir.int<5> : !s32i
+// CIR:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_CONST_TLS_INIT]], %[[FIVE:.*]]) : (!cir.ptr<!rec_CtorDtor> {{.*}}) -> ()
+// CIR:   %[[GET_CONST_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE10const_init : !cir.ptr<!rec_CtorDtor>
+// CIR:   %[[GET_DEL_FUNC:.*]] = cir.get_global @_ZN8CtorDtorD1Ev : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>>
+// CIR:   %[[DEL_FUNC_DECAY:.*]] = cir.cast bitcast %[[GET_DEL_FUNC]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>> -> !cir.ptr<!cir.func<(!cir.ptr<!void>)>>
+// CIR:   %[[TLS_DECAY:.*]] = cir.cast bitcast %[[GET_CONST_TLS_DEL]] : !cir.ptr<!rec_CtorDtor> -> !cir.ptr<!void>
+// CIR:   %[[DSO_HANDLE:.*]] = cir.get_global @__dso_handle : !cir.ptr<i8>
+// CIR:   cir.call @__cxa_thread_atexit(%[[DEL_FUNC_DECAY]], %[[TLS_DECAY]], %[[DSO_HANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR:   cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+// CIR: }
+//
+// CIR-BOTH: %[[GET_TLS:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE4init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LPP: cir.local_init thread_local @_ZZ13test_ctordtoriE4init ctor {
+// CIR-BEFORE-LPP:   %[[GET_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE4init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LPP:   %[[LOAD_PARAM:.*]] = cir.load {{.*}}[[PARAM_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BEFORE-LPP:   %[[LOAD_LOCAL:.*]] = cir.load {{.*}}[[LOCAL_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR-BEFORE-LPP:   %[[ADD1:.*]] = cir.add nsw %[[LOAD_PARAM]], %[[LOAD_LOCAL]] : !s32i
+// CIR-BEFORE-LPP:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {{.*}})
+// CIR-BEFORE-LPP:   %[[ADD2:.*]] = cir.add nsw %[[ADD1]], %[[CALL]] : !s32i
+// CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_TLS_INIT]], %[[ADD2]]) : (!cir.ptr<!rec_CtorDtor> {{.*}}) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+// CIR-BEFORE-LPP: } dtor {
+// CIR-BEFORE-LPP:   %[[GET_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE4init : !cir.ptr<!rec_CtorDtor>
+// CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_TLS_DEL]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
+// CIR-BEFORE-LPP:   cir.yield
+// CIR-BEFORE-LPP: }
+//
+// CIR: %[[GUARD:.*]] = cir.get_global thread_local @_ZGVZ13test_ctordtoriE4init : !cir.ptr<!s8i>
+// CIR: %[[GUARD_LOAD:.*]] = cir.load {{.*}}%[[GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[IS_UNINIT:.*]] = cir.cmp eq %[[GUARD_LOAD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[IS_UNINIT]] {
+// CIR:   %[[GET_TLS_INIT:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE4init : !cir.ptr<!rec_CtorDtor>
+// CIR:   %[[LOAD_PARAM:.*]] = cir.load {{.*}}[[PARAM_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR:   %[[LOAD_LOCAL:.*]] = cir.load {{.*}}[[LOCAL_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CIR:   %[[ADD1:.*]] = cir.add nsw %[[LOAD_PARAM]], %[[LOAD_LOCAL]] : !s32i
+// CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {{.*}})
+// CIR:   %[[ADD2:.*]] = cir.add nsw %[[ADD1]], %[[CALL]] : !s32i
+// CIR:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_TLS_INIT]], %[[ADD2]]) : (!cir.ptr<!rec_CtorDtor> {{.*}}) -> ()
+// CIR:   %[[GET_TLS_DEL:.*]] = cir.get_global thread_local static_local @_ZZ13test_ctordtoriE4init : !cir.ptr<!rec_CtorDtor>
+// CIR:   %[[GET_DEL_FUNC:.*]] = cir.get_global @_ZN8CtorDtorD1Ev : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>>
+// CIR:   %[[DEL_FUNC_DECAY:.*]] = cir.cast bitcast %[[GET_DEL_FUNC]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>> -> !cir.ptr<!cir.func<(!cir.ptr<!void>)>>
+// CIR:   %[[TLS_DECAY:.*]] = cir.cast bitcast %[[GET_TLS_DEL]] : !cir.ptr<!rec_CtorDtor> -> !cir.ptr<!void>
+// CIR:   %[[DSO_HANDLE:.*]] = cir.get_global @__dso_handle : !cir.ptr<i8>
+// CIR:   cir.call @__cxa_thread_atexit(%[[DEL_FUNC_DECAY]], %[[TLS_DECAY]], %[[DSO_HANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR:   cir.store %[[ONE]], %[[GUARD]] : !s8i, !cir.ptr<!s8i>
+// CIR: }
+
+// LLVM-BOTH-LABEL: define dso_local void @_Z13test_ctordtori(
+// LLVM-BOTH: %[[PARAM_ALLOCA:.*]] = alloca i32
+// LLVM-BOTH: %[[LOCAL_ALLOCA:.*]] = alloca i32
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ13test_ctordtoriE10const_init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ13test_ctordtoriE10const_init
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+//
+// LLVM: %[[GET_TLS_INIT:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ13test_ctordtoriE10const_init)
+// LLVM: call void @_ZN8CtorDtorC1Ei(ptr {{.*}}%[[GET_TLS_INIT]], i32 noundef 5)
+// OGCG: call void @_ZN8CtorDtorC1Ei(ptr {{.*}}@_ZZ13test_ctordtoriE10const_init, i32 noundef 5)
+// LLVM: %[[GET_TLS_DEL:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ13test_ctordtoriE10const_init)
+// LLVM: call void @__cxa_thread_atexit(ptr @_ZN8CtorDtorD1Ev, ptr %[[GET_TLS_DEL]], ptr @__dso_handle)
+// OGCG: call i32 @__cxa_thread_atexit(ptr @_ZN8CtorDtorD1Ev, ptr @_ZZ13test_ctordtoriE10const_init, ptr @__dso_handle)
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG: store i8 1, ptr @_ZGVZ13test_ctordtoriE10const_init
+// LLVM-BOTH: br label
+//
+// LLVM: %[[GUARD_ADDR:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGVZ13test_ctordtoriE4init)
+// LLVM: %[[GUARD_LOAD:.*]] = load i8, ptr %[[GUARD_ADDR]]
+// OGCG: %[[GUARD_LOAD:.*]] = load i8, ptr @_ZGVZ13test_ctordtoriE4init, align 1
+// LLVM-BOTH: %[[IS_UNINIT:.*]] = icmp eq i8 %[[GUARD_LOAD]], 0
+// LLVM-BOTH: br i1 %[[IS_UNINIT]]
+//
+// LLVM: %[[GET_TLS_INIT:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ13test_ctordtoriE4init)
+// LLVM-BOTH: %[[LOAD_PARAM:.*]] = load i32, ptr %[[PARAM_ALLOCA]]
+// LLVM-BOTH: %[[LOAD_LOCAL:.*]] = load i32, ptr %[[LOCAL_ALLOCA]]
+// LLVM-BOTH: %[[ADD1:.*]] = add nsw i32 %[[LOAD_PARAM]], %[[LOAD_LOCAL]]
+// LLVM-BOTH: %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
+// LLVM-BOTH: %[[ADD2:.*]] = add nsw i32 %[[ADD1]], %[[CALL]]
+// LLVM: call void @_ZN8CtorDtorC1Ei(ptr {{.*}}%[[GET_TLS_INIT]], i32 noundef %[[ADD2]])
+// OGCG: call void @_ZN8CtorDtorC1Ei(ptr {{.*}}@_ZZ13test_ctordtoriE4init, i32 noundef %[[ADD2]])
+//
+// LLVM: %[[GET_TLS_DEL:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZZ13test_ctordtoriE4init)
+// LLVM: call void @__cxa_thread_atexit(ptr @_ZN8CtorDtorD1Ev, ptr %[[GET_TLS_DEL]], ptr @__dso_handle)
+// OGCG: call i32 @__cxa_thread_atexit(ptr @_ZN8CtorDtorD1Ev, ptr @_ZZ13test_ctordtoriE4init, ptr @__dso_handle)
+// LLVM: store i8 1, ptr %[[GUARD_ADDR]]
+// OGCG: store i8 1, ptr @_ZGVZ13test_ctordtoriE4init
+// LLVM-BOTH: br label
+}
+

--- a/clang/test/CIR/IR/invalid-static-local.cir
+++ b/clang/test/CIR/IR/invalid-static-local.cir
@@ -65,7 +65,7 @@ module {
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
 
 cir.global "private" internal @_AnotherGlobal = ctor : !s32i {
-  // expected-error @below {{'cir.local_init' op expects parent op 'cir.func'}}
+  // expected-error @below {{'cir.local_init' op must be inside of a 'cir.func'}}
   cir.local_init static_local @_ZZ1fvE1y ctor {
     cir.yield
   } dtor {

--- a/clang/test/CIR/IR/invalid-static-local.cir
+++ b/clang/test/CIR/IR/invalid-static-local.cir
@@ -43,31 +43,8 @@ cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s3
 
 cir.func @test_static_local_and_tls() {
   %0 = cir.get_global static_local @_ZZ1fvE1y : !cir.ptr<!s32i>
-  // expected-error @below {{'cir.local_init' op failed to verify that has only one of the optional attributes: tls, static_local}}
-  cir.local_init thread_local static_local @_ZZ1fvE1y ctor {
-    cir.yield
-  } dtor {
-    cir.yield
-  }
-
-  cir.return
-}
-
-}
-
-// -----
-
-!s32i = !cir.int<s, 32>
-
-module {
-
-// local_init is neither static_local and thread_local
-cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
-
-cir.func @test_neither() {
-  %0 = cir.get_global static_local @_ZZ1fvE1y : !cir.ptr<!s32i>
-  // expected-error @below {{'cir.local_init' op static_local attribute mismatch}}
-  cir.local_init @_ZZ1fvE1y ctor {
+  // expected-error @below {{'cir.local_init' op access to global not marked thread local}}
+  cir.local_init thread_local @_ZZ1fvE1y ctor {
     cir.yield
   } dtor {
     cir.yield
@@ -89,7 +66,7 @@ cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s3
 
 cir.global "private" internal @_AnotherGlobal = ctor : !s32i {
   // expected-error @below {{'cir.local_init' op expects parent op 'cir.func'}}
-  cir.local_init @_ZZ1fvE1y ctor {
+  cir.local_init static_local @_ZZ1fvE1y ctor {
     cir.yield
   } dtor {
     cir.yield

--- a/clang/test/CIR/IR/static-local.cir
+++ b/clang/test/CIR/IR/static-local.cir
@@ -14,6 +14,8 @@ cir.global "private" internal static_local_guard<"_HasInitGuard2"> @_HasInit2 : 
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard2"> @_HasInit2 : !s32i
 cir.global "private" internal static_local_guard<"_HasInitGuard3"> @_HasInit3 : !s32i
 // CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard3"> @_HasInit3 : !s32i
+cir.global "private" internal static_local_guard<"_HasInitGuard4"> @_HasInit4 : !s32i
+// CHECK: cir.global "private" internal static_local_guard<"_HasInitGuard4"> @_HasInit4 : !s32i
 
 cir.func @test_static_local() {
   %0 = cir.get_global static_local @_ZZ1fvE1x : !cir.ptr<!s32i>
@@ -33,11 +35,13 @@ cir.func @test_static_local2() {
   cir.local_init static_local @_HasInit2 dtor {
     cir.yield
   }
+  cir.scope {
   %2 = cir.get_global static_local @_HasInit3 : !cir.ptr<!s32i>
-  cir.local_init static_local @_HasInit3 ctor {
-    cir.yield
-  } dtor {
-    cir.yield
+    cir.local_init static_local @_HasInit3 ctor {
+      cir.yield
+    } dtor {
+      cir.yield
+    }
   }
   cir.return
 }
@@ -50,11 +54,13 @@ cir.func @test_static_local2() {
 // CHECK:  cir.local_init static_local @_HasInit2 dtor {
 // CHECK:    cir.yield
 // CHECK:  }
-// CHECK:  %{{.*}} = cir.get_global static_local @_HasInit3 : !cir.ptr<!s32i>
-// CHECK:  cir.local_init static_local @_HasInit3 ctor {
-// CHECK:    cir.yield
-// CHECK:  } dtor {
-// CHECK:    cir.yield
+// CHECK:  cir.scope {
+// CHECK:    %{{.*}} = cir.get_global static_local @_HasInit3 : !cir.ptr<!s32i>
+// CHECK:    cir.local_init static_local @_HasInit3 ctor {
+// CHECK:      cir.yield
+// CHECK:    } dtor {
+// CHECK:      cir.yield
+// CHECK:    }
 // CHECK:  }
 // CHECK:  cir.return
 


### PR DESCRIPTION
thread_local variables at function scope work very much like static-locals, except with slightly different lowering from cir-lowering-prepare. This patch implements  that lowering.  Global tls variables are left to a later patch.

One decision I made here was that LocalInitOp lost its 'static-local'-ness, and assumes it is always static-local. Global TLS is probably just going to use Global directly, so we don't need to to permit it.

I DID leave it in the printing, as it makes it more clear what is happening/for symmetry with get_global/global.