### PR TITLE
[clang][bytecode] Add new IntegralType for function addresses

### DIFF
--- a/clang/lib/AST/ByteCode/Integral.h
+++ b/clang/lib/AST/ByteCode/Integral.h
@@ -218,6 +218,11 @@ public:
       return APValue(D->asValueDecl(), CharUnits::Zero(),
                      APValue::NoLValuePath{});
     }
+    case IntegralKind::FunctionAddress: {
+      return APValue((const FunctionDecl *)Ptr.P,
+                     CharUnits::fromQuantity(Ptr.Offset),
+                     APValue::NoLValuePath{});
+    }
     case IntegralKind::AddrLabelDiff: {
       return APValue(AddrLabelDiff.L1, AddrLabelDiff.L2);
     }
@@ -300,6 +305,9 @@ public:
       break;
     case IntegralKind::LabelAddress:
       OS << Ptr.P << " + " << Ptr.Offset << " (LabelAddress)";
+      break;
+    case IntegralKind::FunctionAddress:
+      OS << Ptr.P << " + " << Ptr.Offset << " (FunctionAddress)";
     }
   }
 
@@ -327,6 +335,7 @@ public:
     case IntegralKind::Address:
     case IntegralKind::BlockAddress:
     case IntegralKind::LabelAddress:
+    case IntegralKind::FunctionAddress:
       return Integral(V.getKind(), V.getPtr(), V.getOffset());
     }
     llvm_unreachable("Unhandled IntegralKind");

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2920,7 +2920,7 @@ bool CastPointerIntegral(InterpState &S, CodePtr OpPC) {
       S.Stk.push<T>(Kind, PtrVal, /*Offset=*/0);
     } else if (Ptr.isFunctionPointer()) {
       const void *FuncDecl = Ptr.asFunctionPointer().Func->getDecl();
-      S.Stk.push<T>(IntegralKind::Address, FuncDecl, /*Offset=*/0);
+      S.Stk.push<T>(IntegralKind::FunctionAddress, FuncDecl, /*Offset=*/0);
     } else {
       S.Stk.push<T>(T::from(Ptr.getIntegerRepresentation()));
     }
@@ -3514,6 +3514,10 @@ inline bool GetIntPtr(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
 
       const Block *B = (const Block *)IntVal.getPtr();
       S.Stk.push<Pointer>(const_cast<Block *>(B));
+    } else if (IntVal.getKind() == IntegralKind::FunctionAddress) {
+      const Function *F =
+          S.P.getFunction((const FunctionDecl *)IntVal.getPtr());
+      S.Stk.push<Pointer>(F, IntVal.getOffset());
     } else {
       S.Stk.push<Pointer>(static_cast<uint64_t>(IntVal), Desc);
     }

--- a/clang/lib/AST/ByteCode/Primitives.h
+++ b/clang/lib/AST/ByteCode/Primitives.h
@@ -30,6 +30,8 @@ enum class IntegralKind : uint8_t {
   BlockAddress,
   /// A pointer to a AddrLabelExpr.
   LabelAddress,
+  /// A pointer to a FunctionDecl.
+  FunctionAddress,
   /// Difference between two AddrLabelExpr.
   AddrLabelDiff
 };

--- a/clang/test/AST/ByteCode/functions.cpp
+++ b/clang/test/AST/ByteCode/functions.cpp
@@ -774,3 +774,12 @@ namespace DependentReturnType {
   S<float> x;
 }
 #endif
+
+namespace FuncToIntRoundtrip {
+  void f() {}
+  constexpr int foo() { // both-error {{constexpr function never produces a constant expression}}
+    auto p = (void*)(__UINTPTR_TYPE__)f; // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
+    return 1;
+  }
+  auto a = foo();
+}


### PR DESCRIPTION
We used to use just `::Address` for functions, which later caused problems because we casted the pointer to `ValueDecl*` and passed it to `Program::getOrCreateGlobal()`, which doesn't work of course.