### PR TITLE
[libc] Add sys/ucontext.h header

### DIFF
--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -53,6 +53,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types
+    libc.include.sys_ucontext
     libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -481,8 +481,6 @@ if(LIBC_TARGET_ARCHITECTURE STREQUAL "x86_64")
     sys_ucontext
     HDR
       sys/ucontext.h
-    DEPENDS
-      .ucontext
   )
 endif()
 

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -476,6 +476,14 @@ if(LIBC_TARGET_ARCHITECTURE STREQUAL "x86_64")
       .llvm-libc-types.sigset_t
       .llvm-libc-types.stack_t
   )
+
+  add_header(
+    sys_ucontext
+    HDR
+      sys/ucontext.h
+    DEPENDS
+      .ucontext
+  )
 endif()
 
 add_header_macro(

--- a/libc/include/sys/ucontext.h
+++ b/libc/include/sys/ucontext.h
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SYS_UCONTEXT_H
-#define SYS_UCONTEXT_H
+#ifndef LLVM_LIBC_SYS_UCONTEXT_H
+#define LLVM_LIBC_SYS_UCONTEXT_H
 
 #include <ucontext.h>
 
-#endif // SYS_UCONTEXT_H
+#endif // LLVM_LIBC_SYS_UCONTEXT_H

--- a/libc/include/sys/ucontext.h
+++ b/libc/include/sys/ucontext.h
@@ -1,0 +1,14 @@
+//===-- POSIX header sys/ucontext.h ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYS_UCONTEXT_H
+#define SYS_UCONTEXT_H
+
+#include <ucontext.h>
+
+#endif // SYS_UCONTEXT_H


### PR DESCRIPTION
POSIX historically provided <sys/ucontext.h> as an alias for <ucontext.h>. Some software still includes the sys/ path. Added the header as a simple wrapper that includes <ucontext.h>, gated to x86_64 alongside the existing ucontext support.