### PR TITLE
[MC][AsmParser]: Don't use SourceMgr::AddIncludeFile when opening .incbin files

### DIFF
--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -202,6 +202,10 @@ public:
   LLVM_ABI ErrorOr<std::unique_ptr<MemoryBuffer>>
   OpenIncludeFile(const std::string &Filename, std::string &IncludedFile);
 
+  LLVM_ABI ErrorOr<std::unique_ptr<MemoryBuffer>>
+  OpenSliceIncludeFile(const std::string &Filename, int64_t Offset,
+                       int64_t Count, std::string &IncludedFile);
+
   /// Return the ID of the buffer containing the specified location.
   ///
   /// 0 is returned if the buffer is not found.

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -203,8 +203,8 @@ public:
   OpenIncludeFile(const std::string &Filename, std::string &IncludedFile);
 
   LLVM_ABI ErrorOr<std::unique_ptr<MemoryBuffer>>
-  OpenSliceIncludeFile(const std::string &Filename, int64_t Offset,
-                       int64_t Count, std::string &IncludedFile);
+  OpenSliceIncludeFile(const std::string &Filename, uint64_t Offset,
+                       uint64_t Count, std::string &IncludedFile);
 
   /// Return the ID of the buffer containing the specified location.
   ///

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -133,6 +133,10 @@ public:
   getBuffer(const Twine &Name, int64_t FileSize = -1,
             bool RequiresNullTerminator = true, bool IsVolatile = false) = 0;
 
+  virtual ErrorOr<std::unique_ptr<MemoryBuffer>>
+  getSliceBuffer(const Twine &Name, int64_t Offset = 0, int64_t Count = -1,
+                 bool IsVolatile = false);
+
   /// Closes the file.
   virtual std::error_code close() = 0;
 
@@ -295,6 +299,11 @@ public:
   getBufferForFile(const Twine &Name, int64_t FileSize = -1,
                    bool RequiresNullTerminator = true, bool IsVolatile = false,
                    bool IsText = true);
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  getSliceBufferForFile(const Twine &Name, int64_t Offset = 0,
+                        int64_t Count = -1, bool IsVolatile = false,
+                        bool IsText = true);
 
   /// Get a directory_iterator for \p Dir.
   /// \note The 'end' iterator is directory_iterator().

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -134,7 +134,7 @@ public:
             bool RequiresNullTerminator = true, bool IsVolatile = false) = 0;
 
   virtual ErrorOr<std::unique_ptr<MemoryBuffer>>
