### PR TITLE
[X86] Explicitly set `getCmpLibcallReturnType` to i32

### DIFF
--- a/compiler-rt/lib/builtins/fp_compare_impl.inc
+++ b/compiler-rt/lib/builtins/fp_compare_impl.inc
@@ -15,6 +15,11 @@
 #if defined(__aarch64__) || defined(__arm64ec__)
 // AArch64 GCC overrides libgcc_cmp_return to use int instead of long.
 typedef int CMP_RESULT;
+#elif defined(__i386__) || defined(__x86_64__)
+// x86 targets always use an i32 for smaller encoding. Note that as of 2026-04
+// this does not match libgcc, but the needed comparisons to 0 are compatible
+// across sizes.
+typedef int CMP_RESULT;
 #elif defined(__wasm__)
 // Both wasm32 and wasm64 use i32
 typedef int CMP_RESULT;

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -323,6 +323,11 @@ namespace llvm {
     EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
                            EVT VT) const override;
 
+    MVT::SimpleValueType getCmpLibcallReturnType() const override {
+      // 32-bit comparisons have a smaller encoding than 64-bit on x86-64.
+      return MVT::i32;
+    }
+
     bool targetShrinkDemandedConstant(SDValue Op, const APInt &DemandedBits,
                                       const APInt &DemandedElts,
                                       TargetLoweringOpt &TLO) const override;


### PR DESCRIPTION
LLVM's default for `getCmpLibcallReturnType` will be changing from an `i32` to word size. On x86-64, the encoding for `test` and `cmp` operations is two bytes for 32-bit operands but three bytes for 64-bit operands. There is no advantage to using the 64-bit versions here, so override to `i32` to keep saving the extra byte.

Note that GCC does not yet match this behavior [1]. 

[1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125034