### PR TITLE
workflows/issue-subscriber: Use a GitHub app token

### DIFF
--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -28,14 +28,25 @@ jobs:
         run: |
           pip install --require-hashes -r requirements.txt
 
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+          private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-members: read
+          permission-contents: read
+          permission-issues: write
+
       - name: Update watchers
         working-directory: ./llvm/utils/git/
         # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
         env:
           LABEL_NAME: ${{ github.event.label.name }}
+          ISSUE_SUBSCRIBER_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python3 ./github-automation.py \
-            --token '${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}' \
+            --token "$ISSUE_SUBSCRIBER_TOKEN" \
             issue-subscriber \
             --issue-number '${{ github.event.issue.number }}' \
             --label-name "$LABEL_NAME"


### PR DESCRIPTION
This removes one user of the ISSUE_SUBSCRIBER_TOKEN secret, which we want to eventually remove since secrets are more difficult to maintain.