### PR TITLE
[libcxx] Remove TODO related to dead_on_return

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1184,9 +1184,6 @@ public:
   }
 #  endif // _LIBCPP_CXX03_LANG
 
-  // TODO(boomanaiden154): Once we mark this in destructors as dead on return,
-  // we can use a normal call to __reset_internal_buffer and remove the extra
-  // __rep constructor.
   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 ~basic_string() { __reset_internal_buffer(__rep(__uninitialized_tag())); }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 operator __self_view() const _NOEXCEPT {


### PR DESCRIPTION
dead_on_return is now implemented, so remove the TODO. Still reset the buffer with __uninitialized_tag however, as it does not seem to have any adverse effects and caught something like 10-20 use-after-destroys when using msan in our internal code base.