### PR TITLE
[lldb][test] Fix Makefile for TestArmPointerMetadataCFADwarfExpr.py

### DIFF
--- a/lldb/test/API/macosx/arm-pointer-metadata-cfa-dwarf-expr/Makefile
+++ b/lldb/test/API/macosx/arm-pointer-metadata-cfa-dwarf-expr/Makefile
@@ -5,7 +5,8 @@ C_SOURCES := main.c
 
 ASM_OBJS := $(ASM_SOURCES:.s=.o)
 
-%.o: %.s
-	$(CC) -c -x assembler $< -o $@
-
 include Makefile.rules
+
+%.o: %.s
+	$(CC) $(CFLAGS) -c -x assembler $< -o $@
+


### PR DESCRIPTION
The makefile did not respect custom target triples. Fixed by using CFLAGS from Makefile.rules.