### PR TITLE
[lldb] Add repeat command for `frame variable`

### DIFF
--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Utility/ValueType.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <memory>
 #include <optional>
@@ -434,6 +435,33 @@ may even involve JITing and running code in the target program.)");
   ~CommandObjectFrameVariable() override = default;
 
   Options *GetOptions() override { return &m_option_group; }
+
+  // `frame variable` repeats by incrementing the printing depth. When the depth
+  // is too shallow, hitting enter a few times will quickly expand the data.
+  std::optional<std::string> GetRepeatCommand(Args &current_command_args,
+                                              uint32_t index) override {
+    uint32_t new_depth = m_varobj_options.max_depth + 1;
+    std::string cmd;
+    llvm::raw_string_ostream os(cmd);
+    bool skip_next = false;
+    for (const auto &entry : current_command_args) {
+      if (skip_next) {
+        skip_next = false;
+        continue;
+      }
+
+      llvm::StringRef arg = entry.ref();
+      if (arg == "--depth" || arg == "-D") {
+        skip_next = true;
+        os << " " << arg << " " << new_depth;
+      } else if (arg.starts_with("-D")) {
+        os << "-D" << new_depth;
+      } else {
+        os << " " << arg;
+      }
+    }
+    return cmd;
+  }
 
 protected:
   llvm::StringRef GetScopeString(VariableSP var_sp) {

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Utility/ValueType.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <memory>
@@ -440,11 +441,15 @@ may even involve JITing and running code in the target program.)");
   // is too shallow, hitting enter a few times will quickly expand the data.
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,
                                               uint32_t index) override {
-    std::string cmd;
-    llvm::raw_string_ostream os(cmd);
-
-    uint32_t new_depth = m_varobj_options.max_depth + 1;
+    Args repeat_args;
     bool has_depth_option = false;
+    auto new_depth = m_varobj_options.max_depth + 1;
+    auto increment_depth_option = [&]() {
+      repeat_args.AppendArgument("--depth");
+      repeat_args.AppendArgument(llvm::utostr(new_depth));
+      has_depth_option = true;
+    };
+
     bool skip_next = false;
     for (const auto &entry : current_command_args) {
       if (skip_next) {
@@ -455,20 +460,22 @@ may even involve JITing and running code in the target program.)");
       llvm::StringRef arg = entry.ref();
       if (arg == "--depth" || arg == "-D") {
         skip_next = true;
-        os << " " << arg << " " << new_depth;
-        has_depth_option = true;
+        increment_depth_option();
       } else if (arg.starts_with("-D")) {
-        os << "-D" << new_depth;
-        has_depth_option = true;
+        increment_depth_option();
       } else {
-        os << " " << arg;
+        repeat_args.AppendArgument(arg);
       }
     }
 
     if (!has_depth_option)
-      os << " --depth " << new_depth;
+      // Default depth was used.
+      increment_depth_option();
 
-    return cmd;
+    std::string repeat_command;
+    if (!repeat_args.GetQuotedCommandString(repeat_command))
+      return std::nullopt;
+    return repeat_command;
   }
 
 protected:

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -440,9 +440,11 @@ may even involve JITing and running code in the target program.)");
   // is too shallow, hitting enter a few times will quickly expand the data.
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,
                                               uint32_t index) override {
-    uint32_t new_depth = m_varobj_options.max_depth + 1;
     std::string cmd;
     llvm::raw_string_ostream os(cmd);
+
+    uint32_t new_depth = m_varobj_options.max_depth + 1;
+    bool has_depth_option = false;
     bool skip_next = false;
     for (const auto &entry : current_command_args) {
       if (skip_next) {
@@ -454,12 +456,18 @@ may even involve JITing and running code in the target program.)");
       if (arg == "--depth" || arg == "-D") {
         skip_next = true;
         os << " " << arg << " " << new_depth;
+        has_depth_option = true;
       } else if (arg.starts_with("-D")) {
         os << "-D" << new_depth;
+        has_depth_option = true;
       } else {
         os << " " << arg;
       }
     }
+
+    if (!has_depth_option)
+      os << " --depth " << new_depth;
+
     return cmd;
   }
 

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -442,13 +442,13 @@ may even involve JITing and running code in the target program.)");
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,
                                               uint32_t index) override {
     Args repeat_args;
-    auto increment_option = [&](llvm::StringRef option) {
+    auto increment_option =
+        [&](llvm::StringRef option) -> std::optional<std::string> {
       uint32_t num;
       bool failed = option.getAsInteger(10, num);
       if (failed)
-        return false;
-      repeat_args.AppendArgument(llvm::utostr(num + 1));
-      return true;
+        return std::nullopt;
+      return llvm::utostr(num + 1);
     };
 
     bool has_depth_option = false;
@@ -458,8 +458,10 @@ may even involve JITing and running code in the target program.)");
 
       if (increment_next_arg) {
         increment_next_arg = false;
-        if (increment_option(arg))
+        if (auto maybe_opt = increment_option(arg)) {
+          repeat_args.AppendArgument(*maybe_opt);
           continue;
+        }
       }
 
       if (arg == "--depth" || arg == "-D") {
@@ -468,9 +470,12 @@ may even involve JITing and running code in the target program.)");
         has_depth_option = true;
         continue;
       }
