### PR TITLE
adds `<cstdlib>` to `ProgramStack.cpp`

### DIFF
--- a/llvm/lib/Support/ProgramStack.cpp
+++ b/llvm/lib/Support/ProgramStack.cpp
@@ -20,6 +20,8 @@
 
 #include "llvm/Support/thread.h"
 
+#include <cstdlib>
+
 using namespace llvm;
 
 uintptr_t llvm::getStackPointer() {


### PR DESCRIPTION
Building `LLVMSupport` with libc++ causes Clang to error because `malloc` and `free` aren't declared before they're used in `ProgramStack.cpp`.