### PR TITLE
[MC] Add MCTargetOptions to MCAsmInfo constructor. NFC

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -679,8 +679,6 @@ public:
 
   std::unique_ptr<MCObjectFileInfo> MOFI;
 
-  MCTargetOptions MCOptions;
-
   std::unique_ptr<const MCAsmInfo> AsmInfo;
 
   std::unique_ptr<const MCInstrInfo> MII;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -157,9 +157,6 @@ BinaryContext::BinaryContext(std::unique_ptr<MCContext> Ctx,
       STI(std::move(STI)), InstPrinter(std::move(InstPrinter)),
       MIA(std::move(MIA)), MIB(std::move(MIB)), MRI(std::move(MRI)),
       DisAsm(std::move(DisAsm)), Logger(Logger), InitialDynoStats(isAArch64()) {
-  // createMCAsmInfo stored a pointer to a local MCTargetOptions in MCAsmInfo.
-  // Update it to point to our member that will outlive MCAsmInfo.
-  const_cast<MCAsmInfo *>(this->AsmInfo.get())->setTargetOptions(MCOptions);
   RegularPageSize = isAArch64() ? RegularPageSizeAArch64 : RegularPageSizeX86;
   PageAlign = opts::NoHugePages ? RegularPageSize : HugePageSize;
 }
@@ -229,8 +226,9 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
         make_error_code(std::errc::not_supported),
         Twine("BOLT-ERROR: no register info for target ", TripleName));
 
-  // Set up disassembler.
-  MCTargetOptions MCOptions;
+  // Set up disassembler. The MCAsmInfo holds a reference to MCTargetOptions, so
+  // make it static to outlive the AsmInfo.
+  static const MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> AsmInfo(
       TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!AsmInfo)

--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -433,18 +433,17 @@ protected:
   llvm::StringMap<uint32_t> NameToAtSpecifier;
   void initializeAtSpecifiers(ArrayRef<AtSpecifier>);
 
-  const MCTargetOptions *TargetOptions = nullptr;
+  const MCTargetOptions &TargetOptions;
 
 public:
-  explicit MCAsmInfo();
+  explicit MCAsmInfo(const MCTargetOptions &Options);
   virtual ~MCAsmInfo();
 
   // Explicitly non-copyable.
   MCAsmInfo(MCAsmInfo const &) = delete;
   MCAsmInfo &operator=(MCAsmInfo const &) = delete;
 
-  const MCTargetOptions *getTargetOptions() const { return TargetOptions; }
-  void setTargetOptions(const MCTargetOptions &TO) { TargetOptions = &TO; }
+  const MCTargetOptions &getTargetOptions() const { return TargetOptions; }
 
   /// Get the code pointer size in bytes.
   unsigned getCodePointerSize() const { return CodePointerSize; }
@@ -568,7 +567,7 @@ public:
   // Return the assembler dialect that output printing should use. Used by
   // createMCInstPrinter.
   unsigned getOutputAssemblerDialect() const {
-    return TargetOptions->OutputAsmVariant.value_or(AssemblerDialect);
+    return TargetOptions.OutputAsmVariant.value_or(AssemblerDialect);
   }
   bool doesAllowAtInName() const { return AllowAtInName; }
   void setAllowAtInName(bool V) { AllowAtInName = V; }

