### PR TITLE
[llvm-dwarfdump] Add --compare for semantic DWARF diffing

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDiff.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDiff.h
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_DEBUGINFO_DWARF_DWARFDIFF_H
+#define LLVM_DEBUGINFO_DWARF_DWARFDIFF_H
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDie.h"
+#include "llvm/Support/Compiler.h"
+#include <string>
+#include <utility>
+
+namespace llvm {
+
+class DWARFContext;
+class raw_ostream;
+
+struct DiffOptions {
+  bool IgnoreLines = false;
+};
+
+struct DiffInput {
+  DWARFContext &Context;
+  StringRef Filename;
+};
+
+/// Lightweight identifier for a DIE, storing its offset, tag, and qualified
+/// name. Used in diff results so the comparison engine does not retain
+/// DWARFDie handles.
+struct DiffDIERef {
+  uint64_t Offset;
+  dwarf::Tag Tag;
+  std::string QualifiedName;
+};
+
+/// A pair of DiffDIERefs identifying a difference between matched DIEs.
+struct DiffEntry {
+  DiffDIERef LHS, RHS;
+};
+
+/// Result of a semantic DWARF comparison.
+struct DiffResult {
+  unsigned NumMatched = 0;
+
+  SmallVector<DiffDIERef> OnlyInLHS;
+  SmallVector<DiffDIERef> OnlyInRHS;
+  SmallVector<DiffEntry> Different;
+
+  bool hasDifferences() const {
+    return !OnlyInLHS.empty() || !OnlyInRHS.empty() || !Different.empty();
+  }
+};
+
+/// Identity key for matching DIEs across files.
+struct DIEIdentity {
+  std::string QualifiedName;
+  dwarf::Tag Tag = dwarf::DW_TAG_null;
+
+  bool operator==(const DIEIdentity &O) const {
+    return Tag == O.Tag && QualifiedName == O.QualifiedName;
+  }
+  bool isValid() const { return Tag != dwarf::DW_TAG_null; }
+};
+
+} // namespace llvm
+
+namespace llvm {
+template <> struct DenseMapInfo<DIEIdentity> {
+  static DIEIdentity getEmptyKey() {
+    return {{}, static_cast<dwarf::Tag>(~0U)};
+  }
+  static DIEIdentity getTombstoneKey() {
+    return {{}, static_cast<dwarf::Tag>(~0U - 1)};
+  }
+  static unsigned getHashValue(const DIEIdentity &V) {
+    return hash_combine(hash_value(V.QualifiedName), hash_value(V.Tag));
+  }
+  static bool isEqual(const DIEIdentity &LHS, const DIEIdentity &RHS) {
+    return LHS.Tag == RHS.Tag && LHS.QualifiedName == RHS.QualifiedName;
+  }
+};
+
+using DIEIndexMap = DenseMap<DIEIdentity, SmallVector<DWARFDie, 2>>;
+using CUMap = DenseMap<DIEIdentity, DWARFDie>;
+
+/// Semantic DWARF diff engine. Compares per-CU, handles cross-CU type
+/// moves, forward declarations, and identity-based references.
+class LLVM_ABI DWARFDiff {
+public:
+  explicit DWARFDiff(const DiffOptions &Opts) : Opts(Opts) {}
+
+  /// Compare two DWARF inputs and return the result.
+  DiffResult diff(const DiffInput &LHS, const DiffInput &RHS);
+
+private:
+  const DiffOptions Opts;
+
+  bool isSkippedAttribute(dwarf::Attribute Attr) const;
+  std::string getTypeKey(DWARFDie Die, DenseSet<uint64_t> &Visited,
+                         unsigned Depth = 0);
+  std::string getQualifiedName(DWARFDie Die);
+  DIEIdentity getIdentity(DWARFDie Die);
+  bool compareTypes(DWARFDie LHS, DWARFDie RHS,
+                    DenseSet<std::pair<uint64_t, uint64_t>> &Visited);
+  bool compareDIEs(DWARFDie LHS, DWARFDie RHS);
+  CUMap collectCUs(DWARFContext &Ctx);
+  void indexDIE(DWARFDie Die, DIEIndexMap &Index);
+  DIEIndexMap buildCUIndex(DWARFDie UnitDie);
+  DiffDIERef makeDIERef(DWARFDie Die);
+};
+
+/// Formats and prints DiffResult as a structured table.
+LLVM_ABI void printDiffResult(raw_ostream &OS, const DiffResult &Result);
+
+} // namespace llvm
+
+#endif // LLVM_DEBUGINFO_DWARF_DWARFDIFF_H

--- a/llvm/lib/DebugInfo/DWARF/CMakeLists.txt
+++ b/llvm/lib/DebugInfo/DWARF/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMDebugInfoDWARF
   DWARFCFIPrinter.cpp
   DWARFCompileUnit.cpp
   DWARFContext.cpp
+  DWARFDiff.cpp
   DWARFDebugAbbrev.cpp
   DWARFDebugAddr.cpp
   DWARFDebugArangeSet.cpp

