### PR TITLE
[llvm-ir2vec] Place IR2Vec Python bindings in the tools/llvm-ir2vec/Bindings build directory

### DIFF
--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -8,6 +8,7 @@ config.llvm_src_root = path(r"@LLVM_SOURCE_DIR@")
 config.llvm_obj_root = path(r"@LLVM_BINARY_DIR@")
 config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
 config.llvm_ir2vec_test_python_bindings = @LLVM_IR2VEC_TEST_PYTHON_BINDINGS@
+config.llvm_ir2vec_bindings_dir = "@LLVM_IR2VEC_BINDINGS_DIR@"
 config.llvm_lib_dir = lit_config.substitute(path(r"@LLVM_LIBS_DIR@"))
 config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
 config.llvm_shlib_ext = "@SHLIBEXT@"

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getBBEmbMap.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmb.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncEmbMap.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getFuncNames.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-getInstEmbMap.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-initEmbedding.py
@@ -1,4 +1,4 @@
-# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+# RUN: env PYTHONPATH=%ir2vec_python_dir %python %s %S/../Inputs/input.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
 
 import sys
 import ir2vec

--- a/llvm/test/tools/llvm-ir2vec/bindings/lit.local.cfg
+++ b/llvm/test/tools/llvm-ir2vec/bindings/lit.local.cfg
@@ -1,9 +1,12 @@
 import sys
+import os
 
 # Only run if user explicitly enabled bindings
 if not config.llvm_ir2vec_test_python_bindings:
     config.unsupported = True
 else:
+    bindings_dir = os.path.join(os.path.dirname(config.llvm_lib_dir),
+                                "tools", "llvm-ir2vec", "Bindings")
     config.substitutions.append(('%python', sys.executable))
-    config.substitutions.append(('%llvm_lib_dir', config.llvm_lib_dir))
+    config.substitutions.append(('%ir2vec_python_dir', bindings_dir))
     config.suffixes = ['.py']

--- a/llvm/test/tools/llvm-ir2vec/bindings/lit.local.cfg
+++ b/llvm/test/tools/llvm-ir2vec/bindings/lit.local.cfg
@@ -1,12 +1,8 @@
 import sys
-import os
 
-# Only run if user explicitly enabled bindings
 if not config.llvm_ir2vec_test_python_bindings:
     config.unsupported = True
 else:
-    bindings_dir = os.path.join(os.path.dirname(config.llvm_lib_dir),
-                                "tools", "llvm-ir2vec", "Bindings")
     config.substitutions.append(('%python', sys.executable))
-    config.substitutions.append(('%ir2vec_python_dir', bindings_dir))
+    config.substitutions.append(('%ir2vec_python_dir', config.llvm_ir2vec_bindings_dir))
     config.suffixes = ['.py']

--- a/llvm/tools/llvm-ir2vec/Bindings/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/Bindings/CMakeLists.txt
@@ -30,6 +30,10 @@ find_package(nanobind CONFIG REQUIRED)
 
 nanobind_add_module(ir2vec MODULE PyIR2Vec.cpp)
 
+set_target_properties(ir2vec PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 # Python bindings require exception handling and RTTI to convert C++ exceptions
 # to Python exceptions. LLVM core is compiled with -fno-exceptions -fno-rtti,
 # but Python bindings are compiled separately with these features enabled.

--- a/llvm/tools/llvm-ir2vec/Bindings/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/Bindings/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(nanobind CONFIG REQUIRED)
 
 nanobind_add_module(ir2vec MODULE PyIR2Vec.cpp)
 
+set(LLVM_IR2VEC_BINDINGS_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERNAL "")
 set_target_properties(ir2vec PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )

--- a/llvm/utils/gn/secondary/llvm/test/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/test/BUILD.gn
@@ -75,6 +75,7 @@ write_lit_config("lit_site_cfg") {
     "LLVM_LINK_LLVM_DYLIB=0",
     "LLVM_LIT_TOOLS_DIR=",  # Intentionally empty, matches cmake build.
     "LLVM_IR2VEC_TEST_PYTHON_BINDINGS=0",
+    "LLVM_IR2VEC_BINDINGS_DIR=",  # GN doesn't build bindings, leave empty
     "LLVM_NATIVE_ARCH=$native_target",
     "LLVM_TOOL_LLVM_DRIVER_BUILD=0",  # FIXME: Add actual support for this.
     "LLVM_USE_INTEL_JITEVENTS=0",


### PR DESCRIPTION
## Place IR2Vec Python bindings `.so` in the Bindings build directory

Without an explicit output directory, CMake places the nanobind extension module
in `<build>/lib/`, alongside unrelated LLVM libraries.

- This change adds `set_target_properties` to redirect the output to
`<build>/tools/llvm-ir2vec/Bindings/`, keeping the Python bindings
isolated within its own tool's build tree. This mirrors MLIR's convention,
where Python extension modules are placed under
`<build>/tools/mlir/python_packages/` rather than the global `lib/`
directory. 


- %llvm_lib_dir was pointing to build-llvm/lib but the .so actually lives at build-llvm/tools/llvm-ir2vec/Bindings/. The tests were silently passing only because the conda env's site-packages had ir2vec installed, masking the broken PYTHONPATH entirely.

- Two changes:
  - `lit.local.cfg` — replaced `%llvm_lib_dir` substitution with `%ir2vec_python_dir` pointing to the correct build output path
  - All 6 test `.py` files — updated the RUN line from `PYTHONPATH=%llvm_lib_dir` to `PYTHONPATH=%ir2vec_python_dir`