### PR TITLE
[llvm-readobj] --unwind: Dump .debug_frame in addition to .eh_frame

### DIFF
--- a/llvm/test/tools/llvm-readobj/ELF/unwind-debug-frame.test
+++ b/llvm/test/tools/llvm-readobj/ELF/unwind-debug-frame.test
@@ -1,0 +1,107 @@
+## Test that --unwind dumps both .eh_frame and .debug_frame.
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-readobj --unwind %t | FileCheck %s
+# RUN: llvm-readelf --unwind %t | FileCheck %s
+
+# CHECK:      .eh_frame section at offset 0x40 address 0x0:
+# CHECK-NEXT:   [0x0] CIE length=20
+# CHECK-NEXT:     version: 1
+# CHECK-NEXT:     augmentation: zR
+# CHECK-NEXT:     code_alignment_factor: 1
+# CHECK-NEXT:     data_alignment_factor: -8
+# CHECK-NEXT:     return_address_register: 16
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_def_cfa: reg7 +8
+# CHECK-NEXT:       DW_CFA_offset: reg16 -8
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT:   [0x18] FDE length=20 cie=[0x0]
+# CHECK-NEXT:     initial_location: 0x20
+# CHECK-NEXT:     address_range: 0x0 (end : 0x20)
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT: .debug_frame section at offset 0x70 address 0x0:
+# CHECK-NEXT:   [0x0] CIE length=20
+# CHECK-NEXT:     version: 4
+# CHECK-NEXT:     augmentation:
+# CHECK-NEXT:     code_alignment_factor: 1
+# CHECK-NEXT:     data_alignment_factor: -8
+# CHECK-NEXT:     return_address_register: 0
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_def_cfa: reg7 +8
+# CHECK-NEXT:       DW_CFA_offset: reg16 -8
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT:   [0x18] FDE length=24 cie=[0x0]
+# CHECK-NEXT:     initial_location: 0x0
+# CHECK-NEXT:     address_range: 0x0 (end : 0x0)
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_advance_loc: 1 to 0x1
+# CHECK-NEXT:       DW_CFA_def_cfa_offset: +16
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT:   [0x34] CIE length=20
+# CHECK-NEXT:     version: 4
+# CHECK-NEXT:     augmentation:
+# CHECK-NEXT:     code_alignment_factor: 1
+# CHECK-NEXT:     data_alignment_factor: -8
+# CHECK-NEXT:     return_address_register: 65
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_def_cfa: reg7 +8
+# CHECK-NEXT:       DW_CFA_offset: reg16 -8
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT:   [0x4c] FDE length=24 cie=[0x34]
+# CHECK-NEXT:     initial_location: 0x0
+# CHECK-NEXT:     address_range: 0x0 (end : 0x0)
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_advance_loc: 1 to 0x1
+# CHECK-NEXT:       DW_CFA_def_cfa_offset: +16
+# CHECK-NEXT:       DW_CFA_nop:
+# CHECK-EMPTY:
+# CHECK-NEXT:   [0x68] FDE length=24 cie=[0x34]
+# CHECK-NEXT:     initial_location: 0x0
+# CHECK-NEXT:     address_range: 0x0 (end : 0x0)
+# CHECK-EMPTY:
+# CHECK-NEXT:     Program:
+# CHECK-NEXT:       DW_CFA_advance_loc: 1 to 0x1
+# CHECK-NEXT:       DW_CFA_def_cfa_offset: +16
+# CHECK-NEXT:       DW_CFA_nop:
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+Sections:
+  - Name:         .eh_frame
+    Type:         SHT_PROGBITS
+    Flags:        [ SHF_ALLOC ]
+    AddressAlign: 8
+    Content:      1400000000000000017A5200017810011B0C070890010000140000001C00000000000000000000000000000000000000
+  - Name:         .debug_frame
+    Type:         SHT_PROGBITS
+    AddressAlign: 8
+    Content:      14000000FFFFFFFF040008000178000C0708900100000000180000000000000000000000000000000000000000000000410E100014000000FFFFFFFF040008000178410C0708900100000000180000003400000000000000000000000000000000000000410E1000180000003400000000000000000000000000000000000000410E1000

--- a/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
+++ b/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
@@ -37,7 +37,7 @@ template <typename ELFT> class PrinterContext {
   const object::ELFObjectFile<ELFT> &ObjF;
 
   void printEHFrameHdr(const Elf_Phdr *EHFramePHdr) const;
-  void printEHFrame(const Elf_Shdr *EHFrameShdr) const;
+  void printFrame(const Elf_Shdr *FrameShdr, bool IsEH) const;
 
 public:
   PrinterContext(ScopedPrinter &W, const object::ELFObjectFile<ELFT> &ObjF)
@@ -89,7 +89,9 @@ void PrinterContext<ELFT>::printUnwindInformation() const {
     if (!NameOrErr)
       reportError(NameOrErr.takeError(), ObjF.getFileName());
     if (*NameOrErr == ".eh_frame")
-      printEHFrame(&Shdr);
+      printFrame(&Shdr, /*IsEH=*/true);
+    else if (*NameOrErr == ".debug_frame")
+      printFrame(&Shdr, /*IsEH=*/false);
   }
 }
 
