### PR TITLE
[FileCheck] --dump-input: render search ranges with `{` ... `}` brackets

### DIFF
--- a/llvm/test/FileCheck/dump-input/annotations.txt
+++ b/llvm/test/FileCheck/dump-input/annotations.txt
@@ -28,16 +28,41 @@
 ; ALIGN-NEXT:<<<<<<
 ; ALIGN-NEXT:           1: hello world 
 ; ALIGN-NEXT:check:1       ^~~~~
-; ALIGN-NEXT:check:2'0          X~~~~~~ error: no match found
+; ALIGN-NEXT:check:2'0          {       error: no match found
 ; ALIGN-NEXT:           2: goodbye 
-; ALIGN-NEXT:check:2'0     ~~~~~~~~
 ; ALIGN-NEXT:           3: world 
-; ALIGN-NEXT:check:2'0     ~~~~~~
 ; ALIGN-NEXT:           4: unicorn 
-; ALIGN-NEXT:check:2'0     ~~~~~~~~
 ; ALIGN-NEXT:check:2'1     ?        possible intended match
+; ALIGN-NEXT:           5: 
+; ALIGN-NEXT:check:2'2     } search range end
 ; ALIGN-NEXT:>>>>>>
 ; ALIGN-NOT:{{.}}
+
+;--------------------------------------------------
+; Strict-whitespace coverage for the success-case bare brackets
+; (CHECK-NOT not firing -> MatchNoneAndExcluded with empty Note).
+;--------------------------------------------------
+
+; RUN: echo 'hello' > %t.in
+; RUN: echo 'world' >> %t.in
+
+; RUN: echo 'CHECK-NOT: missing' > %t.chk
+
+; RUN: %ProtectFileCheckOutput \
+; RUN: FileCheck -dump-input=always -input-file %t.in %t.chk -vv 2>&1 \
+; RUN: | FileCheck -strict-whitespace -match-full-lines -check-prefix=BARE \
+; RUN:             -implicit-check-not='remark:' %s
+
+; BARE:Input was:
+; BARE-NEXT:<<<<<<
+; BARE-NEXT:         1: hello 
+; BARE-NEXT:not:1'0     {
+; BARE-NEXT:         2: world 
+; BARE-NEXT:         3: 
+; BARE-NEXT:eof:1       ^
+; BARE-NEXT:not:1'1     }
+; BARE-NEXT:>>>>>>
+; BARE-NOT:{{.}}
 
 ;--------------------------------------------------
 ; CHECK (also: multi-line search range, fuzzy match)
@@ -72,12 +97,12 @@
 ; CHK:        <<<<<<
 ; CHK-NEXT:              1: hello 
 ; CHK-V-NEXT: check:1       ^~~~~
-; CHK-NEXT:   check:2'0          X error: no match found
+; CHK-NEXT:   check:2'0          { error: no match found
 ; CHK-NEXT:              2: again 
-; CHK-NEXT:   check:2'0     ~~~~~~
 ; CHK-NEXT:              3: whirled 
-; CHK-NEXT:   check:2'0     ~~~~~~~~
 ; CHK-NEXT:   check:2'1     ?        possible intended match
+; CHK-NEXT:              4: 
+; CHK-NEXT:   check:2'2     } search range end
 ; CHK-NEXT:   >>>>>>
 ; CHK-NOT:    {{.}}
 
@@ -114,13 +139,14 @@
 ; CNT-V-NEXT:   count:1'0     ^~~~
 ; CNT-NEXT:                2: repete 
 ; CNT-V-NEXT:   count:1'1       ^~~~
-; CNT-Q-NEXT:   count:1'0           X error: no match found
-; CNT-V-NEXT:   count:1'2           X error: no match found
+; CNT-Q-NEXT:   count:1'0           { error: no match found
+; CNT-V-NEXT:   count:1'2           { error: no match found
 ; CNT-NEXT:                3: repeat 
-; CNT-Q-NEXT:   count:1'0     ~~~~~~~
 ; CNT-Q-NEXT:   count:1'1     ?       possible intended match
-; CNT-V-NEXT:   count:1'2     ~~~~~~~
 ; CNT-V-NEXT:   count:1'3     ?       possible intended match
+; CNT-NEXT:                4: 
+; CNT-Q-NEXT:   count:1'2     } search range end
+; CNT-V-NEXT:   count:1'4     } search range end
 ; CNT-NEXT:     >>>>>>
 ; CNT-NOT:      {{.}}
 
@@ -158,7 +184,9 @@
 ; NXT-V-NEXT: check:1     ^~~~~
 ; NXT-NEXT:            2: again 
 ; NXT-V-NEXT: next:2      ^~~~~
-; NXT-NEXT:   next:3           X error: no match found
+; NXT-NEXT:   next:3'0           { error: no match found
+; NXT-NEXT:            3: 
+; NXT-NEXT:   next:3'1     } search range end
 ; NXT-NEXT:   >>>>>>
 ; NXT-NOT:    {{.}}
 
@@ -213,7 +241,9 @@
 ; SAM-NEXT:            1: hello world! 
 ; SAM-V-NEXT: check:1     ^~~~~
 ; SAM-V-NEXT: same:2            ^~~~~
