### PR TITLE
[MC] Always lower .fill to MCFillFragment

### DIFF
--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -740,25 +740,14 @@ void MCObjectStreamer::emitFill(const MCExpr &NumValues, int64_t Size,
                                 int64_t Expr, SMLoc Loc) {
   int64_t IntNumValues;
   // Do additional checking now if we can resolve the value.
-  if (NumValues.evaluateAsAbsolute(IntNumValues, getAssembler())) {
-    if (IntNumValues < 0) {
-      getContext().getSourceManager()->PrintMessage(
-          Loc, SourceMgr::DK_Warning,
-          "'.fill' directive with negative repeat count has no effect");
-      return;
-    }
-    // Emit now if we can for better errors.
-    int64_t NonZeroSize = Size > 4 ? 4 : Size;
-    Expr &= ~0ULL >> (64 - NonZeroSize * 8);
-    for (uint64_t i = 0, e = IntNumValues; i != e; ++i) {
-      emitIntValue(Expr, NonZeroSize);
-      if (NonZeroSize < Size)
-        emitIntValue(0, Size - NonZeroSize);
-    }
+  if (NumValues.evaluateAsAbsolute(IntNumValues, getAssembler()) &&
+      IntNumValues < 0) {
+    getContext().getSourceManager()->PrintMessage(
+        Loc, SourceMgr::DK_Warning,
+        "'.fill' directive with negative repeat count has no effect");
     return;
   }
 
-  // Otherwise emit as fragment.
   assert(getCurrentSectionOnly() && "need a section");
   newSpecialFragment<MCFillFragment>(Expr, Size, NumValues, Loc);
 }

--- a/llvm/test/MC/AsmParser/directive_fill.s
+++ b/llvm/test/MC/AsmParser/directive_fill.s
@@ -67,7 +67,7 @@ TEST11:
 
 # CHECK: TEST12
 # CHECK: .fill TEST11-TEST12, 4, 0x12345678
-# OBJ-ERRS: '.fill' directive with negative repeat count has no effect
+# OBJ-ERRS: [[#@LINE+2]]:8: error: invalid number of bytes
 TEST12:
 	.fill TEST11 - TEST12, 4, 0x12345678
 


### PR DESCRIPTION
Constant-count, constant-pattern .fill expands inline into the current
fragment via emitIntValue per byte, wasting both memory and time (a
redundant copy at MCAssembler.cpp). #50974 reports a 4s compile dropping
to 0.6s when the loop is removed.

Drop the inline path so .fill always becomes MCFillFragment.
This cannot be done before commit 507efbcce03d (2023) allowed
label differences to be separated by a MCFillFragment.

In directive_fill.s, the parse time warning is now diagnosed by
MCAssembler.
