### PR TITLE
[Profile] Reenable instrprof-tmpdir.c

### DIFF
--- a/compiler-rt/test/profile/instrprof-tmpdir.c
+++ b/compiler-rt/test/profile/instrprof-tmpdir.c
@@ -1,8 +1,3 @@
-// AIX does not support env -u.
-// TODO(boomanaiden154): Reenable AIX support once we use the internal shell by
-// default.
-// UNSUPPORTED: system-aix
-
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: cd %t


### PR DESCRIPTION
env -u is supported by the internal shell which is now the default
everywhere.