### PR TITLE
[llvm][.gitignore] Ignore .agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ autoconf/autom4te.cache
 /.idea
 /cmake-build*
 # Coding assistants' stuff
+.agents/
 /CLAUDE.md
 /instructions.md
 .claude/


### PR DESCRIPTION
The `.agents` directory is a common convention for storing coding agent related stuff like rules and skills, recognized by major coding agents like Claude Code, Codex, GitHub Copilot, OpenCode, etc. Ignore this directory to avoid accidentally commiting these coding agent related content to the repo.