### PR TITLE
[MLIR][OpenMP] Post-translate declare-target USM indirection in OpenMPIRBuilder

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -539,6 +539,26 @@ public:
   /// used in the OpenMPIRBuilder generated from OMPKinds.def.
   LLVM_ABI void initialize();
 
+  SmallVector<std::pair<GlobalVariable *, GlobalVariable *>>
+      declareTargetUsmRefPtrPairs;
+
+  /// Replaces all uses of `origGV` with a load from `refPtrGV`.
+  /// This is used for OpenMP `declare target` global variables mapped under
+  /// Unified Shared Memory (USM) where access is routed through a reference
+  /// pointer.
+  Error rewriteDeclareTargetGlobalUsesWithRefPtr(GlobalVariable *origGV,
+                                                 GlobalVariable *refPtrGV);
+
+  /// Registers a mapping between an original `declare target` global variable
+  /// and the corresponding reference pointer global variable generated for
+  /// Unified Shared Memory (USM).
+  void addDeclareTargetUsmRefPair(GlobalVariable *orig, GlobalVariable *refPtr);
+
+  /// Rewrites the uses of all `declare target` global variables registered via
+  /// `addDeclareTargetUsmRefPair` to use their corresponding USM reference
+  /// pointers. This pass is executed at the end of the module translation.
+  Error finalizeDeclareTargetUsmIndirectLoads();
+
   void setConfig(OpenMPIRBuilderConfig C) { Config = C; }
 
   /// Finalize the underlying module, e.g., by outlining regions.

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -837,6 +837,71 @@ CallInst *OpenMPIRBuilder::createRuntimeFunctionCall(FunctionCallee Callee,
   return Call;
 }
 
+void OpenMPIRBuilder::addDeclareTargetUsmRefPair(GlobalVariable *orig,
+                                                 GlobalVariable *refPtr) {
+  declareTargetUsmRefPtrPairs.emplace_back(orig, refPtr);
+}
+
+Error OpenMPIRBuilder::rewriteDeclareTargetGlobalUsesWithRefPtr(
+    GlobalVariable *origGV, GlobalVariable *refPtrGV) {
+  auto replaceUsesWithRefLoad = [refPtrGV](Instruction *inst, Value *replaced) {
+    IRBuilder<> b(inst);
+    Value *rep =
+        b.CreateLoad(refPtrGV->getValueType(), refPtrGV, "decltgt.ref");
+    if (rep->getType() != replaced->getType())
+      rep = b.CreatePointerBitCastOrAddrSpaceCast(rep, replaced->getType(),
+                                                  "decltgt.as");
+    inst->replaceUsesOfWith(replaced, rep);
+  };
+
+  SmallSetVector<User *, 8> users;
+  for (User *u : origGV->users())
+    users.insert(u);
+
+  for (User *u : users) {
+    if (auto *ce = dyn_cast<ConstantExpr>(u)) {
+      const bool isPointerCast =
+          ce->getOpcode() == Instruction::AddrSpaceCast ||
+          (ce->getOpcode() == Instruction::BitCast &&
+           ce->getType()->isPointerTy());
+
+      if (ce->getOperand(0) != origGV || !isPointerCast)
+        continue;
+
+      SmallVector<User *, 8> instUsers;
+      for (User *ceUser : ce->users())
+        if (isa<Instruction>(ceUser))
+          instUsers.push_back(ceUser);
+
+      for (User *ceUser : instUsers) {
+        auto *inst = cast<Instruction>(ceUser);
+        replaceUsesWithRefLoad(inst, ce);
+      }
+
+      if (ce->use_empty())
+        ce->destroyConstant();
+    } else if (auto *insn = dyn_cast<Instruction>(u)) {
+      replaceUsesWithRefLoad(insn, origGV);
+    }
+  }
+
+  if (!origGV->use_empty())
+    return createStringError(inconvertibleErrorCode(),
+                             "expected all uses of '%s' to be replaced",
+                             origGV->getName().str().c_str());
+
+  return Error::success();
+}
+
+Error OpenMPIRBuilder::finalizeDeclareTargetUsmIndirectLoads() {
+  if (!Config.isTargetDevice() || declareTargetUsmRefPtrPairs.empty())
+    return Error::success();
+  for (auto [orig, ref] : declareTargetUsmRefPtrPairs)
+    if (Error Err = rewriteDeclareTargetGlobalUsesWithRefPtr(orig, ref))
+      return Err;
+  return Error::success();
+}
+
 void OpenMPIRBuilder::initialize() { initializeTypes(M); }
 
 static void raiseUserConstantDataAllocasToEntryBlock(IRBuilderBase &Builder,
@@ -1035,6 +1100,9 @@ void OpenMPIRBuilder::finalize(Function *Fn) {
         M.getGlobalVariable("__openmp_nvptx_data_transfer_temporary_storage")};
     emitUsed("llvm.compiler.used", LLVMCompilerUsed);
   }
