### PR TITLE
[LiveDebugValues] Use std::sort for register sorting in collectIDsForRegs

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -1208,7 +1208,9 @@ void VarLocBasedLDV::collectIDsForRegs(VarLocsInRange &Collected,
   assert(!Regs.empty() && "Nothing to collect");
   SmallVector<Register, 32> SortedRegs;
   append_range(SortedRegs, Regs);
-  array_pod_sort(SortedRegs.begin(), SortedRegs.end());
+  llvm::sort(SortedRegs, [](Register LHS, Register RHS) {
+    return LHS < RHS;
+  });
   auto It = CollectFrom.find(LocIndex::rawIndexForReg(SortedRegs.front()));
   auto End = CollectFrom.end();
   for (Register Reg : SortedRegs) {

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -1208,9 +1208,7 @@ void VarLocBasedLDV::collectIDsForRegs(VarLocsInRange &Collected,
   assert(!Regs.empty() && "Nothing to collect");
   SmallVector<Register, 32> SortedRegs;
   append_range(SortedRegs, Regs);
-  llvm::sort(SortedRegs, [](Register LHS, Register RHS) {
-    return LHS < RHS;
-  });
+  llvm::sort(SortedRegs, [](Register LHS, Register RHS) { return LHS < RHS; });
   auto It = CollectFrom.find(LocIndex::rawIndexForReg(SortedRegs.front()));
   auto End = CollectFrom.end();
   for (Register Reg : SortedRegs) {


### PR DESCRIPTION
`VarLocBasedLDV::collectIDsForRegs` sorts a `SmallVector<Register>` using
array_pod_sort which is a thin wrapper around qsort. That shows up as a hotspot
in compile-time profiles under `__GI___qsort_r`.

Switching this to an explicit-comparator llvm::sort call, which takes the
std::sort path instead improves compile-time with no change to code-size.

CTMark geomean:
- stage1-O0-g: -0.41%
- stage1-aarch64-O0-g: -0.58%
- stage2-O0-g: -0.40%

http://llvm-compile-time-tracker.com/compare.php?from=347aa3f6fbcc48cd752d02aa581b74c33d18dd41&to=cca8df56a576682510733c4c1b6fc12556e2dd7c&stat=instructions%3Au