### PR TITLE
[analyzer] Fix use-after-free in CheckerContext::getMacroNameOrSpelling

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -430,7 +430,7 @@ public:
   /// If AF_INET is a macro, the result should be treated as a source of taint.
   ///
   /// \sa clang::Lexer::getSpelling(), clang::Lexer::getImmediateMacroName().
-  StringRef getMacroNameOrSpelling(SourceLocation &Loc);
+  std::string getMacroNameOrSpelling(SourceLocation &Loc);
 
 private:
   ExplodedNode *addTransitionImpl(ProgramStateRef State,

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -1215,7 +1215,7 @@ void GenericTaintChecker::taintUnsafeSocketProtocol(const CallEvent &Call,
     return;
 
   SourceLocation DomLoc = Call.getArgExpr(0)->getExprLoc();
-  StringRef DomName = C.getMacroNameOrSpelling(DomLoc);
+  std::string DomName = C.getMacroNameOrSpelling(DomLoc);
   // Allow internal communication protocols.
   bool SafeProtocol = DomName == "AF_SYSTEM" || DomName == "AF_LOCAL" ||
                       DomName == "AF_UNIX" || DomName == "AF_RESERVED_36";

--- a/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
@@ -128,12 +128,16 @@ bool CheckerContext::isHardenedVariantOf(const FunctionDecl *FD,
          CompletelyMatchesParts("__builtin_", "__", Name, "_chk");
 }
 
-StringRef CheckerContext::getMacroNameOrSpelling(SourceLocation &Loc) {
+std::string CheckerContext::getMacroNameOrSpelling(SourceLocation &Loc) {
+  const auto &SM = getSourceManager();
+  const auto &LO = getLangOpts();
   if (Loc.isMacroID())
-    return Lexer::getImmediateMacroName(Loc, getSourceManager(),
-                                             getLangOpts());
-  SmallString<16> buf;
-  return Lexer::getSpelling(Loc, buf, getSourceManager(), getLangOpts());
+    return Lexer::getImmediateMacroName(Loc, SM, LO).str();
+
+  Token Tok;
+  if (Lexer::getRawToken(Loc, Tok, SM, LO))
+    return "";
+  return Lexer::getSpelling(Tok, SM, LO);
 }
 
 /// Evaluate comparison and return true if it's known that condition is true

--- a/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
@@ -133,8 +133,8 @@ std::string CheckerContext::getMacroNameOrSpelling(SourceLocation &Loc) {
   const auto &LO = getLangOpts();
   if (Loc.isMacroID())
     return Lexer::getImmediateMacroName(Loc, SM, LO).str();
-  SmallString<16> buf;
-  return Lexer::getSpelling(Loc, buf, SM, LO).str();
+  llvm::SmallString<16> Buf;
+  return Lexer::getSpelling(Loc, Buf, SM, LO).str();
 }
 
 /// Evaluate comparison and return true if it's known that condition is true

--- a/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerContext.cpp
@@ -133,11 +133,8 @@ std::string CheckerContext::getMacroNameOrSpelling(SourceLocation &Loc) {
   const auto &LO = getLangOpts();
   if (Loc.isMacroID())
     return Lexer::getImmediateMacroName(Loc, SM, LO).str();
-
-  Token Tok;
-  if (Lexer::getRawToken(Loc, Tok, SM, LO))
-    return "";
-  return Lexer::getSpelling(Tok, SM, LO);
+  SmallString<16> buf;
+  return Lexer::getSpelling(Loc, buf, SM, LO).str();
 }
 
 /// Evaluate comparison and return true if it's known that condition is true


### PR DESCRIPTION
This UAF bug was introduced 14 years ago, in 43de767b55c07.
The first use of this API was in 3b754b25bde4914e5ab693e7db9533c3260e926e, roughly around the same era.
It was dormant because the first param of `socket` and friends are macros, and those didn't trigger this UAF.

I decided to go against adding a test because I figure that would be not really meaningful.

Fixes #194136