--- a/llvm/lib/DebugInfo/DWARF/DWARFDiff.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDiff.cpp
@@ -1,0 +1,735 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/DebugInfo/DWARF/DWARFDiff.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DIContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFFormValue.h"
+#include "llvm/DebugInfo/DWARF/DWARFUnit.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <string>
+
+using namespace llvm;
+using namespace llvm::dwarf;
+
+/// Tags for which unnamed instances get a structural identity key (e.g.,
+/// an unnamed "const int *" becomes "*Kint"). This lets unnamed type DIEs
+/// participate in identity-based matching.
+static bool hasStructuralTypeKey(dwarf::Tag Tag) {
+  switch (Tag) {
+  case DW_TAG_base_type:
+  case DW_TAG_class_type:
+  case DW_TAG_enumeration_type:
+  case DW_TAG_structure_type:
+  case DW_TAG_typedef:
+  case DW_TAG_union_type:
+  case DW_TAG_pointer_type:
+  case DW_TAG_reference_type:
+  case DW_TAG_rvalue_reference_type:
+  case DW_TAG_const_type:
+  case DW_TAG_volatile_type:
+  case DW_TAG_restrict_type:
+  case DW_TAG_array_type:
+  case DW_TAG_subroutine_type:
+  case DW_TAG_ptr_to_member_type:
+  case DW_TAG_atomic_type:
+  case DW_TAG_unspecified_type:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool isTypeModifierTag(dwarf::Tag Tag) {
+  switch (Tag) {
+  case DW_TAG_pointer_type:
+  case DW_TAG_reference_type:
+  case DW_TAG_rvalue_reference_type:
+  case DW_TAG_const_type:
+  case DW_TAG_volatile_type:
+  case DW_TAG_restrict_type:
+  case DW_TAG_atomic_type:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// Attributes that encode file-level structure rather than semantic content.
+/// These always differ between files and are never compared.
+static bool isStructuralAttribute(dwarf::Attribute Attr) {
+  switch (Attr) {
+  case DW_AT_comp_dir:
+  case DW_AT_producer:
+  case DW_AT_language:
+  case DW_AT_stmt_list:
+  case DW_AT_low_pc:
+  case DW_AT_high_pc:
+  case DW_AT_ranges:
+  case DW_AT_addr_base:
+  case DW_AT_str_offsets_base:
+  case DW_AT_rnglists_base:
+  case DW_AT_loclists_base:
+  case DW_AT_GNU_addr_base:
+  case DW_AT_GNU_ranges_base:
+  case DW_AT_macro_info:
+  case DW_AT_macros:
+  case DW_AT_GNU_pubnames:
+  case DW_AT_sibling:
+  case DW_AT_object_pointer:
+  case DW_AT_location:
+  case DW_AT_frame_base:
+  case DW_AT_segment:
+  case DW_AT_static_link:
+  case DW_AT_use_location:
+  case DW_AT_vtable_elem_location:
+  case DW_AT_data_location:
+  case DW_AT_call_value:
+  case DW_AT_GNU_call_site_value:
+  case DW_AT_call_origin:
+  case DW_AT_call_return_pc:
+  case DW_AT_call_pc:
+  case DW_AT_call_all_calls:
+  case DW_AT_call_all_source_calls:
+  case DW_AT_call_all_tail_calls:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// References that should be compared by following the type graph.
+static bool isTypeReferenceAttribute(dwarf::Attribute Attr) {
+  switch (Attr) {
+  case DW_AT_type:
+  case DW_AT_containing_type:
+  case DW_AT_friend:
+  case DW_AT_default_value:
+  case DW_AT_signature:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// References to declarations/definitions of the same entity. These are
+/// compared by identity (qualified name) rather than structural comparison,
+/// because the referent may have been reorganized across CUs.
+static bool isIdentityReferenceAttribute(dwarf::Attribute Attr) {
+  switch (Attr) {
+  case DW_AT_specification:
+  case DW_AT_abstract_origin:
+  case DW_AT_import:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static std::string buildQualifiedName(StringRef Name, DWARFDie Die) {
+  std::string Result;
+  SmallVector<StringRef, 8> Parts;
+  Parts.push_back(Name);
+
+  DWARFDie Parent = Die.getParent();
+  while (Parent.isValid()) {
+    dwarf::Tag PTag = Parent.getTag();
+    if (PTag == DW_TAG_compile_unit || PTag == DW_TAG_type_unit ||
+        PTag == DW_TAG_partial_unit)
+      break;
+    const char *PName = Parent.getName(DINameKind::ShortName);
+    if (PName && PName[0])
+      Parts.push_back(PName);
+    else if (PTag == DW_TAG_namespace)
+      Parts.push_back("(anonymous namespace)");
+    Parent = Parent.getParent();
+  }
+
+  for (auto I = Parts.rbegin(), E = Parts.rend(); I != E; ++I) {
+    if (!Result.empty())
+      Result += "::";
+    Result += *I;
+  }
+  return Result;
+}
+
+static void sortPreferDefinitions(SmallVectorImpl<DWARFDie> &Dies) {
+  llvm::stable_sort(Dies, [](DWARFDie A, DWARFDie B) {
+    bool AIsDecl = A.find(DW_AT_declaration).has_value();
+    bool BIsDecl = B.find(DW_AT_declaration).has_value();
+    return !AIsDecl && BIsDecl;
+  });
+}
+
+static bool compareFormValues(const DWARFFormValue &LHS,
+                              const DWARFFormValue &RHS) {
+  // The else-after-return is needed: LStr is an Expected<> that must be
+  // consumed in both success and error paths before falling through.
+  if (auto LStr = LHS.getAsCString()) {
+    auto RStr = RHS.getAsCString();
+    if (!RStr) {
+      consumeError(RStr.takeError());
+      return false;
+    }
+    return StringRef(*LStr) == StringRef(*RStr);
+  } else {
+    consumeError(LStr.takeError());
+  }
+
+  if (auto LV = LHS.getAsUnsignedConstant()) {
+    auto RV = RHS.getAsUnsignedConstant();
+    return RV && *LV == *RV;
+  }
+
+  if (auto LV = LHS.getAsSignedConstant()) {
+    auto RV = RHS.getAsSignedConstant();
+    return RV && *LV == *RV;
+  }
+
+  if (auto LV = LHS.getAsBlock()) {
+    auto RV = RHS.getAsBlock();
+    return RV && *LV == *RV;
+  }
+
+  if (auto LV = LHS.getAsAddress()) {
+    auto RV = RHS.getAsAddress();
+    return RV && *LV == *RV;
+  }
+
+  if (LHS.isFormClass(DWARFFormValue::FC_Flag))
+    return LHS.getAsUnsignedConstant() == RHS.getAsUnsignedConstant();
+
+  if (auto LV = LHS.getAsSectionOffset()) {
+    auto RV = RHS.getAsSectionOffset();
+    return RV && *LV == *RV;
+  }
+
+  // Be conservative and treat unrecognized form classes as equal rather than
+  // reporting false differences for vendor extensions or future DWARF forms.
+  return true;
+}
+
+bool DWARFDiff::isSkippedAttribute(dwarf::Attribute Attr) const {
+  if (isStructuralAttribute(Attr))
+    return true;
+  if (Attr == DW_AT_decl_file || Attr == DW_AT_declaration)
+    return true;
+  if (Opts.IgnoreLines && (Attr == DW_AT_decl_line || Attr == DW_AT_call_line))
+    return true;
+  return false;
+}
+
+std::string DWARFDiff::getTypeKey(DWARFDie Die, DenseSet<uint64_t> &Visited,
+                                  unsigned Depth) {
+  if (!Die.isValid())
+    return "void";
+  if (Depth > 128)
+    return "?";
+
+  uint64_t Offset = Die.getOffset();
+  if (!Visited.insert(Offset).second)
+    return "^";
+
+  auto GetInner = [&]() -> std::string {
+    DWARFDie Inner = Die.getAttributeValueAsReferencedDie(DW_AT_type);
+    return getTypeKey(Inner, Visited, Depth + 1);
+  };
+
+  dwarf::Tag Tag = Die.getTag();
+  std::string Result;
+
+  switch (Tag) {
+  case DW_TAG_pointer_type:
+    Result = "*" + GetInner();
+    break;
+  case DW_TAG_reference_type:
+    Result = "&" + GetInner();
+    break;
+  case DW_TAG_rvalue_reference_type:
+    Result = "&&" + GetInner();
+    break;
+  case DW_TAG_const_type:
+    Result = "K" + GetInner();
+    break;
+  case DW_TAG_volatile_type:
+    Result = "V" + GetInner();
+    break;
+  case DW_TAG_restrict_type:
+    Result = "R" + GetInner();
+    break;
+  case DW_TAG_atomic_type:
+    Result = "A" + GetInner();
+    break;
+  case DW_TAG_array_type:
+    Result = "[" + GetInner();
+    break;
+  case DW_TAG_subroutine_type: {
+    Result = "F(";
+    for (DWARFDie C : Die.children()) {
+      if (C.getTag() == DW_TAG_formal_parameter) {
+        DWARFDie PT = C.getAttributeValueAsReferencedDie(DW_AT_type);
+        Result += getTypeKey(PT, Visited, Depth + 1) + ",";
+      } else if (C.getTag() == DW_TAG_unspecified_parameters) {
+        Result += "...,";
+      }
+    }
+    Result += ")" + GetInner();
+    break;
+  }
+  case DW_TAG_ptr_to_member_type: {
+    DWARFDie Cont = Die.getAttributeValueAsReferencedDie(DW_AT_containing_type);
+    Result = "M<" + getTypeKey(Cont, Visited, Depth + 1) + ">" + GetInner();
+    break;
+  }
+  default: {
+    const char *Name = Die.getName(DINameKind::ShortName);
+    if (Name && Name[0])
+      Result = buildQualifiedName(Name, Die);
+    else
+      Result = TagString(Tag).str();
+    break;
+  }
+  }
+
+  Visited.erase(Offset);
+  return Result;
+}
+
+std::string DWARFDiff::getQualifiedName(DWARFDie Die) {
+  if (!Die.isValid())
+    return "";
+
+  dwarf::Tag Tag = Die.getTag();
+
+  if (Tag == DW_TAG_subprogram || Tag == DW_TAG_inlined_subroutine ||
+      Tag == DW_TAG_variable) {
+    const char *Name = Die.getLinkageName();
+    if (Name && Name[0])
+      return Name;
+  }
+
+  if (Tag == DW_TAG_inheritance) {
+    DWARFDie BaseDie = Die.getAttributeValueAsReferencedDie(DW_AT_type);
+    if (BaseDie.isValid())
+      return getQualifiedName(BaseDie);
+    return "";
+  }
+
+  if (Tag == DW_TAG_imported_declaration || Tag == DW_TAG_imported_module) {
+    DWARFDie Imported = Die.getAttributeValueAsReferencedDie(DW_AT_import);
+    if (Imported.isValid())
+      return "import:" + getQualifiedName(Imported);
+    return "";
+  }
+
+  const char *Name = Die.getName(DINameKind::ShortName);
+  if (!Name || !Name[0]) {
+    if (hasStructuralTypeKey(Tag)) {
+      DenseSet<uint64_t> Visited;
+      return getTypeKey(Die, Visited);
+    }
+    return "";
+  }
+
+  return buildQualifiedName(Name, Die);
+}
+
+DIEIdentity DWARFDiff::getIdentity(DWARFDie Die) {
+  if (!Die.isValid())
+    return {};
+
+  dwarf::Tag Tag = Die.getTag();
+
+  switch (Tag) {
+  case DW_TAG_compile_unit:
+  case DW_TAG_type_unit:
+  case DW_TAG_partial_unit: {
+    const char *Name = Die.getName(DINameKind::ShortName);
+    return {Name ? Name : "", Tag};
+  }
+  default:
+    break;
+  }
+
+  std::string QName = getQualifiedName(Die);
+  if (QName.empty())
+    return {};
+  return {std::move(QName), Tag};
+}
+
+bool DWARFDiff::compareTypes(DWARFDie LHS, DWARFDie RHS,
+                             DenseSet<std::pair<uint64_t, uint64_t>> &Visited) {
+  if (!LHS.isValid() && !RHS.isValid())
+    return true;
+  if (!LHS.isValid() || !RHS.isValid())
+    return false;
+  dwarf::Tag Tag = LHS.getTag();
+  if (Tag != RHS.getTag())
+    return false;
+
+  auto Key = std::make_pair(LHS.getOffset(), RHS.getOffset());
+  if (!Visited.insert(Key).second)
+    return true;
+
+  auto Guard = llvm::scope_exit([&] { Visited.erase(Key); });
+
+  auto CompareInner = [&]() {
+    DWARFDie L = LHS.getAttributeValueAsReferencedDie(DW_AT_type);
+    DWARFDie R = RHS.getAttributeValueAsReferencedDie(DW_AT_type);
+    return compareTypes(L, R, Visited);
+  };
+
+  if (isTypeModifierTag(Tag))
+    return CompareInner();
+
+  const char *LName = LHS.getName(DINameKind::ShortName);
+  const char *RName = RHS.getName(DINameKind::ShortName);
+  bool LHasName = LName && LName[0];
+  bool RHasName = RName && RName[0];
+  if (LHasName != RHasName)
+    return false;
+  if (LHasName && StringRef(LName) != StringRef(RName))
+    return false;
+
+  // A forward declaration matches its definition if names and tags agree.
+  bool LIsDecl = LHS.find(DW_AT_declaration).has_value();
+  bool RIsDecl = RHS.find(DW_AT_declaration).has_value();
+  if (LHasName && (LIsDecl || RIsDecl))
+    return true;
+
+  if (Tag == DW_TAG_array_type) {
+    if (!CompareInner())
+      return false;
+    SmallVector<DWARFDie, 2> LSubs, RSubs;
+    for (DWARFDie C : LHS.children())
+      if (C.getTag() == DW_TAG_subrange_type)
+        LSubs.push_back(C);
+    for (DWARFDie C : RHS.children())
+      if (C.getTag() == DW_TAG_subrange_type)
+        RSubs.push_back(C);
+    if (LSubs.size() != RSubs.size())
+      return false;
+    for (size_t I = 0, E = LSubs.size(); I < E; ++I) {
+      auto LC = LSubs[I].find(DW_AT_count);
+      auto RC = RSubs[I].find(DW_AT_count);
+      if (LC.has_value() != RC.has_value())
+        return false;
+      if (LC && RC &&
+          LC->getAsUnsignedConstant() != RC->getAsUnsignedConstant())
+        return false;
+    }
+    return true;
+  }
+
+  if (Tag == DW_TAG_subroutine_type) {
+    if (!CompareInner())
+      return false;
+    SmallVector<DWARFDie, 4> LP, RP;
+    for (DWARFDie C : LHS.children())
+      if (C.getTag() == DW_TAG_formal_parameter ||
+          C.getTag() == DW_TAG_unspecified_parameters)
+        LP.push_back(C);
+    for (DWARFDie C : RHS.children())
+      if (C.getTag() == DW_TAG_formal_parameter ||
+          C.getTag() == DW_TAG_unspecified_parameters)
+        RP.push_back(C);
+    if (LP.size() != RP.size())
+      return false;
+    for (size_t I = 0, E = LP.size(); I < E; ++I) {
+      if (LP[I].getTag() != RP[I].getTag())
+        return false;
+      if (LP[I].getTag() == DW_TAG_formal_parameter) {
+        DWARFDie LT = LP[I].getAttributeValueAsReferencedDie(DW_AT_type);
+        DWARFDie RT = RP[I].getAttributeValueAsReferencedDie(DW_AT_type);
+        if (!compareTypes(LT, RT, Visited))
+          return false;
+      }
+    }
+    return true;
+  }
+
+  if (Tag == DW_TAG_ptr_to_member_type) {
+    DWARFDie LC = LHS.getAttributeValueAsReferencedDie(DW_AT_containing_type);
+    DWARFDie RC = RHS.getAttributeValueAsReferencedDie(DW_AT_containing_type);
+    return compareTypes(LC, RC, Visited) && CompareInner();
+  }
+
+  if (Tag == DW_TAG_typedef)
+    return CompareInner();
+
+  if (Tag == DW_TAG_enumeration_type)
+    return CompareInner();
+
+  return true;
+}
+
+bool DWARFDiff::compareDIEs(DWARFDie LHS, DWARFDie RHS) {
+  if (!LHS.isValid() || !RHS.isValid())
+    return LHS.isValid() == RHS.isValid();
+  if (LHS.getTag() != RHS.getTag())
+    return false;
+
+  // A forward declaration matches its definition. This is safe because the
+  // caller already matched these DIEs by identity (qualified name + tag).
+  bool LIsDecl = LHS.find(DW_AT_declaration).has_value();
+  bool RIsDecl = RHS.find(DW_AT_declaration).has_value();
+  if (LIsDecl || RIsDecl)
+    return true;
+
+  SmallDenseMap<dwarf::Attribute, DWARFFormValue, 16> LAttrs, RAttrs;
+  for (const DWARFAttribute &A : LHS.attributes())
+    LAttrs[A.Attr] = A.Value;
+  for (const DWARFAttribute &A : RHS.attributes())
+    RAttrs[A.Attr] = A.Value;
+
+  for (auto &[Attr, LVal] : LAttrs) {
+    if (isSkippedAttribute(Attr))
+      continue;
+    auto RIt = RAttrs.find(Attr);
+    if (RIt == RAttrs.end())
+      return false;
+    if (isIdentityReferenceAttribute(Attr)) {
+      DWARFDie LRef = LHS.getAttributeValueAsReferencedDie(Attr);
+      DWARFDie RRef = RHS.getAttributeValueAsReferencedDie(Attr);
+      if (getQualifiedName(LRef) != getQualifiedName(RRef))
+        return false;
+    } else if (isTypeReferenceAttribute(Attr)) {
+      DWARFDie LRef = LHS.getAttributeValueAsReferencedDie(Attr);
+      DWARFDie RRef = RHS.getAttributeValueAsReferencedDie(Attr);
+      DenseSet<std::pair<uint64_t, uint64_t>> Visited;
+      if (!compareTypes(LRef, RRef, Visited))
+        return false;
+    } else if (!compareFormValues(LVal, RIt->second)) {
+      return false;
+    }
+  }
+
+  for (auto &[Attr, RVal] : RAttrs) {
+    if (isSkippedAttribute(Attr))
+      continue;
+    if (!LAttrs.contains(Attr))
+      return false;
+  }
+
+  DenseMap<DIEIdentity, SmallVector<DWARFDie, 2>> LNamed, RNamed;
+  DenseMap<dwarf::Tag, SmallVector<DWARFDie, 2>> LUnnamed, RUnnamed;
+
+  for (DWARFDie C : LHS.children()) {
+    DIEIdentity ID = getIdentity(C);
+    if (ID.isValid())
+      LNamed[ID].push_back(C);
+    else if (C.getTag() != DW_TAG_null)
+      LUnnamed[C.getTag()].push_back(C);
+  }
+  for (DWARFDie C : RHS.children()) {
+    DIEIdentity ID = getIdentity(C);
+    if (ID.isValid())
+      RNamed[ID].push_back(C);
+    else if (C.getTag() != DW_TAG_null)
+      RUnnamed[C.getTag()].push_back(C);
+  }
+
+  for (auto &[ID, Dies] : LNamed)
+    sortPreferDefinitions(Dies);
+  for (auto &[ID, Dies] : RNamed)
+    sortPreferDefinitions(Dies);
+
+  for (auto &[ID, LDies] : LNamed) {
+    auto RIt = RNamed.find(ID);
+    if (RIt == RNamed.end())
+      return false;
+    if (!compareDIEs(LDies.front(), RIt->second.front()))
+      return false;
+  }
+  for (auto &[ID, RDies] : RNamed)
+    if (!LNamed.contains(ID))
+      return false;
+
+  for (auto &[Tag, LDies] : LUnnamed) {
+    auto RIt = RUnnamed.find(Tag);
+    if (RIt == RUnnamed.end())
+      return false;
+    auto &RDies = RIt->second;
+    if (LDies.size() != RDies.size())
+      return false;
+    for (size_t I = 0, Count = LDies.size(); I < Count; ++I)
+      if (!compareDIEs(LDies[I], RDies[I]))
+        return false;
+  }
+  for (auto &[Tag, RDies] : RUnnamed)
+    if (!LUnnamed.contains(Tag))
+      return false;
+
+  return true;
+}
+
+CUMap DWARFDiff::collectCUs(DWARFContext &Ctx) {
+  CUMap CUs;
+  for (auto &Unit : Ctx.normal_units()) {
+    DWARFDie UDie = Unit->getUnitDIE(false);
+    if (UDie.isValid())
+      CUs[getIdentity(UDie)] = UDie;
+  }
+  return CUs;
+}
+
+void DWARFDiff::indexDIE(DWARFDie Die, DIEIndexMap &Index) {
+  if (!Die.isValid())
+    return;
+
+  DIEIdentity ID = getIdentity(Die);
+  if (ID.isValid())
+    Index[ID].push_back(Die);
+
+  for (DWARFDie Child : Die.children())
+    indexDIE(Child, Index);
+}
+
+DIEIndexMap DWARFDiff::buildCUIndex(DWARFDie UnitDie) {
+  DIEIndexMap Index;
+  indexDIE(UnitDie, Index);
+  for (auto &[ID, Dies] : Index)
+    sortPreferDefinitions(Dies);
+  return Index;
+}
+
+DiffDIERef DWARFDiff::makeDIERef(DWARFDie Die) {
+  return {Die.getOffset(), Die.getTag(), getQualifiedName(Die)};
+}
+
+DiffResult DWARFDiff::diff(const DiffInput &LHS, const DiffInput &RHS) {
+  DiffResult Result;
+
+  CUMap LCUs = collectCUs(LHS.Context);
+  CUMap RCUs = collectCUs(RHS.Context);
+
+  auto isContainerTag = [](dwarf::Tag T) {
+    return T == DW_TAG_compile_unit || T == DW_TAG_type_unit ||
+           T == DW_TAG_partial_unit || T == DW_TAG_namespace;
+  };
+
+  CUMap LUnmatched, RUnmatched;
+
+  for (auto &[CUID, CUDie] : LCUs) {
+    auto RIt = RCUs.find(CUID);
+    if (RIt == RCUs.end()) {
+      DIEIndexMap Idx = buildCUIndex(CUDie);
+      for (auto &[ID, Dies] : Idx)
+        LUnmatched[ID] = Dies.front();
+      continue;
+    }
+    DIEIndexMap LIdx = buildCUIndex(CUDie);
+    DIEIndexMap RIdx = buildCUIndex(RIt->second);
+
+    for (auto &[ID, LDies] : LIdx) {
+      if (isContainerTag(ID.Tag))
+        continue;
+      auto RFind = RIdx.find(ID);
+      if (RFind == RIdx.end()) {
+        LUnmatched[ID] = LDies.front();
+        continue;
+      }
+      if (compareDIEs(LDies.front(), RFind->second.front())) {
+        ++Result.NumMatched;
+      } else {
+        Result.Different.push_back(
+            {makeDIERef(LDies.front()), makeDIERef(RFind->second.front())});
+      }
+    }
+    for (auto &[ID, RDies] : RIdx)
+      if (!isContainerTag(ID.Tag) && !LIdx.contains(ID))
+        RUnmatched[ID] = RDies.front();
+  }
+  for (auto &[CUID, CUDie] : RCUs) {
+    if (LCUs.contains(CUID))
+      continue;
+    DIEIndexMap Idx = buildCUIndex(CUDie);
+    for (auto &[ID, Dies] : Idx)
+      RUnmatched[ID] = Dies.front();
+  }
+
+  // Phase 2: DIEs unmatched within their CU may have moved to a different
+  // CU. Match them by identity alone.
+  for (auto &[ID, Die] : make_early_inc_range(LUnmatched)) {
+    if (RUnmatched.erase(ID)) {
+      ++Result.NumMatched;
+      LUnmatched.erase(ID);
+    }
+  }
+
+  for (auto &[ID, Die] : LUnmatched)
+    Result.OnlyInLHS.push_back(makeDIERef(Die));
+  for (auto &[ID, Die] : RUnmatched)
+    Result.OnlyInRHS.push_back(makeDIERef(Die));
+
+  auto CmpRef = [](const DiffDIERef &A, const DiffDIERef &B) {
+    if (A.QualifiedName != B.QualifiedName)
+      return A.QualifiedName < B.QualifiedName;
+    return A.Tag < B.Tag;
+  };
+  llvm::sort(Result.OnlyInLHS, CmpRef);
+  llvm::sort(Result.OnlyInRHS, CmpRef);
+  llvm::sort(Result.Different, [&](const DiffEntry &A, const DiffEntry &B) {
+    return CmpRef(A.LHS, B.LHS);
+  });
+
+  return Result;
+}
+
+static constexpr llvm::StringLiteral SepLine =
+    "----------------------------------------------"
+    "----------------------------------";
+
+static void printRow(raw_ostream &OS, const DiffDIERef *LHS,
+                     const DiffDIERef *RHS) {
+  if (LHS)
+    OS << formatv("{0:x8}        ", LHS->Offset);
+  else
+    OS << "                  ";
+  if (RHS)
+    OS << formatv("{0:x8}        ", RHS->Offset);
+  else
+    OS << "                  ";
+
+  const DiffDIERef &Ref = LHS ? *LHS : *RHS;
+  OS << formatv("{0,-31}", TagString(Ref.Tag));
+  if (!Ref.QualifiedName.empty())
+    OS << Ref.QualifiedName;
+  OS << "\n";
+}
+
+void llvm::printDiffResult(raw_ostream &OS, const DiffResult &Result) {
+  bool HasOutput = !Result.OnlyInLHS.empty() || !Result.OnlyInRHS.empty() ||
+                   !Result.Different.empty();
+  if (HasOutput) {
+    OS << SepLine << "\n";
+    OS << formatv("{0,-18}{1,-18}{2,-31}{3}\n", "LHS", "RHS", "TAG", "NAME");
+    OS << SepLine << "\n";
+  }
+
+  for (auto &Ref : Result.OnlyInLHS)
+    printRow(OS, &Ref, nullptr);
+  for (auto &Ref : Result.OnlyInRHS)
+    printRow(OS, nullptr, &Ref);
+  for (auto &E : Result.Different)
+    printRow(OS, &E.LHS, &E.RHS);
+
+  if (HasOutput)
+    OS << SepLine << "\n";
+
+  unsigned NumMissing = Result.OnlyInLHS.size();
+  unsigned NumAdded = Result.OnlyInRHS.size();
+  unsigned NumDiff = Result.Different.size();
+  unsigned Total = Result.NumMatched + NumMissing + NumAdded + NumDiff;
+  OS << formatv("Matched: {0}  Only in LHS: {1}  Only in RHS: {2}  "
+                "Different: {3}  Total: {4}\n",
+                Result.NumMatched, NumMissing, NumAdded, NumDiff, Total);
+}

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration3.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration3.test
@@ -9,6 +9,14 @@
 # RUN: dsymutil --linker=parallel -y %t2.map -f -o %t1.out
 # RUN: llvm-dwarfdump -a %t1.out | FileCheck %s
 
+## Verify the classic and parallel linker produce semantically equivalent output.
+# RUN: dsymutil -y %t2.map -f -o %t.classic.out
+# RUN: llvm-dwarfdump --compare --compare-ignore-lines \
+# RUN:   %t.classic.out %t1.out > %t.compare 2>&1 || true
+# RUN: FileCheck --check-prefix=COMPARE %s < %t.compare
+
+# COMPARE: Matched
+
 ## This test checks debug info for the case when one compilation unit
 ## contains forward declaration of the type and another compilation unit
 ## contains definition for that type. The result should have type table

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-parents.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-parents.test
@@ -6,7 +6,16 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t.parallel.o
+# RUN: llvm-dwarfdump -a %t.parallel.o | FileCheck %s
+
+## Verify the classic and parallel linker produce semantically equivalent output.
+# RUN: dsymutil -y %t2.map -f -o %t.classic.o
+# RUN: llvm-dwarfdump --compare --compare-ignore-lines \
+# RUN:   %t.classic.o %t.parallel.o > %t.compare 2>&1 || true
+# RUN: FileCheck --check-prefix=COMPARE %s < %t.compare
+
+# COMPARE: Matched
 
 ## This test checks debug info for the equally named structures from
 ## different namespaces. The result should contain two variables which

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-template-parameters.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-template-parameters.test
@@ -6,7 +6,16 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker=parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t.parallel.o
+# RUN: llvm-dwarfdump -a %t.parallel.o | FileCheck %s
+
+## Verify the classic and parallel linker produce semantically equivalent output.
+# RUN: dsymutil -y %t2.map -f -o %t.classic.o
+# RUN: llvm-dwarfdump --compare --compare-ignore-lines \
+# RUN:   %t.classic.o %t.parallel.o > %t.compare 2>&1 || true
+# RUN: FileCheck --check-prefix=COMPARE %s < %t.compare
+
+# COMPARE: Matched
 
 ## This test checks debug info for the template parameters of the class.
 ## (i.e. number of the parameters is correct, names of the parameters

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-two-units-in-single-file.test
@@ -11,7 +11,16 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map -f -o %t.parallel.o
+# RUN: llvm-dwarfdump -a %t.parallel.o | FileCheck %s
+
+## Verify the classic and parallel linker produce semantically equivalent output.
+# RUN: dsymutil -y %t2.map -f -o %t.classic.o
+# RUN: llvm-dwarfdump --compare --compare-ignore-lines \
+# RUN:   %t.classic.o %t.parallel.o > %t.compare 2>&1 || true
+# RUN: FileCheck --check-prefix=COMPARE %s < %t.compare
+
+# COMPARE: Matched
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
@@ -11,7 +11,17 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil -y %t2.map -f -o %t.classic.o
+# RUN: llvm-dwarfdump -a %t.classic.o | FileCheck %s
+
+## Verify the classic and parallel linker produce semantically equivalent
+## output: all entities present in classic should be matched in parallel.
+# RUN: dsymutil --linker=parallel -y %t2.map -f -o %t.parallel.o
+# RUN: llvm-dwarfdump --compare --compare-ignore-lines \
+# RUN:   %t.classic.o %t.parallel.o > %t.compare 2>&1 || true
+# RUN: FileCheck --check-prefix=COMPARE %s < %t.compare
+
+# COMPARE: Matched
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/llvm-dwarfdump/compare-basic.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-basic.test
@@ -1,0 +1,128 @@
+## Test that llvm-dwarfdump --compare reports no differences for
+## self-comparison, and detects differences between files with
+## different content.
+
+# REQUIRES: x86-registered-target
+
+## Self-comparison: should report no differences.
+# RUN: yaml2obj --docnum=1 %s -o %t.o
+# RUN: llvm-dwarfdump --compare %t.o %t.o | FileCheck %s --check-prefix=SELF
+
+# SELF: Matched:
+# SELF: Different: 0
+
+## Compare with a modified version: different function name.
+# RUN: yaml2obj --docnum=2 %s -o %t2.o
+# RUN: llvm-dwarfdump --compare %t.o %t2.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t.out
+
+# DIFF: subprogram{{.*}}bar
+# DIFF: subprogram{{.*}}baz
+
+## --- Doc1: subprogram "bar"
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: bar
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- Doc2: subprogram "baz"
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_subprogram
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: baz
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-cross-cu-move.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-cross-cu-move.test
@@ -1,0 +1,160 @@
+## Test that --compare correctly handles DIEs that move between CUs.
+## A type in CU1 in the LHS that appears in CU2 in the RHS should be
+## counted as "Matched", not "Only in LHS" + "Only in RHS".
+
+# REQUIRES: x86-registered-target
+
+## LHS: class1 is in CU1.
+## RHS: class1 moved to CU2, CU1 only has a variable.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s
+
+# CHECK: Matched:
+# CHECK: Only in LHS: 0
+# CHECK: Only in RHS: 0
+# CHECK: Different: 0
+
+## --- LHS: CU1 has class1 + var1, CU2 has var2
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_class_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu1.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: class1
+        - AbbrCode: 3
+          Values:
+            - CStr: var1
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu2.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: var2
+        - AbbrCode: 0
+
+## --- RHS: class1 moved to CU2, CU1 only has var1
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_class_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu1.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: var1
+        - AbbrCode: 0
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu2.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: class1
+        - AbbrCode: 3
+          Values:
+            - CStr: var2
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-deep-type-chain.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-deep-type-chain.test
@@ -1,0 +1,266 @@
+## Test that --compare handles multi-level type modifier chains correctly,
+## including volatile, restrict, and deeply nested pointer/const chains.
+
+# REQUIRES: x86-registered-target
+
+## Identical deep chain: volatile const int ** should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## Missing volatile qualifier should be detected.
+# RUN: yaml2obj --docnum=3 %s -o %t-novolatile.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-novolatile.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=MISSING < %t.out
+
+# MISSING: variable{{.*}}p
+
+## --- LHS: volatile const int **p
+##   pointer -> pointer -> volatile -> const -> int
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_volatile_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_const_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2           # variable p
+          Values:
+            - CStr: p
+            - Value:  0x0000001d # -> ptr1
+        - AbbrCode: 3           # ptr1 -> ptr2
+          Values:
+            - Value:  0x00000022 # -> ptr2
+        - AbbrCode: 3           # ptr2 -> volatile
+          Values:
+            - Value:  0x00000027 # -> volatile
+        - AbbrCode: 4           # volatile -> const
+          Values:
+            - Value:  0x0000002c # -> const
+        - AbbrCode: 5           # const -> int
+          Values:
+            - Value:  0x00000031 # -> int
+        - AbbrCode: 6           # int
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- RHS: identical volatile const int **
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_volatile_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_const_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: p
+            - Value:  0x0000001d
+        - AbbrCode: 3
+          Values:
+            - Value:  0x00000022
+        - AbbrCode: 3
+          Values:
+            - Value:  0x00000027
+        - AbbrCode: 4
+          Values:
+            - Value:  0x0000002c
+        - AbbrCode: 5
+          Values:
+            - Value:  0x00000031
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- NoVolatile: const int ** (volatile dropped)
+##   pointer -> pointer -> const -> int
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_const_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: p
+            - Value:  0x0000001d
+        - AbbrCode: 3           # ptr -> ptr
+          Values:
+            - Value:  0x00000022
+        - AbbrCode: 3           # ptr -> const (no volatile!)
+          Values:
+            - Value:  0x00000027
+        - AbbrCode: 4           # const -> int
+          Values:
+            - Value:  0x0000002c
+        - AbbrCode: 5           # int
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-enum.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-enum.test
@@ -1,0 +1,259 @@
+## Test that llvm-dwarfdump --compare detects enum differences
+## in the underlying base type.
+
+# REQUIRES: x86-registered-target
+
+## Same enum should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs-same.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-same.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+## Enum with different underlying type should differ.
+# RUN: yaml2obj --docnum=3 %s -o %t-rhs-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-diff.o > %t-diff.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t-diff.out
+
+# DIFF: Different:
+
+## --- LHS: enum Color : unsigned int { Red=0, Green=1, Blue=2 }
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_enumeration_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_enumerator
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_const_value
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: Color
+            - Value: 0x00000038
+            - Value: 0x04
+        - AbbrCode: 3
+          Values:
+            - CStr: Red
+            - Value: 0x00
+        - AbbrCode: 3
+          Values:
+            - CStr: Green
+            - Value: 0x01
+        - AbbrCode: 3
+          Values:
+            - CStr: Blue
+            - Value: 0x02
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: unsigned int
+            - Value: 0x07
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-same: identical enum
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_enumeration_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_enumerator
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_const_value
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: Color
+            - Value: 0x00000038
+            - Value: 0x04
+        - AbbrCode: 3
+          Values:
+            - CStr: Red
+            - Value: 0x00
+        - AbbrCode: 3
+          Values:
+            - CStr: Green
+            - Value: 0x01
+        - AbbrCode: 3
+          Values:
+            - CStr: Blue
+            - Value: 0x02
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: unsigned int
+            - Value: 0x07
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-diff: enum Color : unsigned long (different base type)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_enumeration_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_enumerator
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_const_value
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: Color
+            - Value: 0x00000038
+            - Value: 0x08
+        - AbbrCode: 3
+          Values:
+            - CStr: Red
+            - Value: 0x00
+        - AbbrCode: 3
+          Values:
+            - CStr: Green
+            - Value: 0x01
+        - AbbrCode: 3
+          Values:
+            - CStr: Blue
+            - Value: 0x02
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: unsigned long
+            - Value: 0x07
+            - Value: 0x08
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-errors.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-errors.test
@@ -1,0 +1,13 @@
+## Test --compare error handling.
+
+## --compare with only one file should fail.
+# RUN: llvm-dwarfdump --compare /dev/null > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=ONE < %t.out
+
+# ONE: --compare requires exactly two input files
+
+## --compare with three files should fail.
+# RUN: llvm-dwarfdump --compare /dev/null /dev/null /dev/null > %t2.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=THREE < %t2.out
+
+# THREE: --compare requires exactly two input files

--- a/llvm/test/tools/llvm-dwarfdump/compare-fwd-decl-type-ref.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-fwd-decl-type-ref.test
@@ -1,0 +1,152 @@
+## Test that --compare treats a forward declaration and its definition as
+## the same type when referenced via DW_AT_type. This is the common case
+## when the parallel linker deduplicates a type into an artificial type unit.
+
+# REQUIRES: x86-registered-target
+
+## LHS: variable "x" has type pointing to a forward declaration of Foo.
+## RHS: variable "x" has type pointing to the full definition of Foo.
+## These should match semantically.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o > %t.out 2>&1 || true
+# RUN: FileCheck %s < %t.out
+
+# CHECK: Matched:
+# CHECK: Different: 0
+
+## --- LHS: variable x with type -> forward decl of Foo
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_declaration
+            Form:      DW_FORM_flag_present
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: x
+            - Value: 0x0000001f
+        - AbbrCode: 3
+          Values:
+            - CStr: Foo
+        - AbbrCode: 0
+
+## --- RHS: variable x with type -> full definition of Foo
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: x
+            - Value: 0x0000001f
+        - AbbrCode: 3
+          Values:
+            - CStr: Foo
+            - Value: 0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: val
+            - Value: 0x00000030
+            - Value: 0x00
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-fwd-decl.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-fwd-decl.test
@@ -1,0 +1,167 @@
+## Test that llvm-dwarfdump --compare prefers definitions over
+## forward declarations when matching DIEs.
+
+# REQUIRES: x86-registered-target
+
+## A file with both forward decl + definition should match a file
+## with only the definition.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=MATCH
+
+# MATCH: Matched:
+# MATCH: Different: 0
+
+## --- LHS: forward declaration + definition of struct Foo
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_declaration
+            Form:      DW_FORM_flag_present
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2                   # forward decl: struct Foo;
+          Values:
+            - CStr: Foo
+        - AbbrCode: 3                   # definition: struct Foo { int x; }
+          Values:
+            - CStr: Foo
+            - Value: 0x04
+        - AbbrCode: 4                   # member x
+          Values:
+            - CStr: x
+            - Value: 0x0000002c          # -> int
+            - Value: 0x00
+        - AbbrCode: 0
+        - AbbrCode: 5                   # int
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS: only the definition of struct Foo (no forward decl)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2                   # definition: struct Foo { int x; }
+          Values:
+            - CStr: Foo
+            - Value: 0x04
+        - AbbrCode: 3                   # member x
+          Values:
+            - CStr: x
+            - Value: 0x00000027          # -> int
+            - Value: 0x00
+        - AbbrCode: 0
+        - AbbrCode: 4                   # int
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-imports.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-imports.test
@@ -1,0 +1,126 @@
+## Test that llvm-dwarfdump --compare matches imported declarations
+## by the referenced entity rather than positionally.
+
+# REQUIRES: x86-registered-target
+
+## Identical imports should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs-same.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-same.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+## --- LHS: namespace ns { int x; } using ns::x;
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_imported_declaration
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref4
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2                   # namespace ns
+          Values:
+            - CStr: ns
+        - AbbrCode: 3                   # int x
+          Values:
+            - CStr: x
+        - AbbrCode: 0                   # end namespace
+        - AbbrCode: 4                   # using ns::x
+          Values:
+            - Value: 0x0000001c          # -> ns::x
+        - AbbrCode: 0
+
+## --- RHS-same: identical structure
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_imported_declaration
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_import
+            Form:      DW_FORM_ref4
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: ns
+        - AbbrCode: 3
+          Values:
+            - CStr: x
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - Value: 0x0000001c
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-inheritance.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-inheritance.test
@@ -1,0 +1,242 @@
+## Test that llvm-dwarfdump --compare matches inheritance DIEs by
+## base class name rather than positionally.
+
+# REQUIRES: x86-registered-target
+
+## Identical inheritance should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs-same.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-same.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+## Different base class: Base2 replaced with Base3.
+# RUN: yaml2obj --docnum=3 %s -o %t-rhs-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-diff.o > %t-diff.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t-diff.out
+
+# DIFF: structure_type{{.*}}Base2
+# DIFF: structure_type{{.*}}Base3
+
+## --- LHS: struct Derived : Base1, Base2 {}
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_inheritance
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2                   # Derived
+          Values:
+            - CStr: Derived
+            - Value: 0x02
+        - AbbrCode: 3                   # : Base1
+          Values:
+            - Value: 0x0000002f          # -> Base1
+            - Value: 0x00
+        - AbbrCode: 3                   # : Base2
+          Values:
+            - Value: 0x00000037          # -> Base2
+            - Value: 0x01
+        - AbbrCode: 0
+        - AbbrCode: 4                   # Base1
+          Values:
+            - CStr: Base1
+            - Value: 0x01
+        - AbbrCode: 4                   # Base2
+          Values:
+            - CStr: Base2
+            - Value: 0x01
+        - AbbrCode: 0
+
+## --- RHS-same: identical layout
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_inheritance
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: Derived
+            - Value: 0x02
+        - AbbrCode: 3
+          Values:
+            - Value: 0x0000002f
+            - Value: 0x00
+        - AbbrCode: 3
+          Values:
+            - Value: 0x00000037
+            - Value: 0x01
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: Base1
+            - Value: 0x01
+        - AbbrCode: 4
+          Values:
+            - CStr: Base2
+            - Value: 0x01
+        - AbbrCode: 0
+
+## --- RHS-diff: Base2 replaced with Base3
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_inheritance
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+          - Attribute: DW_AT_data_member_location
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value: 0x0004
+        - AbbrCode: 2
+          Values:
+            - CStr: Derived
+            - Value: 0x02
+        - AbbrCode: 3                   # : Base1
+          Values:
+            - Value: 0x0000002f          # -> Base1
+            - Value: 0x00
+        - AbbrCode: 3                   # : Base3
+          Values:
+            - Value: 0x00000037          # -> Base3
+            - Value: 0x01
+        - AbbrCode: 0
+        - AbbrCode: 4                   # Base1
+          Values:
+            - CStr: Base1
+            - Value: 0x01
+        - AbbrCode: 4                   # Base3
+          Values:
+            - CStr: Base3
+            - Value: 0x01
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-multi-cu.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-multi-cu.test
@@ -1,0 +1,387 @@
+## Test that --compare works across multiple CUs in each file.
+## Two CUs should be compared independently, and types from different CUs
+## with the same name should be matched correctly.
+
+# REQUIRES: x86-registered-target
+
+## Same two CUs in both files should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## Second CU has a different member type.
+# RUN: yaml2obj --docnum=3 %s -o %t-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-diff.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t.out
+
+# DIFF: Different:
+
+## --- LHS: CU1 has struct S{int x}, CU2 has struct T{float y}
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu1.c
+            - Value:  0x0001
+        - AbbrCode: 2           # struct S
+          Values:
+            - CStr: S
+            - Value:  0x04
+        - AbbrCode: 3           # int x
+          Values:
+            - CStr: x
+            - Value:  0x00000021 # -> int
+        - AbbrCode: 0           # end S
+        - AbbrCode: 4           # int
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu2.c
+            - Value:  0x0001
+        - AbbrCode: 2           # struct T
+          Values:
+            - CStr: T
+            - Value:  0x04
+        - AbbrCode: 3           # float y
+          Values:
+            - CStr: y
+            - Value:  0x00000021 # -> float
+        - AbbrCode: 0           # end T
+        - AbbrCode: 4           # float
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- RHS: identical two CUs
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu1.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: S
+            - Value:  0x04
+        - AbbrCode: 3
+          Values:
+            - CStr: x
+            - Value:  0x00000021
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu2.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: T
+            - Value:  0x04
+        - AbbrCode: 3
+          Values:
+            - CStr: y
+            - Value:  0x00000021
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- Diff: CU2 struct T has double y instead of float y
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu1.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: S
+            - Value:  0x04
+        - AbbrCode: 3
+          Values:
+            - CStr: x
+            - Value:  0x00000021
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+    - Version: 5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: cu2.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: T
+            - Value:  0x08      # different byte_size
+        - AbbrCode: 3
+          Values:
+            - CStr: y
+            - Value:  0x00000021
+        - AbbrCode: 0
+        - AbbrCode: 4           # double instead of float
+          Values:
+            - CStr: double
+            - Value:  0x04
+            - Value:  0x08
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-namespaces.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-namespaces.test
@@ -1,0 +1,310 @@
+## Test that --compare handles namespaced types correctly: A::C1 and B::C1
+## should be treated as different types despite having the same short name.
+
+# REQUIRES: x86-registered-target
+
+## Same namespaced types should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## Swapping namespace members should be detected.
+# RUN: yaml2obj --docnum=3 %s -o %t-swapped.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-swapped.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=SWAPPED < %t.out
+
+# SWAPPED: member{{.*}}A::Foo::x
+# SWAPPED: member{{.*}}A::Foo::y
+
+## --- LHS: namespace A { struct Foo { int x; }; }
+##          namespace B { struct Foo { float y; }; }
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2           # namespace A
+          Values:
+            - CStr: A
+        - AbbrCode: 3           # struct Foo { int x; }
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: x
+            - Value:  0x0000003c # -> int
+        - AbbrCode: 0           # end Foo
+        - AbbrCode: 0           # end namespace A
+        - AbbrCode: 2           # namespace B
+          Values:
+            - CStr: B
+        - AbbrCode: 3           # struct Foo { float y; }
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: y
+            - Value:  0x00000043 # -> float
+        - AbbrCode: 0           # end Foo
+        - AbbrCode: 0           # end namespace B
+        - AbbrCode: 5           # int
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 5           # float
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0           # end CU
+
+## --- RHS: identical structure (same namespaces, same types)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2
+          Values:
+            - CStr: A
+        - AbbrCode: 3
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: x
+            - Value:  0x0000003c
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 2
+          Values:
+            - CStr: B
+        - AbbrCode: 3
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: y
+            - Value:  0x00000043
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 5
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- Swapped: A::Foo has float y (was int x), B::Foo has int x (was float y)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_namespace
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2
+          Values:
+            - CStr: A
+        - AbbrCode: 3           # A::Foo now has float y
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: y
+            - Value:  0x00000043 # -> float
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 2
+          Values:
+            - CStr: B
+        - AbbrCode: 3           # B::Foo now has int x
+          Values:
+            - CStr: Foo
+            - Value:  0x04
+        - AbbrCode: 4
+          Values:
+            - CStr: x
+            - Value:  0x0000003c # -> int
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 5
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 5
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-nested-types.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-nested-types.test
@@ -1,0 +1,258 @@
+## Test that --compare handles nested structs and multiple members correctly.
+## A struct with nested children should be compared recursively by identity.
+
+# REQUIRES: x86-registered-target
+
+## Identical nested struct should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## Extra member added to the nested struct should be detected.
+# RUN: yaml2obj --docnum=3 %s -o %t-extra.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-extra.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=EXTRA < %t.out
+
+# EXTRA: member{{.*}}Outer::Inner::z
+
+## --- LHS: struct Outer { struct Inner { int x; int y; }; };
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2           # struct Outer
+          Values:
+            - CStr: Outer
+            - Value:  0x08
+        - AbbrCode: 2           # struct Inner (nested)
+          Values:
+            - CStr: Inner
+            - Value:  0x08
+        - AbbrCode: 3           # int x
+          Values:
+            - CStr: x
+            - Value:  0x00000038 # -> int
+        - AbbrCode: 3           # int y
+          Values:
+            - CStr: y
+            - Value:  0x00000038 # -> int
+        - AbbrCode: 0           # end Inner
+        - AbbrCode: 0           # end Outer
+        - AbbrCode: 4           # int
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0           # end CU
+
+## --- RHS: identical nested struct
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2
+          Values:
+            - CStr: Outer
+            - Value:  0x08
+        - AbbrCode: 2
+          Values:
+            - CStr: Inner
+            - Value:  0x08
+        - AbbrCode: 3
+          Values:
+            - CStr: x
+            - Value:  0x00000038
+        - AbbrCode: 3
+          Values:
+            - CStr: y
+            - Value:  0x00000038
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- Extra: Inner has an additional member z
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_structure_type
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+      - Tag:      DW_TAG_member
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.cpp
+            - Value:  0x04
+        - AbbrCode: 2
+          Values:
+            - CStr: Outer
+            - Value:  0x0c
+        - AbbrCode: 2
+          Values:
+            - CStr: Inner
+            - Value:  0x0c
+        - AbbrCode: 3           # x
+          Values:
+            - CStr: x
+            - Value:  0x0000003f
+        - AbbrCode: 3           # y
+          Values:
+            - CStr: y
+            - Value:  0x0000003f
+        - AbbrCode: 3           # z (extra!)
+          Values:
+            - CStr: z
+            - Value:  0x0000003f
+        - AbbrCode: 0
+        - AbbrCode: 0
+        - AbbrCode: 4
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-subroutine-types.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-subroutine-types.test
@@ -1,0 +1,295 @@
+## Test that --compare handles subroutine types (function pointers) by
+## comparing parameter types and return types structurally.
+
+# REQUIRES: x86-registered-target
+
+## Identical function pointer types should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## Different parameter type should be detected.
+# RUN: yaml2obj --docnum=3 %s -o %t-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-diff.o > %t.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t.out
+
+# DIFF: base_type{{.*}}float
+# DIFF: base_type{{.*}}double
+
+## --- LHS: void (*callback)(int, float)
+## Header: 12 bytes (DWARF v5 DW_UT_compile)
+## 0x0c: CU         abbr1  string("test.c")=7 + data2=2           -> 0x17
+## 0x17: variable   abbr2  string("callback")=9 + ref4=4          -> 0x25
+## 0x25: pointer    abbr3  ref4=4                                  -> 0x2a
+## 0x2a: subroutine abbr4  (no attrs)                              -> 0x2b
+## 0x2b: param      abbr5  ref4=4                                  -> 0x30
+## 0x30: param      abbr5  ref4=4                                  -> 0x35
+## 0x35: null                                                      -> 0x36
+## 0x36: int        abbr6  string("int")=4 + data1=1 + data1=1    -> 0x3d
+## 0x3d: float      abbr6  string("float")=6 + data1=1 + data1=1  -> 0x46
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_subroutine_type
+        Children: DW_CHILDREN_yes
+        Attributes: []
+      - Tag:      DW_TAG_formal_parameter
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: callback
+            - Value:  0x00000024
+        - AbbrCode: 3
+          Values:
+            - Value:  0x00000029
+        - AbbrCode: 4
+          Values: []
+        - AbbrCode: 5
+          Values:
+            - Value:  0x00000035
+        - AbbrCode: 5
+          Values:
+            - Value:  0x0000003c
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 6
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- RHS: identical void (*callback)(int, float)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_subroutine_type
+        Children: DW_CHILDREN_yes
+        Attributes: []
+      - Tag:      DW_TAG_formal_parameter
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: callback
+            - Value:  0x00000024
+        - AbbrCode: 3
+          Values:
+            - Value:  0x00000029
+        - AbbrCode: 4
+          Values: []
+        - AbbrCode: 5
+          Values:
+            - Value:  0x00000035
+        - AbbrCode: 5
+          Values:
+            - Value:  0x0000003c
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 6
+          Values:
+            - CStr: float
+            - Value:  0x04
+            - Value:  0x04
+        - AbbrCode: 0
+
+## --- Diff: void (*callback)(int, double) - second param changed
+## Same layout as LHS but "float" replaced with "double"
+## "double" is 7 bytes (with null) vs "float" 6 bytes, so the
+## last base_type shifts by 1 byte: from 0x3c to 0x3d.
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_subroutine_type
+        Children: DW_CHILDREN_yes
+        Attributes: []
+      - Tag:      DW_TAG_formal_parameter
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value:  0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: callback
+            - Value:  0x00000024
+        - AbbrCode: 3
+          Values:
+            - Value:  0x00000029
+        - AbbrCode: 4
+          Values: []
+        - AbbrCode: 5
+          Values:
+            - Value:  0x00000035
+        - AbbrCode: 5
+          Values:
+            - Value:  0x0000003c
+        - AbbrCode: 0
+        - AbbrCode: 6
+          Values:
+            - CStr: int
+            - Value:  0x05
+            - Value:  0x04
+        - AbbrCode: 6
+          Values:
+            - CStr: double
+            - Value:  0x04
+            - Value:  0x08
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-type-structure.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-type-structure.test
@@ -1,0 +1,231 @@
+## Test that llvm-dwarfdump --compare structurally compares the DWARF type
+## graph, including unnamed type modifier DIEs (pointer, const, volatile, etc.).
+
+# REQUIRES: x86-registered-target
+
+## Two files with the same type structure should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs-same.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-same.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+
+## A file with a different type chain (const int* vs int*) should differ.
+# RUN: yaml2obj --docnum=3 %s -o %t-rhs-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-diff.o > %t-diff.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=TYPEDIFF < %t-diff.out
+
+# TYPEDIFF: variable{{.*}}p
+
+## --- LHS: variable "p" has type "const int *" (pointer -> const -> int)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_const_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2                   # variable "p"
+          Values:
+            - CStr: p
+            - Value: 0x0000001d          # -> pointer_type
+        - AbbrCode: 3                   # pointer_type -> const
+          Values:
+            - Value: 0x00000022          # -> const_type
+        - AbbrCode: 4                   # const_type -> int
+          Values:
+            - Value: 0x00000027          # -> base_type "int"
+        - AbbrCode: 5                   # base_type "int"
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-same: identical type structure (const int *)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_const_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2                   # variable "p"
+          Values:
+            - CStr: p
+            - Value: 0x0000001d          # -> pointer_type
+        - AbbrCode: 3                   # pointer_type -> const
+          Values:
+            - Value: 0x00000022          # -> const_type
+        - AbbrCode: 4                   # const_type -> int
+          Values:
+            - Value: 0x00000027          # -> base_type "int"
+        - AbbrCode: 5                   # base_type "int"
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-diff: different type structure (int * instead of const int *)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_variable
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_pointer_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2                   # variable "p"
+          Values:
+            - CStr: p
+            - Value: 0x0000001d          # -> pointer_type
+        - AbbrCode: 3                   # pointer_type -> int (no const!)
+          Values:
+            - Value: 0x00000022          # -> base_type "int" directly
+        - AbbrCode: 4                   # base_type "int"
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0

--- a/llvm/test/tools/llvm-dwarfdump/compare-typedef.test
+++ b/llvm/test/tools/llvm-dwarfdump/compare-typedef.test
@@ -1,0 +1,191 @@
+## Test that llvm-dwarfdump --compare detects typedef differences
+## where the underlying type differs.
+
+# REQUIRES: x86-registered-target
+
+## Same typedef should match.
+# RUN: yaml2obj --docnum=1 %s -o %t-lhs.o
+# RUN: yaml2obj --docnum=2 %s -o %t-rhs-same.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-same.o | FileCheck %s --check-prefix=SAME
+
+# SAME: Matched:
+# SAME: Different: 0
+
+## Typedef with different underlying type should differ.
+# RUN: yaml2obj --docnum=3 %s -o %t-rhs-diff.o
+# RUN: llvm-dwarfdump --compare %t-lhs.o %t-rhs-diff.o > %t-diff.out 2>&1 || true
+# RUN: FileCheck %s --check-prefix=DIFF < %t-diff.out
+
+# DIFF: base_type{{.*}}int
+# DIFF: base_type{{.*}}long
+
+## --- LHS: typedef MyInt -> int
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_typedef
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: MyInt
+            - Value: 0x00000021
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-same: typedef MyInt -> int (identical)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_typedef
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: MyInt
+            - Value: 0x00000021
+        - AbbrCode: 3
+          Values:
+            - CStr: int
+            - Value: 0x05
+            - Value: 0x04
+        - AbbrCode: 0
+
+## --- RHS-diff: typedef MyInt -> long (different underlying type)
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Size:  0x10
+DWARF:
+  debug_abbrev:
+    - Table:
+      - Tag:      DW_TAG_compile_unit
+        Children: DW_CHILDREN_yes
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_language
+            Form:      DW_FORM_data2
+      - Tag:      DW_TAG_typedef
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_type
+            Form:      DW_FORM_ref4
+      - Tag:      DW_TAG_base_type
+        Children: DW_CHILDREN_no
+        Attributes:
+          - Attribute: DW_AT_name
+            Form:      DW_FORM_string
+          - Attribute: DW_AT_encoding
+            Form:      DW_FORM_data1
+          - Attribute: DW_AT_byte_size
+            Form:      DW_FORM_data1
+  debug_info:
+    - Version:  5
+      UnitType: DW_UT_compile
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - CStr: test.c
+            - Value: 0x0001
+        - AbbrCode: 2
+          Values:
+            - CStr: MyInt
+            - Value: 0x00000021
+        - AbbrCode: 3
+          Values:
+            - CStr: long
+            - Value: 0x05
+            - Value: 0x08
+        - AbbrCode: 0

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -20,6 +20,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFDiff.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/Archive.h"
@@ -349,6 +350,17 @@ static opt<bool> CombineInstances(
         "Use with --show-variable-coverage to average variable coverage across "
         "inlined subroutine instances instead of printing them separately."),
     cat(DwarfDumpCategory));
+static opt<bool> Compare(
+    "compare",
+    desc("Semantically compare two DWARF files. Requires exactly two input "
+         "files. Compares the DWARF type graph structurally, ignoring offsets, "
+         "forms, and encoding differences."),
+    cat(DwarfDumpCategory));
+static opt<bool>
+    CompareIgnoreLines("compare-ignore-lines",
+                       desc("Use with --compare to ignore DW_AT_decl_line "
+                            "differences."),
+                       cat(DwarfDumpCategory));
 static cl::extrahelp
     HelpResponse("\nPass @FILE as argument to read options from FILE.\n");
 } // namespace
@@ -951,6 +963,59 @@ int main(int argc, char **argv) {
   }
 
   bool Success = true;
+  if (Compare) {
+    if (Objects.size() != 2) {
+      WithColor::error() << "--compare requires exactly two input files\n";
+      return EXIT_FAILURE;
+    }
+
+    struct OwnedContext {
+      std::unique_ptr<MemoryBuffer> Buffer;
+      std::unique_ptr<Binary> Bin;
+      std::unique_ptr<DWARFContext> Context;
+    };
+
+    auto OpenCtx = [](StringRef Filename) -> std::unique_ptr<OwnedContext> {
+      auto Result = std::make_unique<OwnedContext>();
+      auto BufOrErr = MemoryBuffer::getFileOrSTDIN(Filename);
+      if (!BufOrErr) {
+        WithColor::error() << "cannot open '" << Filename
+                           << "': " << BufOrErr.getError().message() << "\n";
+        return nullptr;
+      }
+      Result->Buffer = std::move(*BufOrErr);
+      auto BinOrErr = createBinary(Result->Buffer->getMemBufferRef());
+      if (!BinOrErr) {
+        WithColor::error() << Filename << ": " << toString(BinOrErr.takeError())
+                           << "\n";
+        return nullptr;
+      }
+      Result->Bin = std::move(*BinOrErr);
+      if (auto *Obj = dyn_cast<ObjectFile>(Result->Bin.get())) {
+        Result->Context = DWARFContext::create(*Obj);
+        return Result;
+      }
+      WithColor::error() << Filename << ": unsupported binary format\n";
+      return nullptr;
+    };
+
+    auto LOwned = OpenCtx(Objects[0]);
+    auto ROwned = OpenCtx(Objects[1]);
+    if (!LOwned || !ROwned)
+      return EXIT_FAILURE;
+
+    DiffOptions DiffOpts;
+    DiffOpts.IgnoreLines = CompareIgnoreLines;
+
+    DiffInput LInput{*LOwned->Context, Objects[0]};
+    DiffInput RInput{*ROwned->Context, Objects[1]};
+
+    DWARFDiff Differ(DiffOpts);
+    DiffResult Result = Differ.diff(LInput, RInput);
+    printDiffResult(OutputFile.os(), Result);
+    return Result.hasDifferences() ? EXIT_FAILURE : EXIT_SUCCESS;
+  }
+
   if (Verify) {
     if (!VerifyNumThreads)
       parallel::strategy =


### PR DESCRIPTION
Add a --compare flag to llvm-dwarfdump that semantically compares two DWARF files. Unlike a byte-level diff, this compares the debug info graph structurally: ignoring offsets, forms, encoding differences, and file-level attributes (comp_dir, producer, stmt_list, etc.) that always differ between independently-compiled files.

The implementation lives in a DWARFDiff engine class that works in two phases:

- Phase 1 (CU-local matching): For each compilation unit present in both files, an index is built mapping every DIE to a semantic identity (qualified name + tag). DIEs with matching identities are compared attribute-by-attribute. Type references (DW_AT_type, DW_AT_signature, etc.) are compared by walking the type graph structurally rather than by offset, so differently-laid-out type sections still match if the types are equivalent. Identity references (DW_AT_specification, DW_AT_abstract_origin) are compared by qualified name. Forward declarations are treated as matching their definitions.

- Phase 2 (cross-CU matching): DIEs unmatched in phase 1 are collected into global left/right sets and matched by identity alone. This handles the case where a DIE moves between compilation units (e.g. due to LTO or different partitioning strategies).

Unnamed type DIEs (e.g. "const int *") get a structural identity key built by recursively encoding the type modifier chain, so they can participate in identity-based matching despite having no name.

Results are sorted deterministically by qualified name for stable output. The --compare-ignore-lines flag additionally suppresses DW_AT_decl_line differences.

Assisted-by: Claude