-; SAM-NEXT:   same:3                 X~ error: no match found
+; SAM-NEXT:   same:3'0                { error: no match found
+; SAM-NEXT:            2:
+; SAM-NEXT:   same:3'1     } search range end
 ; SAM-NEXT:   >>>>>>
 ; SAM-NOT:    {{.}}
 
@@ -281,12 +311,11 @@
 ; EMP-V-NEXT: check:1     ^~~~~
 ; EMP-NEXT:            2:
 ; EMP-V-NEXT: empty:2     ^
-; EMP-NEXT:   empty:3          X error: no match found
-; EMP-NEXT:            3: world 
-; EMP-NEXT:   empty:3     ~~~~~~
-; EMP-NEXT:            4: label 
+; EMP-NEXT:   empty:3'0     { error: no match found
+; EMP-NEXT:            3: world
+; EMP-NEXT:            4: label
 ; EMP-V-NEXT: label:4     ^~~~~
-; EMP-NEXT:   empty:3     ~~~~~
+; EMP-NEXT:   empty:3'1          } search range end
 ; EMP-NEXT:   >>>>>>
 ; EMP-NOT:    {{.}}
 
@@ -353,15 +382,14 @@
 ; NOT: {{.*}}error:{{.*}}
 
 ; NOT:         <<<<<<
-; NOT-NEXT:           1: hello 
-; NOT-VV-NEXT: not:1     X~~~~~
-; NOT-NEXT:           2: world 
-; NOT-VV-NEXT: not:1     ~~~~~~
-; NOT-NEXT:    not:2     !~~~~  error: no match expected
-; NOT-NEXT:           3: again 
-; NOT-VV-NEXT: not:1     ~~~~~~
+; NOT-NEXT:           1: hello
+; NOT-VV-NEXT: not:1'0     {
+; NOT-NEXT:           2: world
+; NOT-NEXT:    not:2       !~~~~  error: no match expected
+; NOT-NEXT:           3: again
 ; NOT-VV-NEXT:        4:
-; NOT-VV-NEXT: eof:2     ^
+; NOT-VV-NEXT: eof:2       ^
+; NOT-VV-NEXT: not:1'1     }
 ; NOT-NEXT:    >>>>>>
 ; NOT-NOT:     {{.}}
 
@@ -386,14 +414,13 @@
 ; NOT2: {{.*}}error:{{.*}}
 
 ; NOT2:         <<<<<<
-; NOT2-NEXT:             1: hello 
-; NOT2-VV-NEXT: not:1       X~~~~~
-; NOT2-NEXT:             2: world 
-; NOT2-VV-NEXT: not:1       ~~~~~~
+; NOT2-NEXT:             1: hello
+; NOT2-VV-NEXT: not:1'0     {
+; NOT2-NEXT:             2: world
 ; NOT2-NEXT:    not:2       !~~~~  error: no match expected
-; NOT2-NEXT:             3: again 
+; NOT2-NEXT:             3: again
 ; NOT2-V-NEXT:  check:3       ^~~
-; NOT2-VV-NEXT: not:1       ~~
+; NOT2-VV-NEXT: not:1'1       }
 ; NOT2-NEXT:    >>>>>>
 ; NOT2-NOT:     {{.}}
 
@@ -436,21 +463,22 @@
 ; DAG: {{.*}}error:{{.*}}
 
 ; DAG:         <<<<<<
-; DAG-NEXT:             1: abc 
+; DAG-NEXT:             1: abc
 ; DAG-V-NEXT:  dag:2       ^~~
 ; DAG-VV-NEXT: dag:3'0     !~~  discard: overlaps earlier match
-; DAG-NEXT:             2: def 
+; DAG-NEXT:             2: def
 ; DAG-V-NEXT:  dag:1       ^~~
 ; DAG-VV-NEXT: dag:4'0     !~~  discard: overlaps earlier match
-; DAG-Q-NEXT:  dag:4          X error: no match found
-; DAG-VQ-NEXT: dag:4          X error: no match found
-; DAG-VV-NEXT: dag:4'1        X error: no match found
-; DAG-NEXT:             3: abc 
+; DAG-Q-NEXT:  dag:4'0        { error: no match found
+; DAG-VQ-NEXT: dag:4'0        { error: no match found
+; DAG-VV-NEXT: dag:4'1        { error: no match found
+; DAG-NEXT:             3: abc
 ; DAG-VQ-NEXT: dag:3       ^~~
 ; DAG-VV-NEXT: dag:3'1     ^~~
-; DAG-Q-NEXT:  dag:4       ~~~~
-; DAG-VQ-NEXT: dag:4       ~~~~
-; DAG-VV-NEXT: dag:4'1     ~~~~
+; DAG-NEXT:             4:
+; DAG-Q-NEXT:  dag:4'1     } search range end
+; DAG-VQ-NEXT: dag:4'1     } search range end
+; DAG-VV-NEXT: dag:4'2     } search range end
 ; DAG-NEXT:    >>>>>>
 ; DAG-NOT:     {{.}}
 
@@ -484,7 +512,7 @@
 ; DAG1L:{{.*}}error:{{.*}}
 
 ;         DAG1L:<<<<<<
-;    DAG1L-NEXT:         1: abc def abc def 
+;    DAG1L-NEXT:         1: abc def abc def
 ;  DAG1L-V-NEXT:dag:1           ^~~
 ;  DAG1L-V-NEXT:dag:2        ^~
 ; DAG1L-VV-NEXT:dag:3'0     !~~              discard: overlaps earlier match
