### PR TITLE
[MC] Change MCContext::getTargetOptions to return a reference. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -414,7 +414,7 @@ public:
 
   const MCSubtargetInfo *getSubtargetInfo() const { return MSTI; }
 
-  LLVM_ABI const MCTargetOptions *getTargetOptions() const;
+  LLVM_ABI const MCTargetOptions &getTargetOptions() const;
 
   LLVM_ABI CodeViewContext &getCVContext();
 

--- a/llvm/include/llvm/MC/MCELFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCELFObjectWriter.h
@@ -181,7 +181,7 @@ public:
   uint64_t writeObject() override;
 
   bool hasRelocationAddend() const;
-  bool usesRela(const MCTargetOptions *TO, const MCSectionELF &Sec) const;
+  bool usesRela(const MCTargetOptions &TO, const MCSectionELF &Sec) const;
 
   bool useSectionSymbol(const MCValue &Val, const MCSymbolELF *Sym, uint64_t C,
                         unsigned Type) const;

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -672,8 +672,8 @@ MCSectionELF *ELFWriter::createRelocationSection(MCContext &Ctx,
     Flags = ELF::SHF_GROUP;
 
   const StringRef SectionName = Sec.getName();
-  const MCTargetOptions *TO = Ctx.getTargetOptions();
-  if (TO->Crel) {
+  const MCTargetOptions &TO = Ctx.getTargetOptions();
+  if (TO.Crel) {
     MCSectionELF *RelaSection =
         Ctx.createELFRelSection(".crel" + SectionName, ELF::SHT_CREL, Flags,
                                 /*EntrySize=*/1, Sec.getGroup(), &Sec);
@@ -724,7 +724,7 @@ void ELFWriter::writeSectionData(MCSection &Sec) {
   StringRef SectionName = Section.getName();
   auto &Ctx = Asm.getContext();
   const DebugCompressionType CompressionType =
-      Ctx.getTargetOptions()->CompressDebugSections;
+      Ctx.getTargetOptions().CompressDebugSections;
   if (CompressionType == DebugCompressionType::None ||
       !SectionName.starts_with(".debug_")) {
     Asm.writeSectionData(W.OS, &Section);
@@ -795,7 +795,7 @@ static void encodeCrel(ArrayRef<ELFRelocationEntry> Relocs, raw_ostream &OS) {
 
 void ELFWriter::writeRelocations(const MCSectionELF &Sec) {
   std::vector<ELFRelocationEntry> &Relocs = OWriter.Relocations[&Sec];
-  const MCTargetOptions *TO = getContext().getTargetOptions();
+  const MCTargetOptions &TO = getContext().getTargetOptions();
   const bool Rela = OWriter.usesRela(TO, Sec);
 
   // Sort the relocation entries. MIPS needs this.
@@ -836,7 +836,7 @@ void ELFWriter::writeRelocations(const MCSectionELF &Sec) {
         }
       }
     }
-  } else if (TO && TO->Crel) {
+  } else if (TO.Crel) {
     if (is64Bit())
       encodeCrel<true>(Relocs, W.OS);
     else
@@ -1357,12 +1357,12 @@ void ELFObjectWriter::recordRelocation(const MCFragment &F,
   // Convert SymA to an STT_SECTION symbol if it's defined, local, and meets
   // specific conditions, unless it's a .reloc directive, which disables
   // STT_SECTION adjustment.
-  const MCTargetOptions *TO = Ctx.getTargetOptions();
+  const MCTargetOptions &TO = Ctx.getTargetOptions();
   bool UseSectionSym = SymA && SymA->getBinding() == ELF::STB_LOCAL &&
                        !SymA->isUndefined() &&
                        !mc::isRelocRelocation(Fixup.getKind());
   if (UseSectionSym) {
-    auto RSS = TO ? TO->RelocSectionSym : RelocSectionSymType::All;
+    auto RSS = TO.RelocSectionSym;
     UseSectionSym = RSS == RelocSectionSymType::All ||
                     (RSS == RelocSectionSymType::Internal &&
                      SymA->getName().starts_with(
@@ -1381,11 +1381,11 @@ void ELFObjectWriter::recordRelocation(const MCFragment &F,
   Relocations[&Section].emplace_back(FixupOffset, SymA, Type, Addend);
 }
 
-bool ELFObjectWriter::usesRela(const MCTargetOptions *TO,
+bool ELFObjectWriter::usesRela(const MCTargetOptions &TO,
                                const MCSectionELF &Sec) const {
   return (hasRelocationAddend() &&
           Sec.getType() != ELF::SHT_LLVM_CALL_GRAPH_PROFILE) ||
-         TO->Crel;
+         TO.Crel;
 }
 
 bool ELFObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -102,12 +102,12 @@ public:
 
     Context.setUseNamesOnTempLabels(true);
 
-    auto *TO = Context.getTargetOptions();
-    IsVerboseAsm = TO->AsmVerbose;
+    const MCTargetOptions &TO = Context.getTargetOptions();
+    IsVerboseAsm = TO.AsmVerbose;
     if (IsVerboseAsm)
       InstPrinter->setCommentStream(CommentStream);
-    ShowInst = TO->ShowMCInst;
-    switch (TO->MCUseDwarfDirectory) {
+    ShowInst = TO.ShowMCInst;
+    switch (TO.MCUseDwarfDirectory) {
     case MCTargetOptions::DisableDwarfDirectory:
       UseDwarfDirectory = false;
       break;

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -74,10 +74,11 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
       AutoReset(DoAutoReset) {
   assert(MAI && MAI->getTargetOptions() &&
          "MCAsmInfo and MCTargetOptions must be available");
-  SaveTempLabels = getTargetOptions()->MCSaveTempLabels;
+  const MCTargetOptions &TO = getTargetOptions();
+  SaveTempLabels = TO.MCSaveTempLabels;
   if (SaveTempLabels)
     setUseNamesOnTempLabels(true);
-  SecureLogFile = getTargetOptions()->AsSecureLogFile;
+  SecureLogFile = TO.AsSecureLogFile;
 
   if (SrcMgr && SrcMgr->getNumBuffers())
     MainFileName = std::string(SrcMgr->getMemoryBuffer(SrcMgr->getMainFileID())
@@ -119,8 +120,8 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
   }
 }
 
-const MCTargetOptions *MCContext::getTargetOptions() const {
-  return MAI->getTargetOptions();
+const MCTargetOptions &MCContext::getTargetOptions() const {
+  return *MAI->getTargetOptions();
 }
 
 MCContext::~MCContext() {
@@ -994,11 +995,11 @@ void MCContext::RemapDebugPaths() {
 //===----------------------------------------------------------------------===//
 
 EmitDwarfUnwindType MCContext::emitDwarfUnwindInfo() const {
-  return getTargetOptions()->EmitDwarfUnwind;
+  return getTargetOptions().EmitDwarfUnwind;
 }
 
 bool MCContext::emitCompactUnwindNonCanonical() const {
-  return getTargetOptions()->EmitCompactUnwindNonCanonical;
+  return getTargetOptions().EmitCompactUnwindNonCanonical;
 }
 
 void MCContext::setGenDwarfRootFile(StringRef InputFileName, StringRef Buffer) {
@@ -1133,9 +1134,9 @@ void MCContext::reportError(SMLoc Loc, const Twine &Msg) {
 }
 
 void MCContext::reportWarning(SMLoc Loc, const Twine &Msg) {
-  if (getTargetOptions()->MCNoWarn)
+  if (getTargetOptions().MCNoWarn)
     return;
-  if (getTargetOptions()->MCFatalWarnings) {
+  if (getTargetOptions().MCFatalWarnings) {
     reportError(Loc, Msg);
   } else {
     reportCommon(Loc, [&](SMDiagnostic &D, const SourceMgr *SMP) {

--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -360,12 +360,10 @@ void MCELFStreamer::finalizeCGProfile() {
 void MCELFStreamer::finishImpl() {
   // Emit .note.GNU-stack, similar to AsmPrinter::doFinalization.
   MCContext &Ctx = getContext();
-  if (const MCTargetOptions *TO = Ctx.getTargetOptions()) {
-    auto *StackSec = Ctx.getAsmInfo()->getStackSection(Ctx,
-                                                       /*Exec=*/false);
-    if (StackSec && TO->MCNoExecStack)
-      switchSection(StackSec);
-  }
+  auto *StackSec = Ctx.getAsmInfo()->getStackSection(Ctx,
+                                                     /*Exec=*/false);
+  if (StackSec && Ctx.getTargetOptions().MCNoExecStack)
+    switchSection(StackSec);
 
   // Emit the .gnu attributes section if any attributes have been added.
   if (!GNUAttributes.empty()) {

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -36,7 +36,7 @@ MCObjectStreamer::MCObjectStreamer(MCContext &Context,
   assert(Assembler->getBackendPtr() && Assembler->getEmitterPtr());
   IsObj = true;
   setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
-  if (Context.getTargetOptions()->MCRelaxAll)
+  if (Context.getTargetOptions().MCRelaxAll)
     Assembler->setRelaxAll(true);
 }
 
@@ -171,7 +171,7 @@ void MCObjectStreamer::emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
 void MCObjectStreamer::reset() {
   if (Assembler) {
     Assembler->reset();
-    Assembler->setRelaxAll(getContext().getTargetOptions()->MCRelaxAll);
+    Assembler->setRelaxAll(getContext().getTargetOptions().MCRelaxAll);
   }
   EmitEHFrame = true;
   EmitDebugFrame = false;
@@ -197,7 +197,7 @@ void MCObjectStreamer::emitFrames() {
   if (EmitDebugFrame)
     MCDwarfFrameEmitter::emit(*this, false);
 
-  if (EmitSFrame || getContext().getTargetOptions()->EmitSFrameUnwind)
+  if (EmitSFrame || getContext().getTargetOptions().EmitSFrameUnwind)
     MCSFrameEmitter::emit(*this);
 }
 

--- a/llvm/lib/MC/MCWinCOFFStreamer.cpp
+++ b/llvm/lib/MC/MCWinCOFFStreamer.cpp
@@ -125,8 +125,7 @@ MCWinCOFFStreamer::MCWinCOFFStreamer(MCContext &Context,
                                      std::unique_ptr<MCObjectWriter> OW)
     : MCObjectStreamer(Context, std::move(MAB), std::move(OW), std::move(CE)),
       CurSymbol(nullptr) {
-  auto *TO = Context.getTargetOptions();
-  if (TO && TO->MCIncrementalLinkerCompatible)
+  if (Context.getTargetOptions().MCIncrementalLinkerCompatible)
     getWriter().setIncrementalLinkerCompatible(true);
 }
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
@@ -316,8 +316,7 @@ public:
       : MCELFStreamer(Context, std::move(TAB), std::move(OW),
                       std::move(Emitter)),
         LastEMS(EMS_None) {
-    auto *TO = getContext().getTargetOptions();
-    ImplicitMapSyms = TO && TO->ImplicitMapSyms;
+    ImplicitMapSyms = getContext().getTargetOptions().ImplicitMapSyms;
   }
 
   void changeSection(MCSection *Section, uint32_t Subsection = 0) override {

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
@@ -65,10 +65,7 @@ public:
       setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
 
     Context.setUseNamesOnTempLabels(true);
-    auto *TO = Context.getTargetOptions();
-    if (!TO)
-      return;
-    IsVerboseAsm = TO->AsmVerbose;
+    IsVerboseAsm = Context.getTargetOptions().AsmVerbose;
     if (IsVerboseAsm)
       InstPrinter->setCommentStream(CommentStream);
   }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
@@ -217,7 +217,7 @@ unsigned X86ELFObjectWriter::getRelocType64(SMLoc Loc, X86::Specifier Specifier,
     // Older versions of ld.bfd/ld.gold/lld
     // do not support GOTPCRELX/REX_GOTPCRELX/CODE_4_GOTPCRELX,
     // and we want to keep back-compatibility.
-    if (!getContext().getTargetOptions()->X86RelaxRelocations)
+    if (!getContext().getTargetOptions().X86RelaxRelocations)
       return ELF::R_X86_64_GOTPCREL;
     switch (unsigned(Kind)) {
     default:
@@ -269,7 +269,7 @@ unsigned X86ELFObjectWriter::getRelocType32(SMLoc Loc, X86::Specifier Specifier,
       return ELF::R_386_GOTPC;
     // Older versions of ld.bfd/ld.gold/lld do not support R_386_GOT32X and we
     // want to maintain compatibility.
-    if (!getContext().getTargetOptions()->X86RelaxRelocations)
+    if (!getContext().getTargetOptions().X86RelaxRelocations)
       return ELF::R_386_GOT32;
 
     return Kind == X86::reloc_signed_4byte_relax ? ELF::R_386_GOT32X

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -572,7 +572,7 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
   // only using GOT when GOTPCRELX is enabled.
   // TODO Delete the workaround when rustc no longer relies on the hack
   bool UseGot = MMI->getModule()->getRtLibUseGOT() &&
-                Ctx.getTargetOptions()->X86RelaxRelocations;
+                Ctx.getTargetOptions().X86RelaxRelocations;
 
   if (Specifier == X86::S_TLSDESC) {
     const MCSymbolRefExpr *Expr = MCSymbolRefExpr::create(


### PR DESCRIPTION
Since #180464, MCAsmInfo stores a non-null MCTargetOptions pointer set by
TargetRegistry::createMCAsmInfo, and MCContext's constructor asserts that
MAI->getTargetOptions() is non-null. Return the options by reference
instead of by pointer so callers can drop the null handling.