--- a/llvm/include/llvm/MC/MCAsmInfoCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoCOFF.h
@@ -20,21 +20,21 @@ class MCAsmInfoCOFF : public MCAsmInfo {
   bool useCodeAlign(const MCSection &Sec) const final;
 
 protected:
-  explicit MCAsmInfoCOFF();
+  explicit MCAsmInfoCOFF(const MCTargetOptions &Options);
 };
 
 class MCAsmInfoMicrosoft : public MCAsmInfoCOFF {
   void anchor() override;
 
 protected:
-  explicit MCAsmInfoMicrosoft();
+  explicit MCAsmInfoMicrosoft(const MCTargetOptions &Options);
 };
 
 class MCAsmInfoGNUCOFF : public MCAsmInfoCOFF {
   void anchor() override;
 
 protected:
-  explicit MCAsmInfoGNUCOFF();
+  explicit MCAsmInfoGNUCOFF(const MCTargetOptions &Options);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCAsmInfoDarwin.h
+++ b/llvm/include/llvm/MC/MCAsmInfoDarwin.h
@@ -20,7 +20,7 @@ namespace llvm {
 
 class MCAsmInfoDarwin : public MCAsmInfo {
 public:
-  explicit MCAsmInfoDarwin();
+  explicit MCAsmInfoDarwin(const MCTargetOptions &Options);
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
   bool useCodeAlign(const MCSection &Sec) const final;

--- a/llvm/include/llvm/MC/MCAsmInfoELF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoELF.h
@@ -21,7 +21,7 @@ class MCAsmInfoELF : public MCAsmInfo {
   bool useCodeAlign(const MCSection &Sec) const final;
 
 protected:
-  MCAsmInfoELF();
+  MCAsmInfoELF(const MCTargetOptions &Options);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCAsmInfoGOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoGOFF.h
@@ -23,7 +23,7 @@ class MCAsmInfoGOFF : public MCAsmInfo {
                             raw_ostream &) const final;
 
 protected:
-  MCAsmInfoGOFF();
+  MCAsmInfoGOFF(const MCTargetOptions &Options);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCAsmInfoWasm.h
+++ b/llvm/include/llvm/MC/MCAsmInfoWasm.h
@@ -17,7 +17,7 @@ class MCAsmInfoWasm : public MCAsmInfo {
                             raw_ostream &) const final;
 
 protected:
-  MCAsmInfoWasm();
+  MCAsmInfoWasm(const MCTargetOptions &Options);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class MCAsmInfoXCOFF : public MCAsmInfo {
 protected:
-  MCAsmInfoXCOFF();
+  MCAsmInfoXCOFF(const MCTargetOptions &Options);
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
   bool useCodeAlign(const MCSection &Sec) const final;

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -411,10 +411,7 @@ public:
                              const MCTargetOptions &Options) const {
     if (!MCAsmInfoCtorFn)
       return nullptr;
-    auto *MAI = MCAsmInfoCtorFn(MRI, TheTriple, Options);
-    if (MAI)
-      MAI->setTargetOptions(Options);
-    return MAI;
+    return MCAsmInfoCtorFn(MRI, TheTriple, Options);
   }
 
   /// Create a MCObjectFileInfo implementation for the specified target

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -473,8 +473,9 @@ unsigned DIEExpr::sizeOf(const dwarf::FormParams &FormParams,
 
 LLVM_DUMP_METHOD
 void DIEExpr::print(raw_ostream &O) const {
+  MCTargetOptions Opts;
   O << "Expr: ";
-  MCAsmInfo().printExpr(O, *Expr);
+  MCAsmInfo(Opts).printExpr(O, *Expr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -41,7 +41,7 @@ cl::opt<cl::boolOrDefault> UseLEB128Directives(
     cl::init(cl::BOU_UNSET));
 }
 
-MCAsmInfo::MCAsmInfo() {
+MCAsmInfo::MCAsmInfo(const MCTargetOptions &Options) : TargetOptions(Options) {
   if (DwarfExtendedLoc != Default)
     SupportsExtendedDwarfLocDirective = DwarfExtendedLoc == Enable;
   if (UseLEB128Directives != cl::BOU_UNSET)

--- a/llvm/lib/MC/MCAsmInfoCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoCOFF.cpp
@@ -24,7 +24,8 @@ using namespace llvm;
 
 void MCAsmInfoCOFF::anchor() {}
 
-MCAsmInfoCOFF::MCAsmInfoCOFF() {
+MCAsmInfoCOFF::MCAsmInfoCOFF(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   // MingW 4.5 and later support .comm with log2 alignment, but .lcomm uses byte
   // alignment.
   COMMDirectiveAlignmentIsInBytes = false;
@@ -61,11 +62,13 @@ bool MCAsmInfoCOFF::useCodeAlign(const MCSection &Sec) const {
 
 void MCAsmInfoMicrosoft::anchor() {}
 
-MCAsmInfoMicrosoft::MCAsmInfoMicrosoft() = default;
+MCAsmInfoMicrosoft::MCAsmInfoMicrosoft(const MCTargetOptions &Options)
+    : MCAsmInfoCOFF(Options) {}
 
 void MCAsmInfoGNUCOFF::anchor() {}
 
-MCAsmInfoGNUCOFF::MCAsmInfoGNUCOFF() {
+MCAsmInfoGNUCOFF::MCAsmInfoGNUCOFF(const MCTargetOptions &Options)
+    : MCAsmInfoCOFF(Options) {
   // If this is a GNU environment (mingw or cygwin), don't use associative
   // comdats for jump tables, unwind information, and other data associated with
   // a function.

--- a/llvm/lib/MC/MCAsmInfoDarwin.cpp
+++ b/llvm/lib/MC/MCAsmInfoDarwin.cpp
@@ -55,7 +55,8 @@ bool MCAsmInfoDarwin::isSectionAtomizableBySymbols(
   }
 }
 
-MCAsmInfoDarwin::MCAsmInfoDarwin() {
+MCAsmInfoDarwin::MCAsmInfoDarwin(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   // Common settings for all Darwin targets.
   // Syntax:
   LinkerPrivateGlobalPrefix = "l";

--- a/llvm/lib/MC/MCAsmInfoELF.cpp
+++ b/llvm/lib/MC/MCAsmInfoELF.cpp
@@ -40,7 +40,8 @@ bool MCAsmInfoELF::useCodeAlign(const MCSection &Sec) const {
   return static_cast<const MCSectionELF &>(Sec).getFlags() & ELF::SHF_EXECINSTR;
 }
 
-MCAsmInfoELF::MCAsmInfoELF() {
+MCAsmInfoELF::MCAsmInfoELF(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   HasIdentDirective = true;
   HasPreferredAlignment = true;
   WeakRefDirective = "\t.weak\t";

--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -21,7 +21,8 @@
 
 using namespace llvm;
 
-MCAsmInfoGOFF::MCAsmInfoGOFF() {
+MCAsmInfoGOFF::MCAsmInfoGOFF(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   Data64bitsDirective = "\t.quad\t";
   WeakRefDirective = "WXTRN";
   InternalSymbolPrefix = "L#";

--- a/llvm/lib/MC/MCAsmInfoWasm.cpp
+++ b/llvm/lib/MC/MCAsmInfoWasm.cpp
@@ -18,7 +18,8 @@
 
 using namespace llvm;
 
-MCAsmInfoWasm::MCAsmInfoWasm() {
+MCAsmInfoWasm::MCAsmInfoWasm(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   HasIdentDirective = true;
   HasNoDeadStrip = true;
   WeakRefDirective = "\t.weak\t";

--- a/llvm/lib/MC/MCAsmInfoXCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoXCOFF.cpp
@@ -20,7 +20,8 @@ namespace llvm {
 extern cl::opt<cl::boolOrDefault> UseLEB128Directives;
 }
 
-MCAsmInfoXCOFF::MCAsmInfoXCOFF() {
+MCAsmInfoXCOFF::MCAsmInfoXCOFF(const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   IsAIX = true;
   IsLittleEndian = false;
 

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -72,8 +72,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset) {
-  assert(MAI && MAI->getTargetOptions() &&
-         "MCAsmInfo and MCTargetOptions must be available");
+  assert(MAI && "MCAsmInfo must be available");
   const MCTargetOptions &TO = getTargetOptions();
   SaveTempLabels = TO.MCSaveTempLabels;
   if (SaveTempLabels)
@@ -121,7 +120,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
 }
 
 const MCTargetOptions &MCContext::getTargetOptions() const {
-  return *MAI->getTargetOptions();
+  return MAI->getTargetOptions();
 }
 
 MCContext::~MCContext() {

--- a/llvm/lib/MC/MCParser/MCAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmParser.cpp
@@ -175,7 +175,8 @@ bool MCAsmParser::parseSymbol(MCSymbol *&Res) {
 void MCParsedAsmOperand::dump() const {
   // Cannot completely remove virtual function even in release mode.
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  MCTargetOptions Opts;
   dbgs() << "  ";
-  print(dbgs(), MCAsmInfo());
+  print(dbgs(), MCAsmInfo(Opts));
 #endif
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -139,7 +139,9 @@ static bool evaluate(const MCSpecifierExpr &Expr, MCValue &Res,
   return !Res.getSubSym();
 }
 
-AArch64MCAsmInfoDarwin::AArch64MCAsmInfoDarwin(bool IsILP32) {
+AArch64MCAsmInfoDarwin::AArch64MCAsmInfoDarwin(bool IsILP32,
+                                               const MCTargetOptions &Options)
+    : MCAsmInfoDarwin(Options) {
   // We prefer NEON instructions to be printed in the short, Apple-specific
   // form when targeting Darwin.
   AssemblerDialect = AsmWriterVariant == Default ? Apple : AsmWriterVariant;
@@ -203,7 +205,9 @@ bool AArch64MCAsmInfoDarwin::evaluateAsRelocatableImpl(
   return evaluate(Expr, Res, Asm);
 }
 
-AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T) {
+AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T,
+                                         const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   if (T.getArch() == Triple::aarch64_be)
     IsLittleEndian = false;
 
@@ -257,7 +261,9 @@ bool AArch64MCAsmInfoELF::evaluateAsRelocatableImpl(
   return evaluate(Expr, Res, Asm);
 }
 
-AArch64MCAsmInfoMicrosoftCOFF::AArch64MCAsmInfoMicrosoftCOFF() {
+AArch64MCAsmInfoMicrosoftCOFF::AArch64MCAsmInfoMicrosoftCOFF(
+    const MCTargetOptions &Options)
+    : MCAsmInfoMicrosoft(Options) {
   InternalSymbolPrefix = ".L";
   PrivateLabelPrefix = ".L";
 
@@ -287,7 +293,8 @@ bool AArch64MCAsmInfoMicrosoftCOFF::evaluateAsRelocatableImpl(
   return evaluate(Expr, Res, Asm);
 }
 
-AArch64MCAsmInfoGNUCOFF::AArch64MCAsmInfoGNUCOFF() {
+AArch64MCAsmInfoGNUCOFF::AArch64MCAsmInfoGNUCOFF(const MCTargetOptions &Options)
+    : MCAsmInfoGNUCOFF(Options) {
   InternalSymbolPrefix = ".L";
   PrivateLabelPrefix = ".L";
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.h
@@ -26,7 +26,7 @@ class MCValue;
 class Triple;
 
 struct AArch64MCAsmInfoDarwin : public MCAsmInfoDarwin {
-  explicit AArch64MCAsmInfoDarwin(bool IsILP32);
+  explicit AArch64MCAsmInfoDarwin(bool IsILP32, const MCTargetOptions &Options);
   const MCExpr *
   getExprForPersonalitySymbol(const MCSymbol *Sym, unsigned Encoding,
                               MCStreamer &Streamer) const override;
@@ -37,7 +37,7 @@ struct AArch64MCAsmInfoDarwin : public MCAsmInfoDarwin {
 };
 
 struct AArch64MCAsmInfoELF : public MCAsmInfoELF {
-  explicit AArch64MCAsmInfoELF(const Triple &T);
+  explicit AArch64MCAsmInfoELF(const Triple &T, const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,
@@ -45,7 +45,7 @@ struct AArch64MCAsmInfoELF : public MCAsmInfoELF {
 };
 
 struct AArch64MCAsmInfoMicrosoftCOFF : public MCAsmInfoMicrosoft {
-  explicit AArch64MCAsmInfoMicrosoftCOFF();
+  explicit AArch64MCAsmInfoMicrosoftCOFF(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,
@@ -53,7 +53,7 @@ struct AArch64MCAsmInfoMicrosoftCOFF : public MCAsmInfoMicrosoft {
 };
 
 struct AArch64MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
-  explicit AArch64MCAsmInfoGNUCOFF();
+  explicit AArch64MCAsmInfoGNUCOFF(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -349,13 +349,14 @@ static MCAsmInfo *createAArch64MCAsmInfo(const MCRegisterInfo &MRI,
                                          const MCTargetOptions &Options) {
   MCAsmInfo *MAI;
   if (TheTriple.isOSBinFormatMachO())
-    MAI = new AArch64MCAsmInfoDarwin(TheTriple.getArch() == Triple::aarch64_32);
+    MAI = new AArch64MCAsmInfoDarwin(TheTriple.getArch() == Triple::aarch64_32,
+                                     Options);
   else if (TheTriple.isOSBinFormatELF())
-    MAI = new AArch64MCAsmInfoELF(TheTriple);
+    MAI = new AArch64MCAsmInfoELF(TheTriple, Options);
   else if (TheTriple.isWindowsMSVCEnvironment())
-    MAI = new AArch64MCAsmInfoMicrosoftCOFF();
+    MAI = new AArch64MCAsmInfoMicrosoftCOFF(Options);
   else if (TheTriple.isOSBinFormatCOFF())
-    MAI = new AArch64MCAsmInfoGNUCOFF();
+    MAI = new AArch64MCAsmInfoGNUCOFF(Options);
   else
     reportFatalUsageError("unsupported object format");
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
@@ -29,7 +29,8 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 };
 
 AMDGPUMCAsmInfo::AMDGPUMCAsmInfo(const Triple &TT,
-                                 const MCTargetOptions &Options) {
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   CodePointerSize = (TT.isAMDGCN()) ? 8 : 4;
   StackGrowsUp = true;
   HasSingleParameterDotFile = false;

--- a/llvm/lib/Target/ARC/MCTargetDesc/ARCMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARC/MCTargetDesc/ARCMCAsmInfo.cpp
@@ -11,7 +11,8 @@ using namespace llvm;
 
 void ARCMCAsmInfo::anchor() {}
 
-ARCMCAsmInfo::ARCMCAsmInfo(const Triple &TT) {
+ARCMCAsmInfo::ARCMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   SupportsDebugInformation = true;
   Data16bitsDirective = "\t.short\t";
   Data32bitsDirective = "\t.word\t";

--- a/llvm/lib/Target/ARC/MCTargetDesc/ARCMCAsmInfo.h
+++ b/llvm/lib/Target/ARC/MCTargetDesc/ARCMCAsmInfo.h
@@ -23,7 +23,7 @@ class ARCMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit ARCMCAsmInfo(const Triple &TT);
+  explicit ARCMCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/ARC/MCTargetDesc/ARCMCTargetDesc.cpp
+++ b/llvm/lib/Target/ARC/MCTargetDesc/ARCMCTargetDesc.cpp
@@ -55,7 +55,7 @@ static MCSubtargetInfo *createARCMCSubtargetInfo(const Triple &TT,
 static MCAsmInfo *createARCMCAsmInfo(const MCRegisterInfo &MRI,
                                      const Triple &TT,
                                      const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new ARCMCAsmInfo(TT);
+  MCAsmInfo *MAI = new ARCMCAsmInfo(TT, Options);
 
   // Initial state of the frame pointer is SP.
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, ARC::SP, 0);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -46,7 +46,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 
 void ARMMCAsmInfoDarwin::anchor() { }
 
-ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple) {
+ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple,
+                                       const MCTargetOptions &Options)
+    : MCAsmInfoDarwin(Options) {
   if ((TheTriple.getArch() == Triple::armeb) ||
       (TheTriple.getArch() == Triple::thumbeb))
     IsLittleEndian = false;
@@ -70,7 +72,9 @@ ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple) {
 
 void ARMELFMCAsmInfo::anchor() { }
 
-ARMELFMCAsmInfo::ARMELFMCAsmInfo(const Triple &TheTriple) {
+ARMELFMCAsmInfo::ARMELFMCAsmInfo(const Triple &TheTriple,
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   if ((TheTriple.getArch() == Triple::armeb) ||
       (TheTriple.getArch() == Triple::thumbeb))
     IsLittleEndian = false;
@@ -114,7 +118,9 @@ void ARMELFMCAsmInfo::setUseIntegratedAssembler(bool Value) {
 
 void ARMCOFFMCAsmInfoMicrosoft::anchor() { }
 
-ARMCOFFMCAsmInfoMicrosoft::ARMCOFFMCAsmInfoMicrosoft() {
+ARMCOFFMCAsmInfoMicrosoft::ARMCOFFMCAsmInfoMicrosoft(
+    const MCTargetOptions &Options)
+    : MCAsmInfoMicrosoft(Options) {
   AlignmentIsInBytes = false;
   SupportsDebugInformation = true;
   ExceptionsType = ExceptionHandling::WinEH;
@@ -131,7 +137,8 @@ ARMCOFFMCAsmInfoMicrosoft::ARMCOFFMCAsmInfoMicrosoft() {
 
 void ARMCOFFMCAsmInfoGNU::anchor() { }
 
-ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU() {
+ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU(const MCTargetOptions &Options)
+    : MCAsmInfoGNUCOFF(Options) {
   AlignmentIsInBytes = false;
   HasSingleParameterDotFile = true;
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.h
@@ -30,7 +30,8 @@ class ARMMCAsmInfoDarwin : public MCAsmInfoDarwin {
   virtual void anchor();
 
 public:
-  explicit ARMMCAsmInfoDarwin(const Triple &TheTriple);
+  explicit ARMMCAsmInfoDarwin(const Triple &TheTriple,
+                              const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override {
     ARM::printSpecifierExpr(*this, OS, Expr);
@@ -45,7 +46,7 @@ class ARMELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit ARMELFMCAsmInfo(const Triple &TT);
+  explicit ARMELFMCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 
   void setUseIntegratedAssembler(bool Value) override;
   void printSpecifierExpr(raw_ostream &OS,
@@ -62,7 +63,7 @@ class ARMCOFFMCAsmInfoMicrosoft : public MCAsmInfoMicrosoft {
   void anchor() override;
 
 public:
-  explicit ARMCOFFMCAsmInfoMicrosoft();
+  explicit ARMCOFFMCAsmInfoMicrosoft(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override {
     ARM::printSpecifierExpr(*this, OS, Expr);
@@ -77,7 +78,7 @@ class ARMCOFFMCAsmInfoGNU : public MCAsmInfoGNUCOFF {
   void anchor() override;
 
 public:
-  explicit ARMCOFFMCAsmInfoGNU();
+  explicit ARMCOFFMCAsmInfoGNU(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override {
     ARM::printSpecifierExpr(*this, OS, Expr);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
@@ -337,13 +337,13 @@ static MCAsmInfo *createARMMCAsmInfo(const MCRegisterInfo &MRI,
                                      const MCTargetOptions &Options) {
   MCAsmInfo *MAI;
   if (TheTriple.isOSDarwin() || TheTriple.isOSBinFormatMachO())
-    MAI = new ARMMCAsmInfoDarwin(TheTriple);
+    MAI = new ARMMCAsmInfoDarwin(TheTriple, Options);
   else if (TheTriple.isWindowsMSVCEnvironment())
-    MAI = new ARMCOFFMCAsmInfoMicrosoft();
+    MAI = new ARMCOFFMCAsmInfoMicrosoft(Options);
   else if (TheTriple.isOSWindows())
-    MAI = new ARMCOFFMCAsmInfoGNU();
+    MAI = new ARMCOFFMCAsmInfoGNU(Options);
   else
-    MAI = new ARMELFMCAsmInfo(TheTriple);
+    MAI = new ARMELFMCAsmInfo(TheTriple, Options);
 
   unsigned Reg = MRI.getDwarfRegNum(ARM::SP, true);
   MAI->addInitialFrameState(MCCFIInstruction::cfiDefCfa(nullptr, Reg, 0));

--- a/llvm/lib/Target/AVR/MCTargetDesc/AVRMCAsmInfo.cpp
+++ b/llvm/lib/Target/AVR/MCTargetDesc/AVRMCAsmInfo.cpp
@@ -19,7 +19,8 @@
 
 using namespace llvm;
 
-AVRMCAsmInfo::AVRMCAsmInfo(const Triple &TT, const MCTargetOptions &Options) {
+AVRMCAsmInfo::AVRMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   CodePointerSize = 2;
   CalleeSaveStackSlotSize = 2;
   CommentString = ";";

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -20,7 +20,8 @@ namespace llvm {
 
 class BPFMCAsmInfo : public MCAsmInfoELF {
 public:
-  explicit BPFMCAsmInfo(const Triple &TT, const MCTargetOptions &Options) {
+  explicit BPFMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+      : MCAsmInfoELF(Options) {
     if (TT.getArch() == Triple::bpfeb)
       IsLittleEndian = false;
 

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCAsmInfo.cpp
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCAsmInfo.cpp
@@ -26,7 +26,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 
 void CSKYMCAsmInfo::anchor() {}
 
-CSKYMCAsmInfo::CSKYMCAsmInfo(const Triple &TargetTriple) {
+CSKYMCAsmInfo::CSKYMCAsmInfo(const Triple &TargetTriple,
+                             const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   AlignmentIsInBytes = false;
   SupportsDebugInformation = true;
   CommentString = "#";

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCAsmInfo.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCAsmInfo.h
@@ -24,7 +24,8 @@ class CSKYMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit CSKYMCAsmInfo(const Triple &TargetTriple);
+  explicit CSKYMCAsmInfo(const Triple &TargetTriple,
+                         const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
 };

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCTargetDesc.cpp
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYMCTargetDesc.cpp
@@ -39,7 +39,7 @@ using namespace llvm;
 static MCAsmInfo *createCSKYMCAsmInfo(const MCRegisterInfo &MRI,
                                       const Triple &TT,
                                       const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new CSKYMCAsmInfo(TT);
+  MCAsmInfo *MAI = new CSKYMCAsmInfo(TT, Options);
 
   // Initial state of the frame pointer is SP.
   unsigned Reg = MRI.getDwarfRegNum(CSKY::R14, true);

--- a/llvm/lib/Target/DirectX/MCTargetDesc/DirectXMCTargetDesc.cpp
+++ b/llvm/lib/Target/DirectX/MCTargetDesc/DirectXMCTargetDesc.cpp
@@ -94,7 +94,7 @@ public:
 class DirectXMCAsmInfo : public MCAsmInfo {
 public:
   explicit DirectXMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
-      : MCAsmInfo() {}
+      : MCAsmInfo(Options) {}
 };
 
 } // namespace

--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -458,7 +458,7 @@ public:
 void HexagonOperand::print(raw_ostream &OS, const MCAsmInfo &MAI) const {
   switch (Kind) {
   case Immediate:
-    HexagonMCAsmInfo(Triple()).printExpr(OS, *getImm());
+    MAI.printExpr(OS, *getImm());
     break;
   case Register:
     OS << "<register R";

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.cpp
@@ -28,7 +28,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 // Pin the vtable to this file.
 void HexagonMCAsmInfo::anchor() {}
 
-HexagonMCAsmInfo::HexagonMCAsmInfo(const Triple &TT) {
+HexagonMCAsmInfo::HexagonMCAsmInfo(const Triple &TT,
+                                   const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   Data16bitsDirective = "\t.half\t";
   Data32bitsDirective = "\t.word\t";
   Data64bitsDirective = nullptr;  // .xword is only supported by V9.

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.h
@@ -22,7 +22,7 @@ class HexagonMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit HexagonMCAsmInfo(const Triple &TT);
+  explicit HexagonMCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -382,7 +382,7 @@ static MCRegisterInfo *createHexagonMCRegisterInfo(const Triple &TT) {
 static MCAsmInfo *createHexagonMCAsmInfo(const MCRegisterInfo &MRI,
                                          const Triple &TT,
                                          const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new HexagonMCAsmInfo(TT);
+  MCAsmInfo *MAI = new HexagonMCAsmInfo(TT, Options);
 
   // VirtualFP = (R30 + #0).
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(

--- a/llvm/lib/Target/Lanai/MCTargetDesc/LanaiMCAsmInfo.cpp
+++ b/llvm/lib/Target/Lanai/MCTargetDesc/LanaiMCAsmInfo.cpp
@@ -20,7 +20,8 @@ using namespace llvm;
 void LanaiMCAsmInfo::anchor() {}
 
 LanaiMCAsmInfo::LanaiMCAsmInfo(const Triple & /*TheTriple*/,
-                               const MCTargetOptions &Options) {
+                               const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   IsLittleEndian = false;
   InternalSymbolPrefix = ".L";
   WeakRefDirective = "\t.weak\t";

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.cpp
@@ -236,7 +236,9 @@ LoongArchMCExpr::Specifier LoongArch::parseSpecifier(StringRef name) {
 
 void LoongArchMCAsmInfo::anchor() {}
 
-LoongArchMCAsmInfo::LoongArchMCAsmInfo(const Triple &TT) {
+LoongArchMCAsmInfo::LoongArchMCAsmInfo(const Triple &TT,
+                                       const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   CodePointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
   AlignmentIsInBytes = false;
   Data8bitsDirective = "\t.byte\t";

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.h
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.h
@@ -42,7 +42,8 @@ class LoongArchMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit LoongArchMCAsmInfo(const Triple &TargetTriple);
+  explicit LoongArchMCAsmInfo(const Triple &TargetTriple,
+                              const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
 };

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCTargetDesc.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCTargetDesc.cpp
@@ -62,7 +62,7 @@ createLoongArchMCSubtargetInfo(const Triple &TT, StringRef CPU, StringRef FS) {
 static MCAsmInfo *createLoongArchMCAsmInfo(const MCRegisterInfo &MRI,
                                            const Triple &TT,
                                            const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new LoongArchMCAsmInfo(TT);
+  MCAsmInfo *MAI = new LoongArchMCAsmInfo(TT, Options);
 
   // Initial state of the frame pointer is sp(r3).
   unsigned SP = MRI.getDwarfRegNum(LoongArch::R3, true);

--- a/llvm/lib/Target/M68k/MCTargetDesc/M68kMCAsmInfo.cpp
+++ b/llvm/lib/Target/M68k/MCTargetDesc/M68kMCAsmInfo.cpp
@@ -27,7 +27,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 
 void M68kELFMCAsmInfo::anchor() {}
 
-M68kELFMCAsmInfo::M68kELFMCAsmInfo(const Triple &T) {
+M68kELFMCAsmInfo::M68kELFMCAsmInfo(const Triple &T,
+                                   const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   CodePointerSize = 4;
   CalleeSaveStackSlotSize = 4;
 

--- a/llvm/lib/Target/M68k/MCTargetDesc/M68kMCAsmInfo.h
+++ b/llvm/lib/Target/M68k/MCTargetDesc/M68kMCAsmInfo.h
@@ -23,7 +23,8 @@ class M68kELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit M68kELFMCAsmInfo(const Triple &Triple);
+  explicit M68kELFMCAsmInfo(const Triple &Triple,
+                            const MCTargetOptions &Options);
 };
 
 namespace M68k {

--- a/llvm/lib/Target/M68k/MCTargetDesc/M68kMCTargetDesc.cpp
+++ b/llvm/lib/Target/M68k/MCTargetDesc/M68kMCTargetDesc.cpp
@@ -73,7 +73,7 @@ static MCSubtargetInfo *createM68kMCSubtargetInfo(const Triple &TT,
 static MCAsmInfo *createM68kMCAsmInfo(const MCRegisterInfo &MRI,
                                       const Triple &TT,
                                       const MCTargetOptions &TO) {
-  MCAsmInfo *MAI = new M68kELFMCAsmInfo(TT);
+  MCAsmInfo *MAI = new M68kELFMCAsmInfo(TT, TO);
 
   // Initialize initial frame state.
   // Calculate amount of bytes used for return address storing

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
@@ -15,7 +15,9 @@ using namespace llvm;
 
 void MSP430MCAsmInfo::anchor() { }
 
-MSP430MCAsmInfo::MSP430MCAsmInfo(const Triple &TT) {
+MSP430MCAsmInfo::MSP430MCAsmInfo(const Triple &TT,
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   // Since MSP430-GCC already generates 32-bit DWARF information, we will
   // also store 16-bit pointers as 32-bit pointers in DWARF, because using
   // 32-bit DWARF pointers is already a working and tested path for LLDB

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.h
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.h
@@ -22,7 +22,7 @@ class MSP430MCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit MSP430MCAsmInfo(const Triple &TT);
+  explicit MSP430MCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCTargetDesc.cpp
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCTargetDesc.cpp
@@ -48,7 +48,7 @@ static MCRegisterInfo *createMSP430MCRegisterInfo(const Triple &TT) {
 static MCAsmInfo *createMSP430MCAsmInfo(const MCRegisterInfo &MRI,
                                         const Triple &TT,
                                         const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new MSP430MCAsmInfo(TT);
+  MCAsmInfo *MAI = new MSP430MCAsmInfo(TT, Options);
 
   // Initialize initial frame state.
   int stackGrowth = -2;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -21,7 +21,8 @@ using namespace llvm;
 void MipsELFMCAsmInfo::anchor() {}
 
 MipsELFMCAsmInfo::MipsELFMCAsmInfo(const Triple &TheTriple,
-                                   const MCTargetOptions &Options) {
+                                   const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   IsLittleEndian = TheTriple.isLittleEndian();
 
   MipsABIInfo ABI =
@@ -50,7 +51,8 @@ MipsELFMCAsmInfo::MipsELFMCAsmInfo(const Triple &TheTriple,
 
 void MipsCOFFMCAsmInfo::anchor() {}
 
-MipsCOFFMCAsmInfo::MipsCOFFMCAsmInfo() {
+MipsCOFFMCAsmInfo::MipsCOFFMCAsmInfo(const MCTargetOptions &Options)
+    : MCAsmInfoGNUCOFF(Options) {
   HasSingleParameterDotFile = true;
   WinEHEncodingType = WinEH::EncodingType::Itanium;
 

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.h
@@ -36,7 +36,7 @@ class MipsCOFFMCAsmInfo : public MCAsmInfoGNUCOFF {
   void anchor() override;
 
 public:
-  explicit MipsCOFFMCAsmInfo();
+  explicit MipsCOFFMCAsmInfo(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
@@ -174,7 +174,7 @@ static MCAsmInfo *createMipsMCAsmInfo(const MCRegisterInfo &MRI,
   MCAsmInfo *MAI;
 
   if (TT.isOSBinFormatCOFF())
-    MAI = new MipsCOFFMCAsmInfo();
+    MAI = new MipsCOFFMCAsmInfo(Options);
   else
     MAI = new MipsELFMCAsmInfo(TT, Options);
 

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
@@ -16,7 +16,8 @@
 using namespace llvm;
 
 NVPTXMCAsmInfo::NVPTXMCAsmInfo(const Triple &TheTriple,
-                               const MCTargetOptions &Options) {
+                               const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   if (TheTriple.getArch() == Triple::nvptx64) {
     CodePointerSize = CalleeSaveStackSlotSize = 8;
   }

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
@@ -169,7 +169,9 @@ static bool evaluateAsRelocatable(const MCSpecifierExpr &Expr, MCValue &Res,
   return true;
 }
 
-PPCELFMCAsmInfo::PPCELFMCAsmInfo(bool is64Bit, const Triple& T) {
+PPCELFMCAsmInfo::PPCELFMCAsmInfo(bool is64Bit, const Triple &T,
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   // FIXME: This is not always needed. For example, it is not needed in the
   // v2 abi.
   NeedsLocalForSize = true;
@@ -219,7 +221,9 @@ bool PPCELFMCAsmInfo::evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr,
   return evaluateAsRelocatable(Expr, Res, Asm);
 }
 
-PPCXCOFFMCAsmInfo::PPCXCOFFMCAsmInfo(bool Is64Bit, const Triple &T) {
+PPCXCOFFMCAsmInfo::PPCXCOFFMCAsmInfo(bool Is64Bit, const Triple &T,
+                                     const MCTargetOptions &Options)
+    : MCAsmInfoXCOFF(Options) {
   if (T.getArch() == Triple::ppc64le || T.getArch() == Triple::ppcle)
     report_fatal_error("XCOFF is not supported for little-endian targets");
   CodePointerSize = CalleeSaveStackSlotSize = Is64Bit ? 8 : 4;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.h
@@ -25,7 +25,8 @@ class PPCELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit PPCELFMCAsmInfo(bool is64Bit, const Triple &);
+  explicit PPCELFMCAsmInfo(bool is64Bit, const Triple &,
+                           const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,
@@ -34,7 +35,8 @@ public:
 
 class PPCXCOFFMCAsmInfo : public MCAsmInfoXCOFF {
 public:
-  explicit PPCXCOFFMCAsmInfo(bool is64Bit, const Triple &);
+  explicit PPCXCOFFMCAsmInfo(bool is64Bit, const Triple &,
+                             const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
@@ -188,9 +188,9 @@ static MCAsmInfo *createPPCMCAsmInfo(const MCRegisterInfo &MRI,
 
   MCAsmInfo *MAI;
   if (TheTriple.isOSBinFormatXCOFF())
-    MAI = new PPCXCOFFMCAsmInfo(isPPC64, TheTriple);
+    MAI = new PPCXCOFFMCAsmInfo(isPPC64, TheTriple, Options);
   else
-    MAI = new PPCELFMCAsmInfo(isPPC64, TheTriple);
+    MAI = new PPCELFMCAsmInfo(isPPC64, TheTriple, Options);
 
   // Initial state of the frame pointer is R1.
   unsigned Reg = isPPC64 ? PPC::X1 : PPC::R1;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -20,7 +20,8 @@ using namespace llvm;
 
 void RISCVMCAsmInfo::anchor() {}
 
-RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT) {
+RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   IsLittleEndian = TT.isLittleEndian();
   CodePointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
   CommentString = "#";
@@ -58,7 +59,8 @@ void RISCVMCAsmInfo::printSpecifierExpr(raw_ostream &OS,
     OS << ')';
 }
 
-RISCVMCAsmInfoDarwin::RISCVMCAsmInfoDarwin() {
+RISCVMCAsmInfoDarwin::RISCVMCAsmInfoDarwin(const MCTargetOptions &Options)
+    : MCAsmInfoDarwin(Options) {
   CodePointerSize = 4;
   InternalSymbolPrefix = "L";
   PrivateLabelPrefix = "L";

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
@@ -24,7 +24,8 @@ class RISCVMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit RISCVMCAsmInfo(const Triple &TargetTriple);
+  explicit RISCVMCAsmInfo(const Triple &TargetTriple,
+                          const MCTargetOptions &Options);
 
   const MCExpr *getExprForFDESymbol(const MCSymbol *Sym, unsigned Encoding,
                                     MCStreamer &Streamer) const override;
@@ -56,7 +57,7 @@ StringRef getSpecifierName(Specifier Kind);
 
 class RISCVMCAsmInfoDarwin : public MCAsmInfoDarwin {
 public:
-  explicit RISCVMCAsmInfoDarwin();
+  explicit RISCVMCAsmInfoDarwin(const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
 };

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -63,9 +63,9 @@ static MCAsmInfo *createRISCVMCAsmInfo(const MCRegisterInfo &MRI,
                                        const MCTargetOptions &Options) {
   MCAsmInfo *MAI = nullptr;
   if (TT.isOSBinFormatELF())
-    MAI = new RISCVMCAsmInfo(TT);
+    MAI = new RISCVMCAsmInfo(TT, Options);
   else if (TT.isOSBinFormatMachO())
-    MAI = new RISCVMCAsmInfoDarwin();
+    MAI = new RISCVMCAsmInfoDarwin(Options);
   else
     reportFatalUsageError("unsupported object format");
 

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCAsmInfo.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCAsmInfo.cpp
@@ -15,8 +15,8 @@
 
 using namespace llvm;
 
-SPIRVMCAsmInfo::SPIRVMCAsmInfo(const Triple &TT,
-                               const MCTargetOptions &Options) {
+SPIRVMCAsmInfo::SPIRVMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+    : MCAsmInfo(Options) {
   IsLittleEndian = true;
 
   HasSingleParameterDotFile = false;

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
@@ -22,7 +22,9 @@ using namespace llvm;
 
 void SparcELFMCAsmInfo::anchor() {}
 
-SparcELFMCAsmInfo::SparcELFMCAsmInfo(const Triple &TheTriple) {
+SparcELFMCAsmInfo::SparcELFMCAsmInfo(const Triple &TheTriple,
+                                     const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   bool isV9 = (TheTriple.getArch() == Triple::sparcv9);
   IsLittleEndian = (TheTriple.getArch() == Triple::sparcel);
 

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
@@ -23,7 +23,8 @@ class SparcELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit SparcELFMCAsmInfo(const Triple &TheTriple);
+  explicit SparcELFMCAsmInfo(const Triple &TheTriple,
+                             const MCTargetOptions &Options);
 
   const MCExpr*
   getExprForPersonalitySymbol(const MCSymbol *Sym, unsigned Encoding,

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.cpp
@@ -49,7 +49,7 @@ using namespace llvm;
 static MCAsmInfo *createSparcMCAsmInfo(const MCRegisterInfo &MRI,
                                        const Triple &TT,
                                        const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new SparcELFMCAsmInfo(TT);
+  MCAsmInfo *MAI = new SparcELFMCAsmInfo(TT, Options);
   unsigned Reg = MRI.getDwarfRegNum(SP::O6, true);
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, Reg, 0);
   MAI->addInitialFrameState(Inst);
@@ -59,7 +59,7 @@ static MCAsmInfo *createSparcMCAsmInfo(const MCRegisterInfo &MRI,
 static MCAsmInfo *createSparcV9MCAsmInfo(const MCRegisterInfo &MRI,
                                          const Triple &TT,
                                          const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new SparcELFMCAsmInfo(TT);
+  MCAsmInfo *MAI = new SparcELFMCAsmInfo(TT, Options);
   unsigned Reg = MRI.getDwarfRegNum(SP::O6, true);
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, Reg, 2047);
   MAI->addInitialFrameState(Inst);

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
@@ -21,7 +21,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
     {SystemZ::S_TLSLDM, "TLSLDM"},
 };
 
-SystemZMCAsmInfoELF::SystemZMCAsmInfoELF(const Triple &TT) {
+SystemZMCAsmInfoELF::SystemZMCAsmInfoELF(const Triple &TT,
+                                         const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   AssemblerDialect = AD_GNU;
   CalleeSaveStackSlotSize = 8;
   CodePointerSize = 8;
@@ -36,7 +38,9 @@ SystemZMCAsmInfoELF::SystemZMCAsmInfoELF(const Triple &TT) {
   initializeAtSpecifiers(atSpecifiers);
 }
 
-SystemZMCAsmInfoGOFF::SystemZMCAsmInfoGOFF(const Triple &TT) {
+SystemZMCAsmInfoGOFF::SystemZMCAsmInfoGOFF(const Triple &TT,
+                                           const MCTargetOptions &Options)
+    : MCAsmInfoGOFF(Options) {
   AllowAdditionalComments = false;
   AllowAtInName = true;
   AllowAtAtStartOfIdentifier = true;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
@@ -19,12 +19,14 @@ enum SystemZAsmDialect { AD_GNU = 0, AD_HLASM = 1 };
 
 class SystemZMCAsmInfoELF : public MCAsmInfoELF {
 public:
-  explicit SystemZMCAsmInfoELF(const Triple &TT);
+  explicit SystemZMCAsmInfoELF(const Triple &TT,
+                               const MCTargetOptions &Options);
 };
 
 class SystemZMCAsmInfoGOFF : public MCAsmInfoGOFF {
 public:
-  explicit SystemZMCAsmInfoGOFF(const Triple &TT);
+  explicit SystemZMCAsmInfoGOFF(const Triple &TT,
+                                const MCTargetOptions &Options);
   bool isAcceptableChar(char C) const override;
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
@@ -162,9 +162,9 @@ static MCAsmInfo *createSystemZMCAsmInfo(const MCRegisterInfo &MRI,
                                          const Triple &TT,
                                          const MCTargetOptions &Options) {
   if (TT.isOSzOS())
-    return new SystemZMCAsmInfoGOFF(TT);
+    return new SystemZMCAsmInfoGOFF(TT, Options);
 
-  MCAsmInfo *MAI = new SystemZMCAsmInfoELF(TT);
+  MCAsmInfo *MAI = new SystemZMCAsmInfoELF(TT, Options);
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(
       nullptr, MRI.getDwarfRegNum(SystemZ::R15D, true),
       SystemZMC::ELFCFAOffsetFromInitialSP);

--- a/llvm/lib/Target/VE/MCTargetDesc/VEMCAsmInfo.cpp
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEMCAsmInfo.cpp
@@ -74,7 +74,9 @@ VE::Fixups VE::getFixupKind(uint8_t S) {
 
 void VEELFMCAsmInfo::anchor() {}
 
-VEELFMCAsmInfo::VEELFMCAsmInfo(const Triple &TheTriple) {
+VEELFMCAsmInfo::VEELFMCAsmInfo(const Triple &TheTriple,
+                               const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
 
   CodePointerSize = CalleeSaveStackSlotSize = 8;
   MaxInstLength = MinInstAlignment = 8;

--- a/llvm/lib/Target/VE/MCTargetDesc/VEMCAsmInfo.h
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEMCAsmInfo.h
@@ -25,7 +25,8 @@ class VEELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit VEELFMCAsmInfo(const Triple &TheTriple);
+  explicit VEELFMCAsmInfo(const Triple &TheTriple,
+                          const MCTargetOptions &Options);
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
   bool evaluateAsRelocatableImpl(const MCSpecifierExpr &Expr, MCValue &Res,

--- a/llvm/lib/Target/VE/MCTargetDesc/VEMCTargetDesc.cpp
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEMCTargetDesc.cpp
@@ -36,7 +36,7 @@ using namespace llvm;
 
 static MCAsmInfo *createVEMCAsmInfo(const MCRegisterInfo &MRI, const Triple &TT,
                                     const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new VEELFMCAsmInfo(TT);
+  MCAsmInfo *MAI = new VEELFMCAsmInfo(TT, Options);
   unsigned Reg = MRI.getDwarfRegNum(VE::SX11, true);
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, Reg, 0);
   MAI->addInitialFrameState(Inst);

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyMCAsmInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyMCAsmInfo.cpp
@@ -34,7 +34,8 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 WebAssemblyMCAsmInfo::~WebAssemblyMCAsmInfo() = default; // anchor.
 
 WebAssemblyMCAsmInfo::WebAssemblyMCAsmInfo(const Triple &T,
-                                           const MCTargetOptions &Options) {
+                                           const MCTargetOptions &Options)
+    : MCAsmInfoWasm(Options) {
   CodePointerSize = CalleeSaveStackSlotSize = T.isArch64Bit() ? 8 : 4;
 
   // TODO: What should MaxInstLength be?

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -67,7 +67,9 @@ const MCAsmInfo::AtSpecifier atSpecifiers[] = {
 
 void X86MCAsmInfoDarwin::anchor() { }
 
-X86MCAsmInfoDarwin::X86MCAsmInfoDarwin(const Triple &T) {
+X86MCAsmInfoDarwin::X86MCAsmInfoDarwin(const Triple &T,
+                                       const MCTargetOptions &Options)
+    : MCAsmInfoDarwin(Options) {
   bool is64Bit = T.isX86_64();
   if (is64Bit)
     CodePointerSize = CalleeSaveStackSlotSize = 8;
@@ -104,13 +106,15 @@ X86MCAsmInfoDarwin::X86MCAsmInfoDarwin(const Triple &T) {
   initializeAtSpecifiers(atSpecifiers);
 }
 
-X86_64MCAsmInfoDarwin::X86_64MCAsmInfoDarwin(const Triple &Triple)
-  : X86MCAsmInfoDarwin(Triple) {
-}
+X86_64MCAsmInfoDarwin::X86_64MCAsmInfoDarwin(const Triple &Triple,
+                                             const MCTargetOptions &Options)
+    : X86MCAsmInfoDarwin(Triple, Options) {}
 
 void X86ELFMCAsmInfo::anchor() { }
 
-X86ELFMCAsmInfo::X86ELFMCAsmInfo(const Triple &T) {
+X86ELFMCAsmInfo::X86ELFMCAsmInfo(const Triple &T,
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   bool is64Bit = T.isX86_64();
   bool isX32 = T.isX32();
 
@@ -145,7 +149,9 @@ X86_64MCAsmInfoDarwin::getExprForPersonalitySymbol(const MCSymbol *Sym,
 
 void X86MCAsmInfoMicrosoft::anchor() { }
 
-X86MCAsmInfoMicrosoft::X86MCAsmInfoMicrosoft(const Triple &Triple) {
+X86MCAsmInfoMicrosoft::X86MCAsmInfoMicrosoft(const Triple &Triple,
+                                             const MCTargetOptions &Options)
+    : MCAsmInfoMicrosoft(Options) {
   if (Triple.isX86_64()) {
     InternalSymbolPrefix = ".L";
     PrivateLabelPrefix = ".L";
@@ -169,8 +175,9 @@ X86MCAsmInfoMicrosoft::X86MCAsmInfoMicrosoft(const Triple &Triple) {
 
 void X86MCAsmInfoMicrosoftMASM::anchor() { }
 
-X86MCAsmInfoMicrosoftMASM::X86MCAsmInfoMicrosoftMASM(const Triple &Triple)
-    : X86MCAsmInfoMicrosoft(Triple) {
+X86MCAsmInfoMicrosoftMASM::X86MCAsmInfoMicrosoftMASM(
+    const Triple &Triple, const MCTargetOptions &Options)
+    : X86MCAsmInfoMicrosoft(Triple, Options) {
   DollarIsPC = true;
   SeparatorString = "\n";
   CommentString = ";";
@@ -210,7 +217,9 @@ bool X86MCAsmInfoGNUCOFF::isValidUnquotedName(StringRef Name) const {
 
 void X86MCAsmInfoGNUCOFF::anchor() { }
 
-X86MCAsmInfoGNUCOFF::X86MCAsmInfoGNUCOFF(const Triple &Triple) {
+X86MCAsmInfoGNUCOFF::X86MCAsmInfoGNUCOFF(const Triple &Triple,
+                                         const MCTargetOptions &Options)
+    : MCAsmInfoGNUCOFF(Options) {
   assert((Triple.isOSWindows() || Triple.isUEFI()) &&
          "Windows and UEFI are the only supported COFF targets");
   if (Triple.isX86_64()) {

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
@@ -28,12 +28,14 @@ class X86MCAsmInfoDarwin : public MCAsmInfoDarwin {
 
 public:
   StringSet<> ReservedIdentifiers;
-  explicit X86MCAsmInfoDarwin(const Triple &Triple);
+  explicit X86MCAsmInfoDarwin(const Triple &Triple,
+                              const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
 };
 
 struct X86_64MCAsmInfoDarwin : public X86MCAsmInfoDarwin {
-  explicit X86_64MCAsmInfoDarwin(const Triple &Triple);
+  explicit X86_64MCAsmInfoDarwin(const Triple &Triple,
+                                 const MCTargetOptions &Options);
   const MCExpr *
   getExprForPersonalitySymbol(const MCSymbol *Sym, unsigned Encoding,
                               MCStreamer &Streamer) const override;
@@ -44,7 +46,8 @@ class X86ELFMCAsmInfo : public MCAsmInfoELF {
 
 public:
   StringSet<> ReservedIdentifiers;
-  explicit X86ELFMCAsmInfo(const Triple &Triple);
+  explicit X86ELFMCAsmInfo(const Triple &Triple,
+                           const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
 };
 
@@ -53,7 +56,8 @@ class X86MCAsmInfoMicrosoft : public MCAsmInfoMicrosoft {
 
 public:
   StringSet<> ReservedIdentifiers;
-  explicit X86MCAsmInfoMicrosoft(const Triple &Triple);
+  explicit X86MCAsmInfoMicrosoft(const Triple &Triple,
+                                 const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
 };
 
@@ -61,7 +65,8 @@ class X86MCAsmInfoMicrosoftMASM : public X86MCAsmInfoMicrosoft {
   void anchor() override;
 
 public:
-  explicit X86MCAsmInfoMicrosoftMASM(const Triple &Triple);
+  explicit X86MCAsmInfoMicrosoftMASM(const Triple &Triple,
+                                     const MCTargetOptions &Options);
 };
 
 class X86MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
@@ -69,7 +74,8 @@ class X86MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
 
 public:
   StringSet<> ReservedIdentifiers;
-  explicit X86MCAsmInfoGNUCOFF(const Triple &Triple);
+  explicit X86MCAsmInfoGNUCOFF(const Triple &Triple,
+                               const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
 };
 

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -448,38 +448,38 @@ static MCAsmInfo *createX86MCAsmInfo(const MCRegisterInfo &MRI,
   MCAsmInfo *MAI;
   if (TheTriple.isOSBinFormatMachO()) {
     if (is64Bit) {
-      auto *P = new X86_64MCAsmInfoDarwin(TheTriple);
+      auto *P = new X86_64MCAsmInfoDarwin(TheTriple, Options);
       populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
       MAI = P;
     } else {
-      auto *P = new X86MCAsmInfoDarwin(TheTriple);
+      auto *P = new X86MCAsmInfoDarwin(TheTriple, Options);
       populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
       MAI = P;
     }
   } else if (TheTriple.isOSBinFormatELF()) {
     // Force the use of an ELF container.
-    auto *P = new X86ELFMCAsmInfo(TheTriple);
+    auto *P = new X86ELFMCAsmInfo(TheTriple, Options);
     populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
     MAI = P;
   } else if (TheTriple.isWindowsMSVCEnvironment() ||
              TheTriple.isWindowsCoreCLREnvironment() || TheTriple.isUEFI()) {
     if (Options.getAssemblyLanguage().equals_insensitive("masm")) {
-      auto *P = new X86MCAsmInfoMicrosoftMASM(TheTriple);
+      auto *P = new X86MCAsmInfoMicrosoftMASM(TheTriple, Options);
       populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
       MAI = P;
     } else {
-      auto *P = new X86MCAsmInfoMicrosoft(TheTriple);
+      auto *P = new X86MCAsmInfoMicrosoft(TheTriple, Options);
       populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
       MAI = P;
     }
   } else if (TheTriple.isOSCygMing() ||
              TheTriple.isWindowsItaniumEnvironment()) {
-    auto *P = new X86MCAsmInfoGNUCOFF(TheTriple);
+    auto *P = new X86MCAsmInfoGNUCOFF(TheTriple, Options);
     populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
     MAI = P;
   } else {
     // The default is ELF.
-    auto *P = new X86ELFMCAsmInfo(TheTriple);
+    auto *P = new X86ELFMCAsmInfo(TheTriple, Options);
     populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
     MAI = P;
   }

--- a/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCAsmInfo.cpp
+++ b/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCAsmInfo.cpp
@@ -11,7 +11,8 @@ using namespace llvm;
 
 void XCoreMCAsmInfo::anchor() { }
 
-XCoreMCAsmInfo::XCoreMCAsmInfo(const Triple &TT) {
+XCoreMCAsmInfo::XCoreMCAsmInfo(const Triple &TT, const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   SupportsDebugInformation = true;
   Data16bitsDirective = "\t.short\t";
   Data32bitsDirective = "\t.long\t";
@@ -31,4 +32,3 @@ XCoreMCAsmInfo::XCoreMCAsmInfo(const Triple &TT) {
 
   UseIntegratedAssembler = false;
 }
-

--- a/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCAsmInfo.h
+++ b/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCAsmInfo.h
@@ -22,7 +22,7 @@ class XCoreMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  explicit XCoreMCAsmInfo(const Triple &TT);
+  explicit XCoreMCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCTargetDesc.cpp
+++ b/llvm/lib/Target/XCore/MCTargetDesc/XCoreMCTargetDesc.cpp
@@ -58,7 +58,7 @@ createXCoreMCSubtargetInfo(const Triple &TT, StringRef CPU, StringRef FS) {
 static MCAsmInfo *createXCoreMCAsmInfo(const MCRegisterInfo &MRI,
                                        const Triple &TT,
                                        const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new XCoreMCAsmInfo(TT);
+  MCAsmInfo *MAI = new XCoreMCAsmInfo(TT, Options);
 
   // Initial state of the frame pointer is SP.
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, XCore::SP, 0);

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCAsmInfo.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCAsmInfo.cpp
@@ -18,7 +18,9 @@
 
 using namespace llvm;
 
-XtensaMCAsmInfo::XtensaMCAsmInfo(const Triple &TT) {
+XtensaMCAsmInfo::XtensaMCAsmInfo(const Triple &TT,
+                                 const MCTargetOptions &Options)
+    : MCAsmInfoELF(Options) {
   CodePointerSize = 4;
   CalleeSaveStackSlotSize = 4;
   InternalSymbolPrefix = ".L";

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCAsmInfo.h
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCAsmInfo.h
@@ -24,7 +24,7 @@ class StringRef;
 
 class XtensaMCAsmInfo : public MCAsmInfoELF {
 public:
-  explicit XtensaMCAsmInfo(const Triple &TT);
+  explicit XtensaMCAsmInfo(const Triple &TT, const MCTargetOptions &Options);
 
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCTargetDesc.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCTargetDesc.cpp
@@ -234,7 +234,7 @@ MCRegister Xtensa::getUserRegister(unsigned Code, const MCRegisterInfo &MRI) {
 static MCAsmInfo *createXtensaMCAsmInfo(const MCRegisterInfo &MRI,
                                         const Triple &TT,
                                         const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new XtensaMCAsmInfo(TT);
+  MCAsmInfo *MAI = new XtensaMCAsmInfo(TT, Options);
   return MAI;
 }
 

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -118,9 +118,7 @@ public:
         ST(*this) {
     // With an empty Triple, `initAsmInfo` cannot be called. Provide a
     // default MCAsmInfo so that MCContext can be created.
-    auto MAI = std::make_unique<MCAsmInfo>();
-    MAI->setTargetOptions(Options.MCOptions);
-    AsmInfo = std::move(MAI);
+    AsmInfo = std::make_unique<MCAsmInfo>(Options.MCOptions);
   }
 
   ~BogusTargetMachine() override = default;

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -40,7 +40,6 @@ namespace {
 MCTargetOptions MCOptions;
 
 std::unique_ptr<MCContext> createMCContext(MCAsmInfo *AsmInfo) {
-  AsmInfo->setTargetOptions(MCOptions);
   Triple TheTriple(/*ArchStr=*/"", /*VendorStr=*/"", /*OSStr=*/"",
                    /*EnvironmentStr=*/"elf");
   return std::make_unique<MCContext>(TheTriple, AsmInfo, nullptr, nullptr,
@@ -271,7 +270,7 @@ TEST(MachineInstrExtraInfo, AddExtraInfo) {
   MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
-  auto MAI = MCAsmInfo();
+  auto MAI = MCAsmInfo(MCOptions);
   auto MC = createMCContext(&MAI);
   auto MMO = MF->getMachineMemOperand(MachinePointerInfo(),
                                       MachineMemOperand::MOLoad, 8, Align(8));
@@ -352,7 +351,7 @@ TEST(MachineInstrExtraInfo, ChangeExtraInfo) {
   MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
-  auto MAI = MCAsmInfo();
+  auto MAI = MCAsmInfo(MCOptions);
   auto MC = createMCContext(&MAI);
   auto MMO = MF->getMachineMemOperand(MachinePointerInfo(),
                                       MachineMemOperand::MOLoad, 8, Align(8));
@@ -407,7 +406,7 @@ TEST(MachineInstrExtraInfo, RemoveExtraInfo) {
   MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
-  auto MAI = MCAsmInfo();
+  auto MAI = MCAsmInfo(MCOptions);
   auto MC = createMCContext(&MAI);
   auto MMO = MF->getMachineMemOperand(MachinePointerInfo(),
                                       MachineMemOperand::MOLoad, 8, Align(8));

--- a/llvm/unittests/CodeGen/MachineOperandTest.cpp
+++ b/llvm/unittests/CodeGen/MachineOperandTest.cpp
@@ -350,8 +350,7 @@ TEST(MachineOperandTest, PrintMetadata) {
 
 TEST(MachineOperandTest, PrintMCSymbol) {
   MCTargetOptions MCOptions;
-  MCAsmInfo MAI;
-  MAI.setTargetOptions(MCOptions);
+  MCAsmInfo MAI(MCOptions);
   Triple T = Triple("unknown-unknown-unknown");
   MCContext Ctx(T, &MAI, /*MRI=*/nullptr, /*MSTI=*/nullptr);
   MCSymbol *Sym = Ctx.getOrCreateSymbol("foo");

--- a/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
@@ -35,8 +35,7 @@ public:
 
 static std::string AArch64InstPrinterTestPrintAlignedLabel(uint64_t value) {
   MCTargetOptions MCOptions;
-  MCAsmInfo MAI;
-  MAI.setTargetOptions(MCOptions);
+  MCAsmInfo MAI(MCOptions);
   MCInstrInfo MII;
   MCRegisterInfo MRI;
   MCSubtargetInfo STI(Triple(""), "", "", "", {}, {}, {}, nullptr, nullptr,


### PR DESCRIPTION
Since #180464 the canonical MCTargetOptions pointer is stored in
MCAsmInfo, but it is bound after construction via `setTargetOptions`
called from TargetRegistry::createMCAsmInfo.

Direct constructions in unit tests can leave the pointer null, leading
to a runtime assert failure. Add MCTargetOptions to every MCAsmInfo
subclass constructor, store it as a reference in MCAsmInfo, and remove
`setTargetOptions()`.