### PR TITLE
[clang][lit] Substitute cir-opt when CIR is enabled

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -146,7 +146,7 @@ tools = [
 ]
 
 if config.clang_enable_cir:
-    tools.append("clang-cir")
+    tools.append("cir-opt")
 
 if config.clang_examples:
     config.available_features.add("examples")


### PR DESCRIPTION
Fix the CIR lit substitution introduced by #193665 to use `cir-opt`.