### PR TITLE
Update GitHub PR Greeter

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -262,8 +262,8 @@ Hello @{self.author} :wave:
 
 Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is your first PR, here are a few useful links covering our main contribution policies and review practices.
 
-* All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, please add a note to the PR description.
-* The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR
+* All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, remember to add a note to the PR description.
+* The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR.
 * Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, your GitHub settings (see e.g. [Email Addresses](https://llvm.org/docs/DeveloperPolicy.html#email-addresses)) and also includes notes on our CI system.
 
 If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -245,9 +245,10 @@ def get_user_values_str(values: list) -> str:
 class PRGreeter:
     COMMENT_TAG = "<!--LLVM NEW CONTRIBUTOR COMMENT-->\n"
 
-    def __init__(self, token: str, repo: str, pr_number: int):
+    def __init__(self, token: str, repo, pr_number: int):
         repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
         self.pr = repo.get_issue(pr_number).as_pull_request()
+        self.author = self.pr.user
 
     def run(self) -> bool:
         # We assume that this is only called for a PR that has just been opened
@@ -257,19 +258,18 @@ class PRGreeter:
 
         comment = f"""\
 {PRGreeter.COMMENT_TAG}
-Thank you for submitting a Pull Request (PR) to the LLVM Project!
+Hello @{self.author} :wave:
 
-This PR will be automatically labeled and the relevant teams will be notified.
+Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is your first PR, here are a few useful links covering our main contribution policies and review practices.
 
-If you wish to, you can add reviewers by using the "Reviewers" section on this page.
+* All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, please add a note to the PR summary.
+* The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR
+* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit/PR summaries, and also includes information on obtaining commit access.
 
-If this is not working for you, it is probably because you do not have write permissions for the repository. In which case you can instead tag reviewers by name in a comment by using `@` followed by their GitHub username.
+If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).
 
-If you have received no comments on your PR for a week, you can request a review by "ping"ing the PR by adding a comment “Ping”. The common courtesy "ping" rate is once a week. Please remember that you are asking for valuable time from other developers.
-
-If you have further questions, they may be answered by the [LLVM GitHub User Guide](https://llvm.org/docs/GitHub.html).
-
-You can also ask questions in a comment on this PR, on the [LLVM Discord](https://discord.com/invite/xS7Z362) or on the [forums](https://discourse.llvm.org/)."""
+Thank you,
+The LLVM Community"""
         self.pr.as_issue().create_comment(comment)
         return True
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -256,19 +256,7 @@ class PRGreeter:
 
         # This text is using Markdown formatting.
 
-        comment_missing_email = ""
-        if self.author.email is None:
-            comment_missing_email = f"""\
----
-
-It looks like your GitHub email is not public. Before proceeding, please update your settings so that it is public:
-* https://llvm.org/docs/DeveloperPolicy.html#email-addresses
-
----
-"""
-
-        comment = (
-            f"""\
+        comment = f"""\
 {PRGreeter.COMMENT_TAG}
 Hello @{self.author} :wave:
 
@@ -276,14 +264,12 @@ Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is 
 
 * All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, please add a note to the PR description.
 * The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR
-* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, and also includes notes on our CI system.
+* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, your GitHub settings (see e.g. [Email Addresses](https://llvm.org/docs/DeveloperPolicy.html#email-addresses)) and also includes notes on our CI system.
 
-If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/)."""
-            + comment_missing_email
-            + f"""\
+If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).
+
 Thank you,
 The LLVM Community"""
-        )
         self.pr.as_issue().create_comment(comment)
         return True
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -245,7 +245,7 @@ def get_user_values_str(values: list) -> str:
 class PRGreeter:
     COMMENT_TAG = "<!--LLVM NEW CONTRIBUTOR COMMENT-->\n"
 
-    def __init__(self, token: str, repo, pr_number: int):
+    def __init__(self, token: str, repo: str, pr_number: int):
         repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
         self.pr = repo.get_issue(pr_number).as_pull_request()
         self.author = self.pr.user
@@ -256,20 +256,34 @@ class PRGreeter:
 
         # This text is using Markdown formatting.
 
-        comment = f"""\
+        comment_missing_email = ""
+        if self.author.email is None:
+            comment_missing_email = f"""\
+---
+
+It looks like your GitHub email is not public. Before proceeding, please update your settings so that it is public:
+* https://llvm.org/docs/DeveloperPolicy.html#email-addresses
+
+---
+"""
+
+        comment = (
+            f"""\
 {PRGreeter.COMMENT_TAG}
 Hello @{self.author} :wave:
 
 Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is your first PR, here are a few useful links covering our main contribution policies and review practices.
 
-* All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, please add a note to the PR summary.
+* All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, please add a note to the PR description.
 * The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR
-* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit/PR summaries, and also includes information on obtaining commit access.
+* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, and also includes notes on our CI system.
 
-If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).
-
+If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/)."""
+            + comment_missing_email
+            + f"""\
 Thank you,
 The LLVM Community"""
+        )
         self.pr.as_issue().create_comment(comment)
         return True
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -268,6 +268,26 @@ Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is 
 
 Please reply to this message to confirm that you have read these policies, especially the LLVM AI Tool Use Policy, and that any AI tool usage has been noted in the PR description.
 
+---
+
+### Frequently asked questions
+
+**How do I add reviewers?**
+
+This PR will be automatically labeled, and the relevant teams will be notified. For some parts of the project, reviewers may also be added automatically.
+
+You can also add reviewers manually using the **Reviewers** section on this page. If you cannot use that section, it is probably because you do not have write permissions for the repository. In that case, you can request a review by tagging reviewers in a comment using `@` followed by their GitHub username.
+
+**What if there are no comments?**
+
+If you have not received any comments on your PR after a week, you can request a review by pinging the PR with a comment such as “Ping”. The common courtesy ping rate is once a week. Please remember that you are asking for volunteer time from other developers.
+
+**Are any special GitHub settings required to contribute to LLVM?**
+
+We only require contributors to have a public email address associated with their GitHub commits, see this [section](https://llvm.org/docs/DeveloperPolicy.html#email-addresses) of LLVM Developer Policy for details.
+
+---
+
 If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).
 
 Thank you,

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -264,7 +264,7 @@ Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is 
 
 * All contributions to LLVM must follow our [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html). In particular, if you used AI while working on this PR, remember to add a note to the PR description.
 * The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR.
-* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, your GitHub settings (see e.g. [Email Addresses](https://llvm.org/docs/DeveloperPolicy.html#email-addresses)) and also includes notes on our CI system.
+* Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality, commit summaries and contains notes on our CI system.
 
 Please reply to this message to confirm that you have read these policies, especially the LLVM AI Tool Use Policy, and that any AI tool usage has been noted in the PR description.
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -266,6 +266,8 @@ Thank you for submitting a Pull Request (PR) to the LLVM Project. Since this is 
 * The [LLVM Code-Review Policy and Practices](https://llvm.org/docs/CodeReview.html) document contains practical information about the PR process, including how patches are reviewed and accepted, and who can review a PR.
 * Our [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html) describes our expectations for code quality and commit summaries, your GitHub settings (see e.g. [Email Addresses](https://llvm.org/docs/DeveloperPolicy.html#email-addresses)) and also includes notes on our CI system.
 
+Please reply to this message to confirm that you have read these policies, especially the LLVM AI Tool Use Policy, and that any AI tool usage has been noted in the PR description.
+
 If you have questions, feel free to leave a comment on this PR, or ask on [LLVM Discord](https://discord.com/invite/xS7Z362) or [LLVM Discourse](https://discourse.llvm.org/).
 
 Thank you,


### PR DESCRIPTION
Following these two discussions:
* https://discourse.llvm.org/t/rfc-mention-our-ai-policy-in-the-greeting-message-for-first-time-contributors/,
* https://discourse.llvm.org/t/concerns-about-influx-of-ai-generated-bug-fixes/,

add a reference to the LLVM AI policy in the GH greeter. 

In addition:
* Update the message to include links to other relevant policies as
  well, since these are often shared during PR review.
* Add FAQ section and move some of the original content there.
* Include a request for people to confirm that they have familiarised themselves with
  the policies.
* Add `Hello @{self.author} 👋` to make the greeting more personal.