### PR TITLE
[AMDGPU][GlobalISel] Add RegBankLegalize rules for amdgcn_sqrt

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1913,8 +1913,10 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Uni(S16, {{UniInVgprS16}, {IntrId, Vgpr16}}, !hasPST)
       .Div(S32, {{Vgpr32}, {IntrId, Vgpr32}})
       .Uni(S32, {{Sgpr32}, {IntrId, Sgpr32}}, hasPST)
-      .Uni(S32, {{UniInVgprS32}, {IntrId, Vgpr32}}, !hasPST);
-
+      .Uni(S32, {{UniInVgprS32}, {IntrId, Vgpr32}}, !hasPST)
+      .Div(S64, {{Vgpr64}, {IntrId, Vgpr64}})
+      .Uni(S64, {{UniInVgprS64}, {IntrId, Vgpr64}});
+      
   addRulesForIOpcs({amdgcn_ds_atomic_async_barrier_arrive_b64})
       .Any({{}, {{}, {IntrId, VgprP3}}});
 

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1916,7 +1916,7 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Uni(S32, {{UniInVgprS32}, {IntrId, Vgpr32}}, !hasPST)
       .Div(S64, {{Vgpr64}, {IntrId, Vgpr64}})
       .Uni(S64, {{UniInVgprS64}, {IntrId, Vgpr64}});
-      
+
   addRulesForIOpcs({amdgcn_ds_atomic_async_barrier_arrive_b64})
       .Any({{}, {{}, {IntrId, VgprP3}}});
 

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1907,6 +1907,14 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Uni(S32, {{Sgpr32}, {IntrId, Sgpr32}}, hasPST)
       .Uni(S32, {{UniInVgprS32}, {IntrId, Vgpr32}}, !hasPST);
 
+  addRulesForIOpcs({amdgcn_sqrt}, Standard)
+      .Div(S16, {{Vgpr16}, {IntrId, Vgpr16}})
+      .Uni(S16, {{Sgpr16}, {IntrId, Sgpr16}}, hasPST)
+      .Uni(S16, {{UniInVgprS16}, {IntrId, Vgpr16}}, !hasPST)
+      .Div(S32, {{Vgpr32}, {IntrId, Vgpr32}})
+      .Uni(S32, {{Sgpr32}, {IntrId, Sgpr32}}, hasPST)
+      .Uni(S32, {{UniInVgprS32}, {IntrId, Vgpr32}}, !hasPST);
+
   addRulesForIOpcs({amdgcn_ds_atomic_async_barrier_arrive_b64})
       .Any({{}, {{}, {IntrId, VgprP3}}});
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-pseudo-scalar-transcendental.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-pseudo-scalar-transcendental.mir
@@ -199,7 +199,23 @@ body:             |
     %2:_(s16) = G_FSQRT %1
     %3:_(s32) = G_ANYEXT %2(s16)
     $vgpr0 = COPY %3(s32)
+...
+---
+name:            v_amdgcn_sqrt_f64_divergent
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $vgpr0_vgpr1
 
+    ; CHECK-LABEL: name: v_amdgcn_sqrt_f64_divergent
+    ; CHECK: liveins: $vgpr0_vgpr1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(s64) = COPY $vgpr0_vgpr1
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:vgpr(s64) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[COPY]](s64)
+    ; CHECK-NEXT: $vgpr0_vgpr1 = COPY [[INT]](s64)
+    %0:_(s64) = COPY $vgpr0_vgpr1
+    %1:_(s64) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %0(s64)
+    $vgpr0_vgpr1 = COPY %1(s64)
 ...
 ---
 name:            v_amdgcn_sqrt_f32_divergent
@@ -239,7 +255,24 @@ body:             |
     %2:_(s16) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %1(s16)
     %3:_(s32) = G_ANYEXT %2(s16)
     $vgpr0 = COPY %3(s32)
+...
+---
+name:            v_amdgcn_sqrt_f64
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $sgpr0_sgpr1
 
