### PR TITLE
[clang][deps] Always initialize module cache out params

### DIFF
--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -147,12 +147,16 @@ public:
     if (Entry.State == ModuleCacheEntry::S_Written) {
       assert(Entry.Buffer && *Entry.Buffer == Buffer &&
              "Wrote the same PCM with different contents");
+      Size = Entry.Buffer->getBufferSize();
+      ModTime = Entry.ModTime;
       return {};
     }
     Entry.Buffer =
         llvm::MemoryBuffer::getMemBufferCopy(Buffer.getBuffer(), Path);
     Entry.ModTime = llvm::sys::toTimeT(std::chrono::system_clock::now());
     Entry.State = ModuleCacheEntry::S_Written;
+    Size = Entry.Buffer->getBufferSize();
+    ModTime = Entry.ModTime;
     return {};
   }
 


### PR DESCRIPTION
We did not initialize the out parameters in #192347, causing the "sanitizer-x86_64-linux-fast" bot to complain with:

```
SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/lib/Frontend/CompilerInstance.cpp:1525:63 in compileModuleImpl(clang::CompilerInstance&, clang::SourceLocation, clang::SourceLocation, clang::Module*, clang::ModuleFileName)
Exiting
==clang==3084515==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x586360f7a604 in compileModuleImpl(clang::CompilerInstance&, clang::SourceLocation, clang::SourceLocation, clang::Module*, clang::ModuleFileName) /home/b/sanitizer-x86_64-linux-fast/build/llvm-project/clang/lib/Frontend/CompilerInstance.cpp:1525:63
    #1 <...>
```

This PR should fix that.