@@ -495,9 +523,13 @@
 ; DAG1L-VV-NEXT:dag:4'1                 ^~
 ; DAG1L-VV-NEXT:dag:5'0         !~~          discard: overlaps earlier match
 ; DAG1L-VV-NEXT:dag:5'1                 !~~  discard: overlaps earlier match
-;  DAG1L-Q-NEXT:dag:5                     X~ error: no match found
-; DAG1L-VQ-NEXT:dag:5                     X~ error: no match found
-; DAG1L-VV-NEXT:dag:5'2                   X~ error: no match found
+;  DAG1L-Q-NEXT:dag:5'0                   {  error: no match found
+; DAG1L-VQ-NEXT:dag:5'0                   {  error: no match found
+; DAG1L-VV-NEXT:dag:5'2                   {  error: no match found
+;    DAG1L-NEXT:         2:
+;  DAG1L-Q-NEXT:dag:5'1     } search range end
+; DAG1L-VQ-NEXT:dag:5'1     } search range end
+; DAG1L-VV-NEXT:dag:5'3     } search range end
 ;    DAG1L-NEXT:>>>>>>
 ;     DAG1L-NOT:{{.}}
 
@@ -566,40 +598,41 @@
 ; LAB:{{.*}}.chk:9:12: error: CHECK-NOT: excluded string found in input
 
 ;         LAB:<<<<<<
-;    LAB-NEXT:            1: text 
+;    LAB-NEXT:            1: text
 ;  LAB-V-NEXT:check:1        ^~~~
-;    LAB-NEXT:            2: labelA 
+;    LAB-NEXT:            2: labelA
 ;  LAB-V-NEXT:label:2'0      ^~~~~~
 ;  LAB-V-NEXT:label:2'1      ^~~~~~
-;    LAB-NEXT:check:3              X error: no match found
-;    LAB-NEXT:            3: textA 
-;    LAB-NEXT:check:3        ~~~~~~
-;    LAB-NEXT:            4: labelB 
+;    LAB-NEXT:check:3'0            { error: no match found
+;    LAB-NEXT:            3: textA
+;    LAB-NEXT:            4: labelB
 ;  LAB-V-NEXT:label:4        ^~~~~~
-;    LAB-NEXT:check:3        ~~~~~~
-;    LAB-NEXT:            5: textB 
-;    LAB-NEXT:            6: labelC 
+;    LAB-NEXT:check:3'1            } search range end
+;    LAB-NEXT:            5: textB
+;    LAB-NEXT:            6: labelC
 ;  LAB-V-NEXT:label:6'0      ^~~~~~
 ;  LAB-V-NEXT:check:5        ^~~~~~
-;  LAB-Q-NEXT:label:6              X error: no match found
-;  LAB-V-NEXT:label:6'1            X error: no match found
-; LAB-VV-NEXT:not:7                X
-;    LAB-NEXT:            7: textC 
-; LAB-VV-NEXT:not:7          ~~~~~~
-;    LAB-NEXT:            8: labelD 
+;  LAB-Q-NEXT:label:6'0            { error: no match found
+;  LAB-V-NEXT:label:6'1            { error: no match found
+; LAB-VV-NEXT:not:7'0              {
+;  LAB-Q-NEXT:label:6'1            } search range end
+;  LAB-V-NEXT:label:6'2            } search range end
+;    LAB-NEXT:            7: textC
+;    LAB-NEXT:            8: labelD
 ;  LAB-V-NEXT:label:8'0      ^~~~~~
 ;  LAB-V-NEXT:label:8'1      ^~~~~~
-;    LAB-NEXT:            9: textD 
+; LAB-VV-NEXT:not:7'1        }
+;    LAB-NEXT:            9: textD
 ;    LAB-NEXT:not:9          !~~~~  error: no match expected
-;    LAB-NEXT:           10: labelE 
+;    LAB-NEXT:           10: labelE
 ;  LAB-V-NEXT:label:10'0     ^~~~~~
 ;  LAB-V-NEXT:label:10'1     ^~~~~~
-; LAB-VV-NEXT:not:11               X
-;    LAB-NEXT:           11: textE 
-; LAB-VV-NEXT:not:11         ~~~~~~
-;    LAB-NEXT:           12: labelF 
+; LAB-VV-NEXT:not:11'0             {
+;    LAB-NEXT:           11: textE
+;    LAB-NEXT:           12: labelF
 ;  LAB-V-NEXT:label:12'0     ^~~~~~
 ;  LAB-V-NEXT:label:12'1     ^~~~~~
+; LAB-VV-NEXT:not:11'1       }
 ;    LAB-NEXT:>>>>>>
 ;     LAB-NOT:{{.}}
 
@@ -653,21 +686,29 @@
 ; IMPNOT:{{.*}}command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
 
 ;         IMPNOT:<<<<<<
-;    IMPNOT-NEXT:            1: hello world again! 
+;    IMPNOT-NEXT:            1: hello world again!
 ;  IMPNOT-V-NEXT:check:1        ^~~
-; IMPNOT-VV-NEXT:not:imp1'0     X
-; IMPNOT-VV-NEXT:not:imp2'0     X
-; IMPNOT-VV-NEXT:not:imp3'0     X
+; IMPNOT-VV-NEXT:not:imp1'0     {
+; IMPNOT-VV-NEXT:not:imp2'0     {
+; IMPNOT-VV-NEXT:not:imp3'0     {
 ;  IMPNOT-V-NEXT:check:2              ^~~
