### PR TITLE
[libcxx] Bump base image version to most recent

### DIFF
--- a/libcxx/utils/ci/docker/docker-compose.yml
+++ b/libcxx/utils/ci/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: ../../../.. # monorepo root
       dockerfile: libcxx/utils/ci/docker/linux-builder.dockerfile
       args:
-        BASE_IMAGE_VERSION: e849c68657d88d03235b87da34c740cda3abebd4
+        BASE_IMAGE_VERSION: bd75c10199a159a20720f8ee5c00afebb033f46e
         GITHUB_RUNNER_VERSION: 2.334.0
 
   libcxx-android-builder:
@@ -32,7 +32,7 @@ services:
       context: ../../../.. # monorepo root
       dockerfile: libcxx/utils/ci/docker/android-builder.dockerfile
       args:
-        BASE_IMAGE_VERSION: e849c68657d88d03235b87da34c740cda3abebd4
+        BASE_IMAGE_VERSION: bd75c10199a159a20720f8ee5c00afebb033f46e
         ANDROID_CLANG_VERSION: r584948b
         ANDROID_CLANG_PREBUILTS_COMMIT: 2b062008b0a7be59ad85f012cfeee60f052808f1
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f


### PR DESCRIPTION
To pull in the changes from bd75c10199a159a20720f8ee5c00afebb033f46e.