+    ; CHECK-LABEL: name: v_amdgcn_sqrt_f64
+    ; CHECK: liveins: $sgpr0_sgpr1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:sgpr(s64) = COPY $sgpr0_sgpr1
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vgpr(s64) = COPY [[COPY]](s64)
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:vgpr(s64) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[COPY1]](s64)
+    ; CHECK-NEXT: $vgpr0_vgpr1 = COPY [[INT]](s64)
+    %0:_(s64) = COPY $sgpr0_sgpr1
+    %1:_(s64) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %0(s64)
+    $vgpr0_vgpr1 = COPY %1(s64)
 ...
 ---
 name:            v_amdgcn_sqrt_f32

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-pseudo-scalar-transcendental.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-pseudo-scalar-transcendental.mir
@@ -202,6 +202,46 @@ body:             |
 
 ...
 ---
+name:            v_amdgcn_sqrt_f32_divergent
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    ; CHECK-LABEL: name: v_amdgcn_sqrt_f32_divergent
+    ; CHECK: liveins: $vgpr0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:vgpr(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[COPY]](s32)
+    ; CHECK-NEXT: $vgpr0 = COPY [[INT]](s32)
+    %0:_(s32) = COPY $vgpr0
+    %1:_(s32) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %0(s32)
+    $vgpr0 = COPY %1(s32)
+
+...
+---
+name:            v_amdgcn_sqrt_f16_divergent
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    ; CHECK-LABEL: name: v_amdgcn_sqrt_f16_divergent
+    ; CHECK: liveins: $vgpr0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
+    ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:vgpr(s16) = G_TRUNC [[COPY]](s32)
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:vgpr(s16) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[TRUNC]](s16)
+    ; CHECK-NEXT: [[ANYEXT:%[0-9]+]]:vgpr(s32) = G_ANYEXT [[INT]](s16)
+    ; CHECK-NEXT: $vgpr0 = COPY [[ANYEXT]](s32)
+    %0:_(s32) = COPY $vgpr0
+    %1:_(s16) = G_TRUNC %0(s32)
+    %2:_(s16) = G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %1(s16)
+    %3:_(s32) = G_ANYEXT %2(s16)
+    $vgpr0 = COPY %3(s32)
+
+...
+---
 name:            v_amdgcn_sqrt_f32
 legalized:       true
 body:             |

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sqrt.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sqrt.ll
@@ -71,8 +71,8 @@ define double @v_fneg_fabs_sqrt_f64(double %src)  {
   ret double %sqrt
 }
 
-define double @s_sqrt_f64_gfx12(double inreg %src) {
-; GFX12-LABEL: s_sqrt_f64_gfx12:
+define double @s_sqrt_f64(double inreg %src) {
+; GFX12-LABEL: s_sqrt_f64:
 ; GFX12:       ; %bb.0:
 ; GFX12:       v_sqrt_f64_e32 v[0:1], s[0:1]
 ; GFX12-NEXT:  s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sqrt.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sqrt.ll
@@ -3,6 +3,7 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=fiji < %s | FileCheck -check-prefix=GCN %s
 ; RUN: llc -global-isel -mtriple=amdgcn-amd-amdhsa -mcpu=hawaii < %s | FileCheck -check-prefix=GCN %s
 ; RUN: llc -global-isel -mtriple=amdgcn-amd-amdhsa -mcpu=fiji < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -global-isel=1 -new-reg-bank-select -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1200 < %s | FileCheck -check-prefix=GFX12 %s
 
 define float @v_sqrt_f32(float %src)  {
 ; GCN-LABEL: v_sqrt_f32:
@@ -67,6 +68,15 @@ define double @v_fneg_fabs_sqrt_f64(double %src)  {
   %fabs.src = call double @llvm.fabs.f64(double %src)
   %neg.fabs.src = fneg double %fabs.src
   %sqrt = call double @llvm.amdgcn.sqrt.f64(double %neg.fabs.src)
+  ret double %sqrt
+}
+
+define double @s_sqrt_f64_gfx12(double inreg %src) {
+; GFX12-LABEL: s_sqrt_f64_gfx12:
+; GFX12:       ; %bb.0:
+; GFX12:       v_sqrt_f64_e32 v[0:1], s[0:1]
+; GFX12-NEXT:  s_setpc_b64 s[30:31]
+  %sqrt = call double @llvm.amdgcn.sqrt.f64(double %src)
   ret double %sqrt
 }
 


### PR DESCRIPTION
The new rule matches the existing uniform/divergent behavior used for
pseudo-scalar transcendental intrinsics

issue #192497