-; IMPNOT-VV-NEXT:not:imp1'1        X~~
-; IMPNOT-VV-NEXT:not:imp2'1        X~~
-; IMPNOT-VV-NEXT:not:imp3'1        X~~
+; IMPNOT-VV-NEXT:not:imp1'1        {
+; IMPNOT-VV-NEXT:not:imp2'1        {
+; IMPNOT-VV-NEXT:not:imp3'1        {
 ;  IMPNOT-V-NEXT:check:3                         ^
-; IMPNOT-VV-NEXT:not:imp1'2              X~~~~~~~
-; IMPNOT-VV-NEXT:not:imp2'2              X~~~~~~~
+; IMPNOT-VV-NEXT:not:imp1'2              {
+; IMPNOT-VV-NEXT:not:imp2'2              {
 ;  IMPNOT-Q-NEXT:not:imp3                   !~~~~   error: no match expected
 ; IMPNOT-VQ-NEXT:not:imp3                   !~~~~   error: no match expected
 ; IMPNOT-VV-NEXT:not:imp3'2                 !~~~~   error: no match expected
+; IMPNOT-VV-NEXT:not:imp1'3     }
+; IMPNOT-VV-NEXT:not:imp2'3     }
+; IMPNOT-VV-NEXT:not:imp3'3     }
+; IMPNOT-VV-NEXT:not:imp1'4           }
+; IMPNOT-VV-NEXT:not:imp2'4           }
+; IMPNOT-VV-NEXT:not:imp3'4           }
+; IMPNOT-VV-NEXT:not:imp1'5                      }
+; IMPNOT-VV-NEXT:not:imp2'5                      }
 ;    IMPNOT-NEXT:>>>>>>
 ;     IMPNOT-NOT:{{.}}
 
@@ -688,17 +729,18 @@
 ; RUN: | FileCheck -match-full-lines %s -check-prefix=SUBST-POS
 
 ;      SUBST-POS:<<<<<<
-; SUBST-POS-NEXT:           1: def-match1 def-match2 
+; SUBST-POS-NEXT:           1: def-match1 def-match2
 ; SUBST-POS-NEXT:check:1'0     ^~~~~~~~~~~~~~~~~~~~~
 ; SUBST-POS-NEXT:check:1'1                            with "DEF_MATCH1" equal to "def-match1"
 ; SUBST-POS-NEXT:check:1'2                            with "DEF_MATCH2" equal to "def-match2"
-; SUBST-POS-NEXT:check:2'0     X error: match failed for invalid pattern
+; SUBST-POS-NEXT:check:2'0                          { error: match failed for invalid pattern
 ; SUBST-POS-NEXT:check:2'1                            undefined variable: UNDEF
 ; SUBST-POS-NEXT:check:2'2                            with "DEF_MATCH1" equal to "def-match1"
 ; SUBST-POS-NEXT:check:2'3                            with "DEF_NOMATCH" equal to "foobar"
 ; SUBST-POS-NEXT:           2: def-match1 def-nomatch
-; SUBST-POS-NEXT:check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~
-; SUBST-POS-NEXT:check:2'4 ? possible intended match
+; SUBST-POS-NEXT:check:2'4              ? possible intended match
+; SUBST-POS-NEXT:           3:
+; SUBST-POS-NEXT:check:2'5     } search range end
 ; SUBST-POS-NEXT:>>>>>>
 
 ;--------------------------------------------------
@@ -721,17 +763,17 @@
 
 ;      SUBST-NEG:<<<<<<
 ; SUBST-NEG-NEXT:         1: def-match1 def-nomatch
-; SUBST-NEG-NEXT:not:1'0     X~~~~~~~~~~~~~~~~~~~~~~ error: match failed for invalid pattern
+; SUBST-NEG-NEXT:not:1'0     {                       error: match failed for invalid pattern
 ; SUBST-NEG-NEXT:not:1'1                             undefined variable: UNDEF
 ; SUBST-NEG-NEXT:not:1'2                             with "DEF_MATCH1" equal to "def-match1"
 ; SUBST-NEG-NEXT:not:1'3                             with "DEF_NOMATCH" equal to "foobar"
 ; SUBST-NEG-NEXT:         2: def-match1 def-match2
-; SUBST-NEG-NEXT:not:1'0     ~~~~~~~~~~~~~~~~~~~~~~
 ; SUBST-NEG-NEXT:not:2'0     !~~~~~~~~~~~~~~~~~~~~  error: no match expected
 ; SUBST-NEG-NEXT:not:2'1                            with "DEF_MATCH1" equal to "def-match1"
 ; SUBST-NEG-NEXT:not:2'2                            with "DEF_MATCH2" equal to "def-match2"
 ; SUBST-NEG-NEXT:         3: END
 ; SUBST-NEG-NEXT:check:3     ^~~
+; SUBST-NEG-NEXT:not:1'4     }    search range end
 ; SUBST-NEG-NEXT:>>>>>>
 
 ;--------------------------------------------------

--- a/llvm/test/FileCheck/dump-input/context.txt
+++ b/llvm/test/FileCheck/dump-input/context.txt
@@ -116,47 +116,48 @@
 ; RUN: echo ' CHECK-NEXT: world'   >> %t.wide.chk
 
 ;      W5: <<<<<<
