### PR TITLE
[CMake] Fix CMAKE_INSTALL_NAME_DIR ignored

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2669,7 +2669,7 @@ function(llvm_codesign name)
 endfunction()
 
 function(llvm_setup_rpath name)
-  if(CMAKE_INSTALL_RPATH)
+  if(CMAKE_INSTALL_RPATH OR CMAKE_INSTALL_NAME_DIR)
     return()
   endif()
 


### PR DESCRIPTION
This allows building LLVM with an absolute path in the install name.