### PR TITLE
[Github] Drop LLVM 21 installation from libc Dockerfile

### DIFF
--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -19,12 +19,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# TODO(boomanaiden154): Remove the LLVM 21 installation once we are no longer
-# using it in the libc fullbuild tests workflow.
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod +x llvm.sh && \
     sudo ./llvm.sh 23 && \
-    sudo ./llvm.sh 21 && \
     rm llvm.sh
     
 # Debian has a multilib setup, so we need to symlink the asm directory.


### PR DESCRIPTION
The compiler version was bumped in
8abce0a63c10124aa26a070ead80a68f705c95f9, so we no longer need to
include this. We should probably just hash pin the version in future
workflows for future toolchain upgrades.