### PR TITLE
[X86][windows] Return `fp128` on the stack

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -201,6 +201,8 @@ Changes to the Windows Target
 
 * The `.seh_startchained` and `.seh_endchained` assembly instructions have been removed and replaced
   with a new `.seh_splitchained` instruction.
+* `fp128` is now returned on the stack, meaning the type is now ABI-compatible
+  with GCC.
 
 Changes to the X86 Backend
 --------------------------

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -130,14 +130,14 @@ def CC_#NAME : CallingConv<[
 
     // __mmask64 (v64i1) --> GPR64 (for x64) or 2 x GPR32 (for IA32)
     CCIfType<[v64i1], CCPromoteToType<i64>>,
-    CCIfSubtarget<"is64Bit()", CCIfType<[i64], 
+    CCIfSubtarget<"is64Bit()", CCIfType<[i64],
       CCAssignToReg<RC.GPR_64>>>,
-    CCIfSubtarget<"is32Bit()", CCIfType<[i64], 
+    CCIfSubtarget<"is32Bit()", CCIfType<[i64],
       CCCustom<"CC_X86_32_RegCall_Assign2Regs">>>,
 
     // float, double, float128 --> XMM
     // In the case of SSE disabled --> save to stack
-    CCIfType<[f32, f64, f128], 
+    CCIfType<[f32, f64, f128],
       CCIfSubtarget<"hasSSE1()", CCAssignToReg<RC.XMM>>>,
 
     // long double --> FP
@@ -145,39 +145,39 @@ def CC_#NAME : CallingConv<[
 
     // __m128, __m128i, __m128d --> XMM
     // In the case of SSE disabled --> save to stack
-    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64], 
+    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64],
       CCIfSubtarget<"hasSSE1()", CCAssignToReg<RC.XMM>>>,
 
     // __m256, __m256i, __m256d --> YMM
     // In the case of SSE disabled --> save to stack
-    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64], 
+    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64],
       CCIfSubtarget<"hasAVX()", CCAssignToReg<RC.YMM>>>,
 
     // __m512, __m512i, __m512d --> ZMM
     // In the case of SSE disabled --> save to stack
-    CCIfType<[v64i8, v32i16, v16i32, v8i64, v16f32, v8f64], 
+    CCIfType<[v64i8, v32i16, v16i32, v8i64, v16f32, v8f64],
       CCIfSubtarget<"hasAVX512()",CCAssignToReg<RC.ZMM>>>,
 
     // If no register was found -> assign to stack
 
     // In 64 bit, assign 64/32 bit values to 8 byte stack
-    CCIfSubtarget<"is64Bit()", CCIfType<[i32, i64, f32, f64], 
+    CCIfSubtarget<"is64Bit()", CCIfType<[i32, i64, f32, f64],
       CCAssignToStack<8, 8>>>,
 
     // In 32 bit, assign 64/32 bit values to 8/4 byte stack
     CCIfType<[i32, f32], CCAssignToStack<4, 4>>,
     CCIfType<[i64, f64], CCAssignToStack<8, 4>>,
 
-    // float 128 get stack slots whose size and alignment depends 
+    // float 128 get stack slots whose size and alignment depends
     // on the subtarget.
     CCIfType<[f80, f128], CCAssignToStack<0, 0>>,
 
     // Vectors get 16-byte stack slots that are 16-byte aligned.
-    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64], 
+    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64],
       CCAssignToStack<16, 16>>,
 
     // 256-bit vectors get 32-byte stack slots that are 32-byte aligned.
-    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64], 
+    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64],
       CCAssignToStack<32, 32>>,
 
     // 512-bit vectors get 64-byte stack slots that are 64-byte aligned.
@@ -205,28 +205,28 @@ def RetCC_#NAME : CallingConv<[
 
     // __mmask64 (v64i1) --> GPR64 (for x64) or 2 x GPR32 (for IA32)
     CCIfType<[v64i1], CCPromoteToType<i64>>,
-    CCIfSubtarget<"is64Bit()", CCIfType<[i64], 
+    CCIfSubtarget<"is64Bit()", CCIfType<[i64],
       CCAssignToReg<RC.GPR_64>>>,
-    CCIfSubtarget<"is32Bit()", CCIfType<[i64], 
+    CCIfSubtarget<"is32Bit()", CCIfType<[i64],
       CCCustom<"CC_X86_32_RegCall_Assign2Regs">>>,
 
     // long double --> FP
     CCIfType<[f80], CCAssignToReg<RC.FP_RET>>,
 
     // float, double, float128 --> XMM
-    CCIfType<[f32, f64, f128], 
+    CCIfType<[f32, f64, f128],
       CCIfSubtarget<"hasSSE1()", CCAssignToReg<RC.XMM>>>,
 
     // __m128, __m128i, __m128d --> XMM
