### PR TITLE
[lldb][test] Fix Makefile for TestInlineSourceFiles.py

### DIFF
--- a/lldb/test/API/functionalities/inline-sourcefile/Makefile
+++ b/lldb/test/API/functionalities/inline-sourcefile/Makefile
@@ -8,4 +8,4 @@ OBJECTS += inline.o
 $(EXE): main.c inline.o
 
 %.o: %.ll
-	$(CC) $< -c -o $@
+	$(CC) $(CFLAGS) $< -c -o $@


### PR DESCRIPTION
The test did not build hidden.o with a custom target triple when specified. Use CFLAGS from Makefile.rules to fix.