### PR TITLE
[lldb][test] Fix Makefile for TestValueObjectErrors.py

### DIFF
--- a/lldb/test/API/functionalities/valobj_errors/Makefile
+++ b/lldb/test/API/functionalities/valobj_errors/Makefile
@@ -1,9 +1,10 @@
 C_SOURCES := main.c
 LD_EXTRAS = hidden.o
 
+include Makefile.rules
+
 a.out: hidden.o
 
 hidden.o: hidden.c
-	$(CC) -g0 -c -o $@ $<
+	$(CC) $(CFLAGS) -g0 -c -o $@ $<
 
-include Makefile.rules


### PR DESCRIPTION
This test does not respect custom triples. hidden.c is intended to be built with no debug info, so pass `-g0` after CFLAGS.