-    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64], 
+    CCIfType<[v16i8, v8i16, v4i32, v2i64, v4f32, v2f64],
       CCIfSubtarget<"hasSSE1()", CCAssignToReg<RC.XMM>>>,
 
     // __m256, __m256i, __m256d --> YMM
-    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64], 
+    CCIfType<[v32i8, v16i16, v8i32, v4i64, v8f32, v4f64],
       CCIfSubtarget<"hasAVX()", CCAssignToReg<RC.YMM>>>,
 
     // __m512, __m512i, __m512d --> ZMM
-    CCIfType<[v64i8, v32i16, v16i32, v8i64, v16f32, v8f64], 
+    CCIfType<[v64i8, v32i16, v16i32, v8i64, v16f32, v8f64],
       CCIfSubtarget<"hasAVX512()", CCAssignToReg<RC.ZMM>>>
 ]>;
 }
@@ -384,6 +384,9 @@ def RetCC_X86_Win64_C : CallingConv<[
   CCIfType<[f32], CCIfNotSubtarget<"hasSSE1()", CCBitConvertToType<i32>>>,
   CCIfType<[f64], CCIfNotSubtarget<"hasSSE1()", CCBitConvertToType<i64>>>,
 
+  // GCC returns f128 on the stack on Windows.
+  CCIfType<[f128], CCAssignToStack<16, 16>>,
+
   // Otherwise, everything is the same as 'normal' X86-64 C CC.
   CCDelegateTo<RetCC_X86_64_C>
 ]>;
@@ -391,7 +394,7 @@ def RetCC_X86_Win64_C : CallingConv<[
 // X86-64 vectorcall return-value convention.
 def RetCC_X86_64_Vectorcall : CallingConv<[
   // Vectorcall calling convention always returns FP values in XMMs.
-  CCIfType<[f32, f64, f128], 
+  CCIfType<[f32, f64, f128],
     CCAssignToReg<[XMM0, XMM1, XMM2, XMM3]>>,
 
   // Otherwise, everything is the same as Windows X86-64 C CC.
@@ -442,7 +445,7 @@ def RetCC_X86_64_AnyReg : CallingConv<[
 defm X86_32_RegCall :
 	 X86_RegCall_base<RC_X86_32_RegCall>;
 defm X86_32_RegCallv4_Win :
-	 X86_RegCall_base<RC_X86_32_RegCallv4_Win>; 
+	 X86_RegCall_base<RC_X86_32_RegCallv4_Win>;
 defm X86_Win64_RegCall :
      X86_RegCall_base<RC_X86_64_RegCall_Win>;
 defm X86_Win64_RegCallv4 :
@@ -493,7 +496,7 @@ def RetCC_X86_64 : CallingConv<[
           CCIfSubtarget<"isTargetWin64()",
                         CCDelegateTo<RetCC_X86_Win64_RegCall>>>,
   CCIfCC<"CallingConv::X86_RegCall", CCDelegateTo<RetCC_X86_SysV64_RegCall>>,
-          
+
   // Mingw64 and native Win64 use Win64 CC
   CCIfSubtarget<"isTargetWin64()", CCDelegateTo<RetCC_X86_Win64_C>>,
 
@@ -1223,5 +1226,5 @@ def CSR_Win64_CFGuard_Check_NoSSE : CalleeSavedRegs<(add CSR_Win64_RegCall_NoSSE
 def CSR_Win64_CFGuard_Check       : CalleeSavedRegs<(add CSR_Win64_RegCall, RCX)>;
 def CSR_SysV64_RegCall_NoSSE : CalleeSavedRegs<(add RBX, RBP,
                                                (sequence "R%u", 12, 15))>;
-def CSR_SysV64_RegCall       : CalleeSavedRegs<(add CSR_SysV64_RegCall_NoSSE,               
+def CSR_SysV64_RegCall       : CalleeSavedRegs<(add CSR_SysV64_RegCall_NoSSE,
                                                (sequence "XMM%u", 8, 15))>;


### PR DESCRIPTION
For x86-64 Windows targets, LLVM currently returns `fp128` in xmm0. This does match `i128` (both Clang and GCC return `__int128` in xmm0) but disagrees with GCC's behavior of returning `__float128` on the stack.

Microsoft does not specify a `__float128` ABI so any decision is purely an extension. The Windows x64 calling convention [1] does say that user- defined types that do not fit in a register should be returned indirectly, so the GCC behavior seems like a reasonable interpretation of this rule.

Thus, change `fp128` to return on the stack for Windows targets. This is done for both MinGW and MSVC targets; if official guidelines are ever published, this can be revisited.

Relates to the pass ABI change in 5ee1c0b71485 ("[windows] Always pass fp128 arguments indirectly").

[1]: https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#return-values