+
+  if (Error Err = finalizeDeclareTargetUsmIndirectLoads())
+    report_fatal_error(std::move(Err));
 
   IsFinalized = true;
 }

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -1399,6 +1399,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelForwardAsPointers) {
 TEST_F(OpenMPIRBuilderTest, CanonicalLoopSimple) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   IRBuilder<> Builder(BB);
   OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
@@ -1456,6 +1457,7 @@ TEST_F(OpenMPIRBuilderTest, CanonicalLoopSimple) {
 
 TEST_F(OpenMPIRBuilderTest, CanonicalLoopTripCount) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   IRBuilder<> Builder(BB);
 
@@ -1525,6 +1527,7 @@ TEST_F(OpenMPIRBuilderTest, CanonicalLoopTripCount) {
 TEST_F(OpenMPIRBuilderTest, CollapseNestedLoops) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
 
@@ -1623,6 +1626,7 @@ TEST_F(OpenMPIRBuilderTest, CollapseNestedLoops) {
 
 TEST_F(OpenMPIRBuilderTest, TileSingleLoop) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   CallInst *Call;
   BasicBlock *BodyCode;
   CanonicalLoopInfo *Loop =
@@ -1668,6 +1672,7 @@ TEST_F(OpenMPIRBuilderTest, TileSingleLoop) {
 TEST_F(OpenMPIRBuilderTest, TileNestedLoops) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
 
@@ -1757,6 +1762,7 @@ TEST_F(OpenMPIRBuilderTest, TileNestedLoops) {
 TEST_F(OpenMPIRBuilderTest, TileNestedLoopsWithBounds) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
 
@@ -1893,6 +1899,7 @@ TEST_F(OpenMPIRBuilderTest, TileNestedLoopsWithBounds) {
 TEST_F(OpenMPIRBuilderTest, TileSingleLoopCounts) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   IRBuilder<> Builder(BB);
 
@@ -1982,6 +1989,7 @@ TEST_F(OpenMPIRBuilderTest, TileSingleLoopCounts) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySimd) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   MapVector<Value *, Value *> AlignedVars;
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
   ASSERT_NE(CLI, nullptr);
@@ -2017,6 +2025,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimd) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySimdCustomAligned) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   IRBuilder<> Builder(BB);
   const int AlignmentValue = 32;
   llvm::BasicBlock *sourceBlock = Builder.GetInsertBlock();
@@ -2080,6 +2089,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdCustomAligned) {
 }
 TEST_F(OpenMPIRBuilderTest, ApplySimdlen) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   MapVector<Value *, Value *> AlignedVars;
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
   ASSERT_NE(CLI, nullptr);
@@ -2116,6 +2126,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdlen) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySafelenOrderConcurrent) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   MapVector<Value *, Value *> AlignedVars;
 
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
@@ -2154,6 +2165,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySafelenOrderConcurrent) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySafelen) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   MapVector<Value *, Value *> AlignedVars;
 
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
@@ -2189,6 +2201,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySafelen) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySimdlenSafelen) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   MapVector<Value *, Value *> AlignedVars;
 
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
@@ -2225,6 +2238,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdlenSafelen) {
 
 TEST_F(OpenMPIRBuilderTest, ApplySimdIf) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   IRBuilder<> Builder(BB);
   MapVector<Value *, Value *> AlignedVars;
   AllocaInst *Alloc1 = Builder.CreateAlloca(Builder.getInt32Ty());
@@ -2288,6 +2302,7 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdIf) {
 
 TEST_F(OpenMPIRBuilderTest, UnrollLoopFull) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
 
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
   ASSERT_NE(CLI, nullptr);
@@ -2313,6 +2328,7 @@ TEST_F(OpenMPIRBuilderTest, UnrollLoopFull) {
 
 TEST_F(OpenMPIRBuilderTest, UnrollLoopPartial) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
   ASSERT_NE(CLI, nullptr);
 
@@ -2347,6 +2363,7 @@ TEST_F(OpenMPIRBuilderTest, UnrollLoopPartial) {
 
 TEST_F(OpenMPIRBuilderTest, UnrollLoopHeuristic) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
 
   CanonicalLoopInfo *CLI = buildSingleLoopFunction(DL, OMPBuilder, 32);
   ASSERT_NE(CLI, nullptr);
@@ -3124,6 +3141,7 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
 TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSource) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3209,6 +3227,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSource) {
 TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSink) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3294,6 +3313,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSink) {
 TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3371,6 +3391,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
 TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3812,6 +3833,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicReadFlt) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3855,6 +3877,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicReadFlt) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicReadInt) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3906,6 +3929,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicReadInt) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicWriteFlt) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3943,6 +3967,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicWriteFlt) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicWriteInt) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -3986,6 +4011,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicWriteInt) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdate) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4055,6 +4081,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdate) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateFloat) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4123,6 +4150,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateFloat) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateIntr) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4192,6 +4220,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateIntr) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicCapture) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4244,6 +4273,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCapture) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicCompare) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4304,6 +4334,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompare) {
 
 TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -4553,6 +4584,7 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicRWStructType) {
   // Test for issue #165184: atomic read/write on struct types should use
   // element type size, not pointer size.
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -7943,6 +7975,7 @@ TEST_F(OpenMPIRBuilderTest, CreateIteratorLoopInvalidLoopBody) {
 TEST_F(OpenMPIRBuilderTest, CreateTaskgroup) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -8379,6 +8412,7 @@ TEST_F(OpenMPIRBuilderTest, EmitOffloadingArraysNonContigCountExpression) {
 TEST_F(OpenMPIRBuilderTest, ScopeDirective) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
@@ -8427,6 +8461,7 @@ TEST_F(OpenMPIRBuilderTest, ScopeDirective) {
 TEST_F(OpenMPIRBuilderTest, ScopeDirectiveNowait) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.Config.IsTargetDevice = false;
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -31,6 +31,8 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/ReplaceConstant.h"
@@ -7682,12 +7684,18 @@ convertDeclareTargetAttr(Operation *op, mlir::omp::DeclareTargetAttr attribute,
           (attribute.getCaptureClause().getValue() !=
                mlir::omp::DeclareTargetCaptureClause::to ||
            ompBuilder->Config.hasRequiresUnifiedSharedMemory())) {
-        ompBuilder->getAddrOfDeclareTargetVar(
+        llvm::Type *ptrTy = gVal->getType();
+        if (ompBuilder->Config.hasRequiresUnifiedSharedMemory())
+          ptrTy = llvm::PointerType::get(llvmModule->getContext(), 0);
+        llvm::Constant *refPtrConst = ompBuilder->getAddrOfDeclareTargetVar(
             captureClause, deviceClause, isDeclaration, isExternallyVisible,
             ompBuilder->getTargetEntryUniqueInfo(fileInfoCallBack, *vfs),
             mangledName, generatedRefs, /*OpenMPSimd*/ false, targetTriple,
-            gVal->getType(), /*GlobalInitializer*/ nullptr,
-            /*VariableLinkage*/ nullptr);
+            ptrTy, /*GlobalInitializer*/ nullptr, /*VariableLinkage*/ nullptr);
+        if (auto *origGV = llvm::dyn_cast<llvm::GlobalVariable>(gVal))
+          if (auto *refPtrGV =
+                  llvm::dyn_cast_or_null<llvm::GlobalVariable>(refPtrConst))
+            ompBuilder->addDeclareTargetUsmRefPair(origGV, refPtrGV);
       }
     }
   }

--- a/mlir/test/Target/LLVMIR/omptarget-declare-target-usm-ref-ptr.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-declare-target-usm-ref-ptr.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// This tests the replacement of uses of a declare target global variable with
+// the unified shared memory (USM) generated reference pointer in an explicit device function.
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_gpu = true, omp.is_target_device = true, omp.requires = #omp<clause_requires unified_shared_memory>} {
+  // CHECK-DAG: @_QMmEnx_vals_decl_tgt_ref_ptr = weak global ptr null, align 8
+  llvm.mlir.global external @_QMmEnx_vals() {addr_space = 1 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link)>} : i32 {
+    %0 = llvm.mlir.zero : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK-LABEL: define void @_QMmPget_dims_noarg(ptr %0)
+  llvm.func @_QMmPget_dims_noarg(%arg0: !llvm.ptr) attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} {
+    // CHECK: %[[REF_LOAD:.*]] = load ptr, ptr @_QMmEnx_vals_decl_tgt_ref_ptr, align 8
+    // CHECK: %[[AS_CAST:.*]] = addrspacecast ptr %[[REF_LOAD]] to ptr addrspace(1)
+    // CHECK: %[[VAL:.*]] = load i32, ptr addrspace(1) %[[AS_CAST]], align 4
+    // CHECK: store i32 %[[VAL]], ptr %0, align 4
+    %0 = llvm.mlir.addressof @_QMmEnx_vals : !llvm.ptr<1>
+    %1 = llvm.load %0 : !llvm.ptr<1> -> i32
+    llvm.store %1, %arg0 : i32, !llvm.ptr
+    llvm.return
+  }
+}

