### PR TITLE
[libc][docs] Add sys/ipc.h POSIX header documentation (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -65,6 +65,7 @@ if (SPHINX_FOUND)
       stdlib
       string
       strings
+      sys/ipc
       sys/mman
       sys/resource
       sys/select

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -33,6 +33,7 @@ Implementation Status
    stdlib
    string
    strings
+   sys/ipc
    sys/mman
    sys/resource
    sys/select

--- a/libc/utils/docgen/sys/ipc.yaml
+++ b/libc/utils/docgen/sys/ipc.yaml
@@ -1,0 +1,19 @@
+functions:
+  ftok:
+    in-latest-posix: ''
+
+macros:
+  IPC_CREAT:
+    in-latest-posix: ''
+  IPC_EXCL:
+    in-latest-posix: ''
+  IPC_NOWAIT:
+    in-latest-posix: ''
+  IPC_PRIVATE:
+    in-latest-posix: ''
+  IPC_RMID:
+    in-latest-posix: ''
+  IPC_SET:
+    in-latest-posix: ''
+  IPC_STAT:
+    in-latest-posix: ''


### PR DESCRIPTION
Add sys/ipc.h implementation-status docs to llvm-libc.