-      if (arg.consume_front("-D") && increment_option(arg)) {
-        has_depth_option = true;
-        continue;
+      if (arg.consume_front("-D")) {
+        if (auto maybe_opt = increment_option(arg)) {
+          repeat_args.AppendArgument(llvm::formatv("-D{0}", *maybe_opt).str());
+          has_depth_option = true;
+          continue;
+        }
       }
 
       repeat_args.AppendArgument(arg);

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -441,6 +441,8 @@ may even involve JITing and running code in the target program.)");
   // is too shallow, hitting enter a few times will quickly expand the data.
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,
                                               uint32_t index) override {
+    llvm::StringRef depth_opt = "--depth";
+
     Args repeat_args;
     auto increment_option =
         [&](llvm::StringRef option) -> std::optional<std::string> {
@@ -456,6 +458,11 @@ may even involve JITing and running code in the target program.)");
     for (const auto &entry : current_command_args) {
       llvm::StringRef arg = entry.ref();
 
+      if (arg == "-" || arg == "--") {
+        repeat_args.AppendArgument(arg);
+        continue;
+      }
+
       if (increment_next_arg) {
         increment_next_arg = false;
         if (auto maybe_opt = increment_option(arg)) {
@@ -464,7 +471,7 @@ may even involve JITing and running code in the target program.)");
         }
       }
 
-      if (arg == "--depth" || arg == "-D") {
+      if (depth_opt.starts_with(arg) || arg == "-D") {
         repeat_args.AppendArgument(arg);
         increment_next_arg = true;
         has_depth_option = true;

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -442,35 +442,53 @@ may even involve JITing and running code in the target program.)");
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,
                                               uint32_t index) override {
     Args repeat_args;
-    bool has_depth_option = false;
-    auto new_depth = m_varobj_options.max_depth + 1;
-    auto increment_depth_option = [&]() {
-      repeat_args.AppendArgument("--depth");
-      repeat_args.AppendArgument(llvm::utostr(new_depth));
-      has_depth_option = true;
+    auto increment_option = [&](llvm::StringRef option) {
+      uint32_t num;
+      bool failed = option.getAsInteger(10, num);
+      if (failed)
+        return false;
+      repeat_args.AppendArgument(llvm::utostr(num + 1));
+      return true;
     };
 
-    bool skip_next = false;
+    bool has_depth_option = false;
+    bool increment_next_arg = false;
     for (const auto &entry : current_command_args) {
-      if (skip_next) {
-        skip_next = false;
+      llvm::StringRef arg = entry.ref();
+
+      if (increment_next_arg) {
+        increment_next_arg = false;
+        if (increment_option(arg))
+          continue;
+      }
+
+      if (arg == "--depth" || arg == "-D") {
+        repeat_args.AppendArgument(arg);
+        increment_next_arg = true;
+        has_depth_option = true;
+        continue;
+      }
+      if (arg.consume_front("-D") && increment_option(arg)) {
+        has_depth_option = true;
         continue;
       }
 
-      llvm::StringRef arg = entry.ref();
-      if (arg == "--depth" || arg == "-D") {
-        skip_next = true;
-        increment_depth_option();
-      } else if (arg.starts_with("-D")) {
-        increment_depth_option();
-      } else {
-        repeat_args.AppendArgument(arg);
-      }
+      repeat_args.AppendArgument(arg);
     }
 
-    if (!has_depth_option)
-      // Default depth was used.
-      increment_depth_option();
+    if (!has_depth_option) {
+      // Access the default max-depth from the target. This is because
+      // GetRepeatCommand is called before ParseOptions, which is when
+      // m_varobj_options.max_depth becomes assigned.
+      if (auto target_sp = GetDebugger().GetSelectedTarget()) {
+        auto [default_depth, _] =
+            target_sp->GetMaximumDepthOfChildrenToDisplay();
+        // Insert the depth after `frame variable`, before positional args.
+        assert(repeat_args[0].ref() == "frame" && "expects resolved command");
+        repeat_args.InsertArgumentAtIndex(2, "--depth");
+        repeat_args.InsertArgumentAtIndex(3, llvm::utostr(default_depth + 1));
+      }
+    }
 
     std::string repeat_command;
     if (!repeat_args.GetQuotedCommandString(repeat_command))

--- a/lldb/test/API/commands/frame/var/repeat/Makefile
+++ b/lldb/test/API/commands/frame/var/repeat/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -4,28 +4,46 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
+
+    def test_explicit_depth(self):
         """Test that repeating 'frame variable' increments --depth."""
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
 
-        # Start with --depth 0 showing a, but not b.
+        # Start with --depth 2 showing a, b, and c, but but not d.
         self.expect(
-            "frame variable --depth 0 a",
+            "frame variable --depth 2 a",
             inHistory=True,
-            patterns=[r"\(A\) a = {", r"(?!.*b = {)"],
+            patterns=[r"\(A\) a = {", "b = {", "c = {", r"(?!.*d = {)"],
         )
 
-        # First repeat: --depth 1 showing b, but not c.
-        self.expect("", patterns=["b = {", "(?!.*c = {)"])
+        # First repeat: --depth 4, showing d, but not e.
+        self.expect("", patterns=["d = {", "(?!.*e = {)"])
 
-        # Second repeat: --depth 2, showing c, but not d.
-        self.expect("", patterns=["c = {", "(?!.*d = {)"])
+        # Second repeat: --depth 5, showing e, but not f.
+        self.expect("", patterns=["e = {", "(?!.*f = {)"])
 
-        # Third repeat: --depth 3, showing d, but not value.
-        self.expect("", patterns=["d = {", "(?!.*value = 42)"])
+        # Third repeat: --depth 6, showing d, but not f.
+        self.expect("", patterns=["e = {", "(?!.*leaf = 42)"])
 
-        # Fourth repeat: --depth 4, showing value, the deepest value.
-        self.expect("", substrs=["value = 42"])
+        # Fourth repeat: --depth 7, showing leaf, the deepest child.
+        self.expect("", substrs=["leaf = 42"])
+
+    def test_default_depth(self):
+        """Test that repeating 'frame variable' adds a --depth option."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Default depth shows f but not leaf.
+        self.expect(
+            "frame variable a",
+            inHistory=True,
+            patterns=[r"f = \{...\}", r"(?!.*leaf = 42)"],
+        )
+
+        # Repeat
+        self.expect("", substrs=["leaf = 42"])

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -4,7 +4,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-
     def test_explicit_depth(self):
         """Test that repeating 'frame variable' increments --depth."""
         self.build()

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -12,23 +12,23 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
 
-        # Start with --depth 2 showing a, b, and c, but but not d.
+        # Start with --depth 2, shows a, b, and c, but but not d.
         self.expect(
             "frame variable --depth 2 a",
             inHistory=True,
             patterns=[r"\(A\) a = {", "b = {", "c = {", r"(?!.*d = {)"],
         )
 
-        # First repeat: --depth 4, showing d, but not e.
+        # First repeat: shows d, but not e.
         self.expect("", patterns=["d = {", "(?!.*e = {)"])
 
-        # Second repeat: --depth 5, showing e, but not f.
+        # Second repeat: shows e, but not f.
         self.expect("", patterns=["e = {", "(?!.*f = {)"])
 
-        # Third repeat: --depth 6, showing d, but not f.
-        self.expect("", patterns=["e = {", "(?!.*leaf = 42)"])
+        # Third repeat: shows f, but not leaf.
+        self.expect("", patterns=["f = {", "(?!.*leaf = 42)"])
 
-        # Fourth repeat: --depth 7, showing leaf, the deepest child.
+        # Fourth repeat: shows leaf, the deepest child.
         self.expect("", substrs=["leaf = 42"])
 
     def test_default_depth(self):
@@ -45,5 +45,5 @@ class TestCase(TestBase):
             patterns=[r"f = \{...\}", r"(?!.*leaf = 42)"],
         )
 
-        # Repeat
+        # Repeat to show leaf.
         self.expect("", substrs=["leaf = 42"])

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -1,0 +1,31 @@
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        """Test that repeating 'frame variable' increments --depth."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Start with --depth 0 showing a, but not b.
+        self.expect(
+            "frame variable --depth 0 a",
+            inHistory=True,
+            patterns=[r"\(A\) a = {", r"(?!.*b = {)"],
+        )
+
+        # First repeat: --depth 1 showing b, but not c.
+        self.expect("", patterns=["b = {", "(?!.*c = {)"])
+
+        # Second repeat: --depth 2, showing c, but not d.
+        self.expect("", patterns=["c = {", "(?!.*d = {)"])
+
+        # Third repeat: --depth 3, showing d, but not value.
+        self.expect("", patterns=["d = {", "(?!.*value = 42)"])
+
+        # Fourth repeat: --depth 4, showing value, the deepest value.
+        self.expect("", substrs=["value = 42"])

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -10,10 +10,14 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
+        self.do_test("--depth ")
+        self.do_test("-D ")
+        self.do_test("-D")
 
+    def do_test(self, depth_option):
         # Start with --depth 2, shows a, b, and c, but but not d.
         self.expect(
-            "frame variable --depth 2 a",
+            f"frame variable {depth_option}2 a",
             inHistory=True,
             patterns=[r"\(A\) a = {", "b = {", "c = {", r"(?!.*d = {)"],
         )

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -11,6 +11,7 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
         self.do_test("--depth ")
+        self.do_test("--de ")
         self.do_test("-D ")
         self.do_test("-D")
 

--- a/lldb/test/API/commands/frame/var/repeat/main.cpp
+++ b/lldb/test/API/commands/frame/var/repeat/main.cpp
@@ -1,0 +1,20 @@
+struct D {
+  int value = 42;
+};
+
+struct C {
+  D d;
+};
+
+struct B {
+  C c;
+};
+
+struct A {
+  B b;
+};
+
+int main() {
+  A a;
+  return 0; // break here
+}

--- a/lldb/test/API/commands/frame/var/repeat/main.cpp
+++ b/lldb/test/API/commands/frame/var/repeat/main.cpp
@@ -1,5 +1,12 @@
+struct F {
+  int leaf = 42;
+};
+
+struct E {
+  F f;
+};
 struct D {
-  int value = 42;
+  E e;
 };
 
 struct C {
@@ -16,5 +23,6 @@ struct A {
 
 int main() {
   A a;
+  (void)a;
   return 0; // break here
 }


### PR DESCRIPTION
Introduce repeat command functionality for `frame variable`. The repeat behavior increments the printing depth.

For example, when the default depth value (`target.max-children-depth`) is not enough, hitting enter one or more times will expand the displayed data as deeply as needed.

See #149282 and then #178717.