-;      W5:            9: lab1 hello 
+; W5-NEXT:            1: foo8 
+; W5-NEXT:            2: foo7 
+; W5-NEXT:            3: foo6 
+; W5-NEXT:            4: foo5 
+; W5-NEXT:            5: foo4 
+; W5-NEXT:            6: foo3 
+; W5-NEXT:            7: foo2 
+; W5-NEXT:            8: foo1 
+; W5-NEXT:            9: lab1 hello 
 ; W5-NEXT: label:1'0     ^~~~
 ; W5-NEXT: label:1'1     ^~~~
 ; W5-NEXT: check:2            ^~~~~
-; W5-NEXT: check:3'0               X error: no match found
+; W5-NEXT: check:3'0               { error: no match found
 ; W5-NEXT:           10: foo1 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT: check:3'1     ?     possible intended match
 ; W5-NEXT:           11: foo2 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           12: foo3 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           13: foo4 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           14: foo5 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           15: foo6 
-; W5-NEXT: check:3'0     ~~~~~
-; W6-NEXT:           16: foo7 
-; W6-NEXT: check:3'0     ~~~~~
-; WM-NEXT:            .
-; WM-NEXT:            .
-; WM-NEXT:            .
-; W6-NEXT:           17: foo7 
-; W6-NEXT: check:3'0     ~~~~~
-; W6-NEXT:           18: foo6 
-; W6-NEXT: check:3'0     ~~~~~
+; W5-NEXT:           16: foo7 
+; W5-NEXT:           17: foo7 
+; W5-NEXT:           18: foo6 
 ; W5-NEXT:           19: foo5 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           20: foo4 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           21: foo3 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           22: foo2 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           23: foo1 
-; W5-NEXT: check:3'0     ~~~~~
 ; W5-NEXT:           24: lab2 world 
 ; W5-NEXT: label:4       ^~~~
-; W5-NEXT: check:3'0     ~~~~
 ; W5-NEXT: next:5             !~~~~  error: match on wrong line
+; W5-NEXT: check:3'2         }       search range end
+; W5-NEXT:           25: foo1 
+; W5-NEXT:           26: foo2 
+; W5-NEXT:           27: foo3 
+; W5-NEXT:           28: foo4 
+; W5-NEXT:           29: foo5 
+; W6-NEXT:           30: foo6 
+; W5-NEXT:            .
+; W5-NEXT:            .
+; W5-NEXT:            .
+; W5-NEXT: >>>>>>
 
 ;--------------------------------------------------
 ; Check -dump-input-context=<bad value>.
@@ -285,7 +286,7 @@ BADVAL: {{F|f}}ile{{C|c}}heck{{.*}}: for the --dump-input-context option: '[[VAL
 ; RUN: %ProtectFileCheckOutput \
 ; RUN: not FileCheck -dump-input=fail -vv %t.wide.chk < %t.wide.in 2>&1 \
 ; RUN:               -dump-input-context=5 \
-; RUN: | FileCheck %s -match-full-lines -check-prefixes=W5,WM
+; RUN: | FileCheck %s -match-full-lines -check-prefix=W5
 
 ; At -dump-input-context=6, the ellipsis is not useful even when annotations on
 ; elided input lines are considered.

--- a/llvm/test/FileCheck/dump-input/enable.txt
+++ b/llvm/test/FileCheck/dump-input/enable.txt
@@ -246,10 +246,11 @@ BADVAL: {{F|f}}ile{{C|c}}heck{{.*}}: for the --dump-input option: Cannot find op
 
 ; DUMP-ERR:        Input was:
 ; DUMP-ERR-NEXT:   <<<<<<
-; DUMP-ERR-NEXT:            1: hello 
+; DUMP-ERR-NEXT:            1: hello
 ; DUMP-ERR-V-NEXT: check:1     ^~~~~
-; DUMP-ERR-NEXT:   next:2'0         X error: no match found
-; DUMP-ERR-NEXT:            2: whirled 
-; DUMP-ERR-NEXT:   next:2'0    ~~~~~~~~
-; DUMP-ERR-NEXT:   next:2'1    ?        possible intended match
+; DUMP-ERR-NEXT:   next:2'0         { error: no match found
+; DUMP-ERR-NEXT:            2: whirled
+; DUMP-ERR-NEXT:   next:2'1 ? possible intended match
+; DUMP-ERR-NEXT:            3:
+; DUMP-ERR-NEXT:   next:2'2 } search range end
 ; DUMP-ERR-NEXT:   >>>>>>

--- a/llvm/test/FileCheck/dump-input/filter.txt
+++ b/llvm/test/FileCheck/dump-input/filter.txt
@@ -68,52 +68,32 @@
 ; ALL-NEXT:           11: foo9 
 ; ALL-NEXT:           12: hello 
 ; ALL-NEXT: check:2       ^~~~~
-; ALL-NEXT: check:3'0          X error: no match found
+; ALL-NEXT: check:3'0          { error: no match found
 ; ALL-NEXT:           13: foo0 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           14: foo1 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           15: foo2 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           16: foo3 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           17: foo4 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           18: foo5 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           19: foo6 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           20: foo7 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           21: foo8 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           22: foo9 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           23: word 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT: check:3'1     ?     possible intended match
 ; ALL-NEXT:           24: foo0 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           25: foo1 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           26: foo2 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           27: foo3 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           28: foo4 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           29: foo5 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           30: foo6 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           31: foo7 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           32: foo8 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           33: foo9 