--- a/offload/test/offloading/fortran/declare-target-usm-ref-ptr.f90
+++ b/offload/test/offloading/fortran/declare-target-usm-ref-ptr.f90
@@ -1,0 +1,39 @@
+! Test declare target global replacement with USM reference pointer.
+!
+! REQUIRES: flang, amdgpu
+! RUN: %libomptarget-compile-fortran-generic -fopenmp-force-usm
+! RUN: env LIBOMPTARGET_INFO=16 HSA_XNACK=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
+
+module m
+    implicit none
+    integer :: nx_vals
+    !$omp declare target(nx_vals)
+contains
+    subroutine get_dims_noarg(kv)
+        !$omp declare target
+        integer, intent(out) :: kv
+        kv = nx_vals
+    end subroutine get_dims_noarg
+end module m
+
+program reproducer
+    use m
+    implicit none
+    integer :: kv, kv_debug
+
+    nx_vals = 6
+    !$omp target enter data map(always, to: nx_vals)
+
+    kv_debug = -1
+    !$omp target map(tofrom: kv_debug)
+    call get_dims_noarg(kv)
+    kv_debug = kv
+    !$omp end target
+
+    print *, 'kv_debug after target (host)', kv_debug
+
+    !$omp target exit data map(release: nx_vals)
+end program reproducer
+
+! CHECK: PluginInterface device {{[0-9]+}} info: Launching kernel
+    ! CHECK: kv_debug after target (host) 6


### PR DESCRIPTION
When lowering OpenMP to LLVM IR for the target device, record pairs of the `declare target` device global and the OMPIRBuilder "ref" pointer global (used for unified shared memory) via `OpenMPIRBuilder`. During the `OpenMPIRBuilder::finalize` pass, run a postpass that rewrites remaining uses of the original global to load from the ref global and adjust the pointer (shared path for `ConstantExpr` addrspace/bitcast chains and for direct instruction uses).

This follows what is done by clang for similar cases: https://reviews.llvm.org/D63108.

Co-authored-by: Composer
Co-authored-by: Gemini Pro


PR stack:
- https://github.com/llvm/llvm-project/pull/194287
- https://github.com/llvm/llvm-project/pull/194291 (this one)