### PR TITLE
workflows/new-issues: Use a GitHub app token

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -16,9 +16,17 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+          private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-issues: write
       - uses: llvm/actions/issue-labeler@89a8cf80982d830faab019237860b344a6390c30 # main
         with:
-          repo-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/new-issues-labeler.yml
           include-title: 1
           include-body: 0

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -19,7 +19,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+          client-id: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: read


### PR DESCRIPTION
This removes one user of the ISSUE_SUBSCRIBER_TOKEN secret, which we want to eventually remove since secrets are more difficult to maintain.  This also allows use to scope the token with less permissions since it isn't shared with other workflows.