### PR TITLE
[ConstantFolding] Fold byte loads from constant globals

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -690,7 +690,7 @@ Constant *FoldReinterpretLoadFromConst(Constant *C, Type *LoadTy,
     // that address spaces don't matter here since we're not going to result in
     // an actual new load.
     if (!LoadTy->isFloatingPointTy() && !LoadTy->isPointerTy() &&
-        !LoadTy->isVectorTy())
+        !LoadTy->isByteTy() && !LoadTy->isVectorTy())
       return nullptr;
 
     Type *MapTy = Type::getIntNTy(C->getContext(),
@@ -904,7 +904,8 @@ Constant *llvm::ConstantFoldLoadFromUniformValue(Constant *C, Type *Ty,
   if (C->isNullValue() && !Ty->isX86_AMXTy())
     return Constant::getNullValue(Ty);
   if (C->isAllOnesValue() &&
-      (Ty->isIntOrIntVectorTy() || Ty->isFPOrFPVectorTy()))
+      (Ty->isIntOrIntVectorTy() || Ty->isByteOrByteVectorTy() ||
+       Ty->isFPOrFPVectorTy()))
     return Constant::getAllOnesValue(Ty);
   return nullptr;
 }

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -535,9 +535,12 @@ namespace {
 /// Recursive helper to read bits out of global. C is the constant being copied
 /// out of. ByteOffset is an offset into C. CurPtr is the pointer to copy
 /// results into and BytesLeft is the number of bytes left in
-/// the CurPtr buffer. DL is the DataLayout.
+/// the CurPtr buffer. DL is the DataLayout. When IsByteLoad is true, do not
+/// unwrap inttoptr constant expressions. The caller would reconstruct those
+/// bits as a ConstantByte, dropping the pointer's provenance.
 bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
-                        unsigned BytesLeft, const DataLayout &DL) {
+                        unsigned BytesLeft, const DataLayout &DL,
+                        bool IsByteLoad = false) {
   assert(ByteOffset <= DL.getTypeAllocSize(C->getType()) &&
          "Out of range access");
 
@@ -571,15 +574,18 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
   if (CFP && CFP->getType()->isFloatingPointTy()) {
     if (CFP->getType()->isDoubleTy()) {
       C = FoldBitCast(C, Type::getInt64Ty(C->getContext()), DL);
-      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL);
+      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL,
+                                IsByteLoad);
     }
     if (CFP->getType()->isFloatTy()){
       C = FoldBitCast(C, Type::getInt32Ty(C->getContext()), DL);
-      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL);
+      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL,
+                                IsByteLoad);
     }
     if (CFP->getType()->isHalfTy()){
       C = FoldBitCast(C, Type::getInt16Ty(C->getContext()), DL);
-      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL);
+      return ReadDataFromGlobal(C, ByteOffset, CurPtr, BytesLeft, DL,
+                                IsByteLoad);
     }
     return false;
   }
@@ -597,7 +603,7 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
 
       if (ByteOffset < EltSize &&
           !ReadDataFromGlobal(CS->getOperand(Index), ByteOffset, CurPtr,
-                              BytesLeft, DL))
+                              BytesLeft, DL, IsByteLoad))
         return false;
 
       ++Index;
@@ -645,7 +651,7 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
 
     for (; Index != NumElts; ++Index) {
       if (!ReadDataFromGlobal(C->getAggregateElement(Index), Offset, CurPtr,
-                              BytesLeft, DL))
+                              BytesLeft, DL, IsByteLoad))
         return false;
 
       uint64_t BytesWritten = EltSize - Offset;
@@ -663,8 +669,12 @@ bool ReadDataFromGlobal(Constant *C, uint64_t ByteOffset, unsigned char *CurPtr,
   if (auto *CE = dyn_cast<ConstantExpr>(C)) {
     if (CE->getOpcode() == Instruction::IntToPtr &&
         CE->getOperand(0)->getType() == DL.getIntPtrType(CE->getType())) {
+      // Folding byte loads through the integer operand would rebuild the result
+      // as a `ConstantByte`, dropping the pointer's provenance.
+      if (IsByteLoad)
+        return false;
       return ReadDataFromGlobal(CE->getOperand(0), ByteOffset, CurPtr,
-                                BytesLeft, DL);
+                                BytesLeft, DL, IsByteLoad);
     }
   }
 
@@ -750,7 +760,8 @@ Constant *FoldReinterpretLoadFromConst(Constant *C, Type *LoadTy,
     Offset = 0;
   }
 
-  if (!ReadDataFromGlobal(C, Offset, CurPtr, BytesLeft, DL))
+  if (!ReadDataFromGlobal(C, Offset, CurPtr, BytesLeft, DL,
+                          /*IsByteLoad=*/OrigLoadTy->isByteOrByteVectorTy()))
     return nullptr;
 
   APInt ResultVal = APInt(IntType->getBitWidth(), 0);

