### PR TITLE
[clang][Modules] Complete the implementation of P2615: Meaningful exports

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -49,6 +49,10 @@ C++ Specific Potentially Breaking Changes
 - Clang now correctly rejects ``export`` declarations in module implementation
   partitions. (#GH107602)
 
+- Clang now correctly rejects explicit instantiations and specializations
+  marked with ``export`` or a language linkage specification, completing
+  its implementation of P2615. (#GH160016)
+
 ABI Changes in This Version
 ---------------------------
 

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3538,6 +3538,10 @@ public:
   static bool classofKind(Kind K) { return K == ExplicitInstantiation; }
 };
 
+/// Determine what kind of template specialization the given declaration
+/// is.
+TemplateSpecializationKind getTemplateSpecializationKind(const Decl *D);
+
 } // namespace clang
 
 #endif // LLVM_CLANG_AST_DECLTEMPLATE_H

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12856,12 +12856,14 @@ def err_extern_def_in_header_unit : Error<
 
 def warn_meaningless_export : Warning<
   "%select{an explicit instantiation|a specialization}0 cannot be "
-  "marked 'export'">;
+  "marked 'export'">,
+  InGroup<DiagGroup<"meaningless-export">>;
 def note_meaningless_export_explanation : Note<
   "it is exported if the primary template is exported">;
 def warn_invalid_decl_in_linkage_spec : Warning<
   "language linkage cannot be specified for "
-  "%select{an explicit instantiation|a specialization|an export declaration}0">;
+  "%select{an explicit instantiation|a specialization|an export declaration}0">,
+  InGroup<DiagGroup<"meaningless-language-linkage">>;
 
 def warn_exposure : Warning <
   "TU local entity %0 is exposed">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12854,12 +12854,12 @@ def err_invalid_module_name : Error<"%0 is an invalid name for a module">;
 def err_extern_def_in_header_unit : Error<
   "non-inline external definitions are not permitted in C++ header units">;
 
-def err_meaningless_export : Error<
+def warn_meaningless_export : Warning<
   "%select{an explicit instantiation|a specialization}0 cannot be "
   "marked 'export'">;
 def note_meaningless_export_explanation : Note<
   "it is exported if the primary template is exported">;
-def err_invalid_decl_in_linkage_spec : Error<
+def warn_invalid_decl_in_linkage_spec : Warning<
   "language linkage cannot be specified for "
   "%select{an explicit instantiation|a specialization|an export declaration}0">;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12858,9 +12858,9 @@ def err_meaningless_export : Error<
   "%select{an explicit instantiation|a specialization}0 cannot be "
   "marked 'export'">;
 def note_meaningless_export_explanation : Note<
-  "as long as its primary template is exported, it will be too">;
+  "it is exported if the primary template is exported">;
 def err_invalid_decl_in_linkage_spec : Error<
-  "language linkage specification cannot be applied to "
+  "language linkage cannot be specified for "
   "%select{an explicit instantiation|a specialization|an export declaration}0">;
 
 def warn_exposure : Warning <

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12854,6 +12854,15 @@ def err_invalid_module_name : Error<"%0 is an invalid name for a module">;
 def err_extern_def_in_header_unit : Error<
   "non-inline external definitions are not permitted in C++ header units">;
 
+def err_meaningless_export : Error<
+  "%select{an explicit instantiation|a specialization}0 cannot be "
+  "marked 'export'">;
+def note_meaningless_export_explanation : Note<
+  "as long as its primary template is exported, it will be too">;
+def err_invalid_decl_in_linkage_spec : Error<
+  "language linkage specification cannot be applied to "
+  "%select{an explicit instantiation|a specialization|an export declaration}0">;
+
 def warn_exposure : Warning <
   "TU local entity %0 is exposed">,
   InGroup<DiagGroup<"TU-local-entity-exposure">>;

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -132,7 +132,7 @@ enum class EmbedResult {
 };
 
 struct CXXStandardLibraryVersionInfo {
-  enum Library { Unknown, LibStdCXX };
+  enum Library { Unknown, LibStdCXX, MsvcStl };
   Library Lib;
   std::uint64_t Version;
 };
@@ -2823,9 +2823,29 @@ private:
   // Standard Library Identification
   std::optional<CXXStandardLibraryVersionInfo> CXXStandardLibraryVersion;
 
+  void ComputeCXXStandardLibraryVersion();
+
+  bool NeedsCXXStandardLibraryWorkaroundBefore(
+      uint64_t FixedVersion, CXXStandardLibraryVersionInfo::Library Lib) {
+    ComputeCXXStandardLibraryVersion();
+    return CXXStandardLibraryVersion && CXXStandardLibraryVersion->Lib == Lib &&
+           CXXStandardLibraryVersion->Version < FixedVersion;
+  }
+
 public:
-  std::optional<std::uint64_t> getStdLibCxxVersion();
-  bool NeedsStdLibCxxWorkaroundBefore(std::uint64_t FixedVersion);
+  bool NeedsStdLibCxxWorkaroundBefore(std::uint64_t FixedVersion) {
+    assert(FixedVersion >= 2000'00'00 && FixedVersion <= 2100'00'00 &&
+           "invalid value for __GLIBCXX__");
+    return NeedsCXXStandardLibraryWorkaroundBefore(
+        FixedVersion, CXXStandardLibraryVersionInfo::LibStdCXX);
+  }
+
+  bool NeedsMsvcStlWorkaroundBefore(std::uint64_t FixedVersion) {
+    assert(FixedVersion >= 2000'00 && FixedVersion <= 2100'00 &&
+           "invalid value for _MSVC_STL_UPDATE");
+    return NeedsCXXStandardLibraryWorkaroundBefore(
+        FixedVersion, CXXStandardLibraryVersionInfo::MsvcStl);
+  }
 
 private:
   //===--------------------------------------------------------------------===//

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3192,7 +3192,7 @@ private:
   /// \verbatim
   ///       linkage-specification: [C++ 7.5p2: dcl.link]
   ///         'extern' string-literal '{' declaration-seq[opt] '}'
-  ///         'extern' string-literal declaration
+  ///         'extern' string-literal name-declaration
   /// \endverbatim
   ///
   Decl *ParseLinkage(ParsingDeclSpec &DS, DeclaratorContext Context);