@@ -184,31 +186,35 @@ void PrinterContext<ELFT>::printEHFrameHdr(const Elf_Phdr *EHFramePHdr) const {
 }
 
 template <typename ELFT>
-void PrinterContext<ELFT>::printEHFrame(const Elf_Shdr *EHFrameShdr) const {
-  uint64_t Address = EHFrameShdr->sh_addr;
-  uint64_t ShOffset = EHFrameShdr->sh_offset;
-  W.startLine() << format(".eh_frame section at offset 0x%" PRIx64
+void PrinterContext<ELFT>::printFrame(const Elf_Shdr *FrameShdr,
+                                      bool IsEH) const {
+  uint64_t Address = FrameShdr->sh_addr;
+  uint64_t ShOffset = FrameShdr->sh_offset;
+  W.startLine() << format("%s section at offset 0x%" PRIx64
                           " address 0x%" PRIx64 ":\n",
-                          ShOffset, Address);
+                          IsEH ? ".eh_frame" : ".debug_frame", ShOffset,
+                          Address);
   W.indent();
 
   Expected<ArrayRef<uint8_t>> DataOrErr =
-      ObjF.getELFFile().getSectionContents(*EHFrameShdr);
+      ObjF.getELFFile().getSectionContents(*FrameShdr);
   if (!DataOrErr)
     reportError(DataOrErr.takeError(), ObjF.getFileName());
 
   // Construct DWARFDataExtractor to handle relocations ("PC Begin" fields).
   std::unique_ptr<DWARFContext> DICtx = DWARFContext::create(
       ObjF, DWARFContext::ProcessDebugRelocations::Process, nullptr);
-  DWARFDataExtractor DE(
-      DICtx->getDWARFObj(), DICtx->getDWARFObj().getEHFrameSection(),
-      ELFT::Endianness == llvm::endianness::little, ELFT::Is64Bits ? 8 : 4);
-  DWARFDebugFrame EHFrame(Triple::ArchType(ObjF.getArch()), /*IsEH=*/true,
-                          /*EHFrameAddress=*/Address);
-  if (Error E = EHFrame.parse(DE))
+  const DWARFSection &Section = IsEH ? DICtx->getDWARFObj().getEHFrameSection()
+                                     : DICtx->getDWARFObj().getFrameSection();
+  DWARFDataExtractor DE(DICtx->getDWARFObj(), Section,
+                        ELFT::Endianness == llvm::endianness::little,
+                        ELFT::Is64Bits ? 8 : 4);
+  DWARFDebugFrame Frame(Triple::ArchType(ObjF.getArch()), IsEH,
+                        /*EHFrameAddress=*/IsEH ? Address : 0);
+  if (Error E = Frame.parse(DE))
     reportError(std::move(E), ObjF.getFileName());
 
-  for (const dwarf::FrameEntry &Entry : EHFrame) {
+  for (const dwarf::FrameEntry &Entry : Frame) {
     std::optional<uint64_t> InitialLocation;
     if (const dwarf::CIE *CIE = dyn_cast<dwarf::CIE>(&Entry)) {
       W.startLine() << format("[0x%" PRIx64 "] CIE length=%" PRIu64 "\n",
@@ -241,7 +247,7 @@ void PrinterContext<ELFT>::printEHFrame(const Elf_Shdr *EHFrameShdr) const {
     W.startLine() << "Program:\n";
     W.indent();
     auto DumpOpts = DIDumpOptions();
-    DumpOpts.IsEH = true;
+    DumpOpts.IsEH = IsEH;
     printCFIProgram(Entry.cfis(), W.getOStream(), DumpOpts, W.getIndentLevel(),
                     InitialLocation);
     W.unindent();


### PR DESCRIPTION
Extend `printUnwindInformation` to also print .debug_frame sections.

Code and unittest derived by Claude opus 4.7 with the goal to eliminate
the #192727 unittest in favor of a new lit test using llvm-readelf
--unwind.

Test derivation: assemble a one-function asm with `.cfi_sections
.debug_frame, .eh_frame` via llvm-mc, hex-dump each section, transcribe
the bytes into a yaml2obj `Content:` field, and use `ET_EXEC` so no
relocations are needed. The .debug_frame FDE is inspired by the #192727
test to test different return-address registers.
