### PR TITLE
[VPlan] Tighten m_CanonicalIV()

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -785,10 +785,15 @@ inline auto m_c_LogicalOr(const Op0_t &Op0, const Op1_t &Op1) {
   return m_c_Select(Op0, m_True(), Op1);
 }
 
-inline auto m_CanonicalIV() {
-  // TODO: Don't assume all region values are canonical IVs.
-  return m_Isa<VPRegionValue>();
-}
+/// Match the canonical induction variable (IV) of any loop region.
+struct canonical_iv_match {
+  template <typename ArgTy> bool match(const ArgTy *V) const {
+    const auto *RV = dyn_cast<VPRegionValue>(V);
+    return RV && RV->getDefiningRegion()->getCanonicalIV() == RV;
+  }
+};
+
+inline canonical_iv_match m_CanonicalIV() { return {}; }
 
 template <typename Op0_t, typename Op1_t, typename Op2_t>
 inline auto m_ScalarIVSteps(const Op0_t &Op0, const Op1_t &Op1,

--- a/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
@@ -50,6 +50,21 @@ TEST_F(VPPatternMatchTest, ScalarIVSteps) {
                                             m_Specific(VF))));
 }
 
+TEST_F(VPPatternMatchTest, CanonicalIV) {
+  VPlan &Plan = getPlan();
+  IntegerType *I64Ty = IntegerType::get(C, 64);
+  VPRegionBlock *VPR =
+      Plan.createLoopRegion(I64Ty, DebugLoc::getCompilerGenerated());
+  VPValue *CanIV = VPR->getCanonicalIV();
+
+  using namespace VPlanPatternMatch;
+
+  ASSERT_TRUE(match(CanIV, m_CanonicalIV()));
+
+  VPValue *LiveIn = Plan.getOrAddLiveIn(ConstantInt::get(I64Ty, 1));
+  ASSERT_FALSE(match(LiveIn, m_CanonicalIV()));
+}
+
 TEST_F(VPPatternMatchTest, GetElementPtr) {
   VPlan &Plan = getPlan();
   VPBasicBlock *VPBB = Plan.createVPBasicBlock("entry");

--- a/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
@@ -20,6 +20,7 @@ namespace llvm {
 
 namespace {
 using VPPatternMatchTest = VPlanTestBase;
+using namespace VPlanPatternMatch;
 
 TEST_F(VPPatternMatchTest, ScalarIVSteps) {
   VPlan &Plan = getPlan();
@@ -39,8 +40,6 @@ TEST_F(VPPatternMatchTest, ScalarIVSteps) {
   VPValue *Steps2 = Builder.createScalarIVSteps(Instruction::Add, nullptr,
                                                 CanIV, Inc2, VF, DebugLoc());
 
-  using namespace VPlanPatternMatch;
-
   ASSERT_TRUE(match(Steps, m_ScalarIVSteps(m_Specific(CanIV), m_SpecificInt(1),
                                            m_Specific(VF))));
   ASSERT_FALSE(
@@ -57,12 +56,10 @@ TEST_F(VPPatternMatchTest, CanonicalIV) {
       Plan.createLoopRegion(I64Ty, DebugLoc::getCompilerGenerated());
   VPValue *CanIV = VPR->getCanonicalIV();
 
-  using namespace VPlanPatternMatch;
-
   ASSERT_TRUE(match(CanIV, m_CanonicalIV()));
 
-  VPValue *LiveIn = Plan.getOrAddLiveIn(ConstantInt::get(I64Ty, 1));
-  ASSERT_FALSE(match(LiveIn, m_CanonicalIV()));
+  VPRegionValue OtherRegionValue(I64Ty, DebugLoc::getCompilerGenerated(), VPR);
+  ASSERT_FALSE(match(&OtherRegionValue, m_CanonicalIV()));
 }
 
 TEST_F(VPPatternMatchTest, GetElementPtr) {
@@ -79,7 +76,6 @@ TEST_F(VPPatternMatchTest, GetElementPtr) {
   VPInstruction *PtrAdd = Builder.createPtrAdd(Ptr, One);
   VPInstruction *WidePtrAdd = Builder.createWidePtrAdd(Ptr, Two);
 
-  using namespace VPlanPatternMatch;
   ASSERT_TRUE(
       match(PtrAdd, m_GetElementPtr(m_Specific(Ptr), m_SpecificInt(1))));
   ASSERT_FALSE(


### PR DESCRIPTION
Previously `m_CanonicalIV()` matched any `VPRegionValue`, which was only correct because the canonical IV is the sole `VPRegionValue` today. Going ahead this is not scalable and there may be more `VPRegionValue`. 