@@ -3201,7 +3201,7 @@ private:
   ///
   /// \verbatim
   ///       export-declaration:
-  ///         'export' declaration
+  ///         'export' name-declaration
   ///         'export' '{' declaration-seq[opt] '}'
   /// \endverbatim
   ///
@@ -3216,6 +3216,29 @@ private:
   /// \endverbatim
   ///
   Decl *ParseExportDeclaration();
+
+  /// Ensure the declaration in an unbraced linkage-specification or
+  /// export-declaration is not an explicit-instantiation,
+  /// explicit-specialization, or export-declaration:
+  ///
+  /// \verbatim
+  ///       export-declaration: [C++: module.interface]
+  ///         export name-declaration
+  ///
+  ///       linkage-specification: [C++: dcl.link]
+  ///         export name-declaration
+  ///
+  ///       declaration: [C++: dcl.pre]
+  ///         name-declaration
+  ///         special-declaration
+  ///
+  ///       special-declaration: [C++: dcl.pre]
+  ///         explicit-instantiation
+  ///         explicit-specialization
+  ///         export-declaration
+  /// \endverbatim
+  ///
+  void CheckUnbracedLinkageOrExportDeclaration(Decl *LinkageOrExportDecl);
 
   /// ParseUsingDirectiveOrDeclaration - Parse C++ using using-declaration or
   /// using-directive. Assumes that current token is 'using'.

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1913,3 +1913,19 @@ SourceRange ExplicitInstantiationDecl::getSourceRange() const {
   SourceLocation Begin = ExternLoc.isValid() ? ExternLoc : getLocation();
   return SourceRange(Begin, getEndLoc());
 }
+
+TemplateSpecializationKind clang::getTemplateSpecializationKind(const Decl *D) {
+  if (!D)
+    return TSK_Undeclared;
+
+  if (const auto *Record = dyn_cast<CXXRecordDecl>(D))
+    return Record->getTemplateSpecializationKind();
+  if (const auto *Function = dyn_cast<FunctionDecl>(D))
+    return Function->getTemplateSpecializationKind();
+  if (const auto *Var = dyn_cast<VarDecl>(D))
+    return Var->getTemplateSpecializationKind();
+  if (const auto *EID = dyn_cast<ExplicitInstantiationDecl>(D))
+    return EID->getTemplateSpecializationKind();
+
+  return TSK_Undeclared;
+}

--- a/clang/lib/Lex/PPExpressions.cpp
+++ b/clang/lib/Lex/PPExpressions.cpp
@@ -1005,24 +1005,18 @@ getCXXStandardLibraryVersion(Preprocessor &PP, StringRef MacroName,
                                        0};
 }
 
