### PR TITLE
[sanitizer] Relax pthread_join tests for different glibc versions

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/pthread_join.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/pthread_join.cpp
@@ -44,8 +44,10 @@ int main(int argc, char **argv) {
     while (pthread_tryjoin_np(thread[1], &res))
       sleep(1);
     assert(~(uintptr_t)res == 1001);
-    assert(check_invalid_join ||
-           (pthread_tryjoin_np(thread[1], &res) == EBUSY));
+    if (!check_invalid_join) {
+      int err = pthread_tryjoin_np(thread[1], &res);
+      assert(err == EBUSY || err == 0);
+    }
   }
 
   {
@@ -54,15 +56,22 @@ int main(int argc, char **argv) {
     while (pthread_timedjoin_np(thread[2], &res, &tm))
       sleep(1);
     assert(~(uintptr_t)res == 1002);
-    assert(check_invalid_join ||
-           (pthread_timedjoin_np(thread[2], &res, &tm) == ESRCH));
+    if (!check_invalid_join) {
+      res = nullptr;
+      int err = pthread_timedjoin_np(thread[2], &res, &tm);
+      assert(err == ESRCH || err == 0);
+    }
   }
 
   {
     void *res;
     assert(!pthread_join(thread[3], &res));
     assert(~(uintptr_t)res == 1003);
-    assert(check_invalid_join || (pthread_join(thread[3], &res) == ESRCH));
+    if (!check_invalid_join) {
+      res = nullptr;
+      int err = pthread_join(thread[3], &res);
+      assert(err == ESRCH || err == 0);
+    }
   }
 
   return 0;


### PR DESCRIPTION
New (2.43) glibc successfully joins already joined threads.
Probably result of https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=f7648bf44384118b6658ddcd741408fc4fbdd056

EDIT: Actually the change in https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=5da15b15adab661c80e373b6af89be0b5fa5b3ad