### PR TITLE
[clang][bytecode] Fix crash involving labels and null sub

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2604,12 +2604,15 @@ inline bool SubPtr(InterpState &S, CodePtr OpPC, bool ElemSizeIsZero) {
 
   if (LHS.pointsToLabel() || RHS.pointsToLabel()) {
     if constexpr (isIntegralOrPointer<T>()) {
-      const auto *LHSAddrExpr =
-          dyn_cast_if_present<AddrLabelExpr>(LHS.getDeclDesc()->asExpr());
-      const auto *RHSAddrExpr =
-          dyn_cast_if_present<AddrLabelExpr>(RHS.getDeclDesc()->asExpr());
-      if (!LHSAddrExpr || !RHSAddrExpr)
+      const AddrLabelExpr *LHSAddrExpr = LHS.getPointedToLabel();
+      const AddrLabelExpr *RHSAddrExpr = RHS.getPointedToLabel();
+      if (!LHSAddrExpr || !RHSAddrExpr) {
+        S.FFDiag(S.Current->getSource(OpPC),
+                 diag::note_constexpr_pointer_arith_unspecified)
+            << LHS.toDiagnosticString(S.getASTContext())
+            << RHS.toDiagnosticString(S.getASTContext());
         return false;
+      }
 
       if (LHSAddrExpr->getLabel()->getDeclContext() !=
           RHSAddrExpr->getLabel()->getDeclContext())

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -830,6 +830,12 @@ public:
   bool pointsToStringLiteral() const;
   /// Whether this points to a block created for an AddrLabelExpr.
   bool pointsToLabel() const;
+  /// Returns the AddrLabelExpr the Pointer points to, if any.
+  const AddrLabelExpr *getPointedToLabel() const {
+    if (const Descriptor *Desc = getDeclDesc())
+      return dyn_cast_if_present<AddrLabelExpr>(Desc->asExpr());
+    return nullptr;
+  }
 
   /// Prints the pointer.
   void print(llvm::raw_ostream &OS) const;

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -451,3 +451,7 @@ int *iptr;
 void ignoredConditional(void) { *iptr = (((_Complex double)1.0 ? 2 : 3), a); } // all-warning {{left operand of comma operator has no effect}}
 
 float r  = (float) (intptr_t) &r; // all-error {{initializer element is not a compile-time constant}}
+
+void labelAndNull(void) { int bar = &*(void *)0 - &&baz; } // all-error {{use of undeclared label 'baz'}} \\
+                                                           // pedantic-warning {{use of GNU address-of-label extension}} \
+                                                           // pedantic-warning {{arithmetic on pointers to void is a GNU extension}}


### PR DESCRIPTION
For null pointers, getDeclDesc() may return null, so we can't call asExpr() on it.