-std::optional<uint64_t> Preprocessor::getStdLibCxxVersion() {
-  if (!CXXStandardLibraryVersion)
-    CXXStandardLibraryVersion = getCXXStandardLibraryVersion(
-        *this, "__GLIBCXX__", CXXStandardLibraryVersionInfo::LibStdCXX);
-  if (!CXXStandardLibraryVersion)
-    return std::nullopt;
+void Preprocessor::ComputeCXXStandardLibraryVersion() {
+  if (CXXStandardLibraryVersion)
+    return;
 
-  if (CXXStandardLibraryVersion->Lib ==
-      CXXStandardLibraryVersionInfo::LibStdCXX)
-    return CXXStandardLibraryVersion->Version;
-  return std::nullopt;
-}
+  static constexpr std::pair<StringRef, CXXStandardLibraryVersionInfo::Library>
+      VersionMacros[] = {
+          {"__GLIBCXX__", CXXStandardLibraryVersionInfo::LibStdCXX},
+          {"_MSVC_STL_UPDATE", CXXStandardLibraryVersionInfo::MsvcStl},
+      };
 
-bool Preprocessor::NeedsStdLibCxxWorkaroundBefore(uint64_t FixedVersion) {
-  assert(FixedVersion >= 2000'00'00 && FixedVersion <= 2100'00'00 &&
-         "invalid value for __GLIBCXX__");
-  std::optional<std::uint64_t> Ver = getStdLibCxxVersion();
-  if (!Ver)
-    return false;
-  return *Ver < FixedVersion;
+  for (const auto &[MacroName, Lib] : VersionMacros)
+    if (std::optional<CXXStandardLibraryVersionInfo> VersionInfo =
+            getCXXStandardLibraryVersion(*this, MacroName, Lib))
+      CXXStandardLibraryVersion = VersionInfo;
 }

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -487,7 +487,7 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
     // on some template specializations, but it would be too disruptive to
     // reject them. This was fixed in
     // https://github.com/microsoft/STL/pull/6074, merged on 2026-02-11.
-    if (LinkageOrExportDecl->isInStdNamespace() &&
+    if (getLangOpts().MicrosoftExt && LinkageOrExportDecl->isInStdNamespace() &&
         getPreprocessor().NeedsMsvcStlWorkaroundBefore(2026'03))
       return;
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -454,7 +454,7 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
   // Nested export declarations are diagnosed elsewhere.
   if (isa<LinkageSpecDecl>(LinkageOrExportDecl) && isa<ExportDecl>(D)) {
     Diag(LinkageOrExportDecl->getLocation(),
-         diag::err_invalid_decl_in_linkage_spec)
+         diag::warn_invalid_decl_in_linkage_spec)
         << /*export declaration*/ 2;
     return;
   }
@@ -475,7 +475,7 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
     return;
 
   if (const auto *ED = dyn_cast<ExportDecl>(LinkageOrExportDecl)) {
-    Diag(ED->getExportLoc(), diag::err_meaningless_export)
+    Diag(ED->getExportLoc(), diag::warn_meaningless_export)
         << (TSK == TSK_ExplicitSpecialization)
         << FixItHint::CreateRemoval(ED->getExportLoc());
     Diag(ED->getExportLoc(), diag::note_meaningless_export_explanation);
@@ -491,7 +491,7 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
         getPreprocessor().NeedsMsvcStlWorkaroundBefore(2026'03))
       return;
 
-    Diag(LS->getLocation(), diag::err_invalid_decl_in_linkage_spec)
+    Diag(LS->getLocation(), diag::warn_invalid_decl_in_linkage_spec)
         << (TSK == TSK_ExplicitSpecialization);
     return;
   }

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -339,9 +339,11 @@ Decl *Parser::ParseLinkage(ParsingDeclSpec &DS, DeclaratorContext Context) {
     // ... but anyway remember that such an "extern" was seen.
     DS.setExternInLinkageSpec(true);
     ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs, &DS);
-    return LinkageSpec ? Actions.ActOnFinishLinkageSpecification(
-                             getCurScope(), LinkageSpec, SourceLocation())
-                       : nullptr;
+    if (!LinkageSpec)
+      return nullptr;
+    CheckUnbracedLinkageOrExportDeclaration(LinkageSpec);
+    return Actions.ActOnFinishLinkageSpecification(getCurScope(), LinkageSpec,
+                                                   SourceLocation());
   }
 
   DS.abort();
@@ -420,6 +422,7 @@ Decl *Parser::ParseExportDeclaration() {
     MaybeParseCXX11Attributes(DeclAttrs);
     ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
     ParseExternalDeclaration(DeclAttrs, EmptyDeclSpecAttrs);
+    CheckUnbracedLinkageOrExportDeclaration(ExportDecl);
     return Actions.ActOnFinishExportDecl(getCurScope(), ExportDecl,
                                          SourceLocation());
   }
@@ -438,6 +441,52 @@ Decl *Parser::ParseExportDeclaration() {
   T.consumeClose();
   return Actions.ActOnFinishExportDecl(getCurScope(), ExportDecl,
                                        T.getCloseLocation());
+}
+
+void Parser::CheckUnbracedLinkageOrExportDeclaration(
+    Decl *LinkageOrExportDecl) {
+  const auto *DC = cast<DeclContext>(LinkageOrExportDecl);
+  if (DC->decls_empty())
+    return;
+
+  const Decl *D = *DC->decls_begin();
+
+  // Nested export declarations are diagnosed elsewhere.
+  if (isa<LinkageSpecDecl>(LinkageOrExportDecl) && isa<ExportDecl>(D)) {
+    Diag(LinkageOrExportDecl->getLocation(),
+         diag::err_invalid_decl_in_linkage_spec)
+        << 2;
+    return;
+  }
+
+  TemplateSpecializationKind TSK = [&] {
+    if (const auto *EID = dyn_cast<ExplicitInstantiationDecl>(D))
+      return EID->getTemplateSpecializationKind();
+    if (const auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D))
+      return CTSD->getTemplateSpecializationKind();
+    if (const auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D))
+      return VTSD->getTemplateSpecializationKind();
+    if (const auto *FD = dyn_cast<FunctionDecl>(D))
+      return FD->getTemplateSpecializationKind();
+    return TSK_Undeclared;
+  }();
+
+  if (TSK == TSK_Undeclared)
+    return;
+
+  if (const auto *ED = dyn_cast<ExportDecl>(LinkageOrExportDecl)) {
+    Diag(ED->getExportLoc(), diag::err_meaningless_export)
+        << (TSK == TSK_ExplicitSpecialization)
+        << FixItHint::CreateRemoval(ED->getExportLoc());
+    Diag(ED->getExportLoc(), diag::note_meaningless_export_explanation);
+    return;
+  }
+
+  if (const auto *LS = dyn_cast<LinkageSpecDecl>(LinkageOrExportDecl)) {
+    Diag(LS->getLocation(), diag::err_invalid_decl_in_linkage_spec)
+        << (TSK == TSK_ExplicitSpecialization);
+    return;
+  }
 }
 
 Parser::DeclGroupPtrTy Parser::ParseUsingDirectiveOrDeclaration(

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -494,6 +494,28 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
   }
 
   if (const auto *LS = dyn_cast<LinkageSpecDecl>(LinkageOrExportDecl)) {
+    // HACK: Old versions of the MSVC STL used to have linkage specifications
+    // on some template specializations, but it would be too disruptive to
+    // reject them. This was fixed in
+    // https://github.com/microsoft/STL/pull/6074, merged on 2026-02-11.
+    bool IsStandardLibrarySymbolInOldMSVCSTL = [&] {
+      const MacroInfo *MSVCSTLUpdateMacro =
+          PP.getMacroInfo(PP.getIdentifierInfo("_MSVC_STL_UPDATE"));
+
+      if (!MSVCSTLUpdateMacro || MSVCSTLUpdateMacro->getNumTokens() != 1)
+        return false;
+
+      bool Invalid;
+      std::string MSVCSTLUpdate =
+          PP.getSpelling(MSVCSTLUpdateMacro->getReplacementToken(0), &Invalid);
+      return !Invalid && MSVCSTLUpdate.size() == 7 &&
+             MSVCSTLUpdate < "202603L" &&
+             LinkageOrExportDecl->isInStdNamespace();
+    }();
+
+    if (IsStandardLibrarySymbolInOldMSVCSTL)
+      return;
+
     Diag(LS->getLocation(), diag::err_invalid_decl_in_linkage_spec)
         << (TSK == TSK_ExplicitSpecialization);
     return;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -459,6 +459,17 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
     return;
   }
 
+  // [module.interface]/1 says:
+  //
+  //     The name-declaration of an export-declaration shall not declare a
+  //     partial specialization.
+  //
+  // There's no equivalent wording for linkage-specification.
+  if (isa<ClassTemplatePartialSpecializationDecl,
+          VarTemplatePartialSpecializationDecl>(D) &&
+      isa<LinkageSpecDecl>(LinkageOrExportDecl))
+    return;
+
   TemplateSpecializationKind TSK = [&] {
     if (const auto *EID = dyn_cast<ExplicitInstantiationDecl>(D))
       return EID->getTemplateSpecializationKind();
@@ -487,6 +498,8 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
         << (TSK == TSK_ExplicitSpecialization);
     return;
   }
+
+  llvm_unreachable("Expected either an ExportDecl or a LinkageSpecDecl");
 }
 
 Parser::DeclGroupPtrTy Parser::ParseUsingDirectiveOrDeclaration(

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -446,16 +446,14 @@ Decl *Parser::ParseExportDeclaration() {
 void Parser::CheckUnbracedLinkageOrExportDeclaration(
     Decl *LinkageOrExportDecl) {
   const auto *DC = cast<DeclContext>(LinkageOrExportDecl);
-  if (DC->decls_empty())
-    return;
-
+  assert(!DC->decls_empty());
   const Decl *D = *DC->decls_begin();
 
   // Nested export declarations are diagnosed elsewhere.
   if (isa<LinkageSpecDecl>(LinkageOrExportDecl) && isa<ExportDecl>(D)) {
     Diag(LinkageOrExportDecl->getLocation(),
          diag::err_invalid_decl_in_linkage_spec)
-        << 2;
+        << /*export declaration*/ 2;
     return;
   }
 
@@ -464,24 +462,13 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
   //     The name-declaration of an export-declaration shall not declare a
   //     partial specialization.
   //
-  // There's no equivalent wording for linkage-specification.
+  // But there's no equivalent wording for linkage-specification.
   if (isa<ClassTemplatePartialSpecializationDecl,
           VarTemplatePartialSpecializationDecl>(D) &&
       isa<LinkageSpecDecl>(LinkageOrExportDecl))
     return;
 
-  TemplateSpecializationKind TSK = [&] {
-    if (const auto *EID = dyn_cast<ExplicitInstantiationDecl>(D))
-      return EID->getTemplateSpecializationKind();
-    if (const auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D))
-      return CTSD->getTemplateSpecializationKind();
-    if (const auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D))
-      return VTSD->getTemplateSpecializationKind();
-    if (const auto *FD = dyn_cast<FunctionDecl>(D))
-      return FD->getTemplateSpecializationKind();
-    return TSK_Undeclared;
-  }();
-
+  TemplateSpecializationKind TSK = getTemplateSpecializationKind(D);
   if (TSK == TSK_Undeclared)
     return;
 
@@ -494,26 +481,12 @@ void Parser::CheckUnbracedLinkageOrExportDeclaration(
   }
 
   if (const auto *LS = dyn_cast<LinkageSpecDecl>(LinkageOrExportDecl)) {
-    // HACK: Old versions of the MSVC STL used to have linkage specifications
+    // Old versions of the MSVC STL used to have linkage specifications
     // on some template specializations, but it would be too disruptive to
     // reject them. This was fixed in
     // https://github.com/microsoft/STL/pull/6074, merged on 2026-02-11.
-    bool IsStandardLibrarySymbolInOldMSVCSTL = [&] {
-      const MacroInfo *MSVCSTLUpdateMacro =
-          PP.getMacroInfo(PP.getIdentifierInfo("_MSVC_STL_UPDATE"));
-
-      if (!MSVCSTLUpdateMacro || MSVCSTLUpdateMacro->getNumTokens() != 1)
-        return false;
-
-      bool Invalid;
-      std::string MSVCSTLUpdate =
-          PP.getSpelling(MSVCSTLUpdateMacro->getReplacementToken(0), &Invalid);
-      return !Invalid && MSVCSTLUpdate.size() == 7 &&
-             MSVCSTLUpdate < "202603L" &&
-             LinkageOrExportDecl->isInStdNamespace();
-    }();
-
-    if (IsStandardLibrarySymbolInOldMSVCSTL)
+    if (LinkageOrExportDecl->isInStdNamespace() &&
+        getPreprocessor().NeedsMsvcStlWorkaroundBefore(2026'03))
       return;
 
     Diag(LS->getLocation(), diag::err_invalid_decl_in_linkage_spec)

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -446,7 +446,9 @@ Decl *Parser::ParseExportDeclaration() {
 void Parser::CheckUnbracedLinkageOrExportDeclaration(
     Decl *LinkageOrExportDecl) {
   const auto *DC = cast<DeclContext>(LinkageOrExportDecl);
-  assert(!DC->decls_empty());
+  if (DC->decls_empty())
+    return;
+
   const Decl *D = *DC->decls_begin();
 
   // Nested export declarations are diagnosed elsewhere.

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4155,8 +4155,6 @@ static bool CheckTemplateSpecializationScope(Sema &S, NamedDecl *Specialized,
                                              SourceLocation Loc,
                                              bool IsPartialSpecialization);
 
-static TemplateSpecializationKind getTemplateSpecializationKind(Decl *D);
-
 static bool isTemplateArgumentTemplateParameter(const TemplateArgument &Arg,
                                                 unsigned Depth,
                                                 unsigned Index) {
@@ -8502,22 +8500,6 @@ Sema::CheckTemplateDeclScope(Scope *S, TemplateParameterList *TemplateParams) {
   return Diag(TemplateParams->getTemplateLoc(),
               diag::err_template_outside_namespace_or_class_scope)
     << TemplateParams->getSourceRange();
-}
-
-/// Determine what kind of template specialization the given declaration
-/// is.
-static TemplateSpecializationKind getTemplateSpecializationKind(Decl *D) {
-  if (!D)
-    return TSK_Undeclared;
-
-  if (CXXRecordDecl *Record = dyn_cast<CXXRecordDecl>(D))
-    return Record->getTemplateSpecializationKind();
-  if (FunctionDecl *Function = dyn_cast<FunctionDecl>(D))
-    return Function->getTemplateSpecializationKind();
-  if (VarDecl *Var = dyn_cast<VarDecl>(D))
-    return Var->getTemplateSpecializationKind();
-
-  return TSK_Undeclared;
 }
 
 /// Check whether a specialization is well-formed in the current

--- a/clang/test/CXX/drs/cwg2443.cpp
+++ b/clang/test/CXX/drs/cwg2443.cpp
@@ -8,41 +8,41 @@ namespace cwg2443 { // cwg2443: 23
 
 export template <typename T> class s1 {};
 export template <typename T> class s1<T *> {};
-// expected-error@-1 {{a specialization cannot be marked 'export'}}
+// expected-warning@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export template <> class s1<int> {};
-// expected-error@-1 {{a specialization cannot be marked 'export'}}
+// expected-warning@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export template class s1<char>;
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export extern template class s1<void>;
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> int v1 = 0;
 export template <typename T> int v1<T *> = 0;
-// expected-error@-1 {{a specialization cannot be marked 'export'}}
+// expected-warning@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export template <> int v1<int> = 0;
-// expected-error@-1 {{a specialization cannot be marked 'export'}}
+// expected-warning@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export template int v1<char>;
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export extern template int v1<void>;
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> void f1() {}
 export template <> void f1<int>() {}
-// expected-error@-1 {{a specialization cannot be marked 'export'}}
+// expected-warning@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export template void f1<char>();
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 export extern template void f1<void>();
-// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+// expected-warning@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 
 

--- a/clang/test/CXX/drs/cwg2443.cpp
+++ b/clang/test/CXX/drs/cwg2443.cpp
@@ -7,41 +7,41 @@ export module foo;
 namespace cwg2443 { // cwg2443: 23
 
 export template <typename T> class s1 {};
-export template <typename T> class s1<T *> {}; 
+export template <typename T> class s1<T *> {};
 // expected-error@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export template <> class s1<int> {}; 
+export template <> class s1<int> {};
 // expected-error@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export template class s1<char>; 
+export template class s1<char>;
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export extern template class s1<void>; 
+export extern template class s1<void>;
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> int v1 = 0;
-export template <typename T> int v1<T *> = 0; 
+export template <typename T> int v1<T *> = 0;
 // expected-error@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export template <> int v1<int> = 0; 
+export template <> int v1<int> = 0;
 // expected-error@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export template int v1<char>; 
+export template int v1<char>;
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export extern template int v1<void>; 
+export extern template int v1<void>;
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> void f1() {}
-export template <> void f1<int>() {} 
+export template <> void f1<int>() {}
 // expected-error@-1 {{a specialization cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export template void f1<char>(); 
+export template void f1<char>();
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
-export extern template void f1<void>(); 
+export extern template void f1<void>();
 // expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
 //   expected-note@-2 {{it is exported if the primary template is exported}}
 

--- a/clang/test/CXX/drs/cwg2443.cpp
+++ b/clang/test/CXX/drs/cwg2443.cpp
@@ -1,49 +1,49 @@
-// RUN: %clang_cc1 -std=c++20 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
-// RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
-// RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
+// RUN: %clang_cc1 -std=c++20 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify -verify-directives
+// RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify -verify-directives
+// RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors %s -verify -verify-directives
 
 export module foo;
 
 namespace cwg2443 { // cwg2443: 23
 
 export template <typename T> class s1 {};
-export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template <typename T> class s1<T *> {}; 
+// expected-error@-1 {{a specialization cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export template <> class s1<int> {}; 
+// expected-error@-1 {{a specialization cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export template class s1<char>; 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export extern template class s1<void>; 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> int v1 = 0;
-export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template <typename T> int v1<T *> = 0; 
+// expected-error@-1 {{a specialization cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export template <> int v1<int> = 0; 
+// expected-error@-1 {{a specialization cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export template int v1<char>; 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export extern template int v1<void>; 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
 
 export template <typename T> void f1() {}
-export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{it is exported if the primary template is exported}}
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template <> void f1<int>() {} 
+// expected-error@-1 {{a specialization cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export template void f1<char>(); 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
+export extern template void f1<void>(); 
+// expected-error@-1 {{an explicit instantiation cannot be marked 'export'}}
+//   expected-note@-2 {{it is exported if the primary template is exported}}
 
 
 export { template <typename T> class s2 {}; }

--- a/clang/test/CXX/drs/cwg2443.cpp
+++ b/clang/test/CXX/drs/cwg2443.cpp
@@ -1,0 +1,66 @@
+// RUN: %clang_cc1 -std=c++20 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
+// RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
+// RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors %s -verify
+
+export module foo;
+
+namespace cwg2443 { // cwg2443: 23
+
+export template <typename T> class s1 {};
+export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+
+export template <typename T> int v1 = 0;
+export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+
+export template <typename T> void f1() {}
+export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
+
+
+export { template <typename T> class s2 {}; }
+export { template <typename T> class s2<T *> {}; }
+export { template <> class s2<int> {}; }
+export { template class s2<char>; }
+export { extern template class s2<void>; }
+
+export { template <typename T> int v2 = 0; }
+export { template <typename T> int v2<T *> = 0; }
+export { template <> int v2<int> = 0; }
+export { template int v2<char>; }
+export { extern template int v2<void>; }
+
+export { template <typename T> void f2() {} }
+export { template <> void f2<int>() {} }
+export { template void f2<char>(); }
+export { extern template void f2<void>(); }
+
+} // namespace cwg2443

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -65,6 +65,9 @@ struct S {
 };
 } // namespace cwg2430
 
+
+// cwg2443 is in cwg2443.cpp
+
 namespace cwg2450 { // cwg2450: 18
 #if __cplusplus >= 202302L
 struct S {int a;};

--- a/clang/test/Modules/explicit-specializations.cppm
+++ b/clang/test/Modules/explicit-specializations.cppm
@@ -20,7 +20,7 @@ struct S {
 
 export struct A {};
 
-export template <>
+template <>
 struct S<A> {
     static constexpr bool selected = true;
 };
@@ -34,7 +34,7 @@ struct V {
     static constexpr bool selected = false;
 };
 
-export template <>
+template<>
 struct V<S> {
     static constexpr bool selected = true;
 };
@@ -46,7 +46,7 @@ struct Numbers {
     static constexpr int value = X;
 };
 
-export template<>
+template<>
 struct Numbers<43> {
     static constexpr bool selected = true;
     static constexpr int value = 43;
@@ -58,7 +58,7 @@ struct Pointers {
 };
 
 export int IntegralValue = 0;
-export template<>
+template<>
 struct Pointers<&IntegralValue> {
     static constexpr bool selected = true;
 };
@@ -68,7 +68,7 @@ struct NullPointers {
     static constexpr bool selected = false;
 };
 
-export template<>
+template<>
 struct NullPointers<nullptr> {
     static constexpr bool selected = true;
 };
@@ -79,7 +79,7 @@ struct Array {
 };
 
 export int array[5];
-export template<>
+template<>
 struct Array<array> {
     static constexpr bool selected = true;
 };

--- a/clang/test/Modules/export-language-linkage.cppm
+++ b/clang/test/Modules/export-language-linkage.cppm
@@ -55,7 +55,7 @@ extern "C++" {
     int h();
 }
 
-extern "C++" export int g();
+export int g();
 
 //--- d.cpp
 import c;

--- a/clang/test/Modules/merge-var-template-spec-cxx-modules.cppm
+++ b/clang/test/Modules/merge-var-template-spec-cxx-modules.cppm
@@ -28,7 +28,7 @@ template <class T> constexpr T* zero<T*> = nullptr; // expected-error-re {{decla
                                                     // expected-note@* {{previous}}
 
 template <> constexpr int** zero<int**> = nullptr; // ok, new specialization.
-template <class T> constexpr T** zero<T**> = nullptr; // ok, new partial specilization.
+template <class T> constexpr T** zero<T**> = nullptr; // ok, new partial specialization.
 
 //--- var_def.cppm
 export module var_def;
@@ -37,8 +37,16 @@ export template <class T> constexpr T zero = 0;
 export struct Int {
     int value;
 };
-export template <> constexpr Int zero<Int> = {0};
-export template <class T> constexpr T* zero<T*> = nullptr;
+
+// FIXME: it should make no difference whether a specialization is
+// exported or not, but currently, removing this 'export'
+// leads to an assertion failure in Sema::shouldLinkPossiblyHiddenDecl.
+export {
+
+template <> constexpr Int zero<Int> = {0};
+template <class T> constexpr T* zero<T*> = nullptr;
+
+}
 
 //--- reexport1.cppm
 export module reexport1;

--- a/clang/test/Modules/pr59780.cppm
+++ b/clang/test/Modules/pr59780.cppm
@@ -25,7 +25,7 @@ export module a;
 export template<typename T>
 int x = 0;
 
-export template<>
+template<>
 int x<int> = 0;
 
 export template<typename T>
@@ -36,7 +36,7 @@ struct Y {
 template <typename T>
 int Y<T>::value = 0;
 
-export template<>
+template<>
 struct Y<int> {
     static int value;
 };

--- a/clang/test/Modules/pr60890.cppm
+++ b/clang/test/Modules/pr60890.cppm
@@ -24,12 +24,12 @@ struct a {
 	void aaa() requires(true) {}
 };
 
-export template struct a<double>;
+template struct a<double>;
 
 export template<typename T>
 void foo(T) requires(true) {}
 
-export template void foo<double>(double);
+template void foo<double>(double);
 
 export template <typename T>
 class A {

--- a/clang/test/Modules/pr97313.cppm
+++ b/clang/test/Modules/pr97313.cppm
@@ -76,7 +76,7 @@ public:
     virtual ~Template();
 };
 
-export template<>
+template<>
 class Template<char> {
 public:
     virtual ~Template();
@@ -84,11 +84,11 @@ public:
 
 // CHECK: @_ZTIW3Mod8TemplateIcE = {{.*}}constant
 
-export template class Template<unsigned>;
+template class Template<unsigned>;
 
 // CHECK: @_ZTIW3Mod8TemplateIjE = {{.*}}weak_odr
 
-export extern template class Template<double>;
+extern template class Template<double>;
 
 auto v = new Template<signed int>();
 

--- a/clang/test/Modules/template-function-specialization.cpp
+++ b/clang/test/Modules/template-function-specialization.cpp
@@ -42,7 +42,7 @@ export template <typename T>
 void foo4() {
 }
 
-export template <>
+template <>
 void foo4<int>() {
 }
 

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -4,7 +4,7 @@
 
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/A.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/B.cpp
-// RUN: not %clang_cc1 -std=c++20 -fsyntax-only -fdiagnostics-parseable-fixits %t/B.cpp 2>&1 | FileCheck %t/B.cpp
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -fdiagnostics-parseable-fixits %t/B.cpp 2>&1 | FileCheck %t/B.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-1.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-2.cpp
 
@@ -18,41 +18,41 @@ export using namespace N;
 export module B;
 
 export template <typename T> class s1 {};
-export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
+export template <typename T> class s1<T *> {}; // expected-warning {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
+export template <> class s1<int> {}; // expected-warning {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export template class s1<char>; // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export extern template class s1<void>; // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> int v1 = 0;
-export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+export template <typename T> int v1<T *> = 0; // expected-warning {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+export template <> int v1<int> = 0; // expected-warning {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export template int v1<char>; // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export extern template int v1<void>; // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> void f1() {}
-export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
+export template <> void f1<int>() {} // expected-warning {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export template void f1<char>(); // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
-export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+export extern template void f1<void>(); // expected-warning {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
@@ -77,23 +77,23 @@ export { extern template void f2<void>(); }
 
 extern "C++" template <typename T> class s3 {};
 extern "C++" template <typename T> class s3<T *> {};
-extern "C++" template <> class s3<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
-extern "C++" template class s3<char>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
-extern "C++" extern template class s3<void>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" template <> class s3<int> {}; // expected-warning {{language linkage cannot be specified for a specialization}}
+extern "C++" template class s3<char>; // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template class s3<void>; // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
 
 extern "C++" template <typename T> int v3 = 0;
 extern "C++" template <typename T> int v3<T *> = 0;
-extern "C++" template <> int v3<int> = 0; // expected-error {{language linkage cannot be specified for a specialization}}
-extern "C++" template int v3<char>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
-extern "C++" extern template int v3<void>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" template <> int v3<int> = 0; // expected-warning {{language linkage cannot be specified for a specialization}}
+extern "C++" template int v3<char>; // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template int v3<void>; // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
 
 extern "C++" template <typename T> void f3() {}
-extern "C++" template <> void f3<int>() {} // expected-error {{language linkage cannot be specified for a specialization}}
-extern "C++" template void f3<char>(); // expected-error {{language linkage cannot be specified for an explicit instantiation}}
-extern "C++" extern template void f3<void>(); // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" template <> void f3<int>() {} // expected-warning {{language linkage cannot be specified for a specialization}}
+extern "C++" template void f3<char>(); // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template void f3<void>(); // expected-warning {{language linkage cannot be specified for an explicit instantiation}}
 
-extern "C++" export int i; // expected-error {{language linkage cannot be specified for an export declaration}}
-extern "C++" export {} // expected-error {{language linkage cannot be specified for an export declaration}}
+extern "C++" export int i; // expected-warning {{language linkage cannot be specified for an export declaration}}
+extern "C++" export {} // expected-warning {{language linkage cannot be specified for an export declaration}}
 
 
 extern "C++" { template <typename T> class s4 {}; }
@@ -124,7 +124,7 @@ extern "C++" template<> struct s<int> {};
 } // namespace std
 
 extern "C++" template <typename T> struct c {};
-extern "C++" template<> struct c<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
+extern "C++" template<> struct c<int> {}; // expected-warning {{language linkage cannot be specified for a specialization}}
 
 //--- msvc-stl-exception-2.cpp
 #define _MSVC_STL_UPDATE 202603L
@@ -132,6 +132,6 @@ extern "C++" template<> struct c<int> {}; // expected-error {{language linkage c
 namespace std {
 
 extern "C++" template <typename T> struct s {};
-extern "C++" template<> struct s<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
+extern "C++" template<> struct s<int> {}; // expected-warning {{language linkage cannot be specified for a specialization}}
 
 } // namespace std

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -5,8 +5,8 @@
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/A.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/B.cpp
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only -fdiagnostics-parseable-fixits %t/B.cpp 2>&1 | FileCheck %t/B.cpp
-// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-1.cpp
-// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-2.cpp
+// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only -fms-extensions %t/msvc-stl-exception-1.cpp
+// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only -fms-extensions %t/msvc-stl-exception-2.cpp
 
 //--- A.cpp
 // expected-no-diagnostics

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -3,9 +3,98 @@
 
 
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/A.cpp
+// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/B.cpp
 
 //--- A.cpp
 // expected-no-diagnostics
 export module A;
 export namespace N {int x = 42;}
 export using namespace N;
+
+//--- B.cpp
+export module B;
+
+export template <typename T> class s1 {};
+export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+
+export template <typename T> int v1 = 0;
+export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+
+export template <typename T> void f1() {}
+export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
+// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+
+
+export { template <typename T> class s2 {}; }
+export { template <typename T> class s2<T *> {}; }
+export { template <> class s2<int> {}; }
+export { template class s2<char>; }
+export { extern template class s2<void>; }
+
+export { template <typename T> int v2 = 0; }
+export { template <typename T> int v2<T *> = 0; }
+export { template <> int v2<int> = 0; }
+export { template int v2<char>; }
+export { extern template int v2<void>; }
+
+export { template <typename T> void f2() {} }
+export { template <> void f2<int>() {} }
+export { template void f2<char>(); }
+export { extern template void f2<void>(); }
+
+
+extern "C++" template <typename T> class s3 {};
+extern "C++" template <typename T> class s3<T *> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template <> class s3<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template class s3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" extern template class s3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+
+extern "C++" template <typename T> int v3 = 0;
+extern "C++" template <typename T> int v3<T *> = 0; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template <> int v3<int> = 0; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template int v3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" extern template int v3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+
+extern "C++" template <typename T> void f3() {}
+extern "C++" template <> void f3<int>() {} // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template void f3<char>(); // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" extern template void f3<void>(); // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+
+extern "C++" export int i; // expected-error {{language linkage specification cannot be applied to an export declaration}}
+extern "C++" export {} // expected-error {{language linkage specification cannot be applied to an export declaration}}
+
+
+extern "C++" { template <typename T> class s4 {}; }
+extern "C++" { template <typename T> class s4<T *> {}; }
+extern "C++" { template <> class s4<int> {}; }
+extern "C++" { template class s4<char>; }
+extern "C++" { extern template class s4<void>; }
+
+extern "C++" { template <typename T> int v4 = 0; }
+extern "C++" { template <typename T> int v4<T *> = 0; }
+extern "C++" { template <> int v4<int> = 0; }
+extern "C++" { template int v4<char>; }
+extern "C++" { extern template int v4<void>; }
+
+extern "C++" { template <typename T> void f4() {} }
+extern "C++" { template <> void f4<int>() {} }
+extern "C++" { template void f4<char>(); }
+extern "C++" { extern template void f4<void>(); }

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -5,6 +5,8 @@
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/A.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/B.cpp
 // RUN: not %clang_cc1 -std=c++20 -fsyntax-only -fdiagnostics-parseable-fixits %t/B.cpp 2>&1 | FileCheck %t/B.cpp
+// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-1.cpp
+// RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/msvc-stl-exception-2.cpp
 
 //--- A.cpp
 // expected-no-diagnostics
@@ -110,3 +112,27 @@ extern "C++" { template <typename T> void f4() {} }
 extern "C++" { template <> void f4<int>() {} }
 extern "C++" { template void f4<char>(); }
 extern "C++" { extern template void f4<void>(); }
+
+//--- msvc-stl-exception-1.cpp
+#define _MSVC_STL_UPDATE 202602L
+
+namespace std {
+
+extern "C++" template <typename T> struct s {};
+extern "C++" template<> struct s<int> {}; // expected-no-error {{language linkage specification cannot be applied to a specialization}}
+
+} // namespace std
+
+// Should still diagnose outside the std namespace.
+extern "C++" template <typename T> struct c {};
+extern "C++" template<> struct c<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+
+//--- msvc-stl-exception-2.cpp
+#define _MSVC_STL_UPDATE 202603L
+
+namespace std {
+
+extern "C++" template <typename T> struct s {};
+extern "C++" template<> struct s<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+
+} // namespace std

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -74,13 +74,13 @@ export { extern template void f2<void>(); }
 
 
 extern "C++" template <typename T> class s3 {};
-extern "C++" template <typename T> class s3<T *> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template <typename T> class s3<T *> {};
 extern "C++" template <> class s3<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
 extern "C++" template class s3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
 extern "C++" extern template class s3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
 
 extern "C++" template <typename T> int v3 = 0;
-extern "C++" template <typename T> int v3<T *> = 0; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template <typename T> int v3<T *> = 0;
 extern "C++" template <> int v3<int> = 0; // expected-error {{language linkage specification cannot be applied to a specialization}}
 extern "C++" template int v3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
 extern "C++" extern template int v3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -19,41 +19,41 @@ export module B;
 
 export template <typename T> class s1 {};
 export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> int v1 = 0;
 export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> void f1() {}
 export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
-// expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// expected-note@-1 {{it is exported if the primary template is exported}}
 // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 
@@ -77,23 +77,23 @@ export { extern template void f2<void>(); }
 
 extern "C++" template <typename T> class s3 {};
 extern "C++" template <typename T> class s3<T *> {};
-extern "C++" template <> class s3<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
-extern "C++" template class s3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
-extern "C++" extern template class s3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" template <> class s3<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
+extern "C++" template class s3<char>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template class s3<void>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
 
 extern "C++" template <typename T> int v3 = 0;
 extern "C++" template <typename T> int v3<T *> = 0;
-extern "C++" template <> int v3<int> = 0; // expected-error {{language linkage specification cannot be applied to a specialization}}
-extern "C++" template int v3<char>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
-extern "C++" extern template int v3<void>; // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" template <> int v3<int> = 0; // expected-error {{language linkage cannot be specified for a specialization}}
+extern "C++" template int v3<char>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template int v3<void>; // expected-error {{language linkage cannot be specified for an explicit instantiation}}
 
 extern "C++" template <typename T> void f3() {}
-extern "C++" template <> void f3<int>() {} // expected-error {{language linkage specification cannot be applied to a specialization}}
-extern "C++" template void f3<char>(); // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
-extern "C++" extern template void f3<void>(); // expected-error {{language linkage specification cannot be applied to an explicit instantiation}}
+extern "C++" template <> void f3<int>() {} // expected-error {{language linkage cannot be specified for a specialization}}
+extern "C++" template void f3<char>(); // expected-error {{language linkage cannot be specified for an explicit instantiation}}
+extern "C++" extern template void f3<void>(); // expected-error {{language linkage cannot be specified for an explicit instantiation}}
 
-extern "C++" export int i; // expected-error {{language linkage specification cannot be applied to an export declaration}}
-extern "C++" export {} // expected-error {{language linkage specification cannot be applied to an export declaration}}
+extern "C++" export int i; // expected-error {{language linkage cannot be specified for an export declaration}}
+extern "C++" export {} // expected-error {{language linkage cannot be specified for an export declaration}}
 
 
 extern "C++" { template <typename T> class s4 {}; }
@@ -119,13 +119,12 @@ extern "C++" { extern template void f4<void>(); }
 namespace std {
 
 extern "C++" template <typename T> struct s {};
-extern "C++" template<> struct s<int> {}; // expected-no-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template<> struct s<int> {};
 
 } // namespace std
 
-// Should still diagnose outside the std namespace.
 extern "C++" template <typename T> struct c {};
-extern "C++" template<> struct c<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template<> struct c<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
 
 //--- msvc-stl-exception-2.cpp
 #define _MSVC_STL_UPDATE 202603L
@@ -133,6 +132,6 @@ extern "C++" template<> struct c<int> {}; // expected-error {{language linkage s
 namespace std {
 
 extern "C++" template <typename T> struct s {};
-extern "C++" template<> struct s<int> {}; // expected-error {{language linkage specification cannot be applied to a specialization}}
+extern "C++" template<> struct s<int> {}; // expected-error {{language linkage cannot be specified for a specialization}}
 
 } // namespace std

--- a/clang/test/SemaCXX/P2615.cpp
+++ b/clang/test/SemaCXX/P2615.cpp
@@ -4,6 +4,7 @@
 
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/A.cpp
 // RUN: %clang_cc1 -std=c++20 -verify -fsyntax-only %t/B.cpp
+// RUN: not %clang_cc1 -std=c++20 -fsyntax-only -fdiagnostics-parseable-fixits %t/B.cpp 2>&1 | FileCheck %t/B.cpp
 
 //--- A.cpp
 // expected-no-diagnostics
@@ -17,30 +18,41 @@ export module B;
 export template <typename T> class s1 {};
 export template <typename T> class s1<T *> {}; // expected-error {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template <> class s1<int> {}; // expected-error {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template class s1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template class s1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> int v1 = 0;
 export template <typename T> int v1<T *> = 0; // expected-error {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template <> int v1<int> = 0; // expected-error {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template int v1<char>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template int v1<void>; // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 export template <typename T> void f1() {}
 export template <> void f1<int>() {} // expected-error {{a specialization cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export template void f1<char>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 export extern template void f1<void>(); // expected-error {{an explicit instantiation cannot be marked 'export'}}
 // expected-note@-1 {{as long as its primary template is exported, it will be too}}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:1-[[@LINE-2]]:8}:""
 
 
 export { template <typename T> class s2 {}; }

--- a/clang/test/SemaHLSL/Language/groupsharedArgs/ExportNoInlineTest.hlsl
+++ b/clang/test/SemaHLSL/Language/groupsharedArgs/ExportNoInlineTest.hlsl
@@ -15,6 +15,6 @@ void fn3(groupshared T A, groupshared T B) {
   A = B;
 }
 
-export template void fn3<uint>(groupshared uint A, groupshared uint B);
+template void fn3<uint>(groupshared uint A, groupshared uint B);
 template __attribute__((noinline)) void fn3<float>(groupshared float A, groupshared float B);
 // expected-error@-1{{'noinline' attribute is not compatible with 'groupshared' parameter attribute}}

--- a/clang/unittests/Serialization/LoadSpecLazilyTest.cpp
+++ b/clang/unittests/Serialization/LoadSpecLazilyTest.cpp
@@ -238,7 +238,7 @@ export class Temp {
 
 export class ExportedClass {};
 
-export template<> class A<ExportedClass> {
+template<> class A<ExportedClass> {
    A<MayBeLoaded> AS;
    A<B>           AB;
 };

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -16894,7 +16894,7 @@
     <td>[<a href="https://wg21.link/module.interface">module.interface</a>]</td>
     <td>C++23</td>
     <td>Meaningless template exports</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="unreleased" align="center">Clang 23</td>
   </tr>
   <tr class="open" id="2444">
     <td><a href="https://cplusplus.github.io/CWG/issues/2444.html">2444</a></td>

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -988,7 +988,7 @@ C++23, informally referred to as C++26.</p>
       </tr>
       <tr> <!-- from Kona 2022 -->
         <td><a href="https://wg21.link/P2615R1">P2615R1</a> (<a href="#dr">DR</a>)</td>
-        <td class="full" align="center">Clang 17</td>
+        <td class="unreleased" align="center">Clang 23</td>
       </tr>
       <tr> <!-- from Issaquah 2023 -->
         <td><a href="https://wg21.link/P2788R0">P2788R0</a> (<a href="#dr">DR</a>)</td>


### PR DESCRIPTION
[P2615](https://wg21.link/p2615) restricted certain declarations from appearing in an unbraced *export-declaration* or *linkage-specification*. This change implements the logic to reject these cases.

Fixes #160016.

Made possible (or at least quite a bit easier) by #191658!