### PR TITLE
[X86] Fold OR of constant splats into GF2P8AFFINEQB

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -53280,6 +53280,16 @@ static SDValue combineAddOrSubToADCOrSBB(SDNode *N, const SDLoc &DL,
   return SDValue();
 }
 
+/// GF2P8AFFINEQB computes each output bit from one row of the
+/// 8x8 affine matrix, then xors the corresponding immediate bit.
+/// OR-ing the result with a constant byte splat forces selected output
+/// bits to 1, so the original affine result for those bits is irrelevant.
+///
+/// Fold:
+///   gf2p8affineqb(X, Matrix, Imm) | Mask
+/// into:
+///   gf2p8affineqb(X, NewMatrix, Imm | Mask)
+///
 static SDValue combineOrWithGF2P8AFFINEQB(SDNode *N, const SDLoc &DL,
                                           SelectionDAG &DAG, EVT VT) {
   using namespace SDPatternMatch;
@@ -53317,17 +53327,21 @@ static SDValue combineOrWithGF2P8AFFINEQB(SDNode *N, const SDLoc &DL,
 
   uint8_t Mask8 = SplatVal.getZExtValue() & 0xFF;
   uint8_t NewImm = Imm.getZExtValue() | Mask8;
-  SmallVector<SDValue, 64> MaskOps;
+  // For each output bit selected by Mask, clear the corresponding matrix row
+  // and set the same bit in the immediate. Rows are encoded in reverse bit
+  // order within each byte: output bit B corresponds to row 7 - B.
+  SmallVector<SDValue, 64> NewMatrixOps;
   for (unsigned I = 0, E = VT.getVectorNumElements(); I != E; ++I) {
     unsigned OutBit = 7 - (I & 7);
-    uint8_t Keep = ((Mask8 >> OutBit) & 1) ? 0x00 : 0xFF;
-    MaskOps.push_back(DAG.getConstant(Keep, DL, MVT::i8));
+    uint8_t OldRow = OldMatrix[I].getZExtValue();
+    uint8_t NewRow = ((Mask8 >> OutBit) & 1) ? 0x00 : OldRow;
+    NewMatrixOps.push_back(DAG.getConstant(NewRow, DL, MVT::i8));
   }
 
-  SDValue KeepMask = DAG.getBuildVector(VT, DL, MaskOps);
-  SDValue NewMatrix = DAG.getNode(ISD::AND, DL, VT, Matrix, KeepMask);
-  return DAG.getNode(X86ISD::GF2P8AFFINEQB, DL, VT, X, NewMatrix,
-                     DAG.getTargetConstant(NewImm, DL, MVT::i8));
+  SDValue NewMatrix = DAG.getBuildVector(VT, DL, NewMatrixOps);
+  SDValue NewGF = DAG.getNode(X86ISD::GF2P8AFFINEQB, DL, VT, X, NewMatrix,
+                              DAG.getTargetConstant(NewImm, DL, MVT::i8));
+  return NewGF;
 }
 
 static SDValue combineOrXorWithSETCC(unsigned Opc, const SDLoc &DL, EVT VT,

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -53285,28 +53285,49 @@ static SDValue combineOrWithGF2P8AFFINEQB(SDNode *N, const SDLoc &DL,
   using namespace SDPatternMatch;
   assert(N->getOpcode() == ISD::OR && "Expected OR node");
 
-  if (!N->getFlags().hasDisjoint() &&
-      !DAG.haveNoCommonBitsSet(N->getOperand(0), N->getOperand(1)))
+  SDValue LHS = N->getOperand(0), RHS = N->getOperand(1);
+
+  SDValue X, Matrix, SplatOp;
+  APInt Imm;
+  if (!sd_match(N, m_Or(m_OneUse(m_TernaryOp(X86ISD::GF2P8AFFINEQB, m_Value(X),
+                                             m_Value(Matrix), m_ConstInt(Imm))),
+                        m_Value(SplatOp))))
     return SDValue();
 
-  SDValue X, Y, SplatOp;
-  APInt Imm, SplatVal;
+  APInt SplatVal;
+  if (!X86::isConstantSplat(SplatOp, SplatVal, /*AllowPartialUndefs=*/false))
+    return SDValue();
 
-  // Fold: (GF2P8AFFINEQB(X, Y, Imm) or_disjoint SplatVal)
-  //     -> GF2P8AFFINEQB(X, Y, Imm ^ SplatVal)
-  // When OR is disjoint (no common bits), the splat constant can be folded
-  //  directly into the GF2P8AFFINEQB immediate via XOR.
-
-  if (sd_match(N, m_Or(m_OneUse(m_TernaryOp(X86ISD::GF2P8AFFINEQB, m_Value(X),
-                                            m_Value(Y), m_ConstInt(Imm))),
-                       m_Value(SplatOp))) &&
-      X86::isConstantSplat(SplatOp, SplatVal, /*AllowPartialUndefs=*/false)) {
+  if (N->getFlags().hasDisjoint() || DAG.haveNoCommonBitsSet(LHS, RHS)) {
+    // Fold: (GF2P8AFFINEQB(X, Matrix, Imm) or_disjoint SplatVal)
+    //     -> GF2P8AFFINEQB(X, Matrix, Imm ^ SplatVal)
+    // When OR is disjoint (no common bits), the splat constant can be folded
+    // directly into the GF2P8AFFINEQB immediate via XOR.
     uint64_t NewImm = (Imm.getZExtValue() ^ SplatVal.getZExtValue()) & 0xFF;
-    return DAG.getNode(X86ISD::GF2P8AFFINEQB, DL, VT, X, Y,
+    return DAG.getNode(X86ISD::GF2P8AFFINEQB, DL, VT, X, Matrix,
                        DAG.getTargetConstant(NewImm, DL, MVT::i8));
   }
 
-  return SDValue();
+  APInt UndefElts;
+  SmallVector<APInt, 16> OldMatrix;
+  if (!getTargetConstantBitsFromNode(Matrix, 8, UndefElts, OldMatrix,
+                                     /*AllowWholeUndefs=*/false,
+                                     /*AllowPartialUndefs=*/false))
+    return SDValue();
+
+  uint8_t Mask8 = SplatVal.getZExtValue() & 0xFF;
+  uint8_t NewImm = Imm.getZExtValue() | Mask8;
+  SmallVector<SDValue, 64> MaskOps;
+  for (unsigned I = 0, E = VT.getVectorNumElements(); I != E; ++I) {
+    unsigned OutBit = 7 - (I & 7);
+    uint8_t Keep = ((Mask8 >> OutBit) & 1) ? 0x00 : 0xFF;
+    MaskOps.push_back(DAG.getConstant(Keep, DL, MVT::i8));
+  }
+
+  SDValue KeepMask = DAG.getBuildVector(VT, DL, MaskOps);
+  SDValue NewMatrix = DAG.getNode(ISD::AND, DL, VT, Matrix, KeepMask);
+  return DAG.getNode(X86ISD::GF2P8AFFINEQB, DL, VT, X, NewMatrix,
+                     DAG.getTargetConstant(NewImm, DL, MVT::i8));
 }
 
 static SDValue combineOrXorWithSETCC(unsigned Opc, const SDLoc &DL, EVT VT,
@@ -53514,6 +53535,9 @@ static SDValue combineOr(SDNode *N, SelectionDAG &DAG,
   }
 
   if (SDValue R = combineOrXorWithSETCC(N->getOpcode(), dl, VT, N0, N1, DAG))
+    return R;
+
+  if (SDValue R = combineOrWithGF2P8AFFINEQB(N, dl, DAG, VT))
     return R;
 
   return SDValue();

--- a/llvm/test/CodeGen/X86/gfni-or-fold.ll
+++ b/llvm/test/CodeGen/X86/gfni-or-fold.ll
@@ -2,6 +2,7 @@
 ; RUN: llc < %s -mtriple=x86_64-- -mattr=+avx512bw,+avx512f,+gfni | FileCheck %s --check-prefixes=AVX512
 
 declare <64 x i8> @llvm.x86.vgf2p8affineqb.512(<64 x i8>, <64 x i8>, i8)
+declare <32 x i8> @llvm.x86.vgf2p8affineqb.256(<32 x i8>, <32 x i8>, i8)
 declare <16 x i8> @llvm.x86.vgf2p8affineqb.128(<16 x i8>, <16 x i8>, i8)
 
 define <64 x i8> @test_or_disjoint_fold_512(<64 x i8> %src, <64 x i8> %matrix) nounwind {
@@ -80,43 +81,31 @@ define <64 x i8> @test_or_disjoint_overlap_with_imm(<64 x i8> %src, <64 x i8> %m
   ret <64 x i8> %or
 }
 
+
 define <16 x i8> @test_affine_or_fold_v16i8(<16 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v16i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $87, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [17,0,53,0,89,0,125,0,2,0,38,0,74,0,110,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
       <16 x i8> %a,
-      <16 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <16 x i8> %gf, splat(i8 15)
+      <16 x i8> <i8 17, i8 35, i8 53, i8 71, i8 89, i8 107, i8 125, i8 -113,
+                 i8 2, i8 20, i8 38, i8 56, i8 74, i8 92, i8 110, i8 -128>,
+      i8 18)
+  %or = or <16 x i8> %gf, splat(i8 85)
   ret <16 x i8> %or
 }
 
-define <16 x i8> @test_affine_or_fold_v16i8_commuted(<16 x i8> %a) {
-; AVX512-LABEL: test_affine_or_fold_v16i8_commuted:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
-; AVX512-NEXT:    retq
-  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
-      <16 x i8> %a,
-      <16 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <16 x i8> splat(i8 15), %gf
-  ret <16 x i8> %or
-}
 
 define <16 x i8> @test_affine_or_fold_v16i8_mask33(<16 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v16i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,0,0,24,129,0,0,109,146,0,0,66,189,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
       <16 x i8> %a,
       <16 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+                 i8 109, i8 -110, i8 36, i8 -37, i8 66, i8 -67, i8 -103, i8 102>,
       i8 0)
   %or = or <16 x i8> %gf, splat(i8 51)
   ret <16 x i8> %or
@@ -126,46 +115,31 @@ define <16 x i8> @test_affine_or_fold_v16i8_mask33(<16 x i8> %a) {
 define <32 x i8> @test_affine_or_fold_v32i8(<32 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $162, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [0,2,52,86,120,154,188,222,0,240,30,225,45,210,60,195,0,85,102,119,136,153,170,187,0,87,155,223,36,104,172,224]
 ; AVX512-NEXT:    retq
   %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
       <32 x i8> %a,
-      <32 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <32 x i8> %gf, splat (i8 15)
+      <32 x i8> <i8 -127, i8 2, i8 52, i8 86, i8 120, i8 -102, i8 -68, i8 -34,
+                 i8 15, i8 -16, i8 30, i8 -31, i8 45, i8 -46, i8 60, i8 -61,
+                 i8 68, i8 85, i8 102, i8 119, i8 -120, i8 -103, i8 -86, i8 -69,
+                 i8 19, i8 87, i8 -101, i8 -33, i8 36, i8 104, i8 -84, i8 -32>,
+      i8 34)
+  %or = or <32 x i8> %gf, splat(i8 -128)
   ret <32 x i8> %or
 }
 
-define <32 x i8> @test_affine_or_fold_v32i8_commuted(<32 x i8> %a) {
-; AVX512-LABEL: test_affine_or_fold_v32i8_commuted:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
-; AVX512-NEXT:    retq
-  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
-      <32 x i8> %a,
-      <32 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <32 x i8> splat (i8 15), %gf
-  ret <32 x i8> %or
-}
 
 define <32 x i8> @test_affine_or_fold_v32i8_mask33(<32 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v32i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,0,0,24,129,0,0,109,146,0,0,66,189,0,0,16,50,0,0,152,186,0,0,239,205,0,0,103,69,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
       <32 x i8> %a,
       <32 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+                 i8 109, i8 -110, i8 36, i8 -37, i8 66, i8 -67, i8 -103, i8 102,
+                 i8 16, i8 50, i8 84, i8 118, i8 -104, i8 -70, i8 -36, i8 -2,
+                 i8 -17, i8 -51, i8 -85, i8 -119, i8 103, i8 69, i8 35, i8 1>,
       i8 0)
   %or = or <32 x i8> %gf, splat(i8 51)
   ret <32 x i8> %or
@@ -175,58 +149,39 @@ define <32 x i8> @test_affine_or_fold_v32i8_mask33(<32 x i8> %a) {
 define <64 x i8> @test_affine_or_fold_512_v64i8(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_512_v64i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $170, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %zmm0, %zmm0 # [0,35,0,103,0,171,0,239,0,50,0,118,0,186,0,254,0,165,0,195,0,129,0,1,0,146,0,219,0,189,0,102,0,240,0,225,0,210,0,195,0,87,0,223,0,104,0,224,0,127,0,191,0,223,0,239,0,85,0,51,0,15,0,102]
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
       <64 x i8> %a,
-      <64 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <64 x i8> %gf, splat(i8 15)
+      <64 x i8> <i8 1, i8 35, i8 69, i8 103, i8 -119, i8 -85, i8 -51, i8 -17,
+                 i8 16, i8 50, i8 84, i8 118, i8 -104, i8 -70, i8 -36, i8 -2,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 109, i8 -110, i8 36, i8 -37, i8 66, i8 -67, i8 -103, i8 102,
+                 i8 15, i8 -16, i8 30, i8 -31, i8 45, i8 -46, i8 60, i8 -61,
+                 i8 19, i8 87, i8 -101, i8 -33, i8 36, i8 104, i8 -84, i8 -32,
+                 i8 -128, i8 127, i8 64, i8 -65, i8 32, i8 -33, i8 16, i8 -17,
+                 i8 -86, i8 85, i8 -52, i8 51, i8 -16, i8 15, i8 -103, i8 102>,
+      i8 10)
+  %or = or <64 x i8> %gf, splat(i8 -86)
   ret <64 x i8> %or
 }
 
-define <64 x i8> @test_affine_or_fold_512_v64i8_commuted(<64 x i8> %a) {
-; AVX512-LABEL: test_affine_or_fold_512_v64i8_commuted:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
-; AVX512-NEXT:    retq
-  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
-      <64 x i8> %a,
-      <64 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
-                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
-      i8 0)
-  %or = or <64 x i8> splat (i8 15), %gf
-  ret <64 x i8> %or
-}
 
 define dso_local <64 x i8> @test_affine_or_fold_v64i8_mask33(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v64i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %zmm0, %zmm0 # [90,165,0,0,24,129,0,0,109,146,0,0,66,189,0,0,16,50,0,0,152,186,0,0,239,205,0,0,103,69,0,0,129,2,0,0,120,154,0,0,15,240,0,0,45,210,0,0,68,85,0,0,136,153,0,0,19,87,0,0,36,104,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
       <64 x i8> %a,
       <64 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
-                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+                 i8 109, i8 -110, i8 36, i8 -37, i8 66, i8 -67, i8 -103, i8 102,
+                 i8 16, i8 50, i8 84, i8 118, i8 -104, i8 -70, i8 -36, i8 -2,
+                 i8 -17, i8 -51, i8 -85, i8 -119, i8 103, i8 69, i8 35, i8 1,
+                 i8 -127, i8 2, i8 52, i8 86, i8 120, i8 -102, i8 -68, i8 -34,
+                 i8 15, i8 -16, i8 30, i8 -31, i8 45, i8 -46, i8 60, i8 -61,
+                 i8 68, i8 85, i8 102, i8 119, i8 -120, i8 -103, i8 -86, i8 -69,
+                 i8 19, i8 87, i8 -101, i8 -33, i8 36, i8 104, i8 -84, i8 -32>,
       i8 0)
   %or = or <64 x i8> %gf, splat(i8 51)
   ret <64 x i8> %or

--- a/llvm/test/CodeGen/X86/gfni-or-fold.ll
+++ b/llvm/test/CodeGen/X86/gfni-or-fold.ll
@@ -79,3 +79,276 @@ define <64 x i8> @test_or_disjoint_overlap_with_imm(<64 x i8> %src, <64 x i8> %m
   %or = or disjoint <64 x i8> %gfni, splat(i8 8)
   ret <64 x i8> %or
 }
+
+define <16 x i8> @test_affine_or_fold_v16i8(<16 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v16i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
+      <16 x i8> %a,
+      <16 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <16 x i8> %gf, splat(i8 15)
+  ret <16 x i8> %or
+}
+
+define <16 x i8> @test_affine_or_fold_v16i8_commuted(<16 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v16i8_commuted:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
+      <16 x i8> %a,
+      <16 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <16 x i8> splat(i8 15), %gf
+  ret <16 x i8> %or
+}
+
+define <16 x i8> @test_affine_or_fold_v16i8_mask33(<16 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v16i8_mask33:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
+      <16 x i8> %a,
+      <16 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <16 x i8> %gf, splat(i8 51)
+  ret <16 x i8> %or
+}
+
+
+define <32 x i8> @test_affine_or_fold_v32i8(<32 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v32i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    retq
+  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
+      <32 x i8> %a,
+      <32 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <32 x i8> %gf, splat (i8 15)
+  ret <32 x i8> %or
+}
+
+define <32 x i8> @test_affine_or_fold_v32i8_commuted(<32 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v32i8_commuted:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    retq
+  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
+      <32 x i8> %a,
+      <32 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <32 x i8> splat (i8 15), %gf
+  ret <32 x i8> %or
+}
+
+define <32 x i8> @test_affine_or_fold_v32i8_mask33(<32 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v32i8_mask33:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    retq
+  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
+      <32 x i8> %a,
+      <32 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <32 x i8> %gf, splat(i8 51)
+  ret <32 x i8> %or
+}
+
+
+define <64 x i8> @test_affine_or_fold_512_v64i8(<64 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_512_v64i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
+; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
+      <64 x i8> %a,
+      <64 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <64 x i8> %gf, splat(i8 15)
+  ret <64 x i8> %or
+}
+
+define <64 x i8> @test_affine_or_fold_512_v64i8_commuted(<64 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_512_v64i8_commuted:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
+; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
+      <64 x i8> %a,
+      <64 x i8> <i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128,
+                 i8 1, i8 2, i8 4, i8 8, i8 16, i8 32, i8 64, i8 -128>,
+      i8 0)
+  %or = or <64 x i8> splat (i8 15), %gf
+  ret <64 x i8> %or
+}
+
+define dso_local <64 x i8> @test_affine_or_fold_v64i8_mask33(<64 x i8> %a) {
+; AVX512-LABEL: test_affine_or_fold_v64i8_mask33:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
+; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
+      <64 x i8> %a,
+      <64 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <64 x i8> %gf, splat(i8 51)
+  ret <64 x i8> %or
+}
+
+
+; Negative
+
+define <16 x i8> @test_affine_or_nofold_nonconst_matrix_v16i8(<16 x i8> %a, <16 x i8> %m) {
+; AVX512-LABEL: test_affine_or_nofold_nonconst_matrix_v16i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, %xmm1, %xmm0, %xmm0
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
+      <16 x i8> %a,
+      <16 x i8> %m,
+      i8 0)
+  %or = or <16 x i8> %gf, splat(i8 51)
+  ret <16 x i8> %or
+}
+
+define <32 x i8> @test_affine_or_nofold_nonconst_matrix_v32i8(<32 x i8>  %a, <32 x i8>  %m) {
+; AVX512-LABEL: test_affine_or_nofold_nonconst_matrix_v32i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, %ymm1, %ymm0, %ymm0
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    retq
+  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
+      <32 x i8> %a,
+      <32 x i8> %m,
+      i8 0)
+  %or = or <32 x i8> %gf, splat(i8 51)
+  ret <32 x i8> %or
+}
+
+define <16 x i8> @test_affine_or_nofold_nonsplat_mask_v16i8(<16 x i8>  %a) {
+; AVX512-LABEL: test_affine_or_nofold_nonsplat_mask_v16i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
+      <16 x i8> %a,
+      <16 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <16 x i8> %gf,
+            <i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+             i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 50>
+  ret <16 x i8> %or
+}
+
+define <32 x i8> @test_affine_or_nofold_nonsplat_mask_v32i8(<32 x i8> %a) {
+; AVX512-LABEL: test_affine_or_nofold_nonsplat_mask_v32i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
+; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    retq
+  %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
+      <32 x i8> %a,
+      <32 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <32 x i8> %gf,
+            <i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 50>
+  ret <32 x i8> %or
+}
+
+define <64 x i8> @test_affine_or_nofold_nonconst_matrix_v64i8(<64 x i8> %a, <64 x i8> %m) {
+; AVX512-LABEL: test_affine_or_nofold_nonconst_matrix_v64i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
+      <64 x i8> %a,
+      <64 x i8> %m,
+      i8 0)
+  %or = or <64 x i8> %gf, splat(i8 51)
+  ret <64 x i8> %or
+}
+
+define <64 x i8> @test_affine_or_nofold_nonsplat_mask_v64i8(<64 x i8> %a) {
+; AVX512-LABEL: test_affine_or_nofold_nonsplat_mask_v64i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
+; AVX512-NEXT:    vporq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %zmm0, %zmm0
+; AVX512-NEXT:    retq
+  %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
+      <64 x i8> %a,
+      <64 x i8> <i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1,
+                 i8 90, i8 -91, i8 60, i8 -61, i8 24, i8 -127, i8 126, i8 1>,
+      i8 0)
+  %or = or <64 x i8> %gf,
+            <i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51,
+            i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 51, i8 50>
+  ret <64 x i8> %or
+}

