### PR TITLE
[libcxx] Include python3-yaml and rsync in container

### DIFF
--- a/libcxx/utils/ci/docker/linux-builder-base.dockerfile
+++ b/libcxx/utils/ci/docker/linux-builder-base.dockerfile
@@ -76,6 +76,8 @@ RUN sudo apt-get update \
         python3-setuptools \
         python3-psutil \
         python3-venv \
+        python3-yaml \
+        rsync \
         software-properties-common \
         swig \
         unzip \


### PR DESCRIPTION
rsync is needed for installing the kernel headers for the libc build. The yaml python package is needed for libc's hdrgen. This means we no longer have to install these utilities at runtime.

They should be small enough relative to the existing container image size to not really have an impact in that regard.