-; ALL-NEXT: check:3'0     ~~~~~
 ; ALL-NEXT:           34: end 
-; ALL-NEXT: check:3'0     ~~~~
+; ALL-NEXT:           35: 
+; ALL-NEXT: check:3'2     } search range end
 ; ALL-NEXT: >>>>>>
 
 ;      ANNOTATION-FULL: <<<<<<
@@ -128,52 +108,25 @@
 ; ANNOTATION-FULL-NEXT:           11: foo9 
 ; ANNOTATION-FULL-NEXT:           12: hello 
 ; ANNOTATION-FULL-NEXT: check:2       ^~~~~
-; ANNOTATION-FULL-NEXT: check:3'0          X error: no match found
+; ANNOTATION-FULL-NEXT: check:3'0          { error: no match found
 ; ANNOTATION-FULL-NEXT:           13: foo0 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT:           14: foo1 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           15: foo2 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           16: foo3 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           17: foo4 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           18: foo5 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           19: foo6 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           20: foo7 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
+; ANNOTATION-FULL-NEXT:            .
+; ANNOTATION-FULL-NEXT:            .
+; ANNOTATION-FULL-NEXT:            .
 ; ANNOTATION-FULL-NEXT:           21: foo8 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT:           22: foo9 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT:           23: word 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT: check:3'1     ?     possible intended match
 ; ANNOTATION-FULL-NEXT:           24: foo0 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT:           25: foo1 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           26: foo2 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           27: foo3 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           28: foo4 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           29: foo5 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           30: foo6 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           31: foo7 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
-; ANNOTATION-FULL-NEXT:           32: foo8 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
+; ANNOTATION-FULL-NEXT:            .
+; ANNOTATION-FULL-NEXT:            .
+; ANNOTATION-FULL-NEXT:            .
 ; ANNOTATION-FULL-NEXT:           33: foo9 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-FULL-NEXT:           34: end 
-; ANNOTATION-FULL-NEXT: check:3'0     ~~~~
+; ANNOTATION-FULL-NEXT:           35: 
+; ANNOTATION-FULL-NEXT: check:3'2     } search range end
 ; ANNOTATION-FULL-NEXT: >>>>>>
 
 ;      ANNOTATION: <<<<<<
@@ -188,28 +141,25 @@
 ; ANNOTATION-NEXT:           11: foo9 
 ; ANNOTATION-NEXT:           12: hello 
 ; ANNOTATION-NEXT: check:2       ^~~~~
-; ANNOTATION-NEXT: check:3'0          X error: no match found
+; ANNOTATION-NEXT: check:3'0          { error: no match found
 ; ANNOTATION-NEXT:           13: foo0 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:           14: foo1 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:            .
 ; ANNOTATION-NEXT:            .
 ; ANNOTATION-NEXT:            .
 ; ANNOTATION-NEXT:           21: foo8 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:           22: foo9 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:           23: word 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT: check:3'1     ?     possible intended match
 ; ANNOTATION-NEXT:           24: foo0 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:           25: foo1 
-; ANNOTATION-NEXT: check:3'0     ~~~~~
 ; ANNOTATION-NEXT:            .
 ; ANNOTATION-NEXT:            .
 ; ANNOTATION-NEXT:            .
+; ANNOTATION-NEXT:           33: foo9 
+; ANNOTATION-NEXT:           34: end 
+; ANNOTATION-NEXT:           35: 
+; ANNOTATION-NEXT: check:3'2     } search range end
 ; ANNOTATION-NEXT: >>>>>>
 
 ;      ERROR: <<<<<<
@@ -220,28 +170,25 @@
 ; ERROR-NEXT:           11: foo9 
 ; ERROR-NEXT:           12: hello 
 ; ERROR-NEXT: check:2       ^~~~~
-; ERROR-NEXT: check:3'0          X error: no match found
+; ERROR-NEXT: check:3'0          { error: no match found
 ; ERROR-NEXT:           13: foo0 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:           14: foo1 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:            .
 ; ERROR-NEXT:            .
 ; ERROR-NEXT:            .
 ; ERROR-NEXT:           21: foo8 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:           22: foo9 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:           23: word 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT: check:3'1     ?     possible intended match
 ; ERROR-NEXT:           24: foo0 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:           25: foo1 
-; ERROR-NEXT: check:3'0     ~~~~~
 ; ERROR-NEXT:            .
 ; ERROR-NEXT:            .
 ; ERROR-NEXT:            .
+; ERROR-NEXT:           33: foo9 
+; ERROR-NEXT:           34: end 
+; ERROR-NEXT:           35: 
+; ERROR-NEXT: check:3'2     } search range end
 ; ERROR-NEXT: >>>>>>
 
 ;--------------------------------------------------

--- a/llvm/utils/FileCheck/FileCheck.cpp
+++ b/llvm/utils/FileCheck/FileCheck.cpp
@@ -235,6 +235,22 @@ static MarkerStyle GetMarker(FileCheckDiag::MatchType MatchTy) {
   llvm_unreachable_internal("unexpected match type");
 }
 
