### PR TITLE
[compiler-rt][WebAssembly] Use an int as CMP_RESULT

### DIFF
--- a/compiler-rt/lib/builtins/fp_compare_impl.inc
+++ b/compiler-rt/lib/builtins/fp_compare_impl.inc
@@ -15,6 +15,9 @@
 #if defined(__aarch64__) || defined(__arm64ec__)
 // AArch64 GCC overrides libgcc_cmp_return to use int instead of long.
 typedef int CMP_RESULT;
+#elif defined(__wasm__)
+// Both wasm32 and wasm64 use i32
+typedef int CMP_RESULT;
 #elif __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 4
 // LLP64 ABIs use long long instead of long.
 typedef long long CMP_RESULT;


### PR DESCRIPTION
LLVM uses an i32 as the default for `getCmpLibcallReturnType`, but compiler-rt uses a word-sized integer by default. On most physical hardware this happens to work because `i32` is largely ABI-compatible with a word. On wasm64, however, they are not compatible so this causes problems.

Resolve this by using `int` as the comparison result in compiler-rt.

Closes: https://github.com/llvm/llvm-project/issues/75302
Closes: https://github.com/llvm/llvm-project/issues/192416