-  getSliceBuffer(const Twine &Name, int64_t Offset = 0, int64_t Count = -1,
+  getSliceBuffer(const Twine &Name, uint64_t Offset = 0, uint64_t Count = -1,
                  bool IsVolatile = false);
 
   /// Closes the file.
@@ -301,8 +301,8 @@ public:
                    bool IsText = true);
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-  getSliceBufferForFile(const Twine &Name, int64_t Offset = 0,
-                        int64_t Count = -1, bool IsVolatile = false,
+  getSliceBufferForFile(const Twine &Name, uint64_t Offset = 0,
+                        uint64_t Count = -1, bool IsVolatile = false,
                         bool IsText = true);
 
   /// Get a directory_iterator for \p Dir.

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -861,13 +861,13 @@ bool AsmParser::processIncbinFile(const std::string &Filename, int64_t Skip,
     return false;
 
   std::string IncludedFile;
-  unsigned NewBuf =
-      SrcMgr.AddIncludeFile(Filename, Lexer.getLoc(), IncludedFile);
-  if (!NewBuf)
+  ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
+      SrcMgr.OpenIncludeFile(Filename, IncludedFile);
+  if (!BuffOrErr)
     return true;
 
   // Pick up the bytes from the file and emit them.
-  StringRef Bytes = SrcMgr.getMemoryBuffer(NewBuf)->getBuffer();
+  StringRef Bytes = (*BuffOrErr)->getBuffer();
   Bytes = Bytes.drop_front(Skip);
   if (Count) {
     int64_t Res;

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -860,16 +860,15 @@ bool AsmParser::processIncbinFile(const std::string &Filename, int64_t Skip,
   if (SymbolScanningMode)
     return false;
 
-  int64_t BytesToRead = -1; // -1 initially for reading the whole file
+  uint64_t BytesToRead =
+      uint64_t(-1); // -1 initially for reading the whole file
   if (Count) {
     int64_t Res;
     if (!Count->evaluateAsAbsolute(Res, getStreamer().getAssemblerPtr()))
       return Error(Loc, "expected absolute expression");
-    if (Res < 0)
-      return Warning(Loc,
-                     "negative count has no effect"); // don't read if assembly
-    // has negative count
-    BytesToRead = Res;
+    if (Res < 0) // don't read if the assembly has negative count
+      return Warning(Loc, "negative count has no effect");
+    BytesToRead = uint64_t(Res);
   }
 
   std::string IncludedFile;

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -860,23 +860,26 @@ bool AsmParser::processIncbinFile(const std::string &Filename, int64_t Skip,
   if (SymbolScanningMode)
     return false;
 
-  std::string IncludedFile;
-  ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
-      SrcMgr.OpenIncludeFile(Filename, IncludedFile);
-  if (!BuffOrErr)
-    return true;
-
-  // Pick up the bytes from the file and emit them.
-  StringRef Bytes = (*BuffOrErr)->getBuffer();
-  Bytes = Bytes.drop_front(Skip);
+  int64_t BytesToRead = -1; // -1 initially for reading the whole file
   if (Count) {
     int64_t Res;
     if (!Count->evaluateAsAbsolute(Res, getStreamer().getAssemblerPtr()))
       return Error(Loc, "expected absolute expression");
     if (Res < 0)
-      return Warning(Loc, "negative count has no effect");
-    Bytes = Bytes.take_front(Res);
+      return Warning(Loc,
+                     "negative count has no effect"); // don't read if assembly
+    // has negative count
+    BytesToRead = Res;
   }
+
+  std::string IncludedFile;
+  ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
+      SrcMgr.OpenSliceIncludeFile(Filename, Skip, BytesToRead, IncludedFile);
+  if (!BuffOrErr)
+    return true;
+
+  // Pick up the bytes from the file and emit them.
+  StringRef Bytes = (*BuffOrErr)->getBuffer();
   getStreamer().emitBytes(Bytes);
   return false;
 }

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -90,6 +90,31 @@ SourceMgr::OpenIncludeFile(const std::string &Filename,
   return NewBufOrErr;
 }
 
+ErrorOr<std::unique_ptr<MemoryBuffer>>
+SourceMgr::OpenSliceIncludeFile(const std::string &Filename, int64_t Offset,
+                                int64_t Count, std::string &IncludedFile) {
+  auto GetFileSlice = [this, Offset, Count](StringRef Path) {
+    return FS ? FS->getSliceBufferForFile(Path, Offset, Count)
+              : MemoryBuffer::getFileSlice(Path, Count, Offset);
+  };
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> NewBufOrErr = GetFileSlice(Filename);
+
+  SmallString<64> Buffer(Filename);
+  // If the file didn't exist directly, see if it's in an include path.
+  for (unsigned i = 0, e = IncludeDirectories.size(); i != e && !NewBufOrErr;
+       ++i) {
+    Buffer = IncludeDirectories[i];
+    sys::path::append(Buffer, Filename);
+    NewBufOrErr = GetFileSlice(Buffer);
+  }
+
+  if (NewBufOrErr)
+    IncludedFile = static_cast<std::string>(Buffer);
+
+  return NewBufOrErr;
+}
+
 unsigned SourceMgr::FindBufferContainingLoc(SMLoc Loc) const {
   for (unsigned i = 0, e = Buffers.size(); i != e; ++i)
     if (Loc.getPointer() >= Buffers[i].Buffer->getBufferStart() &&

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -91,8 +91,8 @@ SourceMgr::OpenIncludeFile(const std::string &Filename,
 }
 
 ErrorOr<std::unique_ptr<MemoryBuffer>>
-SourceMgr::OpenSliceIncludeFile(const std::string &Filename, int64_t Offset,
-                                int64_t Count, std::string &IncludedFile) {
+SourceMgr::OpenSliceIncludeFile(const std::string &Filename, uint64_t Offset,
+                                uint64_t Count, std::string &IncludedFile) {
   auto GetFileSlice = [this, Offset, Count](StringRef Path) {
     return FS ? FS->getSliceBufferForFile(Path, Offset, Count)
               : MemoryBuffer::getFileSlice(Path, Count, Offset);

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -93,9 +93,22 @@ SourceMgr::OpenIncludeFile(const std::string &Filename,
 ErrorOr<std::unique_ptr<MemoryBuffer>>
 SourceMgr::OpenSliceIncludeFile(const std::string &Filename, uint64_t Offset,
                                 uint64_t Count, std::string &IncludedFile) {
-  auto GetFileSlice = [this, Offset, Count](StringRef Path) {
-    return FS ? FS->getSliceBufferForFile(Path, Offset, Count)
-              : MemoryBuffer::getFileSlice(Path, Count, Offset);
+  auto GetFileSlice =
+      [this, Offset,
+       Count](StringRef Path) -> ErrorOr<std::unique_ptr<MemoryBuffer>> {
+    if (FS)
+      return FS->getSliceBufferForFile(Path, Offset, Count);
+
+    if (Count != uint64_t(-1))
+      return MemoryBuffer::getFileSlice(Path, Count, Offset);
+
+    auto BufOrErr = MemoryBuffer::getFile(Path);
+    if (!BufOrErr)
+      return BufOrErr.getError();
+    std::unique_ptr<MemoryBuffer> Buff = std::move(*BufOrErr);
+    StringRef Bytes = Buff->getBuffer();
+    Bytes = Bytes.drop_front(Offset);
+    return MemoryBuffer::getMemBufferCopy(Bytes, Buff->getBufferIdentifier());
   };
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> NewBufOrErr = GetFileSlice(Filename);

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -127,8 +127,9 @@ FileSystem::getBufferForFile(const llvm::Twine &Name, int64_t FileSize,
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
-FileSystem::getSliceBufferForFile(const Twine &Name, int64_t Offset,
-                                  int64_t Count, bool IsVolatile, bool IsText) {
+FileSystem::getSliceBufferForFile(const Twine &Name, uint64_t Offset,
+                                  uint64_t Count, bool IsVolatile,
+                                  bool IsText) {
   auto F = IsText ? openFileForRead(Name) : openFileForReadBinary(Name);
   if (!F)
     return F.getError();
@@ -223,7 +224,7 @@ public:
                                                    bool IsVolatile) override;
 
   ErrorOr<std::unique_ptr<MemoryBuffer>>
-  getSliceBuffer(const Twine &Name, int64_t Offset, int64_t Count,
+  getSliceBuffer(const Twine &Name, uint64_t Offset, uint64_t Count,
                  bool IsVolatile) override;
 
   std::error_code close() override;
@@ -262,11 +263,22 @@ RealFile::getBuffer(const Twine &Name, int64_t FileSize,
 }
 
 ErrorOr<std::unique_ptr<MemoryBuffer>>
-RealFile::getSliceBuffer(const Twine &Name, int64_t Offset, int64_t Count,
+RealFile::getSliceBuffer(const Twine &Name, uint64_t Offset, uint64_t Count,
                          bool IsVolatile) {
   auto BypassSandbox = sys::sandbox::scopedDisable();
 
   assert(FD != kInvalidFile && "cannot get buffer for closed file");
+  if (Count == uint64_t(-1)) {
+    sys::fs::file_status Status;
+    if (std::error_code EC = sys::fs::status(FD, Status))
+      return EC;
+    uint64_t FileSize = Status.getSize();
+    if (Offset < FileSize)
+      Count = FileSize - Offset;
+    else
+      Count = 0;
+  }
+
   return MemoryBuffer::getOpenFileSlice(FD, Name, Count, Offset, IsVolatile);
 }
 
@@ -2603,14 +2615,12 @@ public:
 } // namespace
 
 ErrorOr<std::unique_ptr<MemoryBuffer>> File::getSliceBuffer(const Twine &Name,
-                                                            int64_t Offset,
-                                                            int64_t Count,
+                                                            uint64_t Offset,
+                                                            uint64_t Count,
                                                             bool IsVolatile) {
   auto BuffOrError = getBuffer(Name, -1, false, IsVolatile);
   if (!BuffOrError)
     return BuffOrError.getError();
-  assert(Offset >= 0 && "Negative Offset");
-  assert(Count >= 0 && "Negative Count");
   StringRef Bytes = (*BuffOrError)->getBuffer();
   Bytes = Bytes.drop_front(Offset);
   Bytes = Bytes.take_front(Count);

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -126,6 +126,16 @@ FileSystem::getBufferForFile(const llvm::Twine &Name, int64_t FileSize,
   return (*F)->getBuffer(Name, FileSize, RequiresNullTerminator, IsVolatile);
 }
 
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+FileSystem::getSliceBufferForFile(const Twine &Name, int64_t Offset,
+                                  int64_t Count, bool IsVolatile, bool IsText) {
+  auto F = IsText ? openFileForRead(Name) : openFileForReadBinary(Name);
+  if (!F)
+    return F.getError();
+
+  return (*F)->getSliceBuffer(Name, Offset, Count, IsVolatile);
+}
+
 std::error_code FileSystem::makeAbsolute(SmallVectorImpl<char> &Path) const {
   if (llvm::sys::path::is_absolute(Path))
     return {};
@@ -211,6 +221,11 @@ public:
                                                    int64_t FileSize,
                                                    bool RequiresNullTerminator,
                                                    bool IsVolatile) override;
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>>
+  getSliceBuffer(const Twine &Name, int64_t Offset, int64_t Count,
+                 bool IsVolatile) override;
+
   std::error_code close() override;
   void setPath(const Twine &Path) override;
 };
@@ -244,6 +259,15 @@ RealFile::getBuffer(const Twine &Name, int64_t FileSize,
   assert(FD != kInvalidFile && "cannot get buffer for closed file");
   return MemoryBuffer::getOpenFile(FD, Name, FileSize, RequiresNullTerminator,
                                    IsVolatile);
+}
+
+ErrorOr<std::unique_ptr<MemoryBuffer>>
+RealFile::getSliceBuffer(const Twine &Name, int64_t Offset, int64_t Count,
+                         bool IsVolatile) {
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
+  assert(FD != kInvalidFile && "cannot get buffer for closed file");
+  return MemoryBuffer::getOpenFileSlice(FD, Name, Count, Offset, IsVolatile);
 }
 
 std::error_code RealFile::close() {
@@ -2578,6 +2602,20 @@ public:
 
 } // namespace
 
+ErrorOr<std::unique_ptr<MemoryBuffer>> File::getSliceBuffer(const Twine &Name,
+                                                            int64_t Offset,
+                                                            int64_t Count,
+                                                            bool IsVolatile) {
+  auto BuffOrError = getBuffer(Name, -1, false, IsVolatile);
+  if (!BuffOrError)
+    return BuffOrError.getError();
+  assert(Offset >= 0 && "Negative Offset");
+  assert(Count >= 0 && "Negative Count");
+  StringRef Bytes = (*BuffOrError)->getBuffer();
+  Bytes = Bytes.drop_front(Offset);
+  Bytes = Bytes.take_front(Count);
+  return MemoryBuffer::getMemBufferCopy(Bytes, Name);
+}
 ErrorOr<std::unique_ptr<File>>
 File::getWithPath(ErrorOr<std::unique_ptr<File>> Result, const Twine &P) {
   // See \c getRedirectedFileStatus - don't update path if it's exposing an


### PR DESCRIPTION
Each .incbin directive previously called SourceMgr::AddIncludeFile, which
retains the buffer in memory for long time, thus increasing the memory usage.

Introduced SourceMgr::OpenSliceIncludeFile and related helper functions
which only allocates required amount of data for the incbin file and
gets cleared when the processIncbinFile function moves out of scope.

Measured on a stress test of 1000 .incbin directives against a 1 MB blob:

| Result |  Max resident set size |
| --- | --- |
| Before  | ~1.04 GB   |
| After     |  ~13.5 MB |

- Fixes #62339