+/// Returns true for diagnostics that report a search range -- a region of
+/// input the directive scanned without finding a match.  These get rendered
+/// as `{` ... `}` bracket pairs (plus a separate error annotation when the
+/// search failed) instead of an `X~~~` underline that spans the entire
+/// scanned region.
+static bool isSearchRangeDiag(FileCheckDiag::MatchType MatchTy) {
+  switch (MatchTy) {
+  case FileCheckDiag::MatchNoneButExpected:
+  case FileCheckDiag::MatchNoneAndExcluded:
+  case FileCheckDiag::MatchNoneForInvalidPattern:
+    return true;
+  default:
+    return false;
+  }
+}
+
 static void DumpInputAnnotationHelp(raw_ostream &OS) {
   OS << "The following description was requested by -dump-input=help to\n"
      << "explain the input dump printed by FileCheck.\n"
@@ -289,11 +305,13 @@ static void DumpInputAnnotationHelp(raw_ostream &OS) {
      << "           - CHECK-DAG overlapping match (discarded, reported if "
      << "-vv)\n"
      << "  - ";
-  WithColor(OS, raw_ostream::SAVEDCOLOR, true) << "X~~";
-  OS << "    marks search range when no match is found, such as:\n"
+  WithColor(OS, raw_ostream::SAVEDCOLOR, true) << "{ }";
+  OS << "    bracket the search range when no match is found, such as:\n"
      << "           - CHECK-NEXT not found (error)\n"
      << "           - CHECK-NOT not found (success, reported if -vv)\n"
      << "           - CHECK-DAG not found after discarded matches (error)\n"
+     << "           Bounds are exclusive; the failing directive's error\n"
+     << "           message appears as a separate annotation row\n"
      << "  - ";
   WithColor(OS, raw_ostream::SAVEDCOLOR, true) << "?";
   OS << "      marks fuzzy match when no match is found\n";
@@ -387,38 +405,84 @@ BuildInputAnnotations(const SourceMgr &SM, unsigned CheckFileBufferID,
       return LHS.getPointer() < RHS.getPointer();
     }
   };
-  // How many diagnostics does each pattern have?
+  // A bracketed search-range diag expands to two annotations: `{` carrying
+  // the marker's error note (or empty for the success case) and `}` closing
+  // the range.  Sub-notes attached to a search-range MatchType (e.g.
+  // per-substitution diagnostics alongside MatchNoneForInvalidPattern)
+  // carry a non-empty Note and render as a single Lead=' ' annotation, so
+  // the main diag (Note empty) is the only one that brackets.
+  auto IsBracketedSearchRange = [](const FileCheckDiag &D) {
+    return isSearchRangeDiag(D.MatchTy) && D.Note.empty();
+  };
   std::map<SMLoc, unsigned, CompareSMLoc> DiagCountPerPattern;
   for (const FileCheckDiag &Diag : Diags)
-    ++DiagCountPerPattern[Diag.CheckLoc];
-  // How many diagnostics have we seen so far per pattern?
+    DiagCountPerPattern[Diag.CheckLoc] +=
+        IsBracketedSearchRange(Diag) ? 2u : 1u;
   std::map<SMLoc, unsigned, CompareSMLoc> DiagIndexPerPattern;
-  // How many total diagnostics have we seen so far?
   unsigned DiagIndex = 0;
-  // What's the widest label?
   LabelWidth = 0;
-  for (auto DiagItr = Diags.begin(), DiagEnd = Diags.end(); DiagItr != DiagEnd;
-       ++DiagItr) {
-    InputAnnotation A;
-    A.DiagIndex = DiagIndex++;
 
-    // Build label, which uniquely identifies this check result.
-    unsigned CheckBufferID = SM.FindBufferContainingLoc(DiagItr->CheckLoc);
-    auto CheckLineAndCol =
-        SM.getLineAndColumn(DiagItr->CheckLoc, CheckBufferID);
-    llvm::raw_string_ostream Label(A.Label);
-    Label << GetCheckTypeAbbreviation(DiagItr->CheckTy) << ":";
-    if (CheckBufferID == CheckFileBufferID)
-      Label << CheckLineAndCol.first;
-    else if (ImpPatBufferIDRange.first <= CheckBufferID &&
-             CheckBufferID < ImpPatBufferIDRange.second)
-      Label << "imp" << (CheckBufferID - ImpPatBufferIDRange.first + 1);
+  // Mint the next label for an annotation belonging to \p Diag; each call
+  // takes the next per-pattern `'N` slot.
+  auto MakeLabel = [&](const FileCheckDiag &Diag) {
+    std::string Label;
+    raw_string_ostream LS(Label);
+    LS << GetCheckTypeAbbreviation(Diag.CheckTy) << ":";
+    unsigned BufID = SM.FindBufferContainingLoc(Diag.CheckLoc);
+    auto LineCol = SM.getLineAndColumn(Diag.CheckLoc, BufID);
+    if (BufID == CheckFileBufferID)
+      LS << LineCol.first;
+    else if (ImpPatBufferIDRange.first <= BufID &&
+             BufID < ImpPatBufferIDRange.second)
+      LS << "imp" << (BufID - ImpPatBufferIDRange.first + 1);
     else
       llvm_unreachable("expected diagnostic's check location to be either in "
                        "the check file or for an implicit pattern");
-    if (DiagCountPerPattern[DiagItr->CheckLoc] > 1)
-      Label << "'" << DiagIndexPerPattern[DiagItr->CheckLoc]++;
-    LabelWidth = std::max((std::string::size_type)LabelWidth, A.Label.size());
+    if (DiagCountPerPattern[Diag.CheckLoc] > 1)
+      LS << "'" << DiagIndexPerPattern[Diag.CheckLoc]++;
+    LabelWidth = std::max((std::string::size_type)LabelWidth, Label.size());
+    return Label;
+  };
+
+  // Build a single-character bracket annotation (`{` or `}`) for \p Diag.
+  auto MakeBracket = [&](const FileCheckDiag &Diag, const MarkerStyle &Style,
+                         char Lead, StringRef Note, unsigned Line,
+                         unsigned Col) {
+    InputAnnotation A;
+    A.DiagIndex = DiagIndex++;
+    A.Label = MakeLabel(Diag);
+    A.IsFirstLine = true;
+    A.InputLine = Line;
+    A.InputStartCol = Col;
+    A.InputEndCol = Col + 1;
+    A.Marker = MarkerStyle(Lead, Style.Color, Note.str(), Style.FiltersAsError);
+    A.FoundAndExpectedMatch = false;
+    return A;
+  };
+
+  // `}` close brackets are emitted at the end of the main loop so their
+  // `'N` label suffix follows any other annotations at the same CheckLoc
+  // (e.g. a MatchFuzzy `?` candidate), matching input-position order.
+  // Save the diag + cached MarkerStyle to avoid re-iterating `Diags` and
+  // re-calling GetMarker.
+  SmallVector<std::pair<const FileCheckDiag *, MarkerStyle>, 8> CloseDeferred;
+
+  for (auto DiagItr = Diags.begin(), DiagEnd = Diags.end(); DiagItr != DiagEnd;
+       ++DiagItr) {
+    if (IsBracketedSearchRange(*DiagItr)) {
+      MarkerStyle Style = GetMarker(DiagItr->MatchTy);
+      // `{` carries the marker's error note inline (one row instead of
+      // two).  For success cases (MatchNoneAndExcluded) the note is empty.
+      Annotations.push_back(MakeBracket(*DiagItr, Style, '{', Style.Note,
+                                        DiagItr->InputStartLine,
+                                        DiagItr->InputStartCol));
+      CloseDeferred.emplace_back(&*DiagItr, Style);
+      continue;
+    }
+
+    InputAnnotation A;
+    A.DiagIndex = DiagIndex++;
+    A.Label = MakeLabel(*DiagItr);
 
     A.Marker = GetMarker(DiagItr->MatchTy);
     if (!DiagItr->Note.empty()) {
@@ -458,6 +522,8 @@ BuildInputAnnotations(const SourceMgr &SM, unsigned CheckFileBufferID,
              "expected input range not to be inverted");
       A.InputEndCol = UINT_MAX;
       Annotations.push_back(A);
+      // Multi-line non-search-range matches (e.g. CHECK whose pattern
+      // consumes `\n` via [[:space:]]+) get a `~~~` continuation per line.
       for (unsigned L = DiagItr->InputStartLine + 1, E = DiagItr->InputEndLine;
            L <= E; ++L) {
         // If a range ends before the first column on a line, then it has no
@@ -481,6 +547,15 @@ BuildInputAnnotations(const SourceMgr &SM, unsigned CheckFileBufferID,
         Annotations.push_back(B);
       }
     }
+  }
+
+  for (auto &[D, Style] : CloseDeferred) {
+    // `}` carries a short note for error diags so --dump-input-filter=error
+    // (the default) pulls its line into view alongside the `{` start.
+    // Success diags (MatchNoneAndExcluded) leave it empty.
+    StringRef Note = Style.FiltersAsError ? "search range end" : "";
+    Annotations.push_back(
+        MakeBracket(*D, Style, '}', Note, D->InputEndLine, D->InputEndCol));
   }
 }
 


### PR DESCRIPTION
Replace the X-marker + `~~~` underline for search-range diagnostics
(MatchNoneButExpected, MatchNoneAndExcluded, MatchNoneForInvalidPattern)
with a `{` start bracket carrying the error note inline and a `}` end
bracket closing the range.

Before (gnuhash mutation):
```
    7: GnuHashTable {
  next:13'0                   X error: no match found
    8:  Bloom Filter: [0x3, 0x4]
  next:13'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
    9:  Buckets: [5, 6, 7]
  next:13'0     ~~~~~~~~~~~~~~~~~~~~
  next:13'1      ?                   possible intended match
   10:  Values: [0x8, 0x9, 0xA, 0xB]
  next:13'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   11: }
  next:13'0     ~~
```

After:
```
    7: GnuHashTable {
  next:13'0                   { error: no match found
    8:  Bloom Filter: [0x3, 0x4]
    9:  Buckets: [5, 6, 7]
  next:13'1      ?                   possible intended match
   10:  Values: [0x8, 0x9, 0xA, 0xB]
   11: }
   12:
  next:13'2     } search range end
```

Design by @jdenny-ornl in
https://github.com/llvm/llvm-project/pull/192908#discussion_r3132763408.

A firing CHECK-NOT (MatchFoundButExcluded, `!~~~`) is not wrapped in
brackets here -- its diagnostic range points at the matched text, not
the search range -- and is left to a follow-up.

Related: #77257.  Obsoletes #192908.