### PR TITLE
[Bazel] Add linkopts to adjust for changes in 9ec6788

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4679,6 +4679,13 @@ cc_library(
     srcs = glob(["lib/HTTP/*.cpp"]),
     hdrs = glob(["include/llvm/HTTP/*.h"]),
     includes = ["include"],
+    linkopts = select({
+        "@platforms//os:windows": [
+            "crypt32.lib",
+            "winhttp.lib",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [":Support"],
 )
 


### PR DESCRIPTION
We need to link against crypt32.lib to avoid linker errors on Windows.