--- a/llvm/test/CodeGen/X86/gfni-or-fold.ll
+++ b/llvm/test/CodeGen/X86/gfni-or-fold.ll
@@ -83,8 +83,7 @@ define <64 x i8> @test_or_disjoint_overlap_with_imm(<64 x i8> %src, <64 x i8> %m
 define <16 x i8> @test_affine_or_fold_v16i8(<16 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v16i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
       <16 x i8> %a,
@@ -98,8 +97,7 @@ define <16 x i8> @test_affine_or_fold_v16i8(<16 x i8> %a) {
 define <16 x i8> @test_affine_or_fold_v16i8_commuted(<16 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v16i8_commuted:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
       <16 x i8> %a,
@@ -113,8 +111,7 @@ define <16 x i8> @test_affine_or_fold_v16i8_commuted(<16 x i8> %a) {
 define <16 x i8> @test_affine_or_fold_v16i8_mask33(<16 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v16i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <16 x i8> @llvm.x86.vgf2p8affineqb.128(
       <16 x i8> %a,
@@ -129,8 +126,7 @@ define <16 x i8> @test_affine_or_fold_v16i8_mask33(<16 x i8> %a) {
 define <32 x i8> @test_affine_or_fold_v32i8(<32 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
       <32 x i8> %a,
@@ -146,8 +142,7 @@ define <32 x i8> @test_affine_or_fold_v32i8(<32 x i8> %a) {
 define <32 x i8> @test_affine_or_fold_v32i8_commuted(<32 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v32i8_commuted:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128,1,2,4,8,16,32,64,128]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
       <32 x i8> %a,
@@ -163,8 +158,7 @@ define <32 x i8> @test_affine_or_fold_v32i8_commuted(<32 x i8> %a) {
 define <32 x i8> @test_affine_or_fold_v32i8_mask33(<32 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v32i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
-; AVX512-NEXT:    vpor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <32 x i8> @llvm.x86.vgf2p8affineqb.256(
       <32 x i8> %a,
@@ -181,8 +175,7 @@ define <32 x i8> @test_affine_or_fold_v32i8_mask33(<32 x i8> %a) {
 define <64 x i8> @test_affine_or_fold_512_v64i8(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_512_v64i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
       <64 x i8> %a,
@@ -202,8 +195,7 @@ define <64 x i8> @test_affine_or_fold_512_v64i8(<64 x i8> %a) {
 define <64 x i8> @test_affine_or_fold_512_v64i8_commuted(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_512_v64i8_commuted:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    vgf2p8affineqb $15, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0,1,2,4,8,0,0,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
       <64 x i8> %a,
@@ -223,8 +215,7 @@ define <64 x i8> @test_affine_or_fold_512_v64i8_commuted(<64 x i8> %a) {
 define dso_local <64 x i8> @test_affine_or_fold_v64i8_mask33(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_fold_v64i8_mask33:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
-; AVX512-NEXT:    vpord {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
+; AVX512-NEXT:    vgf2p8affineqb $51, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0,90,165,0,0,24,129,0,0]
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(
       <64 x i8> %a,
@@ -327,7 +318,7 @@ define <64 x i8> @test_affine_or_nofold_nonconst_matrix_v64i8(<64 x i8> %a, <64 
 define <64 x i8> @test_affine_or_nofold_nonsplat_mask_v64i8(<64 x i8> %a) {
 ; AVX512-LABEL: test_affine_or_nofold_nonsplat_mask_v64i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0
+; AVX512-NEXT:    vgf2p8affineqb $0, {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %zmm0, %zmm0 # [90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1,90,165,60,195,24,129,126,1]
 ; AVX512-NEXT:    vporq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %zmm0, %zmm0
 ; AVX512-NEXT:    retq
   %gf = tail call <64 x i8> @llvm.x86.vgf2p8affineqb.512(


### PR DESCRIPTION
Fold OR of a constant byte splat into X86ISD::GF2P8AFFINEQB when the
affine matrix is known at compile time.

For bits forced to 1 by the OR mask, zero the corresponding matrix rows
(in reverse row order within each 64-bit lane) and set the same bits in
the immediate. This turns:

  gf2p8affineqb(x, M, imm) | C

into:

  gf2p8affineqb(x, M & KeepMask, imm | C)

where KeepMask clears the rows for output bits selected by C.

This removes a separate OR after GF2P8AFFINEQB for constant-matrix cases
and extends the existing GFNI combine coverage beyond XOR folds.

Fixes: https://github.com/llvm/llvm-project/issues/191173