### PR TITLE
[VPlan] Support scalarizing vectorized structs in VPTransformState::get()

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -265,10 +265,33 @@ Value *VPTransformState::get(const VPValue *Def, const VPLane &Lane) {
 
   assert(hasVectorValue(Def));
   auto *VecPart = Data.VPV2Vector[Def];
+
+  // VPWidenRecipe converted e.g., { <i64>, <i1> } to { <4 x i64>, <4 x i1> }.
+  // Invert it here.
+  auto *StructTy = dyn_cast<StructType>(VecPart->getType());
+  if (StructTy && isVectorizedStructTy(StructTy)) {
+    Value *LaneV = Lane.getAsRuntimeExpr(Builder, VF);
+
+    Type *StructScalarTy = toScalarizedTy(StructTy);
+    Value *Extract = PoisonValue::get(StructScalarTy);
+
+    for (unsigned i = 0; i != StructTy->getNumElements(); i++) {
+      Value *FieldVectorValue = Builder.CreateExtractValue(VecPart, i);
+      Value *FieldScalarValue =
+          Builder.CreateExtractElement(FieldVectorValue, LaneV);
+      Extract = Builder.CreateInsertValue(Extract, FieldScalarValue, i);
+    }
+
+    // TODO: Cache created scalar values.
+    // set(Def, Extract, Instance);
+    return Extract;
+  }
+
   if (!VecPart->getType()->isVectorTy()) {
     assert(Lane.isFirstLane() && "cannot get lane > 0 for scalar");
     return VecPart;
   }
+
   // TODO: Cache created scalar values.
   Value *LaneV = Lane.getAsRuntimeExpr(Builder, VF);
   auto *Extract = Builder.CreateExtractElement(VecPart, LaneV);

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -266,8 +266,7 @@ Value *VPTransformState::get(const VPValue *Def, const VPLane &Lane) {
   assert(hasVectorValue(Def));
   auto *VecPart = Data.VPV2Vector[Def];
 
-  // VPWidenRecipe converted e.g., { <i64>, <i1> } to { <4 x i64>, <4 x i1> }.
-  // Invert it here.
+  // e.g., { <4 x i64>, <4 x i1> } to { <i64>, <i1> }.
   auto *StructTy = dyn_cast<StructType>(VecPart->getType());
   if (StructTy && isVectorizedStructTy(StructTy)) {
     Value *LaneV = Lane.getAsRuntimeExpr(Builder, VF);

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -291,7 +291,6 @@ Value *VPTransformState::get(const VPValue *Def, const VPLane &Lane) {
     assert(Lane.isFirstLane() && "cannot get lane > 0 for scalar");
     return VecPart;
   }
-
   // TODO: Cache created scalar values.
   Value *LaneV = Lane.getAsRuntimeExpr(Builder, VF);
   auto *Extract = Builder.CreateExtractElement(VecPart, LaneV);


### PR DESCRIPTION
Currently, vectorized struct (e.g., { <4 x i64>, <4 x i1> }) inputs are handled (incorrectly) by the "if (!VecPart->getType()->isVectorTy())" branch; thus, the vectorized struct is returned verbatim, instead of the expected struct of scalars (e.g., { i64, i1 }).