### PR TITLE
workflows/pr-subscriber: Use a GitHub app token

### DIFF
--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -32,7 +32,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+          client-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-members: read

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -29,11 +29,23 @@ jobs:
         run: |
           pip install --require-hashes -r requirements.txt
 
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+          private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-members: read
+          permission-contents: read
+          permission-pull-requests: write
+
       - name: Update watchers
         working-directory: ./llvm/utils/git/
+        env:
+          PR_SUBSCRIBER_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python3 ./github-automation.py \
-            --token '${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}' \
+            --token "$PR_SUBSCRIBER_TOKEN" \
             pr-subscriber \
             --issue-number "${{ github.event.number }}" \
             --label-name "${{ github.event.label.name }}"


### PR DESCRIPTION
This removes one user of the ISSUE_SUBSCRIBER_TOKEN secret, which we want to eventually remove since secrets are more difficult to maintain.