--- a/llvm/test/Transforms/InstSimplify/load.ll
+++ b/llvm/test/Transforms/InstSimplify/load.ll
@@ -119,6 +119,17 @@ define <4 x b8> @load_vb8_from_inttoptr() {
   ret <4 x b8> %load
 }
 
+define <4 x b8> @load_vb8_from_allones_ptr_gep(i64 %idx) {
+; CHECK-LABEL: @load_vb8_from_allones_ptr_gep(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr @allones_ptr, i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x b8>, ptr [[GEP]], align 4
+; CHECK-NEXT:    ret <4 x b8> [[LOAD]]
+;
+  %gep = getelementptr i8, ptr @allones_ptr, i64 %idx
+  %load = load <4 x b8>, ptr %gep
+  ret <4 x b8> %load
+}
+
 define b8 @load_b8_from_struct_inttoptr() {
 ; CHECK-LABEL: @load_b8_from_struct_inttoptr(
 ; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @struct_inttoptr, align 1

--- a/llvm/test/Transforms/InstSimplify/load.ll
+++ b/llvm/test/Transforms/InstSimplify/load.ll
@@ -103,7 +103,8 @@ define <4 x b8> @load_vb8_from_allones_gep(i64 %idx) {
 
 define b8 @load_b8_from_inttoptr() {
 ; CHECK-LABEL: @load_b8_from_inttoptr(
-; CHECK-NEXT:    ret b8 -1
+; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @allones_ptr, align 1
+; CHECK-NEXT:    ret b8 [[LOAD]]
 ;
   %load = load b8, ptr @allones_ptr
   ret b8 %load
@@ -111,7 +112,8 @@ define b8 @load_b8_from_inttoptr() {
 
 define <4 x b8> @load_vb8_from_inttoptr() {
 ; CHECK-LABEL: @load_vb8_from_inttoptr(
-; CHECK-NEXT:    ret <4 x b8> splat (b8 -1)
+; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x b8>, ptr @allones_ptr, align 4
+; CHECK-NEXT:    ret <4 x b8> [[LOAD]]
 ;
   %load = load <4 x b8>, ptr @allones_ptr
   ret <4 x b8> %load
@@ -119,7 +121,8 @@ define <4 x b8> @load_vb8_from_inttoptr() {
 
 define b8 @load_b8_from_struct_inttoptr() {
 ; CHECK-LABEL: @load_b8_from_struct_inttoptr(
-; CHECK-NEXT:    ret b8 -1
+; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @struct_inttoptr, align 1
+; CHECK-NEXT:    ret b8 [[LOAD]]
 ;
   %load = load b8, ptr @struct_inttoptr
   ret b8 %load

--- a/llvm/test/Transforms/InstSimplify/load.ll
+++ b/llvm/test/Transforms/InstSimplify/load.ll
@@ -95,3 +95,57 @@ define <4 x b8> @load_vb8_from_allones_gep(i64 %idx) {
   %load = load <4 x b8>, ptr %gep
   ret <4 x b8> %load
 }
+
+@allones_ptr = constant ptr inttoptr (i64 -1 to ptr)
+@ptr_to_GV = constant ptr @GV
+@struct_inttoptr = constant { ptr, i8 } { ptr inttoptr (i64 -1 to ptr), i8 7 }
+@null_ptr = constant ptr null
+
+define b8 @load_b8_from_inttoptr() {
+; CHECK-LABEL: @load_b8_from_inttoptr(
+; CHECK-NEXT:    ret b8 -1
+;
+  %load = load b8, ptr @allones_ptr
+  ret b8 %load
+}
+
+define <4 x b8> @load_vb8_from_inttoptr() {
+; CHECK-LABEL: @load_vb8_from_inttoptr(
+; CHECK-NEXT:    ret <4 x b8> splat (b8 -1)
+;
+  %load = load <4 x b8>, ptr @allones_ptr
+  ret <4 x b8> %load
+}
+
+define b8 @load_b8_from_struct_inttoptr() {
+; CHECK-LABEL: @load_b8_from_struct_inttoptr(
+; CHECK-NEXT:    ret b8 -1
+;
+  %load = load b8, ptr @struct_inttoptr
+  ret b8 %load
+}
+
+define b8 @load_b8_from_struct_after_inttoptr() {
+; CHECK-LABEL: @load_b8_from_struct_after_inttoptr(
+; CHECK-NEXT:    ret b8 7
+;
+  %gep = getelementptr inbounds i8, ptr @struct_inttoptr, i64 8
+  %load = load b8, ptr %gep
+  ret b8 %load
+}
+
+define b64 @load_b64_from_ptr() {
+; CHECK-LABEL: @load_b64_from_ptr(
+; CHECK-NEXT:    ret b64 bitcast (ptr @GV to b64)
+;
+  %load = load b64, ptr @ptr_to_GV
+  ret b64 %load
+}
+
+define b8 @load_b8_from_null_ptr() {
+; CHECK-LABEL: @load_b8_from_null_ptr(
+; CHECK-NEXT:    ret b8 0
+;
+  %load = load b8, ptr @null_ptr
+  ret b8 %load
+}

--- a/llvm/test/Transforms/InstSimplify/load.ll
+++ b/llvm/test/Transforms/InstSimplify/load.ll
@@ -65,8 +65,7 @@ define i8 @load_i8_multi_gep_const_zero_array(i64 %idx1, i64 %idx2) {
 
 define b8 @load_b8_from_allones_i32() {
 ; CHECK-LABEL: @load_b8_from_allones_i32(
-; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @allones_i32, align 1
-; CHECK-NEXT:    ret b8 [[LOAD]]
+; CHECK-NEXT:    ret b8 -1
 ;
   %load = load b8, ptr @allones_i32
   ret b8 %load
@@ -74,8 +73,7 @@ define b8 @load_b8_from_allones_i32() {
 
 define b8 @load_b8_from_i32_constant() {
 ; CHECK-LABEL: @load_b8_from_i32_constant(
-; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @GV, align 1
-; CHECK-NEXT:    ret b8 [[LOAD]]
+; CHECK-NEXT:    ret b8 42
 ;
   %load = load b8, ptr @GV
   ret b8 %load
@@ -83,8 +81,7 @@ define b8 @load_b8_from_i32_constant() {
 
 define b8 @load_b8_from_fp_constant() {
 ; CHECK-LABEL: @load_b8_from_fp_constant(
-; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @constvec, align 1
-; CHECK-NEXT:    ret b8 [[LOAD]]
+; CHECK-NEXT:    ret b8 -30
 ;
   %load = load b8, ptr @constvec
   ret b8 %load
@@ -92,9 +89,7 @@ define b8 @load_b8_from_fp_constant() {
 
 define <4 x b8> @load_vb8_from_allones_gep(i64 %idx) {
 ; CHECK-LABEL: @load_vb8_from_allones_gep(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr @allones_i32, i64 [[IDX:%.*]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x b8>, ptr [[GEP]], align 4
-; CHECK-NEXT:    ret <4 x b8> [[LOAD]]
+; CHECK-NEXT:    ret <4 x b8> splat (b8 -1)
 ;
   %gep = getelementptr i8, ptr @allones_i32, i64 %idx
   %load = load <4 x b8>, ptr %gep

--- a/llvm/test/Transforms/InstSimplify/load.ll
+++ b/llvm/test/Transforms/InstSimplify/load.ll
@@ -60,3 +60,43 @@ define i8 @load_i8_multi_gep_const_zero_array(i64 %idx1, i64 %idx2) {
   %load = load i8, ptr %gep
   ret i8 %load
 }
+
+@allones_i32 = constant i32 -1
+
+define b8 @load_b8_from_allones_i32() {
+; CHECK-LABEL: @load_b8_from_allones_i32(
+; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @allones_i32, align 1
+; CHECK-NEXT:    ret b8 [[LOAD]]
+;
+  %load = load b8, ptr @allones_i32
+  ret b8 %load
+}
+
+define b8 @load_b8_from_i32_constant() {
+; CHECK-LABEL: @load_b8_from_i32_constant(
+; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @GV, align 1
+; CHECK-NEXT:    ret b8 [[LOAD]]
+;
+  %load = load b8, ptr @GV
+  ret b8 %load
+}
+
+define b8 @load_b8_from_fp_constant() {
+; CHECK-LABEL: @load_b8_from_fp_constant(
+; CHECK-NEXT:    [[LOAD:%.*]] = load b8, ptr @constvec, align 1
+; CHECK-NEXT:    ret b8 [[LOAD]]
+;
+  %load = load b8, ptr @constvec
+  ret b8 %load
+}
+
+define <4 x b8> @load_vb8_from_allones_gep(i64 %idx) {
+; CHECK-LABEL: @load_vb8_from_allones_gep(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr @allones_i32, i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load <4 x b8>, ptr [[GEP]], align 4
+; CHECK-NEXT:    ret <4 x b8> [[LOAD]]
+;
+  %gep = getelementptr i8, ptr @allones_i32, i64 %idx
+  %load = load <4 x b8>, ptr %gep
+  ret <4 x b8> %load
+}


### PR DESCRIPTION
Handle byte types in `FoldReinterpretLoadFromConst` and `ConstantFoldLoadFromUniformValue` so loads from constant globals fold.