### PR TITLE
[flang][OpenMP] Clear branch labels in all program units

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -69,6 +69,10 @@ OmpStructureChecker::OmpStructureChecker(SemanticsContext &context)
   scopeStack_.push_back(&context.globalScope());
 }
 
+void OmpStructureChecker::Enter(const parser::ProgramUnit &) {
+  ClearLabels();
+}
+
 bool OmpStructureChecker::Enter(const parser::MainProgram &x) {
   using StatementProgramStmt = parser::Statement<parser::ProgramStmt>;
   if (auto &stmt{std::get<std::optional<StatementProgramStmt>>(x.t)}) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -69,7 +69,7 @@ OmpStructureChecker::OmpStructureChecker(SemanticsContext &context)
   scopeStack_.push_back(&context.globalScope());
 }
 
-void OmpStructureChecker::Enter(const parser::ProgramUnit &) {
+void OmpStructureChecker::Enter(const parser::ProgramUnit &) { //
   ClearLabels();
 }
 

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -71,6 +71,7 @@ public:
 
   using llvmOmpClause = const llvm::omp::Clause;
 
+  void Enter(const parser::ProgramUnit &);
   bool Enter(const parser::MainProgram &);
   void Leave(const parser::MainProgram &);
   bool Enter(const parser::BlockData &);

--- a/flang/test/Semantics/OpenMP/branching-program-unit.f90
+++ b/flang/test/Semantics/OpenMP/branching-program-unit.f90
@@ -1,0 +1,16 @@
+!RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! This should pass semantic checks.
+
+!CHECK: func.func
+
+subroutine f
+  10 continue
+end
+
+subroutine g
+  !$omp parallel
+  goto 10
+  10 continue
+  !$omp end parallel
+end


### PR DESCRIPTION
The semantic check for branching in or out of an OpenMP construct did not reset its label information in some cases, leading to false positive error messages in valid Fortran code.