### PR TITLE
Revert "[sanitizer] Fix race condition in GetNamedMappingFd with decorate_pro…"

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
@@ -357,9 +357,9 @@ int GetNamedMappingFd(const char *name, uptr size, int *flags) {
   if (!common_flags()->decorate_proc_maps || !name)
     return -1;
   char shmname[200];
-  int len = internal_snprintf(shmname, sizeof(shmname), "/dev/shm/%zu.%zu [%s]",
-                              internal_getpid(), GetTid(), name);
-  CHECK_LT(len, sizeof(shmname));
+  CHECK(internal_strlen(name) < sizeof(shmname) - 10);
+  internal_snprintf(shmname, sizeof(shmname), "/dev/shm/%zu [%s]",
+                    internal_getpid(), name);
   int o_cloexec = 0;
 #if defined(O_CLOEXEC)
   o_cloexec = O_CLOEXEC;


### PR DESCRIPTION
Reverts llvm/llvm-project#190981 due to buildbot failure (https://lab.llvm.org/buildbot/#/builders/66/builds/29993):
```
  SanitizerCommon-asan-i386-Linux :: Linux/decorate_proc_maps.cpp
```
