### PR TITLE
[ARM] Fold more general CMOV in CMOV patterns

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -4899,39 +4899,7 @@ SDValue ARMTargetLowering::LowerSELECT(SDValue Op, SelectionDAG &DAG) const {
     return getCMOV(dl, VT, SelectTrue, SelectFalse, ARMcc, OverflowCmp, DAG);
   }
 
-  // Convert:
-  //
-  //   (select (cmov 1, 0, cond), t, f) -> (cmov t, f, cond)
-  //   (select (cmov 0, 1, cond), t, f) -> (cmov f, t, cond)
-  //
-  if (Cond.getOpcode() == ARMISD::CMOV && Cond.hasOneUse()) {
-    const ConstantSDNode *CMOVTrue =
-      dyn_cast<ConstantSDNode>(Cond.getOperand(0));
-    const ConstantSDNode *CMOVFalse =
-      dyn_cast<ConstantSDNode>(Cond.getOperand(1));
-
-    if (CMOVTrue && CMOVFalse) {
-      unsigned CMOVTrueVal = CMOVTrue->getZExtValue();
-      unsigned CMOVFalseVal = CMOVFalse->getZExtValue();
-
-      SDValue True;
-      SDValue False;
-      if (CMOVTrueVal == 1 && CMOVFalseVal == 0) {
-        True = SelectTrue;
-        False = SelectFalse;
-      } else if (CMOVTrueVal == 0 && CMOVFalseVal == 1) {
-        True = SelectFalse;
-        False = SelectTrue;
-      }
-
-      if (True.getNode() && False.getNode())
-        return getCMOV(dl, Op.getValueType(), True, False, Cond.getOperand(2),
-                       Cond.getOperand(3), DAG);
-    }
-  }
-
-  return DAG.getSelectCC(dl, Cond,
-                         DAG.getConstant(0, dl, Cond.getValueType()),
+  return DAG.getSelectCC(dl, Cond, DAG.getConstant(0, dl, Cond.getValueType()),
                          SelectTrue, SelectFalse, ISD::SETNE);
 }
 
@@ -18502,9 +18470,76 @@ ARMTargetLowering::PerformBRCONDCombine(SDNode *N, SelectionDAG &DAG) const {
   return SDValue();
 }
 
+// (CMOV l r EQ (CMP (CMOV x y cc2 cond) x)) => (CMOV l r !cc2 cond)
+// (CMOV l r EQ (CMP (CMOV x y cc2 cond) y)) => (CMOV l r cc2 cond)
+// Where x and y are constants and x != y
+
+// (CMOV l r NE (CMP (CMOV x y cc2 cond) x)) => (CMOV l r cc2 cond)
+// (CMOV l r NE (CMP (CMOV x y cc2 cond) y)) => (CMOV l r !cc2 cond)
+// Where x and y are constants and x != y
+static SDValue foldCMOVOfCMOV(SDNode *Op, SelectionDAG &DAG) {
+  SDValue L = Op->getOperand(0);
+  SDValue R = Op->getOperand(1);
+  ARMCC::CondCodes OpCC =
+      static_cast<ARMCC::CondCodes>(Op->getConstantOperandVal(2));
+
+  SDValue OpCmp = Op->getOperand(3);
+  if (OpCmp.getOpcode() != ARMISD::CMPZ && OpCmp.getOpcode() != ARMISD::CMP)
+    return SDValue();
+
+  SDValue CmpLHS = OpCmp.getOperand(0);
+  SDValue CmpRHS = OpCmp.getOperand(1);
+
+  if (CmpRHS.getOpcode() == ARMISD::CMOV)
+    std::swap(CmpLHS, CmpRHS);
+  else if (CmpLHS.getOpcode() != ARMISD::CMOV)
+    return SDValue();
+
+  SDValue X = CmpLHS->getOperand(0);
+  SDValue Y = CmpLHS->getOperand(1);
+  if (!isa<ConstantSDNode>(X) || !isa<ConstantSDNode>(Y) || X == Y) {
+    return SDValue();
+  }
+
+  // If one of the constant is opaque constant, x,y sdnode is still different
+  // but the real value maybe the same. So check APInt here to make sure the
+  // code is correct.
+  ConstantSDNode *CX = cast<ConstantSDNode>(X);
+  ConstantSDNode *CY = cast<ConstantSDNode>(Y);
+  if (CX->getAPIntValue() == CY->getAPIntValue())
+    return SDValue();
+
+  ARMCC::CondCodes CC =
+      static_cast<ARMCC::CondCodes>(CmpLHS->getConstantOperandVal(2));
+  SDValue Cond = CmpLHS->getOperand(3);
+
+  if (CmpRHS == X)
+    CC = ARMCC::getOppositeCondition(CC);
+  else if (CmpRHS != Y)
+    return SDValue();
+
+  if (OpCC == ARMCC::NE)
+    CC = ARMCC::getOppositeCondition(CC);
+  else if (OpCC != ARMCC::EQ)
+    return SDValue();
+
+  SDLoc DL(Op);
+  EVT VT = Op->getValueType(0);
+
+  SDValue CCValue = DAG.getConstant(CC, SDLoc(Op), MVT::i32);
+  return DAG.getNode(ARMISD::CMOV, DL, VT, L, R, CCValue, Cond);
+}
+
 /// PerformCMOVCombine - Target-specific DAG combining for ARMISD::CMOV.
 SDValue
 ARMTargetLowering::PerformCMOVCombine(SDNode *N, SelectionDAG &DAG) const {
+  // CMOV x, x, cc -> x
+  if (N->getOperand(0) == N->getOperand(1))
+    return N->getOperand(0);
+
+  if (SDValue R = foldCMOVOfCMOV(N, DAG))
+    return R;
+
   SDLoc dl(N);
   EVT VT = N->getValueType(0);
   SDValue FalseVal = N->getOperand(0);
@@ -18565,15 +18600,6 @@ ARMTargetLowering::PerformCMOVCombine(SDNode *N, SelectionDAG &DAG) const {
     SDValue ARMcc;
     SDValue NewCmp = getARMCmp(LHS, RHS, ISD::SETNE, ARMcc, DAG, dl);
     Res = DAG.getNode(ARMISD::CMOV, dl, VT, LHS, FalseVal, ARMcc, NewCmp);
-  }
-
-  // (cmov F T ne (cmpz (cmov 0 1 CC Flags) 0))
-  // -> (cmov F T CC Flags)
-  if (CC == ARMCC::NE && LHS.getOpcode() == ARMISD::CMOV && LHS->hasOneUse() &&
-      isNullConstant(LHS->getOperand(0)) && isOneConstant(LHS->getOperand(1)) &&
-      isNullConstant(RHS)) {
-    return DAG.getNode(ARMISD::CMOV, dl, VT, FalseVal, TrueVal,
-                       LHS->getOperand(2), LHS->getOperand(3));
   }
 
   if (!VT.isInteger())

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -4981,39 +4981,7 @@ SDValue ARMTargetLowering::LowerSELECT(SDValue Op, SelectionDAG &DAG) const {
     return getCMOV(dl, VT, SelectTrue, SelectFalse, ARMcc, OverflowCmp, DAG);
   }
 
-  // Convert:
-  //
-  //   (select (cmov 1, 0, cond), t, f) -> (cmov t, f, cond)
-  //   (select (cmov 0, 1, cond), t, f) -> (cmov f, t, cond)
-  //
-  if (Cond.getOpcode() == ARMISD::CMOV && Cond.hasOneUse()) {
-    const ConstantSDNode *CMOVTrue =
-      dyn_cast<ConstantSDNode>(Cond.getOperand(0));
-    const ConstantSDNode *CMOVFalse =
-      dyn_cast<ConstantSDNode>(Cond.getOperand(1));
-
-    if (CMOVTrue && CMOVFalse) {
-      unsigned CMOVTrueVal = CMOVTrue->getZExtValue();
-      unsigned CMOVFalseVal = CMOVFalse->getZExtValue();
-
-      SDValue True;
-      SDValue False;
-      if (CMOVTrueVal == 1 && CMOVFalseVal == 0) {
-        True = SelectTrue;
-        False = SelectFalse;
-      } else if (CMOVTrueVal == 0 && CMOVFalseVal == 1) {
-        True = SelectFalse;
-        False = SelectTrue;
-      }
-
-      if (True.getNode() && False.getNode())
-        return getCMOV(dl, Op.getValueType(), True, False, Cond.getOperand(2),
-                       Cond.getOperand(3), DAG);
-    }
-  }
-
-  return DAG.getSelectCC(dl, Cond,
-                         DAG.getConstant(0, dl, Cond.getValueType()),
+  return DAG.getSelectCC(dl, Cond, DAG.getConstant(0, dl, Cond.getValueType()),
                          SelectTrue, SelectFalse, ISD::SETNE);
 }
 
@@ -18625,9 +18593,76 @@ ARMTargetLowering::PerformBRCONDCombine(SDNode *N, SelectionDAG &DAG) const {
   return SDValue();
 }
 
+// (CMOV l r EQ (CMP (CMOV x y cc2 cond) x)) => (CMOV l r !cc2 cond)
+// (CMOV l r EQ (CMP (CMOV x y cc2 cond) y)) => (CMOV l r cc2 cond)
+// Where x and y are constants and x != y
+
+// (CMOV l r NE (CMP (CMOV x y cc2 cond) x)) => (CMOV l r cc2 cond)
+// (CMOV l r NE (CMP (CMOV x y cc2 cond) y)) => (CMOV l r !cc2 cond)
+// Where x and y are constants and x != y
+static SDValue foldCMOVOfCMOV(SDNode *Op, SelectionDAG &DAG) {
+  SDValue L = Op->getOperand(0);
+  SDValue R = Op->getOperand(1);
+  ARMCC::CondCodes OpCC =
+      static_cast<ARMCC::CondCodes>(Op->getConstantOperandVal(2));
+
+  SDValue OpCmp = Op->getOperand(3);
+  if (OpCmp.getOpcode() != ARMISD::CMPZ && OpCmp.getOpcode() != ARMISD::CMP)
+    return SDValue();
+
+  SDValue CmpLHS = OpCmp.getOperand(0);
+  SDValue CmpRHS = OpCmp.getOperand(1);
+
+  if (CmpRHS.getOpcode() == ARMISD::CMOV)
+    std::swap(CmpLHS, CmpRHS);
+  else if (CmpLHS.getOpcode() != ARMISD::CMOV)
+    return SDValue();
+
+  SDValue X = CmpLHS->getOperand(0);
+  SDValue Y = CmpLHS->getOperand(1);
+  if (!isa<ConstantSDNode>(X) || !isa<ConstantSDNode>(Y) || X == Y) {
+    return SDValue();
+  }
+
+  // If one of the constant is opaque constant, x,y sdnode is still different
+  // but the real value maybe the same. So check APInt here to make sure the
+  // code is correct.
+  ConstantSDNode *CX = cast<ConstantSDNode>(X);
+  ConstantSDNode *CY = cast<ConstantSDNode>(Y);
+  if (CX->getAPIntValue() == CY->getAPIntValue())
+    return SDValue();
+
+  ARMCC::CondCodes CC =
+      static_cast<ARMCC::CondCodes>(CmpLHS->getConstantOperandVal(2));
+  SDValue Cond = CmpLHS->getOperand(3);
+
+  if (CmpRHS == X)
+    CC = ARMCC::getOppositeCondition(CC);
+  else if (CmpRHS != Y)
+    return SDValue();
+
+  if (OpCC == ARMCC::NE)
+    CC = ARMCC::getOppositeCondition(CC);
+  else if (OpCC != ARMCC::EQ)
+    return SDValue();
+
+  SDLoc DL(Op);
+  EVT VT = Op->getValueType(0);
+
+  SDValue CCValue = DAG.getConstant(CC, SDLoc(Op), MVT::i32);
+  return DAG.getNode(ARMISD::CMOV, DL, VT, L, R, CCValue, Cond);
+}
+
 /// PerformCMOVCombine - Target-specific DAG combining for ARMISD::CMOV.
 SDValue
 ARMTargetLowering::PerformCMOVCombine(SDNode *N, SelectionDAG &DAG) const {
+  // CMOV x, x, cc -> x
+  if (N->getOperand(0) == N->getOperand(1))
+    return N->getOperand(0);
+
+  if (SDValue R = foldCMOVOfCMOV(N, DAG))
+    return R;
+
   SDLoc dl(N);
   EVT VT = N->getValueType(0);
   SDValue FalseVal = N->getOperand(0);
@@ -18688,15 +18723,6 @@ ARMTargetLowering::PerformCMOVCombine(SDNode *N, SelectionDAG &DAG) const {
     SDValue ARMcc;
     SDValue NewCmp = getARMCmp(LHS, RHS, ISD::SETNE, ARMcc, DAG, dl);
     Res = DAG.getNode(ARMISD::CMOV, dl, VT, LHS, FalseVal, ARMcc, NewCmp);
-  }
-
-  // (cmov F T ne (cmpz (cmov 0 1 CC Flags) 0))
-  // -> (cmov F T CC Flags)
-  if (CC == ARMCC::NE && LHS.getOpcode() == ARMISD::CMOV && LHS->hasOneUse() &&
-      isNullConstant(LHS->getOperand(0)) && isOneConstant(LHS->getOperand(1)) &&
-      isNullConstant(RHS)) {
-    return DAG.getNode(ARMISD::CMOV, dl, VT, FalseVal, TrueVal,
-                       LHS->getOperand(2), LHS->getOperand(3));
   }
 
   if (!VT.isInteger())

--- a/llvm/test/CodeGen/ARM/addsubo-legalization.ll
+++ b/llvm/test/CodeGen/ARM/addsubo-legalization.ll
@@ -22,17 +22,11 @@ define <2 x i1> @uaddo(ptr %ptr, ptr %ptr2) {
 ; CHECK-NEXT:    sbcs.w r2, r12, r2
 ; CHECK-NEXT:    mov.w r2, #0
 ; CHECK-NEXT:    it lo
-; CHECK-NEXT:    movlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    it ne
-; CHECK-NEXT:    movne.w r2, #-1
+; CHECK-NEXT:    movlo.w r2, #-1
 ; CHECK-NEXT:    subs r3, r4, r6
 ; CHECK-NEXT:    sbcs.w r3, r5, r7
 ; CHECK-NEXT:    it lo
-; CHECK-NEXT:    movlo r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    it ne
-; CHECK-NEXT:    movne.w r1, #-1
+; CHECK-NEXT:    movlo.w r1, #-1
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r0]
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
@@ -61,17 +55,11 @@ define <2 x i1> @usubo(ptr %ptr, ptr %ptr2) {
 ; CHECK-NEXT:    sbcs.w r2, r12, r2
 ; CHECK-NEXT:    mov.w r2, #0
 ; CHECK-NEXT:    it lo
-; CHECK-NEXT:    movlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    it ne
-; CHECK-NEXT:    movne.w r2, #-1
+; CHECK-NEXT:    movlo.w r2, #-1
 ; CHECK-NEXT:    subs r3, r4, r6
 ; CHECK-NEXT:    sbcs.w r3, r5, r7
 ; CHECK-NEXT:    it lo
-; CHECK-NEXT:    movlo r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    it ne
-; CHECK-NEXT:    movne.w r1, #-1
+; CHECK-NEXT:    movlo.w r1, #-1
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r0]
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}

--- a/llvm/test/CodeGen/ARM/atomicrmw_exclusive_monitor_ints.ll
+++ b/llvm/test/CodeGen/ARM/atomicrmw_exclusive_monitor_ints.ll
@@ -8363,11 +8363,9 @@ define i64 @test_max_i64() {
 ; CHECK-ARM8-NEXT:    rsbs r0, r2, #1
 ; CHECK-ARM8-NEXT:    rscs r0, r1, #0
 ; CHECK-ARM8-NEXT:    mov r0, #0
-; CHECK-ARM8-NEXT:    movwlt r0, #1
+; CHECK-ARM8-NEXT:    movlt r0, r1
 ; CHECK-ARM8-NEXT:    mov r10, #1
 ; CHECK-ARM8-NEXT:    movlt r10, r2
-; CHECK-ARM8-NEXT:    cmp r0, #0
-; CHECK-ARM8-NEXT:    movne r0, r1
 ; CHECK-ARM8-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM8-NEXT:    mov r11, r0
 ; CHECK-ARM8-NEXT:    movw r6, :lower16:atomic_i64
@@ -8431,11 +8429,9 @@ define i64 @test_max_i64() {
 ; CHECK-ARM6-NEXT:    rsbs r0, r2, #1
 ; CHECK-ARM6-NEXT:    rscs r0, r1, #0
 ; CHECK-ARM6-NEXT:    mov r0, #0
-; CHECK-ARM6-NEXT:    movlt r0, #1
+; CHECK-ARM6-NEXT:    movlt r0, r1
 ; CHECK-ARM6-NEXT:    mov r10, #1
 ; CHECK-ARM6-NEXT:    movlt r10, r2
-; CHECK-ARM6-NEXT:    cmp r0, #0
-; CHECK-ARM6-NEXT:    movne r0, r1
 ; CHECK-ARM6-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM6-NEXT:    mov r11, r0
 ; CHECK-ARM6-NEXT:    ldr r6, .LCPI40_0
@@ -8497,19 +8493,16 @@ define i64 @test_max_i64() {
 ; CHECK-THUMB7-NEXT:    @ Child Loop BB40_2 Depth 2
 ; CHECK-THUMB7-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB7-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
+; CHECK-THUMB7-NEXT:    mov r8, r2
+; CHECK-THUMB7-NEXT:    mov r9, r1
 ; CHECK-THUMB7-NEXT:    rsbs.w r0, r2, #1
 ; CHECK-THUMB7-NEXT:    mov.w r0, #0
 ; CHECK-THUMB7-NEXT:    sbcs.w r3, r0, r1
 ; CHECK-THUMB7-NEXT:    it lt
-; CHECK-THUMB7-NEXT:    movlt r0, #1
-; CHECK-THUMB7-NEXT:    mov r8, r2
-; CHECK-THUMB7-NEXT:    mov r9, r1
+; CHECK-THUMB7-NEXT:    movlt r0, r1
 ; CHECK-THUMB7-NEXT:    mov.w r10, #1
 ; CHECK-THUMB7-NEXT:    it lt
 ; CHECK-THUMB7-NEXT:    movlt r10, r2
-; CHECK-THUMB7-NEXT:    cmp r0, #0
-; CHECK-THUMB7-NEXT:    it ne
-; CHECK-THUMB7-NEXT:    movne r0, r1
 ; CHECK-THUMB7-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-THUMB7-NEXT:    mov r11, r0
 ; CHECK-THUMB7-NEXT:    movw r6, :lower16:atomic_i64
@@ -8569,85 +8562,73 @@ define i64 @test_max_i64() {
 ; CHECK-THUMB8BASE:       @ %bb.0: @ %entry
 ; CHECK-THUMB8BASE-NEXT:    .save {r4, lr}
 ; CHECK-THUMB8BASE-NEXT:    push {r4, lr}
-; CHECK-THUMB8BASE-NEXT:    .pad #72
-; CHECK-THUMB8BASE-NEXT:    sub sp, #72
+; CHECK-THUMB8BASE-NEXT:    .pad #64
+; CHECK-THUMB8BASE-NEXT:    sub sp, #64
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_load_8
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    b .LBB40_1
 ; CHECK-THUMB8BASE-NEXT:  .LBB40_1: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #56] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #60] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #36] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #52] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #28] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r0, #1
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    subs r3, r0, r3
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #36] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r3, #1
+; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    subs r3, r3, r0
 ; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blt .LBB40_3
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB40_3: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #52] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #28] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #44] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #20] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blt .LBB40_5
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.4: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB40_5: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #32] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #20] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    cbnz r1, .LBB40_7
-; CHECK-THUMB8BASE-NEXT:  @ %bb.6: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB40_7: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB40_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #32] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #24] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #64]
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #56]
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #4]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp]
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
-; CHECK-THUMB8BASE-NEXT:    add r1, sp, #64
+; CHECK-THUMB8BASE-NEXT:    add r1, sp, #56
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_compare_exchange_8
 ; CHECK-THUMB8BASE-NEXT:    mov r2, r0
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #12] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #64]
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #56]
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    cmp r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    beq .LBB40_1
-; CHECK-THUMB8BASE-NEXT:    b .LBB40_8
-; CHECK-THUMB8BASE-NEXT:  .LBB40_8: @ %atomicrmw.end
+; CHECK-THUMB8BASE-NEXT:    b .LBB40_6
+; CHECK-THUMB8BASE-NEXT:  .LBB40_6: @ %atomicrmw.end
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #16] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    add sp, #72
+; CHECK-THUMB8BASE-NEXT:    add sp, #64
 ; CHECK-THUMB8BASE-NEXT:    pop {r4, pc}
 entry:
   %0 = atomicrmw max ptr @atomic_i64, i64 1 monotonic
@@ -8679,11 +8660,9 @@ define i64 @test_min_i64() {
 ; CHECK-ARM8-NEXT:    subs r0, r2, #2
 ; CHECK-ARM8-NEXT:    sbcs r0, r1, #0
 ; CHECK-ARM8-NEXT:    mov r0, #0
-; CHECK-ARM8-NEXT:    movwlt r0, #1
+; CHECK-ARM8-NEXT:    movlt r0, r1
 ; CHECK-ARM8-NEXT:    mov r10, #1
 ; CHECK-ARM8-NEXT:    movlt r10, r2
-; CHECK-ARM8-NEXT:    cmp r0, #0
-; CHECK-ARM8-NEXT:    movne r0, r1
 ; CHECK-ARM8-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM8-NEXT:    mov r11, r0
 ; CHECK-ARM8-NEXT:    movw r6, :lower16:atomic_i64
@@ -8747,11 +8726,9 @@ define i64 @test_min_i64() {
 ; CHECK-ARM6-NEXT:    subs r0, r2, #2
 ; CHECK-ARM6-NEXT:    sbcs r0, r1, #0
 ; CHECK-ARM6-NEXT:    mov r0, #0
-; CHECK-ARM6-NEXT:    movlt r0, #1
+; CHECK-ARM6-NEXT:    movlt r0, r1
 ; CHECK-ARM6-NEXT:    mov r10, #1
 ; CHECK-ARM6-NEXT:    movlt r10, r2
-; CHECK-ARM6-NEXT:    cmp r0, #0
-; CHECK-ARM6-NEXT:    movne r0, r1
 ; CHECK-ARM6-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM6-NEXT:    mov r11, r0
 ; CHECK-ARM6-NEXT:    ldr r6, .LCPI41_0
@@ -8819,13 +8796,10 @@ define i64 @test_min_i64() {
 ; CHECK-THUMB7-NEXT:    sbcs r0, r1, #0
 ; CHECK-THUMB7-NEXT:    mov.w r0, #0
 ; CHECK-THUMB7-NEXT:    it lt
-; CHECK-THUMB7-NEXT:    movlt r0, #1
+; CHECK-THUMB7-NEXT:    movlt r0, r1
 ; CHECK-THUMB7-NEXT:    mov.w r10, #1
 ; CHECK-THUMB7-NEXT:    it lt
 ; CHECK-THUMB7-NEXT:    movlt r10, r2
-; CHECK-THUMB7-NEXT:    cmp r0, #0
-; CHECK-THUMB7-NEXT:    it ne
-; CHECK-THUMB7-NEXT:    movne r0, r1
 ; CHECK-THUMB7-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-THUMB7-NEXT:    mov r11, r0
 ; CHECK-THUMB7-NEXT:    movw r6, :lower16:atomic_i64
@@ -8885,85 +8859,73 @@ define i64 @test_min_i64() {
 ; CHECK-THUMB8BASE:       @ %bb.0: @ %entry
 ; CHECK-THUMB8BASE-NEXT:    .save {r4, lr}
 ; CHECK-THUMB8BASE-NEXT:    push {r4, lr}
-; CHECK-THUMB8BASE-NEXT:    .pad #72
-; CHECK-THUMB8BASE-NEXT:    sub sp, #72
+; CHECK-THUMB8BASE-NEXT:    .pad #64
+; CHECK-THUMB8BASE-NEXT:    sub sp, #64
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_load_8
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    b .LBB41_1
 ; CHECK-THUMB8BASE-NEXT:  .LBB41_1: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #56] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #60] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #36] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r0, #1
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #48] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    subs r3, r3, #2
-; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    blt .LBB41_3
-; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB41_3: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #52] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #28] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r2, #1
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #36] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r2, #0
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    subs r3, r0, #2
+; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    blt .LBB41_3
+; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
+; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:  .LBB41_3: @ %atomicrmw.start
+; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #44] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #20] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blt .LBB41_5
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.4: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB41_5: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #32] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #20] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    cbnz r1, .LBB41_7
-; CHECK-THUMB8BASE-NEXT:  @ %bb.6: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB41_7: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB41_1 Depth=1
 ; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #32] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #24] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #64]
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #56]
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #4]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp]
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
-; CHECK-THUMB8BASE-NEXT:    add r1, sp, #64
+; CHECK-THUMB8BASE-NEXT:    add r1, sp, #56
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_compare_exchange_8
 ; CHECK-THUMB8BASE-NEXT:    mov r2, r0
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #12] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #64]
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #56]
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    cmp r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    beq .LBB41_1
-; CHECK-THUMB8BASE-NEXT:    b .LBB41_8
-; CHECK-THUMB8BASE-NEXT:  .LBB41_8: @ %atomicrmw.end
+; CHECK-THUMB8BASE-NEXT:    b .LBB41_6
+; CHECK-THUMB8BASE-NEXT:  .LBB41_6: @ %atomicrmw.end
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #16] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    add sp, #72
+; CHECK-THUMB8BASE-NEXT:    add sp, #64
 ; CHECK-THUMB8BASE-NEXT:    pop {r4, pc}
 entry:
   %0 = atomicrmw min ptr @atomic_i64, i64 1 monotonic
@@ -8995,11 +8957,9 @@ define i64 @test_umax_i64() {
 ; CHECK-ARM8-NEXT:    rsbs r0, r2, #1
 ; CHECK-ARM8-NEXT:    rscs r0, r1, #0
 ; CHECK-ARM8-NEXT:    mov r0, #0
-; CHECK-ARM8-NEXT:    movwlo r0, #1
+; CHECK-ARM8-NEXT:    movlo r0, r1
 ; CHECK-ARM8-NEXT:    mov r10, #1
 ; CHECK-ARM8-NEXT:    movlo r10, r2
-; CHECK-ARM8-NEXT:    cmp r0, #0
-; CHECK-ARM8-NEXT:    movne r0, r1
 ; CHECK-ARM8-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM8-NEXT:    mov r11, r0
 ; CHECK-ARM8-NEXT:    movw r6, :lower16:atomic_i64
@@ -9063,11 +9023,9 @@ define i64 @test_umax_i64() {
 ; CHECK-ARM6-NEXT:    rsbs r0, r2, #1
 ; CHECK-ARM6-NEXT:    rscs r0, r1, #0
 ; CHECK-ARM6-NEXT:    mov r0, #0
-; CHECK-ARM6-NEXT:    movlo r0, #1
+; CHECK-ARM6-NEXT:    movlo r0, r1
 ; CHECK-ARM6-NEXT:    mov r10, #1
 ; CHECK-ARM6-NEXT:    movlo r10, r2
-; CHECK-ARM6-NEXT:    cmp r0, #0
-; CHECK-ARM6-NEXT:    movne r0, r1
 ; CHECK-ARM6-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM6-NEXT:    mov r11, r0
 ; CHECK-ARM6-NEXT:    ldr r6, .LCPI42_0
@@ -9129,19 +9087,16 @@ define i64 @test_umax_i64() {
 ; CHECK-THUMB7-NEXT:    @ Child Loop BB42_2 Depth 2
 ; CHECK-THUMB7-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB7-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
+; CHECK-THUMB7-NEXT:    mov r8, r2
+; CHECK-THUMB7-NEXT:    mov r9, r1
 ; CHECK-THUMB7-NEXT:    rsbs.w r0, r2, #1
 ; CHECK-THUMB7-NEXT:    mov.w r0, #0
 ; CHECK-THUMB7-NEXT:    sbcs.w r3, r0, r1
 ; CHECK-THUMB7-NEXT:    it lo
-; CHECK-THUMB7-NEXT:    movlo r0, #1
-; CHECK-THUMB7-NEXT:    mov r8, r2
-; CHECK-THUMB7-NEXT:    mov r9, r1
+; CHECK-THUMB7-NEXT:    movlo r0, r1
 ; CHECK-THUMB7-NEXT:    mov.w r10, #1
 ; CHECK-THUMB7-NEXT:    it lo
 ; CHECK-THUMB7-NEXT:    movlo r10, r2
-; CHECK-THUMB7-NEXT:    cmp r0, #0
-; CHECK-THUMB7-NEXT:    it ne
-; CHECK-THUMB7-NEXT:    movne r0, r1
 ; CHECK-THUMB7-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-THUMB7-NEXT:    mov r11, r0
 ; CHECK-THUMB7-NEXT:    movw r6, :lower16:atomic_i64
@@ -9201,85 +9156,73 @@ define i64 @test_umax_i64() {
 ; CHECK-THUMB8BASE:       @ %bb.0: @ %entry
 ; CHECK-THUMB8BASE-NEXT:    .save {r4, lr}
 ; CHECK-THUMB8BASE-NEXT:    push {r4, lr}
-; CHECK-THUMB8BASE-NEXT:    .pad #72
-; CHECK-THUMB8BASE-NEXT:    sub sp, #72
+; CHECK-THUMB8BASE-NEXT:    .pad #64
+; CHECK-THUMB8BASE-NEXT:    sub sp, #64
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_load_8
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    b .LBB42_1
 ; CHECK-THUMB8BASE-NEXT:  .LBB42_1: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #56] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #60] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #36] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #52] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #28] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r0, #1
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    subs r3, r0, r3
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #36] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r3, #1
+; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    subs r3, r3, r0
 ; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blo .LBB42_3
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB42_3: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #52] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #28] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #44] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #20] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blo .LBB42_5
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.4: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB42_5: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #32] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #20] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    cbnz r1, .LBB42_7
-; CHECK-THUMB8BASE-NEXT:  @ %bb.6: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB42_7: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB42_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #32] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #24] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #64]
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #56]
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #4]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp]
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
-; CHECK-THUMB8BASE-NEXT:    add r1, sp, #64
+; CHECK-THUMB8BASE-NEXT:    add r1, sp, #56
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_compare_exchange_8
 ; CHECK-THUMB8BASE-NEXT:    mov r2, r0
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #12] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #64]
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #56]
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    cmp r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    beq .LBB42_1
-; CHECK-THUMB8BASE-NEXT:    b .LBB42_8
-; CHECK-THUMB8BASE-NEXT:  .LBB42_8: @ %atomicrmw.end
+; CHECK-THUMB8BASE-NEXT:    b .LBB42_6
+; CHECK-THUMB8BASE-NEXT:  .LBB42_6: @ %atomicrmw.end
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #16] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    add sp, #72
+; CHECK-THUMB8BASE-NEXT:    add sp, #64
 ; CHECK-THUMB8BASE-NEXT:    pop {r4, pc}
 entry:
   %0 = atomicrmw umax ptr @atomic_i64, i64 1 monotonic
@@ -9311,11 +9254,9 @@ define i64 @test_umin_i64() {
 ; CHECK-ARM8-NEXT:    subs r0, r2, #2
 ; CHECK-ARM8-NEXT:    sbcs r0, r1, #0
 ; CHECK-ARM8-NEXT:    mov r0, #0
-; CHECK-ARM8-NEXT:    movwlo r0, #1
+; CHECK-ARM8-NEXT:    movlo r0, r1
 ; CHECK-ARM8-NEXT:    mov r10, #1
 ; CHECK-ARM8-NEXT:    movlo r10, r2
-; CHECK-ARM8-NEXT:    cmp r0, #0
-; CHECK-ARM8-NEXT:    movne r0, r1
 ; CHECK-ARM8-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM8-NEXT:    mov r11, r0
 ; CHECK-ARM8-NEXT:    movw r6, :lower16:atomic_i64
@@ -9379,11 +9320,9 @@ define i64 @test_umin_i64() {
 ; CHECK-ARM6-NEXT:    subs r0, r2, #2
 ; CHECK-ARM6-NEXT:    sbcs r0, r1, #0
 ; CHECK-ARM6-NEXT:    mov r0, #0
-; CHECK-ARM6-NEXT:    movlo r0, #1
+; CHECK-ARM6-NEXT:    movlo r0, r1
 ; CHECK-ARM6-NEXT:    mov r10, #1
 ; CHECK-ARM6-NEXT:    movlo r10, r2
-; CHECK-ARM6-NEXT:    cmp r0, #0
-; CHECK-ARM6-NEXT:    movne r0, r1
 ; CHECK-ARM6-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-ARM6-NEXT:    mov r11, r0
 ; CHECK-ARM6-NEXT:    ldr r6, .LCPI43_0
@@ -9451,13 +9390,10 @@ define i64 @test_umin_i64() {
 ; CHECK-THUMB7-NEXT:    sbcs r0, r1, #0
 ; CHECK-THUMB7-NEXT:    mov.w r0, #0
 ; CHECK-THUMB7-NEXT:    it lo
-; CHECK-THUMB7-NEXT:    movlo r0, #1
+; CHECK-THUMB7-NEXT:    movlo r0, r1
 ; CHECK-THUMB7-NEXT:    mov.w r10, #1
 ; CHECK-THUMB7-NEXT:    it lo
 ; CHECK-THUMB7-NEXT:    movlo r10, r2
-; CHECK-THUMB7-NEXT:    cmp r0, #0
-; CHECK-THUMB7-NEXT:    it ne
-; CHECK-THUMB7-NEXT:    movne r0, r1
 ; CHECK-THUMB7-NEXT:    @ kill: def $r10 killed $r10 def $r10_r11
 ; CHECK-THUMB7-NEXT:    mov r11, r0
 ; CHECK-THUMB7-NEXT:    movw r6, :lower16:atomic_i64
@@ -9517,85 +9453,73 @@ define i64 @test_umin_i64() {
 ; CHECK-THUMB8BASE:       @ %bb.0: @ %entry
 ; CHECK-THUMB8BASE-NEXT:    .save {r4, lr}
 ; CHECK-THUMB8BASE-NEXT:    push {r4, lr}
-; CHECK-THUMB8BASE-NEXT:    .pad #72
-; CHECK-THUMB8BASE-NEXT:    sub sp, #72
+; CHECK-THUMB8BASE-NEXT:    .pad #64
+; CHECK-THUMB8BASE-NEXT:    sub sp, #64
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movs r1, #0
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_load_8
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    b .LBB43_1
 ; CHECK-THUMB8BASE-NEXT:  .LBB43_1: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #56] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #60] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #36] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r3, [sp, #40] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r0, #1
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    movs r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #48] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    subs r3, r3, #2
-; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    blo .LBB43_3
-; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB43_3: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #52] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #28] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r2, #1
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #36] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    movs r2, #0
+; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #40] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    subs r3, r0, #2
+; CHECK-THUMB8BASE-NEXT:    sbcs r1, r2
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    blo .LBB43_3
+; CHECK-THUMB8BASE-NEXT:  @ %bb.2: @ %atomicrmw.start
+; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #44] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:  .LBB43_3: @ %atomicrmw.start
+; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #44] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #20] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    blo .LBB43_5
 ; CHECK-THUMB8BASE-NEXT:  @ %bb.4: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #32] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:  .LBB43_5: @ %atomicrmw.start
 ; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #32] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r2, [sp, #20] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    cbnz r1, .LBB43_7
-; CHECK-THUMB8BASE-NEXT:  @ %bb.6: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #24] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:  .LBB43_7: @ %atomicrmw.start
-; CHECK-THUMB8BASE-NEXT:    @ in Loop: Header=BB43_1 Depth=1
 ; CHECK-THUMB8BASE-NEXT:    ldr r2, [sp, #20] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #48] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #36] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #28] @ 4-byte Reload
+; CHECK-THUMB8BASE-NEXT:    ldr r4, [sp, #32] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r3, [sp, #24] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #64]
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    str r4, [sp, #56]
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #4]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp]
 ; CHECK-THUMB8BASE-NEXT:    movw r0, :lower16:atomic_i64
 ; CHECK-THUMB8BASE-NEXT:    movt r0, :upper16:atomic_i64
-; CHECK-THUMB8BASE-NEXT:    add r1, sp, #64
+; CHECK-THUMB8BASE-NEXT:    add r1, sp, #56
 ; CHECK-THUMB8BASE-NEXT:    bl __atomic_compare_exchange_8
 ; CHECK-THUMB8BASE-NEXT:    mov r2, r0
-; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #68]
+; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #60]
 ; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #12] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #64]
+; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #56]
 ; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #16] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    cmp r2, #0
-; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #56] @ 4-byte Spill
-; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #60] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r1, [sp, #48] @ 4-byte Spill
+; CHECK-THUMB8BASE-NEXT:    str r0, [sp, #52] @ 4-byte Spill
 ; CHECK-THUMB8BASE-NEXT:    beq .LBB43_1
-; CHECK-THUMB8BASE-NEXT:    b .LBB43_8
-; CHECK-THUMB8BASE-NEXT:  .LBB43_8: @ %atomicrmw.end
+; CHECK-THUMB8BASE-NEXT:    b .LBB43_6
+; CHECK-THUMB8BASE-NEXT:  .LBB43_6: @ %atomicrmw.end
 ; CHECK-THUMB8BASE-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
 ; CHECK-THUMB8BASE-NEXT:    ldr r0, [sp, #16] @ 4-byte Reload
-; CHECK-THUMB8BASE-NEXT:    add sp, #72
+; CHECK-THUMB8BASE-NEXT:    add sp, #64
 ; CHECK-THUMB8BASE-NEXT:    pop {r4, pc}
 entry:
   %0 = atomicrmw umin ptr @atomic_i64, i64 1 monotonic

--- a/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
+++ b/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
@@ -601,33 +601,25 @@ define <4 x float> @trunc_v4f32(<4 x float> %x) #0 {
 define <4 x i1> @fcmp_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmp_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmp.f32 s3, s7
+; CHECK-NEXT:    vcmp.f32 s0, s4
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f32 s2, s6
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmp.f32 s0, s4
-; CHECK-NEXT:    movweq r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    vcmp.f32 s3, s7
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-NEXT:    vmov.32 d17[0], r1
+; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vcmp.f32 s1, s5
-; CHECK-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEXT:    movweq r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d16[0], r3
 ; CHECK-NEXT:    vmov.32 d17[1], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvneq r0, #0
 ; CHECK-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
@@ -639,33 +631,25 @@ entry:
 define <4 x i1> @fcmps_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmps_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmpe.f32 s3, s7
+; CHECK-NEXT:    vcmpe.f32 s0, s4
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmpe.f32 s2, s6
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmpe.f32 s0, s4
-; CHECK-NEXT:    movweq r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    vcmpe.f32 s3, s7
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-NEXT:    vmov.32 d17[0], r1
+; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vcmpe.f32 s1, s5
-; CHECK-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEXT:    movweq r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d16[0], r3
 ; CHECK-NEXT:    vmov.32 d17[1], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvneq r0, #0
 ; CHECK-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
@@ -1129,15 +1113,12 @@ define <2 x i1> @fcmp_v2f64(<2 x double> %x, <2 x double> %y) #0 {
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f64 d1, d3
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d0[0], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d0[1], r0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mvneq r0, #0
+; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vorr d0, d16, d16
 ; CHECK-NEXT:    bx lr
 entry:
   %val = call <2 x i1> @llvm.experimental.constrained.fcmp.v2f64(<2 x double> %x, <2 x double> %y, metadata !"oeq", metadata !"fpexcept.strict")
@@ -1152,15 +1133,12 @@ define <2 x i1> @fcmps_v2f64(<2 x double> %x, <2 x double> %y) #0 {
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmpe.f64 d1, d3
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d0[0], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d0[1], r0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mvneq r0, #0
+; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vorr d0, d16, d16
 ; CHECK-NEXT:    bx lr
 entry:
   %val = call <2 x i1> @llvm.experimental.constrained.fcmps.v2f64(<2 x double> %x, <2 x double> %y, metadata !"oeq", metadata !"fpexcept.strict")

--- a/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
+++ b/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
@@ -543,33 +543,25 @@ define <4 x float> @trunc_v4f32(<4 x float> %x) #0 {
 define <4 x i1> @fcmp_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmp_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmp.f32 s1, s5
+; CHECK-NEXT:    vcmp.f32 s2, s6
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f32 s0, s4
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmp.f32 s2, s6
-; CHECK-NEXT:    movweq r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vmov.32 d17[0], r1
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    vcmp.f32 s1, s5
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vcmp.f32 s3, s7
-; CHECK-NEXT:    vmov.32 d16[0], r2
-; CHECK-NEXT:    movweq r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d17[0], r3
 ; CHECK-NEXT:    vmov.32 d16[1], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvneq r0, #0
 ; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
@@ -581,33 +573,25 @@ entry:
 define <4 x i1> @fcmps_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmps_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmpe.f32 s1, s5
+; CHECK-NEXT:    vcmpe.f32 s2, s6
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmpe.f32 s0, s4
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmpe.f32 s2, s6
-; CHECK-NEXT:    movweq r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vmov.32 d17[0], r1
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    vcmpe.f32 s1, s5
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vcmpe.f32 s3, s7
-; CHECK-NEXT:    vmov.32 d16[0], r2
-; CHECK-NEXT:    movweq r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d17[0], r3
 ; CHECK-NEXT:    vmov.32 d16[1], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvneq r0, #0
 ; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
@@ -1039,15 +1023,12 @@ define <2 x i1> @fcmp_v2f64(<2 x double> %x, <2 x double> %y) #0 {
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmp.f64 d1, d3
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d0[0], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d0[1], r0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mvneq r0, #0
+; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vorr d0, d16, d16
 ; CHECK-NEXT:    bx lr
 entry:
   %val = call <2 x i1> @llvm.experimental.constrained.fcmp.v2f64(<2 x double> %x, <2 x double> %y, metadata !"oeq", metadata !"fpexcept.strict")
@@ -1062,15 +1043,12 @@ define <2 x i1> @fcmps_v2f64(<2 x double> %x, <2 x double> %y) #0 {
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    vcmpe.f64 d1, d3
-; CHECK-NEXT:    movweq r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    mvneq r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d0[0], r1
-; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d0[1], r0
+; CHECK-NEXT:    vmov.32 d16[0], r1
+; CHECK-NEXT:    mvneq r0, #0
+; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vorr d0, d16, d16
 ; CHECK-NEXT:    bx lr
 entry:
   %val = call <2 x i1> @llvm.experimental.constrained.fcmps.v2f64(<2 x double> %x, <2 x double> %y, metadata !"oeq", metadata !"fpexcept.strict")

--- a/llvm/test/CodeGen/ARM/fpclamptosat.ll
+++ b/llvm/test/CodeGen/ARM/fpclamptosat.ll
@@ -45,19 +45,15 @@ define i32 @stest_f64i32(double %x) {
 ; VFP2-NEXT:    push {r7, lr}
 ; VFP2-NEXT:    vmov r0, r1, d0
 ; VFP2-NEXT:    bl __aeabi_d2lz
-; VFP2-NEXT:    mvn r12, #-2147483648
-; VFP2-NEXT:    subs.w r3, r0, r12
-; VFP2-NEXT:    mov.w r2, #0
+; VFP2-NEXT:    mvn r2, #-2147483648
+; VFP2-NEXT:    subs r3, r0, r2
 ; VFP2-NEXT:    sbcs r3, r1, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r2, #1
-; VFP2-NEXT:    cmp r2, #0
-; VFP2-NEXT:    ite ne
-; VFP2-NEXT:    movne r2, r1
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    mov.w r1, #-1
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r1, #0
+; VFP2-NEXT:    movge r0, r2
 ; VFP2-NEXT:    rsbs.w r3, r0, #-2147483648
-; VFP2-NEXT:    sbcs r1, r2
+; VFP2-NEXT:    mov.w r2, #-1
+; VFP2-NEXT:    sbcs.w r1, r2, r1
 ; VFP2-NEXT:    it ge
 ; VFP2-NEXT:    movge.w r0, #-2147483648
 ; VFP2-NEXT:    pop {r7, pc}
@@ -139,18 +135,10 @@ define i32 @ustest_f64i32(double %x) {
 ; SOFT-NEXT:    rsbs r3, r0, #0
 ; SOFT-NEXT:    mov r3, r2
 ; SOFT-NEXT:    sbcs r3, r1
-; SOFT-NEXT:    blt .LBB2_7
+; SOFT-NEXT:    blt .LBB2_6
 ; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB2_8
-; SOFT-NEXT:  .LBB2_6: @ %entry
-; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB2_7:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB2_6
-; SOFT-NEXT:  .LBB2_8: @ %entry
 ; SOFT-NEXT:    mov r0, r2
+; SOFT-NEXT:  .LBB2_6: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
 ;
 ; VFP2-LABEL: ustest_f64i32:
@@ -162,20 +150,13 @@ define i32 @ustest_f64i32(double %x) {
 ; VFP2-NEXT:    subs.w r3, r0, #-1
 ; VFP2-NEXT:    mov.w r2, #0
 ; VFP2-NEXT:    sbcs r3, r1, #0
-; VFP2-NEXT:    mov.w r3, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r3, #1
-; VFP2-NEXT:    cmp r3, #0
-; VFP2-NEXT:    ite ne
-; VFP2-NEXT:    movne r3, r1
-; VFP2-NEXT:    moveq.w r0, #-1
-; VFP2-NEXT:    rsbs r1, r0, #0
-; VFP2-NEXT:    sbcs.w r1, r2, r3
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r2, #1
-; VFP2-NEXT:    cmp r2, #0
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r1, r2
+; VFP2-NEXT:    movge.w r0, #-1
+; VFP2-NEXT:    rsbs r3, r0, #0
+; VFP2-NEXT:    sbcs.w r1, r2, r1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r2
 ; VFP2-NEXT:    pop {r7, pc}
 ;
 ; FULL-LABEL: ustest_f64i32:
@@ -292,18 +273,10 @@ define i32 @ustest_f32i32(float %x) {
 ; SOFT-NEXT:    rsbs r3, r0, #0
 ; SOFT-NEXT:    mov r3, r2
 ; SOFT-NEXT:    sbcs r3, r1
-; SOFT-NEXT:    blt .LBB5_7
+; SOFT-NEXT:    blt .LBB5_6
 ; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB5_8
-; SOFT-NEXT:  .LBB5_6: @ %entry
-; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB5_7:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB5_6
-; SOFT-NEXT:  .LBB5_8: @ %entry
 ; SOFT-NEXT:    mov r0, r2
+; SOFT-NEXT:  .LBB5_6: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
 ;
 ; VFP-LABEL: ustest_f32i32:
@@ -448,18 +421,10 @@ define i32 @ustest_f16i32(half %x) {
 ; SOFT-NEXT:    rsbs r3, r0, #0
 ; SOFT-NEXT:    mov r3, r2
 ; SOFT-NEXT:    sbcs r3, r1
-; SOFT-NEXT:    blt .LBB8_7
+; SOFT-NEXT:    blt .LBB8_6
 ; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB8_8
-; SOFT-NEXT:  .LBB8_6: @ %entry
-; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB8_7:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB8_6
-; SOFT-NEXT:  .LBB8_8: @ %entry
 ; SOFT-NEXT:    mov r0, r2
+; SOFT-NEXT:  .LBB8_6: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
 ;
 ; VFP2-LABEL: ustest_f16i32:
@@ -1016,22 +981,18 @@ define i64 @stest_f64i64(double %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
 ; VFP2-NEXT:    itt ge
 ; VFP2-NEXT:    movge r0, r12
 ; VFP2-NEXT:    movge r1, lr
@@ -1042,26 +1003,24 @@ define i64 @stest_f64i64(double %x) {
 ; FULL-NEXT:    .save {r4, r5, r7, lr}
 ; FULL-NEXT:    push {r4, r5, r7, lr}
 ; FULL-NEXT:    bl __fixdfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    it ge
-; FULL-NEXT:    movge r0, #0
-; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi double %x to i128
@@ -1272,22 +1231,18 @@ define i64 @stest_f32i64(float %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
 ; VFP2-NEXT:    itt ge
 ; VFP2-NEXT:    movge r0, r12
 ; VFP2-NEXT:    movge r1, lr
@@ -1298,26 +1253,24 @@ define i64 @stest_f32i64(float %x) {
 ; FULL-NEXT:    .save {r4, r5, r7, lr}
 ; FULL-NEXT:    push {r4, r5, r7, lr}
 ; FULL-NEXT:    bl __fixsfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    it ge
-; FULL-NEXT:    movge r0, #0
-; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi float %x to i128
@@ -1533,22 +1486,18 @@ define i64 @stest_f16i64(half %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
 ; VFP2-NEXT:    itt ge
 ; VFP2-NEXT:    movge r0, r12
 ; VFP2-NEXT:    movge r1, lr
@@ -1561,26 +1510,24 @@ define i64 @stest_f16i64(half %x) {
 ; FULL-NEXT:    vmov.f16 r0, s0
 ; FULL-NEXT:    vmov s0, r0
 ; FULL-NEXT:    bl __fixhfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    it ge
-; FULL-NEXT:    movge r0, #0
-; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi half %x to i128
@@ -1738,26 +1685,24 @@ entry:
 define i32 @stest_f64i32_mm(double %x) {
 ; SOFT-LABEL: stest_f64i32_mm:
 ; SOFT:       @ %bb.0: @ %entry
-; SOFT-NEXT:    .save {r4, r5, r7, lr}
-; SOFT-NEXT:    push {r4, r5, r7, lr}
+; SOFT-NEXT:    .save {r4, lr}
+; SOFT-NEXT:    push {r4, lr}
 ; SOFT-NEXT:    bl __aeabi_d2lz
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    movs r3, #0
-; SOFT-NEXT:    ldr r4, .LCPI27_0
-; SOFT-NEXT:    subs r5, r0, r4
-; SOFT-NEXT:    mov r5, r1
-; SOFT-NEXT:    sbcs r5, r3
-; SOFT-NEXT:    bge .LBB27_7
+; SOFT-NEXT:    movs r2, #0
+; SOFT-NEXT:    ldr r3, .LCPI27_0
+; SOFT-NEXT:    subs r4, r0, r3
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    sbcs r4, r2
+; SOFT-NEXT:    blt .LBB27_2
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    bge .LBB27_8
+; SOFT-NEXT:    mov r1, r2
 ; SOFT-NEXT:  .LBB27_2: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB27_4
-; SOFT-NEXT:  .LBB27_3: @ %entry
-; SOFT-NEXT:    mov r1, r4
+; SOFT-NEXT:    blt .LBB27_4
+; SOFT-NEXT:  @ %bb.3: @ %entry
+; SOFT-NEXT:    mov r0, r3
 ; SOFT-NEXT:  .LBB27_4: @ %entry
-; SOFT-NEXT:    mvns r3, r3
+; SOFT-NEXT:    mvns r3, r2
+; SOFT-NEXT:    movs r2, #1
 ; SOFT-NEXT:    lsls r2, r2, #31
 ; SOFT-NEXT:    subs r4, r2, r0
 ; SOFT-NEXT:    sbcs r3, r1
@@ -1765,18 +1710,9 @@ define i32 @stest_f64i32_mm(double %x) {
 ; SOFT-NEXT:  @ %bb.5: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:  .LBB27_6: @ %entry
-; SOFT-NEXT:    pop {r4, r5, r7, pc}
-; SOFT-NEXT:  .LBB27_7: @ %entry
-; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    blt .LBB27_2
-; SOFT-NEXT:  .LBB27_8: @ %entry
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB27_3
-; SOFT-NEXT:    b .LBB27_4
+; SOFT-NEXT:    pop {r4, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.9:
+; SOFT-NEXT:  @ %bb.7:
 ; SOFT-NEXT:  .LCPI27_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -1789,17 +1725,12 @@ define i32 @stest_f64i32_mm(double %x) {
 ; VFP2-NEXT:    mvn r2, #-2147483648
 ; VFP2-NEXT:    subs r3, r0, r2
 ; VFP2-NEXT:    sbcs r3, r1, #0
-; VFP2-NEXT:    it ge
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r1, #0
 ; VFP2-NEXT:    movge r0, r2
-; VFP2-NEXT:    mov.w r2, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r2, #1
-; VFP2-NEXT:    cmp r2, #0
-; VFP2-NEXT:    it ne
-; VFP2-NEXT:    movne r2, r1
-; VFP2-NEXT:    mov.w r1, #-1
 ; VFP2-NEXT:    rsbs.w r3, r0, #-2147483648
-; VFP2-NEXT:    sbcs r1, r2
+; VFP2-NEXT:    mov.w r2, #-1
+; VFP2-NEXT:    sbcs.w r1, r2, r1
 ; VFP2-NEXT:    it ge
 ; VFP2-NEXT:    movge.w r0, #-2147483648
 ; VFP2-NEXT:    pop {r7, pc}
@@ -1905,26 +1836,24 @@ entry:
 define i32 @stest_f32i32_mm(float %x) {
 ; SOFT-LABEL: stest_f32i32_mm:
 ; SOFT:       @ %bb.0: @ %entry
-; SOFT-NEXT:    .save {r4, r5, r7, lr}
-; SOFT-NEXT:    push {r4, r5, r7, lr}
+; SOFT-NEXT:    .save {r4, lr}
+; SOFT-NEXT:    push {r4, lr}
 ; SOFT-NEXT:    bl __aeabi_f2lz
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    movs r3, #0
-; SOFT-NEXT:    ldr r4, .LCPI30_0
-; SOFT-NEXT:    subs r5, r0, r4
-; SOFT-NEXT:    mov r5, r1
-; SOFT-NEXT:    sbcs r5, r3
-; SOFT-NEXT:    bge .LBB30_7
+; SOFT-NEXT:    movs r2, #0
+; SOFT-NEXT:    ldr r3, .LCPI30_0
+; SOFT-NEXT:    subs r4, r0, r3
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    sbcs r4, r2
+; SOFT-NEXT:    blt .LBB30_2
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    bge .LBB30_8
+; SOFT-NEXT:    mov r1, r2
 ; SOFT-NEXT:  .LBB30_2: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB30_4
-; SOFT-NEXT:  .LBB30_3: @ %entry
-; SOFT-NEXT:    mov r1, r4
+; SOFT-NEXT:    blt .LBB30_4
+; SOFT-NEXT:  @ %bb.3: @ %entry
+; SOFT-NEXT:    mov r0, r3
 ; SOFT-NEXT:  .LBB30_4: @ %entry
-; SOFT-NEXT:    mvns r3, r3
+; SOFT-NEXT:    mvns r3, r2
+; SOFT-NEXT:    movs r2, #1
 ; SOFT-NEXT:    lsls r2, r2, #31
 ; SOFT-NEXT:    subs r4, r2, r0
 ; SOFT-NEXT:    sbcs r3, r1
@@ -1932,18 +1861,9 @@ define i32 @stest_f32i32_mm(float %x) {
 ; SOFT-NEXT:  @ %bb.5: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:  .LBB30_6: @ %entry
-; SOFT-NEXT:    pop {r4, r5, r7, pc}
-; SOFT-NEXT:  .LBB30_7: @ %entry
-; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    blt .LBB30_2
-; SOFT-NEXT:  .LBB30_8: @ %entry
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB30_3
-; SOFT-NEXT:    b .LBB30_4
+; SOFT-NEXT:    pop {r4, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.9:
+; SOFT-NEXT:  @ %bb.7:
 ; SOFT-NEXT:  .LCPI30_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -2023,28 +1943,26 @@ entry:
 define i32 @stest_f16i32_mm(half %x) {
 ; SOFT-LABEL: stest_f16i32_mm:
 ; SOFT:       @ %bb.0: @ %entry
-; SOFT-NEXT:    .save {r4, r5, r7, lr}
-; SOFT-NEXT:    push {r4, r5, r7, lr}
+; SOFT-NEXT:    .save {r4, lr}
+; SOFT-NEXT:    push {r4, lr}
 ; SOFT-NEXT:    uxth r0, r0
 ; SOFT-NEXT:    bl __aeabi_h2f
 ; SOFT-NEXT:    bl __aeabi_f2lz
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    movs r3, #0
-; SOFT-NEXT:    ldr r4, .LCPI33_0
-; SOFT-NEXT:    subs r5, r0, r4
-; SOFT-NEXT:    mov r5, r1
-; SOFT-NEXT:    sbcs r5, r3
-; SOFT-NEXT:    bge .LBB33_7
+; SOFT-NEXT:    movs r2, #0
+; SOFT-NEXT:    ldr r3, .LCPI33_0
+; SOFT-NEXT:    subs r4, r0, r3
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    sbcs r4, r2
+; SOFT-NEXT:    blt .LBB33_2
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    bge .LBB33_8
+; SOFT-NEXT:    mov r1, r2
 ; SOFT-NEXT:  .LBB33_2: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB33_4
-; SOFT-NEXT:  .LBB33_3: @ %entry
-; SOFT-NEXT:    mov r1, r4
+; SOFT-NEXT:    blt .LBB33_4
+; SOFT-NEXT:  @ %bb.3: @ %entry
+; SOFT-NEXT:    mov r0, r3
 ; SOFT-NEXT:  .LBB33_4: @ %entry
-; SOFT-NEXT:    mvns r3, r3
+; SOFT-NEXT:    mvns r3, r2
+; SOFT-NEXT:    movs r2, #1
 ; SOFT-NEXT:    lsls r2, r2, #31
 ; SOFT-NEXT:    subs r4, r2, r0
 ; SOFT-NEXT:    sbcs r3, r1
@@ -2052,18 +1970,9 @@ define i32 @stest_f16i32_mm(half %x) {
 ; SOFT-NEXT:  @ %bb.5: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:  .LBB33_6: @ %entry
-; SOFT-NEXT:    pop {r4, r5, r7, pc}
-; SOFT-NEXT:  .LBB33_7: @ %entry
-; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    blt .LBB33_2
-; SOFT-NEXT:  .LBB33_8: @ %entry
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB33_3
-; SOFT-NEXT:    b .LBB33_4
+; SOFT-NEXT:    pop {r4, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.9:
+; SOFT-NEXT:  @ %bb.7:
 ; SOFT-NEXT:  .LCPI33_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -2592,82 +2501,62 @@ define i64 @stest_f64i64_mm(double %x) {
 ; SOFT:       @ %bb.0: @ %entry
 ; SOFT-NEXT:    .save {r4, r5, r6, r7, lr}
 ; SOFT-NEXT:    push {r4, r5, r6, r7, lr}
-; SOFT-NEXT:    .pad #12
-; SOFT-NEXT:    sub sp, #12
+; SOFT-NEXT:    .pad #4
+; SOFT-NEXT:    sub sp, #4
 ; SOFT-NEXT:    bl __fixdfti
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    movs r0, #1
-; SOFT-NEXT:    movs r5, #0
+; SOFT-NEXT:    movs r4, #0
+; SOFT-NEXT:    mvns r5, r4
 ; SOFT-NEXT:    ldr r6, .LCPI45_0
-; SOFT-NEXT:    adds r4, r7, #1
-; SOFT-NEXT:    mov r4, r1
-; SOFT-NEXT:    sbcs r4, r6
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r0
-; SOFT-NEXT:    blt .LBB45_2
+; SOFT-NEXT:    adds r7, r0, #1
+; SOFT-NEXT:    mov r7, r1
+; SOFT-NEXT:    sbcs r7, r6
+; SOFT-NEXT:    mov r7, r2
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    mov r7, r3
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    bge .LBB45_8
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r5
+; SOFT-NEXT:    bge .LBB45_9
 ; SOFT-NEXT:  .LBB45_2: @ %entry
-; SOFT-NEXT:    mvns r6, r5
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB45_12
-; SOFT-NEXT:  @ %bb.3: @ %entry
-; SOFT-NEXT:    beq .LBB45_13
+; SOFT-NEXT:    bge .LBB45_10
+; SOFT-NEXT:  .LBB45_3: @ %entry
+; SOFT-NEXT:    blt .LBB45_5
 ; SOFT-NEXT:  .LBB45_4: @ %entry
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB45_14
-; SOFT-NEXT:  .LBB45_5: @ %entry
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB45_7
-; SOFT-NEXT:  .LBB45_6: @ %entry
-; SOFT-NEXT:    mov r7, r6
-; SOFT-NEXT:  .LBB45_7: @ %entry
-; SOFT-NEXT:    lsls r3, r0, #31
-; SOFT-NEXT:    rsbs r4, r7, #0
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r1
-; SOFT-NEXT:    mov r4, r6
-; SOFT-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r4, r2
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r6, r2
-; SOFT-NEXT:    bge .LBB45_15
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    beq .LBB45_16
-; SOFT-NEXT:  .LBB45_9: @ %entry
-; SOFT-NEXT:    bne .LBB45_11
-; SOFT-NEXT:  .LBB45_10: @ %entry
-; SOFT-NEXT:    mov r1, r3
-; SOFT-NEXT:  .LBB45_11: @ %entry
-; SOFT-NEXT:    mov r0, r7
-; SOFT-NEXT:    add sp, #12
-; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
-; SOFT-NEXT:  .LBB45_12: @ %entry
-; SOFT-NEXT:    mov r3, r4
-; SOFT-NEXT:    bne .LBB45_4
-; SOFT-NEXT:  .LBB45_13: @ %entry
-; SOFT-NEXT:    mov r2, r4
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB45_5
-; SOFT-NEXT:  .LBB45_14: @ %entry
-; SOFT-NEXT:    ldr r1, .LCPI45_0
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB45_6
-; SOFT-NEXT:    b .LBB45_7
-; SOFT-NEXT:  .LBB45_15: @ %entry
 ; SOFT-NEXT:    mov r0, r5
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    bne .LBB45_9
-; SOFT-NEXT:  .LBB45_16: @ %entry
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    beq .LBB45_10
-; SOFT-NEXT:    b .LBB45_11
+; SOFT-NEXT:  .LBB45_5: @ %entry
+; SOFT-NEXT:    movs r6, #1
+; SOFT-NEXT:    lsls r6, r6, #31
+; SOFT-NEXT:    rsbs r7, r0, #0
+; SOFT-NEXT:    mov r7, r6
+; SOFT-NEXT:    sbcs r7, r1
+; SOFT-NEXT:    mov r7, r5
+; SOFT-NEXT:    sbcs r7, r2
+; SOFT-NEXT:    sbcs r5, r3
+; SOFT-NEXT:    bge .LBB45_11
+; SOFT-NEXT:  @ %bb.6: @ %entry
+; SOFT-NEXT:    bge .LBB45_12
+; SOFT-NEXT:  .LBB45_7: @ %entry
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
+; SOFT-NEXT:  .LBB45_8: @ %entry
+; SOFT-NEXT:    mov r3, r4
+; SOFT-NEXT:    blt .LBB45_2
+; SOFT-NEXT:  .LBB45_9: @ %entry
+; SOFT-NEXT:    mov r2, r4
+; SOFT-NEXT:    blt .LBB45_3
+; SOFT-NEXT:  .LBB45_10: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    bge .LBB45_4
+; SOFT-NEXT:    b .LBB45_5
+; SOFT-NEXT:  .LBB45_11: @ %entry
+; SOFT-NEXT:    mov r0, r4
+; SOFT-NEXT:    blt .LBB45_7
+; SOFT-NEXT:  .LBB45_12: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.17:
+; SOFT-NEXT:  @ %bb.13:
 ; SOFT-NEXT:  .LCPI45_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -2682,28 +2571,21 @@ define i64 @stest_f64i64_mm(double %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, lr
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movge r1, lr
 ; VFP2-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; FULL-LABEL: stest_f64i64_mm:
@@ -2711,27 +2593,24 @@ define i64 @stest_f64i64_mm(double %x) {
 ; FULL-NEXT:    .save {r4, r5, r7, lr}
 ; FULL-NEXT:    push {r4, r5, r7, lr}
 ; FULL-NEXT:    bl __fixdfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi double %x to i128
@@ -2750,22 +2629,15 @@ define i64 @utest_f64i64_mm(double %x) {
 ; SOFT-NEXT:    movs r4, #0
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    sbcs r3, r4
-; SOFT-NEXT:    blo .LBB46_4
+; SOFT-NEXT:    bhs .LBB46_3
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB46_5
+; SOFT-NEXT:    bhs .LBB46_4
 ; SOFT-NEXT:  .LBB46_2: @ %entry
-; SOFT-NEXT:    beq .LBB46_6
-; SOFT-NEXT:  .LBB46_3: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB46_4:
-; SOFT-NEXT:    movs r4, #1
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB46_2
-; SOFT-NEXT:  .LBB46_5: @ %entry
+; SOFT-NEXT:  .LBB46_3: @ %entry
 ; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    bne .LBB46_3
-; SOFT-NEXT:  .LBB46_6: @ %entry
+; SOFT-NEXT:    blo .LBB46_2
+; SOFT-NEXT:  .LBB46_4: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    pop {r4, pc}
 ;
@@ -2777,12 +2649,9 @@ define i64 @utest_f64i64_mm(double %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lo
-; VFP2-NEXT:    movlo.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, r12
+; VFP2-NEXT:    itt hs
+; VFP2-NEXT:    movhs r0, r12
+; VFP2-NEXT:    movhs r1, r12
 ; VFP2-NEXT:    pop {r7, pc}
 ;
 ; FULL-LABEL: utest_f64i64_mm:
@@ -2791,11 +2660,10 @@ define i64 @utest_f64i64_mm(double %x) {
 ; FULL-NEXT:    push {r7, lr}
 ; FULL-NEXT:    bl __fixunsdfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lo
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r2, ne
+; FULL-NEXT:    csel r0, r0, r12, lo
+; FULL-NEXT:    csel r1, r1, r12, lo
 ; FULL-NEXT:    pop {r7, pc}
 entry:
   %conv = fptoui double %x to i128
@@ -2815,41 +2683,33 @@ define i64 @ustest_f64i64_mm(double %x) {
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    mov r2, r3
 ; SOFT-NEXT:    sbcs r2, r1
-; SOFT-NEXT:    blt .LBB47_2
+; SOFT-NEXT:    bge .LBB47_7
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB47_3
-; SOFT-NEXT:    b .LBB47_4
-; SOFT-NEXT:  .LBB47_2:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB47_4
+; SOFT-NEXT:    bge .LBB47_8
+; SOFT-NEXT:  .LBB47_2: @ %entry
+; SOFT-NEXT:    blt .LBB47_4
 ; SOFT-NEXT:  .LBB47_3: @ %entry
-; SOFT-NEXT:    mov r4, r2
+; SOFT-NEXT:    mov r3, r1
 ; SOFT-NEXT:  .LBB47_4: @ %entry
-; SOFT-NEXT:    beq .LBB47_10
-; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    bne .LBB47_7
-; SOFT-NEXT:  .LBB47_6: @ %entry
-; SOFT-NEXT:    mov r3, r2
-; SOFT-NEXT:  .LBB47_7: @ %entry
 ; SOFT-NEXT:    cmp r3, #0
 ; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    bpl .LBB47_11
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    bpl .LBB47_12
-; SOFT-NEXT:  .LBB47_9: @ %entry
+; SOFT-NEXT:    bpl .LBB47_9
+; SOFT-NEXT:  @ %bb.5: @ %entry
+; SOFT-NEXT:    bpl .LBB47_10
+; SOFT-NEXT:  .LBB47_6: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB47_10: @ %entry
-; SOFT-NEXT:    mov r0, r2
-; SOFT-NEXT:    beq .LBB47_6
-; SOFT-NEXT:    b .LBB47_7
-; SOFT-NEXT:  .LBB47_11: @ %entry
+; SOFT-NEXT:  .LBB47_7: @ %entry
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    blt .LBB47_2
+; SOFT-NEXT:  .LBB47_8: @ %entry
+; SOFT-NEXT:    mov r0, r1
+; SOFT-NEXT:    bge .LBB47_3
+; SOFT-NEXT:    b .LBB47_4
+; SOFT-NEXT:  .LBB47_9: @ %entry
 ; SOFT-NEXT:    mov r2, r0
-; SOFT-NEXT:    bmi .LBB47_9
-; SOFT-NEXT:  .LBB47_12: @ %entry
+; SOFT-NEXT:    bmi .LBB47_6
+; SOFT-NEXT:  .LBB47_10: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
@@ -2862,13 +2722,10 @@ define i64 @ustest_f64i64_mm(double %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itte eq
-; VFP2-NEXT:    moveq r1, r12
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    movne r12, r3
+; VFP2-NEXT:    itte ge
+; VFP2-NEXT:    movge r1, r12
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movlt r12, r3
 ; VFP2-NEXT:    cmp.w r12, #0
 ; VFP2-NEXT:    itt mi
 ; VFP2-NEXT:    movmi r0, #0
@@ -2881,12 +2738,11 @@ define i64 @ustest_f64i64_mm(double %x) {
 ; FULL-NEXT:    push {r7, lr}
 ; FULL-NEXT:    bl __fixdfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r1, r1, r2, ne
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r2, r3, r2, ne
+; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r2, r3, r12, lt
 ; FULL-NEXT:    cmp r2, #0
 ; FULL-NEXT:    itt mi
 ; FULL-NEXT:    movmi r0, #0
@@ -2905,82 +2761,62 @@ define i64 @stest_f32i64_mm(float %x) {
 ; SOFT:       @ %bb.0: @ %entry
 ; SOFT-NEXT:    .save {r4, r5, r6, r7, lr}
 ; SOFT-NEXT:    push {r4, r5, r6, r7, lr}
-; SOFT-NEXT:    .pad #12
-; SOFT-NEXT:    sub sp, #12
+; SOFT-NEXT:    .pad #4
+; SOFT-NEXT:    sub sp, #4
 ; SOFT-NEXT:    bl __fixsfti
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    movs r0, #1
-; SOFT-NEXT:    movs r5, #0
+; SOFT-NEXT:    movs r4, #0
+; SOFT-NEXT:    mvns r5, r4
 ; SOFT-NEXT:    ldr r6, .LCPI48_0
-; SOFT-NEXT:    adds r4, r7, #1
-; SOFT-NEXT:    mov r4, r1
-; SOFT-NEXT:    sbcs r4, r6
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r0
-; SOFT-NEXT:    blt .LBB48_2
+; SOFT-NEXT:    adds r7, r0, #1
+; SOFT-NEXT:    mov r7, r1
+; SOFT-NEXT:    sbcs r7, r6
+; SOFT-NEXT:    mov r7, r2
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    mov r7, r3
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    bge .LBB48_8
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r5
+; SOFT-NEXT:    bge .LBB48_9
 ; SOFT-NEXT:  .LBB48_2: @ %entry
-; SOFT-NEXT:    mvns r6, r5
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB48_12
-; SOFT-NEXT:  @ %bb.3: @ %entry
-; SOFT-NEXT:    beq .LBB48_13
+; SOFT-NEXT:    bge .LBB48_10
+; SOFT-NEXT:  .LBB48_3: @ %entry
+; SOFT-NEXT:    blt .LBB48_5
 ; SOFT-NEXT:  .LBB48_4: @ %entry
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB48_14
-; SOFT-NEXT:  .LBB48_5: @ %entry
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB48_7
-; SOFT-NEXT:  .LBB48_6: @ %entry
-; SOFT-NEXT:    mov r7, r6
-; SOFT-NEXT:  .LBB48_7: @ %entry
-; SOFT-NEXT:    lsls r3, r0, #31
-; SOFT-NEXT:    rsbs r4, r7, #0
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r1
-; SOFT-NEXT:    mov r4, r6
-; SOFT-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r4, r2
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r6, r2
-; SOFT-NEXT:    bge .LBB48_15
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    beq .LBB48_16
-; SOFT-NEXT:  .LBB48_9: @ %entry
-; SOFT-NEXT:    bne .LBB48_11
-; SOFT-NEXT:  .LBB48_10: @ %entry
-; SOFT-NEXT:    mov r1, r3
-; SOFT-NEXT:  .LBB48_11: @ %entry
-; SOFT-NEXT:    mov r0, r7
-; SOFT-NEXT:    add sp, #12
-; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
-; SOFT-NEXT:  .LBB48_12: @ %entry
-; SOFT-NEXT:    mov r3, r4
-; SOFT-NEXT:    bne .LBB48_4
-; SOFT-NEXT:  .LBB48_13: @ %entry
-; SOFT-NEXT:    mov r2, r4
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB48_5
-; SOFT-NEXT:  .LBB48_14: @ %entry
-; SOFT-NEXT:    ldr r1, .LCPI48_0
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB48_6
-; SOFT-NEXT:    b .LBB48_7
-; SOFT-NEXT:  .LBB48_15: @ %entry
 ; SOFT-NEXT:    mov r0, r5
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    bne .LBB48_9
-; SOFT-NEXT:  .LBB48_16: @ %entry
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    beq .LBB48_10
-; SOFT-NEXT:    b .LBB48_11
+; SOFT-NEXT:  .LBB48_5: @ %entry
+; SOFT-NEXT:    movs r6, #1
+; SOFT-NEXT:    lsls r6, r6, #31
+; SOFT-NEXT:    rsbs r7, r0, #0
+; SOFT-NEXT:    mov r7, r6
+; SOFT-NEXT:    sbcs r7, r1
+; SOFT-NEXT:    mov r7, r5
+; SOFT-NEXT:    sbcs r7, r2
+; SOFT-NEXT:    sbcs r5, r3
+; SOFT-NEXT:    bge .LBB48_11
+; SOFT-NEXT:  @ %bb.6: @ %entry
+; SOFT-NEXT:    bge .LBB48_12
+; SOFT-NEXT:  .LBB48_7: @ %entry
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
+; SOFT-NEXT:  .LBB48_8: @ %entry
+; SOFT-NEXT:    mov r3, r4
+; SOFT-NEXT:    blt .LBB48_2
+; SOFT-NEXT:  .LBB48_9: @ %entry
+; SOFT-NEXT:    mov r2, r4
+; SOFT-NEXT:    blt .LBB48_3
+; SOFT-NEXT:  .LBB48_10: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    bge .LBB48_4
+; SOFT-NEXT:    b .LBB48_5
+; SOFT-NEXT:  .LBB48_11: @ %entry
+; SOFT-NEXT:    mov r0, r4
+; SOFT-NEXT:    blt .LBB48_7
+; SOFT-NEXT:  .LBB48_12: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.17:
+; SOFT-NEXT:  @ %bb.13:
 ; SOFT-NEXT:  .LCPI48_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -2995,28 +2831,21 @@ define i64 @stest_f32i64_mm(float %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, lr
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movge r1, lr
 ; VFP2-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; FULL-LABEL: stest_f32i64_mm:
@@ -3024,27 +2853,24 @@ define i64 @stest_f32i64_mm(float %x) {
 ; FULL-NEXT:    .save {r4, r5, r7, lr}
 ; FULL-NEXT:    push {r4, r5, r7, lr}
 ; FULL-NEXT:    bl __fixsfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi float %x to i128
@@ -3063,22 +2889,15 @@ define i64 @utest_f32i64_mm(float %x) {
 ; SOFT-NEXT:    movs r4, #0
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    sbcs r3, r4
-; SOFT-NEXT:    blo .LBB49_4
+; SOFT-NEXT:    bhs .LBB49_3
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB49_5
+; SOFT-NEXT:    bhs .LBB49_4
 ; SOFT-NEXT:  .LBB49_2: @ %entry
-; SOFT-NEXT:    beq .LBB49_6
-; SOFT-NEXT:  .LBB49_3: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB49_4:
-; SOFT-NEXT:    movs r4, #1
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB49_2
-; SOFT-NEXT:  .LBB49_5: @ %entry
+; SOFT-NEXT:  .LBB49_3: @ %entry
 ; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    bne .LBB49_3
-; SOFT-NEXT:  .LBB49_6: @ %entry
+; SOFT-NEXT:    blo .LBB49_2
+; SOFT-NEXT:  .LBB49_4: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    pop {r4, pc}
 ;
@@ -3090,12 +2909,9 @@ define i64 @utest_f32i64_mm(float %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lo
-; VFP2-NEXT:    movlo.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, r12
+; VFP2-NEXT:    itt hs
+; VFP2-NEXT:    movhs r0, r12
+; VFP2-NEXT:    movhs r1, r12
 ; VFP2-NEXT:    pop {r7, pc}
 ;
 ; FULL-LABEL: utest_f32i64_mm:
@@ -3104,11 +2920,10 @@ define i64 @utest_f32i64_mm(float %x) {
 ; FULL-NEXT:    push {r7, lr}
 ; FULL-NEXT:    bl __fixunssfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lo
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r2, ne
+; FULL-NEXT:    csel r0, r0, r12, lo
+; FULL-NEXT:    csel r1, r1, r12, lo
 ; FULL-NEXT:    pop {r7, pc}
 entry:
   %conv = fptoui float %x to i128
@@ -3128,41 +2943,33 @@ define i64 @ustest_f32i64_mm(float %x) {
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    mov r2, r3
 ; SOFT-NEXT:    sbcs r2, r1
-; SOFT-NEXT:    blt .LBB50_2
+; SOFT-NEXT:    bge .LBB50_7
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB50_3
-; SOFT-NEXT:    b .LBB50_4
-; SOFT-NEXT:  .LBB50_2:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB50_4
+; SOFT-NEXT:    bge .LBB50_8
+; SOFT-NEXT:  .LBB50_2: @ %entry
+; SOFT-NEXT:    blt .LBB50_4
 ; SOFT-NEXT:  .LBB50_3: @ %entry
-; SOFT-NEXT:    mov r4, r2
+; SOFT-NEXT:    mov r3, r1
 ; SOFT-NEXT:  .LBB50_4: @ %entry
-; SOFT-NEXT:    beq .LBB50_10
-; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    bne .LBB50_7
-; SOFT-NEXT:  .LBB50_6: @ %entry
-; SOFT-NEXT:    mov r3, r2
-; SOFT-NEXT:  .LBB50_7: @ %entry
 ; SOFT-NEXT:    cmp r3, #0
 ; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    bpl .LBB50_11
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    bpl .LBB50_12
-; SOFT-NEXT:  .LBB50_9: @ %entry
+; SOFT-NEXT:    bpl .LBB50_9
+; SOFT-NEXT:  @ %bb.5: @ %entry
+; SOFT-NEXT:    bpl .LBB50_10
+; SOFT-NEXT:  .LBB50_6: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB50_10: @ %entry
-; SOFT-NEXT:    mov r0, r2
-; SOFT-NEXT:    beq .LBB50_6
-; SOFT-NEXT:    b .LBB50_7
-; SOFT-NEXT:  .LBB50_11: @ %entry
+; SOFT-NEXT:  .LBB50_7: @ %entry
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    blt .LBB50_2
+; SOFT-NEXT:  .LBB50_8: @ %entry
+; SOFT-NEXT:    mov r0, r1
+; SOFT-NEXT:    bge .LBB50_3
+; SOFT-NEXT:    b .LBB50_4
+; SOFT-NEXT:  .LBB50_9: @ %entry
 ; SOFT-NEXT:    mov r2, r0
-; SOFT-NEXT:    bmi .LBB50_9
-; SOFT-NEXT:  .LBB50_12: @ %entry
+; SOFT-NEXT:    bmi .LBB50_6
+; SOFT-NEXT:  .LBB50_10: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
@@ -3175,13 +2982,10 @@ define i64 @ustest_f32i64_mm(float %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itte eq
-; VFP2-NEXT:    moveq r1, r12
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    movne r12, r3
+; VFP2-NEXT:    itte ge
+; VFP2-NEXT:    movge r1, r12
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movlt r12, r3
 ; VFP2-NEXT:    cmp.w r12, #0
 ; VFP2-NEXT:    itt mi
 ; VFP2-NEXT:    movmi r0, #0
@@ -3194,12 +2998,11 @@ define i64 @ustest_f32i64_mm(float %x) {
 ; FULL-NEXT:    push {r7, lr}
 ; FULL-NEXT:    bl __fixsfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r1, r1, r2, ne
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r2, r3, r2, ne
+; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r2, r3, r12, lt
 ; FULL-NEXT:    cmp r2, #0
 ; FULL-NEXT:    itt mi
 ; FULL-NEXT:    movmi r0, #0
@@ -3218,84 +3021,64 @@ define i64 @stest_f16i64_mm(half %x) {
 ; SOFT:       @ %bb.0: @ %entry
 ; SOFT-NEXT:    .save {r4, r5, r6, r7, lr}
 ; SOFT-NEXT:    push {r4, r5, r6, r7, lr}
-; SOFT-NEXT:    .pad #12
-; SOFT-NEXT:    sub sp, #12
+; SOFT-NEXT:    .pad #4
+; SOFT-NEXT:    sub sp, #4
 ; SOFT-NEXT:    uxth r0, r0
 ; SOFT-NEXT:    bl __aeabi_h2f
 ; SOFT-NEXT:    bl __fixsfti
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    movs r0, #1
-; SOFT-NEXT:    movs r5, #0
+; SOFT-NEXT:    movs r4, #0
+; SOFT-NEXT:    mvns r5, r4
 ; SOFT-NEXT:    ldr r6, .LCPI51_0
-; SOFT-NEXT:    adds r4, r7, #1
-; SOFT-NEXT:    mov r4, r1
-; SOFT-NEXT:    sbcs r4, r6
-; SOFT-NEXT:    mov r4, r2
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r5
-; SOFT-NEXT:    mov r4, r0
-; SOFT-NEXT:    blt .LBB51_2
+; SOFT-NEXT:    adds r7, r0, #1
+; SOFT-NEXT:    mov r7, r1
+; SOFT-NEXT:    sbcs r7, r6
+; SOFT-NEXT:    mov r7, r2
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    mov r7, r3
+; SOFT-NEXT:    sbcs r7, r4
+; SOFT-NEXT:    bge .LBB51_8
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r4, r5
+; SOFT-NEXT:    bge .LBB51_9
 ; SOFT-NEXT:  .LBB51_2: @ %entry
-; SOFT-NEXT:    mvns r6, r5
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB51_12
-; SOFT-NEXT:  @ %bb.3: @ %entry
-; SOFT-NEXT:    beq .LBB51_13
+; SOFT-NEXT:    bge .LBB51_10
+; SOFT-NEXT:  .LBB51_3: @ %entry
+; SOFT-NEXT:    blt .LBB51_5
 ; SOFT-NEXT:  .LBB51_4: @ %entry
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB51_14
-; SOFT-NEXT:  .LBB51_5: @ %entry
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB51_7
-; SOFT-NEXT:  .LBB51_6: @ %entry
-; SOFT-NEXT:    mov r7, r6
-; SOFT-NEXT:  .LBB51_7: @ %entry
-; SOFT-NEXT:    lsls r3, r0, #31
-; SOFT-NEXT:    rsbs r4, r7, #0
-; SOFT-NEXT:    mov r4, r3
-; SOFT-NEXT:    sbcs r4, r1
-; SOFT-NEXT:    mov r4, r6
-; SOFT-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r4, r2
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    sbcs r6, r2
-; SOFT-NEXT:    bge .LBB51_15
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    beq .LBB51_16
-; SOFT-NEXT:  .LBB51_9: @ %entry
-; SOFT-NEXT:    bne .LBB51_11
-; SOFT-NEXT:  .LBB51_10: @ %entry
-; SOFT-NEXT:    mov r1, r3
-; SOFT-NEXT:  .LBB51_11: @ %entry
-; SOFT-NEXT:    mov r0, r7
-; SOFT-NEXT:    add sp, #12
-; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
-; SOFT-NEXT:  .LBB51_12: @ %entry
-; SOFT-NEXT:    mov r3, r4
-; SOFT-NEXT:    bne .LBB51_4
-; SOFT-NEXT:  .LBB51_13: @ %entry
-; SOFT-NEXT:    mov r2, r4
-; SOFT-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; SOFT-NEXT:    bne .LBB51_5
-; SOFT-NEXT:  .LBB51_14: @ %entry
-; SOFT-NEXT:    ldr r1, .LCPI51_0
-; SOFT-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; SOFT-NEXT:    beq .LBB51_6
-; SOFT-NEXT:    b .LBB51_7
-; SOFT-NEXT:  .LBB51_15: @ %entry
 ; SOFT-NEXT:    mov r0, r5
-; SOFT-NEXT:    cmp r0, #0
-; SOFT-NEXT:    bne .LBB51_9
-; SOFT-NEXT:  .LBB51_16: @ %entry
-; SOFT-NEXT:    mov r7, r0
-; SOFT-NEXT:    beq .LBB51_10
-; SOFT-NEXT:    b .LBB51_11
+; SOFT-NEXT:  .LBB51_5: @ %entry
+; SOFT-NEXT:    movs r6, #1
+; SOFT-NEXT:    lsls r6, r6, #31
+; SOFT-NEXT:    rsbs r7, r0, #0
+; SOFT-NEXT:    mov r7, r6
+; SOFT-NEXT:    sbcs r7, r1
+; SOFT-NEXT:    mov r7, r5
+; SOFT-NEXT:    sbcs r7, r2
+; SOFT-NEXT:    sbcs r5, r3
+; SOFT-NEXT:    bge .LBB51_11
+; SOFT-NEXT:  @ %bb.6: @ %entry
+; SOFT-NEXT:    bge .LBB51_12
+; SOFT-NEXT:  .LBB51_7: @ %entry
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
+; SOFT-NEXT:  .LBB51_8: @ %entry
+; SOFT-NEXT:    mov r3, r4
+; SOFT-NEXT:    blt .LBB51_2
+; SOFT-NEXT:  .LBB51_9: @ %entry
+; SOFT-NEXT:    mov r2, r4
+; SOFT-NEXT:    blt .LBB51_3
+; SOFT-NEXT:  .LBB51_10: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    bge .LBB51_4
+; SOFT-NEXT:    b .LBB51_5
+; SOFT-NEXT:  .LBB51_11: @ %entry
+; SOFT-NEXT:    mov r0, r4
+; SOFT-NEXT:    blt .LBB51_7
+; SOFT-NEXT:  .LBB51_12: @ %entry
+; SOFT-NEXT:    mov r1, r6
+; SOFT-NEXT:    add sp, #4
+; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.17:
+; SOFT-NEXT:  @ %bb.13:
 ; SOFT-NEXT:  .LCPI51_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;
@@ -3313,28 +3096,21 @@ define i64 @stest_f16i64_mm(half %x) {
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r4, r2, #0
 ; VFP2-NEXT:    sbcs r4, r3, #0
-; VFP2-NEXT:    mov.w r4, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt r4, #1
-; VFP2-NEXT:    cmp r4, #0
-; VFP2-NEXT:    itet eq
-; VFP2-NEXT:    moveq r3, r4
-; VFP2-NEXT:    movne r4, r2
-; VFP2-NEXT:    moveq r1, lr
-; VFP2-NEXT:    mov.w r2, #-1
-; VFP2-NEXT:    it eq
-; VFP2-NEXT:    moveq r0, r2
+; VFP2-NEXT:    ittt ge
+; VFP2-NEXT:    movge r3, r12
+; VFP2-NEXT:    movge r2, r12
+; VFP2-NEXT:    movge r1, lr
+; VFP2-NEXT:    mov.w r4, #-1
+; VFP2-NEXT:    it ge
+; VFP2-NEXT:    movge r0, r4
 ; VFP2-NEXT:    rsbs r5, r0, #0
 ; VFP2-NEXT:    mov.w lr, #-2147483648
 ; VFP2-NEXT:    sbcs.w r5, lr, r1
-; VFP2-NEXT:    sbcs.w r4, r2, r4
-; VFP2-NEXT:    sbcs r2, r3
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, lr
+; VFP2-NEXT:    sbcs.w r2, r4, r2
+; VFP2-NEXT:    sbcs.w r2, r4, r3
+; VFP2-NEXT:    itt ge
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movge r1, lr
 ; VFP2-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; FULL-LABEL: stest_f16i64_mm:
@@ -3344,27 +3120,24 @@ define i64 @stest_f16i64_mm(half %x) {
 ; FULL-NEXT:    vmov.f16 r0, s0
 ; FULL-NEXT:    vmov s0, r0
 ; FULL-NEXT:    bl __fixhfti
-; FULL-NEXT:    subs.w lr, r0, #-1
-; FULL-NEXT:    mvn r12, #-2147483648
-; FULL-NEXT:    sbcs.w lr, r1, r12
-; FULL-NEXT:    sbcs lr, r2, #0
-; FULL-NEXT:    sbcs lr, r3, #0
-; FULL-NEXT:    cset lr, lt
-; FULL-NEXT:    cmp.w lr, #0
-; FULL-NEXT:    csel r5, r3, lr, ne
-; FULL-NEXT:    mov.w r3, #-1
-; FULL-NEXT:    csel r0, r0, r3, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
-; FULL-NEXT:    csel r2, r2, lr, ne
-; FULL-NEXT:    rsbs r4, r0, #0
-; FULL-NEXT:    mov.w r12, #-2147483648
-; FULL-NEXT:    sbcs.w r4, r12, r1
-; FULL-NEXT:    sbcs.w r2, r3, r2
-; FULL-NEXT:    sbcs.w r2, r3, r5
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r12, ne
+; FULL-NEXT:    subs.w r4, r0, #-1
+; FULL-NEXT:    mvn lr, #-2147483648
+; FULL-NEXT:    sbcs.w r4, r1, lr
+; FULL-NEXT:    mov.w r12, #0
+; FULL-NEXT:    sbcs r4, r2, #0
+; FULL-NEXT:    sbcs r4, r3, #0
+; FULL-NEXT:    mov.w r4, #-1
+; FULL-NEXT:    csel r1, r1, lr, lt
+; FULL-NEXT:    csel r0, r0, r4, lt
+; FULL-NEXT:    csel r3, r3, r12, lt
+; FULL-NEXT:    csel r2, r2, r12, lt
+; FULL-NEXT:    rsbs r5, r0, #0
+; FULL-NEXT:    mov.w lr, #-2147483648
+; FULL-NEXT:    sbcs.w r5, lr, r1
+; FULL-NEXT:    sbcs.w r2, r4, r2
+; FULL-NEXT:    sbcs.w r2, r4, r3
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r1, r1, lr, lt
 ; FULL-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %conv = fptosi half %x to i128
@@ -3385,22 +3158,15 @@ define i64 @utesth_f16i64_mm(half %x) {
 ; SOFT-NEXT:    movs r4, #0
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    sbcs r3, r4
-; SOFT-NEXT:    blo .LBB52_4
+; SOFT-NEXT:    bhs .LBB52_3
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    beq .LBB52_5
+; SOFT-NEXT:    bhs .LBB52_4
 ; SOFT-NEXT:  .LBB52_2: @ %entry
-; SOFT-NEXT:    beq .LBB52_6
-; SOFT-NEXT:  .LBB52_3: @ %entry
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB52_4:
-; SOFT-NEXT:    movs r4, #1
-; SOFT-NEXT:    cmp r4, #0
-; SOFT-NEXT:    bne .LBB52_2
-; SOFT-NEXT:  .LBB52_5: @ %entry
+; SOFT-NEXT:  .LBB52_3: @ %entry
 ; SOFT-NEXT:    mov r0, r4
-; SOFT-NEXT:    bne .LBB52_3
-; SOFT-NEXT:  .LBB52_6: @ %entry
+; SOFT-NEXT:    blo .LBB52_2
+; SOFT-NEXT:  .LBB52_4: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    pop {r4, pc}
 ;
@@ -3415,12 +3181,9 @@ define i64 @utesth_f16i64_mm(half %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lo
-; VFP2-NEXT:    movlo.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itt eq
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    moveq r1, r12
+; VFP2-NEXT:    itt hs
+; VFP2-NEXT:    movhs r0, r12
+; VFP2-NEXT:    movhs r1, r12
 ; VFP2-NEXT:    pop {r7, pc}
 ;
 ; FULL-LABEL: utesth_f16i64_mm:
@@ -3431,11 +3194,10 @@ define i64 @utesth_f16i64_mm(half %x) {
 ; FULL-NEXT:    vmov s0, r0
 ; FULL-NEXT:    bl __fixunshfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lo
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r1, r1, r2, ne
+; FULL-NEXT:    csel r0, r0, r12, lo
+; FULL-NEXT:    csel r1, r1, r12, lo
 ; FULL-NEXT:    pop {r7, pc}
 entry:
   %conv = fptoui half %x to i128
@@ -3457,41 +3219,33 @@ define i64 @ustest_f16i64_mm(half %x) {
 ; SOFT-NEXT:    subs r2, r2, #1
 ; SOFT-NEXT:    mov r2, r3
 ; SOFT-NEXT:    sbcs r2, r1
-; SOFT-NEXT:    blt .LBB53_2
+; SOFT-NEXT:    bge .LBB53_7
 ; SOFT-NEXT:  @ %bb.1: @ %entry
-; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB53_3
-; SOFT-NEXT:    b .LBB53_4
-; SOFT-NEXT:  .LBB53_2:
-; SOFT-NEXT:    movs r2, #1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB53_4
+; SOFT-NEXT:    bge .LBB53_8
+; SOFT-NEXT:  .LBB53_2: @ %entry
+; SOFT-NEXT:    blt .LBB53_4
 ; SOFT-NEXT:  .LBB53_3: @ %entry
-; SOFT-NEXT:    mov r4, r2
+; SOFT-NEXT:    mov r3, r1
 ; SOFT-NEXT:  .LBB53_4: @ %entry
-; SOFT-NEXT:    beq .LBB53_10
-; SOFT-NEXT:  @ %bb.5: @ %entry
-; SOFT-NEXT:    bne .LBB53_7
-; SOFT-NEXT:  .LBB53_6: @ %entry
-; SOFT-NEXT:    mov r3, r2
-; SOFT-NEXT:  .LBB53_7: @ %entry
 ; SOFT-NEXT:    cmp r3, #0
 ; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    bpl .LBB53_11
-; SOFT-NEXT:  @ %bb.8: @ %entry
-; SOFT-NEXT:    bpl .LBB53_12
-; SOFT-NEXT:  .LBB53_9: @ %entry
+; SOFT-NEXT:    bpl .LBB53_9
+; SOFT-NEXT:  @ %bb.5: @ %entry
+; SOFT-NEXT:    bpl .LBB53_10
+; SOFT-NEXT:  .LBB53_6: @ %entry
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
-; SOFT-NEXT:  .LBB53_10: @ %entry
-; SOFT-NEXT:    mov r0, r2
-; SOFT-NEXT:    beq .LBB53_6
-; SOFT-NEXT:    b .LBB53_7
-; SOFT-NEXT:  .LBB53_11: @ %entry
+; SOFT-NEXT:  .LBB53_7: @ %entry
+; SOFT-NEXT:    mov r4, r1
+; SOFT-NEXT:    blt .LBB53_2
+; SOFT-NEXT:  .LBB53_8: @ %entry
+; SOFT-NEXT:    mov r0, r1
+; SOFT-NEXT:    bge .LBB53_3
+; SOFT-NEXT:    b .LBB53_4
+; SOFT-NEXT:  .LBB53_9: @ %entry
 ; SOFT-NEXT:    mov r2, r0
-; SOFT-NEXT:    bmi .LBB53_9
-; SOFT-NEXT:  .LBB53_12: @ %entry
+; SOFT-NEXT:    bmi .LBB53_6
+; SOFT-NEXT:  .LBB53_10: @ %entry
 ; SOFT-NEXT:    mov r1, r4
 ; SOFT-NEXT:    mov r0, r2
 ; SOFT-NEXT:    pop {r4, pc}
@@ -3507,13 +3261,10 @@ define i64 @ustest_f16i64_mm(half %x) {
 ; VFP2-NEXT:    subs r2, #1
 ; VFP2-NEXT:    mov.w r12, #0
 ; VFP2-NEXT:    sbcs r2, r3, #0
-; VFP2-NEXT:    it lt
-; VFP2-NEXT:    movlt.w r12, #1
-; VFP2-NEXT:    cmp.w r12, #0
-; VFP2-NEXT:    itte eq
-; VFP2-NEXT:    moveq r1, r12
-; VFP2-NEXT:    moveq r0, r12
-; VFP2-NEXT:    movne r12, r3
+; VFP2-NEXT:    itte ge
+; VFP2-NEXT:    movge r1, r12
+; VFP2-NEXT:    movge r0, r12
+; VFP2-NEXT:    movlt r12, r3
 ; VFP2-NEXT:    cmp.w r12, #0
 ; VFP2-NEXT:    itt mi
 ; VFP2-NEXT:    movmi r0, #0
@@ -3528,12 +3279,11 @@ define i64 @ustest_f16i64_mm(half %x) {
 ; FULL-NEXT:    vmov s0, r0
 ; FULL-NEXT:    bl __fixhfti
 ; FULL-NEXT:    subs r2, #1
+; FULL-NEXT:    mov.w r12, #0
 ; FULL-NEXT:    sbcs r2, r3, #0
-; FULL-NEXT:    cset r2, lt
-; FULL-NEXT:    cmp r2, #0
-; FULL-NEXT:    csel r1, r1, r2, ne
-; FULL-NEXT:    csel r0, r0, r2, ne
-; FULL-NEXT:    csel r2, r3, r2, ne
+; FULL-NEXT:    csel r1, r1, r12, lt
+; FULL-NEXT:    csel r0, r0, r12, lt
+; FULL-NEXT:    csel r2, r3, r12, lt
 ; FULL-NEXT:    cmp r2, #0
 ; FULL-NEXT:    itt mi
 ; FULL-NEXT:    movmi r0, #0
@@ -3553,18 +3303,17 @@ define void @unroll_maxmin(ptr nocapture %0, ptr nocapture readonly %1, i32 %2) 
 ; SOFT:       @ %bb.0:
 ; SOFT-NEXT:    .save {r4, r5, r6, r7, lr}
 ; SOFT-NEXT:    push {r4, r5, r6, r7, lr}
-; SOFT-NEXT:    .pad #20
-; SOFT-NEXT:    sub sp, #20
+; SOFT-NEXT:    .pad #12
+; SOFT-NEXT:    sub sp, #12
 ; SOFT-NEXT:    mov r4, r1
 ; SOFT-NEXT:    mov r5, r0
 ; SOFT-NEXT:    movs r0, #0
-; SOFT-NEXT:    str r0, [sp, #16] @ 4-byte Spill
-; SOFT-NEXT:    mvns r0, r0
 ; SOFT-NEXT:    str r0, [sp, #8] @ 4-byte Spill
+; SOFT-NEXT:    mvns r0, r0
+; SOFT-NEXT:    str r0, [sp] @ 4-byte Spill
 ; SOFT-NEXT:    movs r0, #1
 ; SOFT-NEXT:    lsls r1, r0, #31
-; SOFT-NEXT:    str r1, [sp, #12] @ 4-byte Spill
-; SOFT-NEXT:    str r0, [sp, #4] @ 4-byte Spill
+; SOFT-NEXT:    str r1, [sp, #4] @ 4-byte Spill
 ; SOFT-NEXT:    lsls r7, r0, #10
 ; SOFT-NEXT:    b .LBB54_2
 ; SOFT-NEXT:  .LBB54_1: @ in Loop: Header=BB54_2 Depth=1
@@ -3572,7 +3321,7 @@ define void @unroll_maxmin(ptr nocapture %0, ptr nocapture readonly %1, i32 %2) 
 ; SOFT-NEXT:    adds r4, #8
 ; SOFT-NEXT:    adds r5, #8
 ; SOFT-NEXT:    subs r7, r7, #2
-; SOFT-NEXT:    beq .LBB54_18
+; SOFT-NEXT:    beq .LBB54_14
 ; SOFT-NEXT:  .LBB54_2: @ =>This Inner Loop Header: Depth=1
 ; SOFT-NEXT:    ldr r0, [r4]
 ; SOFT-NEXT:    movs r1, #79
@@ -3583,25 +3332,23 @@ define void @unroll_maxmin(ptr nocapture %0, ptr nocapture readonly %1, i32 %2) 
 ; SOFT-NEXT:    ldr r2, .LCPI54_0
 ; SOFT-NEXT:    subs r2, r0, r2
 ; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    ldr r3, [sp, #16] @ 4-byte Reload
+; SOFT-NEXT:    ldr r3, [sp, #8] @ 4-byte Reload
 ; SOFT-NEXT:    sbcs r2, r3
-; SOFT-NEXT:    bge .LBB54_14
+; SOFT-NEXT:    blt .LBB54_4
 ; SOFT-NEXT:  @ %bb.3: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    bge .LBB54_15
+; SOFT-NEXT:    ldr r1, [sp, #8] @ 4-byte Reload
 ; SOFT-NEXT:  .LBB54_4: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB54_6
-; SOFT-NEXT:  .LBB54_5: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    mov r1, r2
+; SOFT-NEXT:    blt .LBB54_6
+; SOFT-NEXT:  @ %bb.5: @ in Loop: Header=BB54_2 Depth=1
+; SOFT-NEXT:    ldr r0, .LCPI54_0
 ; SOFT-NEXT:  .LBB54_6: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r2, [sp, #12] @ 4-byte Reload
+; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
 ; SOFT-NEXT:    subs r2, r2, r0
-; SOFT-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
+; SOFT-NEXT:    ldr r2, [sp] @ 4-byte Reload
 ; SOFT-NEXT:    sbcs r2, r1
 ; SOFT-NEXT:    blt .LBB54_8
 ; SOFT-NEXT:  @ %bb.7: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
+; SOFT-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
 ; SOFT-NEXT:  .LBB54_8: @ in Loop: Header=BB54_2 Depth=1
 ; SOFT-NEXT:    str r0, [r5]
 ; SOFT-NEXT:    ldr r0, [r4, #4]
@@ -3611,48 +3358,29 @@ define void @unroll_maxmin(ptr nocapture %0, ptr nocapture readonly %1, i32 %2) 
 ; SOFT-NEXT:    ldr r2, .LCPI54_0
 ; SOFT-NEXT:    subs r2, r0, r2
 ; SOFT-NEXT:    mov r2, r1
-; SOFT-NEXT:    ldr r3, [sp, #16] @ 4-byte Reload
+; SOFT-NEXT:    ldr r3, [sp, #8] @ 4-byte Reload
 ; SOFT-NEXT:    sbcs r2, r3
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    bge .LBB54_16
+; SOFT-NEXT:    blt .LBB54_10
 ; SOFT-NEXT:  @ %bb.9: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB54_17
+; SOFT-NEXT:    ldr r1, [sp, #8] @ 4-byte Reload
 ; SOFT-NEXT:  .LBB54_10: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    bne .LBB54_12
-; SOFT-NEXT:  .LBB54_11: @ in Loop: Header=BB54_2 Depth=1
+; SOFT-NEXT:    blt .LBB54_12
+; SOFT-NEXT:  @ %bb.11: @ in Loop: Header=BB54_2 Depth=1
 ; SOFT-NEXT:    ldr r0, .LCPI54_0
 ; SOFT-NEXT:  .LBB54_12: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r2, [sp, #12] @ 4-byte Reload
+; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
 ; SOFT-NEXT:    subs r2, r2, r0
-; SOFT-NEXT:    ldr r2, [sp, #8] @ 4-byte Reload
+; SOFT-NEXT:    ldr r2, [sp] @ 4-byte Reload
 ; SOFT-NEXT:    sbcs r2, r1
 ; SOFT-NEXT:    blt .LBB54_1
 ; SOFT-NEXT:  @ %bb.13: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
+; SOFT-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
 ; SOFT-NEXT:    b .LBB54_1
-; SOFT-NEXT:  .LBB54_14: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r0, .LCPI54_0
-; SOFT-NEXT:    ldr r2, [sp, #4] @ 4-byte Reload
-; SOFT-NEXT:    blt .LBB54_4
-; SOFT-NEXT:  .LBB54_15: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r2, [sp, #16] @ 4-byte Reload
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    beq .LBB54_5
-; SOFT-NEXT:    b .LBB54_6
-; SOFT-NEXT:  .LBB54_16: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    ldr r2, [sp, #16] @ 4-byte Reload
-; SOFT-NEXT:    cmp r2, #0
-; SOFT-NEXT:    bne .LBB54_10
-; SOFT-NEXT:  .LBB54_17: @ in Loop: Header=BB54_2 Depth=1
-; SOFT-NEXT:    mov r1, r2
-; SOFT-NEXT:    beq .LBB54_11
-; SOFT-NEXT:    b .LBB54_12
-; SOFT-NEXT:  .LBB54_18:
-; SOFT-NEXT:    add sp, #20
+; SOFT-NEXT:  .LBB54_14:
+; SOFT-NEXT:    add sp, #12
 ; SOFT-NEXT:    pop {r4, r5, r6, r7, pc}
 ; SOFT-NEXT:    .p2align 2
-; SOFT-NEXT:  @ %bb.19:
+; SOFT-NEXT:  @ %bb.15:
 ; SOFT-NEXT:  .LCPI54_0:
 ; SOFT-NEXT:    .long 2147483647 @ 0x7fffffff
 ;

--- a/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
@@ -27,18 +27,14 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mvn r12, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d8[1], r1
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    adr r4, .LCPI0_1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vdup.32 d19, r5
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r2:128]
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    vdup.32 d18, r0
@@ -49,15 +45,11 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    rsbs r0, r0, #-2147483648
 ; CHECK-NEXT:    sbcs r0, r12, r1
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r12, r5
 ; CHECK-NEXT:    vdup.32 d21, r0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d20, r2
 ; CHECK-NEXT:    vbif q8, q9, q10
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -107,16 +99,12 @@ define <2 x i32> @utest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    vmov.32 d9[1], r5
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlo r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d8[1], r1
-; CHECK-NEXT:    movwlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnlo r2, #0
 ; CHECK-NEXT:    vdup.32 d17, r5
-; CHECK-NEXT:    mvnne r2, #0
 ; CHECK-NEXT:    vdup.32 d16, r2
 ; CHECK-NEXT:    vand q9, q4, q8
 ; CHECK-NEXT:    vorn q8, q9, q8
@@ -154,17 +142,13 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d8[1], r1
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vdup.32 d17, r5
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d16, r0
 ; CHECK-NEXT:    vbsl q8, q4, q9
 ; CHECK-NEXT:    vmov r0, r1, d17
@@ -172,15 +156,11 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    rsbs r0, r0, #0
 ; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #0
 ; CHECK-NEXT:    rscs r1, r5, #0
 ; CHECK-NEXT:    vdup.32 d19, r0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d18, r2
 ; CHECK-NEXT:    vand q8, q9, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -205,100 +185,91 @@ define <4 x i32> @stest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    sub sp, sp, #4
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    .pad #8
+; CHECK-NEXT:    sub sp, sp, #8
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, s19
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    adr r1, .LCPI3_0
-; CHECK-NEXT:    vld1.64 {d10, d11}, [r1:128]
-; CHECK-NEXT:    vmov r5, s17
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    mvn r9, #-2147483648
-; CHECK-NEXT:    vmov.32 d13[0], r6
+; CHECK-NEXT:    mov r6, r1
+; CHECK-NEXT:    vmov.32 d13[0], r5
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r6, r9
-; CHECK-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEXT:    sbcs r2, r7, #0
+; CHECK-NEXT:    adr r3, .LCPI3_0
+; CHECK-NEXT:    mvn r4, #-2147483648
+; CHECK-NEXT:    vld1.64 {d10, d11}, [r3:128]
+; CHECK-NEXT:    subs r3, r5, r4
+; CHECK-NEXT:    mov r2, r0
+; CHECK-NEXT:    sbcs r3, r6, #0
+; CHECK-NEXT:    vmov.32 d12[0], r2
+; CHECK-NEXT:    mov r3, #0
+; CHECK-NEXT:    mvnlt r3, #0
+; CHECK-NEXT:    subs r2, r2, r4
+; CHECK-NEXT:    vmov.32 d13[1], r6
+; CHECK-NEXT:    vmov r0, s17
 ; CHECK-NEXT:    vmov r8, s16
+; CHECK-NEXT:    mov r7, #0
+; CHECK-NEXT:    vmov.32 d12[1], r1
+; CHECK-NEXT:    sbcs r1, r1, #0
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    vdup.32 d17, r3
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    vdup.32 d16, r1
+; CHECK-NEXT:    vorr q4, q8, q8
+; CHECK-NEXT:    vbsl q4, q6, q5
+; CHECK-NEXT:    vmov r10, r1, d9
+; CHECK-NEXT:    vmov r9, r11, d8
+; CHECK-NEXT:    str r1, [sp, #4] @ 4-byte Spill
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    vmov.32 d13[0], r0
+; CHECK-NEXT:    mov r0, r8
+; CHECK-NEXT:    mov r6, r1
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    subs r2, r5, r4
+; CHECK-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d13[1], r7
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r0, r9
+; CHECK-NEXT:    vmov.32 d13[1], r6
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    subs r0, r0, r4
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vdup.32 d17, r2
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    rsbs r3, r9, #-2147483648
 ; CHECK-NEXT:    vdup.32 d16, r0
-; CHECK-NEXT:    mov r0, r5
-; CHECK-NEXT:    vorr q4, q8, q8
-; CHECK-NEXT:    vbsl q4, q6, q5
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEXT:    subs r0, r0, r9
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mov r0, r8
-; CHECK-NEXT:    vmov r11, r10, d8
-; CHECK-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    vmov r5, r7, d9
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEXT:    subs r0, r0, r9
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vdup.32 d17, r6
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEXT:    adr r1, .LCPI3_1
-; CHECK-NEXT:    rsbs r3, r11, #-2147483648
-; CHECK-NEXT:    vdup.32 d16, r0
-; CHECK-NEXT:    mvn r0, #0
+; CHECK-NEXT:    adr r0, .LCPI3_1
 ; CHECK-NEXT:    vbsl q8, q6, q5
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-NEXT:    sbcs r3, r0, r10
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
+; CHECK-NEXT:    mvn r2, #0
+; CHECK-NEXT:    sbcs r3, r2, r11
 ; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    vmov r1, r2, d17
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
-; CHECK-NEXT:    rsbs r6, r5, #-2147483648
+; CHECK-NEXT:    ldr r4, [sp, #4] @ 4-byte Reload
+; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    mvnlt r3, #0
+; CHECK-NEXT:    rsbs r6, r10, #-2147483648
 ; CHECK-NEXT:    vmov r6, r5, d16
-; CHECK-NEXT:    sbcs r7, r0, r7
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mvnne r7, #0
-; CHECK-NEXT:    vdup.32 d23, r7
+; CHECK-NEXT:    sbcs r4, r2, r4
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    vdup.32 d23, r4
 ; CHECK-NEXT:    vdup.32 d22, r3
 ; CHECK-NEXT:    vbsl q11, q4, q9
 ; CHECK-NEXT:    vmovn.i64 d1, q11
-; CHECK-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-NEXT:    sbcs r1, r0, r2
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    rsbs r2, r6, #-2147483648
-; CHECK-NEXT:    sbcs r0, r0, r5
-; CHECK-NEXT:    vdup.32 d21, r1
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d20, r4
+; CHECK-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-NEXT:    sbcs r0, r2, r1
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    rsbs r1, r6, #-2147483648
+; CHECK-NEXT:    vdup.32 d21, r0
+; CHECK-NEXT:    sbcs r0, r2, r5
+; CHECK-NEXT:    mvnlt r7, #0
+; CHECK-NEXT:    vdup.32 d20, r7
 ; CHECK-NEXT:    vbif q8, q9, q10
 ; CHECK-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEXT:    add sp, sp, #8
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    add sp, sp, #4
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -327,72 +298,67 @@ entry:
 define <4 x i32> @utest_f32i32(<4 x float> %x) {
 ; CHECK-LABEL: utest_f32i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, sp, #4
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    mov r8, r0
-; CHECK-NEXT:    vmov r0, s16
-; CHECK-NEXT:    mov r9, r1
-; CHECK-NEXT:    vmov r4, s17
-; CHECK-NEXT:    vmov r6, s18
-; CHECK-NEXT:    vmov.32 d9[0], r8
+; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r10, r0
-; CHECK-NEXT:    vmov.32 d10[0], r0
-; CHECK-NEXT:    mov r0, r4
-; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    mov r8, r1
+; CHECK-NEXT:    vmov r7, s17
+; CHECK-NEXT:    vmov r9, s16
+; CHECK-NEXT:    vmov.32 d8[0], r10
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    mov r0, r7
+; CHECK-NEXT:    mov r11, r1
+; CHECK-NEXT:    bl __aeabi_f2ulz
+; CHECK-NEXT:    mov r7, r0
 ; CHECK-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEXT:    mov r0, r6
+; CHECK-NEXT:    mov r0, r9
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mvn r3, #0
-; CHECK-NEXT:    subs r0, r0, r3
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d9[1], r9
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlo r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vmov.32 d8[1], r1
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r8, r3
-; CHECK-NEXT:    sbcs r1, r9, #0
-; CHECK-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlo r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r6, r4, r3
-; CHECK-NEXT:    sbcs r6, r5, #0
-; CHECK-NEXT:    vdup.32 d19, r1
+; CHECK-NEXT:    subs r6, r10, r3
+; CHECK-NEXT:    sbcs r6, r8, #0
+; CHECK-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    vdup.32 d18, r0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    subs r3, r10, r3
-; CHECK-NEXT:    sbcs r3, r7, #0
-; CHECK-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEXT:    movwlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    vdup.32 d17, r6
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlo r6, #0
+; CHECK-NEXT:    subs r4, r4, r3
+; CHECK-NEXT:    sbcs r4, r11, #0
+; CHECK-NEXT:    vmov.32 d9[1], r11
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    mvnlo r4, #0
+; CHECK-NEXT:    subs r7, r7, r3
+; CHECK-NEXT:    sbcs r7, r5, #0
+; CHECK-NEXT:    vmov.32 d11[1], r5
+; CHECK-NEXT:    mov r7, #0
+; CHECK-NEXT:    mvnlo r7, #0
+; CHECK-NEXT:    subs r0, r0, r3
+; CHECK-NEXT:    vdup.32 d19, r4
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    vmov.32 d8[1], r8
+; CHECK-NEXT:    mvnlo r2, #0
+; CHECK-NEXT:    vdup.32 d17, r7
+; CHECK-NEXT:    vdup.32 d18, r6
+; CHECK-NEXT:    vmov.32 d10[1], r1
 ; CHECK-NEXT:    vand q10, q4, q9
 ; CHECK-NEXT:    vdup.32 d16, r2
-; CHECK-NEXT:    vand q11, q5, q8
 ; CHECK-NEXT:    vorn q9, q10, q9
+; CHECK-NEXT:    vand q11, q5, q8
 ; CHECK-NEXT:    vorn q8, q11, q8
 ; CHECK-NEXT:    vmovn.i64 d1, q9
 ; CHECK-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEXT:    add sp, sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 entry:
   %conv = fptoui <4 x float> %x to <4 x i64>
   %0 = icmp ult <4 x i64> %conv, <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>
@@ -409,96 +375,79 @@ define <4 x i32> @ustest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r2, r0
-; CHECK-NEXT:    vmov r0, s17
-; CHECK-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEXT:    mvn r4, #0
-; CHECK-NEXT:    subs r2, r2, r4
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    vmov r0, s18
+; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    vmov r5, s17
 ; CHECK-NEXT:    vmov r8, s16
-; CHECK-NEXT:    vmov.32 d16[0], r5
-; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    vmov.32 d17[1], r1
-; CHECK-NEXT:    sbcs r1, r1, #0
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r5, r4
-; CHECK-NEXT:    sbcs r2, r6, #0
-; CHECK-NEXT:    vdup.32 d19, r1
+; CHECK-NEXT:    vmov.32 d9[0], r6
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    mvn r9, #0
+; CHECK-NEXT:    subs r2, r6, r9
+; CHECK-NEXT:    sbcs r2, r7, #0
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d16[1], r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d18, r2
-; CHECK-NEXT:    vorr q4, q9, q9
-; CHECK-NEXT:    vbsl q4, q8, q5
-; CHECK-NEXT:    vmov r10, r9, d8
+; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    subs r0, r0, r9
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    vmov.32 d9[1], r7
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d17, r2
+; CHECK-NEXT:    vdup.32 d16, r0
+; CHECK-NEXT:    mov r0, r5
+; CHECK-NEXT:    vbif q4, q5, q8
+; CHECK-NEXT:    vmov r7, r10, d8
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    vmov.32 d13[0], r0
 ; CHECK-NEXT:    mov r0, r8
 ; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r5, r4
+; CHECK-NEXT:    subs r2, r5, r9
 ; CHECK-NEXT:    vmov.32 d12[0], r0
 ; CHECK-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    vmov.32 d13[1], r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r0, r4
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    subs r0, r0, r9
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d12[1], r1
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d17, r2
 ; CHECK-NEXT:    vdup.32 d16, r0
 ; CHECK-NEXT:    vmov r0, r1, d9
 ; CHECK-NEXT:    vbsl q8, q6, q5
-; CHECK-NEXT:    rsbs r6, r10, #0
-; CHECK-NEXT:    rscs r6, r9, #0
-; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    rsbs r7, r7, #0
+; CHECK-NEXT:    rscs r5, r10, #0
+; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    vmov r2, r3, d17
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    vmov r5, r4, d16
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vmov r7, r6, d16
 ; CHECK-NEXT:    rsbs r0, r0, #0
 ; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    rsbs r1, r2, #0
-; CHECK-NEXT:    rscs r1, r3, #0
 ; CHECK-NEXT:    vdup.32 d21, r0
+; CHECK-NEXT:    rscs r1, r3, #0
+; CHECK-NEXT:    vdup.32 d20, r5
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    vdup.32 d20, r6
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    rsbs r2, r5, #0
-; CHECK-NEXT:    rscs r2, r4, #0
-; CHECK-NEXT:    vdup.32 d19, r1
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mvnne r7, #0
 ; CHECK-NEXT:    vand q10, q10, q4
-; CHECK-NEXT:    vdup.32 d18, r7
-; CHECK-NEXT:    vand q8, q9, q8
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    rsbs r2, r7, #0
+; CHECK-NEXT:    vdup.32 d19, r1
+; CHECK-NEXT:    rscs r1, r6, #0
+; CHECK-NEXT:    mvnlt r4, #0
 ; CHECK-NEXT:    vmovn.i64 d1, q10
+; CHECK-NEXT:    vdup.32 d18, r4
+; CHECK-NEXT:    vand q8, q9, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
@@ -519,108 +468,100 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEON-NEXT:    .pad #4
 ; CHECK-NEON-NEXT:    sub sp, sp, #4
-; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEON-NEXT:    .pad #8
+; CHECK-NEON-NEXT:    sub sp, sp, #8
 ; CHECK-NEON-NEXT:    vmov r0, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r6, r0
+; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    mov r5, r1
+; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s18
+; CHECK-NEON-NEXT:    mov r2, r0
+; CHECK-NEON-NEXT:    mvn r4, #-2147483648
+; CHECK-NEON-NEXT:    vmov.32 d17[0], r2
+; CHECK-NEON-NEXT:    subs r2, r2, r4
 ; CHECK-NEON-NEXT:    adr r3, .LCPI6_0
-; CHECK-NEON-NEXT:    vld1.64 {d8, d9}, [r3:128]
-; CHECK-NEON-NEXT:    mvn r9, #-2147483648
-; CHECK-NEON-NEXT:    subs r3, r6, r9
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    sbcs r3, r5, #0
-; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    mvnne r4, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d14[0], r6
-; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vmov.32 d16[0], r5
 ; CHECK-NEON-NEXT:    vmov r8, s20
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d15[1], r1
 ; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    vdup.32 d11, r0
-; CHECK-NEON-NEXT:    vmov.32 d14[1], r5
-; CHECK-NEON-NEXT:    mov r0, r2
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vdup.32 d10, r4
-; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    vbsl q5, q7, q4
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    mov r0, r8
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    vmov r11, r10, d10
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    vmov r5, r4, d11
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r6
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEON-NEXT:    adr r1, .LCPI6_1
-; CHECK-NEON-NEXT:    rsbs r3, r11, #-2147483648
-; CHECK-NEON-NEXT:    vdup.32 d16, r0
-; CHECK-NEON-NEXT:    mvn r0, #0
-; CHECK-NEON-NEXT:    vbsl q8, q6, q4
-; CHECK-NEON-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-NEON-NEXT:    sbcs r3, r0, r10
-; CHECK-NEON-NEXT:    mov r3, #0
-; CHECK-NEON-NEXT:    vmov r1, r2, d17
-; CHECK-NEON-NEXT:    movwlt r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    mvnne r3, #0
-; CHECK-NEON-NEXT:    rsbs r6, r5, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r6, r0, r4
-; CHECK-NEON-NEXT:    vmov r5, r4, d16
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d23, r6
-; CHECK-NEON-NEXT:    vdup.32 d22, r3
-; CHECK-NEON-NEXT:    vbsl q11, q5, q9
-; CHECK-NEON-NEXT:    vmovn.i64 d1, q11
-; CHECK-NEON-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r0, r2
+; CHECK-NEON-NEXT:    vmov.32 d17[1], r1
+; CHECK-NEON-NEXT:    sbcs r1, r1, #0
 ; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    rsbs r2, r5, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r0, r4
-; CHECK-NEON-NEXT:    vdup.32 d21, r1
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    mvnne r7, #0
+; CHECK-NEON-NEXT:    mvnlt r1, #0
+; CHECK-NEON-NEXT:    subs r2, r5, r4
+; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    sbcs r2, r6, #0
+; CHECK-NEON-NEXT:    mov r1, #0
+; CHECK-NEON-NEXT:    vld1.64 {d10, d11}, [r3:128]
+; CHECK-NEON-NEXT:    mvnlt r1, #0
+; CHECK-NEON-NEXT:    vdup.32 d18, r1
+; CHECK-NEON-NEXT:    vmov.32 d16[1], r6
+; CHECK-NEON-NEXT:    vorr q4, q9, q9
+; CHECK-NEON-NEXT:    vbsl q4, q8, q5
+; CHECK-NEON-NEXT:    vmov r11, r1, d9
+; CHECK-NEON-NEXT:    vmov r9, r10, d8
+; CHECK-NEON-NEXT:    str r1, [sp, #4] @ 4-byte Spill
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2lz
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
+; CHECK-NEON-NEXT:    mov r0, r8
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2lz
+; CHECK-NEON-NEXT:    subs r2, r5, r4
+; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    sbcs r2, r6, #0
+; CHECK-NEON-NEXT:    mov r2, #0
+; CHECK-NEON-NEXT:    vmov.32 d13[1], r6
+; CHECK-NEON-NEXT:    mvnlt r2, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r4
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vdup.32 d17, r2
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    vmov.32 d12[1], r1
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    rsbs r3, r9, #-2147483648
+; CHECK-NEON-NEXT:    vdup.32 d16, r0
+; CHECK-NEON-NEXT:    adr r0, .LCPI6_1
+; CHECK-NEON-NEXT:    vbsl q8, q6, q5
+; CHECK-NEON-NEXT:    vld1.64 {d18, d19}, [r0:128]
+; CHECK-NEON-NEXT:    mvn r2, #0
+; CHECK-NEON-NEXT:    sbcs r3, r2, r10
+; CHECK-NEON-NEXT:    mov r3, #0
+; CHECK-NEON-NEXT:    ldr r4, [sp, #4] @ 4-byte Reload
+; CHECK-NEON-NEXT:    vmov r0, r1, d17
+; CHECK-NEON-NEXT:    mvnlt r3, #0
+; CHECK-NEON-NEXT:    rsbs r6, r11, #-2147483648
+; CHECK-NEON-NEXT:    vmov r6, r5, d16
+; CHECK-NEON-NEXT:    sbcs r4, r2, r4
+; CHECK-NEON-NEXT:    mov r4, #0
+; CHECK-NEON-NEXT:    mvnlt r4, #0
+; CHECK-NEON-NEXT:    vdup.32 d23, r4
+; CHECK-NEON-NEXT:    vdup.32 d22, r3
+; CHECK-NEON-NEXT:    vbsl q11, q4, q9
+; CHECK-NEON-NEXT:    vmovn.i64 d1, q11
+; CHECK-NEON-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r2, r1
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    rsbs r1, r6, #-2147483648
+; CHECK-NEON-NEXT:    vdup.32 d21, r0
+; CHECK-NEON-NEXT:    sbcs r0, r2, r5
+; CHECK-NEON-NEXT:    mvnlt r7, #0
 ; CHECK-NEON-NEXT:    vdup.32 d20, r7
 ; CHECK-NEON-NEXT:    vbif q8, q9, q10
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
-; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    add sp, sp, #8
+; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    add sp, sp, #4
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ; CHECK-NEON-NEXT:    .p2align 4
@@ -638,107 +579,96 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ;
 ; CHECK-FP16-LABEL: stest_f16i32:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-FP16-NEXT:    .pad #4
+; CHECK-FP16-NEXT:    sub sp, sp, #4
 ; CHECK-FP16-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r8, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r9, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r8, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d8[2]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d9[0], r4
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    adr r2, .LCPI6_0
-; CHECK-FP16-NEXT:    mvn r10, #-2147483648
-; CHECK-FP16-NEXT:    vld1.64 {d10, d11}, [r2:128]
-; CHECK-FP16-NEXT:    subs r2, r4, r10
+; CHECK-FP16-NEXT:    mvn r7, #-2147483648
+; CHECK-FP16-NEXT:    vld1.64 {d12, d13}, [r2:128]
+; CHECK-FP16-NEXT:    subs r2, r4, r7
 ; CHECK-FP16-NEXT:    sbcs r2, r5, #0
-; CHECK-FP16-NEXT:    vmov s0, r9
+; CHECK-FP16-NEXT:    vmov s0, r8
 ; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    vmov.32 d8[0], r0
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
+; CHECK-FP16-NEXT:    mvnlt r2, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r5
 ; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
+; CHECK-FP16-NEXT:    mvnlt r0, #0
 ; CHECK-FP16-NEXT:    vdup.32 d17, r2
 ; CHECK-FP16-NEXT:    vdup.32 d16, r0
-; CHECK-FP16-NEXT:    vbif q4, q5, q8
+; CHECK-FP16-NEXT:    vbif q5, q6, q8
+; CHECK-FP16-NEXT:    vmov r9, r8, d11
+; CHECK-FP16-NEXT:    vmov r11, r10, d10
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
-; CHECK-FP16-NEXT:    vmov s0, r8
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    vmov r9, r8, d8
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r1
-; CHECK-FP16-NEXT:    vmov r5, r4, d9
-; CHECK-FP16-NEXT:    mvnne r7, #0
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    vmov.32 d9[0], r4
+; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    subs r2, r4, r7
+; CHECK-FP16-NEXT:    vmov.32 d8[0], r0
+; CHECK-FP16-NEXT:    sbcs r2, r5, #0
+; CHECK-FP16-NEXT:    mov r2, #0
+; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
+; CHECK-FP16-NEXT:    mvnlt r2, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vdup.32 d17, r2
 ; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r7
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r1
-; CHECK-FP16-NEXT:    adr r1, .LCPI6_1
-; CHECK-FP16-NEXT:    rsbs r3, r9, #-2147483648
+; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    rsbs r3, r11, #-2147483648
 ; CHECK-FP16-NEXT:    vdup.32 d16, r0
-; CHECK-FP16-NEXT:    mvn r0, #0
-; CHECK-FP16-NEXT:    vbsl q8, q6, q5
-; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-FP16-NEXT:    sbcs r3, r0, r8
+; CHECK-FP16-NEXT:    adr r0, .LCPI6_1
+; CHECK-FP16-NEXT:    vbsl q8, q4, q6
+; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r0:128]
+; CHECK-FP16-NEXT:    mvn r2, #0
+; CHECK-FP16-NEXT:    sbcs r3, r2, r10
 ; CHECK-FP16-NEXT:    mov r3, #0
-; CHECK-FP16-NEXT:    vmov r1, r2, d17
-; CHECK-FP16-NEXT:    movwlt r3, #1
-; CHECK-FP16-NEXT:    cmp r3, #0
-; CHECK-FP16-NEXT:    mvnne r3, #0
-; CHECK-FP16-NEXT:    rsbs r7, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r7, r0, r4
-; CHECK-FP16-NEXT:    vmov r5, r4, d16
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d23, r7
+; CHECK-FP16-NEXT:    vmov r0, r1, d17
+; CHECK-FP16-NEXT:    mvnlt r3, #0
+; CHECK-FP16-NEXT:    rsbs r7, r9, #-2147483648
+; CHECK-FP16-NEXT:    vmov r7, r5, d16
+; CHECK-FP16-NEXT:    sbcs r4, r2, r8
+; CHECK-FP16-NEXT:    mov r4, #0
+; CHECK-FP16-NEXT:    mvnlt r4, #0
+; CHECK-FP16-NEXT:    vdup.32 d23, r4
 ; CHECK-FP16-NEXT:    vdup.32 d22, r3
-; CHECK-FP16-NEXT:    vbsl q11, q4, q9
+; CHECK-FP16-NEXT:    vbsl q11, q5, q9
 ; CHECK-FP16-NEXT:    vmovn.i64 d1, q11
-; CHECK-FP16-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r0, r2
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    rsbs r2, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r0, r4
-; CHECK-FP16-NEXT:    vdup.32 d21, r1
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    mvnne r6, #0
+; CHECK-FP16-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r2, r1
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    rsbs r1, r7, #-2147483648
+; CHECK-FP16-NEXT:    vdup.32 d21, r0
+; CHECK-FP16-NEXT:    sbcs r0, r2, r5
+; CHECK-FP16-NEXT:    mvnlt r6, #0
 ; CHECK-FP16-NEXT:    vdup.32 d20, r6
 ; CHECK-FP16-NEXT:    vbif q8, q9, q10
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
 ; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-FP16-NEXT:    add sp, sp, #4
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ; CHECK-FP16-NEXT:    .p2align 4
 ; CHECK-FP16-NEXT:  @ %bb.1:
 ; CHECK-FP16-NEXT:  .LCPI6_0:
@@ -764,151 +694,135 @@ entry:
 define <4 x i32> @utest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i32:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEON-NEXT:    .pad #4
+; CHECK-NEON-NEXT:    sub sp, sp, #4
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r8, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
-; CHECK-NEON-NEXT:    mov r9, r1
+; CHECK-NEON-NEXT:    mov r9, r0
+; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    vmov r4, s18
-; CHECK-NEON-NEXT:    vmov r6, s16
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r8
+; CHECK-NEON-NEXT:    mov r8, r1
+; CHECK-NEON-NEXT:    vmov r10, s20
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r10, r0
-; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r4
-; CHECK-NEON-NEXT:    mov r7, r1
+; CHECK-NEON-NEXT:    mov r11, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEON-NEXT:    mov r0, r6
+; CHECK-NEON-NEXT:    mov r0, r10
 ; CHECK-NEON-NEXT:    mov r5, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    mvn r3, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r3
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r9
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlo r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d8[1], r1
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    subs r1, r8, r3
-; CHECK-NEON-NEXT:    sbcs r1, r9, #0
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlo r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r6, r4, r3
-; CHECK-NEON-NEXT:    sbcs r6, r5, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    subs r6, r9, r3
+; CHECK-NEON-NEXT:    sbcs r6, r8, #0
+; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    subs r3, r10, r3
-; CHECK-NEON-NEXT:    sbcs r3, r7, #0
-; CHECK-NEON-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEON-NEXT:    movwlo r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r6
-; CHECK-NEON-NEXT:    mvnne r2, #0
+; CHECK-NEON-NEXT:    mov r2, #0
+; CHECK-NEON-NEXT:    mvnlo r6, #0
+; CHECK-NEON-NEXT:    subs r7, r7, r3
+; CHECK-NEON-NEXT:    sbcs r7, r11, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r5
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    mvnlo r7, #0
+; CHECK-NEON-NEXT:    subs r4, r4, r3
+; CHECK-NEON-NEXT:    sbcs r5, r5, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r11
+; CHECK-NEON-NEXT:    mov r5, #0
+; CHECK-NEON-NEXT:    mvnlo r5, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r3
+; CHECK-NEON-NEXT:    vdup.32 d19, r7
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r8
+; CHECK-NEON-NEXT:    mvnlo r2, #0
+; CHECK-NEON-NEXT:    vdup.32 d17, r5
+; CHECK-NEON-NEXT:    vdup.32 d18, r6
+; CHECK-NEON-NEXT:    vmov.32 d10[1], r1
 ; CHECK-NEON-NEXT:    vand q10, q4, q9
 ; CHECK-NEON-NEXT:    vdup.32 d16, r2
-; CHECK-NEON-NEXT:    vand q11, q5, q8
 ; CHECK-NEON-NEXT:    vorn q9, q10, q9
+; CHECK-NEON-NEXT:    vand q11, q5, q8
 ; CHECK-NEON-NEXT:    vorn q8, q11, q8
 ; CHECK-NEON-NEXT:    vmovn.i64 d1, q9
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEON-NEXT:    add sp, sp, #4
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i32:
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
-; CHECK-FP16-NEXT:    .vsave {d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    .vsave {d8}
-; CHECK-FP16-NEXT:    vpush {d8}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
+; CHECK-FP16-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-FP16-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[2]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
 ; CHECK-FP16-NEXT:    vmov.u16 r4, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r6, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
-; CHECK-FP16-NEXT:    mov r7, r1
-; CHECK-FP16-NEXT:    vmov.32 d11[0], r6
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-FP16-NEXT:    mov r8, r1
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r6
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    vmov s0, r4
-; CHECK-FP16-NEXT:    mov r8, r0
+; CHECK-FP16-NEXT:    mov r7, r0
 ; CHECK-FP16-NEXT:    mov r9, r1
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[2]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r4
+; CHECK-FP16-NEXT:    vmov.32 d9[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
 ; CHECK-FP16-NEXT:    mvn r3, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r3
+; CHECK-FP16-NEXT:    subs r6, r6, r3
+; CHECK-FP16-NEXT:    sbcs r6, r8, #0
+; CHECK-FP16-NEXT:    vmov.32 d8[0], r0
+; CHECK-FP16-NEXT:    mov r6, #0
 ; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r7
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlo r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    subs r1, r6, r3
-; CHECK-FP16-NEXT:    sbcs r1, r7, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r5
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movwlo r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    subs r7, r4, r3
-; CHECK-FP16-NEXT:    sbcs r7, r5, #0
-; CHECK-FP16-NEXT:    vdup.32 d19, r1
+; CHECK-FP16-NEXT:    mvnlo r6, #0
+; CHECK-FP16-NEXT:    subs r7, r7, r3
+; CHECK-FP16-NEXT:    sbcs r7, r9, #0
+; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
 ; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d18, r0
-; CHECK-FP16-NEXT:    movwlo r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    subs r3, r8, r3
-; CHECK-FP16-NEXT:    sbcs r3, r9, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r9
-; CHECK-FP16-NEXT:    movwlo r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r7
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    mvnlo r7, #0
+; CHECK-FP16-NEXT:    subs r4, r4, r3
+; CHECK-FP16-NEXT:    sbcs r5, r5, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r9
+; CHECK-FP16-NEXT:    mov r5, #0
+; CHECK-FP16-NEXT:    mvnlo r5, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r3
+; CHECK-FP16-NEXT:    vdup.32 d19, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r8
+; CHECK-FP16-NEXT:    mvnlo r2, #0
+; CHECK-FP16-NEXT:    vdup.32 d17, r5
+; CHECK-FP16-NEXT:    vdup.32 d18, r6
+; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
 ; CHECK-FP16-NEXT:    vand q10, q5, q9
 ; CHECK-FP16-NEXT:    vdup.32 d16, r2
-; CHECK-FP16-NEXT:    vand q11, q6, q8
 ; CHECK-FP16-NEXT:    vorn q9, q10, q9
+; CHECK-FP16-NEXT:    vand q11, q4, q8
 ; CHECK-FP16-NEXT:    vorn q8, q11, q8
 ; CHECK-FP16-NEXT:    vmovn.i64 d1, q9
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
-; CHECK-FP16-NEXT:    vpop {d8}
-; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
+; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
   %conv = fptoui <4 x half> %x to <4 x i64>
@@ -925,103 +839,86 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmov.f32 s16, s3
+; CHECK-NEON-NEXT:    vmov r0, s3
+; CHECK-NEON-NEXT:    vmov.f32 s16, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    vmov r5, s18
+; CHECK-NEON-NEXT:    mov r7, r1
+; CHECK-NEON-NEXT:    vmov r8, s20
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r6
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r2, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
-; CHECK-NEON-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEON-NEXT:    mvn r8, #0
-; CHECK-NEON-NEXT:    subs r2, r2, r8
-; CHECK-NEON-NEXT:    vmov r4, s20
-; CHECK-NEON-NEXT:    vmov.32 d16[0], r5
-; CHECK-NEON-NEXT:    vmov.i64 q5, #0xffffffff
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    vmov.32 d17[1], r1
-; CHECK-NEON-NEXT:    sbcs r1, r1, #0
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r2, r5, r8
-; CHECK-NEON-NEXT:    sbcs r2, r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    mvn r9, #0
+; CHECK-NEON-NEXT:    subs r2, r6, r9
+; CHECK-NEON-NEXT:    sbcs r2, r7, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    vmov.32 d16[1], r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r2
-; CHECK-NEON-NEXT:    vorr q4, q9, q9
-; CHECK-NEON-NEXT:    vbsl q4, q8, q5
-; CHECK-NEON-NEXT:    vmov r10, r9, d8
+; CHECK-NEON-NEXT:    vmov.i64 q5, #0xffffffff
+; CHECK-NEON-NEXT:    mvnlt r2, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r9
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r7
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mov r4, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    vdup.32 d17, r2
+; CHECK-NEON-NEXT:    vdup.32 d16, r0
+; CHECK-NEON-NEXT:    mov r0, r5
+; CHECK-NEON-NEXT:    vbif q4, q5, q8
+; CHECK-NEON-NEXT:    vmov r7, r10, d8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    mov r0, r4
+; CHECK-NEON-NEXT:    mov r0, r8
 ; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r5, r8
+; CHECK-NEON-NEXT:    subs r2, r5, r9
 ; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
 ; CHECK-NEON-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEON-NEXT:    mov r2, #0
 ; CHECK-NEON-NEXT:    vmov.32 d13[1], r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r8
+; CHECK-NEON-NEXT:    mvnlt r2, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r9
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEON-NEXT:    vmov.32 d12[1], r1
 ; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
 ; CHECK-NEON-NEXT:    vdup.32 d17, r2
 ; CHECK-NEON-NEXT:    vdup.32 d16, r0
 ; CHECK-NEON-NEXT:    vmov r0, r1, d9
 ; CHECK-NEON-NEXT:    vbsl q8, q6, q5
-; CHECK-NEON-NEXT:    rsbs r6, r10, #0
-; CHECK-NEON-NEXT:    rscs r6, r9, #0
-; CHECK-NEON-NEXT:    mov r6, #0
+; CHECK-NEON-NEXT:    rsbs r7, r7, #0
+; CHECK-NEON-NEXT:    rscs r5, r10, #0
+; CHECK-NEON-NEXT:    mov r5, #0
 ; CHECK-NEON-NEXT:    vmov r2, r3, d17
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    vmov r5, r4, d16
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
+; CHECK-NEON-NEXT:    mvnlt r5, #0
+; CHECK-NEON-NEXT:    vmov r7, r6, d16
 ; CHECK-NEON-NEXT:    rsbs r0, r0, #0
 ; CHECK-NEON-NEXT:    rscs r0, r1, #0
 ; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
 ; CHECK-NEON-NEXT:    rsbs r1, r2, #0
-; CHECK-NEON-NEXT:    rscs r1, r3, #0
 ; CHECK-NEON-NEXT:    vdup.32 d21, r0
+; CHECK-NEON-NEXT:    rscs r1, r3, #0
+; CHECK-NEON-NEXT:    vdup.32 d20, r5
 ; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    vdup.32 d20, r6
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    rsbs r2, r5, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    mvnne r7, #0
 ; CHECK-NEON-NEXT:    vand q10, q10, q4
-; CHECK-NEON-NEXT:    vdup.32 d18, r7
-; CHECK-NEON-NEXT:    vand q8, q9, q8
+; CHECK-NEON-NEXT:    mvnlt r1, #0
+; CHECK-NEON-NEXT:    rsbs r2, r7, #0
+; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    rscs r1, r6, #0
+; CHECK-NEON-NEXT:    mvnlt r4, #0
 ; CHECK-NEON-NEXT:    vmovn.i64 d1, q10
+; CHECK-NEON-NEXT:    vdup.32 d18, r4
+; CHECK-NEON-NEXT:    vand q8, q9, q8
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
@@ -1049,18 +946,14 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
 ; CHECK-FP16-NEXT:    mov r2, #0
 ; CHECK-FP16-NEXT:    vmov.i64 q6, #0xffffffff
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    mvnlt r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
 ; CHECK-FP16-NEXT:    vmov.32 d11[1], r5
 ; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    vmov s0, r8
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
 ; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
 ; CHECK-FP16-NEXT:    vdup.32 d17, r2
 ; CHECK-FP16-NEXT:    vdup.32 d16, r0
@@ -1078,52 +971,40 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    sbcs r2, r5, #0
 ; CHECK-FP16-NEXT:    mov r2, #0
 ; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    mvnlt r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
 ; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
 ; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
 ; CHECK-FP16-NEXT:    vdup.32 d17, r2
 ; CHECK-FP16-NEXT:    vdup.32 d16, r0
 ; CHECK-FP16-NEXT:    vmov r0, r1, d11
 ; CHECK-FP16-NEXT:    vbsl q8, q4, q6
 ; CHECK-FP16-NEXT:    rsbs r7, r9, #0
-; CHECK-FP16-NEXT:    rscs r7, r8, #0
-; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    rscs r4, r8, #0
+; CHECK-FP16-NEXT:    mov r4, #0
 ; CHECK-FP16-NEXT:    vmov r2, r3, d17
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    vmov r5, r4, d16
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
+; CHECK-FP16-NEXT:    mvnlt r4, #0
+; CHECK-FP16-NEXT:    vmov r7, r5, d16
 ; CHECK-FP16-NEXT:    rsbs r0, r0, #0
 ; CHECK-FP16-NEXT:    rscs r0, r1, #0
 ; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
 ; CHECK-FP16-NEXT:    rsbs r1, r2, #0
-; CHECK-FP16-NEXT:    rscs r1, r3, #0
 ; CHECK-FP16-NEXT:    vdup.32 d21, r0
+; CHECK-FP16-NEXT:    rscs r1, r3, #0
+; CHECK-FP16-NEXT:    vdup.32 d20, r4
 ; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    vdup.32 d20, r7
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    rsbs r2, r5, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #0
-; CHECK-FP16-NEXT:    vdup.32 d19, r1
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    mvnne r6, #0
 ; CHECK-FP16-NEXT:    vand q10, q10, q5
+; CHECK-FP16-NEXT:    mvnlt r1, #0
+; CHECK-FP16-NEXT:    rsbs r2, r7, #0
+; CHECK-FP16-NEXT:    vdup.32 d19, r1
+; CHECK-FP16-NEXT:    rscs r1, r5, #0
+; CHECK-FP16-NEXT:    mvnlt r6, #0
+; CHECK-FP16-NEXT:    vmovn.i64 d1, q10
 ; CHECK-FP16-NEXT:    vdup.32 d18, r6
 ; CHECK-FP16-NEXT:    vand q8, q9, q8
-; CHECK-FP16-NEXT:    vmovn.i64 d1, q10
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
 ; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
@@ -1648,56 +1529,46 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d8, d8
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r6
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1720,27 +1591,23 @@ define <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixunsdfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    vorr d0, d8, d8
-; CHECK-NEXT:    sbcs r1, r3, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d1[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1761,50 +1628,40 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #1
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movge r2, r8
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    moveq r4, r1
-; CHECK-NEXT:    movne r1, r0
-; CHECK-NEXT:    rsbs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r4, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r7, #1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r7
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    rscs r0, r4, #0
 ; CHECK-NEXT:    rscs r0, r2, #0
-; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    moveq r4, r7
-; CHECK-NEXT:    movne r7, r1
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    movlt r8, r2
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    moveq r3, r2
-; CHECK-NEXT:    moveq r1, r2
-; CHECK-NEXT:    movne r2, r0
-; CHECK-NEXT:    rsbs r0, r2, #0
-; CHECK-NEXT:    rscs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r8, #0
-; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r2, r5
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r2
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movlt r7, r2
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    rsbs r2, r0, #0
+; CHECK-NEXT:    rscs r2, r1, #0
+; CHECK-NEXT:    rscs r2, r7, #0
+; CHECK-NEXT:    rscs r2, r3, #0
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -1827,56 +1684,46 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    vmov.f32 s0, s16
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r6
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1900,26 +1747,22 @@ define <2 x i64> @utest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    vmov.f32 s0, s16
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d1[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1940,50 +1783,40 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #1
-; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmov.f32 s0, s16
-; CHECK-NEXT:    movge r2, r8
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    moveq r4, r1
-; CHECK-NEXT:    movne r1, r0
-; CHECK-NEXT:    rsbs r0, r1, #0
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r7, #1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r7
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEXT:    rscs r0, r4, #0
-; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    rscs r0, r2, #0
 ; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    moveq r4, r7
-; CHECK-NEXT:    movne r7, r1
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    movlt r8, r2
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    moveq r3, r2
-; CHECK-NEXT:    moveq r1, r2
-; CHECK-NEXT:    movne r2, r0
-; CHECK-NEXT:    rsbs r0, r2, #0
-; CHECK-NEXT:    rscs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r8, #0
-; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r2, r5
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r2
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movlt r7, r2
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    rsbs r2, r0, #0
+; CHECK-NEXT:    rscs r2, r1, #0
+; CHECK-NEXT:    rscs r2, r7, #0
+; CHECK-NEXT:    rscs r2, r3, #0
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -2011,56 +1844,46 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mvn r10, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r10
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r1, r7
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    mvn r9, #0
-; CHECK-NEON-NEXT:    subs r1, r0, r9
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r4, r6
+; CHECK-NEON-NEXT:    sbcs r0, r2, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r8
-; CHECK-NEON-NEXT:    sbcs r1, r2, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r5, r10
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    mov r8, #-2147483648
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    movne r1, r2
-; CHECK-NEON-NEXT:    moveq r4, r6
-; CHECK-NEON-NEXT:    moveq r0, r9
-; CHECK-NEON-NEXT:    rsbs r2, r0, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r1
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r8
+; CHECK-NEON-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r10, r2
+; CHECK-NEON-NEXT:    sbcs r0, r10, r3
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r9
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r7, r0, r9
+; CHECK-NEON-NEXT:    subs r6, r0, r10
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
-; CHECK-NEON-NEXT:    sbcs r7, r1, r6
-; CHECK-NEON-NEXT:    sbcs r7, r2, #0
-; CHECK-NEON-NEXT:    sbcs r7, r3, #0
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r3, r7
-; CHECK-NEON-NEXT:    movne r7, r2
-; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    moveq r0, r9
+; CHECK-NEON-NEXT:    sbcs r6, r1, r7
+; CHECK-NEON-NEXT:    sbcs r6, r2, #0
+; CHECK-NEON-NEXT:    sbcs r6, r3, #0
+; CHECK-NEON-NEXT:    movlt r7, r1
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r0, r10
 ; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r7
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
-; CHECK-NEON-NEXT:    movne r10, r0
-; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEON-NEXT:    rscs r1, r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r10, r2
+; CHECK-NEON-NEXT:    sbcs r1, r10, r3
+; CHECK-NEON-NEXT:    movge r0, r9
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -2069,59 +1892,49 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r9, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    mvn r10, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    mvn r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r1, r6
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    subs r1, r0, r9
-; CHECK-FP16-NEXT:    mvn r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r4, r5
-; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    sbcs r1, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #-2147483648
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    mov r10, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    movne r1, r2
-; CHECK-FP16-NEXT:    moveq r4, r5
-; CHECK-FP16-NEXT:    moveq r0, r9
-; CHECK-FP16-NEXT:    rsbs r2, r0, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r1
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
-; CHECK-FP16-NEXT:    moveq r4, r8
+; CHECK-FP16-NEXT:    sbcs r0, r2, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    vmov s0, r9
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r5, r10
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    mov r9, #-2147483648
+; CHECK-FP16-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r10, r2
+; CHECK-FP16-NEXT:    sbcs r0, r10, r3
+; CHECK-FP16-NEXT:    movge r4, r9
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
-; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
-; CHECK-FP16-NEXT:    sbcs r6, r1, r5
-; CHECK-FP16-NEXT:    sbcs r6, r2, #0
-; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r3, r6
-; CHECK-FP16-NEXT:    movne r6, r2
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    moveq r0, r9
+; CHECK-FP16-NEXT:    subs r7, r0, r10
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    sbcs r7, r1, r6
+; CHECK-FP16-NEXT:    sbcs r7, r2, #0
+; CHECK-FP16-NEXT:    sbcs r7, r3, #0
+; CHECK-FP16-NEXT:    movlt r6, r1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r0, r10
 ; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r6
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r10, #1
-; CHECK-FP16-NEXT:    cmp r10, #0
-; CHECK-FP16-NEXT:    movne r10, r0
-; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r10
+; CHECK-FP16-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r10, r2
+; CHECK-FP16-NEXT:    sbcs r1, r10, r3
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r6, r9
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r6
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2136,72 +1949,64 @@ entry:
 define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i64:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
 ; CHECK-NEON-NEXT:    vmov r0, s0
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
-; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    vmov s0, r5
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlo r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r4, r5
-; CHECK-NEON-NEXT:    movne r5, r0
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r4
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movhs r6, r7
+; CHECK-NEON-NEXT:    movhs r5, r7
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    moveq r0, r6
-; CHECK-NEON-NEXT:    movne r6, r1
+; CHECK-NEON-NEXT:    movhs r0, r7
+; CHECK-NEON-NEXT:    movhs r1, r7
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i64:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
 ; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
-; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
 ; CHECK-FP16-NEXT:    vmov s0, r6
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlo r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r4, r6
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movhs r5, r7
+; CHECK-FP16-NEXT:    movhs r4, r7
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r4
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlo r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r0, r5
-; CHECK-FP16-NEXT:    movne r5, r1
+; CHECK-FP16-NEXT:    movhs r0, r7
+; CHECK-FP16-NEXT:    movhs r1, r7
 ; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r1
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -2220,55 +2025,45 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    vmov r0, s0
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r6
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r8, #1
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movge r2, r8
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    moveq r4, r1
-; CHECK-NEON-NEXT:    movne r1, r0
-; CHECK-NEON-NEXT:    rsbs r0, r1, #0
+; CHECK-NEON-NEXT:    mov r8, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    mov r6, #1
+; CHECK-NEON-NEXT:    movge r3, r8
+; CHECK-NEON-NEXT:    movge r2, r6
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r8
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    rscs r0, r4, #0
-; CHECK-NEON-NEXT:    vmov s0, r5
 ; CHECK-NEON-NEXT:    rscs r0, r2, #0
-; CHECK-NEON-NEXT:    mov r7, #0
 ; CHECK-NEON-NEXT:    rscs r0, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r4, r7
-; CHECK-NEON-NEXT:    movne r7, r1
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r8
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r6, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEON-NEXT:    sbcs r6, r3, #0
-; CHECK-NEON-NEXT:    movlt r8, r2
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    moveq r3, r2
-; CHECK-NEON-NEXT:    moveq r1, r2
-; CHECK-NEON-NEXT:    movne r2, r0
-; CHECK-NEON-NEXT:    rsbs r0, r2, #0
-; CHECK-NEON-NEXT:    rscs r0, r1, #0
-; CHECK-NEON-NEXT:    rscs r0, r8, #0
-; CHECK-NEON-NEXT:    rscs r0, r3, #0
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r2, r5
-; CHECK-NEON-NEXT:    movne r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r2
+; CHECK-NEON-NEXT:    subs r7, r2, #1
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    sbcs r7, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r8
+; CHECK-NEON-NEXT:    movlt r6, r2
+; CHECK-NEON-NEXT:    movge r1, r8
+; CHECK-NEON-NEXT:    movge r0, r8
+; CHECK-NEON-NEXT:    rsbs r2, r0, #0
+; CHECK-NEON-NEXT:    rscs r2, r1, #0
+; CHECK-NEON-NEXT:    rscs r2, r6, #0
+; CHECK-NEON-NEXT:    rscs r2, r3, #0
+; CHECK-NEON-NEXT:    movge r0, r8
+; CHECK-NEON-NEXT:    movge r1, r8
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 ;
@@ -2277,53 +2072,43 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
+; CHECK-FP16-NEXT:    vmov s0, r7
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #1
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movge r2, r8
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    moveq r4, r1
-; CHECK-FP16-NEXT:    movne r1, r0
-; CHECK-FP16-NEXT:    rsbs r0, r1, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    mov r7, #1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r7
+; CHECK-FP16-NEXT:    movge r4, r8
+; CHECK-FP16-NEXT:    movge r5, r8
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
 ; CHECK-FP16-NEXT:    rscs r0, r4, #0
-; CHECK-FP16-NEXT:    vmov s0, r5
 ; CHECK-FP16-NEXT:    rscs r0, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
 ; CHECK-FP16-NEXT:    rscs r0, r3, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    moveq r4, r7
-; CHECK-FP16-NEXT:    movne r7, r1
+; CHECK-FP16-NEXT:    movge r4, r8
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r6, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
 ; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    movlt r8, r2
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    moveq r3, r2
-; CHECK-FP16-NEXT:    moveq r1, r2
-; CHECK-FP16-NEXT:    movne r2, r0
-; CHECK-FP16-NEXT:    rsbs r0, r2, #0
-; CHECK-FP16-NEXT:    rscs r0, r1, #0
-; CHECK-FP16-NEXT:    rscs r0, r8, #0
-; CHECK-FP16-NEXT:    rscs r0, r3, #0
-; CHECK-FP16-NEXT:    movwlt r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r2, r5
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r2
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movlt r7, r2
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    rsbs r2, r0, #0
+; CHECK-FP16-NEXT:    rscs r2, r1, #0
+; CHECK-FP16-NEXT:    rscs r2, r7, #0
+; CHECK-FP16-NEXT:    rscs r2, r3, #0
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r1
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2350,34 +2135,29 @@ define <2 x i32> @stest_f64i32_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    mov r8, r1
-; CHECK-NEXT:    vmov r0, r1, d9
-; CHECK-NEXT:    mvn r6, #-2147483648
-; CHECK-NEXT:    subs r2, r4, r6
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    sbcs r2, r8, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    movge r4, r6
-; CHECK-NEXT:    movwlt r5, #1
+; CHECK-NEXT:    vmov r0, r2, d9
+; CHECK-NEXT:    mvn r5, #-2147483648
+; CHECK-NEXT:    subs r3, r4, r5
+; CHECK-NEXT:    sbcs r3, r1, #0
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r3, r4, #-2147483648
+; CHECK-NEXT:    mvn r7, #0
+; CHECK-NEXT:    sbcs r1, r7, r1
+; CHECK-NEXT:    mov r8, #-2147483648
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    mov r1, r2
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mov r0, #-2147483648
-; CHECK-NEXT:    movne r7, r1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r8
-; CHECK-NEXT:    rsbs r2, r4, #-2147483648
-; CHECK-NEXT:    mvn r1, #0
-; CHECK-NEXT:    sbcs r2, r1, r5
-; CHECK-NEXT:    movge r4, r0
-; CHECK-NEXT:    rsbs r2, r6, #-2147483648
+; CHECK-NEXT:    subs r2, r0, r5
 ; CHECK-NEXT:    vmov.32 d0[0], r4
-; CHECK-NEXT:    sbcs r1, r1, r7
-; CHECK-NEXT:    movge r6, r0
-; CHECK-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #-2147483648
+; CHECK-NEXT:    sbcs r0, r7, r6
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -2429,38 +2209,27 @@ define <2 x i32> @ustest_f64i32_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    vmov r2, r12, d9
-; CHECK-NEXT:    mvn r4, #0
-; CHECK-NEXT:    subs r5, r0, r4
-; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    sbcs r5, r1, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r0, r2, d9
+; CHECK-NEXT:    mvn r5, #0
+; CHECK-NEXT:    subs r3, r4, r5
+; CHECK-NEXT:    sbcs r3, r1, #0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movge r0, r4
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movne r3, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    movne r6, r0
-; CHECK-NEXT:    mov r0, r2
-; CHECK-NEXT:    mov r1, r12
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r3, r4, #0
+; CHECK-NEXT:    rscs r1, r1, #0
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    mov r1, r2
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    subs r2, r0, r4
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    subs r2, r0, r5
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r4, r0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    movne r0, r1
-; CHECK-NEXT:    rsbs r1, r4, #0
-; CHECK-NEXT:    rscs r0, r0, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r4
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    movge r5, r6
 ; CHECK-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
@@ -2475,81 +2244,61 @@ entry:
 define <4 x i32> @stest_f32i32_mm(<4 x float> %x) {
 ; CHECK-LABEL: stest_f32i32_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, sp, #4
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
 ; CHECK-NEXT:    vorr q4, q0, q0
+; CHECK-NEXT:    mov r8, #-2147483648
+; CHECK-NEXT:    mvn r9, #0
+; CHECK-NEXT:    mov r10, #0
 ; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r5, s16
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s18
-; CHECK-NEXT:    mov r11, r0
-; CHECK-NEXT:    vmov r0, s17
-; CHECK-NEXT:    mvn r6, #-2147483648
-; CHECK-NEXT:    mov r3, #-2147483648
-; CHECK-NEXT:    mvn r10, #0
-; CHECK-NEXT:    vmov r7, s16
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-NEXT:    subs r2, r11, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r11, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r11, #-2147483648
-; CHECK-NEXT:    sbcs r1, r10, r2
-; CHECK-NEXT:    movge r11, r3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    mvn r7, #-2147483648
+; CHECK-NEXT:    subs r0, r0, r7
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r4, r7
+; CHECK-NEXT:    rsbs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r9, r1
+; CHECK-NEXT:    mov r0, r5
+; CHECK-NEXT:    movge r4, r8
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    subs r0, r0, r6
+; CHECK-NEXT:    subs r0, r0, r7
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r9, #0
-; CHECK-NEXT:    mov r0, r7
-; CHECK-NEXT:    movge r5, r6
-; CHECK-NEXT:    movwlt r9, #1
-; CHECK-NEXT:    cmp r9, #0
-; CHECK-NEXT:    movne r9, r1
+; CHECK-NEXT:    vmov r0, s18
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r5, r7
+; CHECK-NEXT:    rsbs r2, r5, #-2147483648
+; CHECK-NEXT:    sbcs r1, r9, r1
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r7, r0
-; CHECK-NEXT:    subs r0, r0, r6
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    subs r0, r0, r7
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r8, #0
-; CHECK-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; CHECK-NEXT:    movge r7, r6
-; CHECK-NEXT:    movwlt r8, #1
-; CHECK-NEXT:    cmp r8, #0
-; CHECK-NEXT:    movne r8, r1
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    movne r4, r1
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r6, r7
 ; CHECK-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-NEXT:    sbcs r0, r10, r4
-; CHECK-NEXT:    mov r1, #-2147483648
-; CHECK-NEXT:    movge r6, r1
-; CHECK-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-NEXT:    sbcs r0, r10, r8
+; CHECK-NEXT:    sbcs r0, r9, r1
+; CHECK-NEXT:    vmov r0, s17
+; CHECK-NEXT:    movge r6, r8
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    subs r2, r0, r7
 ; CHECK-NEXT:    vmov.32 d1[0], r6
-; CHECK-NEXT:    movge r7, r1
-; CHECK-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEXT:    sbcs r0, r10, r9
-; CHECK-NEXT:    movge r5, r1
-; CHECK-NEXT:    vmov.32 d1[1], r11
-; CHECK-NEXT:    vmov.32 d0[1], r5
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    movlt r10, r1
+; CHECK-NEXT:    movlt r7, r0
+; CHECK-NEXT:    rsbs r0, r7, #-2147483648
+; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    sbcs r0, r9, r10
+; CHECK-NEXT:    vmov.32 d1[1], r4
+; CHECK-NEXT:    movge r7, r8
+; CHECK-NEXT:    vmov.32 d0[1], r7
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    add sp, sp, #4
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <4 x float> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
@@ -2607,81 +2356,60 @@ entry:
 define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-LABEL: ustest_f32i32_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, s19
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s16
-; CHECK-NEXT:    mvn r6, #0
-; CHECK-NEXT:    subs r3, r0, r6
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    sbcs r3, r1, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r0, s16
+; CHECK-NEXT:    mvn r5, #0
+; CHECK-NEXT:    subs r2, r4, r5
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    mov r9, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r2, r4, #0
+; CHECK-NEXT:    vmov r7, s18
+; CHECK-NEXT:    rscs r1, r1, #0
 ; CHECK-NEXT:    vmov r8, s17
-; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    movne r3, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    vmov r9, s18
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    movne r4, r0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    mov r0, r2
+; CHECK-NEXT:    movge r4, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r2, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r0
-; CHECK-NEXT:    mov r0, r9
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r6, r5
+; CHECK-NEXT:    rsbs r0, r6, #0
+; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    mov r0, r7
+; CHECK-NEXT:    movge r6, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r2, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
+; CHECK-NEXT:    mov r7, r0
+; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r7, r5
+; CHECK-NEXT:    rsbs r0, r7, #0
+; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, r8
+; CHECK-NEXT:    movge r7, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
+; CHECK-NEXT:    subs r2, r0, r5
 ; CHECK-NEXT:    vmov.32 d1[0], r7
 ; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    movne r0, r1
-; CHECK-NEXT:    rsbs r1, r6, #0
-; CHECK-NEXT:    rscs r0, r0, #0
-; CHECK-NEXT:    vmov.32 d0[0], r5
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    movne r10, r6
-; CHECK-NEXT:    vmov.32 d0[1], r10
+; CHECK-NEXT:    movge r5, r9
+; CHECK-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
   %conv = fptosi <4 x float> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>)
@@ -2693,164 +2421,128 @@ entry:
 define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-LABEL: stest_f16i32_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    .pad #4
-; CHECK-NEON-NEXT:    sub sp, sp, #4
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
-; CHECK-NEON-NEXT:    .pad #8
-; CHECK-NEON-NEXT:    sub sp, sp, #8
 ; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
-; CHECK-NEON-NEXT:    vmov.f32 s18, s1
+; CHECK-NEON-NEXT:    vmov.f32 s18, s2
+; CHECK-NEON-NEXT:    vmov.f32 s16, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s16
-; CHECK-NEON-NEXT:    mov r11, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    mov r3, #-2147483648
-; CHECK-NEON-NEXT:    mvn r10, #0
-; CHECK-NEON-NEXT:    vmov r7, s20
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-NEON-NEXT:    subs r2, r11, r6
+; CHECK-NEON-NEXT:    mov r4, r0
+; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    subs r2, r4, r7
 ; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r11, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r11, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r10, r2
-; CHECK-NEON-NEXT:    movge r11, r3
+; CHECK-NEON-NEXT:    mov r10, #0
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    rsbs r2, r4, #-2147483648
+; CHECK-NEON-NEXT:    mvn r9, #0
+; CHECK-NEON-NEXT:    mov r8, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r9, r1
+; CHECK-NEON-NEXT:    movge r4, r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    subs r0, r0, r6
+; CHECK-NEON-NEXT:    subs r0, r0, r7
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r8, #0
-; CHECK-NEON-NEXT:    mov r0, r7
-; CHECK-NEON-NEXT:    movge r5, r6
-; CHECK-NEON-NEXT:    movwlt r8, #1
-; CHECK-NEON-NEXT:    cmp r8, #0
-; CHECK-NEON-NEXT:    movne r8, r1
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r5, r7
+; CHECK-NEON-NEXT:    rsbs r2, r5, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r9, r1
+; CHECK-NEON-NEXT:    movge r5, r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r7, r0
-; CHECK-NEON-NEXT:    subs r0, r0, r6
+; CHECK-NEON-NEXT:    mov r6, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r7
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r9, #0
-; CHECK-NEON-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; CHECK-NEON-NEXT:    movge r7, r6
-; CHECK-NEON-NEXT:    movwlt r9, #1
-; CHECK-NEON-NEXT:    cmp r9, #0
-; CHECK-NEON-NEXT:    movne r9, r1
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    movlt r6, r0
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    movne r4, r1
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r6, r7
 ; CHECK-NEON-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r10, r4
-; CHECK-NEON-NEXT:    mov r1, #-2147483648
-; CHECK-NEON-NEXT:    movge r6, r1
-; CHECK-NEON-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r10, r9
+; CHECK-NEON-NEXT:    sbcs r0, r9, r1
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    movge r6, r8
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2lz
+; CHECK-NEON-NEXT:    subs r2, r0, r7
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r6
-; CHECK-NEON-NEXT:    movge r7, r1
-; CHECK-NEON-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEON-NEXT:    sbcs r0, r10, r8
-; CHECK-NEON-NEXT:    movge r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r11
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r5
-; CHECK-NEON-NEXT:    add sp, sp, #8
+; CHECK-NEON-NEXT:    sbcs r2, r1, #0
+; CHECK-NEON-NEXT:    movlt r10, r1
+; CHECK-NEON-NEXT:    movlt r7, r0
+; CHECK-NEON-NEXT:    rsbs r0, r7, #-2147483648
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEON-NEXT:    sbcs r0, r9, r10
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
-; CHECK-NEON-NEXT:    add sp, sp, #4
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
 ; CHECK-FP16-LABEL: stest_f16i32_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-FP16-NEXT:    .pad #4
-; CHECK-FP16-NEXT:    sub sp, sp, #4
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    .vsave {d8, d9}
 ; CHECK-FP16-NEXT:    vpush {d8, d9}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
-; CHECK-FP16-NEXT:    vmov.u16 r4, d0[2]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
+; CHECK-FP16-NEXT:    vorr d8, d0, d0
+; CHECK-FP16-NEXT:    vmov.u16 r5, d0[2]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    mov r10, r0
+; CHECK-FP16-NEXT:    mov r4, r0
 ; CHECK-FP16-NEXT:    mvn r7, #-2147483648
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    mov r10, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    mov r2, #-2147483648
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movge r10, r7
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    movne r0, r1
-; CHECK-FP16-NEXT:    rsbs r1, r10, #-2147483648
+; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    movge r1, r10
+; CHECK-FP16-NEXT:    movge r4, r7
+; CHECK-FP16-NEXT:    rsbs r0, r4, #-2147483648
 ; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    sbcs r0, r9, r0
-; CHECK-FP16-NEXT:    vmov s16, r4
-; CHECK-FP16-NEXT:    mov r11, #0
+; CHECK-FP16-NEXT:    mov r8, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
 ; CHECK-FP16-NEXT:    vmov s18, r5
-; CHECK-FP16-NEXT:    movge r10, r2
+; CHECK-FP16-NEXT:    movge r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s18
 ; CHECK-FP16-NEXT:    mov r5, r0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    mov r4, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r10
 ; CHECK-FP16-NEXT:    movge r5, r7
-; CHECK-FP16-NEXT:    movwlt r4, #1
-; CHECK-FP16-NEXT:    cmp r4, #0
-; CHECK-FP16-NEXT:    movne r4, r1
+; CHECK-FP16-NEXT:    rsbs r0, r5, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.f32 s0, s16
 ; CHECK-FP16-NEXT:    mov r6, r0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    mov r8, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
+; CHECK-FP16-NEXT:    movge r1, r10
 ; CHECK-FP16-NEXT:    movge r6, r7
-; CHECK-FP16-NEXT:    movwlt r8, #1
-; CHECK-FP16-NEXT:    cmp r8, #0
-; CHECK-FP16-NEXT:    movne r8, r1
+; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    rsbs r0, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
+; CHECK-FP16-NEXT:    movge r6, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    subs r2, r0, r7
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r1, #0
+; CHECK-FP16-NEXT:    movlt r10, r1
 ; CHECK-FP16-NEXT:    movlt r7, r0
-; CHECK-FP16-NEXT:    movwlt r11, #1
-; CHECK-FP16-NEXT:    cmp r11, #0
-; CHECK-FP16-NEXT:    movne r11, r1
 ; CHECK-FP16-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r9, r11
-; CHECK-FP16-NEXT:    mov r1, #-2147483648
-; CHECK-FP16-NEXT:    movge r7, r1
-; CHECK-FP16-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r9, r8
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
-; CHECK-FP16-NEXT:    movge r6, r1
-; CHECK-FP16-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
-; CHECK-FP16-NEXT:    sbcs r0, r9, r4
-; CHECK-FP16-NEXT:    movge r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r10
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
+; CHECK-FP16-NEXT:    sbcs r0, r9, r10
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
+; CHECK-FP16-NEXT:    movge r7, r8
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r7
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
-; CHECK-FP16-NEXT:    add sp, sp, #4
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
@@ -2957,8 +2649,8 @@ entry:
 define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-LABEL: ustest_f16i32_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vmov r0, s3
@@ -2967,77 +2659,56 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s20
-; CHECK-NEON-NEXT:    mvn r6, #0
-; CHECK-NEON-NEXT:    subs r3, r0, r6
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    sbcs r3, r1, #0
+; CHECK-NEON-NEXT:    mov r4, r0
+; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    mvn r5, #0
+; CHECK-NEON-NEXT:    subs r2, r4, r5
+; CHECK-NEON-NEXT:    sbcs r2, r1, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r4, r5
+; CHECK-NEON-NEXT:    rsbs r2, r4, #0
+; CHECK-NEON-NEXT:    vmov r7, s16
+; CHECK-NEON-NEXT:    rscs r1, r1, #0
 ; CHECK-NEON-NEXT:    vmov r8, s18
-; CHECK-NEON-NEXT:    mov r3, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    movne r3, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r3, #0
-; CHECK-NEON-NEXT:    vmov r9, s16
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    movne r4, r0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    mov r0, r2
+; CHECK-NEON-NEXT:    movge r4, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r2, #0
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    mov r0, r9
+; CHECK-NEON-NEXT:    mov r6, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r6, r5
+; CHECK-NEON-NEXT:    rsbs r0, r6, #0
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
+; CHECK-NEON-NEXT:    mov r0, r7
+; CHECK-NEON-NEXT:    movge r6, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r2, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    movne r7, r0
+; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r7, r5
+; CHECK-NEON-NEXT:    rsbs r0, r7, #0
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
 ; CHECK-NEON-NEXT:    mov r0, r8
+; CHECK-NEON-NEXT:    movge r7, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
+; CHECK-NEON-NEXT:    subs r2, r0, r5
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
 ; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    movlt r6, r0
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    movne r0, r1
-; CHECK-NEON-NEXT:    rsbs r1, r6, #0
-; CHECK-NEON-NEXT:    rscs r0, r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movlt r5, r0
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
 ; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    movne r10, r6
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r10
+; CHECK-NEON-NEXT:    movge r5, r9
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 ;
 ; CHECK-FP16-LABEL: ustest_f16i32_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
@@ -3048,75 +2719,55 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
 ; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[2]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.u16 r2, d8[1]
-; CHECK-FP16-NEXT:    mvn r4, #0
-; CHECK-FP16-NEXT:    vmov.u16 r3, d8[2]
-; CHECK-FP16-NEXT:    vmov s0, r5
-; CHECK-FP16-NEXT:    mov r6, #0
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
+; CHECK-FP16-NEXT:    mvn r7, #0
 ; CHECK-FP16-NEXT:    mov r8, #0
-; CHECK-FP16-NEXT:    vmov s16, r2
-; CHECK-FP16-NEXT:    subs r2, r0, r4
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    vmov s18, r3
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    vmov s0, r5
+; CHECK-FP16-NEXT:    vmov s18, r6
+; CHECK-FP16-NEXT:    vmov s16, r0
+; CHECK-FP16-NEXT:    subs r0, r4, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r4, r7
+; CHECK-FP16-NEXT:    rsbs r0, r4, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s18
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r5, r7
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s16
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    movne r5, r0
+; CHECK-FP16-NEXT:    mov r6, r0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r6, r7
+; CHECK-FP16-NEXT:    rsbs r0, r6, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r6, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    subs r2, r0, r7
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    movlt r4, r0
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    movne r0, r1
-; CHECK-FP16-NEXT:    rsbs r1, r4, #0
-; CHECK-FP16-NEXT:    rscs r0, r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
-; CHECK-FP16-NEXT:    movwlt r8, #1
-; CHECK-FP16-NEXT:    cmp r8, #0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r6
-; CHECK-FP16-NEXT:    movne r8, r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r8
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movlt r7, r0
+; CHECK-FP16-NEXT:    rsbs r0, r7, #0
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
+; CHECK-FP16-NEXT:    movge r7, r8
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r7
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -3623,56 +3274,46 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d8, d8
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r6
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3693,27 +3334,23 @@ define <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixunsdfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    vorr d0, d8, d8
-; CHECK-NEXT:    sbcs r1, r3, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d1[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3735,28 +3372,23 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
-; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d8, d8
-; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    moveq r5, r0
-; CHECK-NEXT:    moveq r4, r0
-; CHECK-NEXT:    movne r0, r3
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movge r5, r6
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r3, r6
+; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    movwmi r4, #0
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r2, r2, #1
 ; CHECK-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r1, r6
-; CHECK-NEXT:    moveq r0, r6
-; CHECK-NEXT:    movne r6, r3
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r0, r6
+; CHECK-NEXT:    movlt r6, r3
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
@@ -3783,56 +3415,46 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    vmov.f32 s0, s16
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r6
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3854,26 +3476,22 @@ define <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    vmov.f32 s0, s16
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d1[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3897,26 +3515,21 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    moveq r5, r0
-; CHECK-NEXT:    moveq r4, r0
-; CHECK-NEXT:    movne r0, r3
-; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movge r5, r6
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r3, r6
+; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    movwmi r4, #0
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r2, r2, #1
 ; CHECK-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r1, r6
-; CHECK-NEXT:    moveq r0, r6
-; CHECK-NEXT:    movne r6, r3
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r0, r6
+; CHECK-NEXT:    movlt r6, r3
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
@@ -3948,56 +3561,46 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mvn r10, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r10
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r1, r7
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    mvn r9, #0
-; CHECK-NEON-NEXT:    subs r1, r0, r9
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r4, r6
+; CHECK-NEON-NEXT:    sbcs r0, r2, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r8
-; CHECK-NEON-NEXT:    sbcs r1, r2, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r5, r10
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    mov r8, #-2147483648
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    movne r1, r2
-; CHECK-NEON-NEXT:    moveq r4, r6
-; CHECK-NEON-NEXT:    moveq r0, r9
-; CHECK-NEON-NEXT:    rsbs r2, r0, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r1
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r8
+; CHECK-NEON-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r10, r2
+; CHECK-NEON-NEXT:    sbcs r0, r10, r3
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r9
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r7, r0, r9
+; CHECK-NEON-NEXT:    subs r6, r0, r10
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
-; CHECK-NEON-NEXT:    sbcs r7, r1, r6
-; CHECK-NEON-NEXT:    sbcs r7, r2, #0
-; CHECK-NEON-NEXT:    sbcs r7, r3, #0
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r3, r7
-; CHECK-NEON-NEXT:    movne r7, r2
-; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    moveq r0, r9
+; CHECK-NEON-NEXT:    sbcs r6, r1, r7
+; CHECK-NEON-NEXT:    sbcs r6, r2, #0
+; CHECK-NEON-NEXT:    sbcs r6, r3, #0
+; CHECK-NEON-NEXT:    movlt r7, r1
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r0, r10
 ; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r7
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
-; CHECK-NEON-NEXT:    movne r10, r0
-; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r10
+; CHECK-NEON-NEXT:    rscs r1, r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r10, r2
+; CHECK-NEON-NEXT:    sbcs r1, r10, r3
+; CHECK-NEON-NEXT:    movge r0, r9
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -4006,59 +3609,49 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r9, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    mvn r10, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    mvn r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r1, r6
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    subs r1, r0, r9
-; CHECK-FP16-NEXT:    mvn r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r4, r5
-; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    sbcs r1, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #-2147483648
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    mov r10, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    movne r1, r2
-; CHECK-FP16-NEXT:    moveq r4, r5
-; CHECK-FP16-NEXT:    moveq r0, r9
-; CHECK-FP16-NEXT:    rsbs r2, r0, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r1
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
-; CHECK-FP16-NEXT:    moveq r4, r8
+; CHECK-FP16-NEXT:    sbcs r0, r2, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    vmov s0, r9
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r5, r10
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    mov r9, #-2147483648
+; CHECK-FP16-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r10, r2
+; CHECK-FP16-NEXT:    sbcs r0, r10, r3
+; CHECK-FP16-NEXT:    movge r4, r9
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
-; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
-; CHECK-FP16-NEXT:    sbcs r6, r1, r5
-; CHECK-FP16-NEXT:    sbcs r6, r2, #0
-; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r3, r6
-; CHECK-FP16-NEXT:    movne r6, r2
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    moveq r0, r9
+; CHECK-FP16-NEXT:    subs r7, r0, r10
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    sbcs r7, r1, r6
+; CHECK-FP16-NEXT:    sbcs r7, r2, #0
+; CHECK-FP16-NEXT:    sbcs r7, r3, #0
+; CHECK-FP16-NEXT:    movlt r6, r1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r0, r10
 ; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r6
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r10, #1
-; CHECK-FP16-NEXT:    cmp r10, #0
-; CHECK-FP16-NEXT:    movne r10, r0
-; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r10
+; CHECK-FP16-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r10, r2
+; CHECK-FP16-NEXT:    sbcs r1, r10, r3
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r6, r9
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r6
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -4071,72 +3664,64 @@ entry:
 define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i64_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
 ; CHECK-NEON-NEXT:    vmov r0, s0
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
-; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    vmov s0, r5
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlo r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r4, r5
-; CHECK-NEON-NEXT:    movne r5, r0
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r4
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movhs r6, r7
+; CHECK-NEON-NEXT:    movhs r5, r7
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    moveq r0, r6
-; CHECK-NEON-NEXT:    movne r6, r1
+; CHECK-NEON-NEXT:    movhs r0, r7
+; CHECK-NEON-NEXT:    movhs r1, r7
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i64_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
 ; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
-; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
 ; CHECK-FP16-NEXT:    vmov s0, r6
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlo r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r4, r6
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movhs r5, r7
+; CHECK-FP16-NEXT:    movhs r4, r7
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r4
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlo r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r0, r5
-; CHECK-FP16-NEXT:    movne r5, r1
+; CHECK-FP16-NEXT:    movhs r0, r7
+; CHECK-FP16-NEXT:    movhs r1, r7
 ; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r1
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -4161,28 +3746,23 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    subs r0, r2, #1
-; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r6
-; CHECK-NEON-NEXT:    mov r0, #0
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    moveq r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r0
-; CHECK-NEON-NEXT:    movne r0, r3
-; CHECK-NEON-NEXT:    cmp r0, #0
 ; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movge r5, r7
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r3, r7
+; CHECK-NEON-NEXT:    cmp r3, #0
 ; CHECK-NEON-NEXT:    movwmi r4, #0
 ; CHECK-NEON-NEXT:    movwmi r5, #0
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r1, r7
-; CHECK-NEON-NEXT:    moveq r0, r7
-; CHECK-NEON-NEXT:    movne r7, r3
+; CHECK-NEON-NEXT:    movge r1, r7
+; CHECK-NEON-NEXT:    movge r0, r7
+; CHECK-NEON-NEXT:    movlt r7, r3
 ; CHECK-NEON-NEXT:    cmp r7, #0
 ; CHECK-NEON-NEXT:    movwmi r0, #0
 ; CHECK-NEON-NEXT:    movwmi r1, #0
@@ -4202,28 +3782,23 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r5, r0
 ; CHECK-FP16-NEXT:    subs r0, r2, #1
-; CHECK-FP16-NEXT:    sbcs r0, r3, #0
 ; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    moveq r5, r0
-; CHECK-FP16-NEXT:    moveq r4, r0
-; CHECK-FP16-NEXT:    movne r0, r3
-; CHECK-FP16-NEXT:    cmp r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movge r5, r6
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r3, r6
+; CHECK-FP16-NEXT:    cmp r3, #0
 ; CHECK-FP16-NEXT:    movwmi r4, #0
 ; CHECK-FP16-NEXT:    movwmi r5, #0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
 ; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r1, r6
-; CHECK-FP16-NEXT:    moveq r0, r6
-; CHECK-FP16-NEXT:    movne r6, r3
+; CHECK-FP16-NEXT:    movge r1, r6
+; CHECK-FP16-NEXT:    movge r0, r6
+; CHECK-FP16-NEXT:    movlt r6, r3
 ; CHECK-FP16-NEXT:    cmp r6, #0
 ; CHECK-FP16-NEXT:    movwmi r0, #0
 ; CHECK-FP16-NEXT:    movwmi r1, #0

--- a/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
@@ -27,18 +27,14 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mvn r12, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    adr r4, .LCPI0_1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vdup.32 d18, r5
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r2:128]
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    vdup.32 d19, r0
@@ -49,15 +45,11 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    rsbs r0, r0, #-2147483648
 ; CHECK-NEXT:    sbcs r0, r12, r1
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r12, r5
 ; CHECK-NEXT:    vdup.32 d20, r0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d21, r2
 ; CHECK-NEXT:    vbif q8, q9, q10
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -107,16 +99,12 @@ define <2 x i32> @utest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    vmov.32 d8[1], r5
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlo r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d9[1], r1
-; CHECK-NEXT:    movwlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnlo r2, #0
 ; CHECK-NEXT:    vdup.32 d16, r5
-; CHECK-NEXT:    mvnne r2, #0
 ; CHECK-NEXT:    vdup.32 d17, r2
 ; CHECK-NEXT:    vand q9, q4, q8
 ; CHECK-NEXT:    vorn q8, q9, q8
@@ -154,17 +142,13 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vdup.32 d18, r5
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d19, r0
 ; CHECK-NEXT:    vbit q8, q4, q9
 ; CHECK-NEXT:    vmov r0, r1, d16
@@ -172,15 +156,11 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    rsbs r0, r0, #0
 ; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #0
 ; CHECK-NEXT:    rscs r1, r5, #0
 ; CHECK-NEXT:    vdup.32 d18, r0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d19, r2
 ; CHECK-NEXT:    vand q8, q9, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -206,96 +186,80 @@ define <4 x i32> @stest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r8, r0
+; CHECK-NEXT:    mov r10, r0
 ; CHECK-NEXT:    vmov r0, s17
 ; CHECK-NEXT:    mov r9, r1
 ; CHECK-NEXT:    vmov r4, s16
 ; CHECK-NEXT:    vmov r5, s19
-; CHECK-NEXT:    vmov.32 d10[0], r8
+; CHECK-NEXT:    vmov.32 d10[0], r10
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r7, r0
 ; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mov r0, r4
-; CHECK-NEXT:    mov r10, r1
+; CHECK-NEXT:    mov r8, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    subs r3, r4, r5
-; CHECK-NEXT:    sbcs r3, r6, #0
-; CHECK-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEXT:    mov r3, #0
+; CHECK-NEXT:    mvn r3, #-2147483648
+; CHECK-NEXT:    subs r5, r4, r3
+; CHECK-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEXT:    sbcs r6, r6, #0
+; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    adr r2, .LCPI3_0
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
-; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    subs r5, r10, r3
+; CHECK-NEXT:    sbcs r5, r9, #0
+; CHECK-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d10[1], r9
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vmov.32 d11[1], r1
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r8, r5
-; CHECK-NEXT:    sbcs r1, r9, #0
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r2:128]
-; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r7, r7, r5
-; CHECK-NEXT:    vdup.32 d16, r1
-; CHECK-NEXT:    sbcs r1, r10, #0
+; CHECK-NEXT:    vdup.32 d16, r5
+; CHECK-NEXT:    adr r5, .LCPI3_1
+; CHECK-NEXT:    vmov.32 d11[1], r1
 ; CHECK-NEXT:    vdup.32 d17, r0
-; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    subs r0, r7, r3
 ; CHECK-NEXT:    vbsl q8, q5, q9
-; CHECK-NEXT:    vmov.32 d8[1], r6
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vdup.32 d20, r3
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d9[1], r10
-; CHECK-NEXT:    vmov r3, r12, d17
-; CHECK-NEXT:    mvn r1, #0
-; CHECK-NEXT:    vmov r4, r7, d16
-; CHECK-NEXT:    vdup.32 d21, r0
-; CHECK-NEXT:    adr r0, .LCPI3_1
-; CHECK-NEXT:    vbit q9, q4, q10
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]
-; CHECK-NEXT:    vmov r6, r5, d18
-; CHECK-NEXT:    rsbs r0, r3, #-2147483648
-; CHECK-NEXT:    sbcs r0, r1, r12
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    rsbs r3, r6, #-2147483648
-; CHECK-NEXT:    sbcs r3, r1, r5
-; CHECK-NEXT:    vmov r6, r5, d19
+; CHECK-NEXT:    sbcs r0, r8, #0
 ; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
-; CHECK-NEXT:    rsbs r4, r4, #-2147483648
-; CHECK-NEXT:    sbcs r7, r1, r7
-; CHECK-NEXT:    vdup.32 d24, r3
+; CHECK-NEXT:    vdup.32 d20, r6
+; CHECK-NEXT:    mvnlt r3, #0
+; CHECK-NEXT:    vmov.32 d9[1], r8
+; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    mvn r6, #0
+; CHECK-NEXT:    vdup.32 d21, r3
+; CHECK-NEXT:    vbit q9, q4, q10
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r5:128]
+; CHECK-NEXT:    vmov r5, r4, d16
+; CHECK-NEXT:    vmov r3, r7, d18
+; CHECK-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-NEXT:    sbcs r0, r6, r1
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    rsbs r1, r3, #-2147483648
+; CHECK-NEXT:    vmov r1, r3, d19
+; CHECK-NEXT:    sbcs r7, r6, r7
 ; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mvnne r7, #0
-; CHECK-NEXT:    vdup.32 d22, r7
+; CHECK-NEXT:    mvnlt r7, #0
+; CHECK-NEXT:    rsbs r5, r5, #-2147483648
+; CHECK-NEXT:    sbcs r5, r6, r4
+; CHECK-NEXT:    vdup.32 d24, r7
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d22, r5
 ; CHECK-NEXT:    vdup.32 d23, r0
 ; CHECK-NEXT:    vbif q8, q10, q11
-; CHECK-NEXT:    rsbs r6, r6, #-2147483648
-; CHECK-NEXT:    sbcs r1, r1, r5
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    rsbs r1, r1, #-2147483648
+; CHECK-NEXT:    sbcs r1, r6, r3
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d25, r2
 ; CHECK-NEXT:    vbif q9, q10, q12
 ; CHECK-NEXT:    vmovn.i64 d0, q9
@@ -332,62 +296,54 @@ define <4 x i32> @utest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s16
+; CHECK-NEXT:    vmov r0, s17
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r8, r0
-; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r0, s16
 ; CHECK-NEXT:    mov r9, r1
-; CHECK-NEXT:    vmov r6, s18
-; CHECK-NEXT:    vmov r10, s17
-; CHECK-NEXT:    vmov.32 d8[0], r8
+; CHECK-NEXT:    vmov r7, s18
+; CHECK-NEXT:    vmov r10, s19
+; CHECK-NEXT:    vmov.32 d9[0], r8
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEXT:    mov r0, r6
-; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    mov r0, r7
+; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    mov r7, r0
 ; CHECK-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEXT:    mov r0, r10
-; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    mvn r12, #0
-; CHECK-NEXT:    subs r3, r5, r12
-; CHECK-NEXT:    sbcs r3, r4, #0
-; CHECK-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEXT:    mov r3, #0
+; CHECK-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEXT:    mvn r3, #0
+; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlo r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mvnne r3, #0
-; CHECK-NEXT:    subs r5, r8, r12
-; CHECK-NEXT:    sbcs r5, r9, #0
-; CHECK-NEXT:    vmov.32 d9[0], r0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    mvnne r5, #0
-; CHECK-NEXT:    subs r6, r6, r12
-; CHECK-NEXT:    sbcs r7, r7, #0
-; CHECK-NEXT:    vmov.32 d8[1], r9
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    movwlo r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mvnne r7, #0
-; CHECK-NEXT:    subs r0, r0, r12
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d9[1], r1
-; CHECK-NEXT:    movwlo r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    vdup.32 d18, r5
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vmov.32 d10[1], r4
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlo r0, #0
+; CHECK-NEXT:    subs r5, r5, r3
+; CHECK-NEXT:    vmov.32 d11[1], r1
+; CHECK-NEXT:    sbcs r1, r6, #0
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    mvnlo r1, #0
+; CHECK-NEXT:    subs r7, r7, r3
+; CHECK-NEXT:    sbcs r7, r4, #0
+; CHECK-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEXT:    mov r7, #0
+; CHECK-NEXT:    mvnlo r7, #0
+; CHECK-NEXT:    subs r3, r8, r3
+; CHECK-NEXT:    sbcs r3, r9, #0
+; CHECK-NEXT:    vmov.32 d9[1], r9
+; CHECK-NEXT:    mvnlo r2, #0
+; CHECK-NEXT:    vdup.32 d18, r1
 ; CHECK-NEXT:    vdup.32 d16, r7
 ; CHECK-NEXT:    vdup.32 d19, r2
-; CHECK-NEXT:    vmov.32 d11[1], r4
 ; CHECK-NEXT:    vand q10, q4, q9
-; CHECK-NEXT:    vdup.32 d17, r3
-; CHECK-NEXT:    vorn q9, q10, q9
+; CHECK-NEXT:    vdup.32 d17, r0
 ; CHECK-NEXT:    vand q11, q5, q8
+; CHECK-NEXT:    vorn q9, q10, q9
 ; CHECK-NEXT:    vorn q8, q11, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q9
 ; CHECK-NEXT:    vmovn.i64 d1, q8
@@ -424,18 +380,14 @@ define <4 x i32> @ustest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    subs r0, r0, r9
 ; CHECK-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d8[1], r7
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vmov.32 d9[1], r1
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d16, r2
 ; CHECK-NEXT:    vdup.32 d17, r0
 ; CHECK-NEXT:    mov r0, r5
@@ -452,48 +404,36 @@ define <4 x i32> @ustest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    vmov.32 d12[1], r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    subs r0, r0, r9
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vmov r3, r6, d8
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    vdup.32 d16, r2
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d17, r0
-; CHECK-NEXT:    rsbs r0, r7, #0
-; CHECK-NEXT:    vbsl q8, q6, q5
-; CHECK-NEXT:    rscs r0, r10, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vmov r1, r2, d16
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov r7, r5, d17
-; CHECK-NEXT:    rsbs r1, r1, #0
-; CHECK-NEXT:    rscs r1, r2, #0
+; CHECK-NEXT:    vmov.32 d13[1], r1
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vmov r2, r3, d8
+; CHECK-NEXT:    vdup.32 d17, r0
+; CHECK-NEXT:    rsbs r7, r7, #0
+; CHECK-NEXT:    vbsl q8, q6, q5
+; CHECK-NEXT:    rscs r5, r10, #0
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vmov r0, r1, d16
+; CHECK-NEXT:    vmov r7, r6, d17
+; CHECK-NEXT:    rsbs r0, r0, #0
+; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    rsbs r1, r2, #0
+; CHECK-NEXT:    rscs r1, r3, #0
+; CHECK-NEXT:    vdup.32 d20, r0
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    rsbs r2, r3, #0
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    rsbs r2, r7, #0
 ; CHECK-NEXT:    rscs r2, r6, #0
-; CHECK-NEXT:    vdup.32 d20, r1
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    rsbs r3, r7, #0
-; CHECK-NEXT:    rscs r3, r5, #0
-; CHECK-NEXT:    vdup.32 d18, r2
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vdup.32 d18, r1
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    vdup.32 d19, r5
 ; CHECK-NEXT:    vdup.32 d21, r4
 ; CHECK-NEXT:    vand q9, q9, q4
 ; CHECK-NEXT:    vand q8, q10, q8
@@ -524,18 +464,18 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r8, r0
+; CHECK-NEON-NEXT:    mov r10, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    vmov r4, s20
 ; CHECK-NEON-NEXT:    mov r9, r1
 ; CHECK-NEON-NEXT:    vmov r5, s16
-; CHECK-NEON-NEXT:    vmov.32 d10[0], r8
+; CHECK-NEON-NEXT:    vmov.32 d10[0], r10
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r4
-; CHECK-NEON-NEXT:    mov r10, r1
+; CHECK-NEON-NEXT:    mov r8, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r4, r0
@@ -544,79 +484,63 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mvn r5, #-2147483648
-; CHECK-NEON-NEXT:    subs r3, r4, r5
-; CHECK-NEON-NEXT:    sbcs r3, r6, #0
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEON-NEXT:    mov r3, #0
+; CHECK-NEON-NEXT:    mvn r3, #-2147483648
+; CHECK-NEON-NEXT:    subs r5, r4, r3
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEON-NEXT:    sbcs r6, r6, #0
+; CHECK-NEON-NEXT:    mov r6, #0
 ; CHECK-NEON-NEXT:    adr r2, .LCPI6_0
-; CHECK-NEON-NEXT:    movwlt r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    mvnne r3, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    mvnlt r6, #0
+; CHECK-NEON-NEXT:    subs r5, r10, r3
+; CHECK-NEON-NEXT:    sbcs r5, r9, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    mov r5, #0
+; CHECK-NEON-NEXT:    mvnlt r5, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r3
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
 ; CHECK-NEON-NEXT:    vmov.32 d10[1], r9
 ; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r1
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    subs r1, r8, r5
-; CHECK-NEON-NEXT:    sbcs r1, r9, #0
 ; CHECK-NEON-NEXT:    vld1.64 {d18, d19}, [r2:128]
-; CHECK-NEON-NEXT:    mov r1, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r7, r7, r5
-; CHECK-NEON-NEXT:    vdup.32 d16, r1
-; CHECK-NEON-NEXT:    sbcs r1, r10, #0
+; CHECK-NEON-NEXT:    vdup.32 d16, r5
+; CHECK-NEON-NEXT:    adr r5, .LCPI6_1
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r1
 ; CHECK-NEON-NEXT:    vdup.32 d17, r0
-; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    subs r0, r7, r3
 ; CHECK-NEON-NEXT:    vbsl q8, q5, q9
-; CHECK-NEON-NEXT:    vmov.32 d8[1], r6
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    vdup.32 d20, r3
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r10
-; CHECK-NEON-NEXT:    vmov r3, r12, d17
-; CHECK-NEON-NEXT:    mvn r1, #0
-; CHECK-NEON-NEXT:    vmov r4, r7, d16
-; CHECK-NEON-NEXT:    vdup.32 d21, r0
-; CHECK-NEON-NEXT:    adr r0, .LCPI6_1
-; CHECK-NEON-NEXT:    vbit q9, q4, q10
-; CHECK-NEON-NEXT:    vld1.64 {d20, d21}, [r0:128]
-; CHECK-NEON-NEXT:    vmov r6, r5, d18
-; CHECK-NEON-NEXT:    rsbs r0, r3, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r1, r12
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    rsbs r3, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r3, r1, r5
-; CHECK-NEON-NEXT:    vmov r6, r5, d19
+; CHECK-NEON-NEXT:    sbcs r0, r8, #0
 ; CHECK-NEON-NEXT:    mov r3, #0
-; CHECK-NEON-NEXT:    movwlt r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    mvnne r3, #0
-; CHECK-NEON-NEXT:    rsbs r4, r4, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r7, r1, r7
-; CHECK-NEON-NEXT:    vdup.32 d24, r3
+; CHECK-NEON-NEXT:    vdup.32 d20, r6
+; CHECK-NEON-NEXT:    mvnlt r3, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r8
+; CHECK-NEON-NEXT:    vmov r0, r1, d17
+; CHECK-NEON-NEXT:    mvn r6, #0
+; CHECK-NEON-NEXT:    vdup.32 d21, r3
+; CHECK-NEON-NEXT:    vbit q9, q4, q10
+; CHECK-NEON-NEXT:    vld1.64 {d20, d21}, [r5:128]
+; CHECK-NEON-NEXT:    vmov r5, r4, d16
+; CHECK-NEON-NEXT:    vmov r3, r7, d18
+; CHECK-NEON-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r6, r1
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    rsbs r1, r3, #-2147483648
+; CHECK-NEON-NEXT:    vmov r1, r3, d19
+; CHECK-NEON-NEXT:    sbcs r7, r6, r7
 ; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    mvnne r7, #0
-; CHECK-NEON-NEXT:    vdup.32 d22, r7
+; CHECK-NEON-NEXT:    mvnlt r7, #0
+; CHECK-NEON-NEXT:    rsbs r5, r5, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r5, r6, r4
+; CHECK-NEON-NEXT:    vdup.32 d24, r7
+; CHECK-NEON-NEXT:    mov r5, #0
+; CHECK-NEON-NEXT:    mvnlt r5, #0
+; CHECK-NEON-NEXT:    vdup.32 d22, r5
 ; CHECK-NEON-NEXT:    vdup.32 d23, r0
 ; CHECK-NEON-NEXT:    vbif q8, q10, q11
-; CHECK-NEON-NEXT:    rsbs r6, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r1, r5
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
+; CHECK-NEON-NEXT:    rsbs r1, r1, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r6, r3
+; CHECK-NEON-NEXT:    mvnlt r2, #0
 ; CHECK-NEON-NEXT:    vdup.32 d25, r2
 ; CHECK-NEON-NEXT:    vbif q9, q10, q12
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q9
@@ -638,8 +562,8 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ;
 ; CHECK-FP16-LABEL: stest_f16i32:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-FP16-NEXT:    .vsave {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    .vsave {d8}
@@ -649,15 +573,15 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.u16 r4, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    mov r8, r0
+; CHECK-FP16-NEXT:    mov r7, r0
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
-; CHECK-FP16-NEXT:    mov r9, r1
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r8
+; CHECK-FP16-NEXT:    mov r6, r1
+; CHECK-FP16-NEXT:    vmov.32 d12[0], r7
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    vmov s0, r4
-; CHECK-FP16-NEXT:    mov r7, r0
-; CHECK-FP16-NEXT:    mov r10, r1
+; CHECK-FP16-NEXT:    mov r9, r0
+; CHECK-FP16-NEXT:    mov r8, r1
 ; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
@@ -666,86 +590,70 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.32 d10[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    mvn r6, #-2147483648
-; CHECK-FP16-NEXT:    subs r3, r4, r6
-; CHECK-FP16-NEXT:    sbcs r3, r5, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
-; CHECK-FP16-NEXT:    mov r3, #0
-; CHECK-FP16-NEXT:    adr r2, .LCPI6_0
-; CHECK-FP16-NEXT:    movwlt r3, #1
-; CHECK-FP16-NEXT:    cmp r3, #0
-; CHECK-FP16-NEXT:    mvnne r3, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r6
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r9
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    subs r1, r8, r6
-; CHECK-FP16-NEXT:    sbcs r1, r9, #0
-; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r2:128]
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    subs r7, r7, r6
-; CHECK-FP16-NEXT:    vdup.32 d16, r1
-; CHECK-FP16-NEXT:    sbcs r1, r10, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r0
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    vbsl q8, q6, q9
+; CHECK-FP16-NEXT:    mvn r3, #-2147483648
+; CHECK-FP16-NEXT:    subs r4, r4, r3
 ; CHECK-FP16-NEXT:    vmov.32 d10[1], r5
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d20, r3
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r10
-; CHECK-FP16-NEXT:    vmov r3, r12, d17
-; CHECK-FP16-NEXT:    mvn r1, #0
-; CHECK-FP16-NEXT:    vmov r4, r7, d16
-; CHECK-FP16-NEXT:    vdup.32 d21, r0
-; CHECK-FP16-NEXT:    adr r0, .LCPI6_1
-; CHECK-FP16-NEXT:    vbit q9, q5, q10
-; CHECK-FP16-NEXT:    vld1.64 {d20, d21}, [r0:128]
-; CHECK-FP16-NEXT:    vmov r6, r5, d18
-; CHECK-FP16-NEXT:    rsbs r0, r3, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r1, r12
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    rsbs r3, r6, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r3, r1, r5
-; CHECK-FP16-NEXT:    vmov r6, r5, d19
-; CHECK-FP16-NEXT:    mov r3, #0
-; CHECK-FP16-NEXT:    movwlt r3, #1
-; CHECK-FP16-NEXT:    cmp r3, #0
-; CHECK-FP16-NEXT:    mvnne r3, #0
-; CHECK-FP16-NEXT:    rsbs r4, r4, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r7, r1, r7
-; CHECK-FP16-NEXT:    vdup.32 d24, r3
+; CHECK-FP16-NEXT:    sbcs r5, r5, #0
+; CHECK-FP16-NEXT:    mov r5, #0
+; CHECK-FP16-NEXT:    adr r2, .LCPI6_0
+; CHECK-FP16-NEXT:    mvnlt r5, #0
+; CHECK-FP16-NEXT:    subs r7, r7, r3
+; CHECK-FP16-NEXT:    sbcs r7, r6, #0
+; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
 ; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d22, r7
+; CHECK-FP16-NEXT:    mvnlt r7, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r3
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d12[1], r6
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    mvn r6, #0
+; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r2:128]
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    mov r2, #0
+; CHECK-FP16-NEXT:    vdup.32 d16, r7
+; CHECK-FP16-NEXT:    vmov.32 d13[1], r1
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
+; CHECK-FP16-NEXT:    subs r0, r9, r3
+; CHECK-FP16-NEXT:    vbsl q8, q6, q9
+; CHECK-FP16-NEXT:    sbcs r0, r8, #0
+; CHECK-FP16-NEXT:    mov r3, #0
+; CHECK-FP16-NEXT:    vdup.32 d20, r5
+; CHECK-FP16-NEXT:    mvnlt r3, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r8
+; CHECK-FP16-NEXT:    vmov r0, r1, d17
+; CHECK-FP16-NEXT:    adr r5, .LCPI6_1
+; CHECK-FP16-NEXT:    vdup.32 d21, r3
+; CHECK-FP16-NEXT:    vbit q9, q5, q10
+; CHECK-FP16-NEXT:    vld1.64 {d20, d21}, [r5:128]
+; CHECK-FP16-NEXT:    vmov r5, r4, d16
+; CHECK-FP16-NEXT:    vmov r3, r7, d18
+; CHECK-FP16-NEXT:    rsbs r0, r0, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r6, r1
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    rsbs r1, r3, #-2147483648
+; CHECK-FP16-NEXT:    vmov r1, r3, d19
+; CHECK-FP16-NEXT:    sbcs r7, r6, r7
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    mvnlt r7, #0
+; CHECK-FP16-NEXT:    rsbs r5, r5, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r5, r6, r4
+; CHECK-FP16-NEXT:    vdup.32 d24, r7
+; CHECK-FP16-NEXT:    mov r5, #0
+; CHECK-FP16-NEXT:    mvnlt r5, #0
+; CHECK-FP16-NEXT:    vdup.32 d22, r5
 ; CHECK-FP16-NEXT:    vdup.32 d23, r0
 ; CHECK-FP16-NEXT:    vbif q8, q10, q11
-; CHECK-FP16-NEXT:    rsbs r6, r6, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r1, r5
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    rsbs r1, r1, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r6, r3
+; CHECK-FP16-NEXT:    mvnlt r2, #0
 ; CHECK-FP16-NEXT:    vdup.32 d25, r2
 ; CHECK-FP16-NEXT:    vbif q9, q10, q12
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q9
 ; CHECK-FP16-NEXT:    vmovn.i64 d1, q8
 ; CHECK-FP16-NEXT:    vpop {d8}
 ; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 ; CHECK-FP16-NEXT:    .p2align 4
 ; CHECK-FP16-NEXT:  @ %bb.1:
 ; CHECK-FP16-NEXT:  .LCPI6_0:
@@ -771,154 +679,132 @@ entry:
 define <4 x i32> @utest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i32:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    .pad #4
-; CHECK-NEON-NEXT:    sub sp, sp, #4
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov r0, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s2
-; CHECK-NEON-NEXT:    vmov.f32 s20, s1
+; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEON-NEXT:    mov r8, r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    vmov r6, s18
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    mov r9, r1
-; CHECK-NEON-NEXT:    vmov r10, s20
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r8
+; CHECK-NEON-NEXT:    vmov r4, s18
+; CHECK-NEON-NEXT:    vmov r10, s16
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEON-NEXT:    mov r0, r6
-; CHECK-NEON-NEXT:    mov r4, r1
+; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    mov r0, r4
+; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r11, r0
+; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r10
-; CHECK-NEON-NEXT:    mov r7, r1
+; CHECK-NEON-NEXT:    mov r5, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mvn r6, #0
-; CHECK-NEON-NEXT:    subs r3, r5, r6
-; CHECK-NEON-NEXT:    sbcs r3, r4, #0
-; CHECK-NEON-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEON-NEXT:    mov r3, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    mvn r3, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r3
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movwlo r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    mvnne r3, #0
-; CHECK-NEON-NEXT:    subs r5, r8, r6
-; CHECK-NEON-NEXT:    sbcs r5, r9, #0
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r4
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    movwlo r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    mvnne r5, #0
-; CHECK-NEON-NEXT:    subs r4, r11, r6
-; CHECK-NEON-NEXT:    sbcs r7, r7, #0
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlo r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    mvnne r7, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r6
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d8[1], r9
-; CHECK-NEON-NEXT:    movwlo r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r1
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r5
+; CHECK-NEON-NEXT:    vmov.32 d10[1], r5
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mvnlo r0, #0
+; CHECK-NEON-NEXT:    subs r7, r7, r3
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r1
+; CHECK-NEON-NEXT:    sbcs r1, r6, #0
+; CHECK-NEON-NEXT:    mov r1, #0
+; CHECK-NEON-NEXT:    mvnlo r1, #0
+; CHECK-NEON-NEXT:    subs r7, r4, r3
+; CHECK-NEON-NEXT:    sbcs r7, r5, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    mvnlo r7, #0
+; CHECK-NEON-NEXT:    subs r3, r8, r3
+; CHECK-NEON-NEXT:    sbcs r3, r9, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r9
+; CHECK-NEON-NEXT:    mvnlo r2, #0
+; CHECK-NEON-NEXT:    vdup.32 d18, r1
 ; CHECK-NEON-NEXT:    vdup.32 d16, r7
 ; CHECK-NEON-NEXT:    vdup.32 d19, r2
 ; CHECK-NEON-NEXT:    vand q10, q4, q9
-; CHECK-NEON-NEXT:    vdup.32 d17, r3
+; CHECK-NEON-NEXT:    vdup.32 d17, r0
 ; CHECK-NEON-NEXT:    vand q11, q5, q8
 ; CHECK-NEON-NEXT:    vorn q9, q10, q9
 ; CHECK-NEON-NEXT:    vorn q8, q11, q8
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q9
 ; CHECK-NEON-NEXT:    vmovn.i64 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    add sp, sp, #4
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i32:
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
-; CHECK-FP16-NEXT:    .vsave {d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    .vsave {d8}
-; CHECK-FP16-NEXT:    vpush {d8}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-FP16-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[2]
+; CHECK-FP16-NEXT:    vmov.u16 r4, d0[2]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r8, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
 ; CHECK-FP16-NEXT:    mov r9, r1
-; CHECK-FP16-NEXT:    vmov.32 d10[0], r8
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r8
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    vmov s0, r4
+; CHECK-FP16-NEXT:    mov r7, r0
+; CHECK-FP16-NEXT:    mov r6, r1
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
+; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
-; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    mov r6, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
-; CHECK-FP16-NEXT:    mov r7, r1
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d8[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    mvn r12, #0
-; CHECK-FP16-NEXT:    subs r3, r4, r12
-; CHECK-FP16-NEXT:    sbcs r3, r5, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r7
-; CHECK-FP16-NEXT:    mov r3, #0
+; CHECK-FP16-NEXT:    vmov.32 d9[0], r0
+; CHECK-FP16-NEXT:    mvn r3, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r3
 ; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movwlo r3, #1
-; CHECK-FP16-NEXT:    cmp r3, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r5
-; CHECK-FP16-NEXT:    mvnne r3, #0
-; CHECK-FP16-NEXT:    subs r5, r8, r12
-; CHECK-FP16-NEXT:    sbcs r5, r9, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlo r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    mvnne r5, #0
-; CHECK-FP16-NEXT:    subs r6, r6, r12
-; CHECK-FP16-NEXT:    sbcs r7, r7, #0
-; CHECK-FP16-NEXT:    vmov.32 d10[1], r9
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    movwlo r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r12
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r1
-; CHECK-FP16-NEXT:    movwlo r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    vdup.32 d18, r5
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    vmov.32 d8[1], r5
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    mvnlo r0, #0
+; CHECK-FP16-NEXT:    subs r7, r7, r3
+; CHECK-FP16-NEXT:    vmov.32 d9[1], r1
+; CHECK-FP16-NEXT:    sbcs r1, r6, #0
+; CHECK-FP16-NEXT:    mov r1, #0
+; CHECK-FP16-NEXT:    mvnlo r1, #0
+; CHECK-FP16-NEXT:    subs r7, r4, r3
+; CHECK-FP16-NEXT:    sbcs r7, r5, #0
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r6
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    mvnlo r7, #0
+; CHECK-FP16-NEXT:    subs r3, r8, r3
+; CHECK-FP16-NEXT:    sbcs r3, r9, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r9
+; CHECK-FP16-NEXT:    mvnlo r2, #0
+; CHECK-FP16-NEXT:    vdup.32 d18, r1
 ; CHECK-FP16-NEXT:    vdup.32 d16, r7
 ; CHECK-FP16-NEXT:    vdup.32 d19, r2
 ; CHECK-FP16-NEXT:    vand q10, q5, q9
-; CHECK-FP16-NEXT:    vdup.32 d17, r3
-; CHECK-FP16-NEXT:    vand q11, q6, q8
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
+; CHECK-FP16-NEXT:    vand q11, q4, q8
 ; CHECK-FP16-NEXT:    vorn q9, q10, q9
 ; CHECK-FP16-NEXT:    vorn q8, q11, q8
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q9
 ; CHECK-FP16-NEXT:    vmovn.i64 d1, q8
-; CHECK-FP16-NEXT:    vpop {d8}
-; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
+; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
   %conv = fptoui <4 x half> %x to <4 x i64>
@@ -935,44 +821,39 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    vmov r8, s18
+; CHECK-NEON-NEXT:    mov r7, r1
+; CHECK-NEON-NEXT:    vmov r5, s20
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r6
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r2, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
-; CHECK-NEON-NEXT:    vmov.32 d16[0], r2
-; CHECK-NEON-NEXT:    mvn r4, #0
-; CHECK-NEON-NEXT:    subs r2, r2, r4
-; CHECK-NEON-NEXT:    vmov r8, s18
-; CHECK-NEON-NEXT:    vmov.32 d17[0], r5
-; CHECK-NEON-NEXT:    vmov.i64 q5, #0xffffffff
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    vmov.32 d16[1], r1
-; CHECK-NEON-NEXT:    sbcs r1, r1, #0
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r2, r5, r4
-; CHECK-NEON-NEXT:    sbcs r2, r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r1
+; CHECK-NEON-NEXT:    mvn r9, #0
+; CHECK-NEON-NEXT:    subs r2, r6, r9
+; CHECK-NEON-NEXT:    sbcs r2, r7, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    vmov.32 d17[1], r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r2
-; CHECK-NEON-NEXT:    vorr q4, q9, q9
-; CHECK-NEON-NEXT:    vbsl q4, q8, q5
-; CHECK-NEON-NEXT:    vmov r10, r9, d9
+; CHECK-NEON-NEXT:    vmov.i64 q5, #0xffffffff
+; CHECK-NEON-NEXT:    mvnlt r2, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r9
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r7
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mov r4, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r1
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    vdup.32 d16, r2
+; CHECK-NEON-NEXT:    vdup.32 d17, r0
+; CHECK-NEON-NEXT:    mov r0, r5
+; CHECK-NEON-NEXT:    vbif q4, q5, q8
+; CHECK-NEON-NEXT:    vmov r7, r10, d9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r5, r0
@@ -981,54 +862,42 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r5, r4
+; CHECK-NEON-NEXT:    subs r2, r5, r9
 ; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
 ; CHECK-NEON-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEON-NEXT:    mov r2, #0
 ; CHECK-NEON-NEXT:    vmov.32 d12[1], r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r4
+; CHECK-NEON-NEXT:    mvnlt r2, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r9
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    vmov r3, r6, d8
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
 ; CHECK-NEON-NEXT:    vdup.32 d16, r2
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r0
-; CHECK-NEON-NEXT:    rsbs r0, r10, #0
-; CHECK-NEON-NEXT:    vbsl q8, q6, q5
-; CHECK-NEON-NEXT:    rscs r0, r9, #0
 ; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    vmov r1, r2, d16
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov r5, r4, d17
-; CHECK-NEON-NEXT:    rsbs r1, r1, #0
-; CHECK-NEON-NEXT:    rscs r1, r2, #0
+; CHECK-NEON-NEXT:    vmov.32 d13[1], r1
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    vmov r2, r3, d8
+; CHECK-NEON-NEXT:    vdup.32 d17, r0
+; CHECK-NEON-NEXT:    rsbs r7, r7, #0
+; CHECK-NEON-NEXT:    vbsl q8, q6, q5
+; CHECK-NEON-NEXT:    rscs r5, r10, #0
+; CHECK-NEON-NEXT:    mov r5, #0
+; CHECK-NEON-NEXT:    mvnlt r5, #0
+; CHECK-NEON-NEXT:    vmov r0, r1, d16
+; CHECK-NEON-NEXT:    vmov r7, r6, d17
+; CHECK-NEON-NEXT:    rsbs r0, r0, #0
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    mvnlt r0, #0
+; CHECK-NEON-NEXT:    rsbs r1, r2, #0
+; CHECK-NEON-NEXT:    rscs r1, r3, #0
+; CHECK-NEON-NEXT:    vdup.32 d20, r0
 ; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    rsbs r2, r3, #0
+; CHECK-NEON-NEXT:    mvnlt r1, #0
+; CHECK-NEON-NEXT:    rsbs r2, r7, #0
 ; CHECK-NEON-NEXT:    rscs r2, r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d20, r1
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    rsbs r3, r5, #0
-; CHECK-NEON-NEXT:    rscs r3, r4, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r2
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    mvnne r7, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r0
-; CHECK-NEON-NEXT:    vdup.32 d21, r7
+; CHECK-NEON-NEXT:    vdup.32 d18, r1
+; CHECK-NEON-NEXT:    mvnlt r4, #0
+; CHECK-NEON-NEXT:    vdup.32 d19, r5
+; CHECK-NEON-NEXT:    vdup.32 d21, r4
 ; CHECK-NEON-NEXT:    vand q9, q9, q4
 ; CHECK-NEON-NEXT:    vand q8, q10, q8
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
@@ -1059,18 +928,14 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    mov r2, #0
 ; CHECK-FP16-NEXT:    vmov.i64 q6, #0xffffffff
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    mvnlt r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
 ; CHECK-FP16-NEXT:    vmov.32 d10[1], r5
 ; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    vmov s0, r8
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
 ; CHECK-FP16-NEXT:    vmov.32 d11[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
 ; CHECK-FP16-NEXT:    vdup.32 d16, r2
 ; CHECK-FP16-NEXT:    vdup.32 d17, r0
@@ -1088,48 +953,36 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    sbcs r2, r5, #0
 ; CHECK-FP16-NEXT:    mov r2, #0
 ; CHECK-FP16-NEXT:    vmov.32 d8[1], r5
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    mvnlt r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d9[1], r1
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    vmov r3, r7, d10
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
 ; CHECK-FP16-NEXT:    vdup.32 d16, r2
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r0
-; CHECK-FP16-NEXT:    rsbs r0, r9, #0
-; CHECK-FP16-NEXT:    vbsl q8, q4, q6
-; CHECK-FP16-NEXT:    rscs r0, r8, #0
 ; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov r1, r2, d16
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vmov r5, r4, d17
-; CHECK-FP16-NEXT:    rsbs r1, r1, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
+; CHECK-FP16-NEXT:    vmov.32 d9[1], r1
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    vmov r2, r3, d10
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
+; CHECK-FP16-NEXT:    rsbs r7, r9, #0
+; CHECK-FP16-NEXT:    vbsl q8, q4, q6
+; CHECK-FP16-NEXT:    rscs r4, r8, #0
+; CHECK-FP16-NEXT:    mov r4, #0
+; CHECK-FP16-NEXT:    mvnlt r4, #0
+; CHECK-FP16-NEXT:    vmov r0, r1, d16
+; CHECK-FP16-NEXT:    vmov r7, r5, d17
+; CHECK-FP16-NEXT:    rsbs r0, r0, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    mvnlt r0, #0
+; CHECK-FP16-NEXT:    rsbs r1, r2, #0
+; CHECK-FP16-NEXT:    rscs r1, r3, #0
+; CHECK-FP16-NEXT:    vdup.32 d20, r0
 ; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    rsbs r2, r3, #0
-; CHECK-FP16-NEXT:    rscs r2, r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d20, r1
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
-; CHECK-FP16-NEXT:    rsbs r3, r5, #0
-; CHECK-FP16-NEXT:    rscs r3, r4, #0
-; CHECK-FP16-NEXT:    vdup.32 d18, r2
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    mvnne r6, #0
-; CHECK-FP16-NEXT:    vdup.32 d19, r0
+; CHECK-FP16-NEXT:    mvnlt r1, #0
+; CHECK-FP16-NEXT:    rsbs r2, r7, #0
+; CHECK-FP16-NEXT:    rscs r2, r5, #0
+; CHECK-FP16-NEXT:    vdup.32 d18, r1
+; CHECK-FP16-NEXT:    mvnlt r6, #0
+; CHECK-FP16-NEXT:    vdup.32 d19, r4
 ; CHECK-FP16-NEXT:    vdup.32 d21, r6
 ; CHECK-FP16-NEXT:    vand q9, q9, q5
 ; CHECK-FP16-NEXT:    vand q8, q10, q8
@@ -1657,56 +1510,46 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d9, d9
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1728,27 +1571,23 @@ define <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    bl __fixunsdfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    vorr d0, d9, d9
-; CHECK-NEXT:    sbcs r1, r3, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1768,50 +1607,40 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #1
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movge r2, r8
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    moveq r4, r1
-; CHECK-NEXT:    movne r1, r0
-; CHECK-NEXT:    rsbs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r4, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r7, #1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r7
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEXT:    vorr d0, d9, d9
+; CHECK-NEXT:    rscs r0, r4, #0
 ; CHECK-NEXT:    rscs r0, r2, #0
-; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    moveq r4, r7
-; CHECK-NEXT:    movne r7, r1
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    movlt r8, r2
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    moveq r3, r2
-; CHECK-NEXT:    moveq r1, r2
-; CHECK-NEXT:    movne r2, r0
-; CHECK-NEXT:    rsbs r0, r2, #0
-; CHECK-NEXT:    rscs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r8, #0
-; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r2, r5
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movlt r7, r2
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    rsbs r2, r0, #0
+; CHECK-NEXT:    rscs r2, r1, #0
+; CHECK-NEXT:    rscs r2, r7, #0
+; CHECK-NEXT:    rscs r2, r3, #0
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -1833,56 +1662,46 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    vmov.f32 s0, s17
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1905,26 +1724,22 @@ define <2 x i64> @utest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    vmov.f32 s0, s17
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1944,50 +1759,40 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #1
-; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmov.f32 s0, s17
-; CHECK-NEXT:    movge r2, r8
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    moveq r4, r1
-; CHECK-NEXT:    movne r1, r0
-; CHECK-NEXT:    rsbs r0, r1, #0
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r7, #1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r7
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEXT:    rscs r0, r4, #0
-; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    rscs r0, r2, #0
 ; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    moveq r4, r7
-; CHECK-NEXT:    movne r7, r1
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    movlt r8, r2
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    moveq r3, r2
-; CHECK-NEXT:    moveq r1, r2
-; CHECK-NEXT:    movne r2, r0
-; CHECK-NEXT:    rsbs r0, r2, #0
-; CHECK-NEXT:    rscs r0, r1, #0
-; CHECK-NEXT:    rscs r0, r8, #0
-; CHECK-NEXT:    rscs r0, r3, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r2, r5
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movlt r7, r2
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    rsbs r2, r0, #0
+; CHECK-NEXT:    rscs r2, r1, #0
+; CHECK-NEXT:    rscs r2, r7, #0
+; CHECK-NEXT:    rscs r2, r3, #0
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r1, r8
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -2015,56 +1820,46 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mvn r10, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r10
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r1, r7
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    mvn r9, #0
-; CHECK-NEON-NEXT:    subs r1, r0, r9
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r4, r6
+; CHECK-NEON-NEXT:    sbcs r0, r2, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r8
-; CHECK-NEON-NEXT:    sbcs r1, r2, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r5, r10
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    mov r8, #-2147483648
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    movne r1, r2
-; CHECK-NEON-NEXT:    moveq r4, r6
-; CHECK-NEON-NEXT:    moveq r0, r9
-; CHECK-NEON-NEXT:    rsbs r2, r0, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r1
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r8
+; CHECK-NEON-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r10, r2
+; CHECK-NEON-NEXT:    sbcs r0, r10, r3
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r9
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r7, r0, r9
+; CHECK-NEON-NEXT:    subs r6, r0, r10
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
-; CHECK-NEON-NEXT:    sbcs r7, r1, r6
-; CHECK-NEON-NEXT:    sbcs r7, r2, #0
-; CHECK-NEON-NEXT:    sbcs r7, r3, #0
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r3, r7
-; CHECK-NEON-NEXT:    movne r7, r2
-; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    moveq r0, r9
+; CHECK-NEON-NEXT:    sbcs r6, r1, r7
+; CHECK-NEON-NEXT:    sbcs r6, r2, #0
+; CHECK-NEON-NEXT:    sbcs r6, r3, #0
+; CHECK-NEON-NEXT:    movlt r7, r1
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r0, r10
 ; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r7
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
-; CHECK-NEON-NEXT:    movne r10, r0
-; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEON-NEXT:    rscs r1, r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r10, r2
+; CHECK-NEON-NEXT:    sbcs r1, r10, r3
+; CHECK-NEON-NEXT:    movge r0, r9
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -2073,59 +1868,49 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r9, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    mvn r10, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    mvn r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r1, r6
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    subs r1, r0, r9
-; CHECK-FP16-NEXT:    mvn r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r4, r5
-; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    sbcs r1, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #-2147483648
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    mov r10, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    movne r1, r2
-; CHECK-FP16-NEXT:    moveq r4, r5
-; CHECK-FP16-NEXT:    moveq r0, r9
-; CHECK-FP16-NEXT:    rsbs r2, r0, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r1
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
-; CHECK-FP16-NEXT:    moveq r4, r8
+; CHECK-FP16-NEXT:    sbcs r0, r2, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    vmov s0, r9
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r5, r10
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    mov r9, #-2147483648
+; CHECK-FP16-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r10, r2
+; CHECK-FP16-NEXT:    sbcs r0, r10, r3
+; CHECK-FP16-NEXT:    movge r4, r9
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
-; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
-; CHECK-FP16-NEXT:    sbcs r6, r1, r5
-; CHECK-FP16-NEXT:    sbcs r6, r2, #0
-; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r3, r6
-; CHECK-FP16-NEXT:    movne r6, r2
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    moveq r0, r9
+; CHECK-FP16-NEXT:    subs r7, r0, r10
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
+; CHECK-FP16-NEXT:    sbcs r7, r1, r6
+; CHECK-FP16-NEXT:    sbcs r7, r2, #0
+; CHECK-FP16-NEXT:    sbcs r7, r3, #0
+; CHECK-FP16-NEXT:    movlt r6, r1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r0, r10
 ; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r6
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r10, #1
-; CHECK-FP16-NEXT:    cmp r10, #0
-; CHECK-FP16-NEXT:    movne r10, r0
-; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r10
+; CHECK-FP16-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r10, r2
+; CHECK-FP16-NEXT:    sbcs r1, r10, r3
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r6, r9
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r6
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2140,72 +1925,64 @@ entry:
 define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i64:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
 ; CHECK-NEON-NEXT:    vmov r0, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
-; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    vmov s0, r5
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlo r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r4, r5
-; CHECK-NEON-NEXT:    movne r5, r0
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r4
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movhs r6, r7
+; CHECK-NEON-NEXT:    movhs r5, r7
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    moveq r0, r6
-; CHECK-NEON-NEXT:    movne r6, r1
+; CHECK-NEON-NEXT:    movhs r0, r7
+; CHECK-NEON-NEXT:    movhs r1, r7
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i64:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
 ; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
-; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
 ; CHECK-FP16-NEXT:    vmov s0, r6
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlo r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r4, r6
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movhs r5, r7
+; CHECK-FP16-NEXT:    movhs r4, r7
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r4
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlo r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r0, r5
-; CHECK-FP16-NEXT:    movne r5, r1
+; CHECK-FP16-NEXT:    movhs r0, r7
+; CHECK-FP16-NEXT:    movhs r1, r7
 ; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r1
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -2224,55 +2001,45 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    vmov r0, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r6
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r8, #1
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movge r2, r8
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    moveq r4, r1
-; CHECK-NEON-NEXT:    movne r1, r0
-; CHECK-NEON-NEXT:    rsbs r0, r1, #0
+; CHECK-NEON-NEXT:    mov r8, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    mov r6, #1
+; CHECK-NEON-NEXT:    movge r3, r8
+; CHECK-NEON-NEXT:    movge r2, r6
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r8
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    rscs r0, r4, #0
-; CHECK-NEON-NEXT:    vmov s0, r5
 ; CHECK-NEON-NEXT:    rscs r0, r2, #0
-; CHECK-NEON-NEXT:    mov r7, #0
 ; CHECK-NEON-NEXT:    rscs r0, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r4, r7
-; CHECK-NEON-NEXT:    movne r7, r1
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r8
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r6, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEON-NEXT:    sbcs r6, r3, #0
-; CHECK-NEON-NEXT:    movlt r8, r2
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    moveq r3, r2
-; CHECK-NEON-NEXT:    moveq r1, r2
-; CHECK-NEON-NEXT:    movne r2, r0
-; CHECK-NEON-NEXT:    rsbs r0, r2, #0
-; CHECK-NEON-NEXT:    rscs r0, r1, #0
-; CHECK-NEON-NEXT:    rscs r0, r8, #0
-; CHECK-NEON-NEXT:    rscs r0, r3, #0
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r2, r5
-; CHECK-NEON-NEXT:    movne r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEON-NEXT:    subs r7, r2, #1
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEON-NEXT:    sbcs r7, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r8
+; CHECK-NEON-NEXT:    movlt r6, r2
+; CHECK-NEON-NEXT:    movge r1, r8
+; CHECK-NEON-NEXT:    movge r0, r8
+; CHECK-NEON-NEXT:    rsbs r2, r0, #0
+; CHECK-NEON-NEXT:    rscs r2, r1, #0
+; CHECK-NEON-NEXT:    rscs r2, r6, #0
+; CHECK-NEON-NEXT:    rscs r2, r3, #0
+; CHECK-NEON-NEXT:    movge r0, r8
+; CHECK-NEON-NEXT:    movge r1, r8
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 ;
@@ -2281,53 +2048,43 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
+; CHECK-FP16-NEXT:    vmov s0, r7
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #1
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movge r2, r8
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    moveq r4, r1
-; CHECK-FP16-NEXT:    movne r1, r0
-; CHECK-FP16-NEXT:    rsbs r0, r1, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    mov r7, #1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r7
+; CHECK-FP16-NEXT:    movge r4, r8
+; CHECK-FP16-NEXT:    movge r5, r8
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
 ; CHECK-FP16-NEXT:    rscs r0, r4, #0
-; CHECK-FP16-NEXT:    vmov s0, r5
 ; CHECK-FP16-NEXT:    rscs r0, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
 ; CHECK-FP16-NEXT:    rscs r0, r3, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    moveq r4, r7
-; CHECK-FP16-NEXT:    movne r7, r1
+; CHECK-FP16-NEXT:    movge r4, r8
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r6, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
 ; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    movlt r8, r2
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    moveq r3, r2
-; CHECK-FP16-NEXT:    moveq r1, r2
-; CHECK-FP16-NEXT:    movne r2, r0
-; CHECK-FP16-NEXT:    rsbs r0, r2, #0
-; CHECK-FP16-NEXT:    rscs r0, r1, #0
-; CHECK-FP16-NEXT:    rscs r0, r8, #0
-; CHECK-FP16-NEXT:    rscs r0, r3, #0
-; CHECK-FP16-NEXT:    movwlt r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r2, r5
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r2
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movlt r7, r2
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    rsbs r2, r0, #0
+; CHECK-FP16-NEXT:    rscs r2, r1, #0
+; CHECK-FP16-NEXT:    rscs r2, r7, #0
+; CHECK-FP16-NEXT:    rscs r2, r3, #0
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r1
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2354,34 +2111,29 @@ define <2 x i32> @stest_f64i32_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    mov r8, r1
-; CHECK-NEXT:    vmov r0, r1, d9
-; CHECK-NEXT:    mvn r6, #-2147483648
-; CHECK-NEXT:    subs r2, r4, r6
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    sbcs r2, r8, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    movge r4, r6
-; CHECK-NEXT:    movwlt r5, #1
+; CHECK-NEXT:    vmov r0, r2, d9
+; CHECK-NEXT:    mvn r5, #-2147483648
+; CHECK-NEXT:    subs r3, r4, r5
+; CHECK-NEXT:    sbcs r3, r1, #0
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r3, r4, #-2147483648
+; CHECK-NEXT:    mvn r7, #0
+; CHECK-NEXT:    sbcs r1, r7, r1
+; CHECK-NEXT:    mov r8, #-2147483648
+; CHECK-NEXT:    movge r4, r8
+; CHECK-NEXT:    mov r1, r2
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mov r0, #-2147483648
-; CHECK-NEXT:    movne r7, r1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r8
-; CHECK-NEXT:    rsbs r2, r4, #-2147483648
-; CHECK-NEXT:    mvn r1, #0
-; CHECK-NEXT:    sbcs r2, r1, r5
-; CHECK-NEXT:    movge r4, r0
-; CHECK-NEXT:    rsbs r2, r6, #-2147483648
+; CHECK-NEXT:    subs r2, r0, r5
 ; CHECK-NEXT:    vmov.32 d0[0], r4
-; CHECK-NEXT:    sbcs r1, r1, r7
-; CHECK-NEXT:    movge r6, r0
-; CHECK-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #-2147483648
+; CHECK-NEXT:    sbcs r0, r7, r6
+; CHECK-NEXT:    movge r5, r8
+; CHECK-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -2433,38 +2185,27 @@ define <2 x i32> @ustest_f64i32_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    vmov r2, r12, d9
-; CHECK-NEXT:    mvn r4, #0
-; CHECK-NEXT:    subs r5, r0, r4
-; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    sbcs r5, r1, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r0, r2, d9
+; CHECK-NEXT:    mvn r5, #0
+; CHECK-NEXT:    subs r3, r4, r5
+; CHECK-NEXT:    sbcs r3, r1, #0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movge r0, r4
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movne r3, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    movne r6, r0
-; CHECK-NEXT:    mov r0, r2
-; CHECK-NEXT:    mov r1, r12
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r3, r4, #0
+; CHECK-NEXT:    rscs r1, r1, #0
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    mov r1, r2
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    subs r2, r0, r4
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    subs r2, r0, r5
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r4, r0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    movne r0, r1
-; CHECK-NEXT:    rsbs r1, r4, #0
-; CHECK-NEXT:    rscs r0, r0, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r4
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    movge r5, r6
 ; CHECK-NEXT:    vmov.32 d0[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
@@ -2479,81 +2220,61 @@ entry:
 define <4 x i32> @stest_f32i32_mm(<4 x float> %x) {
 ; CHECK-LABEL: stest_f32i32_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, sp, #4
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
 ; CHECK-NEXT:    vorr q4, q0, q0
+; CHECK-NEXT:    mov r8, #-2147483648
+; CHECK-NEXT:    mvn r9, #0
+; CHECK-NEXT:    mov r10, #0
 ; CHECK-NEXT:    vmov r0, s17
+; CHECK-NEXT:    vmov r5, s18
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s16
-; CHECK-NEXT:    mov r11, r0
-; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    mvn r6, #-2147483648
-; CHECK-NEXT:    mov r3, #-2147483648
-; CHECK-NEXT:    mvn r10, #0
-; CHECK-NEXT:    vmov r7, s18
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-NEXT:    subs r2, r11, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r11, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r11, #-2147483648
-; CHECK-NEXT:    sbcs r1, r10, r2
-; CHECK-NEXT:    movge r11, r3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    mvn r7, #-2147483648
+; CHECK-NEXT:    subs r0, r0, r7
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r4, r7
+; CHECK-NEXT:    rsbs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r9, r1
+; CHECK-NEXT:    mov r0, r5
+; CHECK-NEXT:    movge r4, r8
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    subs r0, r0, r6
+; CHECK-NEXT:    subs r0, r0, r7
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r9, #0
-; CHECK-NEXT:    mov r0, r7
-; CHECK-NEXT:    movge r5, r6
-; CHECK-NEXT:    movwlt r9, #1
-; CHECK-NEXT:    cmp r9, #0
-; CHECK-NEXT:    movne r9, r1
+; CHECK-NEXT:    vmov r0, s16
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r5, r7
+; CHECK-NEXT:    rsbs r2, r5, #-2147483648
+; CHECK-NEXT:    sbcs r1, r9, r1
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r7, r0
-; CHECK-NEXT:    subs r0, r0, r6
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    subs r0, r0, r7
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r8, #0
-; CHECK-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; CHECK-NEXT:    movge r7, r6
-; CHECK-NEXT:    movwlt r8, #1
-; CHECK-NEXT:    cmp r8, #0
-; CHECK-NEXT:    movne r8, r1
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    movne r4, r1
+; CHECK-NEXT:    movge r1, r10
+; CHECK-NEXT:    movge r6, r7
 ; CHECK-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-NEXT:    sbcs r0, r10, r4
-; CHECK-NEXT:    mov r1, #-2147483648
-; CHECK-NEXT:    movge r6, r1
-; CHECK-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-NEXT:    sbcs r0, r10, r8
+; CHECK-NEXT:    sbcs r0, r9, r1
+; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    movge r6, r8
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    subs r2, r0, r7
 ; CHECK-NEXT:    vmov.32 d0[0], r6
-; CHECK-NEXT:    movge r7, r1
-; CHECK-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEXT:    sbcs r0, r10, r9
-; CHECK-NEXT:    movge r5, r1
-; CHECK-NEXT:    vmov.32 d0[1], r11
-; CHECK-NEXT:    vmov.32 d1[1], r5
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    movlt r10, r1
+; CHECK-NEXT:    movlt r7, r0
+; CHECK-NEXT:    rsbs r0, r7, #-2147483648
+; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    sbcs r0, r9, r10
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    movge r7, r8
+; CHECK-NEXT:    vmov.32 d1[1], r7
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    add sp, sp, #4
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <4 x float> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
@@ -2611,81 +2332,60 @@ entry:
 define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-LABEL: ustest_f32i32_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, s17
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s18
-; CHECK-NEXT:    mvn r6, #0
-; CHECK-NEXT:    subs r3, r0, r6
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    sbcs r3, r1, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r0, s18
+; CHECK-NEXT:    mvn r5, #0
+; CHECK-NEXT:    subs r2, r4, r5
+; CHECK-NEXT:    sbcs r2, r1, #0
+; CHECK-NEXT:    mov r9, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r4, r5
+; CHECK-NEXT:    rsbs r2, r4, #0
+; CHECK-NEXT:    vmov r7, s16
+; CHECK-NEXT:    rscs r1, r1, #0
 ; CHECK-NEXT:    vmov r8, s19
-; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r3, #1
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    movne r3, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    vmov r9, s16
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    movne r4, r0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    mov r0, r2
+; CHECK-NEXT:    movge r4, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r2, #0
-; CHECK-NEXT:    movwlt r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    movne r5, r0
-; CHECK-NEXT:    mov r0, r9
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r6, r5
+; CHECK-NEXT:    rsbs r0, r6, #0
+; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    mov r0, r7
+; CHECK-NEXT:    movge r6, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movge r0, r6
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    movne r2, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r2, #0
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
+; CHECK-NEXT:    mov r7, r0
+; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movge r7, r5
+; CHECK-NEXT:    rsbs r0, r7, #0
+; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, r8
+; CHECK-NEXT:    movge r7, r9
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r0, r6
+; CHECK-NEXT:    subs r2, r0, r5
 ; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r2, r1, #0
-; CHECK-NEXT:    movlt r6, r0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    movne r0, r1
-; CHECK-NEXT:    rsbs r1, r6, #0
-; CHECK-NEXT:    rscs r0, r0, #0
-; CHECK-NEXT:    vmov.32 d1[0], r5
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
+; CHECK-NEXT:    movge r1, r9
+; CHECK-NEXT:    movlt r5, r0
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    movne r10, r6
-; CHECK-NEXT:    vmov.32 d1[1], r10
+; CHECK-NEXT:    movge r5, r9
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
   %conv = fptosi <4 x float> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 4294967295, i64 4294967295, i64 4294967295, i64 4294967295>)
@@ -2697,164 +2397,128 @@ entry:
 define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-LABEL: stest_f16i32_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    .pad #4
-; CHECK-NEON-NEXT:    sub sp, sp, #4
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
-; CHECK-NEON-NEXT:    .pad #8
-; CHECK-NEON-NEXT:    sub sp, sp, #8
 ; CHECK-NEON-NEXT:    vmov r0, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s20
-; CHECK-NEON-NEXT:    mov r11, r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    mov r3, #-2147483648
-; CHECK-NEON-NEXT:    mvn r10, #0
-; CHECK-NEON-NEXT:    vmov r7, s18
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-NEON-NEXT:    subs r2, r11, r6
+; CHECK-NEON-NEXT:    mov r4, r0
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    subs r2, r4, r7
 ; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r11, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r11, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r10, r2
-; CHECK-NEON-NEXT:    movge r11, r3
+; CHECK-NEON-NEXT:    mov r10, #0
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    rsbs r2, r4, #-2147483648
+; CHECK-NEON-NEXT:    mvn r9, #0
+; CHECK-NEON-NEXT:    mov r8, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r9, r1
+; CHECK-NEON-NEXT:    movge r4, r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    subs r0, r0, r6
+; CHECK-NEON-NEXT:    subs r0, r0, r7
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r8, #0
-; CHECK-NEON-NEXT:    mov r0, r7
-; CHECK-NEON-NEXT:    movge r5, r6
-; CHECK-NEON-NEXT:    movwlt r8, #1
-; CHECK-NEON-NEXT:    cmp r8, #0
-; CHECK-NEON-NEXT:    movne r8, r1
+; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r5, r7
+; CHECK-NEON-NEXT:    rsbs r2, r5, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r9, r1
+; CHECK-NEON-NEXT:    movge r5, r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r7, r0
-; CHECK-NEON-NEXT:    subs r0, r0, r6
+; CHECK-NEON-NEXT:    mov r6, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r7
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r9, #0
-; CHECK-NEON-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; CHECK-NEON-NEXT:    movge r7, r6
-; CHECK-NEON-NEXT:    movwlt r9, #1
-; CHECK-NEON-NEXT:    cmp r9, #0
-; CHECK-NEON-NEXT:    movne r9, r1
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    movlt r6, r0
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    movne r4, r1
+; CHECK-NEON-NEXT:    movge r1, r10
+; CHECK-NEON-NEXT:    movge r6, r7
 ; CHECK-NEON-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r10, r4
-; CHECK-NEON-NEXT:    mov r1, #-2147483648
-; CHECK-NEON-NEXT:    movge r6, r1
-; CHECK-NEON-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r10, r9
+; CHECK-NEON-NEXT:    sbcs r0, r9, r1
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    movge r6, r8
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2lz
+; CHECK-NEON-NEXT:    subs r2, r0, r7
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r6
-; CHECK-NEON-NEXT:    movge r7, r1
-; CHECK-NEON-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
-; CHECK-NEON-NEXT:    sbcs r0, r10, r8
-; CHECK-NEON-NEXT:    movge r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r11
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r5
-; CHECK-NEON-NEXT:    add sp, sp, #8
+; CHECK-NEON-NEXT:    sbcs r2, r1, #0
+; CHECK-NEON-NEXT:    movlt r10, r1
+; CHECK-NEON-NEXT:    movlt r7, r0
+; CHECK-NEON-NEXT:    rsbs r0, r7, #-2147483648
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    sbcs r0, r9, r10
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
-; CHECK-NEON-NEXT:    add sp, sp, #4
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
 ; CHECK-FP16-LABEL: stest_f16i32_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-FP16-NEXT:    .pad #4
-; CHECK-FP16-NEXT:    sub sp, sp, #4
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    .vsave {d8, d9}
 ; CHECK-FP16-NEXT:    vpush {d8, d9}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r4, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[2]
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[3]
+; CHECK-FP16-NEXT:    vorr d8, d0, d0
+; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[2]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    mov r10, r0
+; CHECK-FP16-NEXT:    mov r4, r0
 ; CHECK-FP16-NEXT:    mvn r7, #-2147483648
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    mov r10, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    mov r2, #-2147483648
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movge r10, r7
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    movne r0, r1
-; CHECK-FP16-NEXT:    rsbs r1, r10, #-2147483648
+; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    movge r1, r10
+; CHECK-FP16-NEXT:    movge r4, r7
+; CHECK-FP16-NEXT:    rsbs r0, r4, #-2147483648
 ; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    sbcs r0, r9, r0
-; CHECK-FP16-NEXT:    vmov s16, r4
-; CHECK-FP16-NEXT:    mov r11, #0
+; CHECK-FP16-NEXT:    mov r8, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
 ; CHECK-FP16-NEXT:    vmov s18, r5
-; CHECK-FP16-NEXT:    movge r10, r2
+; CHECK-FP16-NEXT:    movge r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s18
 ; CHECK-FP16-NEXT:    mov r5, r0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    mov r4, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r10
 ; CHECK-FP16-NEXT:    movge r5, r7
-; CHECK-FP16-NEXT:    movwlt r4, #1
-; CHECK-FP16-NEXT:    cmp r4, #0
-; CHECK-FP16-NEXT:    movne r4, r1
+; CHECK-FP16-NEXT:    rsbs r0, r5, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.f32 s0, s16
 ; CHECK-FP16-NEXT:    mov r6, r0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
-; CHECK-FP16-NEXT:    mov r8, #0
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-FP16-NEXT:    movge r1, r10
 ; CHECK-FP16-NEXT:    movge r6, r7
-; CHECK-FP16-NEXT:    movwlt r8, #1
-; CHECK-FP16-NEXT:    cmp r8, #0
-; CHECK-FP16-NEXT:    movne r8, r1
+; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    rsbs r0, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r9, r1
+; CHECK-FP16-NEXT:    movge r6, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    subs r2, r0, r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r1, #0
+; CHECK-FP16-NEXT:    movlt r10, r1
 ; CHECK-FP16-NEXT:    movlt r7, r0
-; CHECK-FP16-NEXT:    movwlt r11, #1
-; CHECK-FP16-NEXT:    cmp r11, #0
-; CHECK-FP16-NEXT:    movne r11, r1
 ; CHECK-FP16-NEXT:    rsbs r0, r7, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r9, r11
-; CHECK-FP16-NEXT:    mov r1, #-2147483648
-; CHECK-FP16-NEXT:    movge r7, r1
-; CHECK-FP16-NEXT:    rsbs r0, r6, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r9, r8
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
-; CHECK-FP16-NEXT:    movge r6, r1
-; CHECK-FP16-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
-; CHECK-FP16-NEXT:    sbcs r0, r9, r4
-; CHECK-FP16-NEXT:    movge r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r10
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    sbcs r0, r9, r10
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    movge r7, r8
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r7
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
-; CHECK-FP16-NEXT:    add sp, sp, #4
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <4 x half> %x to <4 x i64>
   %spec.store.select = call <4 x i64> @llvm.smin.v4i64(<4 x i64> %conv, <4 x i64> <i64 2147483647, i64 2147483647, i64 2147483647, i64 2147483647>)
@@ -2961,8 +2625,8 @@ entry:
 define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-LABEL: ustest_f16i32_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vmov r0, s1
@@ -2971,77 +2635,56 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s18
-; CHECK-NEON-NEXT:    mvn r6, #0
-; CHECK-NEON-NEXT:    subs r3, r0, r6
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    sbcs r3, r1, #0
+; CHECK-NEON-NEXT:    mov r4, r0
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    mvn r5, #0
+; CHECK-NEON-NEXT:    subs r2, r4, r5
+; CHECK-NEON-NEXT:    sbcs r2, r1, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r4, r5
+; CHECK-NEON-NEXT:    rsbs r2, r4, #0
+; CHECK-NEON-NEXT:    vmov r7, s20
+; CHECK-NEON-NEXT:    rscs r1, r1, #0
 ; CHECK-NEON-NEXT:    vmov r8, s16
-; CHECK-NEON-NEXT:    mov r3, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r3, #1
-; CHECK-NEON-NEXT:    cmp r3, #0
-; CHECK-NEON-NEXT:    movne r3, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r3, #0
-; CHECK-NEON-NEXT:    vmov r9, s20
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    movne r4, r0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    mov r0, r2
+; CHECK-NEON-NEXT:    movge r4, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r2, #0
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    mov r0, r9
+; CHECK-NEON-NEXT:    mov r6, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r6, r5
+; CHECK-NEON-NEXT:    rsbs r0, r6, #0
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
+; CHECK-NEON-NEXT:    mov r0, r7
+; CHECK-NEON-NEXT:    movge r6, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    movge r0, r6
-; CHECK-NEON-NEXT:    movwlt r2, #1
-; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    movne r2, r1
-; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r2, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    movne r7, r0
+; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movge r7, r5
+; CHECK-NEON-NEXT:    rsbs r0, r7, #0
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
 ; CHECK-NEON-NEXT:    mov r0, r8
+; CHECK-NEON-NEXT:    movge r7, r9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r0, r6
+; CHECK-NEON-NEXT:    subs r2, r0, r5
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEON-NEXT:    sbcs r2, r1, #0
-; CHECK-NEON-NEXT:    movlt r6, r0
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    movne r0, r1
-; CHECK-NEON-NEXT:    rsbs r1, r6, #0
-; CHECK-NEON-NEXT:    rscs r0, r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
+; CHECK-NEON-NEXT:    movge r1, r9
+; CHECK-NEON-NEXT:    movlt r5, r0
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEON-NEXT:    rscs r0, r1, #0
 ; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    movne r10, r6
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r10
+; CHECK-NEON-NEXT:    movge r5, r9
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 ;
 ; CHECK-FP16-LABEL: ustest_f16i32_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
@@ -3052,75 +2695,55 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
 ; CHECK-FP16-NEXT:    vmov.u16 r5, d0[2]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.u16 r2, d8[3]
-; CHECK-FP16-NEXT:    mvn r4, #0
-; CHECK-FP16-NEXT:    vmov.u16 r3, d8[0]
-; CHECK-FP16-NEXT:    vmov s0, r5
-; CHECK-FP16-NEXT:    mov r6, #0
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-FP16-NEXT:    mvn r7, #0
 ; CHECK-FP16-NEXT:    mov r8, #0
-; CHECK-FP16-NEXT:    vmov s16, r2
-; CHECK-FP16-NEXT:    subs r2, r0, r4
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    vmov s18, r3
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    vmov s0, r5
+; CHECK-FP16-NEXT:    vmov s18, r6
+; CHECK-FP16-NEXT:    vmov s16, r0
+; CHECK-FP16-NEXT:    subs r0, r4, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r4, r7
+; CHECK-FP16-NEXT:    rsbs r0, r4, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s18
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r5, r7
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
 ; CHECK-FP16-NEXT:    vmov.f32 s0, s16
-; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    movge r0, r4
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    movne r2, r1
-; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r2, #0
-; CHECK-FP16-NEXT:    movwlt r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    movne r5, r0
+; CHECK-FP16-NEXT:    mov r6, r0
+; CHECK-FP16-NEXT:    subs r0, r0, r7
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movge r6, r7
+; CHECK-FP16-NEXT:    rsbs r0, r6, #0
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    movge r6, r8
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    subs r2, r0, r4
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
+; CHECK-FP16-NEXT:    subs r2, r0, r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r1, #0
-; CHECK-FP16-NEXT:    movlt r4, r0
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    movne r0, r1
-; CHECK-FP16-NEXT:    rsbs r1, r4, #0
-; CHECK-FP16-NEXT:    rscs r0, r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
-; CHECK-FP16-NEXT:    movwlt r8, #1
-; CHECK-FP16-NEXT:    cmp r8, #0
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r6
-; CHECK-FP16-NEXT:    movne r8, r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r8
+; CHECK-FP16-NEXT:    movge r1, r8
+; CHECK-FP16-NEXT:    movlt r7, r0
+; CHECK-FP16-NEXT:    rsbs r0, r7, #0
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    movge r7, r8
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r7
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -3626,56 +3249,46 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d9, d9
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3695,27 +3308,23 @@ define <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    bl __fixunsdfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    vorr d0, d9, d9
-; CHECK-NEXT:    sbcs r1, r3, #0
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3736,28 +3345,23 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
-; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    vorr d0, d9, d9
-; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    moveq r5, r0
-; CHECK-NEXT:    moveq r4, r0
-; CHECK-NEXT:    movne r0, r3
-; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movge r5, r6
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r3, r6
+; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    movwmi r4, #0
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r2, r2, #1
 ; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r1, r6
-; CHECK-NEXT:    moveq r0, r6
-; CHECK-NEXT:    movne r6, r3
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r0, r6
+; CHECK-NEXT:    movlt r6, r3
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
@@ -3783,56 +3387,46 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    mvn r9, #0
-; CHECK-NEXT:    subs r1, r0, r9
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r4, r5
+; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mvn r10, #0
+; CHECK-NEXT:    subs r0, r0, r10
+; CHECK-NEXT:    mvn r6, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r6
 ; CHECK-NEXT:    vmov.f32 s0, s17
-; CHECK-NEXT:    sbcs r1, r2, #0
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r8, #-2147483648
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    mov r10, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    moveq r3, r1
-; CHECK-NEXT:    movne r1, r2
-; CHECK-NEXT:    moveq r4, r5
-; CHECK-NEXT:    moveq r0, r9
-; CHECK-NEXT:    rsbs r2, r0, #0
-; CHECK-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r1
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    movne r7, r0
-; CHECK-NEXT:    moveq r4, r8
+; CHECK-NEXT:    sbcs r0, r2, #0
+; CHECK-NEXT:    mov r4, r1
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    mov r8, #0
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r5, r10
+; CHECK-NEXT:    rsbs r0, r5, #0
+; CHECK-NEXT:    mov r9, #-2147483648
+; CHECK-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEXT:    sbcs r0, r10, r2
+; CHECK-NEXT:    sbcs r0, r10, r3
+; CHECK-NEXT:    movge r4, r9
+; CHECK-NEXT:    movge r5, r8
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d0[0], r7
-; CHECK-NEXT:    sbcs r6, r1, r5
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r3, r6
-; CHECK-NEXT:    movne r6, r2
-; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    moveq r0, r9
+; CHECK-NEXT:    subs r7, r0, r10
+; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    sbcs r7, r1, r6
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    movlt r6, r1
+; CHECK-NEXT:    movge r3, r8
+; CHECK-NEXT:    movge r2, r8
+; CHECK-NEXT:    movge r0, r10
 ; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-NEXT:    sbcs r1, r9, r6
-; CHECK-NEXT:    sbcs r1, r9, r3
-; CHECK-NEXT:    movwlt r10, #1
-; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    movne r10, r0
-; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r10, r2
+; CHECK-NEXT:    sbcs r1, r10, r3
+; CHECK-NEXT:    movge r0, r8
+; CHECK-NEXT:    movge r6, r9
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3853,26 +3447,22 @@ define <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    vmov.f64 d8, d0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    vmov.f32 s0, s17
-; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    subs r1, r2, #1
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    subs r0, r2, #1
+; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    sbcs r1, r3, #0
-; CHECK-NEXT:    mov r5, #0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r4, r6
-; CHECK-NEXT:    movne r6, r0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movhs r5, r6
+; CHECK-NEXT:    movhs r4, r6
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d0[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r4
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlo r5, #1
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    moveq r0, r5
-; CHECK-NEXT:    movne r5, r1
+; CHECK-NEXT:    movhs r0, r6
+; CHECK-NEXT:    movhs r1, r6
 ; CHECK-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEXT:    vmov.32 d1[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3895,26 +3485,21 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    moveq r5, r0
-; CHECK-NEXT:    moveq r4, r0
-; CHECK-NEXT:    movne r0, r3
-; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    sbcs r0, r3, #0
+; CHECK-NEXT:    movge r5, r6
+; CHECK-NEXT:    movge r4, r6
+; CHECK-NEXT:    movge r3, r6
+; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    movwmi r4, #0
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r2, r2, #1
 ; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    moveq r1, r6
-; CHECK-NEXT:    moveq r0, r6
-; CHECK-NEXT:    movne r6, r3
+; CHECK-NEXT:    movge r1, r6
+; CHECK-NEXT:    movge r0, r6
+; CHECK-NEXT:    movlt r6, r3
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
@@ -3946,56 +3531,46 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixsfti
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mvn r10, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r10
+; CHECK-NEON-NEXT:    mvn r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r1, r7
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    mvn r9, #0
-; CHECK-NEON-NEXT:    subs r1, r0, r9
-; CHECK-NEON-NEXT:    mvn r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r4, r6
+; CHECK-NEON-NEXT:    sbcs r0, r2, #0
+; CHECK-NEON-NEXT:    mov r9, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r8
-; CHECK-NEON-NEXT:    sbcs r1, r2, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r5, r10
+; CHECK-NEON-NEXT:    rsbs r0, r5, #0
 ; CHECK-NEON-NEXT:    mov r8, #-2147483648
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    mov r10, #0
-; CHECK-NEON-NEXT:    movwlt r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    moveq r3, r1
-; CHECK-NEON-NEXT:    movne r1, r2
-; CHECK-NEON-NEXT:    moveq r4, r6
-; CHECK-NEON-NEXT:    moveq r0, r9
-; CHECK-NEON-NEXT:    rsbs r2, r0, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r1
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    movne r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r8
+; CHECK-NEON-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r10, r2
+; CHECK-NEON-NEXT:    sbcs r0, r10, r3
+; CHECK-NEON-NEXT:    movge r4, r8
+; CHECK-NEON-NEXT:    movge r5, r9
 ; CHECK-NEON-NEXT:    bl __fixsfti
-; CHECK-NEON-NEXT:    subs r7, r0, r9
+; CHECK-NEON-NEXT:    subs r6, r0, r10
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
-; CHECK-NEON-NEXT:    sbcs r7, r1, r6
-; CHECK-NEON-NEXT:    sbcs r7, r2, #0
-; CHECK-NEON-NEXT:    sbcs r7, r3, #0
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r3, r7
-; CHECK-NEON-NEXT:    movne r7, r2
-; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    moveq r0, r9
+; CHECK-NEON-NEXT:    sbcs r6, r1, r7
+; CHECK-NEON-NEXT:    sbcs r6, r2, #0
+; CHECK-NEON-NEXT:    sbcs r6, r3, #0
+; CHECK-NEON-NEXT:    movlt r7, r1
+; CHECK-NEON-NEXT:    movge r3, r9
+; CHECK-NEON-NEXT:    movge r2, r9
+; CHECK-NEON-NEXT:    movge r0, r10
 ; CHECK-NEON-NEXT:    rsbs r1, r0, #0
-; CHECK-NEON-NEXT:    rscs r1, r6, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r9, r7
-; CHECK-NEON-NEXT:    sbcs r1, r9, r3
-; CHECK-NEON-NEXT:    movwlt r10, #1
-; CHECK-NEON-NEXT:    cmp r10, #0
-; CHECK-NEON-NEXT:    movne r10, r0
-; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEON-NEXT:    rscs r1, r7, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r10, r2
+; CHECK-NEON-NEXT:    sbcs r1, r10, r3
+; CHECK-NEON-NEXT:    movge r0, r9
+; CHECK-NEON-NEXT:    movge r7, r8
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r7
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -4004,59 +3579,49 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r9, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
+; CHECK-FP16-NEXT:    mov r5, r0
+; CHECK-FP16-NEXT:    mvn r10, #0
+; CHECK-FP16-NEXT:    subs r0, r0, r10
+; CHECK-FP16-NEXT:    mvn r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r1, r6
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    mvn r9, #0
-; CHECK-FP16-NEXT:    subs r1, r0, r9
-; CHECK-FP16-NEXT:    mvn r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r4, r5
-; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    sbcs r1, r2, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r8, #-2147483648
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    mov r10, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    moveq r3, r1
-; CHECK-FP16-NEXT:    movne r1, r2
-; CHECK-FP16-NEXT:    moveq r4, r5
-; CHECK-FP16-NEXT:    moveq r0, r9
-; CHECK-FP16-NEXT:    rsbs r2, r0, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r1
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    movne r7, r0
-; CHECK-FP16-NEXT:    moveq r4, r8
+; CHECK-FP16-NEXT:    sbcs r0, r2, #0
+; CHECK-FP16-NEXT:    mov r8, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    vmov s0, r9
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r5, r10
+; CHECK-FP16-NEXT:    rsbs r0, r5, #0
+; CHECK-FP16-NEXT:    mov r9, #-2147483648
+; CHECK-FP16-NEXT:    rscs r0, r4, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r10, r2
+; CHECK-FP16-NEXT:    sbcs r0, r10, r3
+; CHECK-FP16-NEXT:    movge r4, r9
+; CHECK-FP16-NEXT:    movge r5, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
-; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
-; CHECK-FP16-NEXT:    sbcs r6, r1, r5
-; CHECK-FP16-NEXT:    sbcs r6, r2, #0
-; CHECK-FP16-NEXT:    sbcs r6, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r3, r6
-; CHECK-FP16-NEXT:    movne r6, r2
-; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    moveq r0, r9
+; CHECK-FP16-NEXT:    subs r7, r0, r10
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
+; CHECK-FP16-NEXT:    sbcs r7, r1, r6
+; CHECK-FP16-NEXT:    sbcs r7, r2, #0
+; CHECK-FP16-NEXT:    sbcs r7, r3, #0
+; CHECK-FP16-NEXT:    movlt r6, r1
+; CHECK-FP16-NEXT:    movge r3, r8
+; CHECK-FP16-NEXT:    movge r2, r8
+; CHECK-FP16-NEXT:    movge r0, r10
 ; CHECK-FP16-NEXT:    rsbs r1, r0, #0
-; CHECK-FP16-NEXT:    rscs r1, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r9, r6
-; CHECK-FP16-NEXT:    sbcs r1, r9, r3
-; CHECK-FP16-NEXT:    movwlt r10, #1
-; CHECK-FP16-NEXT:    cmp r10, #0
-; CHECK-FP16-NEXT:    movne r10, r0
-; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r10
+; CHECK-FP16-NEXT:    rscs r1, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r10, r2
+; CHECK-FP16-NEXT:    sbcs r1, r10, r3
+; CHECK-FP16-NEXT:    movge r0, r8
+; CHECK-FP16-NEXT:    movge r6, r9
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
 ; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r6
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -4069,72 +3634,64 @@ entry:
 define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i64_mm:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
 ; CHECK-NEON-NEXT:    vmov r0, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    mov r4, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
-; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    subs r1, r2, #1
-; CHECK-NEON-NEXT:    vmov s0, r5
-; CHECK-NEON-NEXT:    sbcs r1, r3, #0
-; CHECK-NEON-NEXT:    mov r5, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlo r5, #1
-; CHECK-NEON-NEXT:    cmp r5, #0
-; CHECK-NEON-NEXT:    moveq r4, r5
-; CHECK-NEON-NEXT:    movne r5, r0
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    subs r0, r2, #1
+; CHECK-NEON-NEXT:    vmov s0, r4
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movhs r6, r7
+; CHECK-NEON-NEXT:    movhs r5, r7
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    moveq r0, r6
-; CHECK-NEON-NEXT:    movne r6, r1
+; CHECK-NEON-NEXT:    movhs r0, r7
+; CHECK-NEON-NEXT:    movhs r1, r7
 ; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i64_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
+; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
 ; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
-; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    subs r1, r2, #1
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    subs r0, r2, #1
 ; CHECK-FP16-NEXT:    vmov s0, r6
-; CHECK-FP16-NEXT:    sbcs r1, r3, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    mov r5, #0
-; CHECK-FP16-NEXT:    movwlo r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r4, r6
-; CHECK-FP16-NEXT:    movne r6, r0
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    mov r7, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movhs r5, r7
+; CHECK-FP16-NEXT:    movhs r4, r7
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r4
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlo r5, #1
-; CHECK-FP16-NEXT:    cmp r5, #0
-; CHECK-FP16-NEXT:    moveq r0, r5
-; CHECK-FP16-NEXT:    movne r5, r1
+; CHECK-FP16-NEXT:    movhs r0, r7
+; CHECK-FP16-NEXT:    movhs r1, r7
 ; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
-; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r1
+; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -4159,28 +3716,23 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    subs r0, r2, #1
-; CHECK-NEON-NEXT:    sbcs r0, r3, #0
 ; CHECK-NEON-NEXT:    vmov s0, r6
-; CHECK-NEON-NEXT:    mov r0, #0
 ; CHECK-NEON-NEXT:    mov r4, r1
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    moveq r5, r0
-; CHECK-NEON-NEXT:    moveq r4, r0
-; CHECK-NEON-NEXT:    movne r0, r3
-; CHECK-NEON-NEXT:    cmp r0, #0
 ; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    sbcs r0, r3, #0
+; CHECK-NEON-NEXT:    movge r5, r7
+; CHECK-NEON-NEXT:    movge r4, r7
+; CHECK-NEON-NEXT:    movge r3, r7
+; CHECK-NEON-NEXT:    cmp r3, #0
 ; CHECK-NEON-NEXT:    movwmi r4, #0
 ; CHECK-NEON-NEXT:    movwmi r5, #0
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
 ; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
-; CHECK-NEON-NEXT:    movwlt r7, #1
-; CHECK-NEON-NEXT:    cmp r7, #0
-; CHECK-NEON-NEXT:    moveq r1, r7
-; CHECK-NEON-NEXT:    moveq r0, r7
-; CHECK-NEON-NEXT:    movne r7, r3
+; CHECK-NEON-NEXT:    movge r1, r7
+; CHECK-NEON-NEXT:    movge r0, r7
+; CHECK-NEON-NEXT:    movlt r7, r3
 ; CHECK-NEON-NEXT:    cmp r7, #0
 ; CHECK-NEON-NEXT:    movwmi r0, #0
 ; CHECK-NEON-NEXT:    movwmi r1, #0
@@ -4200,28 +3752,23 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r5, r0
 ; CHECK-FP16-NEXT:    subs r0, r2, #1
-; CHECK-FP16-NEXT:    sbcs r0, r3, #0
 ; CHECK-FP16-NEXT:    vmov s0, r7
-; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    moveq r5, r0
-; CHECK-FP16-NEXT:    moveq r4, r0
-; CHECK-FP16-NEXT:    movne r0, r3
-; CHECK-FP16-NEXT:    cmp r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
+; CHECK-FP16-NEXT:    sbcs r0, r3, #0
+; CHECK-FP16-NEXT:    movge r5, r6
+; CHECK-FP16-NEXT:    movge r4, r6
+; CHECK-FP16-NEXT:    movge r3, r6
+; CHECK-FP16-NEXT:    cmp r3, #0
 ; CHECK-FP16-NEXT:    movwmi r4, #0
 ; CHECK-FP16-NEXT:    movwmi r5, #0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
 ; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    moveq r1, r6
-; CHECK-FP16-NEXT:    moveq r0, r6
-; CHECK-FP16-NEXT:    movne r6, r3
+; CHECK-FP16-NEXT:    movge r1, r6
+; CHECK-FP16-NEXT:    movge r0, r6
+; CHECK-FP16-NEXT:    movlt r6, r3
 ; CHECK-FP16-NEXT:    cmp r6, #0
 ; CHECK-FP16-NEXT:    movwmi r0, #0
 ; CHECK-FP16-NEXT:    movwmi r1, #0

--- a/llvm/test/CodeGen/ARM/neon_vabd.ll
+++ b/llvm/test/CodeGen/ARM/neon_vabd.ll
@@ -144,24 +144,20 @@ define <2 x i64> @sabd_2d(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d1
+; CHECK-NEXT:    vmov r0, r12, d1
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vmov r2, r3, d3
-; CHECK-NEXT:    vmov r12, lr, d0
+; CHECK-NEXT:    vmov r1, lr, d0
 ; CHECK-NEXT:    vmov r4, r5, d2
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r3, r1
+; CHECK-NEXT:    sbcs r0, r3, r12
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r4, r12
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r1, r4, r1
 ; CHECK-NEXT:    sbcs r1, r5, lr
 ; CHECK-NEXT:    vdup.32 d19, r0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    mvnlt r6, #0
 ; CHECK-NEXT:    vdup.32 d18, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8
@@ -475,24 +471,20 @@ define <2 x i64> @smaxmin_v2i64(<2 x i64> %0, <2 x i64> %1) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d1
+; CHECK-NEXT:    vmov r0, r12, d1
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vmov r2, r3, d3
-; CHECK-NEXT:    vmov r12, lr, d0
+; CHECK-NEXT:    vmov r1, lr, d0
 ; CHECK-NEXT:    vmov r4, r5, d2
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r3, r1
+; CHECK-NEXT:    sbcs r0, r3, r12
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r4, r12
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r1, r4, r1
 ; CHECK-NEXT:    sbcs r1, r5, lr
 ; CHECK-NEXT:    vdup.32 d19, r0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    mvnlt r6, #0
 ; CHECK-NEXT:    vdup.32 d18, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8

--- a/llvm/test/CodeGen/ARM/neon_vabd.ll
+++ b/llvm/test/CodeGen/ARM/neon_vabd.ll
@@ -144,24 +144,20 @@ define <2 x i64> @sabd_2d(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d0
+; CHECK-NEXT:    vmov r0, r12, d0
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vmov r2, r3, d2
-; CHECK-NEXT:    vmov r12, lr, d1
+; CHECK-NEXT:    vmov r1, lr, d1
 ; CHECK-NEXT:    vmov r4, r5, d3
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r3, r1
+; CHECK-NEXT:    sbcs r0, r3, r12
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r4, r12
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r1, r4, r1
 ; CHECK-NEXT:    sbcs r1, r5, lr
 ; CHECK-NEXT:    vdup.32 d18, r0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    mvnlt r6, #0
 ; CHECK-NEXT:    vdup.32 d19, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8
@@ -475,24 +471,20 @@ define <2 x i64> @smaxmin_v2i64(<2 x i64> %0, <2 x i64> %1) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d0
+; CHECK-NEXT:    vmov r0, r12, d0
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vmov r2, r3, d2
-; CHECK-NEXT:    vmov r12, lr, d1
+; CHECK-NEXT:    vmov r1, lr, d1
 ; CHECK-NEXT:    vmov r4, r5, d3
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r3, r1
+; CHECK-NEXT:    sbcs r0, r3, r12
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r4, r12
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r1, r4, r1
 ; CHECK-NEXT:    sbcs r1, r5, lr
 ; CHECK-NEXT:    vdup.32 d18, r0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    mvnlt r6, #0
 ; CHECK-NEXT:    vdup.32 d19, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8

--- a/llvm/test/CodeGen/ARM/vector-trunc.ll
+++ b/llvm/test/CodeGen/ARM/vector-trunc.ll
@@ -9,9 +9,7 @@ define i32 @test(i64 %arg1) {
 ; LE-NEXT:    mov r2, #0
 ; LE-NEXT:    sbcs r0, r1, #0
 ; LE-NEXT:    vldr s0, .LCPI0_0
-; LE-NEXT:    movwhs r2, #1
-; LE-NEXT:    cmp r2, #0
-; LE-NEXT:    mvnne r2, #0
+; LE-NEXT:    mvnhs r2, #0
 ; LE-NEXT:    vmov s1, r2
 ; LE-NEXT:    vmovn.i32 d16, q0
 ; LE-NEXT:    vmovn.i16 d16, q8
@@ -29,9 +27,7 @@ define i32 @test(i64 %arg1) {
 ; BE-NEXT:    mov r2, #0
 ; BE-NEXT:    sbcs r0, r0, #0
 ; BE-NEXT:    vldr s0, .LCPI0_0
-; BE-NEXT:    movwhs r2, #1
-; BE-NEXT:    cmp r2, #0
-; BE-NEXT:    mvnne r2, #0
+; BE-NEXT:    mvnhs r2, #0
 ; BE-NEXT:    vmov s1, r2
 ; BE-NEXT:    vmovn.i32 d16, q0
 ; BE-NEXT:    vmovn.i16 d16, q8

--- a/llvm/test/CodeGen/ARM/vselect_imax.ll
+++ b/llvm/test/CodeGen/ARM/vselect_imax.ll
@@ -111,53 +111,45 @@ define void @func_blend15(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 define void @func_blend18(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storeaddr) {
 ; CHECK-LABEL: func_blend18:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]!
+; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    vld1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r6, d16
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]
+; CHECK-NEXT:    vmov r1, r6, d16
 ; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]
-; CHECK-NEXT:    vmov lr, r12, d18
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vmov r2, r1, d20
-; CHECK-NEXT:    subs r2, r2, lr
-; CHECK-NEXT:    vmov r2, r5, d22
-; CHECK-NEXT:    sbcs r1, r1, r12
+; CHECK-NEXT:    vmov r0, r12, d18
+; CHECK-NEXT:    vmov r2, lr, d20
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    vmov r0, r2, d22
+; CHECK-NEXT:    sbcs r4, lr, r12
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    vmov r7, lr, d19
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    subs r0, r0, r1
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r2, r4
-; CHECK-NEXT:    sbcs r6, r5, r6
-; CHECK-NEXT:    vmov r2, r12, d17
-; CHECK-NEXT:    vmov r5, r4, d23
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    subs r2, r5, r2
-; CHECK-NEXT:    sbcs r2, r4, r12
-; CHECK-NEXT:    vmov lr, r12, d19
-; CHECK-NEXT:    vmov r4, r5, d21
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d25, r2
-; CHECK-NEXT:    vdup.32 d24, r6
+; CHECK-NEXT:    sbcs r2, r2, r6
+; CHECK-NEXT:    vmov r0, r12, d17
+; CHECK-NEXT:    vmov r2, r6, d23
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    sbcs r6, r6, r12
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    vmov r6, r2, d21
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d25, r0
+; CHECK-NEXT:    vdup.32 d24, r1
 ; CHECK-NEXT:    vbit q8, q11, q12
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]!
-; CHECK-NEXT:    subs r4, r4, lr
-; CHECK-NEXT:    sbcs r5, r5, r12
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d27, r0
-; CHECK-NEXT:    vdup.32 d26, r1
+; CHECK-NEXT:    subs r7, r6, r7
+; CHECK-NEXT:    sbcs r2, r2, lr
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d27, r5
+; CHECK-NEXT:    vdup.32 d26, r4
 ; CHECK-NEXT:    vbit q9, q10, q13
 ; CHECK-NEXT:    vst1.64 {d18, d19}, [r3:128]
-; CHECK-NEXT:    pop {r4, r5, r6, lr}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend18
 ; COST: cost of 0 {{.*}} icmp
@@ -178,93 +170,78 @@ define void @func_blend19(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    vld1.64 {d28, d29}, [r1:128]!
-; CHECK-NEXT:    mov lr, #0
+; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
+; CHECK-NEXT:    vmov lr, r12, d29
+; CHECK-NEXT:    vmov r2, r4, d31
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d16, d17}, [r0:128]!
 ; CHECK-NEXT:    vld1.64 {d22, d23}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
-; CHECK-NEXT:    vmov r0, r12, d16
-; CHECK-NEXT:    vmov r1, r2, d18
-; CHECK-NEXT:    subs r0, r1, r0
-; CHECK-NEXT:    vmov r1, r4, d25
-; CHECK-NEXT:    sbcs r0, r2, r12
-; CHECK-NEXT:    mov r12, #0
-; CHECK-NEXT:    vmov r2, r0, d21
-; CHECK-NEXT:    movlt r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    mvnne r12, #0
-; CHECK-NEXT:    subs r1, r1, r2
-; CHECK-NEXT:    sbcs r0, r4, r0
-; CHECK-NEXT:    vmov r2, r4, d24
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d1, r0
-; CHECK-NEXT:    vmov r0, r1, d20
-; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r4, r1
-; CHECK-NEXT:    vmov r2, r4, d26
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d0, r0
-; CHECK-NEXT:    vmov r0, r1, d22
-; CHECK-NEXT:    vbit q10, q12, q0
-; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    sbcs r0, r4, r1
-; CHECK-NEXT:    vmov r4, r5, d31
-; CHECK-NEXT:    vmov r0, r1, d29
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r4, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]
+; CHECK-NEXT:    subs r2, r2, lr
+; CHECK-NEXT:    sbcs r4, r4, r12
+; CHECK-NEXT:    vmov r2, lr, d28
 ; CHECK-NEXT:    vmov r4, r5, d30
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d3, r0
-; CHECK-NEXT:    vmov r0, r1, d28
-; CHECK-NEXT:    subs r0, r4, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r4, r5, d27
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d2, r0
-; CHECK-NEXT:    vmov r0, r1, d23
-; CHECK-NEXT:    vbit q14, q15, q1
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d1, r6
+; CHECK-NEXT:    mov r12, #0
+; CHECK-NEXT:    subs r2, r4, r2
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    sbcs r1, r5, lr
+; CHECK-NEXT:    vmov r2, r6, d26
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    mov lr, #0
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    vdup.32 d0, r1
+; CHECK-NEXT:    vmov r0, r1, d20
+; CHECK-NEXT:    vbit q14, q15, q0
 ; CHECK-NEXT:    vst1.64 {d28, d29}, [r3:128]!
-; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]!
-; CHECK-NEXT:    subs r0, r4, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r1, r4, d17
-; CHECK-NEXT:    vmov r5, r6, d19
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    vmov r2, r5, d22
+; CHECK-NEXT:    sbcs r0, r6, r1
+; CHECK-NEXT:    vmov r1, r6, d24
+; CHECK-NEXT:    mvnlt lr, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    subs r1, r1, r2
+; CHECK-NEXT:    sbcs r1, r6, r5
+; CHECK-NEXT:    vmov r6, r5, d17
+; CHECK-NEXT:    vmov r1, r2, d19
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r6, r5, d16
+; CHECK-NEXT:    vmov r1, r2, d18
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d31, r0
-; CHECK-NEXT:    vdup.32 d30, r2
-; CHECK-NEXT:    vbit q11, q13, q15
-; CHECK-NEXT:    vst1.64 {d22, d23}, [r3:128]!
-; CHECK-NEXT:    subs r1, r5, r1
-; CHECK-NEXT:    sbcs r1, r6, r4
-; CHECK-NEXT:    movlt lr, #1
-; CHECK-NEXT:    cmp lr, #0
-; CHECK-NEXT:    mvnne lr, #0
-; CHECK-NEXT:    vdup.32 d3, lr
-; CHECK-NEXT:    vdup.32 d2, r12
-; CHECK-NEXT:    vbit q8, q9, q1
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r2, r5, d25
+; CHECK-NEXT:    vmov r0, r1, d23
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d30, r6
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    vbif q8, q9, q15
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]!
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    sbcs r0, r5, r1
+; CHECK-NEXT:    vmov r2, r5, d27
+; CHECK-NEXT:    vmov r0, r1, d21
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d1, r6
+; CHECK-NEXT:    vdup.32 d0, r4
+; CHECK-NEXT:    vorr q9, q0, q0
+; CHECK-NEXT:    vbsl q9, q12, q11
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r3:128]!
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    sbcs r0, r5, r1
+; CHECK-NEXT:    mvnlt r12, #0
+; CHECK-NEXT:    vdup.32 d3, r12
+; CHECK-NEXT:    vdup.32 d2, lr
+; CHECK-NEXT:    vbit q10, q13, q1
+; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]
 ; CHECK-NEXT:    pop {r4, r5, r6, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend19
@@ -283,194 +260,165 @@ define void @func_blend19(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 define void @func_blend20(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storeaddr) {
 ; CHECK-LABEL: func_blend20:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    add r8, r1, #64
-; CHECK-NEXT:    add lr, r0, #64
-; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]!
-; CHECK-NEXT:    mov r12, #0
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r5, d17
-; CHECK-NEXT:    vmov r6, r7, d25
-; CHECK-NEXT:    vld1.64 {d18, d19}, [lr:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d0, d1}, [lr:128]!
-; CHECK-NEXT:    vld1.64 {d22, d23}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d28, d29}, [lr:128]!
-; CHECK-NEXT:    subs r4, r6, r4
-; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r5, r6, d16
-; CHECK-NEXT:    vmov r7, r2, d24
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d27, r4
-; CHECK-NEXT:    subs r5, r7, r5
-; CHECK-NEXT:    sbcs r2, r2, r6
-; CHECK-NEXT:    vmov r5, r6, d1
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d26, r2
-; CHECK-NEXT:    vmov r2, r4, d23
-; CHECK-NEXT:    vbit q8, q12, q13
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, sp, #4
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    add r2, r0, #64
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]!
+; CHECK-NEXT:    add lr, r1, #64
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r1:128]!
+; CHECK-NEXT:    vmov r5, r6, d19
+; CHECK-NEXT:    vmov r12, r4, d25
+; CHECK-NEXT:    vld1.64 {d22, d23}, [r0:128]!
 ; CHECK-NEXT:    vld1.64 {d26, d27}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d6, d7}, [r0:128]!
-; CHECK-NEXT:    subs r2, r5, r2
-; CHECK-NEXT:    sbcs r2, r6, r4
-; CHECK-NEXT:    vmov r4, r5, d22
-; CHECK-NEXT:    vmov r6, r7, d0
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d3, r2
-; CHECK-NEXT:    subs r4, r6, r4
-; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r2, r5, d27
-; CHECK-NEXT:    vmov r6, r7, d25
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d2, r4
-; CHECK-NEXT:    vbit q11, q0, q1
-; CHECK-NEXT:    vld1.64 {d2, d3}, [r0:128]
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d24
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d5, r2
-; CHECK-NEXT:    vmov r2, r5, d26
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d19
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d4, r2
-; CHECK-NEXT:    vmov r2, r5, d21
-; CHECK-NEXT:    vbit q13, q12, q2
-; CHECK-NEXT:    vld1.64 {d24, d25}, [lr:128]
-; CHECK-NEXT:    mov lr, #0
-; CHECK-NEXT:    vld1.64 {d4, d5}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d0, d1}, [r1:128]
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    vld1.64 {d0, d1}, [r2:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d30, d31}, [r2:128]!
+; CHECK-NEXT:    vld1.64 {d28, d29}, [r2:128]!
+; CHECK-NEXT:    vld1.64 {d16, d17}, [r2:128]
+; CHECK-NEXT:    vmov r10, r9, d16
+; CHECK-NEXT:    subs r5, r5, r12
+; CHECK-NEXT:    mov r12, #0
+; CHECK-NEXT:    sbcs r6, r6, r4
+; CHECK-NEXT:    vmov r4, r8, d24
 ; CHECK-NEXT:    vmov r6, r7, d18
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d31, r2
-; CHECK-NEXT:    vmov r2, r5, d20
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r5, d25
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d30, r2
-; CHECK-NEXT:    vbif q9, q10, q15
-; CHECK-NEXT:    vld1.64 {d30, d31}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r8:128]
-; CHECK-NEXT:    vmov r2, r7, d21
-; CHECK-NEXT:    subs r1, r6, r2
-; CHECK-NEXT:    vmov r0, r6, d2
-; CHECK-NEXT:    sbcs r1, r5, r7
-; CHECK-NEXT:    vmov r2, r7, d0
-; CHECK-NEXT:    movlt lr, #1
-; CHECK-NEXT:    cmp lr, #0
-; CHECK-NEXT:    mvnne lr, #0
-; CHECK-NEXT:    subs r0, r0, r2
-; CHECK-NEXT:    sbcs r0, r6, r7
-; CHECK-NEXT:    vmov r2, r7, d30
-; CHECK-NEXT:    vmov r6, r5, d28
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r5, r7
-; CHECK-NEXT:    vmov r7, r6, d31
-; CHECK-NEXT:    vmov r5, r4, d29
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r7, r5, r7
-; CHECK-NEXT:    vmov r5, r1, d7
-; CHECK-NEXT:    sbcs r7, r4, r6
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d3, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    subs r4, r6, r4
+; CHECK-NEXT:    sbcs r4, r7, r8
+; CHECK-NEXT:    vmov r6, r7, d23
+; CHECK-NEXT:    vmov r4, r8, d27
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d2, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    vbit q12, q9, q1
+; CHECK-NEXT:    vld1.64 {d2, d3}, [lr:128]!
+; CHECK-NEXT:    subs r4, r6, r4
+; CHECK-NEXT:    sbcs r4, r7, r8
+; CHECK-NEXT:    vmov r6, r7, d1
+; CHECK-NEXT:    vmov r4, r8, d21
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d5, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    subs r4, r6, r4
+; CHECK-NEXT:    sbcs r4, r7, r8
+; CHECK-NEXT:    vmov r6, r7, d0
+; CHECK-NEXT:    vmov r4, r8, d20
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d7, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    subs r4, r6, r4
+; CHECK-NEXT:    sbcs r4, r7, r8
+; CHECK-NEXT:    vmov r6, r7, d22
+; CHECK-NEXT:    vmov r4, r8, d26
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d6, r5
+; CHECK-NEXT:    vorr q9, q3, q3
+; CHECK-NEXT:    vld1.64 {d6, d7}, [r0:128]!
+; CHECK-NEXT:    vbsl q9, q0, q10
+; CHECK-NEXT:    vld1.64 {d0, d1}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [lr:128]
+; CHECK-NEXT:    subs r4, r6, r4
+; CHECK-NEXT:    vmov r6, r5, d6
+; CHECK-NEXT:    sbcs r4, r7, r8
 ; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    vmov r7, r6, d5
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    subs r5, r5, r7
-; CHECK-NEXT:    sbcs r1, r1, r6
-; CHECK-NEXT:    vmov r6, r7, d6
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    vdup.32 d4, r4
+; CHECK-NEXT:    vbif q11, q13, q2
+; CHECK-NEXT:    vld1.64 {d4, d5}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]
+; CHECK-NEXT:    vmov r4, r7, d5
+; CHECK-NEXT:    vmov r0, r2, d7
+; CHECK-NEXT:    vmov r8, lr, d4
+; CHECK-NEXT:    subs r0, r0, r4
+; CHECK-NEXT:    sbcs r0, r2, r7
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r2, r6, r8
+; CHECK-NEXT:    sbcs r2, r5, lr
+; CHECK-NEXT:    vmov r7, r6, d3
+; CHECK-NEXT:    vmov r5, r4, d31
+; CHECK-NEXT:    vdup.32 d9, r0
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    vmov r8, lr, d20
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d8, r0
+; CHECK-NEXT:    vmov r0, r2, d2
+; CHECK-NEXT:    subs r7, r5, r7
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    sbcs r7, r4, r6
+; CHECK-NEXT:    vmov r7, r6, d30
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d11, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    subs r0, r7, r0
+; CHECK-NEXT:    sbcs r0, r6, r2
+; CHECK-NEXT:    vmov r7, r6, d29
+; CHECK-NEXT:    vmov r0, r2, d1
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d10, r5
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    vbif q15, q1, q5
+; CHECK-NEXT:    vorr q1, q4, q4
+; CHECK-NEXT:    vbsl q1, q3, q2
+; CHECK-NEXT:    subs r0, r7, r0
+; CHECK-NEXT:    sbcs r0, r6, r2
+; CHECK-NEXT:    vmov r7, r6, d28
+; CHECK-NEXT:    vmov r0, r2, d0
+; CHECK-NEXT:    mvnlt r5, #0
+; CHECK-NEXT:    vdup.32 d13, r5
+; CHECK-NEXT:    subs r0, r7, r0
+; CHECK-NEXT:    sbcs r0, r6, r2
+; CHECK-NEXT:    vmov r2, r7, d27
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d12, r0
+; CHECK-NEXT:    vbif q14, q0, q6
+; CHECK-NEXT:    vld1.64 {d0, d1}, [r1:128]
+; CHECK-NEXT:    vmov r0, r1, d1
+; CHECK-NEXT:    vmov r6, r5, d0
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    vmov r4, r2, d26
+; CHECK-NEXT:    sbcs r1, r7, r1
+; CHECK-NEXT:    vmov r0, r11, d21
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d9, r1
-; CHECK-NEXT:    vmov r1, r5, d4
-; CHECK-NEXT:    subs r1, r6, r1
-; CHECK-NEXT:    sbcs r1, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d3
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    vdup.32 d5, r1
+; CHECK-NEXT:    vmov r1, r7, d17
+; CHECK-NEXT:    subs r4, r4, r6
+; CHECK-NEXT:    sbcs r2, r2, r5
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    subs r0, r1, r0
+; CHECK-NEXT:    vdup.32 d4, r2
+; CHECK-NEXT:    sbcs r0, r7, r11
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d8, r1
-; CHECK-NEXT:    vmov r1, r5, d1
-; CHECK-NEXT:    vbit q2, q3, q4
-; CHECK-NEXT:    vdup.32 d9, r4
-; CHECK-NEXT:    vdup.32 d8, r2
-; CHECK-NEXT:    subs r1, r6, r1
-; CHECK-NEXT:    sbcs r1, r7, r5
-; CHECK-NEXT:    vmov r5, r6, d24
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d7, r1
-; CHECK-NEXT:    vmov r1, r4, d20
-; CHECK-NEXT:    vdup.32 d6, r0
-; CHECK-NEXT:    subs r1, r5, r1
-; CHECK-NEXT:    mov r1, r3
-; CHECK-NEXT:    sbcs r0, r6, r4
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r1:128]!
-; CHECK-NEXT:    vorr q8, q4, q4
-; CHECK-NEXT:    movlt r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    vbsl q8, q14, q15
-; CHECK-NEXT:    add r0, r3, #64
-; CHECK-NEXT:    vorr q15, q3, q3
-; CHECK-NEXT:    vdup.32 d29, lr
-; CHECK-NEXT:    mvnne r12, #0
-; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; CHECK-NEXT:    vbsl q15, q1, q0
-; CHECK-NEXT:    vdup.32 d28, r12
-; CHECK-NEXT:    vst1.64 {d26, d27}, [r1:128]!
-; CHECK-NEXT:    vbit q10, q12, q14
+; CHECK-NEXT:    mov r0, r3
+; CHECK-NEXT:    vbif q13, q0, q2
+; CHECK-NEXT:    vst1.64 {d24, d25}, [r0:128]!
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    subs r2, r10, r8
 ; CHECK-NEXT:    vst1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d4, d5}, [r1:128]!
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d30, d31}, [r1:128]
-; CHECK-NEXT:    vst1.64 {d20, d21}, [r0:128]
-; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    sbcs r2, r9, lr
+; CHECK-NEXT:    mvnlt r12, #0
+; CHECK-NEXT:    vst1.64 {d2, d3}, [r0:128]!
+; CHECK-NEXT:    vdup.32 d25, r1
+; CHECK-NEXT:    vst1.64 {d26, d27}, [r0:128]
+; CHECK-NEXT:    add r0, r3, #64
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
+; CHECK-NEXT:    vdup.32 d24, r12
+; CHECK-NEXT:    vst1.64 {d30, d31}, [r0:128]!
+; CHECK-NEXT:    vbif q8, q10, q12
+; CHECK-NEXT:    vst1.64 {d28, d29}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    add sp, sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend20
 ; COST: cost of 0 {{.*}} icmp

--- a/llvm/test/CodeGen/ARM/vselect_imax.ll
+++ b/llvm/test/CodeGen/ARM/vselect_imax.ll
@@ -115,45 +115,37 @@ define void @func_blend18(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
 ; CHECK-NEXT:    vld1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r6, d21
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]
+; CHECK-NEXT:    vmov r1, r6, d20
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
-; CHECK-NEXT:    vmov lr, r12, d16
+; CHECK-NEXT:    vmov r0, r12, d16
+; CHECK-NEXT:    vmov r2, lr, d18
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    vmov r2, r5, d22
+; CHECK-NEXT:    sbcs r4, lr, r12
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vmov r2, r1, d18
-; CHECK-NEXT:    subs r2, r2, lr
-; CHECK-NEXT:    vmov r2, r5, d23
-; CHECK-NEXT:    sbcs r1, r1, r12
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r2, r4
-; CHECK-NEXT:    sbcs r6, r5, r6
-; CHECK-NEXT:    vmov r2, r12, d20
-; CHECK-NEXT:    vmov r5, r4, d22
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    subs r2, r5, r2
-; CHECK-NEXT:    sbcs r2, r4, r12
-; CHECK-NEXT:    vmov lr, r12, d17
-; CHECK-NEXT:    vmov r4, r5, d19
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    subs r1, r2, r1
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    sbcs r6, r5, r6
+; CHECK-NEXT:    vmov r1, r12, d21
+; CHECK-NEXT:    vmov r6, r5, d23
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d24, r2
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    sbcs r5, r5, r12
+; CHECK-NEXT:    vmov r1, lr, d17
+; CHECK-NEXT:    vmov r2, r5, d19
+; CHECK-NEXT:    mvnlt r6, #0
 ; CHECK-NEXT:    vdup.32 d25, r6
 ; CHECK-NEXT:    vbit q10, q11, q12
-; CHECK-NEXT:    vdup.32 d22, r1
+; CHECK-NEXT:    vdup.32 d22, r4
 ; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]!
-; CHECK-NEXT:    subs r4, r4, lr
-; CHECK-NEXT:    sbcs r5, r5, r12
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    subs r1, r2, r1
+; CHECK-NEXT:    sbcs r1, r5, lr
+; CHECK-NEXT:    mvnlt r0, #0
 ; CHECK-NEXT:    vdup.32 d23, r0
 ; CHECK-NEXT:    vbit q8, q9, q11
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]
@@ -178,94 +170,77 @@ define void @func_blend19(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    vld1.64 {d28, d29}, [r1:128]!
-; CHECK-NEXT:    mov r12, #0
+; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
-; CHECK-NEXT:    vmov r2, lr, d28
-; CHECK-NEXT:    vmov r4, r5, d30
+; CHECK-NEXT:    vmov lr, r12, d28
+; CHECK-NEXT:    vmov r2, r4, d30
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r0:128]!
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r1:128]!
 ; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d22, d23}, [r1:128]
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]
-; CHECK-NEXT:    vmov r0, r1, d23
+; CHECK-NEXT:    vld1.64 {d22, d23}, [r0:128]
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]
+; CHECK-NEXT:    subs r2, r2, lr
+; CHECK-NEXT:    sbcs r4, r4, r12
+; CHECK-NEXT:    vmov r2, lr, d29
+; CHECK-NEXT:    vmov r4, r5, d31
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d0, r6
+; CHECK-NEXT:    mov r12, #0
 ; CHECK-NEXT:    subs r2, r4, r2
-; CHECK-NEXT:    vmov r4, r6, d31
+; CHECK-NEXT:    mov r4, #0
 ; CHECK-NEXT:    sbcs r2, r5, lr
-; CHECK-NEXT:    vmov r5, lr, d29
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d0, r2
-; CHECK-NEXT:    subs r4, r4, r5
-; CHECK-NEXT:    vmov r2, r5, d25
-; CHECK-NEXT:    sbcs r6, r6, lr
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    vdup.32 d1, r6
+; CHECK-NEXT:    mov lr, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vmov r2, r6, d23
+; CHECK-NEXT:    vdup.32 d1, r0
+; CHECK-NEXT:    vmov r0, r1, d21
 ; CHECK-NEXT:    vbit q14, q15, q0
 ; CHECK-NEXT:    vst1.64 {d28, d29}, [r3:128]!
 ; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r1, r2, d21
-; CHECK-NEXT:    vmov r6, r5, d27
+; CHECK-NEXT:    vmov r2, r5, d25
+; CHECK-NEXT:    sbcs r0, r6, r1
+; CHECK-NEXT:    vmov r1, r6, d27
+; CHECK-NEXT:    mvnlt lr, #0
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    subs r1, r1, r2
+; CHECK-NEXT:    sbcs r1, r6, r5
+; CHECK-NEXT:    vmov r6, r5, d16
+; CHECK-NEXT:    vmov r1, r2, d18
+; CHECK-NEXT:    mvnlt r4, #0
 ; CHECK-NEXT:    subs r1, r6, r1
 ; CHECK-NEXT:    sbcs r1, r5, r2
-; CHECK-NEXT:    vmov r2, r6, d18
-; CHECK-NEXT:    vmov r5, r4, d16
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r5, r2
-; CHECK-NEXT:    sbcs r2, r4, r6
-; CHECK-NEXT:    vmov r6, lr, d19
-; CHECK-NEXT:    vmov r4, r5, d17
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d30, r2
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    subs r4, r4, r6
-; CHECK-NEXT:    sbcs r6, r5, lr
-; CHECK-NEXT:    vmov r4, r5, d26
-; CHECK-NEXT:    vmov r6, lr, d20
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d31, r2
-; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    vmov r6, r5, d17
+; CHECK-NEXT:    vmov r1, r2, d19
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d30, r0
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r2, r5, d26
+; CHECK-NEXT:    vmov r0, r1, d24
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d31, r6
+; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    vbif q8, q9, q15
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]!
-; CHECK-NEXT:    subs r4, r4, r6
-; CHECK-NEXT:    sbcs r6, r5, lr
-; CHECK-NEXT:    vmov r4, r5, d24
-; CHECK-NEXT:    vmov r6, lr, d22
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d0, r2
-; CHECK-NEXT:    vdup.32 d1, r1
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    sbcs r0, r5, r1
+; CHECK-NEXT:    vmov r2, r5, d22
+; CHECK-NEXT:    vmov r0, r1, d20
+; CHECK-NEXT:    mvnlt r6, #0
+; CHECK-NEXT:    vdup.32 d0, r6
+; CHECK-NEXT:    vdup.32 d1, r4
 ; CHECK-NEXT:    vorr q9, q0, q0
-; CHECK-NEXT:    vbsl q9, q13, q10
+; CHECK-NEXT:    vbsl q9, q13, q12
 ; CHECK-NEXT:    vst1.64 {d18, d19}, [r3:128]!
-; CHECK-NEXT:    subs r4, r4, r6
-; CHECK-NEXT:    sbcs r6, r5, lr
-; CHECK-NEXT:    movlt r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    mvnne r12, #0
+; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    sbcs r0, r5, r1
+; CHECK-NEXT:    mvnlt r12, #0
 ; CHECK-NEXT:    vdup.32 d2, r12
-; CHECK-NEXT:    vdup.32 d3, r0
-; CHECK-NEXT:    vorr q10, q1, q1
-; CHECK-NEXT:    vbsl q10, q12, q11
+; CHECK-NEXT:    vdup.32 d3, lr
+; CHECK-NEXT:    vbit q10, q11, q1
 ; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]
 ; CHECK-NEXT:    pop {r4, r5, r6, lr}
 ; CHECK-NEXT:    mov pc, lr
@@ -285,195 +260,167 @@ define void @func_blend19(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 define void @func_blend20(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storeaddr) {
 ; CHECK-LABEL: func_blend20:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    add lr, r1, #64
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, sp, #4
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    add r8, r1, #64
+; CHECK-NEXT:    add lr, r0, #64
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]!
-; CHECK-NEXT:    add r8, r0, #64
+; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    mov r12, #0
-; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r5, d16
-; CHECK-NEXT:    vmov r6, r7, d26
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]!
+; CHECK-NEXT:    vmov r2, r4, d18
+; CHECK-NEXT:    vmov r5, r6, d20
 ; CHECK-NEXT:    vld1.64 {d22, d23}, [lr:128]!
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d4, d5}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d0, d1}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d2, d3}, [r1:128]!
-; CHECK-NEXT:    subs r4, r6, r4
-; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r5, r6, d17
-; CHECK-NEXT:    vmov r7, r2, d27
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d28, r4
-; CHECK-NEXT:    subs r5, r7, r5
-; CHECK-NEXT:    sbcs r2, r2, r6
-; CHECK-NEXT:    vmov r5, r6, d24
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d29, r2
-; CHECK-NEXT:    vmov r2, r4, d22
-; CHECK-NEXT:    vbit q8, q13, q14
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r8:128]!
+; CHECK-NEXT:    vld1.64 {d2, d3}, [r8:128]!
+; CHECK-NEXT:    vld1.64 {d4, d5}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d30, d31}, [r8:128]!
+; CHECK-NEXT:    vld1.64 {d12, d13}, [r1:128]!
+; CHECK-NEXT:    vmov r10, r9, d12
 ; CHECK-NEXT:    subs r2, r5, r2
 ; CHECK-NEXT:    sbcs r2, r6, r4
-; CHECK-NEXT:    vmov r4, r5, d23
-; CHECK-NEXT:    vmov r6, r7, d25
+; CHECK-NEXT:    vmov r5, r6, d21
+; CHECK-NEXT:    vmov r2, r4, d19
+; CHECK-NEXT:    mvnlt r7, #0
+; CHECK-NEXT:    vdup.32 d0, r7
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d4
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d28, r2
-; CHECK-NEXT:    subs r4, r6, r4
-; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r2, r5, d4
-; CHECK-NEXT:    vmov r6, r7, d30
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d29, r4
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    vbit q11, q12, q14
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r1:128]
-; CHECK-NEXT:    vld1.64 {d28, d29}, [r0:128]
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d31
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d1, r2
+; CHECK-NEXT:    vmov r2, r4, d2
+; CHECK-NEXT:    vbif q10, q9, q0
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d5
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d6, r2
-; CHECK-NEXT:    vmov r2, r5, d5
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d18
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d7, r2
-; CHECK-NEXT:    vmov r2, r5, d20
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d19
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d26, r2
-; CHECK-NEXT:    vmov r2, r5, d21
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d27, r2
-; CHECK-NEXT:    vbif q9, q10, q13
-; CHECK-NEXT:    vld1.64 {d26, d27}, [r8:128]!
-; CHECK-NEXT:    vorr q10, q3, q3
-; CHECK-NEXT:    vmov r6, r7, d27
-; CHECK-NEXT:    vbsl q10, q15, q2
-; CHECK-NEXT:    vld1.64 {d30, d31}, [lr:128]!
-; CHECK-NEXT:    vmov r2, r5, d31
-; CHECK-NEXT:    vld1.64 {d4, d5}, [r8:128]
-; CHECK-NEXT:    vld1.64 {d6, d7}, [lr:128]
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d26
-; CHECK-NEXT:    vmov r2, r5, d30
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r0, r7, r5
-; CHECK-NEXT:    vmov r1, r2, d24
-; CHECK-NEXT:    vmov r5, r6, d28
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r5, r1
-; CHECK-NEXT:    sbcs r1, r6, r2
-; CHECK-NEXT:    vmov r2, r5, d2
-; CHECK-NEXT:    vmov r6, r7, d0
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d1
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d8, r2
-; CHECK-NEXT:    vmov r2, r5, d3
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    vmov r2, r4, d3
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d22
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
 ; CHECK-NEXT:    vdup.32 d9, r2
-; CHECK-NEXT:    vmov r2, r7, d25
-; CHECK-NEXT:    vbif q0, q1, q4
-; CHECK-NEXT:    vdup.32 d2, r1
-; CHECK-NEXT:    vmov r1, r6, d29
+; CHECK-NEXT:    vmov r2, r4, d26
+; CHECK-NEXT:    vorr q9, q4, q4
+; CHECK-NEXT:    vbsl q9, q2, q1
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d23
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d10, r2
+; CHECK-NEXT:    vmov r2, r4, d27
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d24
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d11, r2
+; CHECK-NEXT:    vmov r2, r4, d16
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    vmov r5, r6, d25
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d28, r2
+; CHECK-NEXT:    vmov r2, r4, d17
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r6, r4
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d29, r2
+; CHECK-NEXT:    vorr q3, q14, q14
+; CHECK-NEXT:    vld1.64 {d28, d29}, [lr:128]!
+; CHECK-NEXT:    vbsl q3, q12, q8
+; CHECK-NEXT:    vld1.64 {d0, d1}, [lr:128]
+; CHECK-NEXT:    vorr q8, q5, q5
+; CHECK-NEXT:    vld1.64 {d10, d11}, [r0:128]!
+; CHECK-NEXT:    vbsl q8, q11, q13
+; CHECK-NEXT:    vld1.64 {d22, d23}, [r1:128]
+; CHECK-NEXT:    vmov r1, r5, d28
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]
+; CHECK-NEXT:    vmov r0, r2, d30
+; CHECK-NEXT:    vmov r4, r11, d22
+; CHECK-NEXT:    vmov r6, r7, d24
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r8:128]
+; CHECK-NEXT:    subs r0, r1, r0
+; CHECK-NEXT:    sbcs r0, r5, r2
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    subs r1, r6, r4
+; CHECK-NEXT:    sbcs r1, r7, r11
+; CHECK-NEXT:    mov r7, #0
+; CHECK-NEXT:    vmov r1, r2, d10
+; CHECK-NEXT:    mvnlt r7, #0
+; CHECK-NEXT:    vmov r6, r5, d11
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    vdup.32 d4, r7
 ; CHECK-NEXT:    vdup.32 d8, r0
-; CHECK-NEXT:    vdup.32 d9, r4
-; CHECK-NEXT:    vmov r5, r4, d7
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    subs r1, r1, r10
+; CHECK-NEXT:    sbcs r1, r2, r9
+; CHECK-NEXT:    vmov r1, r2, d13
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    vdup.32 d2, r4
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r6, r5, d29
+; CHECK-NEXT:    vmov r1, r2, d31
+; CHECK-NEXT:    mvnlt r4, #0
+; CHECK-NEXT:    vdup.32 d3, r4
+; CHECK-NEXT:    vbsl q1, q5, q6
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    vmov r7, r6, d25
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r5, r4, d27
+; CHECK-NEXT:    vmov r1, r2, d23
+; CHECK-NEXT:    mvnlt r0, #0
+; CHECK-NEXT:    vdup.32 d9, r0
 ; CHECK-NEXT:    mov r0, r3
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
-; CHECK-NEXT:    vorr q8, q4, q4
+; CHECK-NEXT:    vst1.64 {d6, d7}, [r0:128]!
+; CHECK-NEXT:    vbif q14, q15, q4
 ; CHECK-NEXT:    vst1.64 {d20, d21}, [r0:128]!
-; CHECK-NEXT:    vbsl q8, q13, q15
-; CHECK-NEXT:    vst1.64 {d0, d1}, [r0:128]!
-; CHECK-NEXT:    subs r1, r1, r2
-; CHECK-NEXT:    sbcs r1, r6, r7
-; CHECK-NEXT:    vmov r7, r6, d4
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d3, r1
-; CHECK-NEXT:    vmov r1, r2, d6
-; CHECK-NEXT:    vbit q12, q14, q1
-; CHECK-NEXT:    vst1.64 {d24, d25}, [r0:128]
-; CHECK-NEXT:    add r0, r3, #64
-; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d2, d3}, [r0:128]!
 ; CHECK-NEXT:    subs r1, r7, r1
 ; CHECK-NEXT:    sbcs r1, r6, r2
-; CHECK-NEXT:    vmov r2, r7, d5
+; CHECK-NEXT:    vmov r7, r6, d0
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d26, r1
-; CHECK-NEXT:    subs r2, r2, r5
-; CHECK-NEXT:    sbcs r2, r7, r4
-; CHECK-NEXT:    movlt r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    mvnne r12, #0
-; CHECK-NEXT:    vdup.32 d27, r12
-; CHECK-NEXT:    vorr q10, q13, q13
-; CHECK-NEXT:    vbsl q10, q2, q3
+; CHECK-NEXT:    mvnlt r1, #0
+; CHECK-NEXT:    vdup.32 d5, r1
+; CHECK-NEXT:    vmov r1, r2, d26
+; CHECK-NEXT:    vbit q11, q12, q2
+; CHECK-NEXT:    vst1.64 {d22, d23}, [r0:128]
+; CHECK-NEXT:    add r0, r3, #64
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d28, d29}, [r0:128]!
+; CHECK-NEXT:    subs r1, r7, r1
+; CHECK-NEXT:    vmov r1, r7, d1
+; CHECK-NEXT:    sbcs r2, r6, r2
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    mvnlt r2, #0
+; CHECK-NEXT:    vdup.32 d30, r2
+; CHECK-NEXT:    subs r1, r1, r5
+; CHECK-NEXT:    sbcs r1, r7, r4
+; CHECK-NEXT:    mvnlt r12, #0
+; CHECK-NEXT:    vdup.32 d31, r12
+; CHECK-NEXT:    vorr q10, q15, q15
+; CHECK-NEXT:    vbsl q10, q0, q13
 ; CHECK-NEXT:    vst1.64 {d20, d21}, [r0:128]
-; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    add sp, sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend20
 ; COST: cost of 0 {{.*}} icmp

--- a/llvm/test/CodeGen/Thumb2/mve-fmas.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-fmas.ll
@@ -400,78 +400,71 @@ define arm_aapcs_vfpcc <8 x half> @vfma16_v1_pred(<8 x half> %src1, <8 x half> %
 ;
 ; CHECK-MVE-LABEL: vfma16_v1_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s13, s0
-; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmov.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmla.f16 s15, s14, s12
+; CHECK-MVE-NEXT:    vmov.f32 s12, s0
+; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmla.f16 s12, s4, s8
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmov.f32 s14, s0
-; CHECK-MVE-NEXT:    vmla.f16 s14, s4, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s13, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s0, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s12, s0
+; CHECK-MVE-NEXT:    vmov.f32 s13, s1
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmov.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s1
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
+; CHECK-MVE-NEXT:    vmla.f16 s14, s4, s0
+; CHECK-MVE-NEXT:    vmla.f16 s13, s5, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s5, #0
-; CHECK-MVE-NEXT:    vmla.f16 s14, s8, s4
-; CHECK-MVE-NEXT:    vmov.f32 s8, s1
-; CHECK-MVE-NEXT:    vmla.f16 s8, s5, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s1, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s13, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
+; CHECK-MVE-NEXT:    vins.f16 s13, s14
+; CHECK-MVE-NEXT:    vmov.f32 s14, s2
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmov.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
-; CHECK-MVE-NEXT:    vmla.f16 s14, s8, s4
+; CHECK-MVE-NEXT:    vmla.f16 s1, s4, s0
+; CHECK-MVE-NEXT:    vmla.f16 s14, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    vmov.f32 s8, s2
-; CHECK-MVE-NEXT:    vmla.f16 s8, s6, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s7
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s2, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s2
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
+; CHECK-MVE-NEXT:    vins.f16 s12, s15
+; CHECK-MVE-NEXT:    vmov.f32 s15, s3
+; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    vmov.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s3
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmla.f16 s10, s6, s4
+; CHECK-MVE-NEXT:    vmla.f16 s6, s2, s0
+; CHECK-MVE-NEXT:    vmla.f16 s15, s7, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s6, s3
-; CHECK-MVE-NEXT:    vmla.f16 s6, s7, s11
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s10
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s3, s6
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s3
+; CHECK-MVE-NEXT:    vins.f16 s14, s1
+; CHECK-MVE-NEXT:    vins.f16 s15, s6
+; CHECK-MVE-NEXT:    vmov q0, q3
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <8 x half> %src2, %src3
@@ -497,78 +490,71 @@ define arm_aapcs_vfpcc <8 x half> @vfma16_v2_pred(<8 x half> %src1, <8 x half> %
 ;
 ; CHECK-MVE-LABEL: vfma16_v2_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s13, s0
-; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmov.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmla.f16 s15, s14, s12
+; CHECK-MVE-NEXT:    vmov.f32 s12, s0
+; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmla.f16 s12, s4, s8
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmov.f32 s14, s0
-; CHECK-MVE-NEXT:    vmla.f16 s14, s4, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s13, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s0, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s12, s0
+; CHECK-MVE-NEXT:    vmov.f32 s13, s1
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmov.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s1
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
+; CHECK-MVE-NEXT:    vmla.f16 s14, s4, s0
+; CHECK-MVE-NEXT:    vmla.f16 s13, s5, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s5, #0
-; CHECK-MVE-NEXT:    vmla.f16 s14, s8, s4
-; CHECK-MVE-NEXT:    vmov.f32 s8, s1
-; CHECK-MVE-NEXT:    vmla.f16 s8, s5, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s1, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s13, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
+; CHECK-MVE-NEXT:    vins.f16 s13, s14
+; CHECK-MVE-NEXT:    vmov.f32 s14, s2
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmov.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
-; CHECK-MVE-NEXT:    vmla.f16 s14, s8, s4
+; CHECK-MVE-NEXT:    vmla.f16 s1, s4, s0
+; CHECK-MVE-NEXT:    vmla.f16 s14, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    vmov.f32 s8, s2
-; CHECK-MVE-NEXT:    vmla.f16 s8, s6, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s7
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s2, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s2
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
+; CHECK-MVE-NEXT:    vins.f16 s12, s15
+; CHECK-MVE-NEXT:    vmov.f32 s15, s3
+; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    vmov.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s3
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmla.f16 s10, s6, s4
+; CHECK-MVE-NEXT:    vmla.f16 s6, s2, s0
+; CHECK-MVE-NEXT:    vmla.f16 s15, s7, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s6, s3
-; CHECK-MVE-NEXT:    vmla.f16 s6, s7, s11
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s10
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s3, s6
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s3
+; CHECK-MVE-NEXT:    vins.f16 s14, s1
+; CHECK-MVE-NEXT:    vins.f16 s15, s6
+; CHECK-MVE-NEXT:    vmov q0, q3
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <8 x half> %src2, %src3
@@ -594,78 +580,71 @@ define arm_aapcs_vfpcc <8 x half> @vfms16_pred(<8 x half> %src1, <8 x half> %src
 ;
 ; CHECK-MVE-LABEL: vfms16_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s13, s0
-; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmov.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmls.f16 s15, s14, s12
+; CHECK-MVE-NEXT:    vmov.f32 s12, s0
+; CHECK-MVE-NEXT:    vcmp.f16 s14, #0
+; CHECK-MVE-NEXT:    vmls.f16 s12, s4, s8
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmov.f32 s14, s0
-; CHECK-MVE-NEXT:    vmls.f16 s14, s4, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s13, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s0, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s12, s0
+; CHECK-MVE-NEXT:    vmov.f32 s13, s1
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmov.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s1
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
+; CHECK-MVE-NEXT:    vmls.f16 s14, s4, s0
+; CHECK-MVE-NEXT:    vmls.f16 s13, s5, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s5, #0
-; CHECK-MVE-NEXT:    vmls.f16 s14, s8, s4
-; CHECK-MVE-NEXT:    vmov.f32 s8, s1
-; CHECK-MVE-NEXT:    vmls.f16 s8, s5, s9
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s1, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s13, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
+; CHECK-MVE-NEXT:    vins.f16 s13, s14
+; CHECK-MVE-NEXT:    vmov.f32 s14, s2
+; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmov.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
-; CHECK-MVE-NEXT:    vmls.f16 s14, s8, s4
+; CHECK-MVE-NEXT:    vmls.f16 s1, s4, s0
+; CHECK-MVE-NEXT:    vmls.f16 s14, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    vmov.f32 s8, s2
-; CHECK-MVE-NEXT:    vmls.f16 s8, s6, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s7
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s2, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s2
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
+; CHECK-MVE-NEXT:    vins.f16 s12, s15
+; CHECK-MVE-NEXT:    vmov.f32 s15, s3
+; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    vmov.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s3
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmls.f16 s10, s6, s4
+; CHECK-MVE-NEXT:    vmls.f16 s6, s2, s0
+; CHECK-MVE-NEXT:    vmls.f16 s15, s7, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s6, s3
-; CHECK-MVE-NEXT:    vmls.f16 s6, s7, s11
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s10
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s3, s6
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s15, s3
+; CHECK-MVE-NEXT:    vins.f16 s14, s1
+; CHECK-MVE-NEXT:    vins.f16 s15, s6
+; CHECK-MVE-NEXT:    vmov q0, q3
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <8 x half> %src2, %src3
@@ -696,75 +675,68 @@ define arm_aapcs_vfpcc <8 x half> @vfmar16_pred(<8 x half> %src1, <8 x half> %sr
 ;
 ; CHECK-MVE-LABEL: vfmar16_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vcmp.f16 s10, #0
-; CHECK-MVE-NEXT:    vcvtb.f16.f32 s8, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s10, s0
+; CHECK-MVE-NEXT:    vcvtb.f16.f32 s12, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s4
+; CHECK-MVE-NEXT:    vmov.f32 s14, s10
+; CHECK-MVE-NEXT:    vcmp.f16 s8, #0
+; CHECK-MVE-NEXT:    vmla.f16 s14, s8, s12
+; CHECK-MVE-NEXT:    vmov.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s14, s12
-; CHECK-MVE-NEXT:    vmla.f16 s14, s10, s8
+; CHECK-MVE-NEXT:    vmla.f16 s8, s4, s12
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s10, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s12, s0
-; CHECK-MVE-NEXT:    vmla.f16 s12, s4, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s0, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmov.f32 s9, s1
+; CHECK-MVE-NEXT:    vmov.f32 s10, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmla.f16 s10, s0, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vins.f16 s0, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s1
-; CHECK-MVE-NEXT:    vmov.f32 s12, s10
+; CHECK-MVE-NEXT:    vmla.f16 s9, s5, s12
 ; CHECK-MVE-NEXT:    vcmp.f16 s5, #0
-; CHECK-MVE-NEXT:    vmla.f16 s12, s4, s8
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s10, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s10, s1
-; CHECK-MVE-NEXT:    vmla.f16 s10, s5, s8
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s1, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s2
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmov.f32 s12, s10
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmla.f16 s12, s4, s8
-; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s10, s12
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s14
+; CHECK-MVE-NEXT:    vmov.f32 s14, s4
+; CHECK-MVE-NEXT:    vins.f16 s9, s10
 ; CHECK-MVE-NEXT:    vmov.f32 s10, s2
-; CHECK-MVE-NEXT:    vmla.f16 s10, s6, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s2, s10
-; CHECK-MVE-NEXT:    vmov.f32 s10, s6
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmla.f16 s10, s4, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmla.f16 s14, s0, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmla.f16 s10, s6, s12
+; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s4
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s2
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
+; CHECK-MVE-NEXT:    vmov.f32 s11, s3
+; CHECK-MVE-NEXT:    vmov.f32 s4, s2
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmla.f16 s4, s0, s12
+; CHECK-MVE-NEXT:    vmla.f16 s11, s7, s12
 ; CHECK-MVE-NEXT:    vcmp.f16 s7, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s10
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s6, s3
-; CHECK-MVE-NEXT:    vmla.f16 s6, s7, s8
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s3, s6
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s3
+; CHECK-MVE-NEXT:    vins.f16 s10, s14
+; CHECK-MVE-NEXT:    vins.f16 s11, s4
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %src3 = fptrunc float %src3o to half
@@ -797,74 +769,67 @@ define arm_aapcs_vfpcc <8 x half> @vfma16_pred(<8 x half> %src1, <8 x half> %src
 ;
 ; CHECK-MVE-LABEL: vfma16_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s4
-; CHECK-MVE-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-MVE-NEXT:    vcmp.f16 s10, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
+; CHECK-MVE-NEXT:    vmov q3, q0
+; CHECK-MVE-NEXT:    vcvtb.f16.f32 s3, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s12
+; CHECK-MVE-NEXT:    vmov.f32 s8, s3
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmla.f16 s8, s2, s0
+; CHECK-MVE-NEXT:    vmov.f32 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s14, s8
-; CHECK-MVE-NEXT:    vmla.f16 s14, s12, s10
+; CHECK-MVE-NEXT:    vmla.f16 s0, s12, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s10, s12, s14
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s12, s8
-; CHECK-MVE-NEXT:    vmla.f16 s12, s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s0, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s0, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s5
+; CHECK-MVE-NEXT:    vmov.f32 s1, s3
+; CHECK-MVE-NEXT:    vins.f16 s0, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s13
+; CHECK-MVE-NEXT:    vmov.f32 s8, s3
+; CHECK-MVE-NEXT:    vmla.f16 s8, s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vins.f16 s0, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s1
-; CHECK-MVE-NEXT:    vmov.f32 s12, s8
+; CHECK-MVE-NEXT:    vmla.f16 s1, s13, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s5, #0
-; CHECK-MVE-NEXT:    vmla.f16 s12, s10, s4
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s10, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmla.f16 s10, s1, s5
-; CHECK-MVE-NEXT:    vmov.f32 s12, s8
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s1, s10
-; CHECK-MVE-NEXT:    vmovx.f16 s10, s2
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmla.f16 s12, s10, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s6
+; CHECK-MVE-NEXT:    vins.f16 s1, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s14
+; CHECK-MVE-NEXT:    vmov.f32 s8, s3
+; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
+; CHECK-MVE-NEXT:    vmla.f16 s8, s4, s2
+; CHECK-MVE-NEXT:    vmov.f32 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmla.f16 s2, s14, s6
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s10, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmla.f16 s10, s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s2, s10
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vins.f16 s2, s8
+; CHECK-MVE-NEXT:    vmov.f32 s8, s3
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmla.f16 s10, s6, s4
+; CHECK-MVE-NEXT:    vmla.f16 s8, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmla.f16 s3, s15, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s7, #0
-; CHECK-MVE-NEXT:    vmla.f16 s8, s3, s7
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s10
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s3, s8
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s3, s15
+; CHECK-MVE-NEXT:    vins.f16 s3, s8
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %src3 = fptrunc float %src3o to half
@@ -893,34 +858,30 @@ define arm_aapcs_vfpcc <4 x float> @vfma32_v1_pred(<4 x float> %src1, <4 x float
 ;
 ; CHECK-MVE-LABEL: vfma32_v1_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    vmov q3, q0
+; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
+; CHECK-MVE-NEXT:    vmov.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmov.f32 s1, s13
+; CHECK-MVE-NEXT:    vmov.f32 s0, s12
+; CHECK-MVE-NEXT:    vmla.f32 s2, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f32 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s3
-; CHECK-MVE-NEXT:    vmla.f32 s12, s6, s10
-; CHECK-MVE-NEXT:    vmov.f32 s10, s1
-; CHECK-MVE-NEXT:    vmla.f32 s14, s7, s11
-; CHECK-MVE-NEXT:    vmla.f32 s10, s5, s9
-; CHECK-MVE-NEXT:    vmov.f32 s9, s0
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s5, #0
-; CHECK-MVE-NEXT:    vmla.f32 s9, s4, s8
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    vmla.f32 s3, s7, s11
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vmla.f32 s1, s5, s9
+; CHECK-MVE-NEXT:    vmla.f32 s0, s4, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s13
+; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s2, s12
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s1, s10
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s3, s14
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s0, s9
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s0, s12
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <4 x float> %src2, %src3
@@ -946,34 +907,30 @@ define arm_aapcs_vfpcc <4 x float> @vfma32_v2_pred(<4 x float> %src1, <4 x float
 ;
 ; CHECK-MVE-LABEL: vfma32_v2_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    vmov q3, q0
+; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
+; CHECK-MVE-NEXT:    vmov.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmov.f32 s1, s13
+; CHECK-MVE-NEXT:    vmov.f32 s0, s12
+; CHECK-MVE-NEXT:    vmla.f32 s2, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f32 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s3
-; CHECK-MVE-NEXT:    vmla.f32 s12, s6, s10
-; CHECK-MVE-NEXT:    vmov.f32 s10, s1
-; CHECK-MVE-NEXT:    vmla.f32 s14, s7, s11
-; CHECK-MVE-NEXT:    vmla.f32 s10, s5, s9
-; CHECK-MVE-NEXT:    vmov.f32 s9, s0
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s5, #0
-; CHECK-MVE-NEXT:    vmla.f32 s9, s4, s8
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    vmla.f32 s3, s7, s11
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vmla.f32 s1, s5, s9
+; CHECK-MVE-NEXT:    vmla.f32 s0, s4, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s13
+; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s2, s12
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s1, s10
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s3, s14
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s0, s9
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s0, s12
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <4 x float> %src2, %src3
@@ -999,34 +956,30 @@ define arm_aapcs_vfpcc <4 x float> @vfms32_pred(<4 x float> %src1, <4 x float> %
 ;
 ; CHECK-MVE-LABEL: vfms32_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    vmov q3, q0
+; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
+; CHECK-MVE-NEXT:    vmov.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmov.f32 s1, s13
+; CHECK-MVE-NEXT:    vmov.f32 s0, s12
+; CHECK-MVE-NEXT:    vmls.f32 s2, s6, s10
 ; CHECK-MVE-NEXT:    vcmp.f32 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s12, s2
-; CHECK-MVE-NEXT:    vmov.f32 s14, s3
-; CHECK-MVE-NEXT:    vmls.f32 s12, s6, s10
-; CHECK-MVE-NEXT:    vmov.f32 s10, s1
-; CHECK-MVE-NEXT:    vmls.f32 s14, s7, s11
-; CHECK-MVE-NEXT:    vmls.f32 s10, s5, s9
-; CHECK-MVE-NEXT:    vmov.f32 s9, s0
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s5, #0
-; CHECK-MVE-NEXT:    vmls.f32 s9, s4, s8
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    vmls.f32 s3, s7, s11
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vmls.f32 s1, s5, s9
+; CHECK-MVE-NEXT:    vmls.f32 s0, s4, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s13
+; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s2, s12
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s1, s10
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s3, s14
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s0, s9
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s0, s12
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %0 = fmul <4 x float> %src2, %src3
@@ -1055,34 +1008,30 @@ define arm_aapcs_vfpcc <4 x float> @vfmar32_pred(<4 x float> %src1, <4 x float> 
 ;
 ; CHECK-MVE-LABEL: vfmar32_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    vmov q3, q0
+; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
+; CHECK-MVE-NEXT:    vmov.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmov.f32 s1, s13
+; CHECK-MVE-NEXT:    vmov.f32 s0, s12
+; CHECK-MVE-NEXT:    vmla.f32 s2, s6, s8
 ; CHECK-MVE-NEXT:    vcmp.f32 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s10, s2
-; CHECK-MVE-NEXT:    vmov.f32 s12, s1
-; CHECK-MVE-NEXT:    vmov.f32 s14, s3
-; CHECK-MVE-NEXT:    vmov.f32 s9, s0
-; CHECK-MVE-NEXT:    vmla.f32 s10, s6, s8
-; CHECK-MVE-NEXT:    vmla.f32 s12, s5, s8
-; CHECK-MVE-NEXT:    vmla.f32 s14, s7, s8
-; CHECK-MVE-NEXT:    vmla.f32 s9, s4, s8
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s5, #0
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    vmla.f32 s3, s7, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s3, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vmla.f32 s1, s5, s8
+; CHECK-MVE-NEXT:    vmla.f32 s0, s4, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s1, s13
+; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s2, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s1, s12
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s3, s14
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s0, s9
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s0, s12
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %i = insertelement <4 x float> undef, float %src3, i32 0
@@ -1112,33 +1061,30 @@ define arm_aapcs_vfpcc <4 x float> @vfmas32_pred(<4 x float> %src1, <4 x float> 
 ;
 ; CHECK-MVE-LABEL: vfmas32_pred:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    vmov.f32 s10, s8
+; CHECK-MVE-NEXT:    vmov.f32 s11, s8
+; CHECK-MVE-NEXT:    vmov.f32 s9, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s7, #0
-; CHECK-MVE-NEXT:    vmov.f32 s10, s8
-; CHECK-MVE-NEXT:    vmov.f32 s12, s8
-; CHECK-MVE-NEXT:    vmov.f32 s14, s8
 ; CHECK-MVE-NEXT:    vmla.f32 s8, s0, s4
 ; CHECK-MVE-NEXT:    vmla.f32 s10, s2, s6
-; CHECK-MVE-NEXT:    vmla.f32 s12, s1, s5
-; CHECK-MVE-NEXT:    vmla.f32 s14, s3, s7
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmla.f32 s11, s3, s7
 ; CHECK-MVE-NEXT:    vcmp.f32 s5, #0
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s6, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vmla.f32 s9, s1, s5
+; CHECK-MVE-NEXT:    vcmp.f32 s4, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s1
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s2, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s1, s12
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s3, s14
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s0, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 entry:
   %i = insertelement <4 x float> undef, float %src3, i32 0

--- a/llvm/test/CodeGen/Thumb2/mve-fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-fpclamptosat_vec.ll
@@ -670,63 +670,51 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-LABEL: stest_f64i64:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, lr}
-; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, #4
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vmov q4, q0
+; CHECK-NEXT:    movs r4, #0
+; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    mvn r8, #-2147483648
+; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    subs.w r7, r0, #-1
+; CHECK-NEXT:    mov.w r6, #-1
+; CHECK-NEXT:    sbcs.w r7, r1, r8
+; CHECK-NEXT:    mov.w r9, #-2147483648
+; CHECK-NEXT:    sbcs r7, r2, #0
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    csel r7, r0, r6, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r4, lt
+; CHECK-NEXT:    csel r5, r1, r8, lt
+; CHECK-NEXT:    rsbs r0, r7, #0
+; CHECK-NEXT:    sbcs.w r0, r9, r5
+; CHECK-NEXT:    sbcs.w r0, r6, r2
 ; CHECK-NEXT:    vmov r0, r1, d8
+; CHECK-NEXT:    sbcs.w r2, r6, r3
+; CHECK-NEXT:    csel r10, r5, r9, lt
+; CHECK-NEXT:    csel r7, r7, r4, lt
 ; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    vmov r12, lr, d9
 ; CHECK-NEXT:    subs.w r5, r0, #-1
-; CHECK-NEXT:    mvn r4, #-2147483648
-; CHECK-NEXT:    sbcs.w r5, r1, r4
+; CHECK-NEXT:    sbcs.w r5, r1, r8
 ; CHECK-NEXT:    sbcs r5, r2, #0
-; CHECK-NEXT:    mov.w r7, #-2147483648
 ; CHECK-NEXT:    sbcs r5, r3, #0
-; CHECK-NEXT:    cset r5, lt
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    csel r3, r3, r5, ne
-; CHECK-NEXT:    csel r2, r2, r5, ne
-; CHECK-NEXT:    mov.w r5, #-1
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    csel r0, r0, r5, ne
-; CHECK-NEXT:    rsbs r6, r0, #0
-; CHECK-NEXT:    sbcs.w r6, r7, r1
-; CHECK-NEXT:    sbcs.w r2, r5, r2
-; CHECK-NEXT:    sbcs.w r2, r5, r3
-; CHECK-NEXT:    csel r8, r1, r7, lt
-; CHECK-NEXT:    cset r1, lt
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    csel r9, r0, r1, ne
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs.w r6, r0, #-1
-; CHECK-NEXT:    sbcs.w r6, r1, r4
-; CHECK-NEXT:    sbcs r6, r2, #0
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    cset r6, lt
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    csel r0, r0, r5, ne
-; CHECK-NEXT:    csel r3, r3, r6, ne
-; CHECK-NEXT:    csel r2, r2, r6, ne
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    rsbs r6, r0, #0
-; CHECK-NEXT:    sbcs.w r6, r7, r1
-; CHECK-NEXT:    sbcs.w r2, r5, r2
-; CHECK-NEXT:    sbcs.w r2, r5, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    csel r1, r1, r7, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r9, r0
-; CHECK-NEXT:    vmov q0[3], q0[1], r8, r1
+; CHECK-NEXT:    csel r0, r0, r6, lt
+; CHECK-NEXT:    csel r1, r1, r8, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r4, lt
+; CHECK-NEXT:    rsbs r5, r0, #0
+; CHECK-NEXT:    sbcs.w r5, r9, r1
+; CHECK-NEXT:    sbcs.w r2, r6, r2
+; CHECK-NEXT:    sbcs.w r2, r6, r3
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r10
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    add sp, #4
-; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, pc}
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 9223372036854775807, i128 9223372036854775807>
@@ -740,8 +728,8 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-LABEL: utest_f64i64:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r7, lr}
-; CHECK-NEXT:    push {r4, r5, r7, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, lr}
+; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vmov q4, q0
@@ -749,24 +737,21 @@ define arm_aapcs_vfpcc <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    vmov r12, lr, d8
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r4, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r4, r1, r2, ne
-; CHECK-NEXT:    csel r5, r0, r2, ne
+; CHECK-NEXT:    csel r5, r1, r4, lo
+; CHECK-NEXT:    csel r6, r0, r4, lo
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    mov r1, lr
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r5
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r4
+; CHECK-NEXT:    csel r0, r0, r4, lo
+; CHECK-NEXT:    csel r1, r1, r4, lo
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r7, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
   %conv = fptoui <2 x double> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -786,45 +771,37 @@ define arm_aapcs_vfpcc <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    vmov r0, r1, d9
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    vmov r12, lr, d8
-; CHECK-NEXT:    subs r4, r2, #1
-; CHECK-NEXT:    sbcs r4, r3, #0
-; CHECK-NEXT:    mov.w r8, #1
-; CHECK-NEXT:    cset r4, lt
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    csel r0, r0, r4, ne
-; CHECK-NEXT:    csel r3, r3, r4, ne
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    csel r2, r2, r8, ne
-; CHECK-NEXT:    rsbs r5, r0, #0
+; CHECK-NEXT:    subs r5, r2, #1
 ; CHECK-NEXT:    mov.w r4, #0
-; CHECK-NEXT:    sbcs.w r5, r4, r1
-; CHECK-NEXT:    sbcs.w r2, r4, r2
-; CHECK-NEXT:    sbcs.w r2, r4, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r5, r1, r2, ne
-; CHECK-NEXT:    csel r7, r0, r2, ne
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    sbcs r6, r3, #0
-; CHECK-NEXT:    cset r6, lt
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    csel r0, r0, r6, ne
-; CHECK-NEXT:    csel r3, r3, r6, ne
-; CHECK-NEXT:    csel r1, r1, r6, ne
-; CHECK-NEXT:    csel r2, r2, r8, ne
+; CHECK-NEXT:    sbcs r5, r3, #0
+; CHECK-NEXT:    mov.w r8, #1
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r8, lt
+; CHECK-NEXT:    csel r1, r1, r4, lt
 ; CHECK-NEXT:    rsbs r6, r0, #0
 ; CHECK-NEXT:    sbcs.w r6, r4, r1
 ; CHECK-NEXT:    sbcs.w r2, r4, r2
 ; CHECK-NEXT:    sbcs.w r2, r4, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
+; CHECK-NEXT:    csel r6, r1, r4, lt
+; CHECK-NEXT:    csel r7, r0, r4, lt
+; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    mov r1, lr
+; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    subs r5, r2, #1
+; CHECK-NEXT:    sbcs r5, r3, #0
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r8, lt
+; CHECK-NEXT:    csel r1, r1, r4, lt
+; CHECK-NEXT:    rsbs r5, r0, #0
+; CHECK-NEXT:    sbcs.w r5, r4, r1
+; CHECK-NEXT:    sbcs.w r2, r4, r2
+; CHECK-NEXT:    sbcs.w r2, r4, r3
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r1, r1, r4, lt
 ; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r6
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
 entry:
@@ -840,54 +817,50 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-LABEL: stest_f32i64:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    vmov r0, r9, d0
-; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs.w r7, r0, #-1
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs.w r7, r1, r5
-; CHECK-NEXT:    mov.w r6, #-1
-; CHECK-NEXT:    sbcs r7, r2, #0
-; CHECK-NEXT:    sbcs r7, r3, #0
-; CHECK-NEXT:    cset r7, lt
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csel r0, r0, r6, ne
-; CHECK-NEXT:    csel r3, r3, r7, ne
-; CHECK-NEXT:    csel r2, r2, r7, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    rsbs r4, r0, #0
-; CHECK-NEXT:    mov.w r7, #-2147483648
-; CHECK-NEXT:    sbcs.w r4, r7, r1
-; CHECK-NEXT:    sbcs.w r2, r6, r2
-; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    csel r8, r1, r7, lt
-; CHECK-NEXT:    cset r1, lt
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    csel r10, r0, r1, ne
-; CHECK-NEXT:    mov r0, r9
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, #4
+; CHECK-NEXT:    vmov r8, r0, d0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs.w r4, r0, #-1
-; CHECK-NEXT:    sbcs.w r4, r1, r5
+; CHECK-NEXT:    mvn r9, #-2147483648
+; CHECK-NEXT:    sbcs.w r4, r1, r9
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r4, r2, #0
+; CHECK-NEXT:    mov.w r7, #-2147483648
 ; CHECK-NEXT:    sbcs r4, r3, #0
-; CHECK-NEXT:    cset r4, lt
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    csel r0, r0, r6, ne
-; CHECK-NEXT:    csel r3, r3, r4, ne
-; CHECK-NEXT:    csel r2, r2, r4, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    rsbs r5, r0, #0
-; CHECK-NEXT:    sbcs.w r5, r7, r1
-; CHECK-NEXT:    sbcs.w r2, r6, r2
-; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    cset r2, lt
+; CHECK-NEXT:    mov.w r4, #-1
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r2, r2, r5, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    rsbs r6, r0, #0
+; CHECK-NEXT:    sbcs.w r6, r7, r1
+; CHECK-NEXT:    sbcs.w r2, r4, r2
+; CHECK-NEXT:    sbcs.w r2, r4, r3
+; CHECK-NEXT:    csel r11, r0, r5, lt
+; CHECK-NEXT:    mov r0, r8
+; CHECK-NEXT:    csel r10, r1, r7, lt
+; CHECK-NEXT:    bl __fixsfti
+; CHECK-NEXT:    subs.w r6, r0, #-1
+; CHECK-NEXT:    sbcs.w r6, r1, r9
+; CHECK-NEXT:    sbcs r6, r2, #0
+; CHECK-NEXT:    sbcs r6, r3, #0
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r2, r2, r5, lt
+; CHECK-NEXT:    rsbs r6, r0, #0
+; CHECK-NEXT:    sbcs.w r6, r7, r1
+; CHECK-NEXT:    sbcs.w r2, r4, r2
+; CHECK-NEXT:    sbcs.w r2, r4, r3
+; CHECK-NEXT:    csel r0, r0, r5, lt
 ; CHECK-NEXT:    csel r1, r1, r7, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r10, r0
-; CHECK-NEXT:    vmov q0[3], q0[1], r8, r1
-; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r11
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r10
+; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %0 = icmp slt <2 x i128> %conv, <i128 9223372036854775807, i128 9223372036854775807>
@@ -901,27 +874,27 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @utest_f32i64(<2 x float> %x) {
 ; CHECK-LABEL: utest_f32i64:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vmov r4, r0, d0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r6, r0, r2, ne
+; CHECK-NEXT:    csel r7, r0, r5, lo
 ; CHECK-NEXT:    mov r0, r4
-; CHECK-NEXT:    csel r5, r1, r2, ne
+; CHECK-NEXT:    csel r6, r1, r5, lo
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
-; CHECK-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEXT:    csel r0, r0, r5, lo
+; CHECK-NEXT:    csel r1, r1, r5, lo
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r6
+; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 entry:
   %conv = fptoui <2 x float> %x to <2 x i128>
   %0 = icmp ult <2 x i128> %conv, <i128 18446744073709551616, i128 18446744073709551616>
@@ -935,44 +908,36 @@ define arm_aapcs_vfpcc <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    vmov r5, r0, d0
+; CHECK-NEXT:    vmov r6, r0, d0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r4, r2, #1
-; CHECK-NEXT:    mov.w r8, #1
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r4, r3, #0
-; CHECK-NEXT:    mov.w r6, #0
-; CHECK-NEXT:    cset r4, lt
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    csel r0, r0, r4, ne
-; CHECK-NEXT:    csel r3, r3, r4, ne
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    csel r2, r2, r8, ne
+; CHECK-NEXT:    mov.w r8, #1
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r2, r2, r8, lt
+; CHECK-NEXT:    csel r1, r1, r5, lt
 ; CHECK-NEXT:    rsbs r4, r0, #0
-; CHECK-NEXT:    sbcs.w r4, r6, r1
-; CHECK-NEXT:    sbcs.w r2, r6, r2
-; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r7, r0, r2, ne
-; CHECK-NEXT:    mov r0, r5
-; CHECK-NEXT:    csel r4, r1, r2, ne
+; CHECK-NEXT:    sbcs.w r4, r5, r1
+; CHECK-NEXT:    sbcs.w r2, r5, r2
+; CHECK-NEXT:    sbcs.w r2, r5, r3
+; CHECK-NEXT:    csel r7, r0, r5, lt
+; CHECK-NEXT:    mov r0, r6
+; CHECK-NEXT:    csel r4, r1, r5, lt
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs r5, r2, #1
-; CHECK-NEXT:    sbcs r5, r3, #0
-; CHECK-NEXT:    cset r5, lt
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    csel r0, r0, r5, ne
-; CHECK-NEXT:    csel r3, r3, r5, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    csel r2, r2, r8, ne
-; CHECK-NEXT:    rsbs r5, r0, #0
-; CHECK-NEXT:    sbcs.w r5, r6, r1
-; CHECK-NEXT:    sbcs.w r2, r6, r2
-; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
+; CHECK-NEXT:    subs r6, r2, #1
+; CHECK-NEXT:    sbcs r6, r3, #0
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r2, r2, r8, lt
+; CHECK-NEXT:    csel r1, r1, r5, lt
+; CHECK-NEXT:    rsbs r6, r0, #0
+; CHECK-NEXT:    sbcs.w r6, r5, r1
+; CHECK-NEXT:    sbcs.w r2, r5, r2
+; CHECK-NEXT:    sbcs.w r2, r5, r3
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r1, r1, r5, lt
 ; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
 ; CHECK-NEXT:    vmov q0[3], q0[1], r1, r4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
@@ -1057,20 +1022,16 @@ define arm_aapcs_vfpcc <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEXT:    sbcs.w r4, r5, r1
 ; CHECK-NEXT:    sbcs.w r2, r5, r2
 ; CHECK-NEXT:    sbcs.w r2, r5, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r6, r0, r2, ne
+; CHECK-NEXT:    csel r6, r0, r5, lt
 ; CHECK-NEXT:    vmov.u16 r0, q4[0]
-; CHECK-NEXT:    csel r7, r1, r2, ne
+; CHECK-NEXT:    csel r7, r1, r5, lt
 ; CHECK-NEXT:    bl __fixhfti
 ; CHECK-NEXT:    rsbs r4, r0, #0
 ; CHECK-NEXT:    sbcs.w r4, r5, r1
 ; CHECK-NEXT:    sbcs.w r2, r5, r2
 ; CHECK-NEXT:    sbcs.w r2, r5, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r1, r1, r5, lt
 ; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
 ; CHECK-NEXT:    vmov q0[3], q0[1], r1, r7
 ; CHECK-NEXT:    vpop {d8, d9}
@@ -1727,63 +1688,51 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-LABEL: stest_f64i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, lr}
-; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, #4
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vmov q4, q0
+; CHECK-NEXT:    movs r4, #0
 ; CHECK-NEXT:    vmov r0, r1, d9
-; CHECK-NEXT:    bl __fixdfti
-; CHECK-NEXT:    vmov r12, lr, d8
-; CHECK-NEXT:    subs.w r5, r0, #-1
-; CHECK-NEXT:    mvn r4, #-2147483648
-; CHECK-NEXT:    sbcs.w r5, r1, r4
-; CHECK-NEXT:    sbcs r5, r2, #0
-; CHECK-NEXT:    mov.w r6, #-1
-; CHECK-NEXT:    sbcs r5, r3, #0
-; CHECK-NEXT:    cset r5, lt
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    csel r0, r0, r6, ne
-; CHECK-NEXT:    csel r3, r3, r5, ne
-; CHECK-NEXT:    csel r2, r2, r5, ne
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    rsbs r7, r0, #0
-; CHECK-NEXT:    mov.w r5, #-2147483648
-; CHECK-NEXT:    sbcs.w r7, r5, r1
-; CHECK-NEXT:    sbcs.w r2, r6, r2
-; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r9, r0, r2, ne
-; CHECK-NEXT:    csel r8, r1, r5, ne
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    mov r1, lr
+; CHECK-NEXT:    mvn r8, #-2147483648
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs.w r7, r0, #-1
-; CHECK-NEXT:    sbcs.w r7, r1, r4
+; CHECK-NEXT:    mov.w r6, #-1
+; CHECK-NEXT:    sbcs.w r7, r1, r8
+; CHECK-NEXT:    mov.w r9, #-2147483648
 ; CHECK-NEXT:    sbcs r7, r2, #0
 ; CHECK-NEXT:    sbcs r7, r3, #0
-; CHECK-NEXT:    cset r7, lt
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csel r0, r0, r6, ne
-; CHECK-NEXT:    csel r3, r3, r7, ne
-; CHECK-NEXT:    csel r2, r2, r7, ne
-; CHECK-NEXT:    csel r1, r1, r4, ne
-; CHECK-NEXT:    rsbs r7, r0, #0
-; CHECK-NEXT:    sbcs.w r7, r5, r1
+; CHECK-NEXT:    csel r7, r0, r6, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r4, lt
+; CHECK-NEXT:    csel r5, r1, r8, lt
+; CHECK-NEXT:    rsbs r0, r7, #0
+; CHECK-NEXT:    sbcs.w r0, r9, r5
+; CHECK-NEXT:    sbcs.w r0, r6, r2
+; CHECK-NEXT:    vmov r0, r1, d8
+; CHECK-NEXT:    sbcs.w r2, r6, r3
+; CHECK-NEXT:    csel r10, r5, r9, lt
+; CHECK-NEXT:    csel r7, r7, r4, lt
+; CHECK-NEXT:    bl __fixdfti
+; CHECK-NEXT:    subs.w r5, r0, #-1
+; CHECK-NEXT:    sbcs.w r5, r1, r8
+; CHECK-NEXT:    sbcs r5, r2, #0
+; CHECK-NEXT:    sbcs r5, r3, #0
+; CHECK-NEXT:    csel r0, r0, r6, lt
+; CHECK-NEXT:    csel r1, r1, r8, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r4, lt
+; CHECK-NEXT:    rsbs r5, r0, #0
+; CHECK-NEXT:    sbcs.w r5, r9, r1
 ; CHECK-NEXT:    sbcs.w r2, r6, r2
 ; CHECK-NEXT:    sbcs.w r2, r6, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r9
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r8
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r10
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    add sp, #4
-; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, pc}
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 9223372036854775807, i128 9223372036854775807>)
@@ -1795,8 +1744,8 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-LABEL: utest_f64i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r7, lr}
-; CHECK-NEXT:    push {r4, r5, r7, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, lr}
+; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vmov q4, q0
@@ -1804,24 +1753,21 @@ define arm_aapcs_vfpcc <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    vmov r12, lr, d8
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r4, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r4, r1, r2, ne
-; CHECK-NEXT:    csel r5, r0, r2, ne
+; CHECK-NEXT:    csel r5, r1, r4, lo
+; CHECK-NEXT:    csel r6, r0, r4, lo
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    mov r1, lr
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r5
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r4
+; CHECK-NEXT:    csel r0, r0, r4, lo
+; CHECK-NEXT:    csel r1, r1, r4, lo
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r7, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
   %conv = fptoui <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -1832,8 +1778,8 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-LABEL: ustest_f64i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r7, lr}
-; CHECK-NEXT:    push {r4, r5, r7, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, lr}
+; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vmov q4, q0
@@ -1841,34 +1787,31 @@ define arm_aapcs_vfpcc <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    vmov r12, lr, d8
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r4, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r5, r0, r2, ne
-; CHECK-NEXT:    csel r0, r3, r2, ne
-; CHECK-NEXT:    csel r4, r1, r2, ne
+; CHECK-NEXT:    csel r5, r0, r4, lt
+; CHECK-NEXT:    csel r0, r3, r4, lt
+; CHECK-NEXT:    csel r6, r1, r4, lt
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    itt mi
-; CHECK-NEXT:    movmi r4, #0
+; CHECK-NEXT:    movmi r6, #0
 ; CHECK-NEXT:    movmi r5, #0
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    mov r1, lr
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r2, r3, r2, ne
+; CHECK-NEXT:    csel r1, r1, r4, lt
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r2, r3, r4, lt
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    itt mi
 ; CHECK-NEXT:    movmi r0, #0
 ; CHECK-NEXT:    movmi r1, #0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r0, r5
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r4
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r6
 ; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop {r4, r5, r7, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
   %conv = fptosi <2 x double> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -1880,54 +1823,50 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-LABEL: stest_f32i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vmov r8, r0, d0
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    subs.w r7, r0, #-1
-; CHECK-NEXT:    mvn r5, #-2147483648
-; CHECK-NEXT:    sbcs.w r7, r1, r5
-; CHECK-NEXT:    mov.w r6, #-2147483648
-; CHECK-NEXT:    sbcs r7, r2, #0
-; CHECK-NEXT:    sbcs r7, r3, #0
-; CHECK-NEXT:    cset r7, lt
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csel r3, r3, r7, ne
-; CHECK-NEXT:    csel r2, r2, r7, ne
-; CHECK-NEXT:    mov.w r7, #-1
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    csel r0, r0, r7, ne
-; CHECK-NEXT:    rsbs r4, r0, #0
-; CHECK-NEXT:    sbcs.w r4, r6, r1
-; CHECK-NEXT:    sbcs.w r2, r7, r2
-; CHECK-NEXT:    sbcs.w r2, r7, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r10, r0, r2, ne
-; CHECK-NEXT:    mov r0, r8
-; CHECK-NEXT:    csel r9, r1, r6, ne
-; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs.w r4, r0, #-1
-; CHECK-NEXT:    sbcs.w r4, r1, r5
+; CHECK-NEXT:    mvn r9, #-2147483648
+; CHECK-NEXT:    sbcs.w r4, r1, r9
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r4, r2, #0
+; CHECK-NEXT:    mov.w r7, #-2147483648
 ; CHECK-NEXT:    sbcs r4, r3, #0
-; CHECK-NEXT:    cset r4, lt
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    csel r0, r0, r7, ne
-; CHECK-NEXT:    csel r3, r3, r4, ne
-; CHECK-NEXT:    csel r2, r2, r4, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    rsbs r5, r0, #0
-; CHECK-NEXT:    sbcs.w r5, r6, r1
-; CHECK-NEXT:    sbcs.w r2, r7, r2
-; CHECK-NEXT:    sbcs.w r2, r7, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r6, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r10
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r9
-; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEXT:    mov.w r4, #-1
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r2, r2, r5, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    rsbs r6, r0, #0
+; CHECK-NEXT:    sbcs.w r6, r7, r1
+; CHECK-NEXT:    sbcs.w r2, r4, r2
+; CHECK-NEXT:    sbcs.w r2, r4, r3
+; CHECK-NEXT:    csel r11, r0, r5, lt
+; CHECK-NEXT:    mov r0, r8
+; CHECK-NEXT:    csel r10, r1, r7, lt
+; CHECK-NEXT:    bl __fixsfti
+; CHECK-NEXT:    subs.w r6, r0, #-1
+; CHECK-NEXT:    sbcs.w r6, r1, r9
+; CHECK-NEXT:    sbcs r6, r2, #0
+; CHECK-NEXT:    sbcs r6, r3, #0
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r1, r1, r9, lt
+; CHECK-NEXT:    csel r3, r3, r5, lt
+; CHECK-NEXT:    csel r2, r2, r5, lt
+; CHECK-NEXT:    rsbs r6, r0, #0
+; CHECK-NEXT:    sbcs.w r6, r7, r1
+; CHECK-NEXT:    sbcs.w r2, r4, r2
+; CHECK-NEXT:    sbcs.w r2, r4, r3
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r1, r1, r7, lt
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r11
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r10
+; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 9223372036854775807, i128 9223372036854775807>)
@@ -1939,27 +1878,27 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ; CHECK-LABEL: utest_f32i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vmov r4, r0, d0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r6, r0, r2, ne
+; CHECK-NEXT:    csel r7, r0, r5, lo
 ; CHECK-NEXT:    mov r0, r4
-; CHECK-NEXT:    csel r5, r1, r2, ne
+; CHECK-NEXT:    csel r6, r1, r5, lo
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lo
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
-; CHECK-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEXT:    csel r0, r0, r5, lo
+; CHECK-NEXT:    csel r1, r1, r5, lo
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r7
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r6
+; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 entry:
   %conv = fptoui <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.umin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)
@@ -1970,37 +1909,37 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-LABEL: ustest_f32i64_mm:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    .pad #4
+; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vmov r4, r0, d0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r2, #1
+; CHECK-NEXT:    mov.w r5, #0
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r6, r0, r2, ne
-; CHECK-NEXT:    csel r0, r3, r2, ne
-; CHECK-NEXT:    csel r5, r1, r2, ne
+; CHECK-NEXT:    csel r6, r0, r5, lt
+; CHECK-NEXT:    csel r0, r3, r5, lt
+; CHECK-NEXT:    csel r7, r1, r5, lt
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mov r0, r4
 ; CHECK-NEXT:    itt mi
-; CHECK-NEXT:    movmi r5, #0
+; CHECK-NEXT:    movmi r7, #0
 ; CHECK-NEXT:    movmi r6, #0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r2, #1
 ; CHECK-NEXT:    sbcs r2, r3, #0
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r1, r1, r2, ne
-; CHECK-NEXT:    csel r0, r0, r2, ne
-; CHECK-NEXT:    csel r2, r3, r2, ne
+; CHECK-NEXT:    csel r1, r1, r5, lt
+; CHECK-NEXT:    csel r0, r0, r5, lt
+; CHECK-NEXT:    csel r2, r3, r5, lt
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    itt mi
 ; CHECK-NEXT:    movmi r0, #0
 ; CHECK-NEXT:    movmi r1, #0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
-; CHECK-NEXT:    vmov q0[3], q0[1], r1, r5
-; CHECK-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEXT:    vmov q0[3], q0[1], r1, r7
+; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 entry:
   %conv = fptosi <2 x float> %x to <2 x i128>
   %spec.store.select = call <2 x i128> @llvm.smin.v2i128(<2 x i128> %conv, <2 x i128> <i128 18446744073709551616, i128 18446744073709551616>)

--- a/llvm/test/CodeGen/Thumb2/mve-vcmpf.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vcmpf.ll
@@ -5,26 +5,23 @@
 define arm_aapcs_vfpcc <4 x float> @vcmp_oeq_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oeq_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, eq
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, eq
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v4f32:
@@ -82,26 +79,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ogt_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ogt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, gt
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, gt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ogt_v4f32:
@@ -118,26 +112,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_oge_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, ge
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ge
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oge_v4f32:
@@ -154,26 +145,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_olt_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_olt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_olt_v4f32:
@@ -190,26 +178,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ole_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ole_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, ls
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ls
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ole_v4f32:
@@ -295,26 +280,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ugt_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ugt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, hi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, hi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ugt_v4f32:
@@ -331,26 +313,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uge_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, pl
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, pl
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uge_v4f32:
@@ -367,26 +346,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ult_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ult_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, lt
+; CHECK-MVE-NEXT:    vselge.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
+; CHECK-MVE-NEXT:    vselge.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, lt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselge.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselge.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ult_v4f32:
@@ -403,26 +374,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ule_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ule_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, le
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, le
+; CHECK-MVE-NEXT:    vselgt.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, le
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
+; CHECK-MVE-NEXT:    vselgt.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, le
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselgt.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselgt.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ule_v4f32:
@@ -439,26 +402,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ord_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ord_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, vc
+; CHECK-MVE-NEXT:    vselvs.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
+; CHECK-MVE-NEXT:    vselvs.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vc
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselvs.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselvs.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ord_v4f32:
@@ -476,26 +431,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uno_v4f32(<4 x float> %src, <4 x float> %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uno_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s7
-; CHECK-MVE-NEXT:    cset r0, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s5
-; CHECK-MVE-NEXT:    cset r1, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s6
-; CHECK-MVE-NEXT:    cset r2, vs
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vs
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uno_v4f32:
@@ -520,63 +472,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oeq_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -687,63 +632,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ogt_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -766,63 +704,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oge_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -845,63 +776,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_olt_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -924,63 +848,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ole_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1154,63 +1071,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ugt_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1233,63 +1143,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uge_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1314,16 +1217,12 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vselge.f16 s16, s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselge.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
@@ -1331,29 +1230,21 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
 ; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselge.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselge.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
@@ -1361,13 +1252,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselge.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
@@ -1393,16 +1280,12 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vselgt.f16 s16, s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselgt.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
@@ -1410,29 +1293,21 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
 ; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselgt.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselgt.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
@@ -1440,13 +1315,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselgt.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
@@ -1472,16 +1343,12 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vselvs.f16 s16, s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselvs.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
@@ -1489,29 +1356,21 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
 ; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselvs.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselvs.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
@@ -1519,13 +1378,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselvs.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
@@ -1550,63 +1405,56 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uno_v8f16(<8 x half> %src, <8 x half> %s
 ; CHECK-MVE-NEXT:    vmovx.f16 s16, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s18, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s18, s16
-; CHECK-MVE-NEXT:    vmovx.f16 s16, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s18, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s18, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s16, s18, s16
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s5
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
+; CHECK-MVE-NEXT:    vmovx.f16 s16, s12
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s18, s16
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s5
-; CHECK-MVE-NEXT:    vins.f16 s0, s16
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s2
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
-; CHECK-MVE-NEXT:    vcmp.f16 s8, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
+; CHECK-MVE-NEXT:    vins.f16 s9, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
+; CHECK-MVE-NEXT:    vins.f16 s8, s18
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s7
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s2, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s15
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s7
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s10, s4
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    vpop {d8, d9}
 ; CHECK-MVE-NEXT:    bx lr
 ;

--- a/llvm/test/CodeGen/Thumb2/mve-vcmpfr.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vcmpfr.ll
@@ -5,26 +5,23 @@
 define arm_aapcs_vfpcc <4 x float> @vcmp_oeq_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oeq_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, eq
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, eq
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v4f32:
@@ -88,26 +85,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ogt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ogt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, gt
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, gt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ogt_v4f32:
@@ -127,26 +121,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_oge_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, ge
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ge
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oge_v4f32:
@@ -166,26 +157,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_olt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_olt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_olt_v4f32:
@@ -205,26 +193,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ole_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ole_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, ls
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ls
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ole_v4f32:
@@ -319,26 +304,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ugt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ugt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, hi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, hi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ugt_v4f32:
@@ -358,26 +340,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uge_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, pl
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, pl
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uge_v4f32:
@@ -397,26 +376,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ult_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ult_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, lt
+; CHECK-MVE-NEXT:    vselge.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
+; CHECK-MVE-NEXT:    vselge.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, lt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselge.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselge.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ult_v4f32:
@@ -436,26 +407,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ule_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ule_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, le
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, le
+; CHECK-MVE-NEXT:    vselgt.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, le
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
+; CHECK-MVE-NEXT:    vselgt.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, le
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselgt.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselgt.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ule_v4f32:
@@ -475,26 +438,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ord_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ord_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, vc
+; CHECK-MVE-NEXT:    vselvs.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
+; CHECK-MVE-NEXT:    vselvs.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vc
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vselvs.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselvs.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ord_v4f32:
@@ -515,26 +470,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uno_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uno_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s4
-; CHECK-MVE-NEXT:    cset r0, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s4
-; CHECK-MVE-NEXT:    cset r1, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s4
-; CHECK-MVE-NEXT:    cset r2, vs
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vs
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uno_v4f32:
@@ -558,61 +510,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oeq_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_oeq_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v8f16:
@@ -717,61 +662,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ogt_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_ogt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ogt_v8f16:
@@ -792,61 +730,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oge_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_oge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oge_v8f16:
@@ -867,61 +798,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_olt_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_olt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_olt_v8f16:
@@ -942,61 +866,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ole_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_ole_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ole_v8f16:
@@ -1160,61 +1077,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ugt_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_ugt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ugt_v8f16:
@@ -1235,61 +1145,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uge_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_uge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uge_v8f16:
@@ -1315,13 +1218,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselge.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -1329,41 +1228,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselge.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselge.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselge.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1390,13 +1277,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselgt.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -1404,41 +1287,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselgt.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselgt.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselgt.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1465,13 +1336,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselvs.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -1479,41 +1346,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselvs.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselvs.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselvs.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1536,61 +1391,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uno_v8f16(<8 x half> %src, half %src2, <
 ; CHECK-MVE-LABEL: vcmp_uno_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uno_v8f16:
@@ -1614,26 +1462,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_oeq_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_oeq_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, eq
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, eq
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oeq_v4f32:
@@ -1697,26 +1542,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ogt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ogt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, gt
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, gt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ogt_v4f32:
@@ -1736,26 +1578,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_oge_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_oge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, ge
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ge
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oge_v4f32:
@@ -1775,26 +1614,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_olt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_olt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_olt_v4f32:
@@ -1814,26 +1650,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ole_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ole_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, ls
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ls
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ole_v4f32:
@@ -1928,26 +1761,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ugt_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ugt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, hi
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, hi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ugt_v4f32:
@@ -1967,26 +1797,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_uge_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_uge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, pl
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, pl
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uge_v4f32:
@@ -2006,26 +1833,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ult_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ult_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, lt
+; CHECK-MVE-NEXT:    vselge.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
+; CHECK-MVE-NEXT:    vselge.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, lt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vselge.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselge.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ult_v4f32:
@@ -2045,26 +1864,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ule_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ule_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, le
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, le
+; CHECK-MVE-NEXT:    vselgt.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, le
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
+; CHECK-MVE-NEXT:    vselgt.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, le
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vselgt.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselgt.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ule_v4f32:
@@ -2084,26 +1895,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ord_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ord_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, vc
+; CHECK-MVE-NEXT:    vselvs.f32 s2, s14, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
+; CHECK-MVE-NEXT:    vselvs.f32 s1, s13, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vc
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vselvs.f32 s3, s15, s11
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselvs.f32 s0, s12, s8
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ord_v4f32:
@@ -2124,26 +1927,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_uno_v4f32(<4 x float> %src, float %src2, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_uno_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s3
-; CHECK-MVE-NEXT:    cset r0, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s4, s1
-; CHECK-MVE-NEXT:    cset r1, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s4, s2
-; CHECK-MVE-NEXT:    cset r2, vs
+; CHECK-MVE-NEXT:    vcmp.f32 s4, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vs
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s14, s10
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s13, s9
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s15, s11
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s12, s8
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uno_v4f32:
@@ -2167,61 +1967,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_oeq_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_oeq_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oeq_v8f16:
@@ -2326,61 +2119,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ogt_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_ogt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ogt_v8f16:
@@ -2401,61 +2187,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_oge_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_oge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oge_v8f16:
@@ -2476,61 +2255,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_olt_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_olt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_olt_v8f16:
@@ -2551,61 +2323,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ole_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_ole_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ole_v8f16:
@@ -2769,61 +2534,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ugt_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_ugt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ugt_v8f16:
@@ -2844,61 +2602,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uge_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_uge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uge_v8f16:
@@ -2924,13 +2675,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ult_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselge.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -2938,41 +2685,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ult_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselge.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselge.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselge.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselge.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -2999,13 +2734,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ule_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselgt.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -3013,41 +2744,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ule_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselgt.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselgt.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselgt.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -3074,13 +2793,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ord_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
+; CHECK-MVE-NEXT:    vselvs.f16 s0, s12, s8
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
 ; CHECK-MVE-NEXT:    vins.f16 s0, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
@@ -3088,41 +2803,29 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ord_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
+; CHECK-MVE-NEXT:    vselvs.f16 s1, s13, s9
 ; CHECK-MVE-NEXT:    vins.f16 s1, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
+; CHECK-MVE-NEXT:    vselvs.f16 s2, s14, s10
 ; CHECK-MVE-NEXT:    vins.f16 s2, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s6, s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
+; CHECK-MVE-NEXT:    vselvs.f16 s3, s15, s11
 ; CHECK-MVE-NEXT:    vins.f16 s3, s6
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -3145,61 +2848,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uno_v8f16(<8 x half> %src, half %src2,
 ; CHECK-MVE-LABEL: vcmp_r_uno_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s1
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s2
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s4, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s3
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uno_v8f16:
@@ -3223,61 +2919,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oeq_v8f16_bc(<8 x half> %src, half %src2
 ; CHECK-MVE-LABEL: vcmp_oeq_v8f16_bc:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s5, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s5, s8
 ; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s6, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s5, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s12, s8
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s13
-; CHECK-MVE-NEXT:    vins.f16 s0, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s12
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s13
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s9
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s14
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s13, s9
-; CHECK-MVE-NEXT:    vins.f16 s1, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s9, s13
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s9, s6
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s14
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s15
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s14, s10
-; CHECK-MVE-NEXT:    vins.f16 s2, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s6, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s10, s14
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s11
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s4
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s6, s8, s6
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s15
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s15, s11
-; CHECK-MVE-NEXT:    vins.f16 s3, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s11, s15
+; CHECK-MVE-NEXT:    vins.f16 s8, s5
+; CHECK-MVE-NEXT:    vins.f16 s10, s6
+; CHECK-MVE-NEXT:    vins.f16 s11, s2
+; CHECK-MVE-NEXT:    vmov q0, q2
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v8f16_bc:

--- a/llvm/test/CodeGen/Thumb2/mve-vcmpfz.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vcmpfz.ll
@@ -5,26 +5,23 @@
 define arm_aapcs_vfpcc <4 x float> @vcmp_oeq_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oeq_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, eq
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, eq
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v4f32:
@@ -82,26 +79,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ogt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ogt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, gt
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, gt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ogt_v4f32:
@@ -118,26 +112,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_oge_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_oge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, ge
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ge
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oge_v4f32:
@@ -154,26 +145,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_olt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_olt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_olt_v4f32:
@@ -190,26 +178,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ole_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ole_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, ls
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ls
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ole_v4f32:
@@ -295,26 +280,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ugt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ugt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, hi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, hi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ugt_v4f32:
@@ -331,26 +313,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uge_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, pl
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, pl
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uge_v4f32:
@@ -367,26 +346,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ult_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ult_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, lt
+; CHECK-MVE-NEXT:    vselge.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
+; CHECK-MVE-NEXT:    vselge.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, lt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vselge.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselge.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ult_v4f32:
@@ -403,26 +374,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ule_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ule_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, le
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, le
+; CHECK-MVE-NEXT:    vselgt.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, le
+; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
+; CHECK-MVE-NEXT:    vselgt.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, le
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vselgt.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselgt.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ule_v4f32:
@@ -439,26 +402,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_ord_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_ord_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s1
-; CHECK-MVE-NEXT:    cset r1, vc
+; CHECK-MVE-NEXT:    vselvs.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
-; CHECK-MVE-NEXT:    cset r2, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
+; CHECK-MVE-NEXT:    vselvs.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vc
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    vselvs.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselvs.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ord_v4f32:
@@ -476,26 +431,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_uno_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_uno_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s1
-; CHECK-MVE-NEXT:    cset r1, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
-; CHECK-MVE-NEXT:    cset r2, vs
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vs
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uno_v4f32:
@@ -516,61 +468,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oeq_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_oeq_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oeq_v8f16:
@@ -669,61 +614,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ogt_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_ogt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ogt_v8f16:
@@ -741,61 +679,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_oge_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_oge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_oge_v8f16:
@@ -813,61 +744,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_olt_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_olt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_olt_v8f16:
@@ -885,61 +809,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ole_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_ole_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ole_v8f16:
@@ -1094,61 +1011,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ugt_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_ugt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_ugt_v8f16:
@@ -1166,61 +1076,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uge_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_uge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uge_v8f16:
@@ -1243,13 +1146,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselge.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -1257,27 +1156,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselge.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselge.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -1285,13 +1176,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ult_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselge.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1315,13 +1202,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselgt.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -1329,27 +1212,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselgt.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -1357,13 +1232,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ule_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselgt.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1387,13 +1258,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselvs.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -1401,27 +1268,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s1
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselvs.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s2
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -1429,13 +1288,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_ord_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselvs.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -1455,61 +1310,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_uno_v8f16(<8 x half> %src, <8 x half> %a
 ; CHECK-MVE-LABEL: vcmp_uno_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s1
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s2
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_uno_v8f16:
@@ -1530,26 +1378,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_oeq_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_oeq_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, eq
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, eq
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, eq
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oeq_v4f32:
@@ -1607,26 +1452,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ogt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ogt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, mi
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, mi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, mi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ogt_v4f32:
@@ -1643,26 +1485,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_oge_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_oge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, ls
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, ls
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ls
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oge_v4f32:
@@ -1679,26 +1518,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_olt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_olt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, gt
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, gt
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, gt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_olt_v4f32:
@@ -1715,26 +1551,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ole_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ole_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, ge
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, ge
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, ge
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ole_v4f32:
@@ -1820,26 +1653,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ugt_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ugt_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, lt
+; CHECK-MVE-NEXT:    vselge.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, lt
+; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
+; CHECK-MVE-NEXT:    vselge.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, lt
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vselge.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselge.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ugt_v4f32:
@@ -1856,26 +1681,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_uge_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_uge_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, le
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, le
+; CHECK-MVE-NEXT:    vselgt.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, le
+; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
+; CHECK-MVE-NEXT:    vselgt.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, le
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vselgt.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselgt.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uge_v4f32:
@@ -1892,26 +1709,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ult_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ult_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, hi
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, hi
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, hi
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ult_v4f32:
@@ -1928,26 +1742,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ule_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ule_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, #0
-; CHECK-MVE-NEXT:    cset r0, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, #0
-; CHECK-MVE-NEXT:    cset r1, pl
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, #0
-; CHECK-MVE-NEXT:    cset r2, pl
+; CHECK-MVE-NEXT:    vcmp.f32 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, pl
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ule_v4f32:
@@ -1964,26 +1775,18 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_ord_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_ord_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
-; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s1
-; CHECK-MVE-NEXT:    cset r1, vc
+; CHECK-MVE-NEXT:    vselvs.f32 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
-; CHECK-MVE-NEXT:    cset r2, vc
+; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
+; CHECK-MVE-NEXT:    vselvs.f32 s1, s9, s5
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vc
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    vselvs.f32 s3, s11, s7
+; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vselvs.f32 s0, s8, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ord_v4f32:
@@ -2001,26 +1804,23 @@ entry:
 define arm_aapcs_vfpcc <4 x float> @vcmp_r_uno_v4f32(<4 x float> %src, <4 x float> %a, <4 x float> %b) {
 ; CHECK-MVE-LABEL: vcmp_r_uno_v4f32:
 ; CHECK-MVE:       @ %bb.0: @ %entry
-; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f32 s1, s1
-; CHECK-MVE-NEXT:    cset r1, vs
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s7, s11
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vcmp.f32 s2, s2
-; CHECK-MVE-NEXT:    cset r2, vs
+; CHECK-MVE-NEXT:    vcmp.f32 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s9
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r3, vs
-; CHECK-MVE-NEXT:    cmp r3, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s2, s10, s6
-; CHECK-MVE-NEXT:    cmp r2, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s1, s9, s5
-; CHECK-MVE-NEXT:    cmp r1, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s3, s11, s7
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f32 s0, s8, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s8
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uno_v4f32:
@@ -2041,61 +1841,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_oeq_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_oeq_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, eq
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ne
+; CHECK-MVE-NEXT:    vmovne.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oeq_v8f16:
@@ -2194,61 +1987,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ogt_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_ogt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, mi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it pl
+; CHECK-MVE-NEXT:    vmovpl.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ogt_v8f16:
@@ -2266,61 +2052,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_oge_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_oge_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ls
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it hi
+; CHECK-MVE-NEXT:    vmovhi.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_oge_v8f16:
@@ -2338,61 +2117,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_olt_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_olt_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, gt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it le
+; CHECK-MVE-NEXT:    vmovle.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_olt_v8f16:
@@ -2410,61 +2182,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ole_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_ole_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, ge
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it lt
+; CHECK-MVE-NEXT:    vmovlt.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ole_v8f16:
@@ -2624,13 +2389,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ugt_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselge.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -2638,27 +2399,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ugt_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselge.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselge.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -2666,13 +2419,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ugt_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselge.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, lt
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselge.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -2696,13 +2445,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uge_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselgt.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -2710,27 +2455,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uge_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselgt.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselgt.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -2738,13 +2475,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uge_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselgt.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, le
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselgt.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -2763,61 +2496,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ult_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_ult_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, hi
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it ls
+; CHECK-MVE-NEXT:    vmovls.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ult_v8f16:
@@ -2835,61 +2561,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ule_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_ule_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, #0
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, #0
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, #0
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, #0
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, pl
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it mi
+; CHECK-MVE-NEXT:    vmovmi.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_ule_v8f16:
@@ -2912,13 +2631,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ord_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vselvs.f16 s12, s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s0, s8, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
@@ -2926,27 +2641,19 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ord_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s1
 ; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
+; CHECK-MVE-NEXT:    vselvs.f16 s1, s9, s5
 ; CHECK-MVE-NEXT:    vins.f16 s1, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
 ; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s2
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s8, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
+; CHECK-MVE-NEXT:    vselvs.f16 s2, s10, s6
 ; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
 ; CHECK-MVE-NEXT:    vins.f16 s2, s4
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
@@ -2954,13 +2661,9 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_ord_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vselvs.f16 s4, s6, s4
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vc
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
+; CHECK-MVE-NEXT:    vselvs.f16 s3, s11, s7
 ; CHECK-MVE-NEXT:    vins.f16 s3, s4
 ; CHECK-MVE-NEXT:    bx lr
 ;
@@ -2980,61 +2683,54 @@ define arm_aapcs_vfpcc <8 x half> @vcmp_r_uno_v8f16(<8 x half> %src, <8 x half> 
 ; CHECK-MVE-LABEL: vcmp_r_uno_v8f16:
 ; CHECK-MVE:       @ %bb.0: @ %entry
 ; CHECK-MVE-NEXT:    vmovx.f16 s12, s0
-; CHECK-MVE-NEXT:    vmovx.f16 s14, s8
+; CHECK-MVE-NEXT:    vmovx.f16 s14, s4
 ; CHECK-MVE-NEXT:    vcmp.f16 s12, s12
-; CHECK-MVE-NEXT:    vmovx.f16 s12, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s12, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s12, s14, s12
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s1
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s14, s12
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s0, s8, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s1
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s5
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s4, s8
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s5
 ; CHECK-MVE-NEXT:    vcmp.f16 s1, s1
-; CHECK-MVE-NEXT:    vins.f16 s0, s12
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    vmovx.f16 s8, s10
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s1, s9, s5
-; CHECK-MVE-NEXT:    vins.f16 s1, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s2
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s6
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s5, s9
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s2
+; CHECK-MVE-NEXT:    vins.f16 s5, s8
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s10
+; CHECK-MVE-NEXT:    vmovx.f16 s8, s6
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s8, s0
 ; CHECK-MVE-NEXT:    vcmp.f16 s2, s2
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s8, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s3
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s2, s10, s6
-; CHECK-MVE-NEXT:    vmovx.f16 s6, s11
-; CHECK-MVE-NEXT:    vins.f16 s2, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s3
-; CHECK-MVE-NEXT:    vcmp.f16 s4, s4
-; CHECK-MVE-NEXT:    vmovx.f16 s4, s7
+; CHECK-MVE-NEXT:    vcmp.f16 s0, s0
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s6, s10
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
+; CHECK-MVE-NEXT:    vmovx.f16 s2, s7
 ; CHECK-MVE-NEXT:    vcmp.f16 s3, s3
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s4, s6, s4
+; CHECK-MVE-NEXT:    vmovx.f16 s0, s11
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s2, s0
 ; CHECK-MVE-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-MVE-NEXT:    cset r0, vs
-; CHECK-MVE-NEXT:    cmp r0, #0
-; CHECK-MVE-NEXT:    vseleq.f16 s3, s11, s7
-; CHECK-MVE-NEXT:    vins.f16 s3, s4
+; CHECK-MVE-NEXT:    it vc
+; CHECK-MVE-NEXT:    vmovvc.f32 s7, s11
+; CHECK-MVE-NEXT:    vins.f16 s4, s14
+; CHECK-MVE-NEXT:    vins.f16 s6, s8
+; CHECK-MVE-NEXT:    vins.f16 s7, s2
+; CHECK-MVE-NEXT:    vmov q0, q1
 ; CHECK-MVE-NEXT:    bx lr
 ;
 ; CHECK-MVEFP-LABEL: vcmp_r_uno_v8f16:

--- a/llvm/test/CodeGen/Thumb2/mve-vqdmulh.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vqdmulh.ll
@@ -495,42 +495,34 @@ define <2 x i64> @large_i128(<2 x double> %x) {
 ; CHECK-NEXT:    mov r5, r2
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r7, r2, #1
-; CHECK-NEXT:    mov.w r9, #1
-; CHECK-NEXT:    sbcs r7, r3, #0
 ; CHECK-NEXT:    mov.w r4, #0
-; CHECK-NEXT:    cset r7, lt
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csel r0, r0, r7, ne
-; CHECK-NEXT:    csel r3, r3, r7, ne
-; CHECK-NEXT:    csel r1, r1, r7, ne
-; CHECK-NEXT:    csel r2, r2, r9, ne
+; CHECK-NEXT:    sbcs r7, r3, #0
+; CHECK-NEXT:    mov.w r9, #1
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r9, lt
+; CHECK-NEXT:    csel r1, r1, r4, lt
 ; CHECK-NEXT:    rsbs r7, r0, #0
 ; CHECK-NEXT:    sbcs.w r7, r4, r1
 ; CHECK-NEXT:    sbcs.w r2, r4, r2
 ; CHECK-NEXT:    sbcs.w r2, r4, r3
-; CHECK-NEXT:    cset r2, lt
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csel r6, r0, r2, ne
-; CHECK-NEXT:    csel r7, r1, r2, ne
+; CHECK-NEXT:    csel r6, r0, r4, lt
+; CHECK-NEXT:    csel r7, r1, r4, lt
 ; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    mov r1, r8
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r5, r2, #1
 ; CHECK-NEXT:    sbcs r5, r3, #0
-; CHECK-NEXT:    cset r5, lt
-; CHECK-NEXT:    cmp r5, #0
-; CHECK-NEXT:    csel r0, r0, r5, ne
-; CHECK-NEXT:    csel r3, r3, r5, ne
-; CHECK-NEXT:    csel r1, r1, r5, ne
-; CHECK-NEXT:    csel r2, r2, r9, ne
+; CHECK-NEXT:    csel r0, r0, r4, lt
+; CHECK-NEXT:    csel r3, r3, r4, lt
+; CHECK-NEXT:    csel r2, r2, r9, lt
+; CHECK-NEXT:    csel r1, r1, r4, lt
 ; CHECK-NEXT:    rsbs r5, r0, #0
 ; CHECK-NEXT:    sbcs.w r5, r4, r1
 ; CHECK-NEXT:    sbcs.w r2, r4, r2
 ; CHECK-NEXT:    sbcs.w r2, r4, r3
-; CHECK-NEXT:    cset r3, lt
-; CHECK-NEXT:    cmp r3, #0
-; CHECK-NEXT:    csel r2, r0, r3, ne
-; CHECK-NEXT:    csel r3, r1, r3, ne
+; CHECK-NEXT:    csel r2, r0, r4, lt
+; CHECK-NEXT:    csel r3, r1, r4, lt
 ; CHECK-NEXT:    mov r0, r6
 ; CHECK-NEXT:    mov r1, r7
 ; CHECK-NEXT:    add sp, #4


### PR DESCRIPTION
Remove redundant patterns that prevent us from matching cmov of cmov further.