### PR TITLE
[unittest] Use TempDir() in gtest death-test stream capture on Linux

### DIFF
--- a/third-party/unittest/googletest/src/gtest-port.cc
+++ b/third-party/unittest/googletest/src/gtest-port.cc
@@ -1087,7 +1087,7 @@ class CapturedStream {
     if (name_template.back() != GTEST_PATH_SEP_[0])
       name_template.push_back(GTEST_PATH_SEP_[0]);
 #else
-    name_template = "/tmp/";
+    name_template = TempDir();
 #endif
     name_template.append("gtest_captured_stream.XXXXXX");
 


### PR DESCRIPTION
gtest's CapturedStream on Linux hardcoded /tmp/ for its temp file without consulting the environment, causing failures in sandboxed environments where /tmp is read-only. Use TempDir() instead, which checks TEST_TMPDIR then TMPDIR and falls back to /tmp/, matching the behavior already present on Android and macOS/iOS.

See also upstream PR: https://github.com/google/googletest/pull/4962

Assisted-by: Claude Code