### PR TITLE
[AArch64] Simplify codegen for LRINT.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5184,12 +5184,9 @@ SDValue AArch64TargetLowering::LowerVectorXRINT(SDValue Op,
       *DAG.getContext(), Src.getValueType().getVectorElementType());
 
   // Round the floating-point value into a floating-point register with the
-  // current rounding mode.
+  // current rounding mode and convert to an integer.
   SDValue FOp = DAG.getNode(ISD::FRINT, DL, CastVT, Src);
-
-  // Truncate the rounded floating point to an integer.
-  return DAG.getNode(ISD::FP_TO_SINT_SAT, DL, VT, FOp,
-                     DAG.getValueType(VT.getVectorElementType()));
+  return DAG.getFreeze(DAG.getNode(ISD::FP_TO_SINT, DL, VT, FOp));
 }
 
 SDValue AArch64TargetLowering::LowerVectorINT_TO_FP(SDValue Op,

--- a/llvm/test/CodeGen/AArch64/sve-fixed-vector-llrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-vector-llrint.ll
@@ -34,17 +34,14 @@ define <4 x i64> @llrint_v4i64_v4f16(<4 x half> %x) nounwind {
 ; CHECK-LABEL: llrint_v4i64_v4f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    frintx v0.4h, v0.4h
-; CHECK-NEXT:    mov h1, v0.h[2]
-; CHECK-NEXT:    mov h2, v0.h[3]
-; CHECK-NEXT:    mov h3, v0.h[1]
-; CHECK-NEXT:    fcvtzs x9, h0
-; CHECK-NEXT:    fcvtzs x8, h1
-; CHECK-NEXT:    fcvtzs x10, h2
-; CHECK-NEXT:    fcvtzs x11, h3
-; CHECK-NEXT:    fmov d0, x9
-; CHECK-NEXT:    fmov d1, x8
-; CHECK-NEXT:    mov v0.d[1], x11
-; CHECK-NEXT:    mov v1.d[1], x10
+; CHECK-NEXT:    ptrue p0.d, vl4
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-NEXT:    ret
   %a = call <4 x i64> @llvm.llrint.v4i64.v4f16(<4 x half> %x)
   ret <4 x i64> %a
@@ -56,29 +53,23 @@ define <8 x i64> @llrint_v8i64_v8f16(<8 x half> %x) nounwind {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
 ; CHECK-NEXT:    frintx v0.4h, v0.4h
+; CHECK-NEXT:    ptrue p0.d, vl4
 ; CHECK-NEXT:    frintx v1.4h, v1.4h
-; CHECK-NEXT:    mov h3, v0.h[2]
-; CHECK-NEXT:    mov h4, v0.h[1]
-; CHECK-NEXT:    mov h5, v0.h[3]
-; CHECK-NEXT:    fcvtzs x8, h0
-; CHECK-NEXT:    mov h2, v1.h[2]
-; CHECK-NEXT:    mov h6, v1.h[3]
-; CHECK-NEXT:    mov h7, v1.h[1]
-; CHECK-NEXT:    fcvtzs x10, h1
-; CHECK-NEXT:    fcvtzs x11, h3
-; CHECK-NEXT:    fcvtzs x12, h4
-; CHECK-NEXT:    fcvtzs x13, h5
-; CHECK-NEXT:    fmov d0, x8
-; CHECK-NEXT:    fcvtzs x9, h2
-; CHECK-NEXT:    fcvtzs x14, h6
-; CHECK-NEXT:    fcvtzs x15, h7
-; CHECK-NEXT:    fmov d2, x10
-; CHECK-NEXT:    fmov d1, x11
-; CHECK-NEXT:    mov v0.d[1], x12
-; CHECK-NEXT:    fmov d3, x9
-; CHECK-NEXT:    mov v1.d[1], x13
-; CHECK-NEXT:    mov v2.d[1], x15
-; CHECK-NEXT:    mov v3.d[1], x14
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    movprfx z2, z1
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-NEXT:    ret
   %a = call <8 x i64> @llvm.llrint.v8i64.v8f16(<8 x half> %x)
   ret <8 x i64> %a
@@ -88,56 +79,43 @@ declare <8 x i64> @llvm.llrint.v8i64.v8f16(<8 x half>)
 define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) nounwind {
 ; CHECK-LABEL: llrint_v16i64_v16f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    ext v2.16b, v1.16b, v1.16b, #8
-; CHECK-NEXT:    ext v3.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
 ; CHECK-NEXT:    frintx v0.4h, v0.4h
 ; CHECK-NEXT:    frintx v1.4h, v1.4h
+; CHECK-NEXT:    ptrue p0.d, vl4
 ; CHECK-NEXT:    frintx v2.4h, v2.4h
 ; CHECK-NEXT:    frintx v3.4h, v3.4h
-; CHECK-NEXT:    mov h5, v0.h[2]
-; CHECK-NEXT:    mov h4, v1.h[2]
-; CHECK-NEXT:    mov h6, v0.h[1]
-; CHECK-NEXT:    fcvtzs x8, h1
-; CHECK-NEXT:    mov h16, v0.h[3]
-; CHECK-NEXT:    fcvtzs x9, h0
-; CHECK-NEXT:    mov h7, v1.h[1]
-; CHECK-NEXT:    mov h1, v1.h[3]
-; CHECK-NEXT:    mov h0, v2.h[3]
-; CHECK-NEXT:    mov h17, v2.h[2]
-; CHECK-NEXT:    fcvtzs x12, h5
-; CHECK-NEXT:    mov h5, v3.h[2]
-; CHECK-NEXT:    fcvtzs x11, h2
-; CHECK-NEXT:    mov h18, v3.h[3]
-; CHECK-NEXT:    fcvtzs x14, h3
-; CHECK-NEXT:    mov h3, v3.h[1]
-; CHECK-NEXT:    mov h19, v2.h[1]
-; CHECK-NEXT:    fcvtzs x10, h4
-; CHECK-NEXT:    fmov d4, x8
-; CHECK-NEXT:    fcvtzs x13, h6
-; CHECK-NEXT:    fcvtzs x15, h0
-; CHECK-NEXT:    fcvtzs x8, h17
-; CHECK-NEXT:    fmov d0, x9
-; CHECK-NEXT:    fcvtzs x9, h5
-; CHECK-NEXT:    fcvtzs x16, h7
-; CHECK-NEXT:    fcvtzs x17, h16
-; CHECK-NEXT:    fmov d6, x11
-; CHECK-NEXT:    fcvtzs x11, h18
-; CHECK-NEXT:    fcvtzs x18, h3
-; CHECK-NEXT:    fmov d2, x14
-; CHECK-NEXT:    fcvtzs x14, h19
-; CHECK-NEXT:    fcvtzs x0, h1
-; CHECK-NEXT:    fmov d5, x10
-; CHECK-NEXT:    fmov d1, x12
-; CHECK-NEXT:    fmov d7, x8
-; CHECK-NEXT:    fmov d3, x9
-; CHECK-NEXT:    mov v0.d[1], x13
-; CHECK-NEXT:    mov v4.d[1], x16
-; CHECK-NEXT:    mov v2.d[1], x18
-; CHECK-NEXT:    mov v1.d[1], x17
-; CHECK-NEXT:    mov v5.d[1], x0
-; CHECK-NEXT:    mov v6.d[1], x14
-; CHECK-NEXT:    mov v3.d[1], x11
-; CHECK-NEXT:    mov v7.d[1], x15
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    movprfx z4, z1
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z1.h
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-NEXT:    movprfx z6, z3
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z3.h
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    movprfx z5, z4
+; CHECK-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    movprfx z7, z6
+; CHECK-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-NEXT:    ret
   %a = call <16 x i64> @llvm.llrint.v16i64.v16f16(<16 x half> %x)
   ret <16 x i64> %a
@@ -147,128 +125,58 @@ declare <16 x i64> @llvm.llrint.v16i64.v16f16(<16 x half>)
 define <32 x i64> @llrint_v32i64_v32f16(<32 x half> %x) nounwind {
 ; CHECK-LABEL: llrint_v32i64_v32f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-NEXT:    sub x9, sp, #272
-; CHECK-NEXT:    mov x29, sp
-; CHECK-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-NEXT:    frintx v5.4h, v0.4h
-; CHECK-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-NEXT:    ext v4.16b, v1.16b, v1.16b, #8
-; CHECK-NEXT:    ext v17.16b, v2.16b, v2.16b, #8
-; CHECK-NEXT:    frintx v1.4h, v1.4h
-; CHECK-NEXT:    frintx v2.4h, v2.4h
-; CHECK-NEXT:    ptrue p0.d, vl4
-; CHECK-NEXT:    mov h6, v5.h[3]
-; CHECK-NEXT:    frintx v0.4h, v0.4h
-; CHECK-NEXT:    mov h7, v5.h[2]
-; CHECK-NEXT:    mov h16, v5.h[1]
-; CHECK-NEXT:    frintx v4.4h, v4.4h
-; CHECK-NEXT:    fcvtzs x12, h5
-; CHECK-NEXT:    ext v5.16b, v3.16b, v3.16b, #8
-; CHECK-NEXT:    frintx v17.4h, v17.4h
+; CHECK-NEXT:    ext v4.16b, v3.16b, v3.16b, #8
+; CHECK-NEXT:    ext v5.16b, v2.16b, v2.16b, #8
+; CHECK-NEXT:    mov x9, #24 // =0x18
 ; CHECK-NEXT:    frintx v3.4h, v3.4h
-; CHECK-NEXT:    fcvtzs x9, h6
-; CHECK-NEXT:    mov h6, v0.h[3]
-; CHECK-NEXT:    fcvtzs x10, h7
-; CHECK-NEXT:    mov h7, v0.h[2]
-; CHECK-NEXT:    fcvtzs x11, h16
-; CHECK-NEXT:    mov h16, v0.h[1]
-; CHECK-NEXT:    fcvtzs x13, h6
-; CHECK-NEXT:    mov h6, v4.h[3]
-; CHECK-NEXT:    stp x10, x9, [sp, #48]
-; CHECK-NEXT:    fcvtzs x9, h7
-; CHECK-NEXT:    mov h7, v4.h[2]
-; CHECK-NEXT:    fcvtzs x10, h16
-; CHECK-NEXT:    mov h16, v4.h[1]
-; CHECK-NEXT:    stp x12, x11, [sp, #32]
-; CHECK-NEXT:    fcvtzs x11, h0
-; CHECK-NEXT:    frintx v0.4h, v5.4h
-; CHECK-NEXT:    mov h5, v17.h[3]
-; CHECK-NEXT:    fcvtzs x12, h6
-; CHECK-NEXT:    mov h6, v17.h[2]
-; CHECK-NEXT:    stp x9, x13, [sp, #16]
-; CHECK-NEXT:    fcvtzs x13, h7
-; CHECK-NEXT:    mov h7, v17.h[1]
-; CHECK-NEXT:    fcvtzs x9, h16
-; CHECK-NEXT:    stp x11, x10, [sp]
-; CHECK-NEXT:    fcvtzs x10, h4
-; CHECK-NEXT:    fcvtzs x11, h5
-; CHECK-NEXT:    mov h4, v0.h[3]
-; CHECK-NEXT:    mov h5, v0.h[2]
-; CHECK-NEXT:    stp x13, x12, [sp, #80]
-; CHECK-NEXT:    fcvtzs x12, h6
-; CHECK-NEXT:    fcvtzs x13, h7
-; CHECK-NEXT:    mov h6, v0.h[1]
-; CHECK-NEXT:    stp x10, x9, [sp, #64]
-; CHECK-NEXT:    fcvtzs x9, h17
-; CHECK-NEXT:    mov h7, v1.h[3]
-; CHECK-NEXT:    fcvtzs x10, h4
-; CHECK-NEXT:    mov h4, v1.h[2]
-; CHECK-NEXT:    stp x12, x11, [sp, #144]
-; CHECK-NEXT:    fcvtzs x11, h5
-; CHECK-NEXT:    mov h5, v1.h[1]
-; CHECK-NEXT:    fcvtzs x12, h6
-; CHECK-NEXT:    stp x9, x13, [sp, #128]
-; CHECK-NEXT:    fcvtzs x9, h0
-; CHECK-NEXT:    fcvtzs x13, h7
-; CHECK-NEXT:    mov h0, v2.h[3]
-; CHECK-NEXT:    stp x11, x10, [sp, #208]
-; CHECK-NEXT:    fcvtzs x10, h4
-; CHECK-NEXT:    mov h4, v2.h[2]
-; CHECK-NEXT:    fcvtzs x11, h5
-; CHECK-NEXT:    mov h5, v2.h[1]
-; CHECK-NEXT:    stp x9, x12, [sp, #192]
-; CHECK-NEXT:    fcvtzs x9, h1
-; CHECK-NEXT:    fcvtzs x12, h0
-; CHECK-NEXT:    mov h0, v3.h[3]
-; CHECK-NEXT:    mov h1, v3.h[2]
-; CHECK-NEXT:    stp x10, x13, [sp, #112]
-; CHECK-NEXT:    fcvtzs x10, h4
-; CHECK-NEXT:    mov h4, v3.h[1]
-; CHECK-NEXT:    fcvtzs x13, h5
-; CHECK-NEXT:    stp x9, x11, [sp, #96]
-; CHECK-NEXT:    fcvtzs x9, h2
-; CHECK-NEXT:    fcvtzs x11, h0
-; CHECK-NEXT:    stp x10, x12, [sp, #176]
-; CHECK-NEXT:    fcvtzs x10, h1
-; CHECK-NEXT:    fcvtzs x12, h4
-; CHECK-NEXT:    stp x9, x13, [sp, #160]
-; CHECK-NEXT:    fcvtzs x9, h3
-; CHECK-NEXT:    stp x10, x11, [sp, #240]
-; CHECK-NEXT:    add x10, sp, #64
-; CHECK-NEXT:    stp x9, x12, [sp, #224]
-; CHECK-NEXT:    add x9, sp, #32
-; CHECK-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #224
-; CHECK-NEXT:    add x10, sp, #128
-; CHECK-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #160
-; CHECK-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-NEXT:    add x10, sp, #96
-; CHECK-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #192
-; CHECK-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-NEXT:    mov x10, #24 // =0x18
-; CHECK-NEXT:    ld1d { z7.d }, p0/z, [x9]
+; CHECK-NEXT:    ext v6.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    frintx v2.4h, v2.4h
+; CHECK-NEXT:    ext v7.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    frintx v1.4h, v1.4h
+; CHECK-NEXT:    frintx v0.4h, v0.4h
+; CHECK-NEXT:    ptrue p0.d, vl4
+; CHECK-NEXT:    frintx v4.4h, v4.4h
+; CHECK-NEXT:    frintx v5.4h, v5.4h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
+; CHECK-NEXT:    frintx v6.4h, v6.4h
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    frintx v7.4h, v7.4h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z4.s, z4.h
+; CHECK-NEXT:    uunpklo z5.s, z5.h
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    uunpklo z6.s, z6.h
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    uunpklo z7.s, z7.h
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-NEXT:    uunpklo z6.d, z6.s
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-NEXT:    st1d { z3.d }, p0, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #16 // =0x10
-; CHECK-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #8 // =0x8
-; CHECK-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #28 // =0x1c
-; CHECK-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #20 // =0x14
-; CHECK-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #12 // =0xc
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.h
 ; CHECK-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #4 // =0x4
+; CHECK-NEXT:    mov x9, #8 // =0x8
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.h
 ; CHECK-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #28 // =0x1c
+; CHECK-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #20 // =0x14
+; CHECK-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #12 // =0xc
+; CHECK-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #4 // =0x4
+; CHECK-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
 ; CHECK-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-NEXT:    mov sp, x29
-; CHECK-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
 ; CHECK-NEXT:    ret
   %a = call <32 x i64> @llvm.llrint.v32i64.v32f16(<32 x half> %x)
   ret <32 x i64> %a
@@ -304,17 +212,13 @@ define <4 x i64> @llrint_v4i64_v4f32(<4 x float> %x) nounwind {
 ; CHECK-LABEL: llrint_v4i64_v4f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    frintx v0.4s, v0.4s
-; CHECK-NEXT:    mov s1, v0.s[2]
-; CHECK-NEXT:    mov s2, v0.s[3]
-; CHECK-NEXT:    mov s3, v0.s[1]
-; CHECK-NEXT:    fcvtzs x9, s0
-; CHECK-NEXT:    fcvtzs x8, s1
-; CHECK-NEXT:    fcvtzs x10, s2
-; CHECK-NEXT:    fcvtzs x11, s3
-; CHECK-NEXT:    fmov d0, x9
-; CHECK-NEXT:    fmov d1, x8
-; CHECK-NEXT:    mov v0.d[1], x11
-; CHECK-NEXT:    mov v1.d[1], x10
+; CHECK-NEXT:    ptrue p0.d, vl4
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-NEXT:    ret
   %a = call <4 x i64> @llvm.llrint.v4i64.v4f32(<4 x float> %x)
   ret <4 x i64> %a
@@ -326,28 +230,20 @@ define <8 x i64> @llrint_v8i64_v8f32(<8 x float> %x) nounwind {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    frintx v1.4s, v1.4s
 ; CHECK-NEXT:    frintx v0.4s, v0.4s
-; CHECK-NEXT:    mov s2, v1.s[2]
-; CHECK-NEXT:    mov s3, v0.s[2]
-; CHECK-NEXT:    mov s4, v0.s[1]
-; CHECK-NEXT:    mov s5, v1.s[3]
-; CHECK-NEXT:    mov s6, v1.s[1]
-; CHECK-NEXT:    mov s7, v0.s[3]
-; CHECK-NEXT:    fcvtzs x8, s0
-; CHECK-NEXT:    fcvtzs x10, s1
-; CHECK-NEXT:    fcvtzs x9, s2
-; CHECK-NEXT:    fcvtzs x11, s3
-; CHECK-NEXT:    fcvtzs x12, s4
-; CHECK-NEXT:    fcvtzs x13, s5
-; CHECK-NEXT:    fcvtzs x14, s6
-; CHECK-NEXT:    fcvtzs x15, s7
-; CHECK-NEXT:    fmov d0, x8
-; CHECK-NEXT:    fmov d2, x10
-; CHECK-NEXT:    fmov d3, x9
-; CHECK-NEXT:    fmov d1, x11
-; CHECK-NEXT:    mov v0.d[1], x12
-; CHECK-NEXT:    mov v2.d[1], x14
-; CHECK-NEXT:    mov v1.d[1], x15
-; CHECK-NEXT:    mov v3.d[1], x13
+; CHECK-NEXT:    ptrue p0.d, vl4
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    movprfx z2, z1
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z1.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-NEXT:    ret
   %a = call <8 x i64> @llvm.llrint.v8i64.v8f32(<8 x float> %x)
   ret <8 x i64> %a
@@ -357,54 +253,37 @@ declare <8 x i64> @llvm.llrint.v8i64.v8f32(<8 x float>)
 define <16 x i64> @llrint_v16i64_v16f32(<16 x float> %x) nounwind {
 ; CHECK-LABEL: llrint_v16i64_v16f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintx v3.4s, v3.4s
-; CHECK-NEXT:    frintx v2.4s, v2.4s
 ; CHECK-NEXT:    frintx v1.4s, v1.4s
 ; CHECK-NEXT:    frintx v0.4s, v0.4s
-; CHECK-NEXT:    mov s4, v3.s[2]
-; CHECK-NEXT:    mov s5, v2.s[2]
-; CHECK-NEXT:    mov s6, v2.s[1]
-; CHECK-NEXT:    mov s7, v1.s[2]
-; CHECK-NEXT:    fcvtzs x8, s3
-; CHECK-NEXT:    mov s16, v0.s[2]
-; CHECK-NEXT:    fcvtzs x9, s2
-; CHECK-NEXT:    mov s17, v1.s[3]
-; CHECK-NEXT:    mov s18, v0.s[1]
-; CHECK-NEXT:    mov s19, v3.s[3]
-; CHECK-NEXT:    fcvtzs x14, s1
-; CHECK-NEXT:    mov s1, v1.s[1]
-; CHECK-NEXT:    fcvtzs x10, s4
-; CHECK-NEXT:    fcvtzs x11, s5
-; CHECK-NEXT:    mov s5, v0.s[3]
-; CHECK-NEXT:    mov s3, v3.s[1]
-; CHECK-NEXT:    mov s2, v2.s[3]
-; CHECK-NEXT:    fcvtzs x12, s6
-; CHECK-NEXT:    fcvtzs x13, s7
-; CHECK-NEXT:    fcvtzs x15, s16
-; CHECK-NEXT:    fmov d6, x8
-; CHECK-NEXT:    fcvtzs x8, s0
-; CHECK-NEXT:    fmov d4, x9
-; CHECK-NEXT:    fcvtzs x9, s17
-; CHECK-NEXT:    fcvtzs x16, s5
-; CHECK-NEXT:    fcvtzs x17, s18
-; CHECK-NEXT:    fmov d7, x10
-; CHECK-NEXT:    fmov d5, x11
-; CHECK-NEXT:    fcvtzs x10, s1
-; CHECK-NEXT:    fcvtzs x11, s19
-; CHECK-NEXT:    fcvtzs x18, s3
-; CHECK-NEXT:    fcvtzs x0, s2
-; CHECK-NEXT:    fmov d3, x13
-; CHECK-NEXT:    fmov d1, x15
-; CHECK-NEXT:    fmov d0, x8
-; CHECK-NEXT:    fmov d2, x14
-; CHECK-NEXT:    mov v4.d[1], x12
-; CHECK-NEXT:    mov v3.d[1], x9
-; CHECK-NEXT:    mov v7.d[1], x11
-; CHECK-NEXT:    mov v0.d[1], x17
-; CHECK-NEXT:    mov v1.d[1], x16
-; CHECK-NEXT:    mov v2.d[1], x10
-; CHECK-NEXT:    mov v5.d[1], x0
-; CHECK-NEXT:    mov v6.d[1], x18
+; CHECK-NEXT:    frintx v3.4s, v3.4s
+; CHECK-NEXT:    frintx v2.4s, v2.4s
+; CHECK-NEXT:    ptrue p0.d, vl4
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    uunpklo z4.d, z2.s
+; CHECK-NEXT:    movprfx z2, z1
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z1.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    movprfx z6, z3
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z3.s
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    movprfx z7, z6
+; CHECK-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-NEXT:    movprfx z5, z4
+; CHECK-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-NEXT:    // kill: def $q7 killed $q7 killed $z7
+; CHECK-NEXT:    // kill: def $q5 killed $q5 killed $z5
 ; CHECK-NEXT:    ret
   %a = call <16 x i64> @llvm.llrint.v16i64.v16f32(<16 x float> %x)
   ret <16 x i64> %a
@@ -414,124 +293,46 @@ declare <16 x i64> @llvm.llrint.v16i64.v16f32(<16 x float>)
 define <32 x i64> @llrint_v32i64_v32f32(<32 x float> %x) nounwind {
 ; CHECK-LABEL: llrint_v32i64_v32f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-NEXT:    sub x9, sp, #272
-; CHECK-NEXT:    mov x29, sp
-; CHECK-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-NEXT:    frintx v0.4s, v0.4s
-; CHECK-NEXT:    frintx v1.4s, v1.4s
+; CHECK-NEXT:    frintx v7.4s, v7.4s
+; CHECK-NEXT:    frintx v6.4s, v6.4s
+; CHECK-NEXT:    mov x9, #28 // =0x1c
+; CHECK-NEXT:    frintx v5.4s, v5.4s
+; CHECK-NEXT:    frintx v4.4s, v4.4s
+; CHECK-NEXT:    frintx v3.4s, v3.4s
 ; CHECK-NEXT:    frintx v2.4s, v2.4s
 ; CHECK-NEXT:    ptrue p0.d, vl4
-; CHECK-NEXT:    mov s16, v0.s[3]
-; CHECK-NEXT:    mov s17, v0.s[2]
-; CHECK-NEXT:    mov s18, v0.s[1]
-; CHECK-NEXT:    fcvtzs x12, s0
-; CHECK-NEXT:    frintx v0.4s, v3.4s
-; CHECK-NEXT:    mov s3, v2.s[3]
-; CHECK-NEXT:    fcvtzs x9, s16
-; CHECK-NEXT:    mov s16, v1.s[3]
-; CHECK-NEXT:    fcvtzs x10, s17
-; CHECK-NEXT:    mov s17, v1.s[2]
-; CHECK-NEXT:    fcvtzs x11, s18
-; CHECK-NEXT:    mov s18, v1.s[1]
-; CHECK-NEXT:    fcvtzs x13, s16
-; CHECK-NEXT:    stp x10, x9, [sp, #16]
-; CHECK-NEXT:    mov s16, v2.s[2]
-; CHECK-NEXT:    fcvtzs x9, s17
-; CHECK-NEXT:    fcvtzs x10, s18
-; CHECK-NEXT:    mov s17, v2.s[1]
-; CHECK-NEXT:    stp x12, x11, [sp]
-; CHECK-NEXT:    fcvtzs x11, s1
-; CHECK-NEXT:    frintx v1.4s, v4.4s
-; CHECK-NEXT:    fcvtzs x12, s3
-; CHECK-NEXT:    mov s3, v0.s[3]
-; CHECK-NEXT:    mov s4, v0.s[2]
-; CHECK-NEXT:    stp x9, x13, [sp, #48]
-; CHECK-NEXT:    fcvtzs x13, s16
-; CHECK-NEXT:    fcvtzs x9, s17
-; CHECK-NEXT:    mov s16, v0.s[1]
-; CHECK-NEXT:    stp x11, x10, [sp, #32]
-; CHECK-NEXT:    fcvtzs x10, s2
-; CHECK-NEXT:    frintx v2.4s, v5.4s
-; CHECK-NEXT:    fcvtzs x11, s3
-; CHECK-NEXT:    mov s3, v1.s[3]
-; CHECK-NEXT:    mov s5, v1.s[1]
-; CHECK-NEXT:    stp x13, x12, [sp, #80]
-; CHECK-NEXT:    fcvtzs x12, s4
-; CHECK-NEXT:    mov s4, v1.s[2]
-; CHECK-NEXT:    fcvtzs x13, s16
-; CHECK-NEXT:    stp x10, x9, [sp, #64]
-; CHECK-NEXT:    fcvtzs x9, s0
-; CHECK-NEXT:    mov s0, v2.s[3]
-; CHECK-NEXT:    fcvtzs x10, s3
-; CHECK-NEXT:    frintx v3.4s, v6.4s
-; CHECK-NEXT:    stp x12, x11, [sp, #112]
-; CHECK-NEXT:    fcvtzs x11, s4
-; CHECK-NEXT:    mov s4, v2.s[2]
-; CHECK-NEXT:    fcvtzs x12, s5
-; CHECK-NEXT:    mov s5, v2.s[1]
-; CHECK-NEXT:    stp x9, x13, [sp, #96]
-; CHECK-NEXT:    fcvtzs x9, s1
-; CHECK-NEXT:    fcvtzs x13, s0
-; CHECK-NEXT:    mov s0, v3.s[3]
-; CHECK-NEXT:    frintx v1.4s, v7.4s
-; CHECK-NEXT:    stp x11, x10, [sp, #144]
-; CHECK-NEXT:    fcvtzs x10, s4
-; CHECK-NEXT:    mov s4, v3.s[2]
-; CHECK-NEXT:    fcvtzs x11, s5
-; CHECK-NEXT:    mov s5, v3.s[1]
-; CHECK-NEXT:    stp x9, x12, [sp, #128]
-; CHECK-NEXT:    fcvtzs x9, s2
-; CHECK-NEXT:    fcvtzs x12, s0
-; CHECK-NEXT:    mov s0, v1.s[3]
-; CHECK-NEXT:    mov s2, v1.s[2]
-; CHECK-NEXT:    stp x10, x13, [sp, #176]
-; CHECK-NEXT:    fcvtzs x10, s4
-; CHECK-NEXT:    mov s4, v1.s[1]
-; CHECK-NEXT:    fcvtzs x13, s5
-; CHECK-NEXT:    stp x9, x11, [sp, #160]
-; CHECK-NEXT:    fcvtzs x9, s3
-; CHECK-NEXT:    fcvtzs x11, s0
-; CHECK-NEXT:    stp x10, x12, [sp, #208]
-; CHECK-NEXT:    fcvtzs x10, s2
-; CHECK-NEXT:    fcvtzs x12, s4
-; CHECK-NEXT:    stp x9, x13, [sp, #192]
-; CHECK-NEXT:    fcvtzs x9, s1
-; CHECK-NEXT:    stp x10, x11, [sp, #240]
-; CHECK-NEXT:    add x10, sp, #64
-; CHECK-NEXT:    stp x9, x12, [sp, #224]
-; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #32
-; CHECK-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #224
-; CHECK-NEXT:    add x10, sp, #96
-; CHECK-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #192
-; CHECK-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-NEXT:    add x10, sp, #160
-; CHECK-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #128
-; CHECK-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-NEXT:    mov x10, #28 // =0x1c
-; CHECK-NEXT:    ld1d { z7.d }, p0/z, [x9]
-; CHECK-NEXT:    mov x9, #24 // =0x18
-; CHECK-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #20 // =0x14
-; CHECK-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #16 // =0x10
+; CHECK-NEXT:    frintx v1.4s, v1.4s
+; CHECK-NEXT:    frintx v0.4s, v0.4s
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    uunpklo z6.d, z6.s
+; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.s
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.s
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.s
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.s
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    mov x9, #12 // =0xc
+; CHECK-NEXT:    mov x9, #24 // =0x18
+; CHECK-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #20 // =0x14
+; CHECK-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #16 // =0x10
 ; CHECK-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    mov x9, #12 // =0xc
+; CHECK-NEXT:    st1d { z3.d }, p0, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #8 // =0x8
 ; CHECK-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #4 // =0x4
 ; CHECK-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
 ; CHECK-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-NEXT:    mov sp, x29
-; CHECK-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
 ; CHECK-NEXT:    ret
   %a = call <32 x i64> @llvm.llrint.v32i64.v32f32(<32 x float> %x)
   ret <32 x i64> %a
@@ -569,15 +370,11 @@ define <4 x i64> @llrint_v4i64_v4f64(<4 x double> %x) nounwind {
 ; CHECK-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ptrue p0.d, vl4
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    mov z1.d, z0.d[3]
-; CHECK-NEXT:    mov z2.d, z0.d[2]
-; CHECK-NEXT:    mov z3.d, z0.d[1]
-; CHECK-NEXT:    fcvtzs d0, d0
-; CHECK-NEXT:    fcvtzs x8, d1
-; CHECK-NEXT:    fcvtzs d1, d2
-; CHECK-NEXT:    fcvtzs x9, d3
-; CHECK-NEXT:    mov v0.d[1], x9
-; CHECK-NEXT:    mov v1.d[1], x8
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-NEXT:    ret
   %a = call <4 x i64> @llvm.llrint.v4i64.v4f64(<4 x double> %x)
   ret <4 x i64> %a
@@ -597,24 +394,16 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) nounwind {
 ; CHECK-NEXT:    ptrue p0.d, vl4
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    mov z1.d, z2.d[3]
-; CHECK-NEXT:    mov z3.d, z0.d[3]
-; CHECK-NEXT:    mov z4.d, z0.d[1]
-; CHECK-NEXT:    mov z5.d, z2.d[2]
-; CHECK-NEXT:    mov z6.d, z0.d[2]
-; CHECK-NEXT:    mov z7.d, z2.d[1]
-; CHECK-NEXT:    fcvtzs d2, d2
-; CHECK-NEXT:    fcvtzs d0, d0
-; CHECK-NEXT:    fcvtzs x8, d1
-; CHECK-NEXT:    fcvtzs x9, d3
-; CHECK-NEXT:    fcvtzs x10, d4
-; CHECK-NEXT:    fcvtzs d3, d5
-; CHECK-NEXT:    fcvtzs d1, d6
-; CHECK-NEXT:    fcvtzs x11, d7
-; CHECK-NEXT:    mov v0.d[1], x10
-; CHECK-NEXT:    mov v2.d[1], x11
-; CHECK-NEXT:    mov v1.d[1], x9
-; CHECK-NEXT:    mov v3.d[1], x8
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-NEXT:    ret
   %a = call <8 x i64> @llvm.llrint.v8i64.v8f64(<8 x double> %x)
   ret <8 x i64> %a
@@ -628,56 +417,40 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-NEXT:    // kill: def $q3 killed $q3 def $z3
-; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-NEXT:    splice z4.d, p0, z4.d, z5.d
-; CHECK-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-NEXT:    splice z6.d, p0, z6.d, z7.d
 ; CHECK-NEXT:    ptrue p0.d, vl4
-; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    mov z1.d, z6.d[3]
-; CHECK-NEXT:    mov z3.d, z4.d[3]
-; CHECK-NEXT:    mov z5.d, z2.d[3]
-; CHECK-NEXT:    mov z16.d, z4.d[1]
-; CHECK-NEXT:    mov z7.d, z0.d[3]
-; CHECK-NEXT:    mov z17.d, z0.d[2]
-; CHECK-NEXT:    mov z18.d, z4.d[2]
-; CHECK-NEXT:    mov z19.d, z6.d[1]
-; CHECK-NEXT:    fcvtzs d4, d4
-; CHECK-NEXT:    fcvtzs x8, d1
-; CHECK-NEXT:    mov z1.d, z2.d[1]
-; CHECK-NEXT:    fcvtzs x9, d3
-; CHECK-NEXT:    mov z3.d, z0.d[1]
-; CHECK-NEXT:    fcvtzs x10, d5
-; CHECK-NEXT:    mov z5.d, z6.d[2]
-; CHECK-NEXT:    fcvtzs x12, d16
-; CHECK-NEXT:    mov z16.d, z2.d[2]
-; CHECK-NEXT:    fcvtzs x11, d7
-; CHECK-NEXT:    fcvtzs x13, d1
-; CHECK-NEXT:    fcvtzs d1, d17
-; CHECK-NEXT:    fcvtzs d0, d0
-; CHECK-NEXT:    fcvtzs x14, d3
-; CHECK-NEXT:    fcvtzs d7, d5
-; CHECK-NEXT:    fcvtzs d2, d2
-; CHECK-NEXT:    fcvtzs d3, d16
-; CHECK-NEXT:    fcvtzs d5, d18
-; CHECK-NEXT:    fcvtzs x15, d19
-; CHECK-NEXT:    fcvtzs d6, d6
-; CHECK-NEXT:    mov v4.d[1], x12
-; CHECK-NEXT:    mov v1.d[1], x11
-; CHECK-NEXT:    mov v0.d[1], x14
-; CHECK-NEXT:    mov v2.d[1], x13
-; CHECK-NEXT:    mov v7.d[1], x8
-; CHECK-NEXT:    mov v3.d[1], x10
-; CHECK-NEXT:    mov v5.d[1], x9
-; CHECK-NEXT:    mov v6.d[1], x15
+; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-NEXT:    movprfx z1, z0
+; CHECK-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-NEXT:    movprfx z3, z2
+; CHECK-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-NEXT:    movprfx z5, z4
+; CHECK-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-NEXT:    movprfx z7, z6
+; CHECK-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-NEXT:    ret
   %a = call <16 x i64> @llvm.llrint.v16i64.v16f64(<16 x double> %x)
   ret <16 x i64> %a
@@ -687,148 +460,59 @@ declare <16 x i64> @llvm.llrint.v16i64.v16f64(<16 x double>)
 define <32 x i64> @llrint_v32f64(<32 x double> %x) nounwind {
 ; CHECK-LABEL: llrint_v32f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-NEXT:    sub x9, sp, #272
-; CHECK-NEXT:    mov x29, sp
-; CHECK-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-NEXT:    ptrue p1.d, vl2
-; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
-; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-NEXT:    // kill: def $q3 killed $q3 def $z3
-; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-NEXT:    // kill: def $q7 killed $q7 def $z7
+; CHECK-NEXT:    ldp q16, q17, [sp, #96]
+; CHECK-NEXT:    ptrue p0.d, vl2
+; CHECK-NEXT:    ldp q19, q18, [sp, #64]
+; CHECK-NEXT:    ptrue p1.d, vl4
 ; CHECK-NEXT:    // kill: def $q6 killed $q6 def $z6
+; CHECK-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-NEXT:    // kill: def $q5 killed $q5 def $z5
-; CHECK-NEXT:    ptrue p0.d, vl4
-; CHECK-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-NEXT:    splice z2.d, p1, z2.d, z3.d
-; CHECK-NEXT:    splice z4.d, p1, z4.d, z5.d
-; CHECK-NEXT:    splice z6.d, p1, z6.d, z7.d
-; CHECK-NEXT:    ldp q5, q19, [x29, #16]
-; CHECK-NEXT:    movprfx z3, z0
-; CHECK-NEXT:    frintx z3.d, p0/m, z0.d
-; CHECK-NEXT:    movprfx z16, z2
-; CHECK-NEXT:    frintx z16.d, p0/m, z2.d
-; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    splice z5.d, p1, z5.d, z19.d
-; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-NEXT:    ldp q2, q17, [x29, #48]
-; CHECK-NEXT:    ldp q0, q1, [x29, #112]
-; CHECK-NEXT:    mov z18.d, z3.d[3]
-; CHECK-NEXT:    mov z7.d, z3.d[2]
-; CHECK-NEXT:    fcvtzs x9, d3
-; CHECK-NEXT:    mov z3.d, z3.d[1]
-; CHECK-NEXT:    mov z20.d, z16.d[3]
-; CHECK-NEXT:    fcvtzs x12, d16
-; CHECK-NEXT:    splice z2.d, p1, z2.d, z17.d
-; CHECK-NEXT:    frintx z5.d, p0/m, z5.d
-; CHECK-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-NEXT:    fcvtzs x10, d18
-; CHECK-NEXT:    fcvtzs x11, d7
-; CHECK-NEXT:    mov z18.d, z16.d[2]
-; CHECK-NEXT:    mov z7.d, z16.d[1]
-; CHECK-NEXT:    fcvtzs x13, d3
-; CHECK-NEXT:    str x9, [sp, #128]
-; CHECK-NEXT:    fcvtzs x9, d20
-; CHECK-NEXT:    mov z16.d, z4.d[3]
-; CHECK-NEXT:    ldp q3, q19, [x29, #80]
-; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
-; CHECK-NEXT:    stp x11, x10, [sp, #144]
-; CHECK-NEXT:    fcvtzs x10, d18
-; CHECK-NEXT:    fcvtzs x11, d7
-; CHECK-NEXT:    mov z18.d, z4.d[2]
-; CHECK-NEXT:    mov z7.d, z4.d[1]
-; CHECK-NEXT:    str x13, [sp, #136]
-; CHECK-NEXT:    fcvtzs x13, d16
-; CHECK-NEXT:    mov z16.d, z6.d[3]
-; CHECK-NEXT:    splice z3.d, p1, z3.d, z19.d
-; CHECK-NEXT:    mov z1.d, z5.d[1]
-; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    stp x10, x9, [sp, #176]
-; CHECK-NEXT:    fcvtzs x9, d18
-; CHECK-NEXT:    fcvtzs x10, d4
-; CHECK-NEXT:    stp x12, x11, [sp, #160]
-; CHECK-NEXT:    fcvtzs x11, d7
-; CHECK-NEXT:    mov z4.d, z6.d[2]
-; CHECK-NEXT:    mov z7.d, z6.d[1]
-; CHECK-NEXT:    fcvtzs x12, d6
-; CHECK-NEXT:    mov z6.d, z5.d[2]
-; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-NEXT:    stp x9, x13, [sp, #208]
-; CHECK-NEXT:    fcvtzs x9, d16
-; CHECK-NEXT:    fcvtzs x13, d4
-; CHECK-NEXT:    stp x10, x11, [sp, #192]
-; CHECK-NEXT:    fcvtzs x10, d7
-; CHECK-NEXT:    mov z4.d, z5.d[3]
-; CHECK-NEXT:    fcvtzs x11, d4
-; CHECK-NEXT:    stp x13, x9, [sp, #240]
-; CHECK-NEXT:    fcvtzs x9, d6
-; CHECK-NEXT:    stp x12, x10, [sp, #224]
-; CHECK-NEXT:    fcvtzs x10, d5
-; CHECK-NEXT:    fcvtzs x12, d1
-; CHECK-NEXT:    mov z4.d, z2.d[3]
-; CHECK-NEXT:    mov z5.d, z2.d[2]
-; CHECK-NEXT:    mov z1.d, z2.d[1]
-; CHECK-NEXT:    fcvtzs x13, d2
-; CHECK-NEXT:    mov z2.d, z3.d[2]
-; CHECK-NEXT:    stp x9, x11, [sp, #16]
-; CHECK-NEXT:    fcvtzs x9, d4
-; CHECK-NEXT:    fcvtzs x11, d5
-; CHECK-NEXT:    stp x10, x12, [sp]
-; CHECK-NEXT:    fcvtzs x10, d1
-; CHECK-NEXT:    mov z4.d, z3.d[3]
-; CHECK-NEXT:    mov z1.d, z3.d[1]
-; CHECK-NEXT:    fcvtzs x12, d4
-; CHECK-NEXT:    stp x11, x9, [sp, #48]
-; CHECK-NEXT:    fcvtzs x9, d2
-; CHECK-NEXT:    fcvtzs x11, d3
-; CHECK-NEXT:    stp x13, x10, [sp, #32]
-; CHECK-NEXT:    fcvtzs x10, d1
-; CHECK-NEXT:    mov z2.d, z0.d[3]
-; CHECK-NEXT:    mov z3.d, z0.d[2]
-; CHECK-NEXT:    mov z1.d, z0.d[1]
-; CHECK-NEXT:    stp x9, x12, [sp, #80]
-; CHECK-NEXT:    fcvtzs x12, d0
-; CHECK-NEXT:    fcvtzs x13, d2
-; CHECK-NEXT:    fcvtzs x9, d3
-; CHECK-NEXT:    stp x11, x10, [sp, #64]
-; CHECK-NEXT:    fcvtzs x10, d1
-; CHECK-NEXT:    stp x9, x13, [sp, #112]
-; CHECK-NEXT:    add x9, sp, #128
-; CHECK-NEXT:    stp x12, x10, [sp, #96]
-; CHECK-NEXT:    add x10, sp, #192
-; CHECK-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #160
-; CHECK-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #96
-; CHECK-NEXT:    add x10, sp, #224
-; CHECK-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-NEXT:    add x9, sp, #64
-; CHECK-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-NEXT:    add x10, sp, #32
-; CHECK-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-NEXT:    mov x9, sp
-; CHECK-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-NEXT:    mov x10, #28 // =0x1c
-; CHECK-NEXT:    ld1d { z7.d }, p0/z, [x9]
+; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-NEXT:    mov x9, #28 // =0x1c
+; CHECK-NEXT:    splice z16.d, p0, z16.d, z17.d
+; CHECK-NEXT:    ldp q20, q17, [sp, #32]
+; CHECK-NEXT:    splice z19.d, p0, z19.d, z18.d
+; CHECK-NEXT:    ldp q21, q18, [sp]
+; CHECK-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-NEXT:    splice z4.d, p0, z4.d, z5.d
+; CHECK-NEXT:    splice z2.d, p0, z2.d, z3.d
+; CHECK-NEXT:    splice z20.d, p0, z20.d, z17.d
+; CHECK-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-NEXT:    splice z21.d, p0, z21.d, z18.d
+; CHECK-NEXT:    frintx z16.d, p1/m, z16.d
+; CHECK-NEXT:    frintx z19.d, p1/m, z19.d
+; CHECK-NEXT:    frintx z6.d, p1/m, z6.d
+; CHECK-NEXT:    frintx z4.d, p1/m, z4.d
+; CHECK-NEXT:    frintx z2.d, p1/m, z2.d
+; CHECK-NEXT:    frintx z20.d, p1/m, z20.d
+; CHECK-NEXT:    frintx z0.d, p1/m, z0.d
+; CHECK-NEXT:    frintx z21.d, p1/m, z21.d
+; CHECK-NEXT:    fcvtzs z16.d, p1/m, z16.d
+; CHECK-NEXT:    fcvtzs z19.d, p1/m, z19.d
+; CHECK-NEXT:    fcvtzs z6.d, p1/m, z6.d
+; CHECK-NEXT:    fcvtzs z4.d, p1/m, z4.d
+; CHECK-NEXT:    fcvtzs z2.d, p1/m, z2.d
+; CHECK-NEXT:    fcvtzs z20.d, p1/m, z20.d
+; CHECK-NEXT:    fcvtzs z0.d, p1/m, z0.d
+; CHECK-NEXT:    fcvtzs z21.d, p1/m, z21.d
+; CHECK-NEXT:    st1d { z16.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #24 // =0x18
-; CHECK-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z19.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #20 // =0x14
-; CHECK-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z20.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #16 // =0x10
-; CHECK-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z21.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #12 // =0xc
-; CHECK-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z6.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #8 // =0x8
-; CHECK-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z4.d }, p1, [x8, x9, lsl #3]
 ; CHECK-NEXT:    mov x9, #4 // =0x4
-; CHECK-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
-; CHECK-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-NEXT:    mov sp, x29
-; CHECK-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
+; CHECK-NEXT:    st1d { z2.d }, p1, [x8, x9, lsl #3]
+; CHECK-NEXT:    st1d { z0.d }, p1, [x8]
 ; CHECK-NEXT:    ret
   %a = call <32 x i64> @llvm.llrint.v32i64.v16f64(<32 x double> %x)
   ret <32 x i64> %a

--- a/llvm/test/CodeGen/AArch64/sve-fixed-vector-lrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-vector-lrint.ll
@@ -64,17 +64,14 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) nounwind {
 ; CHECK-i64-LABEL: lrint_v4f16:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    frintx v0.4h, v0.4h
-; CHECK-i64-NEXT:    mov h1, v0.h[2]
-; CHECK-i64-NEXT:    mov h2, v0.h[3]
-; CHECK-i64-NEXT:    mov h3, v0.h[1]
-; CHECK-i64-NEXT:    fcvtzs x9, h0
-; CHECK-i64-NEXT:    fcvtzs x8, h1
-; CHECK-i64-NEXT:    fcvtzs x10, h2
-; CHECK-i64-NEXT:    fcvtzs x11, h3
-; CHECK-i64-NEXT:    fmov d0, x9
-; CHECK-i64-NEXT:    fmov d1, x8
-; CHECK-i64-NEXT:    mov v0.d[1], x11
-; CHECK-i64-NEXT:    mov v1.d[1], x10
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
+; CHECK-i64-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i64-NEXT:    ret
   %a = call <4 x iXLen> @llvm.lrint.v4iXLen.v4f16(<4 x half> %x)
   ret <4 x iXLen> %a
@@ -84,59 +81,37 @@ declare <4 x iXLen> @llvm.lrint.v4iXLen.v4f16(<4 x half>)
 define <8 x iXLen> @lrint_v8f16(<8 x half> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v8f16:
 ; CHECK-i32:       // %bb.0:
-; CHECK-i32-NEXT:    frintx v2.8h, v0.8h
-; CHECK-i32-NEXT:    mov h0, v2.h[4]
-; CHECK-i32-NEXT:    mov h1, v2.h[5]
-; CHECK-i32-NEXT:    mov h3, v2.h[1]
-; CHECK-i32-NEXT:    fcvtzs w9, h2
-; CHECK-i32-NEXT:    mov h4, v2.h[6]
-; CHECK-i32-NEXT:    fcvtzs w8, h0
-; CHECK-i32-NEXT:    mov h0, v2.h[2]
-; CHECK-i32-NEXT:    fcvtzs w10, h1
-; CHECK-i32-NEXT:    fcvtzs w11, h3
-; CHECK-i32-NEXT:    mov h3, v2.h[7]
-; CHECK-i32-NEXT:    fcvtzs w12, h4
-; CHECK-i32-NEXT:    mov h2, v2.h[3]
-; CHECK-i32-NEXT:    fmov s1, w8
-; CHECK-i32-NEXT:    fcvtzs w8, h0
-; CHECK-i32-NEXT:    fmov s0, w9
-; CHECK-i32-NEXT:    fcvtzs w9, h3
-; CHECK-i32-NEXT:    mov v0.s[1], w11
-; CHECK-i32-NEXT:    mov v1.s[1], w10
-; CHECK-i32-NEXT:    fcvtzs w10, h2
-; CHECK-i32-NEXT:    mov v0.s[2], w8
-; CHECK-i32-NEXT:    mov v1.s[2], w12
-; CHECK-i32-NEXT:    mov v0.s[3], w10
-; CHECK-i32-NEXT:    mov v1.s[3], w9
+; CHECK-i32-NEXT:    frintx v0.8h, v0.8h
+; CHECK-i32-NEXT:    ptrue p0.s, vl8
+; CHECK-i32-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.h
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v8f16:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
 ; CHECK-i64-NEXT:    frintx v0.4h, v0.4h
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
 ; CHECK-i64-NEXT:    frintx v1.4h, v1.4h
-; CHECK-i64-NEXT:    mov h3, v0.h[2]
-; CHECK-i64-NEXT:    mov h4, v0.h[1]
-; CHECK-i64-NEXT:    mov h5, v0.h[3]
-; CHECK-i64-NEXT:    fcvtzs x8, h0
-; CHECK-i64-NEXT:    mov h2, v1.h[2]
-; CHECK-i64-NEXT:    mov h6, v1.h[3]
-; CHECK-i64-NEXT:    mov h7, v1.h[1]
-; CHECK-i64-NEXT:    fcvtzs x10, h1
-; CHECK-i64-NEXT:    fcvtzs x11, h3
-; CHECK-i64-NEXT:    fcvtzs x12, h4
-; CHECK-i64-NEXT:    fcvtzs x13, h5
-; CHECK-i64-NEXT:    fmov d0, x8
-; CHECK-i64-NEXT:    fcvtzs x9, h2
-; CHECK-i64-NEXT:    fcvtzs x14, h6
-; CHECK-i64-NEXT:    fcvtzs x15, h7
-; CHECK-i64-NEXT:    fmov d2, x10
-; CHECK-i64-NEXT:    fmov d1, x11
-; CHECK-i64-NEXT:    mov v0.d[1], x12
-; CHECK-i64-NEXT:    fmov d3, x9
-; CHECK-i64-NEXT:    mov v1.d[1], x13
-; CHECK-i64-NEXT:    mov v2.d[1], x15
-; CHECK-i64-NEXT:    mov v3.d[1], x14
+; CHECK-i64-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i64-NEXT:    uunpklo z1.s, z1.h
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-i64-NEXT:    movprfx z2, z1
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z1.h
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-i64-NEXT:    ret
   %a = call <8 x iXLen> @llvm.lrint.v8iXLen.v8f16(<8 x half> %x)
   ret <8 x iXLen> %a
@@ -147,107 +122,62 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v16f16:
 ; CHECK-i32:       // %bb.0:
 ; CHECK-i32-NEXT:    frintx v1.8h, v1.8h
-; CHECK-i32-NEXT:    frintx v4.8h, v0.8h
-; CHECK-i32-NEXT:    mov h0, v1.h[6]
-; CHECK-i32-NEXT:    mov h2, v1.h[5]
-; CHECK-i32-NEXT:    mov h3, v1.h[4]
-; CHECK-i32-NEXT:    mov h5, v4.h[4]
-; CHECK-i32-NEXT:    mov h7, v4.h[1]
-; CHECK-i32-NEXT:    fcvtzs w10, h1
-; CHECK-i32-NEXT:    fcvtzs w13, h4
-; CHECK-i32-NEXT:    mov h6, v1.h[2]
-; CHECK-i32-NEXT:    mov h16, v1.h[3]
-; CHECK-i32-NEXT:    mov h17, v4.h[7]
-; CHECK-i32-NEXT:    fcvtzs w8, h0
-; CHECK-i32-NEXT:    mov h0, v1.h[1]
-; CHECK-i32-NEXT:    fcvtzs w9, h2
-; CHECK-i32-NEXT:    mov h2, v4.h[5]
-; CHECK-i32-NEXT:    fcvtzs w11, h3
-; CHECK-i32-NEXT:    mov h3, v4.h[6]
-; CHECK-i32-NEXT:    fcvtzs w12, h5
-; CHECK-i32-NEXT:    mov h5, v4.h[2]
-; CHECK-i32-NEXT:    fcvtzs w14, h7
-; CHECK-i32-NEXT:    mov h7, v1.h[7]
-; CHECK-i32-NEXT:    fcvtzs w17, h6
-; CHECK-i32-NEXT:    mov h4, v4.h[3]
-; CHECK-i32-NEXT:    fcvtzs w15, h0
-; CHECK-i32-NEXT:    fmov s0, w13
-; CHECK-i32-NEXT:    fcvtzs w16, h2
-; CHECK-i32-NEXT:    fmov s2, w10
-; CHECK-i32-NEXT:    fcvtzs w10, h3
-; CHECK-i32-NEXT:    fmov s3, w11
-; CHECK-i32-NEXT:    fmov s1, w12
-; CHECK-i32-NEXT:    fcvtzs w18, h5
-; CHECK-i32-NEXT:    mov v0.s[1], w14
-; CHECK-i32-NEXT:    fcvtzs w11, h16
-; CHECK-i32-NEXT:    fcvtzs w12, h17
-; CHECK-i32-NEXT:    mov v2.s[1], w15
-; CHECK-i32-NEXT:    fcvtzs w13, h4
-; CHECK-i32-NEXT:    mov v1.s[1], w16
-; CHECK-i32-NEXT:    mov v3.s[1], w9
-; CHECK-i32-NEXT:    fcvtzs w9, h7
-; CHECK-i32-NEXT:    mov v0.s[2], w18
-; CHECK-i32-NEXT:    mov v2.s[2], w17
-; CHECK-i32-NEXT:    mov v1.s[2], w10
-; CHECK-i32-NEXT:    mov v3.s[2], w8
-; CHECK-i32-NEXT:    mov v0.s[3], w13
-; CHECK-i32-NEXT:    mov v2.s[3], w11
-; CHECK-i32-NEXT:    mov v1.s[3], w12
-; CHECK-i32-NEXT:    mov v3.s[3], w9
+; CHECK-i32-NEXT:    frintx v0.8h, v0.8h
+; CHECK-i32-NEXT:    ptrue p0.s, vl8
+; CHECK-i32-NEXT:    uunpklo z1.s, z1.h
+; CHECK-i32-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i32-NEXT:    movprfx z2, z1
+; CHECK-i32-NEXT:    fcvtzs z2.s, p0/m, z1.h
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.h
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    movprfx z3, z2
+; CHECK-i32-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v16f16:
 ; CHECK-i64:       // %bb.0:
-; CHECK-i64-NEXT:    ext v2.16b, v1.16b, v1.16b, #8
-; CHECK-i64-NEXT:    ext v3.16b, v0.16b, v0.16b, #8
+; CHECK-i64-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-i64-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
 ; CHECK-i64-NEXT:    frintx v0.4h, v0.4h
 ; CHECK-i64-NEXT:    frintx v1.4h, v1.4h
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
 ; CHECK-i64-NEXT:    frintx v2.4h, v2.4h
 ; CHECK-i64-NEXT:    frintx v3.4h, v3.4h
-; CHECK-i64-NEXT:    mov h5, v0.h[2]
-; CHECK-i64-NEXT:    mov h4, v1.h[2]
-; CHECK-i64-NEXT:    mov h6, v0.h[1]
-; CHECK-i64-NEXT:    fcvtzs x8, h1
-; CHECK-i64-NEXT:    mov h16, v0.h[3]
-; CHECK-i64-NEXT:    fcvtzs x9, h0
-; CHECK-i64-NEXT:    mov h7, v1.h[1]
-; CHECK-i64-NEXT:    mov h1, v1.h[3]
-; CHECK-i64-NEXT:    mov h0, v2.h[3]
-; CHECK-i64-NEXT:    mov h17, v2.h[2]
-; CHECK-i64-NEXT:    fcvtzs x12, h5
-; CHECK-i64-NEXT:    mov h5, v3.h[2]
-; CHECK-i64-NEXT:    fcvtzs x11, h2
-; CHECK-i64-NEXT:    mov h18, v3.h[3]
-; CHECK-i64-NEXT:    fcvtzs x14, h3
-; CHECK-i64-NEXT:    mov h3, v3.h[1]
-; CHECK-i64-NEXT:    mov h19, v2.h[1]
-; CHECK-i64-NEXT:    fcvtzs x10, h4
-; CHECK-i64-NEXT:    fmov d4, x8
-; CHECK-i64-NEXT:    fcvtzs x13, h6
-; CHECK-i64-NEXT:    fcvtzs x15, h0
-; CHECK-i64-NEXT:    fcvtzs x8, h17
-; CHECK-i64-NEXT:    fmov d0, x9
-; CHECK-i64-NEXT:    fcvtzs x9, h5
-; CHECK-i64-NEXT:    fcvtzs x16, h7
-; CHECK-i64-NEXT:    fcvtzs x17, h16
-; CHECK-i64-NEXT:    fmov d6, x11
-; CHECK-i64-NEXT:    fcvtzs x11, h18
-; CHECK-i64-NEXT:    fcvtzs x18, h3
-; CHECK-i64-NEXT:    fmov d2, x14
-; CHECK-i64-NEXT:    fcvtzs x14, h19
-; CHECK-i64-NEXT:    fcvtzs x0, h1
-; CHECK-i64-NEXT:    fmov d5, x10
-; CHECK-i64-NEXT:    fmov d1, x12
-; CHECK-i64-NEXT:    fmov d7, x8
-; CHECK-i64-NEXT:    fmov d3, x9
-; CHECK-i64-NEXT:    mov v0.d[1], x13
-; CHECK-i64-NEXT:    mov v4.d[1], x16
-; CHECK-i64-NEXT:    mov v2.d[1], x18
-; CHECK-i64-NEXT:    mov v1.d[1], x17
-; CHECK-i64-NEXT:    mov v5.d[1], x0
-; CHECK-i64-NEXT:    mov v6.d[1], x14
-; CHECK-i64-NEXT:    mov v3.d[1], x11
-; CHECK-i64-NEXT:    mov v7.d[1], x15
+; CHECK-i64-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i64-NEXT:    uunpklo z1.s, z1.h
+; CHECK-i64-NEXT:    uunpklo z2.s, z2.h
+; CHECK-i64-NEXT:    uunpklo z3.s, z3.h
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    uunpklo z2.d, z2.s
+; CHECK-i64-NEXT:    uunpklo z3.d, z3.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-i64-NEXT:    movprfx z4, z1
+; CHECK-i64-NEXT:    fcvtzs z4.d, p0/m, z1.h
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-i64-NEXT:    movprfx z6, z3
+; CHECK-i64-NEXT:    fcvtzs z6.d, p0/m, z3.h
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    movprfx z5, z4
+; CHECK-i64-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    movprfx z7, z6
+; CHECK-i64-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-i64-NEXT:    ret
   %a = call <16 x iXLen> @llvm.lrint.v16iXLen.v16f16(<16 x half> %x)
   ret <16 x iXLen> %a
@@ -257,230 +187,93 @@ declare <16 x iXLen> @llvm.lrint.v16iXLen.v16f16(<16 x half>)
 define <32 x iXLen> @lrint_v32f16(<32 x half> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v32f16:
 ; CHECK-i32:       // %bb.0:
-; CHECK-i32-NEXT:    stp x20, x19, [sp, #-16]! // 16-byte Folded Spill
+; CHECK-i32-NEXT:    frintx v1.8h, v1.8h
+; CHECK-i32-NEXT:    frintx v0.8h, v0.8h
 ; CHECK-i32-NEXT:    frintx v3.8h, v3.8h
 ; CHECK-i32-NEXT:    frintx v2.8h, v2.8h
-; CHECK-i32-NEXT:    frintx v1.8h, v1.8h
-; CHECK-i32-NEXT:    mov h16, v3.h[3]
-; CHECK-i32-NEXT:    mov h17, v3.h[2]
-; CHECK-i32-NEXT:    mov h4, v3.h[7]
-; CHECK-i32-NEXT:    mov h5, v3.h[6]
-; CHECK-i32-NEXT:    mov h6, v3.h[5]
-; CHECK-i32-NEXT:    mov h7, v3.h[4]
-; CHECK-i32-NEXT:    mov h18, v3.h[1]
-; CHECK-i32-NEXT:    fcvtzs w13, h3
-; CHECK-i32-NEXT:    mov h3, v2.h[7]
-; CHECK-i32-NEXT:    mov h19, v2.h[4]
-; CHECK-i32-NEXT:    fcvtzs w18, h2
-; CHECK-i32-NEXT:    mov h20, v2.h[3]
-; CHECK-i32-NEXT:    fcvtzs w9, h16
-; CHECK-i32-NEXT:    fcvtzs w11, h17
-; CHECK-i32-NEXT:    mov h16, v2.h[1]
-; CHECK-i32-NEXT:    frintx v17.8h, v0.8h
-; CHECK-i32-NEXT:    fcvtzs w8, h4
-; CHECK-i32-NEXT:    mov h4, v2.h[6]
-; CHECK-i32-NEXT:    mov h0, v1.h[6]
-; CHECK-i32-NEXT:    fcvtzs w10, h5
-; CHECK-i32-NEXT:    mov h5, v2.h[5]
-; CHECK-i32-NEXT:    mov h21, v2.h[2]
-; CHECK-i32-NEXT:    mov h2, v1.h[4]
-; CHECK-i32-NEXT:    fcvtzs w15, h7
-; CHECK-i32-NEXT:    fcvtzs w1, h16
-; CHECK-i32-NEXT:    fcvtzs w12, h6
-; CHECK-i32-NEXT:    fcvtzs w17, h19
-; CHECK-i32-NEXT:    mov h16, v17.h[4]
-; CHECK-i32-NEXT:    fcvtzs w14, h18
-; CHECK-i32-NEXT:    fmov s6, w13
-; CHECK-i32-NEXT:    fcvtzs w13, h3
-; CHECK-i32-NEXT:    fcvtzs w16, h4
-; CHECK-i32-NEXT:    mov h3, v1.h[5]
-; CHECK-i32-NEXT:    mov h18, v17.h[5]
-; CHECK-i32-NEXT:    fmov s4, w18
-; CHECK-i32-NEXT:    fcvtzs w18, h0
-; CHECK-i32-NEXT:    mov h0, v17.h[1]
-; CHECK-i32-NEXT:    mov h19, v1.h[1]
-; CHECK-i32-NEXT:    fcvtzs w2, h2
-; CHECK-i32-NEXT:    mov h2, v1.h[2]
-; CHECK-i32-NEXT:    fcvtzs w4, h1
-; CHECK-i32-NEXT:    fcvtzs w6, h16
-; CHECK-i32-NEXT:    fcvtzs w7, h17
-; CHECK-i32-NEXT:    fmov s7, w15
-; CHECK-i32-NEXT:    fcvtzs w0, h5
-; CHECK-i32-NEXT:    fcvtzs w15, h20
-; CHECK-i32-NEXT:    fcvtzs w3, h3
-; CHECK-i32-NEXT:    mov h20, v17.h[6]
-; CHECK-i32-NEXT:    fcvtzs w5, h18
-; CHECK-i32-NEXT:    mov h18, v17.h[2]
-; CHECK-i32-NEXT:    fcvtzs w19, h0
-; CHECK-i32-NEXT:    fcvtzs w20, h19
-; CHECK-i32-NEXT:    fmov s5, w17
-; CHECK-i32-NEXT:    fcvtzs w17, h21
-; CHECK-i32-NEXT:    mov h16, v1.h[7]
-; CHECK-i32-NEXT:    fmov s3, w2
-; CHECK-i32-NEXT:    mov h21, v1.h[3]
-; CHECK-i32-NEXT:    fcvtzs w2, h2
-; CHECK-i32-NEXT:    fmov s2, w4
-; CHECK-i32-NEXT:    fmov s1, w6
-; CHECK-i32-NEXT:    fmov s0, w7
-; CHECK-i32-NEXT:    mov h19, v17.h[7]
-; CHECK-i32-NEXT:    fcvtzs w4, h20
-; CHECK-i32-NEXT:    fcvtzs w6, h18
-; CHECK-i32-NEXT:    mov h17, v17.h[3]
-; CHECK-i32-NEXT:    mov v3.s[1], w3
-; CHECK-i32-NEXT:    mov v1.s[1], w5
-; CHECK-i32-NEXT:    mov v2.s[1], w20
-; CHECK-i32-NEXT:    mov v4.s[1], w1
-; CHECK-i32-NEXT:    mov v0.s[1], w19
-; CHECK-i32-NEXT:    mov v5.s[1], w0
-; CHECK-i32-NEXT:    mov v6.s[1], w14
-; CHECK-i32-NEXT:    mov v7.s[1], w12
-; CHECK-i32-NEXT:    fcvtzs w12, h16
-; CHECK-i32-NEXT:    fcvtzs w14, h21
-; CHECK-i32-NEXT:    fcvtzs w0, h19
-; CHECK-i32-NEXT:    fcvtzs w1, h17
-; CHECK-i32-NEXT:    mov v3.s[2], w18
-; CHECK-i32-NEXT:    mov v1.s[2], w4
-; CHECK-i32-NEXT:    mov v2.s[2], w2
-; CHECK-i32-NEXT:    mov v4.s[2], w17
-; CHECK-i32-NEXT:    mov v0.s[2], w6
-; CHECK-i32-NEXT:    mov v5.s[2], w16
-; CHECK-i32-NEXT:    mov v6.s[2], w11
-; CHECK-i32-NEXT:    mov v7.s[2], w10
-; CHECK-i32-NEXT:    mov v3.s[3], w12
-; CHECK-i32-NEXT:    mov v1.s[3], w0
-; CHECK-i32-NEXT:    mov v2.s[3], w14
-; CHECK-i32-NEXT:    mov v4.s[3], w15
-; CHECK-i32-NEXT:    mov v0.s[3], w1
-; CHECK-i32-NEXT:    mov v5.s[3], w13
-; CHECK-i32-NEXT:    mov v6.s[3], w9
-; CHECK-i32-NEXT:    mov v7.s[3], w8
-; CHECK-i32-NEXT:    ldp x20, x19, [sp], #16 // 16-byte Folded Reload
+; CHECK-i32-NEXT:    ptrue p0.s, vl8
+; CHECK-i32-NEXT:    uunpklo z1.s, z1.h
+; CHECK-i32-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i32-NEXT:    uunpklo z3.s, z3.h
+; CHECK-i32-NEXT:    uunpklo z4.s, z2.h
+; CHECK-i32-NEXT:    movprfx z2, z1
+; CHECK-i32-NEXT:    fcvtzs z2.s, p0/m, z1.h
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.h
+; CHECK-i32-NEXT:    movprfx z6, z3
+; CHECK-i32-NEXT:    fcvtzs z6.s, p0/m, z3.h
+; CHECK-i32-NEXT:    fcvtzs z4.s, p0/m, z4.h
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    movprfx z3, z2
+; CHECK-i32-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i32-NEXT:    movprfx z7, z6
+; CHECK-i32-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-i32-NEXT:    movprfx z5, z4
+; CHECK-i32-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 killed $z7
+; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 killed $z5
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v32f16:
 ; CHECK-i64:       // %bb.0:
-; CHECK-i64-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-i64-NEXT:    sub x9, sp, #272
-; CHECK-i64-NEXT:    mov x29, sp
-; CHECK-i64-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-i64-NEXT:    frintx v5.4h, v0.4h
-; CHECK-i64-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-i64-NEXT:    ext v4.16b, v1.16b, v1.16b, #8
-; CHECK-i64-NEXT:    ext v17.16b, v2.16b, v2.16b, #8
-; CHECK-i64-NEXT:    frintx v1.4h, v1.4h
-; CHECK-i64-NEXT:    frintx v2.4h, v2.4h
-; CHECK-i64-NEXT:    ptrue p0.d, vl4
-; CHECK-i64-NEXT:    mov h6, v5.h[3]
-; CHECK-i64-NEXT:    frintx v0.4h, v0.4h
-; CHECK-i64-NEXT:    mov h7, v5.h[2]
-; CHECK-i64-NEXT:    mov h16, v5.h[1]
-; CHECK-i64-NEXT:    frintx v4.4h, v4.4h
-; CHECK-i64-NEXT:    fcvtzs x12, h5
-; CHECK-i64-NEXT:    ext v5.16b, v3.16b, v3.16b, #8
-; CHECK-i64-NEXT:    frintx v17.4h, v17.4h
+; CHECK-i64-NEXT:    ext v4.16b, v3.16b, v3.16b, #8
+; CHECK-i64-NEXT:    ext v5.16b, v2.16b, v2.16b, #8
+; CHECK-i64-NEXT:    mov x9, #24 // =0x18
 ; CHECK-i64-NEXT:    frintx v3.4h, v3.4h
-; CHECK-i64-NEXT:    fcvtzs x9, h6
-; CHECK-i64-NEXT:    mov h6, v0.h[3]
-; CHECK-i64-NEXT:    fcvtzs x10, h7
-; CHECK-i64-NEXT:    mov h7, v0.h[2]
-; CHECK-i64-NEXT:    fcvtzs x11, h16
-; CHECK-i64-NEXT:    mov h16, v0.h[1]
-; CHECK-i64-NEXT:    fcvtzs x13, h6
-; CHECK-i64-NEXT:    mov h6, v4.h[3]
-; CHECK-i64-NEXT:    stp x10, x9, [sp, #48]
-; CHECK-i64-NEXT:    fcvtzs x9, h7
-; CHECK-i64-NEXT:    mov h7, v4.h[2]
-; CHECK-i64-NEXT:    fcvtzs x10, h16
-; CHECK-i64-NEXT:    mov h16, v4.h[1]
-; CHECK-i64-NEXT:    stp x12, x11, [sp, #32]
-; CHECK-i64-NEXT:    fcvtzs x11, h0
-; CHECK-i64-NEXT:    frintx v0.4h, v5.4h
-; CHECK-i64-NEXT:    mov h5, v17.h[3]
-; CHECK-i64-NEXT:    fcvtzs x12, h6
-; CHECK-i64-NEXT:    mov h6, v17.h[2]
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #16]
-; CHECK-i64-NEXT:    fcvtzs x13, h7
-; CHECK-i64-NEXT:    mov h7, v17.h[1]
-; CHECK-i64-NEXT:    fcvtzs x9, h16
-; CHECK-i64-NEXT:    stp x11, x10, [sp]
-; CHECK-i64-NEXT:    fcvtzs x10, h4
-; CHECK-i64-NEXT:    fcvtzs x11, h5
-; CHECK-i64-NEXT:    mov h4, v0.h[3]
-; CHECK-i64-NEXT:    mov h5, v0.h[2]
-; CHECK-i64-NEXT:    stp x13, x12, [sp, #80]
-; CHECK-i64-NEXT:    fcvtzs x12, h6
-; CHECK-i64-NEXT:    fcvtzs x13, h7
-; CHECK-i64-NEXT:    mov h6, v0.h[1]
-; CHECK-i64-NEXT:    stp x10, x9, [sp, #64]
-; CHECK-i64-NEXT:    fcvtzs x9, h17
-; CHECK-i64-NEXT:    mov h7, v1.h[3]
-; CHECK-i64-NEXT:    fcvtzs x10, h4
-; CHECK-i64-NEXT:    mov h4, v1.h[2]
-; CHECK-i64-NEXT:    stp x12, x11, [sp, #144]
-; CHECK-i64-NEXT:    fcvtzs x11, h5
-; CHECK-i64-NEXT:    mov h5, v1.h[1]
-; CHECK-i64-NEXT:    fcvtzs x12, h6
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #128]
-; CHECK-i64-NEXT:    fcvtzs x9, h0
-; CHECK-i64-NEXT:    fcvtzs x13, h7
-; CHECK-i64-NEXT:    mov h0, v2.h[3]
-; CHECK-i64-NEXT:    stp x11, x10, [sp, #208]
-; CHECK-i64-NEXT:    fcvtzs x10, h4
-; CHECK-i64-NEXT:    mov h4, v2.h[2]
-; CHECK-i64-NEXT:    fcvtzs x11, h5
-; CHECK-i64-NEXT:    mov h5, v2.h[1]
-; CHECK-i64-NEXT:    stp x9, x12, [sp, #192]
-; CHECK-i64-NEXT:    fcvtzs x9, h1
-; CHECK-i64-NEXT:    fcvtzs x12, h0
-; CHECK-i64-NEXT:    mov h0, v3.h[3]
-; CHECK-i64-NEXT:    mov h1, v3.h[2]
-; CHECK-i64-NEXT:    stp x10, x13, [sp, #112]
-; CHECK-i64-NEXT:    fcvtzs x10, h4
-; CHECK-i64-NEXT:    mov h4, v3.h[1]
-; CHECK-i64-NEXT:    fcvtzs x13, h5
-; CHECK-i64-NEXT:    stp x9, x11, [sp, #96]
-; CHECK-i64-NEXT:    fcvtzs x9, h2
-; CHECK-i64-NEXT:    fcvtzs x11, h0
-; CHECK-i64-NEXT:    stp x10, x12, [sp, #176]
-; CHECK-i64-NEXT:    fcvtzs x10, h1
-; CHECK-i64-NEXT:    fcvtzs x12, h4
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #160]
-; CHECK-i64-NEXT:    fcvtzs x9, h3
-; CHECK-i64-NEXT:    stp x10, x11, [sp, #240]
-; CHECK-i64-NEXT:    add x10, sp, #64
-; CHECK-i64-NEXT:    stp x9, x12, [sp, #224]
-; CHECK-i64-NEXT:    add x9, sp, #32
-; CHECK-i64-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    mov x9, sp
-; CHECK-i64-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #224
-; CHECK-i64-NEXT:    add x10, sp, #128
-; CHECK-i64-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #160
-; CHECK-i64-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    add x10, sp, #96
-; CHECK-i64-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #192
-; CHECK-i64-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    mov x10, #24 // =0x18
-; CHECK-i64-NEXT:    ld1d { z7.d }, p0/z, [x9]
+; CHECK-i64-NEXT:    ext v6.16b, v1.16b, v1.16b, #8
+; CHECK-i64-NEXT:    frintx v2.4h, v2.4h
+; CHECK-i64-NEXT:    ext v7.16b, v0.16b, v0.16b, #8
+; CHECK-i64-NEXT:    frintx v1.4h, v1.4h
+; CHECK-i64-NEXT:    frintx v0.4h, v0.4h
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
+; CHECK-i64-NEXT:    frintx v4.4h, v4.4h
+; CHECK-i64-NEXT:    frintx v5.4h, v5.4h
+; CHECK-i64-NEXT:    uunpklo z3.s, z3.h
+; CHECK-i64-NEXT:    frintx v6.4h, v6.4h
+; CHECK-i64-NEXT:    uunpklo z2.s, z2.h
+; CHECK-i64-NEXT:    frintx v7.4h, v7.4h
+; CHECK-i64-NEXT:    uunpklo z1.s, z1.h
+; CHECK-i64-NEXT:    uunpklo z0.s, z0.h
+; CHECK-i64-NEXT:    uunpklo z4.s, z4.h
+; CHECK-i64-NEXT:    uunpklo z5.s, z5.h
+; CHECK-i64-NEXT:    uunpklo z3.d, z3.s
+; CHECK-i64-NEXT:    uunpklo z6.s, z6.h
+; CHECK-i64-NEXT:    uunpklo z2.d, z2.s
+; CHECK-i64-NEXT:    uunpklo z7.s, z7.h
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    uunpklo z4.d, z4.s
+; CHECK-i64-NEXT:    uunpklo z5.d, z5.s
+; CHECK-i64-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-i64-NEXT:    uunpklo z6.d, z6.s
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-i64-NEXT:    uunpklo z7.d, z7.s
+; CHECK-i64-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-i64-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-i64-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-i64-NEXT:    st1d { z3.d }, p0, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #16 // =0x10
-; CHECK-i64-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-i64-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #8 // =0x8
-; CHECK-i64-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #28 // =0x1c
-; CHECK-i64-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #20 // =0x14
-; CHECK-i64-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #12 // =0xc
+; CHECK-i64-NEXT:    fcvtzs z6.d, p0/m, z6.h
 ; CHECK-i64-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #4 // =0x4
+; CHECK-i64-NEXT:    mov x9, #8 // =0x8
+; CHECK-i64-NEXT:    fcvtzs z7.d, p0/m, z7.h
 ; CHECK-i64-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #28 // =0x1c
+; CHECK-i64-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #20 // =0x14
+; CHECK-i64-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #12 // =0xc
+; CHECK-i64-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #4 // =0x4
+; CHECK-i64-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-i64-NEXT:    mov sp, x29
-; CHECK-i64-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
 ; CHECK-i64-NEXT:    ret
   %a = call <32 x iXLen> @llvm.lrint.v32iXLen.v32f16(<32 x half> %x)
   ret <32 x iXLen> %a
@@ -534,17 +327,13 @@ define <4 x iXLen> @lrint_v4f32(<4 x float> %x) nounwind {
 ; CHECK-i64-LABEL: lrint_v4f32:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    frintx v0.4s, v0.4s
-; CHECK-i64-NEXT:    mov s1, v0.s[2]
-; CHECK-i64-NEXT:    mov s2, v0.s[3]
-; CHECK-i64-NEXT:    mov s3, v0.s[1]
-; CHECK-i64-NEXT:    fcvtzs x9, s0
-; CHECK-i64-NEXT:    fcvtzs x8, s1
-; CHECK-i64-NEXT:    fcvtzs x10, s2
-; CHECK-i64-NEXT:    fcvtzs x11, s3
-; CHECK-i64-NEXT:    fmov d0, x9
-; CHECK-i64-NEXT:    fmov d1, x8
-; CHECK-i64-NEXT:    mov v0.d[1], x11
-; CHECK-i64-NEXT:    mov v1.d[1], x10
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i64-NEXT:    ret
   %a = call <4 x iXLen> @llvm.lrint.v4iXLen.v4f32(<4 x float> %x)
   ret <4 x iXLen> %a
@@ -559,57 +348,32 @@ define <8 x iXLen> @lrint_v8f32(<8 x float> %x) nounwind {
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i32-NEXT:    ptrue p0.s, vl8
-; CHECK-i32-NEXT:    movprfx z2, z0
-; CHECK-i32-NEXT:    frintx z2.s, p0/m, z0.s
-; CHECK-i32-NEXT:    mov z0.s, z2.s[5]
-; CHECK-i32-NEXT:    mov z1.s, z2.s[4]
-; CHECK-i32-NEXT:    mov z3.s, z2.s[1]
-; CHECK-i32-NEXT:    mov z4.s, z2.s[6]
-; CHECK-i32-NEXT:    mov z5.s, z2.s[2]
-; CHECK-i32-NEXT:    fcvtzs w8, s0
-; CHECK-i32-NEXT:    fcvtzs s1, s1
-; CHECK-i32-NEXT:    fcvtzs w9, s3
-; CHECK-i32-NEXT:    fcvtzs s0, s2
-; CHECK-i32-NEXT:    fcvtzs w10, s4
-; CHECK-i32-NEXT:    fcvtzs w11, s5
-; CHECK-i32-NEXT:    mov z3.s, z2.s[7]
-; CHECK-i32-NEXT:    mov z2.s, z2.s[3]
-; CHECK-i32-NEXT:    mov v1.s[1], w8
-; CHECK-i32-NEXT:    mov v0.s[1], w9
-; CHECK-i32-NEXT:    fcvtzs w8, s3
-; CHECK-i32-NEXT:    fcvtzs w9, s2
-; CHECK-i32-NEXT:    mov v1.s[2], w10
-; CHECK-i32-NEXT:    mov v0.s[2], w11
-; CHECK-i32-NEXT:    mov v1.s[3], w8
-; CHECK-i32-NEXT:    mov v0.s[3], w9
+; CHECK-i32-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v8f32:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    frintx v1.4s, v1.4s
 ; CHECK-i64-NEXT:    frintx v0.4s, v0.4s
-; CHECK-i64-NEXT:    mov s2, v1.s[2]
-; CHECK-i64-NEXT:    mov s3, v0.s[2]
-; CHECK-i64-NEXT:    mov s4, v0.s[1]
-; CHECK-i64-NEXT:    mov s5, v1.s[3]
-; CHECK-i64-NEXT:    mov s6, v1.s[1]
-; CHECK-i64-NEXT:    mov s7, v0.s[3]
-; CHECK-i64-NEXT:    fcvtzs x8, s0
-; CHECK-i64-NEXT:    fcvtzs x10, s1
-; CHECK-i64-NEXT:    fcvtzs x9, s2
-; CHECK-i64-NEXT:    fcvtzs x11, s3
-; CHECK-i64-NEXT:    fcvtzs x12, s4
-; CHECK-i64-NEXT:    fcvtzs x13, s5
-; CHECK-i64-NEXT:    fcvtzs x14, s6
-; CHECK-i64-NEXT:    fcvtzs x15, s7
-; CHECK-i64-NEXT:    fmov d0, x8
-; CHECK-i64-NEXT:    fmov d2, x10
-; CHECK-i64-NEXT:    fmov d3, x9
-; CHECK-i64-NEXT:    fmov d1, x11
-; CHECK-i64-NEXT:    mov v0.d[1], x12
-; CHECK-i64-NEXT:    mov v2.d[1], x14
-; CHECK-i64-NEXT:    mov v1.d[1], x15
-; CHECK-i64-NEXT:    mov v3.d[1], x13
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    movprfx z2, z1
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z1.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-i64-NEXT:    ret
   %a = call <8 x iXLen> @llvm.lrint.v8iXLen.v8f32(<8 x float> %x)
   ret <8 x iXLen> %a
@@ -624,107 +388,56 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) nounwind {
 ; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i32-NEXT:    ptrue p0.s, vl8
-; CHECK-i32-NEXT:    movprfx z4, z2
-; CHECK-i32-NEXT:    frintx z4.s, p0/m, z2.s
-; CHECK-i32-NEXT:    movprfx z5, z0
-; CHECK-i32-NEXT:    frintx z5.s, p0/m, z0.s
-; CHECK-i32-NEXT:    mov z0.s, z4.s[5]
-; CHECK-i32-NEXT:    mov z1.s, z5.s[5]
-; CHECK-i32-NEXT:    mov z3.s, z4.s[4]
-; CHECK-i32-NEXT:    mov z2.s, z4.s[1]
-; CHECK-i32-NEXT:    mov z7.s, z5.s[1]
-; CHECK-i32-NEXT:    mov z17.s, z5.s[4]
-; CHECK-i32-NEXT:    mov z6.s, z4.s[6]
-; CHECK-i32-NEXT:    mov z16.s, z5.s[6]
-; CHECK-i32-NEXT:    mov z18.s, z4.s[2]
-; CHECK-i32-NEXT:    fcvtzs w8, s0
-; CHECK-i32-NEXT:    fcvtzs w9, s1
-; CHECK-i32-NEXT:    fcvtzs s0, s5
-; CHECK-i32-NEXT:    fcvtzs w10, s2
-; CHECK-i32-NEXT:    fcvtzs w11, s7
-; CHECK-i32-NEXT:    fcvtzs s2, s4
-; CHECK-i32-NEXT:    fcvtzs s3, s3
-; CHECK-i32-NEXT:    fcvtzs s1, s17
-; CHECK-i32-NEXT:    mov z19.s, z5.s[2]
-; CHECK-i32-NEXT:    fcvtzs w12, s6
-; CHECK-i32-NEXT:    fcvtzs w13, s16
-; CHECK-i32-NEXT:    fcvtzs w14, s18
-; CHECK-i32-NEXT:    mov z6.s, z4.s[7]
-; CHECK-i32-NEXT:    mov z7.s, z5.s[7]
-; CHECK-i32-NEXT:    mov z4.s, z4.s[3]
-; CHECK-i32-NEXT:    fcvtzs w15, s19
-; CHECK-i32-NEXT:    mov v0.s[1], w11
-; CHECK-i32-NEXT:    mov v2.s[1], w10
-; CHECK-i32-NEXT:    mov v1.s[1], w9
-; CHECK-i32-NEXT:    mov v3.s[1], w8
-; CHECK-i32-NEXT:    mov z5.s, z5.s[3]
-; CHECK-i32-NEXT:    fcvtzs w8, s6
-; CHECK-i32-NEXT:    fcvtzs w9, s7
-; CHECK-i32-NEXT:    fcvtzs w10, s4
-; CHECK-i32-NEXT:    fcvtzs w11, s5
-; CHECK-i32-NEXT:    mov v0.s[2], w15
-; CHECK-i32-NEXT:    mov v2.s[2], w14
-; CHECK-i32-NEXT:    mov v1.s[2], w13
-; CHECK-i32-NEXT:    mov v3.s[2], w12
-; CHECK-i32-NEXT:    mov v0.s[3], w11
-; CHECK-i32-NEXT:    mov v2.s[3], w10
-; CHECK-i32-NEXT:    mov v1.s[3], w9
-; CHECK-i32-NEXT:    mov v3.s[3], w8
+; CHECK-i32-NEXT:    frintx z2.s, p0/m, z2.s
+; CHECK-i32-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    fcvtzs z2.s, p0/m, z2.s
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    movprfx z3, z2
+; CHECK-i32-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v16f32:
 ; CHECK-i64:       // %bb.0:
-; CHECK-i64-NEXT:    frintx v3.4s, v3.4s
-; CHECK-i64-NEXT:    frintx v2.4s, v2.4s
 ; CHECK-i64-NEXT:    frintx v1.4s, v1.4s
 ; CHECK-i64-NEXT:    frintx v0.4s, v0.4s
-; CHECK-i64-NEXT:    mov s4, v3.s[2]
-; CHECK-i64-NEXT:    mov s5, v2.s[2]
-; CHECK-i64-NEXT:    mov s6, v2.s[1]
-; CHECK-i64-NEXT:    mov s7, v1.s[2]
-; CHECK-i64-NEXT:    fcvtzs x8, s3
-; CHECK-i64-NEXT:    mov s16, v0.s[2]
-; CHECK-i64-NEXT:    fcvtzs x9, s2
-; CHECK-i64-NEXT:    mov s17, v1.s[3]
-; CHECK-i64-NEXT:    mov s18, v0.s[1]
-; CHECK-i64-NEXT:    mov s19, v3.s[3]
-; CHECK-i64-NEXT:    fcvtzs x14, s1
-; CHECK-i64-NEXT:    mov s1, v1.s[1]
-; CHECK-i64-NEXT:    fcvtzs x10, s4
-; CHECK-i64-NEXT:    fcvtzs x11, s5
-; CHECK-i64-NEXT:    mov s5, v0.s[3]
-; CHECK-i64-NEXT:    mov s3, v3.s[1]
-; CHECK-i64-NEXT:    mov s2, v2.s[3]
-; CHECK-i64-NEXT:    fcvtzs x12, s6
-; CHECK-i64-NEXT:    fcvtzs x13, s7
-; CHECK-i64-NEXT:    fcvtzs x15, s16
-; CHECK-i64-NEXT:    fmov d6, x8
-; CHECK-i64-NEXT:    fcvtzs x8, s0
-; CHECK-i64-NEXT:    fmov d4, x9
-; CHECK-i64-NEXT:    fcvtzs x9, s17
-; CHECK-i64-NEXT:    fcvtzs x16, s5
-; CHECK-i64-NEXT:    fcvtzs x17, s18
-; CHECK-i64-NEXT:    fmov d7, x10
-; CHECK-i64-NEXT:    fmov d5, x11
-; CHECK-i64-NEXT:    fcvtzs x10, s1
-; CHECK-i64-NEXT:    fcvtzs x11, s19
-; CHECK-i64-NEXT:    fcvtzs x18, s3
-; CHECK-i64-NEXT:    fcvtzs x0, s2
-; CHECK-i64-NEXT:    fmov d3, x13
-; CHECK-i64-NEXT:    fmov d1, x15
-; CHECK-i64-NEXT:    fmov d0, x8
-; CHECK-i64-NEXT:    fmov d2, x14
-; CHECK-i64-NEXT:    mov v4.d[1], x12
-; CHECK-i64-NEXT:    mov v3.d[1], x9
-; CHECK-i64-NEXT:    mov v7.d[1], x11
-; CHECK-i64-NEXT:    mov v0.d[1], x17
-; CHECK-i64-NEXT:    mov v1.d[1], x16
-; CHECK-i64-NEXT:    mov v2.d[1], x10
-; CHECK-i64-NEXT:    mov v5.d[1], x0
-; CHECK-i64-NEXT:    mov v6.d[1], x18
+; CHECK-i64-NEXT:    frintx v3.4s, v3.4s
+; CHECK-i64-NEXT:    frintx v2.4s, v2.4s
+; CHECK-i64-NEXT:    ptrue p0.d, vl4
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    uunpklo z3.d, z3.s
+; CHECK-i64-NEXT:    uunpklo z4.d, z2.s
+; CHECK-i64-NEXT:    movprfx z2, z1
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z1.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-i64-NEXT:    movprfx z6, z3
+; CHECK-i64-NEXT:    fcvtzs z6.d, p0/m, z3.s
+; CHECK-i64-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    movprfx z7, z6
+; CHECK-i64-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-i64-NEXT:    movprfx z5, z4
+; CHECK-i64-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 killed $z7
+; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 killed $z5
 ; CHECK-i64-NEXT:    ret
   %a = call <16 x iXLen> @llvm.lrint.v16iXLen.v16f32(<16 x float> %x)
   ret <16 x iXLen> %a
@@ -734,236 +447,88 @@ declare <16 x iXLen> @llvm.lrint.v16iXLen.v16f32(<16 x float>)
 define <32 x iXLen> @lrint_v32f32(<32 x float> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v32f32:
 ; CHECK-i32:       // %bb.0:
-; CHECK-i32-NEXT:    str x19, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-i32-NEXT:    ptrue p1.d, vl2
+; CHECK-i32-NEXT:    ptrue p0.d, vl2
 ; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
-; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
 ; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
+; CHECK-i32-NEXT:    splice z4.d, p0, z4.d, z5.d
+; CHECK-i32-NEXT:    splice z6.d, p0, z6.d, z7.d
 ; CHECK-i32-NEXT:    ptrue p0.s, vl8
-; CHECK-i32-NEXT:    splice z6.d, p1, z6.d, z7.d
-; CHECK-i32-NEXT:    splice z4.d, p1, z4.d, z5.d
-; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z3.d
-; CHECK-i32-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i32-NEXT:    movprfx z16, z6
-; CHECK-i32-NEXT:    frintx z16.s, p0/m, z6.s
-; CHECK-i32-NEXT:    movprfx z17, z4
-; CHECK-i32-NEXT:    frintx z17.s, p0/m, z4.s
-; CHECK-i32-NEXT:    movprfx z18, z2
-; CHECK-i32-NEXT:    frintx z18.s, p0/m, z2.s
-; CHECK-i32-NEXT:    movprfx z19, z0
-; CHECK-i32-NEXT:    frintx z19.s, p0/m, z0.s
-; CHECK-i32-NEXT:    mov z0.s, z16.s[7]
-; CHECK-i32-NEXT:    mov z2.s, z16.s[5]
-; CHECK-i32-NEXT:    mov z3.s, z16.s[4]
-; CHECK-i32-NEXT:    mov z1.s, z16.s[6]
-; CHECK-i32-NEXT:    mov z4.s, z17.s[7]
-; CHECK-i32-NEXT:    mov z6.s, z17.s[6]
-; CHECK-i32-NEXT:    mov z20.s, z17.s[5]
-; CHECK-i32-NEXT:    mov z5.s, z17.s[4]
-; CHECK-i32-NEXT:    mov z21.s, z19.s[1]
-; CHECK-i32-NEXT:    fcvtzs w8, s0
-; CHECK-i32-NEXT:    mov z0.s, z18.s[7]
-; CHECK-i32-NEXT:    fcvtzs w13, s2
-; CHECK-i32-NEXT:    mov z2.s, z18.s[5]
-; CHECK-i32-NEXT:    fcvtzs s7, s3
-; CHECK-i32-NEXT:    mov z3.s, z19.s[7]
-; CHECK-i32-NEXT:    fcvtzs w10, s1
-; CHECK-i32-NEXT:    mov z1.s, z18.s[6]
-; CHECK-i32-NEXT:    fcvtzs w9, s4
-; CHECK-i32-NEXT:    fcvtzs w12, s6
-; CHECK-i32-NEXT:    fcvtzs w11, s0
-; CHECK-i32-NEXT:    mov z0.s, z19.s[6]
-; CHECK-i32-NEXT:    mov z4.s, z19.s[5]
-; CHECK-i32-NEXT:    fcvtzs w18, s2
-; CHECK-i32-NEXT:    mov z2.s, z18.s[4]
-; CHECK-i32-NEXT:    fcvtzs w15, s3
-; CHECK-i32-NEXT:    mov z3.s, z16.s[1]
-; CHECK-i32-NEXT:    mov z6.s, z17.s[1]
-; CHECK-i32-NEXT:    fcvtzs w14, s1
-; CHECK-i32-NEXT:    mov z1.s, z16.s[2]
-; CHECK-i32-NEXT:    fcvtzs w17, s0
-; CHECK-i32-NEXT:    fcvtzs w1, s4
-; CHECK-i32-NEXT:    mov z0.s, z17.s[2]
-; CHECK-i32-NEXT:    mov z4.s, z19.s[4]
-; CHECK-i32-NEXT:    fcvtzs w2, s3
-; CHECK-i32-NEXT:    fcvtzs s3, s2
-; CHECK-i32-NEXT:    mov z2.s, z18.s[1]
-; CHECK-i32-NEXT:    fcvtzs w6, s6
-; CHECK-i32-NEXT:    mov z6.s, z19.s[2]
-; CHECK-i32-NEXT:    fcvtzs w16, s20
-; CHECK-i32-NEXT:    fcvtzs w0, s1
-; CHECK-i32-NEXT:    fcvtzs w3, s0
-; CHECK-i32-NEXT:    fcvtzs s1, s4
-; CHECK-i32-NEXT:    fcvtzs w7, s21
-; CHECK-i32-NEXT:    fcvtzs s0, s19
-; CHECK-i32-NEXT:    fcvtzs s4, s17
-; CHECK-i32-NEXT:    fcvtzs w19, s2
-; CHECK-i32-NEXT:    fcvtzs s2, s18
-; CHECK-i32-NEXT:    fcvtzs s5, s5
-; CHECK-i32-NEXT:    fcvtzs w5, s6
-; CHECK-i32-NEXT:    fcvtzs s6, s16
-; CHECK-i32-NEXT:    mov z20.s, z18.s[2]
-; CHECK-i32-NEXT:    mov v1.s[1], w1
-; CHECK-i32-NEXT:    mov v3.s[1], w18
-; CHECK-i32-NEXT:    mov v7.s[1], w13
-; CHECK-i32-NEXT:    mov v0.s[1], w7
-; CHECK-i32-NEXT:    mov v4.s[1], w6
-; CHECK-i32-NEXT:    mov z16.s, z16.s[3]
-; CHECK-i32-NEXT:    fcvtzs w4, s20
-; CHECK-i32-NEXT:    mov v2.s[1], w19
-; CHECK-i32-NEXT:    mov v5.s[1], w16
-; CHECK-i32-NEXT:    mov v6.s[1], w2
-; CHECK-i32-NEXT:    mov z17.s, z17.s[3]
-; CHECK-i32-NEXT:    mov z18.s, z18.s[3]
-; CHECK-i32-NEXT:    mov z19.s, z19.s[3]
-; CHECK-i32-NEXT:    fcvtzs w13, s16
-; CHECK-i32-NEXT:    mov v1.s[2], w17
-; CHECK-i32-NEXT:    mov v0.s[2], w5
-; CHECK-i32-NEXT:    mov v4.s[2], w3
-; CHECK-i32-NEXT:    mov v3.s[2], w14
-; CHECK-i32-NEXT:    fcvtzs w16, s17
-; CHECK-i32-NEXT:    fcvtzs w18, s18
-; CHECK-i32-NEXT:    mov v2.s[2], w4
-; CHECK-i32-NEXT:    fcvtzs w1, s19
-; CHECK-i32-NEXT:    mov v6.s[2], w0
-; CHECK-i32-NEXT:    mov v5.s[2], w12
-; CHECK-i32-NEXT:    mov v7.s[2], w10
-; CHECK-i32-NEXT:    mov v1.s[3], w15
-; CHECK-i32-NEXT:    mov v3.s[3], w11
-; CHECK-i32-NEXT:    mov v2.s[3], w18
-; CHECK-i32-NEXT:    mov v4.s[3], w16
-; CHECK-i32-NEXT:    mov v0.s[3], w1
-; CHECK-i32-NEXT:    mov v6.s[3], w13
-; CHECK-i32-NEXT:    mov v5.s[3], w9
-; CHECK-i32-NEXT:    mov v7.s[3], w8
-; CHECK-i32-NEXT:    ldr x19, [sp], #16 // 8-byte Folded Reload
+; CHECK-i32-NEXT:    frintx z2.s, p0/m, z2.s
+; CHECK-i32-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    frintx z4.s, p0/m, z4.s
+; CHECK-i32-NEXT:    frintx z6.s, p0/m, z6.s
+; CHECK-i32-NEXT:    fcvtzs z2.s, p0/m, z2.s
+; CHECK-i32-NEXT:    fcvtzs z0.s, p0/m, z0.s
+; CHECK-i32-NEXT:    fcvtzs z4.s, p0/m, z4.s
+; CHECK-i32-NEXT:    fcvtzs z6.s, p0/m, z6.s
+; CHECK-i32-NEXT:    movprfx z1, z0
+; CHECK-i32-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i32-NEXT:    movprfx z3, z2
+; CHECK-i32-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i32-NEXT:    movprfx z5, z4
+; CHECK-i32-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-i32-NEXT:    movprfx z7, z6
+; CHECK-i32-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v32f32:
 ; CHECK-i64:       // %bb.0:
-; CHECK-i64-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-i64-NEXT:    sub x9, sp, #272
-; CHECK-i64-NEXT:    mov x29, sp
-; CHECK-i64-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-i64-NEXT:    frintx v0.4s, v0.4s
-; CHECK-i64-NEXT:    frintx v1.4s, v1.4s
+; CHECK-i64-NEXT:    frintx v7.4s, v7.4s
+; CHECK-i64-NEXT:    frintx v6.4s, v6.4s
+; CHECK-i64-NEXT:    mov x9, #28 // =0x1c
+; CHECK-i64-NEXT:    frintx v5.4s, v5.4s
+; CHECK-i64-NEXT:    frintx v4.4s, v4.4s
+; CHECK-i64-NEXT:    frintx v3.4s, v3.4s
 ; CHECK-i64-NEXT:    frintx v2.4s, v2.4s
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
-; CHECK-i64-NEXT:    mov s16, v0.s[3]
-; CHECK-i64-NEXT:    mov s17, v0.s[2]
-; CHECK-i64-NEXT:    mov s18, v0.s[1]
-; CHECK-i64-NEXT:    fcvtzs x12, s0
-; CHECK-i64-NEXT:    frintx v0.4s, v3.4s
-; CHECK-i64-NEXT:    mov s3, v2.s[3]
-; CHECK-i64-NEXT:    fcvtzs x9, s16
-; CHECK-i64-NEXT:    mov s16, v1.s[3]
-; CHECK-i64-NEXT:    fcvtzs x10, s17
-; CHECK-i64-NEXT:    mov s17, v1.s[2]
-; CHECK-i64-NEXT:    fcvtzs x11, s18
-; CHECK-i64-NEXT:    mov s18, v1.s[1]
-; CHECK-i64-NEXT:    fcvtzs x13, s16
-; CHECK-i64-NEXT:    stp x10, x9, [sp, #16]
-; CHECK-i64-NEXT:    mov s16, v2.s[2]
-; CHECK-i64-NEXT:    fcvtzs x9, s17
-; CHECK-i64-NEXT:    fcvtzs x10, s18
-; CHECK-i64-NEXT:    mov s17, v2.s[1]
-; CHECK-i64-NEXT:    stp x12, x11, [sp]
-; CHECK-i64-NEXT:    fcvtzs x11, s1
-; CHECK-i64-NEXT:    frintx v1.4s, v4.4s
-; CHECK-i64-NEXT:    fcvtzs x12, s3
-; CHECK-i64-NEXT:    mov s3, v0.s[3]
-; CHECK-i64-NEXT:    mov s4, v0.s[2]
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #48]
-; CHECK-i64-NEXT:    fcvtzs x13, s16
-; CHECK-i64-NEXT:    fcvtzs x9, s17
-; CHECK-i64-NEXT:    mov s16, v0.s[1]
-; CHECK-i64-NEXT:    stp x11, x10, [sp, #32]
-; CHECK-i64-NEXT:    fcvtzs x10, s2
-; CHECK-i64-NEXT:    frintx v2.4s, v5.4s
-; CHECK-i64-NEXT:    fcvtzs x11, s3
-; CHECK-i64-NEXT:    mov s3, v1.s[3]
-; CHECK-i64-NEXT:    mov s5, v1.s[1]
-; CHECK-i64-NEXT:    stp x13, x12, [sp, #80]
-; CHECK-i64-NEXT:    fcvtzs x12, s4
-; CHECK-i64-NEXT:    mov s4, v1.s[2]
-; CHECK-i64-NEXT:    fcvtzs x13, s16
-; CHECK-i64-NEXT:    stp x10, x9, [sp, #64]
-; CHECK-i64-NEXT:    fcvtzs x9, s0
-; CHECK-i64-NEXT:    mov s0, v2.s[3]
-; CHECK-i64-NEXT:    fcvtzs x10, s3
-; CHECK-i64-NEXT:    frintx v3.4s, v6.4s
-; CHECK-i64-NEXT:    stp x12, x11, [sp, #112]
-; CHECK-i64-NEXT:    fcvtzs x11, s4
-; CHECK-i64-NEXT:    mov s4, v2.s[2]
-; CHECK-i64-NEXT:    fcvtzs x12, s5
-; CHECK-i64-NEXT:    mov s5, v2.s[1]
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #96]
-; CHECK-i64-NEXT:    fcvtzs x9, s1
-; CHECK-i64-NEXT:    fcvtzs x13, s0
-; CHECK-i64-NEXT:    mov s0, v3.s[3]
-; CHECK-i64-NEXT:    frintx v1.4s, v7.4s
-; CHECK-i64-NEXT:    stp x11, x10, [sp, #144]
-; CHECK-i64-NEXT:    fcvtzs x10, s4
-; CHECK-i64-NEXT:    mov s4, v3.s[2]
-; CHECK-i64-NEXT:    fcvtzs x11, s5
-; CHECK-i64-NEXT:    mov s5, v3.s[1]
-; CHECK-i64-NEXT:    stp x9, x12, [sp, #128]
-; CHECK-i64-NEXT:    fcvtzs x9, s2
-; CHECK-i64-NEXT:    fcvtzs x12, s0
-; CHECK-i64-NEXT:    mov s0, v1.s[3]
-; CHECK-i64-NEXT:    mov s2, v1.s[2]
-; CHECK-i64-NEXT:    stp x10, x13, [sp, #176]
-; CHECK-i64-NEXT:    fcvtzs x10, s4
-; CHECK-i64-NEXT:    mov s4, v1.s[1]
-; CHECK-i64-NEXT:    fcvtzs x13, s5
-; CHECK-i64-NEXT:    stp x9, x11, [sp, #160]
-; CHECK-i64-NEXT:    fcvtzs x9, s3
-; CHECK-i64-NEXT:    fcvtzs x11, s0
-; CHECK-i64-NEXT:    stp x10, x12, [sp, #208]
-; CHECK-i64-NEXT:    fcvtzs x10, s2
-; CHECK-i64-NEXT:    fcvtzs x12, s4
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #192]
-; CHECK-i64-NEXT:    fcvtzs x9, s1
-; CHECK-i64-NEXT:    stp x10, x11, [sp, #240]
-; CHECK-i64-NEXT:    add x10, sp, #64
-; CHECK-i64-NEXT:    stp x9, x12, [sp, #224]
-; CHECK-i64-NEXT:    mov x9, sp
-; CHECK-i64-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #32
-; CHECK-i64-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #224
-; CHECK-i64-NEXT:    add x10, sp, #96
-; CHECK-i64-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #192
-; CHECK-i64-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    add x10, sp, #160
-; CHECK-i64-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #128
-; CHECK-i64-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    mov x10, #28 // =0x1c
-; CHECK-i64-NEXT:    ld1d { z7.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    mov x9, #24 // =0x18
-; CHECK-i64-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-i64-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #20 // =0x14
-; CHECK-i64-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #16 // =0x10
+; CHECK-i64-NEXT:    frintx v1.4s, v1.4s
+; CHECK-i64-NEXT:    frintx v0.4s, v0.4s
+; CHECK-i64-NEXT:    uunpklo z7.d, z7.s
+; CHECK-i64-NEXT:    uunpklo z6.d, z6.s
+; CHECK-i64-NEXT:    uunpklo z5.d, z5.s
+; CHECK-i64-NEXT:    uunpklo z4.d, z4.s
+; CHECK-i64-NEXT:    uunpklo z3.d, z3.s
+; CHECK-i64-NEXT:    uunpklo z2.d, z2.s
+; CHECK-i64-NEXT:    uunpklo z1.d, z1.s
+; CHECK-i64-NEXT:    uunpklo z0.d, z0.s
+; CHECK-i64-NEXT:    fcvtzs z7.d, p0/m, z7.s
+; CHECK-i64-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-i64-NEXT:    fcvtzs z5.d, p0/m, z5.s
+; CHECK-i64-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-i64-NEXT:    fcvtzs z3.d, p0/m, z3.s
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z2.s
+; CHECK-i64-NEXT:    fcvtzs z1.d, p0/m, z1.s
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-i64-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    mov x9, #12 // =0xc
+; CHECK-i64-NEXT:    mov x9, #24 // =0x18
+; CHECK-i64-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #20 // =0x14
+; CHECK-i64-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #16 // =0x10
 ; CHECK-i64-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    mov x9, #12 // =0xc
+; CHECK-i64-NEXT:    st1d { z3.d }, p0, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #8 // =0x8
 ; CHECK-i64-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #4 // =0x4
 ; CHECK-i64-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-i64-NEXT:    mov sp, x29
-; CHECK-i64-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
 ; CHECK-i64-NEXT:    ret
   %a = call <32 x iXLen> @llvm.lrint.v32iXLen.v32f32(<32 x float> %x)
   ret <32 x iXLen> %a
@@ -992,12 +557,8 @@ define <2 x iXLen> @lrint_v2f64(<2 x double> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v2f64:
 ; CHECK-i32:       // %bb.0:
 ; CHECK-i32-NEXT:    frintx v0.2d, v0.2d
-; CHECK-i32-NEXT:    mov d1, v0.d[1]
-; CHECK-i32-NEXT:    fcvtzs w8, d0
-; CHECK-i32-NEXT:    fcvtzs w9, d1
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    mov v0.s[1], w9
-; CHECK-i32-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-i32-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-NEXT:    xtn v0.2s, v0.2d
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v2f64:
@@ -1018,19 +579,10 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) nounwind {
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i32-NEXT:    ptrue p0.d, vl4
-; CHECK-i32-NEXT:    movprfx z1, z0
-; CHECK-i32-NEXT:    frintx z1.d, p0/m, z0.d
-; CHECK-i32-NEXT:    mov z0.d, z1.d[1]
-; CHECK-i32-NEXT:    fcvtzs w8, d1
-; CHECK-i32-NEXT:    mov z2.d, z1.d[2]
-; CHECK-i32-NEXT:    mov z1.d, z1.d[3]
-; CHECK-i32-NEXT:    fcvtzs w9, d0
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    fcvtzs w8, d2
-; CHECK-i32-NEXT:    mov v0.s[1], w9
-; CHECK-i32-NEXT:    mov v0.s[2], w8
-; CHECK-i32-NEXT:    fcvtzs w8, d1
-; CHECK-i32-NEXT:    mov v0.s[3], w8
+; CHECK-i32-NEXT:    frintx z0.d, p0/m, z0.d
+; CHECK-i32-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i32-NEXT:    uzp1 z0.s, z0.s, z0.s
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v4f64:
@@ -1041,15 +593,11 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) nounwind {
 ; CHECK-i64-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
 ; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    mov z1.d, z0.d[3]
-; CHECK-i64-NEXT:    mov z2.d, z0.d[2]
-; CHECK-i64-NEXT:    mov z3.d, z0.d[1]
-; CHECK-i64-NEXT:    fcvtzs d0, d0
-; CHECK-i64-NEXT:    fcvtzs x8, d1
-; CHECK-i64-NEXT:    fcvtzs d1, d2
-; CHECK-i64-NEXT:    fcvtzs x9, d3
-; CHECK-i64-NEXT:    mov v0.d[1], x9
-; CHECK-i64-NEXT:    mov v1.d[1], x8
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i64-NEXT:    ret
   %a = call <4 x iXLen> @llvm.lrint.v4iXLen.v4f64(<4 x double> %x)
   ret <4 x iXLen> %a
@@ -1064,34 +612,17 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) nounwind {
 ; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
+; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i32-NEXT:    ptrue p0.d, vl4
-; CHECK-i32-NEXT:    movprfx z3, z0
-; CHECK-i32-NEXT:    frintx z3.d, p0/m, z0.d
+; CHECK-i32-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-i32-NEXT:    frintx z2.d, p0/m, z2.d
-; CHECK-i32-NEXT:    mov z0.d, z3.d[1]
-; CHECK-i32-NEXT:    mov z1.d, z2.d[1]
-; CHECK-i32-NEXT:    fcvtzs w8, d3
-; CHECK-i32-NEXT:    fcvtzs w9, d2
-; CHECK-i32-NEXT:    mov z4.d, z3.d[2]
-; CHECK-i32-NEXT:    mov z5.d, z2.d[2]
-; CHECK-i32-NEXT:    mov z3.d, z3.d[3]
-; CHECK-i32-NEXT:    mov z2.d, z2.d[3]
-; CHECK-i32-NEXT:    fcvtzs w10, d0
-; CHECK-i32-NEXT:    fcvtzs w11, d1
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    fcvtzs w8, d4
-; CHECK-i32-NEXT:    fmov s1, w9
-; CHECK-i32-NEXT:    fcvtzs w9, d5
-; CHECK-i32-NEXT:    mov v0.s[1], w10
-; CHECK-i32-NEXT:    mov v1.s[1], w11
-; CHECK-i32-NEXT:    mov v0.s[2], w8
-; CHECK-i32-NEXT:    fcvtzs w8, d3
-; CHECK-i32-NEXT:    mov v1.s[2], w9
-; CHECK-i32-NEXT:    fcvtzs w9, d2
-; CHECK-i32-NEXT:    mov v0.s[3], w8
-; CHECK-i32-NEXT:    mov v1.s[3], w9
+; CHECK-i32-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i32-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-i32-NEXT:    uzp1 z0.s, z0.s, z0.s
+; CHECK-i32-NEXT:    uzp1 z1.s, z2.s, z2.s
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v8f64:
@@ -1106,24 +637,16 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) nounwind {
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
 ; CHECK-i64-NEXT:    frintx z2.d, p0/m, z2.d
 ; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    mov z1.d, z2.d[3]
-; CHECK-i64-NEXT:    mov z3.d, z0.d[3]
-; CHECK-i64-NEXT:    mov z4.d, z0.d[1]
-; CHECK-i64-NEXT:    mov z5.d, z2.d[2]
-; CHECK-i64-NEXT:    mov z6.d, z0.d[2]
-; CHECK-i64-NEXT:    mov z7.d, z2.d[1]
-; CHECK-i64-NEXT:    fcvtzs d2, d2
-; CHECK-i64-NEXT:    fcvtzs d0, d0
-; CHECK-i64-NEXT:    fcvtzs x8, d1
-; CHECK-i64-NEXT:    fcvtzs x9, d3
-; CHECK-i64-NEXT:    fcvtzs x10, d4
-; CHECK-i64-NEXT:    fcvtzs d3, d5
-; CHECK-i64-NEXT:    fcvtzs d1, d6
-; CHECK-i64-NEXT:    fcvtzs x11, d7
-; CHECK-i64-NEXT:    mov v0.d[1], x10
-; CHECK-i64-NEXT:    mov v2.d[1], x11
-; CHECK-i64-NEXT:    mov v1.d[1], x9
-; CHECK-i64-NEXT:    mov v3.d[1], x8
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
 ; CHECK-i64-NEXT:    ret
   %a = call <8 x iXLen> @llvm.lrint.v8iXLen.v8f64(<8 x double> %x)
   ret <8 x iXLen> %a
@@ -1133,70 +656,36 @@ declare <8 x iXLen> @llvm.lrint.v8iXLen.v8f64(<8 x double>)
 define <16 x iXLen> @lrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v16f64:
 ; CHECK-i32:       // %bb.0:
-; CHECK-i32-NEXT:    ptrue p1.d, vl2
-; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i32-NEXT:    ptrue p0.d, vl2
 ; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i32-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-i32-NEXT:    splice z4.d, p0, z4.d, z5.d
+; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i32-NEXT:    ptrue p0.d, vl4
-; CHECK-i32-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z3.d
-; CHECK-i32-NEXT:    splice z4.d, p1, z4.d, z5.d
-; CHECK-i32-NEXT:    splice z6.d, p1, z6.d, z7.d
-; CHECK-i32-NEXT:    movprfx z5, z0
-; CHECK-i32-NEXT:    frintx z5.d, p0/m, z0.d
-; CHECK-i32-NEXT:    movprfx z7, z2
-; CHECK-i32-NEXT:    frintx z7.d, p0/m, z2.d
+; CHECK-i32-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-i32-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-i32-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-i32-NEXT:    fcvtzs w8, d5
-; CHECK-i32-NEXT:    mov z0.d, z5.d[1]
-; CHECK-i32-NEXT:    mov z1.d, z7.d[1]
-; CHECK-i32-NEXT:    fcvtzs w9, d7
-; CHECK-i32-NEXT:    mov z3.d, z4.d[1]
-; CHECK-i32-NEXT:    fcvtzs w10, d4
-; CHECK-i32-NEXT:    mov z16.d, z6.d[1]
-; CHECK-i32-NEXT:    fcvtzs w12, d6
-; CHECK-i32-NEXT:    mov z2.d, z5.d[2]
-; CHECK-i32-NEXT:    fcvtzs w11, d0
-; CHECK-i32-NEXT:    fcvtzs w13, d1
-; CHECK-i32-NEXT:    mov z17.d, z7.d[2]
-; CHECK-i32-NEXT:    fcvtzs w14, d3
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    mov z18.d, z4.d[2]
-; CHECK-i32-NEXT:    fcvtzs w8, d16
-; CHECK-i32-NEXT:    mov z19.d, z6.d[2]
-; CHECK-i32-NEXT:    fcvtzs w15, d2
-; CHECK-i32-NEXT:    fmov s1, w9
-; CHECK-i32-NEXT:    fmov s2, w10
-; CHECK-i32-NEXT:    fmov s3, w12
-; CHECK-i32-NEXT:    fcvtzs w9, d17
-; CHECK-i32-NEXT:    fcvtzs w10, d18
-; CHECK-i32-NEXT:    mov v0.s[1], w11
-; CHECK-i32-NEXT:    fcvtzs w11, d19
-; CHECK-i32-NEXT:    mov z5.d, z5.d[3]
-; CHECK-i32-NEXT:    mov z7.d, z7.d[3]
-; CHECK-i32-NEXT:    mov v1.s[1], w13
-; CHECK-i32-NEXT:    mov v2.s[1], w14
-; CHECK-i32-NEXT:    mov v3.s[1], w8
-; CHECK-i32-NEXT:    mov z4.d, z4.d[3]
-; CHECK-i32-NEXT:    mov z6.d, z6.d[3]
-; CHECK-i32-NEXT:    mov v0.s[2], w15
-; CHECK-i32-NEXT:    fcvtzs w8, d5
-; CHECK-i32-NEXT:    mov v1.s[2], w9
-; CHECK-i32-NEXT:    fcvtzs w9, d7
-; CHECK-i32-NEXT:    mov v2.s[2], w10
-; CHECK-i32-NEXT:    fcvtzs w10, d4
-; CHECK-i32-NEXT:    mov v3.s[2], w11
-; CHECK-i32-NEXT:    fcvtzs w11, d6
-; CHECK-i32-NEXT:    mov v0.s[3], w8
-; CHECK-i32-NEXT:    mov v1.s[3], w9
-; CHECK-i32-NEXT:    mov v2.s[3], w10
-; CHECK-i32-NEXT:    mov v3.s[3], w11
+; CHECK-i32-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-i32-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i32-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-i32-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-i32-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-i32-NEXT:    uzp1 z0.s, z0.s, z0.s
+; CHECK-i32-NEXT:    uzp1 z3.s, z6.s, z6.s
+; CHECK-i32-NEXT:    uzp1 z1.s, z2.s, z2.s
+; CHECK-i32-NEXT:    uzp1 z2.s, z4.s, z4.s
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v16f64:
@@ -1205,56 +694,40 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 def $z3
-; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-i64-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-i64-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i64-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i64-NEXT:    splice z4.d, p0, z4.d, z5.d
-; CHECK-i64-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i64-NEXT:    splice z6.d, p0, z6.d, z7.d
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
-; CHECK-i64-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-i64-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-i64-NEXT:    frintx z2.d, p0/m, z2.d
 ; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    mov z1.d, z6.d[3]
-; CHECK-i64-NEXT:    mov z3.d, z4.d[3]
-; CHECK-i64-NEXT:    mov z5.d, z2.d[3]
-; CHECK-i64-NEXT:    mov z16.d, z4.d[1]
-; CHECK-i64-NEXT:    mov z7.d, z0.d[3]
-; CHECK-i64-NEXT:    mov z17.d, z0.d[2]
-; CHECK-i64-NEXT:    mov z18.d, z4.d[2]
-; CHECK-i64-NEXT:    mov z19.d, z6.d[1]
-; CHECK-i64-NEXT:    fcvtzs d4, d4
-; CHECK-i64-NEXT:    fcvtzs x8, d1
-; CHECK-i64-NEXT:    mov z1.d, z2.d[1]
-; CHECK-i64-NEXT:    fcvtzs x9, d3
-; CHECK-i64-NEXT:    mov z3.d, z0.d[1]
-; CHECK-i64-NEXT:    fcvtzs x10, d5
-; CHECK-i64-NEXT:    mov z5.d, z6.d[2]
-; CHECK-i64-NEXT:    fcvtzs x12, d16
-; CHECK-i64-NEXT:    mov z16.d, z2.d[2]
-; CHECK-i64-NEXT:    fcvtzs x11, d7
-; CHECK-i64-NEXT:    fcvtzs x13, d1
-; CHECK-i64-NEXT:    fcvtzs d1, d17
-; CHECK-i64-NEXT:    fcvtzs d0, d0
-; CHECK-i64-NEXT:    fcvtzs x14, d3
-; CHECK-i64-NEXT:    fcvtzs d7, d5
-; CHECK-i64-NEXT:    fcvtzs d2, d2
-; CHECK-i64-NEXT:    fcvtzs d3, d16
-; CHECK-i64-NEXT:    fcvtzs d5, d18
-; CHECK-i64-NEXT:    fcvtzs x15, d19
-; CHECK-i64-NEXT:    fcvtzs d6, d6
-; CHECK-i64-NEXT:    mov v4.d[1], x12
-; CHECK-i64-NEXT:    mov v1.d[1], x11
-; CHECK-i64-NEXT:    mov v0.d[1], x14
-; CHECK-i64-NEXT:    mov v2.d[1], x13
-; CHECK-i64-NEXT:    mov v7.d[1], x8
-; CHECK-i64-NEXT:    mov v3.d[1], x10
-; CHECK-i64-NEXT:    mov v5.d[1], x9
-; CHECK-i64-NEXT:    mov v6.d[1], x15
+; CHECK-i64-NEXT:    frintx z4.d, p0/m, z4.d
+; CHECK-i64-NEXT:    frintx z6.d, p0/m, z6.d
+; CHECK-i64-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-i64-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i64-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-i64-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-i64-NEXT:    movprfx z1, z0
+; CHECK-i64-NEXT:    ext z1.b, z1.b, z0.b, #16
+; CHECK-i64-NEXT:    movprfx z3, z2
+; CHECK-i64-NEXT:    ext z3.b, z3.b, z2.b, #16
+; CHECK-i64-NEXT:    movprfx z5, z4
+; CHECK-i64-NEXT:    ext z5.b, z5.b, z4.b, #16
+; CHECK-i64-NEXT:    movprfx z7, z6
+; CHECK-i64-NEXT:    ext z7.b, z7.b, z6.b, #16
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-i64-NEXT:    ret
   %a = call <16 x iXLen> @llvm.lrint.v16iXLen.v16f64(<16 x double> %x)
   ret <16 x iXLen> %a
@@ -1264,276 +737,118 @@ declare <16 x iXLen> @llvm.lrint.v16iXLen.v16f64(<16 x double>)
 define <32 x iXLen> @lrint_v32f64(<32 x double> %x) nounwind {
 ; CHECK-i32-LABEL: lrint_v32f64:
 ; CHECK-i32:       // %bb.0:
-; CHECK-i32-NEXT:    ptrue p1.d, vl2
-; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i32-NEXT:    ldp q16, q17, [sp, #96]
+; CHECK-i32-NEXT:    ptrue p0.d, vl2
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
 ; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i32-NEXT:    ldp q20, q19, [sp]
+; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
-; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
+; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
+; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i32-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-i32-NEXT:    splice z16.d, p0, z16.d, z17.d
+; CHECK-i32-NEXT:    ldp q18, q17, [sp, #64]
+; CHECK-i32-NEXT:    ldp q3, q1, [sp, #32]
+; CHECK-i32-NEXT:    splice z20.d, p0, z20.d, z19.d
+; CHECK-i32-NEXT:    splice z4.d, p0, z4.d, z5.d
+; CHECK-i32-NEXT:    splice z18.d, p0, z18.d, z17.d
+; CHECK-i32-NEXT:    splice z3.d, p0, z3.d, z1.d
 ; CHECK-i32-NEXT:    ptrue p0.d, vl4
-; CHECK-i32-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z3.d
-; CHECK-i32-NEXT:    splice z4.d, p1, z4.d, z5.d
-; CHECK-i32-NEXT:    ldp q1, q3, [sp]
-; CHECK-i32-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-i32-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i32-NEXT:    movprfx z18, z2
-; CHECK-i32-NEXT:    frintx z18.d, p0/m, z2.d
-; CHECK-i32-NEXT:    splice z1.d, p1, z1.d, z3.d
-; CHECK-i32-NEXT:    ldp q5, q3, [sp, #96]
+; CHECK-i32-NEXT:    frintx z2.d, p0/m, z2.d
 ; CHECK-i32-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-i32-NEXT:    ldp q2, q7, [sp, #64]
-; CHECK-i32-NEXT:    movprfx z16, z6
-; CHECK-i32-NEXT:    frintx z16.d, p0/m, z6.d
-; CHECK-i32-NEXT:    mov z19.d, z0.d[1]
-; CHECK-i32-NEXT:    fcvtzs w8, d0
-; CHECK-i32-NEXT:    splice z5.d, p1, z5.d, z3.d
-; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z7.d
-; CHECK-i32-NEXT:    ldp q3, q7, [sp, #32]
-; CHECK-i32-NEXT:    mov z20.d, z18.d[1]
-; CHECK-i32-NEXT:    fcvtzs w9, d18
-; CHECK-i32-NEXT:    movprfx z17, z1
-; CHECK-i32-NEXT:    frintx z17.d, p0/m, z1.d
-; CHECK-i32-NEXT:    mov z1.d, z0.d[2]
-; CHECK-i32-NEXT:    fcvtzs w10, d19
-; CHECK-i32-NEXT:    mov z6.d, z18.d[2]
-; CHECK-i32-NEXT:    splice z3.d, p1, z3.d, z7.d
-; CHECK-i32-NEXT:    mov z7.d, z0.d[3]
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    fcvtzs w11, d20
-; CHECK-i32-NEXT:    mov z20.d, z18.d[3]
-; CHECK-i32-NEXT:    mov z18.d, z4.d[1]
-; CHECK-i32-NEXT:    fcvtzs w12, d4
-; CHECK-i32-NEXT:    mov z21.d, z4.d[2]
-; CHECK-i32-NEXT:    fcvtzs w13, d1
-; CHECK-i32-NEXT:    fmov s1, w9
-; CHECK-i32-NEXT:    mov v0.s[1], w10
-; CHECK-i32-NEXT:    movprfx z19, z2
-; CHECK-i32-NEXT:    frintx z19.d, p0/m, z2.d
-; CHECK-i32-NEXT:    fcvtzs w15, d18
-; CHECK-i32-NEXT:    movprfx z18, z3
-; CHECK-i32-NEXT:    frintx z18.d, p0/m, z3.d
-; CHECK-i32-NEXT:    mov z3.d, z4.d[3]
-; CHECK-i32-NEXT:    fcvtzs w16, d16
-; CHECK-i32-NEXT:    mov z4.d, z16.d[1]
-; CHECK-i32-NEXT:    fcvtzs w14, d6
-; CHECK-i32-NEXT:    mov v1.s[1], w11
-; CHECK-i32-NEXT:    fcvtzs w11, d21
-; CHECK-i32-NEXT:    movprfx z21, z5
-; CHECK-i32-NEXT:    frintx z21.d, p0/m, z5.d
-; CHECK-i32-NEXT:    fcvtzs w8, d7
-; CHECK-i32-NEXT:    fmov s2, w12
-; CHECK-i32-NEXT:    mov z7.d, z17.d[1]
-; CHECK-i32-NEXT:    mov z6.d, z16.d[2]
-; CHECK-i32-NEXT:    mov v0.s[2], w13
-; CHECK-i32-NEXT:    fcvtzs w12, d4
-; CHECK-i32-NEXT:    fcvtzs w13, d17
-; CHECK-i32-NEXT:    fcvtzs w10, d3
-; CHECK-i32-NEXT:    fmov s3, w16
-; CHECK-i32-NEXT:    mov v2.s[1], w15
-; CHECK-i32-NEXT:    mov z4.d, z18.d[1]
-; CHECK-i32-NEXT:    fcvtzs w15, d7
-; CHECK-i32-NEXT:    mov z5.d, z19.d[1]
-; CHECK-i32-NEXT:    fcvtzs w17, d18
-; CHECK-i32-NEXT:    fcvtzs w0, d19
-; CHECK-i32-NEXT:    mov z7.d, z21.d[1]
-; CHECK-i32-NEXT:    fcvtzs w2, d21
-; CHECK-i32-NEXT:    fcvtzs w9, d20
-; CHECK-i32-NEXT:    mov v1.s[2], w14
-; CHECK-i32-NEXT:    mov z20.d, z17.d[2]
-; CHECK-i32-NEXT:    fcvtzs w14, d6
-; CHECK-i32-NEXT:    mov z6.d, z18.d[2]
-; CHECK-i32-NEXT:    fcvtzs w18, d4
-; CHECK-i32-NEXT:    fmov s4, w13
-; CHECK-i32-NEXT:    fcvtzs w13, d5
-; CHECK-i32-NEXT:    mov v3.s[1], w12
-; CHECK-i32-NEXT:    fcvtzs w12, d7
-; CHECK-i32-NEXT:    fcvtzs w16, d20
-; CHECK-i32-NEXT:    mov z20.d, z19.d[2]
-; CHECK-i32-NEXT:    mov z22.d, z21.d[2]
-; CHECK-i32-NEXT:    fcvtzs w1, d6
-; CHECK-i32-NEXT:    fmov s5, w17
-; CHECK-i32-NEXT:    fmov s6, w0
-; CHECK-i32-NEXT:    fmov s7, w2
-; CHECK-i32-NEXT:    mov v4.s[1], w15
-; CHECK-i32-NEXT:    mov z16.d, z16.d[3]
-; CHECK-i32-NEXT:    fcvtzs w15, d20
-; CHECK-i32-NEXT:    mov z17.d, z17.d[3]
-; CHECK-i32-NEXT:    mov z18.d, z18.d[3]
-; CHECK-i32-NEXT:    mov v5.s[1], w18
-; CHECK-i32-NEXT:    mov v6.s[1], w13
-; CHECK-i32-NEXT:    fcvtzs w13, d22
-; CHECK-i32-NEXT:    mov v7.s[1], w12
-; CHECK-i32-NEXT:    mov z19.d, z19.d[3]
-; CHECK-i32-NEXT:    mov z20.d, z21.d[3]
-; CHECK-i32-NEXT:    mov v2.s[2], w11
-; CHECK-i32-NEXT:    mov v3.s[2], w14
-; CHECK-i32-NEXT:    fcvtzs w11, d16
-; CHECK-i32-NEXT:    mov v4.s[2], w16
-; CHECK-i32-NEXT:    fcvtzs w12, d17
-; CHECK-i32-NEXT:    fcvtzs w14, d18
-; CHECK-i32-NEXT:    mov v5.s[2], w1
-; CHECK-i32-NEXT:    mov v6.s[2], w15
-; CHECK-i32-NEXT:    fcvtzs w15, d19
-; CHECK-i32-NEXT:    mov v7.s[2], w13
-; CHECK-i32-NEXT:    fcvtzs w13, d20
-; CHECK-i32-NEXT:    mov v0.s[3], w8
-; CHECK-i32-NEXT:    mov v1.s[3], w9
-; CHECK-i32-NEXT:    mov v2.s[3], w10
-; CHECK-i32-NEXT:    mov v3.s[3], w11
-; CHECK-i32-NEXT:    mov v4.s[3], w12
-; CHECK-i32-NEXT:    mov v5.s[3], w14
-; CHECK-i32-NEXT:    mov v6.s[3], w15
-; CHECK-i32-NEXT:    mov v7.s[3], w13
+; CHECK-i32-NEXT:    frintx z6.d, p0/m, z6.d
+; CHECK-i32-NEXT:    frintx z20.d, p0/m, z20.d
+; CHECK-i32-NEXT:    frintx z18.d, p0/m, z18.d
+; CHECK-i32-NEXT:    frintx z3.d, p0/m, z3.d
+; CHECK-i32-NEXT:    frintx z16.d, p0/m, z16.d
+; CHECK-i32-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-i32-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-i32-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-i32-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-i32-NEXT:    fcvtzs z20.d, p0/m, z20.d
+; CHECK-i32-NEXT:    fcvtzs z18.d, p0/m, z18.d
+; CHECK-i32-NEXT:    movprfx z5, z3
+; CHECK-i32-NEXT:    fcvtzs z5.d, p0/m, z3.d
+; CHECK-i32-NEXT:    fcvtzs z16.d, p0/m, z16.d
+; CHECK-i32-NEXT:    uzp1 z0.s, z0.s, z0.s
+; CHECK-i32-NEXT:    uzp1 z1.s, z2.s, z2.s
+; CHECK-i32-NEXT:    uzp1 z2.s, z4.s, z4.s
+; CHECK-i32-NEXT:    uzp1 z3.s, z6.s, z6.s
+; CHECK-i32-NEXT:    uzp1 z4.s, z20.s, z20.s
+; CHECK-i32-NEXT:    uzp1 z6.s, z18.s, z18.s
+; CHECK-i32-NEXT:    uzp1 z5.s, z5.s, z5.s
+; CHECK-i32-NEXT:    uzp1 z7.s, z16.s, z16.s
+; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 killed $z1
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 killed $z2
+; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 killed $z3
+; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 killed $z4
+; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 killed $z6
+; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 killed $z5
+; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 killed $z7
 ; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v32f64:
 ; CHECK-i64:       // %bb.0:
-; CHECK-i64-NEXT:    stp x29, x30, [sp, #-16]! // 16-byte Folded Spill
-; CHECK-i64-NEXT:    sub x9, sp, #272
-; CHECK-i64-NEXT:    mov x29, sp
-; CHECK-i64-NEXT:    and sp, x9, #0xffffffffffffffe0
-; CHECK-i64-NEXT:    ptrue p1.d, vl2
-; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
-; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 def $z1
-; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 def $z3
-; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 def $z7
+; CHECK-i64-NEXT:    ldp q16, q17, [sp, #96]
+; CHECK-i64-NEXT:    ptrue p0.d, vl2
+; CHECK-i64-NEXT:    ldp q19, q18, [sp, #64]
+; CHECK-i64-NEXT:    ptrue p1.d, vl4
 ; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 def $z6
+; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 def $z5
-; CHECK-i64-NEXT:    ptrue p0.d, vl4
-; CHECK-i64-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i64-NEXT:    splice z2.d, p1, z2.d, z3.d
-; CHECK-i64-NEXT:    splice z4.d, p1, z4.d, z5.d
-; CHECK-i64-NEXT:    splice z6.d, p1, z6.d, z7.d
-; CHECK-i64-NEXT:    ldp q5, q19, [x29, #16]
-; CHECK-i64-NEXT:    movprfx z3, z0
-; CHECK-i64-NEXT:    frintx z3.d, p0/m, z0.d
-; CHECK-i64-NEXT:    movprfx z16, z2
-; CHECK-i64-NEXT:    frintx z16.d, p0/m, z2.d
-; CHECK-i64-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-i64-NEXT:    splice z5.d, p1, z5.d, z19.d
-; CHECK-i64-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-i64-NEXT:    ldp q2, q17, [x29, #48]
-; CHECK-i64-NEXT:    ldp q0, q1, [x29, #112]
-; CHECK-i64-NEXT:    mov z18.d, z3.d[3]
-; CHECK-i64-NEXT:    mov z7.d, z3.d[2]
-; CHECK-i64-NEXT:    fcvtzs x9, d3
-; CHECK-i64-NEXT:    mov z3.d, z3.d[1]
-; CHECK-i64-NEXT:    mov z20.d, z16.d[3]
-; CHECK-i64-NEXT:    fcvtzs x12, d16
-; CHECK-i64-NEXT:    splice z2.d, p1, z2.d, z17.d
-; CHECK-i64-NEXT:    frintx z5.d, p0/m, z5.d
-; CHECK-i64-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i64-NEXT:    fcvtzs x10, d18
-; CHECK-i64-NEXT:    fcvtzs x11, d7
-; CHECK-i64-NEXT:    mov z18.d, z16.d[2]
-; CHECK-i64-NEXT:    mov z7.d, z16.d[1]
-; CHECK-i64-NEXT:    fcvtzs x13, d3
-; CHECK-i64-NEXT:    str x9, [sp, #128]
-; CHECK-i64-NEXT:    fcvtzs x9, d20
-; CHECK-i64-NEXT:    mov z16.d, z4.d[3]
-; CHECK-i64-NEXT:    ldp q3, q19, [x29, #80]
-; CHECK-i64-NEXT:    frintx z2.d, p0/m, z2.d
-; CHECK-i64-NEXT:    stp x11, x10, [sp, #144]
-; CHECK-i64-NEXT:    fcvtzs x10, d18
-; CHECK-i64-NEXT:    fcvtzs x11, d7
-; CHECK-i64-NEXT:    mov z18.d, z4.d[2]
-; CHECK-i64-NEXT:    mov z7.d, z4.d[1]
-; CHECK-i64-NEXT:    str x13, [sp, #136]
-; CHECK-i64-NEXT:    fcvtzs x13, d16
-; CHECK-i64-NEXT:    mov z16.d, z6.d[3]
-; CHECK-i64-NEXT:    splice z3.d, p1, z3.d, z19.d
-; CHECK-i64-NEXT:    mov z1.d, z5.d[1]
-; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    stp x10, x9, [sp, #176]
-; CHECK-i64-NEXT:    fcvtzs x9, d18
-; CHECK-i64-NEXT:    fcvtzs x10, d4
-; CHECK-i64-NEXT:    stp x12, x11, [sp, #160]
-; CHECK-i64-NEXT:    fcvtzs x11, d7
-; CHECK-i64-NEXT:    mov z4.d, z6.d[2]
-; CHECK-i64-NEXT:    mov z7.d, z6.d[1]
-; CHECK-i64-NEXT:    fcvtzs x12, d6
-; CHECK-i64-NEXT:    mov z6.d, z5.d[2]
-; CHECK-i64-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #208]
-; CHECK-i64-NEXT:    fcvtzs x9, d16
-; CHECK-i64-NEXT:    fcvtzs x13, d4
-; CHECK-i64-NEXT:    stp x10, x11, [sp, #192]
-; CHECK-i64-NEXT:    fcvtzs x10, d7
-; CHECK-i64-NEXT:    mov z4.d, z5.d[3]
-; CHECK-i64-NEXT:    fcvtzs x11, d4
-; CHECK-i64-NEXT:    stp x13, x9, [sp, #240]
-; CHECK-i64-NEXT:    fcvtzs x9, d6
-; CHECK-i64-NEXT:    stp x12, x10, [sp, #224]
-; CHECK-i64-NEXT:    fcvtzs x10, d5
-; CHECK-i64-NEXT:    fcvtzs x12, d1
-; CHECK-i64-NEXT:    mov z4.d, z2.d[3]
-; CHECK-i64-NEXT:    mov z5.d, z2.d[2]
-; CHECK-i64-NEXT:    mov z1.d, z2.d[1]
-; CHECK-i64-NEXT:    fcvtzs x13, d2
-; CHECK-i64-NEXT:    mov z2.d, z3.d[2]
-; CHECK-i64-NEXT:    stp x9, x11, [sp, #16]
-; CHECK-i64-NEXT:    fcvtzs x9, d4
-; CHECK-i64-NEXT:    fcvtzs x11, d5
-; CHECK-i64-NEXT:    stp x10, x12, [sp]
-; CHECK-i64-NEXT:    fcvtzs x10, d1
-; CHECK-i64-NEXT:    mov z4.d, z3.d[3]
-; CHECK-i64-NEXT:    mov z1.d, z3.d[1]
-; CHECK-i64-NEXT:    fcvtzs x12, d4
-; CHECK-i64-NEXT:    stp x11, x9, [sp, #48]
-; CHECK-i64-NEXT:    fcvtzs x9, d2
-; CHECK-i64-NEXT:    fcvtzs x11, d3
-; CHECK-i64-NEXT:    stp x13, x10, [sp, #32]
-; CHECK-i64-NEXT:    fcvtzs x10, d1
-; CHECK-i64-NEXT:    mov z2.d, z0.d[3]
-; CHECK-i64-NEXT:    mov z3.d, z0.d[2]
-; CHECK-i64-NEXT:    mov z1.d, z0.d[1]
-; CHECK-i64-NEXT:    stp x9, x12, [sp, #80]
-; CHECK-i64-NEXT:    fcvtzs x12, d0
-; CHECK-i64-NEXT:    fcvtzs x13, d2
-; CHECK-i64-NEXT:    fcvtzs x9, d3
-; CHECK-i64-NEXT:    stp x11, x10, [sp, #64]
-; CHECK-i64-NEXT:    fcvtzs x10, d1
-; CHECK-i64-NEXT:    stp x9, x13, [sp, #112]
-; CHECK-i64-NEXT:    add x9, sp, #128
-; CHECK-i64-NEXT:    stp x12, x10, [sp, #96]
-; CHECK-i64-NEXT:    add x10, sp, #192
-; CHECK-i64-NEXT:    ld1d { z0.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #160
-; CHECK-i64-NEXT:    ld1d { z2.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    ld1d { z1.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #96
-; CHECK-i64-NEXT:    add x10, sp, #224
-; CHECK-i64-NEXT:    ld1d { z3.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    add x9, sp, #64
-; CHECK-i64-NEXT:    ld1d { z4.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    add x10, sp, #32
-; CHECK-i64-NEXT:    ld1d { z5.d }, p0/z, [x9]
-; CHECK-i64-NEXT:    mov x9, sp
-; CHECK-i64-NEXT:    ld1d { z6.d }, p0/z, [x10]
-; CHECK-i64-NEXT:    mov x10, #28 // =0x1c
-; CHECK-i64-NEXT:    ld1d { z7.d }, p0/z, [x9]
+; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 def $z2
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-i64-NEXT:    mov x9, #28 // =0x1c
+; CHECK-i64-NEXT:    splice z16.d, p0, z16.d, z17.d
+; CHECK-i64-NEXT:    ldp q20, q17, [sp, #32]
+; CHECK-i64-NEXT:    splice z19.d, p0, z19.d, z18.d
+; CHECK-i64-NEXT:    ldp q21, q18, [sp]
+; CHECK-i64-NEXT:    splice z6.d, p0, z6.d, z7.d
+; CHECK-i64-NEXT:    splice z4.d, p0, z4.d, z5.d
+; CHECK-i64-NEXT:    splice z2.d, p0, z2.d, z3.d
+; CHECK-i64-NEXT:    splice z20.d, p0, z20.d, z17.d
+; CHECK-i64-NEXT:    splice z0.d, p0, z0.d, z1.d
+; CHECK-i64-NEXT:    splice z21.d, p0, z21.d, z18.d
+; CHECK-i64-NEXT:    frintx z16.d, p1/m, z16.d
+; CHECK-i64-NEXT:    frintx z19.d, p1/m, z19.d
+; CHECK-i64-NEXT:    frintx z6.d, p1/m, z6.d
+; CHECK-i64-NEXT:    frintx z4.d, p1/m, z4.d
+; CHECK-i64-NEXT:    frintx z2.d, p1/m, z2.d
+; CHECK-i64-NEXT:    frintx z20.d, p1/m, z20.d
+; CHECK-i64-NEXT:    frintx z0.d, p1/m, z0.d
+; CHECK-i64-NEXT:    frintx z21.d, p1/m, z21.d
+; CHECK-i64-NEXT:    fcvtzs z16.d, p1/m, z16.d
+; CHECK-i64-NEXT:    fcvtzs z19.d, p1/m, z19.d
+; CHECK-i64-NEXT:    fcvtzs z6.d, p1/m, z6.d
+; CHECK-i64-NEXT:    fcvtzs z4.d, p1/m, z4.d
+; CHECK-i64-NEXT:    fcvtzs z2.d, p1/m, z2.d
+; CHECK-i64-NEXT:    fcvtzs z20.d, p1/m, z20.d
+; CHECK-i64-NEXT:    fcvtzs z0.d, p1/m, z0.d
+; CHECK-i64-NEXT:    fcvtzs z21.d, p1/m, z21.d
+; CHECK-i64-NEXT:    st1d { z16.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #24 // =0x18
-; CHECK-i64-NEXT:    st1d { z3.d }, p0, [x8, x10, lsl #3]
-; CHECK-i64-NEXT:    st1d { z5.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z19.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #20 // =0x14
-; CHECK-i64-NEXT:    st1d { z6.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z20.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #16 // =0x10
-; CHECK-i64-NEXT:    st1d { z7.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z21.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #12 // =0xc
-; CHECK-i64-NEXT:    st1d { z4.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z6.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #8 // =0x8
-; CHECK-i64-NEXT:    st1d { z2.d }, p0, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z4.d }, p1, [x8, x9, lsl #3]
 ; CHECK-i64-NEXT:    mov x9, #4 // =0x4
-; CHECK-i64-NEXT:    st1d { z1.d }, p0, [x8, x9, lsl #3]
-; CHECK-i64-NEXT:    st1d { z0.d }, p0, [x8]
-; CHECK-i64-NEXT:    mov sp, x29
-; CHECK-i64-NEXT:    ldp x29, x30, [sp], #16 // 16-byte Folded Reload
+; CHECK-i64-NEXT:    st1d { z2.d }, p1, [x8, x9, lsl #3]
+; CHECK-i64-NEXT:    st1d { z0.d }, p1, [x8]
 ; CHECK-i64-NEXT:    ret
   %a = call <32 x iXLen> @llvm.lrint.v32iXLen.v16f64(<32 x double> %x)
   ret <32 x iXLen> %a

--- a/llvm/test/CodeGen/AArch64/sve-llrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-llrint.ll
@@ -5,18 +5,8 @@ define <vscale x 1 x i64> @llrint_v1i64_v1f16(<vscale x 1 x half> %x) {
 ; CHECK-LABEL: llrint_v1i64_v1f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.llrint.nxv1i64.nxv1f16(<vscale x 1 x half> %x)
   ret <vscale x 1 x i64> %a
@@ -27,18 +17,8 @@ define <vscale x 2 x i64> @llrint_v1i64_v2f16(<vscale x 2 x half> %x) {
 ; CHECK-LABEL: llrint_v1i64_v2f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.llrint.nxv2i64.nxv2f16(<vscale x 2 x half> %x)
   ret <vscale x 2 x i64> %a
@@ -50,27 +30,14 @@ define <vscale x 4 x i64> @llrint_v4i64_v4f16(<vscale x 4 x half> %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    uunpklo z1.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
-; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z1.h, z2.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z0.h, z2.h
-; CHECK-NEXT:    mov z2.h, w8
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z1.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z2.h
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z0.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z0.h, z2.h
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    movprfx z2, z0
+; CHECK-NEXT:    frintx z2.h, p0/m, z0.h
+; CHECK-NEXT:    movprfx z0, z1
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f16(<vscale x 4 x half> %x)
   ret <vscale x 4 x i64> %a
@@ -80,62 +47,25 @@ declare <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f16(<vscale x 4 x half>)
 define <vscale x 8 x i64> @llrint_v8i64_v8f16(<vscale x 8 x half> %x) {
 ; CHECK-LABEL: llrint_v8i64_v8f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    uunpklo z1.s, z0.h
 ; CHECK-NEXT:    uunpkhi z0.s, z0.h
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z4.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    uunpklo z2.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
 ; CHECK-NEXT:    uunpklo z3.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
 ; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
 ; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
-; CHECK-NEXT:    movprfx z24, z0
-; CHECK-NEXT:    frintx z24.h, p0/m, z0.h
-; CHECK-NEXT:    mov z0.h, w8
-; CHECK-NEXT:    fcmge p1.h, p0/z, z2.h, z4.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z1.h, z4.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z3.h, z4.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z2.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z24.h, z4.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z6.d, p2/m, z1.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z2.h, z0.h
-; CHECK-NEXT:    fcvtzs z7.d, p3/m, z3.h
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z3.h, z0.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z0.h
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z24.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z2.h, z2.h
-; CHECK-NEXT:    sel z0.d, p2, z25.d, z5.d
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    sel z1.d, p4, z25.d, z6.d
-; CHECK-NEXT:    sel z2.d, p5, z25.d, z7.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z3.h, z3.h
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z24.h, z24.h
-; CHECK-NEXT:    sel z3.d, p6, z25.d, z4.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    frintx z4.h, p0/m, z0.h
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z0, z2
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z2.h
+; CHECK-NEXT:    movprfx z2, z3
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z3.h
+; CHECK-NEXT:    movprfx z3, z4
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z4.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f16(<vscale x 8 x half> %x)
   ret <vscale x 8 x i64> %a
@@ -145,110 +75,46 @@ declare <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f16(<vscale x 8 x half>)
 define <vscale x 16 x i64> @llrint_v16i64_v16f16(<vscale x 16 x half> %x) {
 ; CHECK-LABEL: llrint_v16i64_v16f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    uunpkhi z3.s, z0.h
 ; CHECK-NEXT:    uunpklo z2.s, z0.h
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
-; CHECK-NEXT:    uunpklo z7.s, z1.h
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z0.h, #-1025 // =0xfffffffffffffbff
+; CHECK-NEXT:    uunpkhi z0.s, z0.h
+; CHECK-NEXT:    uunpklo z3.s, z1.h
 ; CHECK-NEXT:    uunpkhi z1.s, z1.h
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.h, w8
-; CHECK-NEXT:    uunpkhi z25.d, z3.s
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    uunpklo z4.d, z2.s
-; CHECK-NEXT:    uunpkhi z6.d, z2.s
-; CHECK-NEXT:    uunpklo z24.d, z3.s
-; CHECK-NEXT:    uunpklo z26.d, z7.s
-; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    uunpklo z30.d, z1.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
+; CHECK-NEXT:    uunpkhi z2.d, z2.s
+; CHECK-NEXT:    uunpklo z5.d, z0.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uunpklo z6.d, z3.s
+; CHECK-NEXT:    uunpkhi z3.d, z3.s
+; CHECK-NEXT:    uunpklo z7.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
-; CHECK-NEXT:    movprfx z27, z4
-; CHECK-NEXT:    frintx z27.h, p0/m, z4.h
-; CHECK-NEXT:    movprfx z28, z6
-; CHECK-NEXT:    frintx z28.h, p0/m, z6.h
-; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
-; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
-; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
+; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
+; CHECK-NEXT:    movprfx z24, z0
+; CHECK-NEXT:    frintx z24.h, p0/m, z0.h
+; CHECK-NEXT:    frintx z6.h, p0/m, z6.h
+; CHECK-NEXT:    movprfx z25, z3
+; CHECK-NEXT:    frintx z25.h, p0/m, z3.h
 ; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z30.h, p0/m, z30.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z25.h, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z28.h, z0.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z26.h, z0.h
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z27.h
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z28.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z7.h, z0.h
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z26.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z28.h, z29.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    movprfx z28, z1
-; CHECK-NEXT:    frintx z28.h, p0/m, z1.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z29.h
-; CHECK-NEXT:    fcmuo p7.h, p0/z, z24.h, z24.h
-; CHECK-NEXT:    mov z24.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmgt p8.h, p0/z, z25.h, z29.h
-; CHECK-NEXT:    fcvtzs z27.d, p4/m, z30.h
-; CHECK-NEXT:    fcmuo p10.h, p0/z, z25.h, z25.h
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    sel z1.d, p5, z24.d, z3.d
-; CHECK-NEXT:    fcmge p4.h, p0/z, z28.h, z0.h
-; CHECK-NEXT:    sel z0.d, p3, z24.d, z2.d
-; CHECK-NEXT:    sel z2.d, p6, z24.d, z4.d
-; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p9.h, p0/z, z26.h, z29.h
-; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcvtzs z25.d, p4/m, z28.h
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z7.h, z29.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z30.h, z29.h
-; CHECK-NEXT:    sel z4.d, p9, z24.d, z6.d
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z28.h, z29.h
-; CHECK-NEXT:    fcmuo p8.h, p0/z, z7.h, z7.h
-; CHECK-NEXT:    sel z5.d, p5, z24.d, z31.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.h, p0/z, z30.h, z30.h
-; CHECK-NEXT:    sel z6.d, p6, z24.d, z27.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    sel z7.d, p4, z24.d, z25.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z26, z1
+; CHECK-NEXT:    frintx z26.h, p0/m, z1.h
+; CHECK-NEXT:    movprfx z0, z4
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z4.h
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.h
+; CHECK-NEXT:    movprfx z2, z5
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z5.h
+; CHECK-NEXT:    movprfx z3, z24
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z24.h
+; CHECK-NEXT:    movprfx z4, z6
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z6.h
+; CHECK-NEXT:    movprfx z5, z25
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z25.h
+; CHECK-NEXT:    movprfx z6, z7
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z7.h
+; CHECK-NEXT:    movprfx z7, z26
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z26.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f16(<vscale x 16 x half> %x)
   ret <vscale x 16 x i64> %a
@@ -258,252 +124,79 @@ declare <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f16(<vscale x 16 x half>)
 define <vscale x 32 x i64> @llrint_v32i64_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-LABEL: llrint_v32i64_v32f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    uunpklo z4.s, z0.h
-; CHECK-NEXT:    uunpkhi z0.s, z0.h
-; CHECK-NEXT:    mov w9, #31743 // =0x7bff
-; CHECK-NEXT:    uunpklo z5.s, z1.h
+; CHECK-NEXT:    uunpkhi z4.s, z3.h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z28.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    uunpkhi z29.s, z1.h
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z13.s, z2.h
-; CHECK-NEXT:    mov z9.d, #0x8000000000000000
-; CHECK-NEXT:    uunpkhi z14.s, z2.h
-; CHECK-NEXT:    uunpkhi z17.s, z3.h
-; CHECK-NEXT:    uunpklo z6.d, z4.s
-; CHECK-NEXT:    uunpkhi z4.d, z4.s
-; CHECK-NEXT:    uunpklo z27.d, z0.s
-; CHECK-NEXT:    uunpklo z31.d, z5.s
-; CHECK-NEXT:    uunpkhi z8.d, z5.s
-; CHECK-NEXT:    uunpkhi z30.d, z0.s
-; CHECK-NEXT:    uunpkhi z11.d, z29.s
-; CHECK-NEXT:    uunpklo z10.d, z29.s
-; CHECK-NEXT:    uunpklo z15.s, z3.h
-; CHECK-NEXT:    uunpklo z16.d, z14.s
-; CHECK-NEXT:    uunpkhi z14.d, z14.s
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z5, z27
-; CHECK-NEXT:    frintx z5.h, p0/m, z27.h
-; CHECK-NEXT:    movprfx z1, z6
-; CHECK-NEXT:    frintx z1.h, p0/m, z6.h
+; CHECK-NEXT:    uunpkhi z7.s, z2.h
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    uunpkhi z24.s, z0.h
+; CHECK-NEXT:    uunpkhi z25.s, z1.h
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpkhi z5.d, z4.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpkhi z6.d, z3.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    uunpkhi z26.d, z7.s
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    uunpkhi z27.d, z2.s
+; CHECK-NEXT:    uunpkhi z28.d, z24.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    uunpkhi z29.d, z25.s
+; CHECK-NEXT:    uunpklo z25.d, z25.s
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
 ; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
-; CHECK-NEXT:    movprfx z12, z31
-; CHECK-NEXT:    frintx z12.h, p0/m, z31.h
-; CHECK-NEXT:    movprfx z27, z8
-; CHECK-NEXT:    frintx z27.h, p0/m, z8.h
-; CHECK-NEXT:    movprfx z6, z30
-; CHECK-NEXT:    frintx z6.h, p0/m, z30.h
-; CHECK-NEXT:    movprfx z31, z10
-; CHECK-NEXT:    frintx z31.h, p0/m, z10.h
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
-; CHECK-NEXT:    movprfx z3, z16
-; CHECK-NEXT:    frintx z3.h, p0/m, z16.h
-; CHECK-NEXT:    mov z30.h, w9
-; CHECK-NEXT:    uunpklo z10.d, z13.s
-; CHECK-NEXT:    uunpkhi z13.d, z13.s
-; CHECK-NEXT:    uunpkhi z20.d, z15.s
-; CHECK-NEXT:    uunpklo z16.d, z17.s
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    mov z18.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z15.d, z15.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z10.h, p0/m, z10.h
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.d, #0x7fffffffffffffff
-; CHECK-NEXT:    movprfx z19, z13
-; CHECK-NEXT:    frintx z19.h, p0/m, z13.h
-; CHECK-NEXT:    movprfx z13, z14
-; CHECK-NEXT:    frintx z13.h, p0/m, z14.h
-; CHECK-NEXT:    frintx z20.h, p0/m, z20.h
-; CHECK-NEXT:    frintx z16.h, p0/m, z16.h
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z15.h, p0/m, z15.h
-; CHECK-NEXT:    mov z14.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p4.h, p0/z, z4.h, z28.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z12.h, z28.h
-; CHECK-NEXT:    fcmgt p9.h, p0/z, z12.h, z30.h
-; CHECK-NEXT:    fcmuo p8.h, p0/z, z12.h, z12.h
-; CHECK-NEXT:    fcvtzs z7.d, p4/m, z4.h
-; CHECK-NEXT:    fcvtzs z8.d, p2/m, z12.h
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p4.h, p0/z, z27.h, z28.h
-; CHECK-NEXT:    fcmuo p10.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z5.h, z28.h
-; CHECK-NEXT:    mov z8.d, p9/m, z29.d
-; CHECK-NEXT:    fcvtzs z9.d, p4/m, z27.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z11.h, z28.h
-; CHECK-NEXT:    fcvtzs z24.d, p3/m, z5.h
-; CHECK-NEXT:    mov z8.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p1.h, p0/z, z6.h, z28.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z1.h, z28.h
-; CHECK-NEXT:    str z8, [x8, #4, mul vl]
-; CHECK-NEXT:    fcvtzs z12.d, p4/m, z11.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
-; CHECK-NEXT:    uunpkhi z11.d, z17.s
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z25.d, p1/m, z6.h
-; CHECK-NEXT:    fcvtzs z0.d, p5/m, z1.h
-; CHECK-NEXT:    fcmge p6.h, p0/z, z10.h, z28.h
-; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z31.h, z28.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z13.h, z28.h
-; CHECK-NEXT:    fcvtzs z18.d, p6/m, z10.h
-; CHECK-NEXT:    fcmgt p11.h, p0/z, z10.h, z30.h
-; CHECK-NEXT:    fcvtzs z2.d, p3/m, z31.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z13.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z20.h, z28.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z16.h, z28.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z10.h, z10.h
-; CHECK-NEXT:    sel z10.d, p4, z29.d, z12.d
-; CHECK-NEXT:    sel z12.d, p11, z29.d, z18.d
-; CHECK-NEXT:    fcvtzs z26.d, p5/m, z11.h
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z20.h
-; CHECK-NEXT:    fcvtzs z23.d, p3/m, z16.h
-; CHECK-NEXT:    mov z10.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
-; CHECK-NEXT:    fcmge p6.h, p0/z, z19.h, z28.h
-; CHECK-NEXT:    str z10, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmge p7.h, p0/z, z3.h, z28.h
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcmge p2.h, p0/z, z15.h, z28.h
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, p4/m, z29.d
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z16.h, z30.h
-; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
-; CHECK-NEXT:    fcvtzs z17.d, p7/m, z3.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z20.h, z30.h
-; CHECK-NEXT:    fcvtzs z28.d, p2/m, z15.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    sel z11.d, p5, z29.d, z23.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z19.h, z30.h
-; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
-; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z13.h, z30.h
-; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    sel z26.d, p4, z29.d, z14.d
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z20.h, z20.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
-; CHECK-NEXT:    str z11, [x8, #14, mul vl]
-; CHECK-NEXT:    mov z28.d, p3/m, z29.d
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z13.h, z13.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z3.h, z3.h
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z21.d
-; CHECK-NEXT:    mov z16.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    sel z11.d, p2, z29.d, z17.d
-; CHECK-NEXT:    fcmgt p12.h, p0/z, z27.h, z30.h
-; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z16, [x8, #13, mul vl]
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z15.h, z15.h
-; CHECK-NEXT:    mov z11.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
-; CHECK-NEXT:    str z3, [x8, #11, mul vl]
-; CHECK-NEXT:    fcmuo p5.h, p0/z, z19.h, z19.h
-; CHECK-NEXT:    mov z9.d, p12/m, z29.d
-; CHECK-NEXT:    str z11, [x8, #10, mul vl]
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
-; CHECK-NEXT:    mov z28.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z6.h, z30.h
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    str z28, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z31.h, z30.h
-; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
-; CHECK-NEXT:    str z26, [x8, #9, mul vl]
-; CHECK-NEXT:    sel z24.d, p4, z29.d, z25.d
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
-; CHECK-NEXT:    fcmuo p5.h, p0/z, z31.h, z31.h
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p6/m, z29.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
-; CHECK-NEXT:    str z9, [x8, #5, mul vl]
-; CHECK-NEXT:    mov z0.d, p1/m, z29.d
-; CHECK-NEXT:    mov z2.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z2, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z24, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z7, [x8, #2, mul vl]
-; CHECK-NEXT:    str z3, [x8, #1, mul vl]
+; CHECK-NEXT:    frintx z6.h, p0/m, z6.h
+; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
+; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
+; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
+; CHECK-NEXT:    frintx z27.h, p0/m, z27.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
+; CHECK-NEXT:    frintx z28.h, p0/m, z28.h
+; CHECK-NEXT:    frintx z29.h, p0/m, z29.h
+; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.h
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.h
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.h
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.h
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.h
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.h
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.h
+; CHECK-NEXT:    str z5, [x8, #15, mul vl]
+; CHECK-NEXT:    uunpkhi z5.d, z1.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    str z4, [x8, #14, mul vl]
+; CHECK-NEXT:    uunpkhi z4.d, z0.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    str z3, [x8, #12, mul vl]
+; CHECK-NEXT:    uunpklo z3.d, z24.s
+; CHECK-NEXT:    str z6, [x8, #13, mul vl]
+; CHECK-NEXT:    str z26, [x8, #11, mul vl]
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
+; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
+; CHECK-NEXT:    str z7, [x8, #10, mul vl]
+; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
+; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
+; CHECK-NEXT:    str z27, [x8, #9, mul vl]
+; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
+; CHECK-NEXT:    str z2, [x8, #8, mul vl]
+; CHECK-NEXT:    str z29, [x8, #7, mul vl]
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-NEXT:    str z25, [x8, #6, mul vl]
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-NEXT:    str z5, [x8, #5, mul vl]
+; CHECK-NEXT:    str z1, [x8, #4, mul vl]
+; CHECK-NEXT:    str z3, [x8, #2, mul vl]
+; CHECK-NEXT:    str z4, [x8, #1, mul vl]
 ; CHECK-NEXT:    str z0, [x8]
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.llrint.nxv32i64.nxv32f16(<vscale x 32 x half> %x)
   ret <vscale x 32 x i64> %a
@@ -514,19 +207,8 @@ define <vscale x 1 x i64> @llrint_v1i64_v1f32(<vscale x 1 x float> %x) {
 ; CHECK-LABEL: llrint_v1i64_v1f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
 ; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.llrint.nxv1i64.nxv1f32(<vscale x 1 x float> %x)
   ret <vscale x 1 x i64> %a
@@ -537,19 +219,8 @@ define <vscale x 2 x i64> @llrint_v2i64_v2f32(<vscale x 2 x float> %x) {
 ; CHECK-LABEL: llrint_v2i64_v2f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
 ; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.llrint.nxv2i64.nxv2f32(<vscale x 2 x float> %x)
   ret <vscale x 2 x i64> %a
@@ -561,28 +232,14 @@ define <vscale x 4 x i64> @llrint_v4i64_v4f32(<vscale x 4 x float> %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    uunpklo z1.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
-; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z0.s, z2.s
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z1.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z0.s
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z0.s, z2.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    movprfx z2, z0
+; CHECK-NEXT:    frintx z2.s, p0/m, z0.s
+; CHECK-NEXT:    movprfx z0, z1
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z1.s
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f32(<vscale x 4 x float> %x)
   ret <vscale x 4 x i64> %a
@@ -592,61 +249,25 @@ declare <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f32(<vscale x 4 x float>)
 define <vscale x 8 x i64> @llrint_v8i64_v8f32(<vscale x 8 x float> %x) {
 ; CHECK-LABEL: llrint_v8i64_v8f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    uunpklo z2.d, z0.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
 ; CHECK-NEXT:    uunpklo z3.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
-; CHECK-NEXT:    mov z4.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.s, w8
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    frintx z2.s, p0/m, z2.s
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z6, z0
-; CHECK-NEXT:    frintx z6.s, p0/m, z0.s
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    frintx z4.s, p0/m, z0.s
 ; CHECK-NEXT:    frintx z3.s, p0/m, z3.s
-; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z2.s, z4.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z4.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z3.s, z4.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z2.s, z25.s
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z2.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z1.s, z4.s
-; CHECK-NEXT:    mov z4.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcvtzs z7.d, p2/m, z6.s
-; CHECK-NEXT:    fcvtzs z24.d, p3/m, z3.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z25.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z3.s, z25.s
-; CHECK-NEXT:    fcvtzs z26.d, p1/m, z1.s
-; CHECK-NEXT:    sel z0.d, p4, z4.d, z5.d
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z25.s
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z3.s, z3.s
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z2.s, z2.s
-; CHECK-NEXT:    sel z2.d, p5, z4.d, z24.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    sel z1.d, p3, z4.d, z7.d
-; CHECK-NEXT:    sel z3.d, p1, z4.d, z26.d
-; CHECK-NEXT:    mov z2.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z1.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z5, z1
+; CHECK-NEXT:    frintx z5.s, p0/m, z1.s
+; CHECK-NEXT:    movprfx z0, z2
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z2.s
+; CHECK-NEXT:    movprfx z1, z4
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z4.s
+; CHECK-NEXT:    movprfx z2, z3
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z3.s
+; CHECK-NEXT:    movprfx z3, z5
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z5.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f32(<vscale x 8 x float> %x)
   ret <vscale x 8 x i64> %a
@@ -656,114 +277,43 @@ declare <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f32(<vscale x 8 x float>)
 define <vscale x 16 x i64> @llrint_v16i64_v16f32(<vscale x 16 x float> %x) {
 ; CHECK-LABEL: llrint_v16i64_v16f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-3
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z9, [sp, #1, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x48, 0x1e, 0x22 // sp + 16 + 24 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
 ; CHECK-NEXT:    uunpklo z4.d, z0.s
-; CHECK-NEXT:    uunpkhi z5.d, z0.s
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    uunpkhi z7.d, z1.s
-; CHECK-NEXT:    uunpklo z24.d, z2.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    uunpklo z6.d, z1.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uunpklo z5.d, z1.s
+; CHECK-NEXT:    uunpkhi z1.d, z1.s
+; CHECK-NEXT:    uunpklo z6.d, z2.s
 ; CHECK-NEXT:    uunpkhi z2.d, z2.s
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z25, z4
-; CHECK-NEXT:    frintx z25.s, p0/m, z4.s
+; CHECK-NEXT:    uunpklo z7.d, z3.s
+; CHECK-NEXT:    uunpkhi z3.d, z3.s
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    frintx z4.s, p0/m, z4.s
+; CHECK-NEXT:    movprfx z24, z0
+; CHECK-NEXT:    frintx z24.s, p0/m, z0.s
 ; CHECK-NEXT:    frintx z5.s, p0/m, z5.s
-; CHECK-NEXT:    mov z4.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
-; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
-; CHECK-NEXT:    movprfx z30, z2
-; CHECK-NEXT:    frintx z30.s, p0/m, z2.s
+; CHECK-NEXT:    movprfx z25, z1
+; CHECK-NEXT:    frintx z25.s, p0/m, z1.s
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
-; CHECK-NEXT:    uunpklo z2.d, z3.s
-; CHECK-NEXT:    mov z29.s, w8
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
-; CHECK-NEXT:    mov z9.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p5.s, p0/z, z25.s, z4.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z5.s, z4.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z7.s, z4.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z24.s, z4.s
-; CHECK-NEXT:    fcvtzs z0.d, p5/m, z25.s
-; CHECK-NEXT:    fcvtzs z1.d, p1/m, z5.s
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z7.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z4.s
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z24.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z30.s, z4.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    movprfx z25, z2
-; CHECK-NEXT:    frintx z25.s, p0/m, z2.s
-; CHECK-NEXT:    uunpkhi z2.d, z3.s
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z6.s
-; CHECK-NEXT:    mov z0.d, p3/m, z9.d
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z30.s
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    movprfx z5, z2
-; CHECK-NEXT:    frintx z5.s, p0/m, z2.s
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z4.s
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z6.s, z29.s
-; CHECK-NEXT:    mov z1.d, p5/m, z9.d
-; CHECK-NEXT:    fcmgt p8.s, p0/z, z7.s, z29.s
-; CHECK-NEXT:    fcmuo p10.s, p0/z, z7.s, z7.s
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z8.d, p4/m, z25.s
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    sel z2.d, p6, z9.d, z26.d
-; CHECK-NEXT:    sel z3.d, p8, z9.d, z27.d
-; CHECK-NEXT:    fcmge p4.s, p0/z, z5.s, z4.s
-; CHECK-NEXT:    fcmgt p9.s, p0/z, z24.s, z29.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcvtzs z7.d, p4/m, z5.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    sel z4.d, p9, z9.d, z28.d
-; CHECK-NEXT:    fcmuo p7.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    sel z6.d, p6, z9.d, z8.d
-; CHECK-NEXT:    ldr z8, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p8.s, p0/z, z30.s, z30.s
-; CHECK-NEXT:    fcmuo p9.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    mov z7.d, p4/m, z9.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    sel z5.d, p5, z9.d, z31.d
-; CHECK-NEXT:    ldr z9, [sp, #1, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #3
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z26, z2
+; CHECK-NEXT:    frintx z26.s, p0/m, z2.s
+; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
+; CHECK-NEXT:    movprfx z27, z3
+; CHECK-NEXT:    frintx z27.s, p0/m, z3.s
+; CHECK-NEXT:    movprfx z0, z4
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z4.s
+; CHECK-NEXT:    movprfx z1, z24
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z24.s
+; CHECK-NEXT:    movprfx z2, z5
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z5.s
+; CHECK-NEXT:    movprfx z3, z25
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z25.s
+; CHECK-NEXT:    movprfx z4, z6
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z6.s
+; CHECK-NEXT:    movprfx z5, z26
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z26.s
+; CHECK-NEXT:    movprfx z6, z7
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z7.s
+; CHECK-NEXT:    movprfx z7, z27
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z27.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f32(<vscale x 16 x float> %x)
   ret <vscale x 16 x i64> %a
@@ -773,251 +323,71 @@ declare <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f32(<vscale x 16 x float>
 define <vscale x 32 x i64> @llrint_v32i64_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-LABEL: llrint_v32i64_v32f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x98, 0x01, 0x1e, 0x22 // sp + 16 + 152 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    uunpklo z24.d, z0.s
-; CHECK-NEXT:    uunpklo z26.d, z1.s
-; CHECK-NEXT:    mov w9, #-553648128 // =0xdf000000
-; CHECK-NEXT:    uunpklo z28.d, z2.s
-; CHECK-NEXT:    uunpkhi z30.d, z2.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    uunpkhi z25.d, z0.s
-; CHECK-NEXT:    uunpkhi z13.d, z3.s
-; CHECK-NEXT:    uunpklo z14.d, z4.s
-; CHECK-NEXT:    uunpkhi z27.d, z1.s
-; CHECK-NEXT:    uunpklo z9.d, z3.s
-; CHECK-NEXT:    mov z29.s, w9
-; CHECK-NEXT:    movprfx z0, z24
-; CHECK-NEXT:    frintx z0.s, p0/m, z24.s
-; CHECK-NEXT:    movprfx z24, z26
-; CHECK-NEXT:    frintx z24.s, p0/m, z26.s
-; CHECK-NEXT:    mov w9, #1593835519 // =0x5effffff
-; CHECK-NEXT:    movprfx z10, z28
-; CHECK-NEXT:    frintx z10.s, p0/m, z28.s
-; CHECK-NEXT:    frintx z30.s, p0/m, z30.s
-; CHECK-NEXT:    uunpklo z17.d, z5.s
-; CHECK-NEXT:    movprfx z1, z25
-; CHECK-NEXT:    frintx z1.s, p0/m, z25.s
-; CHECK-NEXT:    movprfx z15, z13
-; CHECK-NEXT:    frintx z15.s, p0/m, z13.s
-; CHECK-NEXT:    movprfx z13, z14
-; CHECK-NEXT:    frintx z13.s, p0/m, z14.s
-; CHECK-NEXT:    uunpkhi z14.d, z4.s
-; CHECK-NEXT:    uunpkhi z18.d, z5.s
-; CHECK-NEXT:    uunpkhi z19.d, z6.s
-; CHECK-NEXT:    movprfx z25, z27
-; CHECK-NEXT:    frintx z25.s, p0/m, z27.s
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    mov z11.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p3.s, p0/z, z24.s, z29.s
-; CHECK-NEXT:    str z0, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p5.s, p0/z, z10.s, z29.s
-; CHECK-NEXT:    frintx z9.s, p0/m, z9.s
-; CHECK-NEXT:    uunpklo z20.d, z7.s
-; CHECK-NEXT:    movprfx z5, z14
-; CHECK-NEXT:    frintx z5.s, p0/m, z14.s
-; CHECK-NEXT:    movprfx z14, z17
-; CHECK-NEXT:    frintx z14.s, p0/m, z17.s
-; CHECK-NEXT:    movprfx z17, z18
-; CHECK-NEXT:    frintx z17.s, p0/m, z18.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    mov z31.s, w9
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z19.s, p0/m, z19.s
+; CHECK-NEXT:    uunpkhi z24.d, z7.s
+; CHECK-NEXT:    uunpkhi z25.d, z6.s
 ; CHECK-NEXT:    uunpklo z6.d, z6.s
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z24.s
-; CHECK-NEXT:    fcvtzs z11.d, p5/m, z10.s
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z22, z7
-; CHECK-NEXT:    frintx z22.s, p0/m, z7.s
-; CHECK-NEXT:    fcvtzs z12.d, p6/m, z30.s
-; CHECK-NEXT:    frintx z20.s, p0/m, z20.s
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    uunpkhi z26.d, z5.s
+; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    uunpkhi z27.d, z4.s
+; CHECK-NEXT:    uunpkhi z28.d, z1.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpkhi z29.d, z3.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
-; CHECK-NEXT:    mov z3.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z18.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z1.s, z29.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcmgt p9.s, p0/z, z10.s, z31.s
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z1.s
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z25.s
-; CHECK-NEXT:    mov z11.d, p9/m, z3.d
-; CHECK-NEXT:    fcmuo p8.s, p0/z, z10.s, z10.s
-; CHECK-NEXT:    mov z10.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p5.s, p0/z, z9.s, z29.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z15.s, z29.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z13.s, z29.s
-; CHECK-NEXT:    mov z11.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z10.d, p5/m, z9.s
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z15.s
-; CHECK-NEXT:    fcvtzs z16.d, p6/m, z13.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z17.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z19.s, z29.s
-; CHECK-NEXT:    fcmgt p12.s, p0/z, z30.s, z31.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z15.s, z31.s
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z17.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
-; CHECK-NEXT:    fcvtzs z23.d, p2/m, z19.s
-; CHECK-NEXT:    sel z7.d, p12, z3.d, z12.d
-; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
-; CHECK-NEXT:    mov z4.d, p5/m, z3.d
-; CHECK-NEXT:    fcmge p4.s, p0/z, z22.s, z29.s
-; CHECK-NEXT:    fcvtzs z0.d, p3/m, z20.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    fcmge p7.s, p0/z, z14.s, z29.s
-; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
-; CHECK-NEXT:    fcvtzs z8.d, p4/m, z22.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z29.s
-; CHECK-NEXT:    mov z29.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z18.d, p7/m, z14.s
-; CHECK-NEXT:    fcmuo p10.s, p0/z, z15.s, z15.s
-; CHECK-NEXT:    mov z15.d, #0x8000000000000000
-; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z22.s, z31.s
-; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcvtzs z15.d, p6/m, z5.s
-; CHECK-NEXT:    mov z4.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z19.s, z31.s
-; CHECK-NEXT:    mov z8.d, p4/m, z3.d
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
-; CHECK-NEXT:    str z4, [x8, #7, mul vl]
-; CHECK-NEXT:    mov z0.d, p5/m, z3.d
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z19.s, z19.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z31.s
-; CHECK-NEXT:    mov z8.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    sel z5.d, p3, z3.d, z23.d
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z31.s
-; CHECK-NEXT:    str z8, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z17.s, z31.s
-; CHECK-NEXT:    str z0, [x8, #14, mul vl]
-; CHECK-NEXT:    mov z5.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z14.s, z31.s
-; CHECK-NEXT:    sel z0.d, p3, z3.d, z29.d
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    str z5, [x8, #13, mul vl]
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
-; CHECK-NEXT:    sel z5.d, p1, z3.d, z21.d
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
-; CHECK-NEXT:    sel z29.d, p2, z3.d, z18.d
-; CHECK-NEXT:    mov z6.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z14.s, z14.s
-; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z31.s
-; CHECK-NEXT:    str z6, [x8, #9, mul vl]
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z29.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    str z5, [x8, #11, mul vl]
-; CHECK-NEXT:    sel z5.d, p1, z3.d, z26.d
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
-; CHECK-NEXT:    str z29, [x8, #10, mul vl]
-; CHECK-NEXT:    ldr z4, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    str z11, [x8, #4, mul vl]
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
-; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z9.s, z31.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z4.s, z31.s
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    sel z0.d, p6, z3.d, z10.d
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    sel z1.d, p1, z3.d, z2.d
-; CHECK-NEXT:    str z7, [x8, #5, mul vl]
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
-; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z6.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z26.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #3, mul vl]
-; CHECK-NEXT:    str z26, [x8, #2, mul vl]
-; CHECK-NEXT:    str z5, [x8, #1, mul vl]
-; CHECK-NEXT:    str z1, [x8]
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
+; CHECK-NEXT:    frintx z25.s, p0/m, z25.s
+; CHECK-NEXT:    frintx z26.s, p0/m, z26.s
+; CHECK-NEXT:    frintx z5.s, p0/m, z5.s
+; CHECK-NEXT:    frintx z27.s, p0/m, z27.s
+; CHECK-NEXT:    frintx z28.s, p0/m, z28.s
+; CHECK-NEXT:    frintx z4.s, p0/m, z4.s
+; CHECK-NEXT:    frintx z29.s, p0/m, z29.s
+; CHECK-NEXT:    frintx z3.s, p0/m, z3.s
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.s
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.s
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.s
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.s
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.s
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.s
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.s
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.s
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.s
+; CHECK-NEXT:    str z24, [x8, #15, mul vl]
+; CHECK-NEXT:    uunpkhi z24.d, z2.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    str z6, [x8, #12, mul vl]
+; CHECK-NEXT:    uunpkhi z6.d, z0.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    str z7, [x8, #14, mul vl]
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.s
+; CHECK-NEXT:    str z25, [x8, #13, mul vl]
+; CHECK-NEXT:    str z26, [x8, #11, mul vl]
+; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
+; CHECK-NEXT:    frintx z2.s, p0/m, z2.s
+; CHECK-NEXT:    str z5, [x8, #10, mul vl]
+; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
+; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-NEXT:    str z27, [x8, #9, mul vl]
+; CHECK-NEXT:    str z4, [x8, #8, mul vl]
+; CHECK-NEXT:    str z29, [x8, #7, mul vl]
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.s
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.s
+; CHECK-NEXT:    str z3, [x8, #6, mul vl]
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    str z1, [x8, #2, mul vl]
+; CHECK-NEXT:    str z24, [x8, #5, mul vl]
+; CHECK-NEXT:    str z2, [x8, #4, mul vl]
+; CHECK-NEXT:    str z6, [x8, #1, mul vl]
+; CHECK-NEXT:    str z0, [x8]
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.llrint.nxv32i64.nxv32f32(<vscale x 32 x float> %x)
   ret <vscale x 32 x i64> %a
@@ -1028,19 +398,8 @@ define <vscale x 1 x i64> @llrint_v1i64_v1f64(<vscale x 1 x double> %x) {
 ; CHECK-LABEL: llrint_v1i64_v1f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.llrint.nxv1i64.nxv1f64(<vscale x 1 x double> %x)
   ret <vscale x 1 x i64> %a
@@ -1051,19 +410,8 @@ define <vscale x 2 x i64> @llrint_v2i64_v2f64(<vscale x 2 x double> %x) {
 ; CHECK-LABEL: llrint_v2i64_v2f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.llrint.nxv2i64.nxv2f64(<vscale x 2 x double> %x)
   ret <vscale x 2 x i64> %a
@@ -1074,27 +422,10 @@ define <vscale x 4 x i64> @llrint_v4i64_v4f64(<vscale x 4 x double> %x) {
 ; CHECK-LABEL: llrint_v4i64_v4f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z2.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z2.d
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z1.d
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f64(<vscale x 4 x double> %x)
   ret <vscale x 4 x i64> %a
@@ -1104,56 +435,15 @@ declare <vscale x 4 x i64> @llvm.llrint.nxv4i64.nxv4f64(<vscale x 4 x double>)
 define <vscale x 8 x i64> @llrint_v8i64_v8f64(<vscale x 8 x double> %x) {
 ; CHECK-LABEL: llrint_v8i64_v8f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
-; CHECK-NEXT:    mov z24.d, x8
 ; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z5.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z5.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z2.d, z5.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z0.d, z24.d
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z3.d, z5.d
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z6.d, p2/m, z1.d
-; CHECK-NEXT:    fcvtzs z7.d, p3/m, z2.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z1.d, z24.d
-; CHECK-NEXT:    sel z0.d, p4, z25.d, z4.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z2.d, z24.d
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z3.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z24.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    sel z1.d, p3, z25.d, z6.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z2.d, z2.d
-; CHECK-NEXT:    sel z2.d, p4, z25.d, z7.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    sel z3.d, p1, z25.d, z5.d
-; CHECK-NEXT:    mov z1.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z2.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f64(<vscale x 8 x double> %x)
   ret <vscale x 8 x i64> %a
@@ -1163,103 +453,23 @@ declare <vscale x 8 x i64> @llvm.llrint.nxv8i64.nxv8f64(<vscale x 8 x double>)
 define <vscale x 16 x i64> @llrint_v16f64(<vscale x 16 x double> %x) {
 ; CHECK-LABEL: llrint_v16f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-3
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z9, [sp, #1, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x48, 0x1e, 0x22 // sp + 16 + 24 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z24, z0
-; CHECK-NEXT:    frintx z24.d, p0/m, z0.d
-; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-NEXT:    mov z0.d, x8
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-NEXT:    mov z30.d, x8
-; CHECK-NEXT:    mov z29.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z5.d, p0/m, z5.d
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
 ; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z9.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.d, p0/z, z24.d, z0.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z0.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z0.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z2.d, z0.d
-; CHECK-NEXT:    fcvtzs z25.d, p1/m, z24.d
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z3.d
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z1.d
-; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z0.d
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z2.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z24.d, z30.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z24.d, z24.d
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p7.d, p0/z, z6.d, z0.d
-; CHECK-NEXT:    fcvtzs z29.d, p5/m, z4.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z5.d, z0.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z1.d, z30.d
-; CHECK-NEXT:    fcvtzs z24.d, p7/m, z6.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z2.d, z30.d
-; CHECK-NEXT:    fcmge p7.d, p0/z, z7.d, z0.d
-; CHECK-NEXT:    fcvtzs z31.d, p3/m, z5.d
-; CHECK-NEXT:    sel z0.d, p4, z8.d, z25.d
-; CHECK-NEXT:    fcmgt p8.d, p0/z, z3.d, z30.d
-; CHECK-NEXT:    fcmgt p9.d, p0/z, z4.d, z30.d
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z9.d, p7/m, z7.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    sel z1.d, p5, z8.d, z26.d
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z2.d, z2.d
-; CHECK-NEXT:    sel z2.d, p6, z8.d, z27.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z5.d, z30.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z6.d, z30.d
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p7.d, p0/z, z7.d, z30.d
-; CHECK-NEXT:    fcmuo p10.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    sel z3.d, p8, z8.d, z28.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    sel z4.d, p9, z8.d, z29.d
-; CHECK-NEXT:    fcmuo p8.d, p0/z, z5.d, z5.d
-; CHECK-NEXT:    sel z5.d, p5, z8.d, z31.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.d, p0/z, z6.d, z6.d
-; CHECK-NEXT:    sel z6.d, p6, z8.d, z24.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z7.d, z7.d
-; CHECK-NEXT:    sel z7.d, p7, z8.d, z9.d
-; CHECK-NEXT:    ldr z9, [sp, #1, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #3
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.d
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f64(<vscale x 16 x double> %x)
   ret <vscale x 16 x i64> %a
@@ -1269,242 +479,71 @@ declare <vscale x 16 x i64> @llvm.llrint.nxv16i64.nxv16f64(<vscale x 16 x double
 define <vscale x 32 x i64> @llrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-LABEL: llrint_v32f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    ldr z0, [x0]
-; CHECK-NEXT:    ldr z7, [x0, #3, mul vl]
+; CHECK-NEXT:    ldr z5, [x0, #15, mul vl]
+; CHECK-NEXT:    ldr z4, [x0, #14, mul vl]
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
-; CHECK-NEXT:    ldr z4, [x0, #2, mul vl]
-; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, x9
-; CHECK-NEXT:    ldr z2, [x0, #1, mul vl]
-; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
-; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
-; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
-; CHECK-NEXT:    movprfx z14, z27
-; CHECK-NEXT:    frintx z14.d, p0/m, z27.d
+; CHECK-NEXT:    ldr z3, [x0, #13, mul vl]
+; CHECK-NEXT:    ldr z2, [x0, #12, mul vl]
+; CHECK-NEXT:    ldr z1, [x0, #11, mul vl]
+; CHECK-NEXT:    ldr z0, [x0, #10, mul vl]
+; CHECK-NEXT:    ldr z6, [x0, #9, mul vl]
+; CHECK-NEXT:    ldr z7, [x0, #8, mul vl]
+; CHECK-NEXT:    frintx z5.d, p0/m, z5.d
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    ldr z27, [x0, #5, mul vl]
-; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
-; CHECK-NEXT:    mov x9, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    movprfx z3, z2
-; CHECK-NEXT:    frintx z3.d, p0/m, z2.d
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z25.d
-; CHECK-NEXT:    movprfx z28, z27
-; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
+; CHECK-NEXT:    ldr z24, [x0, #7, mul vl]
+; CHECK-NEXT:    ldr z25, [x0, #6, mul vl]
+; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
+; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    ldr z26, [x0, #5, mul vl]
+; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
+; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
+; CHECK-NEXT:    ldr z28, [x0, #3, mul vl]
+; CHECK-NEXT:    ldr z29, [x0, #2, mul vl]
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
+; CHECK-NEXT:    ldr z30, [x0, #1, mul vl]
+; CHECK-NEXT:    ldr z31, [x0]
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
+; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
+; CHECK-NEXT:    frintx z24.d, p0/m, z24.d
+; CHECK-NEXT:    frintx z25.d, p0/m, z25.d
+; CHECK-NEXT:    frintx z26.d, p0/m, z26.d
+; CHECK-NEXT:    frintx z27.d, p0/m, z27.d
+; CHECK-NEXT:    frintx z28.d, p0/m, z28.d
 ; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
-; CHECK-NEXT:    mov z1.d, x9
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
-; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
-; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z25.d
-; CHECK-NEXT:    ldr z19, [x0, #9, mul vl]
-; CHECK-NEXT:    movprfx z20, z31
-; CHECK-NEXT:    frintx z20.d, p0/m, z31.d
-; CHECK-NEXT:    frintx z15.d, p0/m, z15.d
-; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
-; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
-; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z29.d, z25.d
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
-; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
-; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z8.d, p0/m, z8.d
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    fcmuo p8.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    movprfx z14, z19
-; CHECK-NEXT:    frintx z14.d, p0/m, z19.d
-; CHECK-NEXT:    movprfx z19, z11
-; CHECK-NEXT:    frintx z19.d, p0/m, z11.d
-; CHECK-NEXT:    mov z11.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, p10/m, z27.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
-; CHECK-NEXT:    fcmge p5.d, p0/z, z20.d, z25.d
-; CHECK-NEXT:    mov z30.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z3.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z18.d, z25.d
-; CHECK-NEXT:    str z30, [x8, #4, mul vl]
-; CHECK-NEXT:    fcvtzs z16.d, p5/m, z20.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
-; CHECK-NEXT:    fcvtzs z17.d, p6/m, z15.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z20.d, z1.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z10.d, z25.d
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
-; CHECK-NEXT:    fcmgt p11.d, p0/z, z15.d, z1.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z9.d, z25.d
-; CHECK-NEXT:    fcmge p6.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    fcvtzs z23.d, p3/m, z10.d
-; CHECK-NEXT:    fcmge p7.d, p0/z, z13.d, z25.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z15.d, z15.d
-; CHECK-NEXT:    sel z15.d, p5, z27.d, z16.d
-; CHECK-NEXT:    sel z16.d, p11, z27.d, z17.d
-; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
-; CHECK-NEXT:    fcvtzs z11.d, p6/m, z14.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z8.d, z25.d
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z16.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z9.d, z1.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z10.d, z1.d
-; CHECK-NEXT:    str z16, [x8, #8, mul vl]
-; CHECK-NEXT:    fcvtzs z25.d, p2/m, z8.d
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z19.d, z1.d
-; CHECK-NEXT:    fcmuo p9.d, p0/z, z20.d, z20.d
-; CHECK-NEXT:    mov z20.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, p4/m, z27.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z9.d, z9.d
-; CHECK-NEXT:    sel z9.d, p5, z27.d, z23.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z10.d, z10.d
-; CHECK-NEXT:    sel z10.d, p3, z27.d, z22.d
-; CHECK-NEXT:    fcvtzs z20.d, p7/m, z13.d
-; CHECK-NEXT:    mov z15.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z9.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    str z15, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z8.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
-; CHECK-NEXT:    str z9, [x8, #14, mul vl]
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z18.d, z1.d
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z13.d, z1.d
-; CHECK-NEXT:    sel z26.d, p4, z27.d, z11.d
-; CHECK-NEXT:    mov z25.d, p3/m, z27.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z18.d, z18.d
-; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z13.d, z13.d
-; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
-; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
-; CHECK-NEXT:    str z10, [x8, #13, mul vl]
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z8.d, z8.d
-; CHECK-NEXT:    sel z8.d, p1, z27.d, z21.d
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    mov z8.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    mov z12.d, p12/m, z27.d
-; CHECK-NEXT:    str z9, [x8, #10, mul vl]
-; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
-; CHECK-NEXT:    str z8, [x8, #11, mul vl]
-; CHECK-NEXT:    mov z5.d, p1/m, z27.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
-; CHECK-NEXT:    str z25, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
-; CHECK-NEXT:    mov z6.d, p2/m, z27.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #9, mul vl]
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z24.d, p4/m, z27.d
-; CHECK-NEXT:    mov z12.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z29.d, z29.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z7.d, z7.d
-; CHECK-NEXT:    sel z25.d, p6, z27.d, z31.d
-; CHECK-NEXT:    str z12, [x8, #5, mul vl]
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    mov z25.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z27.d, z2.d
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z6.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    frintx z30.d, p0/m, z30.d
+; CHECK-NEXT:    frintx z31.d, p0/m, z31.d
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.d
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.d
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.d
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.d
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.d
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.d
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.d
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.d
+; CHECK-NEXT:    fcvtzs z30.d, p0/m, z30.d
+; CHECK-NEXT:    fcvtzs z31.d, p0/m, z31.d
+; CHECK-NEXT:    str z5, [x8, #15, mul vl]
+; CHECK-NEXT:    str z4, [x8, #14, mul vl]
+; CHECK-NEXT:    str z3, [x8, #13, mul vl]
+; CHECK-NEXT:    str z2, [x8, #12, mul vl]
+; CHECK-NEXT:    str z1, [x8, #11, mul vl]
+; CHECK-NEXT:    str z0, [x8, #10, mul vl]
+; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    str z7, [x8, #8, mul vl]
+; CHECK-NEXT:    str z24, [x8, #7, mul vl]
 ; CHECK-NEXT:    str z25, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z24, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #2, mul vl]
-; CHECK-NEXT:    str z5, [x8, #1, mul vl]
-; CHECK-NEXT:    str z0, [x8]
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    str z26, [x8, #5, mul vl]
+; CHECK-NEXT:    str z27, [x8, #4, mul vl]
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    str z29, [x8, #2, mul vl]
+; CHECK-NEXT:    str z30, [x8, #1, mul vl]
+; CHECK-NEXT:    str z31, [x8]
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.llrint.nxv32i64.nxv16f64(<vscale x 32 x double> %x)
   ret <vscale x 32 x i64> %a

--- a/llvm/test/CodeGen/AArch64/sve-lrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-lrint.ll
@@ -5,18 +5,8 @@ define <vscale x 1 x i64> @lrint_v1f16(<vscale x 1 x half> %x) {
 ; CHECK-LABEL: lrint_v1f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.lrint.nxv1i64.nxv1f16(<vscale x 1 x half> %x)
   ret <vscale x 1 x i64> %a
@@ -26,18 +16,8 @@ define <vscale x 2 x i64> @lrint_v2f16(<vscale x 2 x half> %x) {
 ; CHECK-LABEL: lrint_v2f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z1.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.h, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z0.h, z1.h
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.lrint.nxv2i64.nxv2f16(<vscale x 2 x half> %x)
   ret <vscale x 2 x i64> %a
@@ -48,27 +28,14 @@ define <vscale x 4 x i64> @lrint_v4f16(<vscale x 4 x half> %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    uunpklo z1.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
-; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z1.h, z2.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z0.h, z2.h
-; CHECK-NEXT:    mov z2.h, w8
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z1.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z2.h
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z0.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z0.h, z2.h
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z0.h, z0.h
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    movprfx z2, z0
+; CHECK-NEXT:    frintx z2.h, p0/m, z0.h
+; CHECK-NEXT:    movprfx z0, z1
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.lrint.nxv4i64.nxv4f16(<vscale x 4 x half> %x)
   ret <vscale x 4 x i64> %a
@@ -77,62 +44,25 @@ define <vscale x 4 x i64> @lrint_v4f16(<vscale x 4 x half> %x) {
 define <vscale x 8 x i64> @lrint_v8f16(<vscale x 8 x half> %x) {
 ; CHECK-LABEL: lrint_v8f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    uunpklo z1.s, z0.h
 ; CHECK-NEXT:    uunpkhi z0.s, z0.h
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z4.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    uunpklo z2.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
 ; CHECK-NEXT:    uunpklo z3.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
 ; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
 ; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
-; CHECK-NEXT:    movprfx z24, z0
-; CHECK-NEXT:    frintx z24.h, p0/m, z0.h
-; CHECK-NEXT:    mov z0.h, w8
-; CHECK-NEXT:    fcmge p1.h, p0/z, z2.h, z4.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z1.h, z4.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z3.h, z4.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z1.h, z0.h
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z2.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z24.h, z4.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z6.d, p2/m, z1.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z2.h, z0.h
-; CHECK-NEXT:    fcvtzs z7.d, p3/m, z3.h
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z3.h, z0.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z0.h
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z24.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z2.h, z2.h
-; CHECK-NEXT:    sel z0.d, p2, z25.d, z5.d
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    sel z1.d, p4, z25.d, z6.d
-; CHECK-NEXT:    sel z2.d, p5, z25.d, z7.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z3.h, z3.h
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z24.h, z24.h
-; CHECK-NEXT:    sel z3.d, p6, z25.d, z4.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    frintx z4.h, p0/m, z0.h
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z0, z2
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z2.h
+; CHECK-NEXT:    movprfx z2, z3
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z3.h
+; CHECK-NEXT:    movprfx z3, z4
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z4.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.lrint.nxv8i64.nxv8f16(<vscale x 8 x half> %x)
   ret <vscale x 8 x i64> %a
@@ -141,110 +71,46 @@ define <vscale x 8 x i64> @lrint_v8f16(<vscale x 8 x half> %x) {
 define <vscale x 16 x i64> @lrint_v16f16(<vscale x 16 x half> %x) {
 ; CHECK-LABEL: lrint_v16f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    uunpkhi z3.s, z0.h
 ; CHECK-NEXT:    uunpklo z2.s, z0.h
-; CHECK-NEXT:    mov w8, #31743 // =0x7bff
-; CHECK-NEXT:    uunpklo z7.s, z1.h
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z0.h, #-1025 // =0xfffffffffffffbff
+; CHECK-NEXT:    uunpkhi z0.s, z0.h
+; CHECK-NEXT:    uunpklo z3.s, z1.h
 ; CHECK-NEXT:    uunpkhi z1.s, z1.h
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.h, w8
-; CHECK-NEXT:    uunpkhi z25.d, z3.s
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    uunpklo z4.d, z2.s
-; CHECK-NEXT:    uunpkhi z6.d, z2.s
-; CHECK-NEXT:    uunpklo z24.d, z3.s
-; CHECK-NEXT:    uunpklo z26.d, z7.s
-; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    uunpklo z30.d, z1.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
+; CHECK-NEXT:    uunpkhi z2.d, z2.s
+; CHECK-NEXT:    uunpklo z5.d, z0.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uunpklo z6.d, z3.s
+; CHECK-NEXT:    uunpkhi z3.d, z3.s
+; CHECK-NEXT:    uunpklo z7.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
-; CHECK-NEXT:    movprfx z27, z4
-; CHECK-NEXT:    frintx z27.h, p0/m, z4.h
-; CHECK-NEXT:    movprfx z28, z6
-; CHECK-NEXT:    frintx z28.h, p0/m, z6.h
-; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
-; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
-; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
+; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
+; CHECK-NEXT:    movprfx z24, z0
+; CHECK-NEXT:    frintx z24.h, p0/m, z0.h
+; CHECK-NEXT:    frintx z6.h, p0/m, z6.h
+; CHECK-NEXT:    movprfx z25, z3
+; CHECK-NEXT:    frintx z25.h, p0/m, z3.h
 ; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z30.h, p0/m, z30.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z25.h, z0.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z28.h, z0.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z26.h, z0.h
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z27.h
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z28.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z7.h, z0.h
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z26.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z28.h, z29.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    movprfx z28, z1
-; CHECK-NEXT:    frintx z28.h, p0/m, z1.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z29.h
-; CHECK-NEXT:    fcmuo p7.h, p0/z, z24.h, z24.h
-; CHECK-NEXT:    mov z24.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmgt p8.h, p0/z, z25.h, z29.h
-; CHECK-NEXT:    fcvtzs z27.d, p4/m, z30.h
-; CHECK-NEXT:    fcmuo p10.h, p0/z, z25.h, z25.h
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    sel z1.d, p5, z24.d, z3.d
-; CHECK-NEXT:    fcmge p4.h, p0/z, z28.h, z0.h
-; CHECK-NEXT:    sel z0.d, p3, z24.d, z2.d
-; CHECK-NEXT:    sel z2.d, p6, z24.d, z4.d
-; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p9.h, p0/z, z26.h, z29.h
-; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcvtzs z25.d, p4/m, z28.h
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z7.h, z29.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z30.h, z29.h
-; CHECK-NEXT:    sel z4.d, p9, z24.d, z6.d
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z28.h, z29.h
-; CHECK-NEXT:    fcmuo p8.h, p0/z, z7.h, z7.h
-; CHECK-NEXT:    sel z5.d, p5, z24.d, z31.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.h, p0/z, z30.h, z30.h
-; CHECK-NEXT:    sel z6.d, p6, z24.d, z27.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    sel z7.d, p4, z24.d, z25.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z26, z1
+; CHECK-NEXT:    frintx z26.h, p0/m, z1.h
+; CHECK-NEXT:    movprfx z0, z4
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z4.h
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.h
+; CHECK-NEXT:    movprfx z2, z5
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z5.h
+; CHECK-NEXT:    movprfx z3, z24
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z24.h
+; CHECK-NEXT:    movprfx z4, z6
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z6.h
+; CHECK-NEXT:    movprfx z5, z25
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z25.h
+; CHECK-NEXT:    movprfx z6, z7
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z7.h
+; CHECK-NEXT:    movprfx z7, z26
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z26.h
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.lrint.nxv16i64.nxv16f16(<vscale x 16 x half> %x)
   ret <vscale x 16 x i64> %a
@@ -253,252 +119,79 @@ define <vscale x 16 x i64> @lrint_v16f16(<vscale x 16 x half> %x) {
 define <vscale x 32 x i64> @lrint_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-LABEL: lrint_v32f16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    uunpklo z4.s, z0.h
-; CHECK-NEXT:    uunpkhi z0.s, z0.h
-; CHECK-NEXT:    mov w9, #31743 // =0x7bff
-; CHECK-NEXT:    uunpklo z5.s, z1.h
+; CHECK-NEXT:    uunpkhi z4.s, z3.h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z28.h, #-1025 // =0xfffffffffffffbff
-; CHECK-NEXT:    uunpkhi z29.s, z1.h
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z13.s, z2.h
-; CHECK-NEXT:    mov z9.d, #0x8000000000000000
-; CHECK-NEXT:    uunpkhi z14.s, z2.h
-; CHECK-NEXT:    uunpkhi z17.s, z3.h
-; CHECK-NEXT:    uunpklo z6.d, z4.s
-; CHECK-NEXT:    uunpkhi z4.d, z4.s
-; CHECK-NEXT:    uunpklo z27.d, z0.s
-; CHECK-NEXT:    uunpklo z31.d, z5.s
-; CHECK-NEXT:    uunpkhi z8.d, z5.s
-; CHECK-NEXT:    uunpkhi z30.d, z0.s
-; CHECK-NEXT:    uunpkhi z11.d, z29.s
-; CHECK-NEXT:    uunpklo z10.d, z29.s
-; CHECK-NEXT:    uunpklo z15.s, z3.h
-; CHECK-NEXT:    uunpklo z16.d, z14.s
-; CHECK-NEXT:    uunpkhi z14.d, z14.s
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z5, z27
-; CHECK-NEXT:    frintx z5.h, p0/m, z27.h
-; CHECK-NEXT:    movprfx z1, z6
-; CHECK-NEXT:    frintx z1.h, p0/m, z6.h
+; CHECK-NEXT:    uunpkhi z7.s, z2.h
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    uunpkhi z24.s, z0.h
+; CHECK-NEXT:    uunpkhi z25.s, z1.h
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpkhi z5.d, z4.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpkhi z6.d, z3.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    uunpkhi z26.d, z7.s
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    uunpkhi z27.d, z2.s
+; CHECK-NEXT:    uunpkhi z28.d, z24.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    uunpkhi z29.d, z25.s
+; CHECK-NEXT:    uunpklo z25.d, z25.s
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
 ; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
-; CHECK-NEXT:    movprfx z12, z31
-; CHECK-NEXT:    frintx z12.h, p0/m, z31.h
-; CHECK-NEXT:    movprfx z27, z8
-; CHECK-NEXT:    frintx z27.h, p0/m, z8.h
-; CHECK-NEXT:    movprfx z6, z30
-; CHECK-NEXT:    frintx z6.h, p0/m, z30.h
-; CHECK-NEXT:    movprfx z31, z10
-; CHECK-NEXT:    frintx z31.h, p0/m, z10.h
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
-; CHECK-NEXT:    movprfx z3, z16
-; CHECK-NEXT:    frintx z3.h, p0/m, z16.h
-; CHECK-NEXT:    mov z30.h, w9
-; CHECK-NEXT:    uunpklo z10.d, z13.s
-; CHECK-NEXT:    uunpkhi z13.d, z13.s
-; CHECK-NEXT:    uunpkhi z20.d, z15.s
-; CHECK-NEXT:    uunpklo z16.d, z17.s
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    mov z18.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z15.d, z15.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z10.h, p0/m, z10.h
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.d, #0x7fffffffffffffff
-; CHECK-NEXT:    movprfx z19, z13
-; CHECK-NEXT:    frintx z19.h, p0/m, z13.h
-; CHECK-NEXT:    movprfx z13, z14
-; CHECK-NEXT:    frintx z13.h, p0/m, z14.h
-; CHECK-NEXT:    frintx z20.h, p0/m, z20.h
-; CHECK-NEXT:    frintx z16.h, p0/m, z16.h
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z15.h, p0/m, z15.h
-; CHECK-NEXT:    mov z14.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p4.h, p0/z, z4.h, z28.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z12.h, z28.h
-; CHECK-NEXT:    fcmgt p9.h, p0/z, z12.h, z30.h
-; CHECK-NEXT:    fcmuo p8.h, p0/z, z12.h, z12.h
-; CHECK-NEXT:    fcvtzs z7.d, p4/m, z4.h
-; CHECK-NEXT:    fcvtzs z8.d, p2/m, z12.h
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p4.h, p0/z, z27.h, z28.h
-; CHECK-NEXT:    fcmuo p10.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z5.h, z28.h
-; CHECK-NEXT:    mov z8.d, p9/m, z29.d
-; CHECK-NEXT:    fcvtzs z9.d, p4/m, z27.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z11.h, z28.h
-; CHECK-NEXT:    fcvtzs z24.d, p3/m, z5.h
-; CHECK-NEXT:    mov z8.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p1.h, p0/z, z6.h, z28.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z1.h, z28.h
-; CHECK-NEXT:    str z8, [x8, #4, mul vl]
-; CHECK-NEXT:    fcvtzs z12.d, p4/m, z11.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
-; CHECK-NEXT:    uunpkhi z11.d, z17.s
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z25.d, p1/m, z6.h
-; CHECK-NEXT:    fcvtzs z0.d, p5/m, z1.h
-; CHECK-NEXT:    fcmge p6.h, p0/z, z10.h, z28.h
-; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z31.h, z28.h
-; CHECK-NEXT:    fcmge p1.h, p0/z, z13.h, z28.h
-; CHECK-NEXT:    fcvtzs z18.d, p6/m, z10.h
-; CHECK-NEXT:    fcmgt p11.h, p0/z, z10.h, z30.h
-; CHECK-NEXT:    fcvtzs z2.d, p3/m, z31.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z13.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z20.h, z28.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z16.h, z28.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z10.h, z10.h
-; CHECK-NEXT:    sel z10.d, p4, z29.d, z12.d
-; CHECK-NEXT:    sel z12.d, p11, z29.d, z18.d
-; CHECK-NEXT:    fcvtzs z26.d, p5/m, z11.h
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z20.h
-; CHECK-NEXT:    fcvtzs z23.d, p3/m, z16.h
-; CHECK-NEXT:    mov z10.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
-; CHECK-NEXT:    fcmge p6.h, p0/z, z19.h, z28.h
-; CHECK-NEXT:    str z10, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmge p7.h, p0/z, z3.h, z28.h
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcmge p2.h, p0/z, z15.h, z28.h
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, p4/m, z29.d
-; CHECK-NEXT:    fcmgt p5.h, p0/z, z16.h, z30.h
-; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
-; CHECK-NEXT:    fcvtzs z17.d, p7/m, z3.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z20.h, z30.h
-; CHECK-NEXT:    fcvtzs z28.d, p2/m, z15.h
-; CHECK-NEXT:    fcmuo p1.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    sel z11.d, p5, z29.d, z23.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z19.h, z30.h
-; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
-; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z13.h, z30.h
-; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    sel z26.d, p4, z29.d, z14.d
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z20.h, z20.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
-; CHECK-NEXT:    str z11, [x8, #14, mul vl]
-; CHECK-NEXT:    mov z28.d, p3/m, z29.d
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z13.h, z13.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z3.h, z3.h
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z21.d
-; CHECK-NEXT:    mov z16.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    sel z11.d, p2, z29.d, z17.d
-; CHECK-NEXT:    fcmgt p12.h, p0/z, z27.h, z30.h
-; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z16, [x8, #13, mul vl]
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z15.h, z15.h
-; CHECK-NEXT:    mov z11.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
-; CHECK-NEXT:    str z3, [x8, #11, mul vl]
-; CHECK-NEXT:    fcmuo p5.h, p0/z, z19.h, z19.h
-; CHECK-NEXT:    mov z9.d, p12/m, z29.d
-; CHECK-NEXT:    str z11, [x8, #10, mul vl]
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
-; CHECK-NEXT:    mov z28.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z6.h, z30.h
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    str z28, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z31.h, z30.h
-; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
-; CHECK-NEXT:    str z26, [x8, #9, mul vl]
-; CHECK-NEXT:    sel z24.d, p4, z29.d, z25.d
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
-; CHECK-NEXT:    fcmuo p5.h, p0/z, z31.h, z31.h
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p6/m, z29.d
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
-; CHECK-NEXT:    str z9, [x8, #5, mul vl]
-; CHECK-NEXT:    mov z0.d, p1/m, z29.d
-; CHECK-NEXT:    mov z2.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z2, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z24, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z7, [x8, #2, mul vl]
-; CHECK-NEXT:    str z3, [x8, #1, mul vl]
+; CHECK-NEXT:    frintx z6.h, p0/m, z6.h
+; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
+; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
+; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
+; CHECK-NEXT:    frintx z27.h, p0/m, z27.h
+; CHECK-NEXT:    frintx z2.h, p0/m, z2.h
+; CHECK-NEXT:    frintx z28.h, p0/m, z28.h
+; CHECK-NEXT:    frintx z29.h, p0/m, z29.h
+; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.h
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.h
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.h
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.h
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.h
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.h
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.h
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.h
+; CHECK-NEXT:    str z5, [x8, #15, mul vl]
+; CHECK-NEXT:    uunpkhi z5.d, z1.s
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    str z4, [x8, #14, mul vl]
+; CHECK-NEXT:    uunpkhi z4.d, z0.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    str z3, [x8, #12, mul vl]
+; CHECK-NEXT:    uunpklo z3.d, z24.s
+; CHECK-NEXT:    str z6, [x8, #13, mul vl]
+; CHECK-NEXT:    str z26, [x8, #11, mul vl]
+; CHECK-NEXT:    frintx z5.h, p0/m, z5.h
+; CHECK-NEXT:    frintx z1.h, p0/m, z1.h
+; CHECK-NEXT:    str z7, [x8, #10, mul vl]
+; CHECK-NEXT:    frintx z4.h, p0/m, z4.h
+; CHECK-NEXT:    frintx z0.h, p0/m, z0.h
+; CHECK-NEXT:    str z27, [x8, #9, mul vl]
+; CHECK-NEXT:    frintx z3.h, p0/m, z3.h
+; CHECK-NEXT:    str z2, [x8, #8, mul vl]
+; CHECK-NEXT:    str z29, [x8, #7, mul vl]
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
+; CHECK-NEXT:    str z25, [x8, #6, mul vl]
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
+; CHECK-NEXT:    str z5, [x8, #5, mul vl]
+; CHECK-NEXT:    str z1, [x8, #4, mul vl]
+; CHECK-NEXT:    str z3, [x8, #2, mul vl]
+; CHECK-NEXT:    str z4, [x8, #1, mul vl]
 ; CHECK-NEXT:    str z0, [x8]
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.lrint.nxv32i64.nxv32f16(<vscale x 32 x half> %x)
   ret <vscale x 32 x i64> %a
@@ -508,19 +201,8 @@ define <vscale x 1 x i64> @lrint_v1f32(<vscale x 1 x float> %x) {
 ; CHECK-LABEL: lrint_v1f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
 ; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.lrint.nxv1i64.nxv1f32(<vscale x 1 x float> %x)
   ret <vscale x 1 x i64> %a
@@ -530,19 +212,8 @@ define <vscale x 2 x i64> @lrint_v2f32(<vscale x 2 x float> %x) {
 ; CHECK-LABEL: lrint_v2f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
 ; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.s, w8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z0.s, z1.s
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.lrint.nxv2i64.nxv2f32(<vscale x 2 x float> %x)
   ret <vscale x 2 x i64> %a
@@ -553,28 +224,14 @@ define <vscale x 4 x i64> @lrint_v4f32(<vscale x 4 x float> %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    uunpklo z1.d, z0.s
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
-; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z0.s, z2.s
-; CHECK-NEXT:    mov z2.s, w8
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z1.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z2.s
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z0.s
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z0.s, z2.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z0.s, z0.s
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    movprfx z2, z0
+; CHECK-NEXT:    frintx z2.s, p0/m, z0.s
+; CHECK-NEXT:    movprfx z0, z1
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z1.s
+; CHECK-NEXT:    movprfx z1, z2
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z2.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.lrint.nxv4i64.nxv4f32(<vscale x 4 x float> %x)
   ret <vscale x 4 x i64> %a
@@ -583,61 +240,25 @@ define <vscale x 4 x i64> @lrint_v4f32(<vscale x 4 x float> %x) {
 define <vscale x 8 x i64> @lrint_v8f32(<vscale x 8 x float> %x) {
 ; CHECK-LABEL: lrint_v8f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    uunpklo z2.d, z0.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
 ; CHECK-NEXT:    uunpkhi z0.d, z0.s
 ; CHECK-NEXT:    uunpklo z3.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
-; CHECK-NEXT:    mov z4.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.s, w8
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    frintx z2.s, p0/m, z2.s
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z6, z0
-; CHECK-NEXT:    frintx z6.s, p0/m, z0.s
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    frintx z4.s, p0/m, z0.s
 ; CHECK-NEXT:    frintx z3.s, p0/m, z3.s
-; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z2.s, z4.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z4.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z3.s, z4.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z2.s, z25.s
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z2.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z1.s, z4.s
-; CHECK-NEXT:    mov z4.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcvtzs z7.d, p2/m, z6.s
-; CHECK-NEXT:    fcvtzs z24.d, p3/m, z3.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z25.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z3.s, z25.s
-; CHECK-NEXT:    fcvtzs z26.d, p1/m, z1.s
-; CHECK-NEXT:    sel z0.d, p4, z4.d, z5.d
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z25.s
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z3.s, z3.s
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z2.s, z2.s
-; CHECK-NEXT:    sel z2.d, p5, z4.d, z24.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    sel z1.d, p3, z4.d, z7.d
-; CHECK-NEXT:    sel z3.d, p1, z4.d, z26.d
-; CHECK-NEXT:    mov z2.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z1.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z5, z1
+; CHECK-NEXT:    frintx z5.s, p0/m, z1.s
+; CHECK-NEXT:    movprfx z0, z2
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z2.s
+; CHECK-NEXT:    movprfx z1, z4
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z4.s
+; CHECK-NEXT:    movprfx z2, z3
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z3.s
+; CHECK-NEXT:    movprfx z3, z5
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z5.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.lrint.nxv8i64.nxv8f32(<vscale x 8 x float> %x)
   ret <vscale x 8 x i64> %a
@@ -646,114 +267,43 @@ define <vscale x 8 x i64> @lrint_v8f32(<vscale x 8 x float> %x) {
 define <vscale x 16 x i64> @lrint_v16f32(<vscale x 16 x float> %x) {
 ; CHECK-LABEL: lrint_v16f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-3
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z9, [sp, #1, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x48, 0x1e, 0x22 // sp + 16 + 24 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
 ; CHECK-NEXT:    uunpklo z4.d, z0.s
-; CHECK-NEXT:    uunpkhi z5.d, z0.s
-; CHECK-NEXT:    mov w8, #-553648128 // =0xdf000000
-; CHECK-NEXT:    uunpkhi z7.d, z1.s
-; CHECK-NEXT:    uunpklo z24.d, z2.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    uunpklo z6.d, z1.s
+; CHECK-NEXT:    uunpkhi z0.d, z0.s
+; CHECK-NEXT:    uunpklo z5.d, z1.s
+; CHECK-NEXT:    uunpkhi z1.d, z1.s
+; CHECK-NEXT:    uunpklo z6.d, z2.s
 ; CHECK-NEXT:    uunpkhi z2.d, z2.s
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z25, z4
-; CHECK-NEXT:    frintx z25.s, p0/m, z4.s
+; CHECK-NEXT:    uunpklo z7.d, z3.s
+; CHECK-NEXT:    uunpkhi z3.d, z3.s
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    frintx z4.s, p0/m, z4.s
+; CHECK-NEXT:    movprfx z24, z0
+; CHECK-NEXT:    frintx z24.s, p0/m, z0.s
 ; CHECK-NEXT:    frintx z5.s, p0/m, z5.s
-; CHECK-NEXT:    mov z4.s, w8
-; CHECK-NEXT:    mov w8, #1593835519 // =0x5effffff
-; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
-; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
-; CHECK-NEXT:    movprfx z30, z2
-; CHECK-NEXT:    frintx z30.s, p0/m, z2.s
+; CHECK-NEXT:    movprfx z25, z1
+; CHECK-NEXT:    frintx z25.s, p0/m, z1.s
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
-; CHECK-NEXT:    uunpklo z2.d, z3.s
-; CHECK-NEXT:    mov z29.s, w8
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
-; CHECK-NEXT:    mov z9.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p5.s, p0/z, z25.s, z4.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z5.s, z4.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z7.s, z4.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z24.s, z4.s
-; CHECK-NEXT:    fcvtzs z0.d, p5/m, z25.s
-; CHECK-NEXT:    fcvtzs z1.d, p1/m, z5.s
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z7.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z4.s
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z24.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z30.s, z4.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    movprfx z25, z2
-; CHECK-NEXT:    frintx z25.s, p0/m, z2.s
-; CHECK-NEXT:    uunpkhi z2.d, z3.s
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z6.s
-; CHECK-NEXT:    mov z0.d, p3/m, z9.d
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z30.s
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    movprfx z5, z2
-; CHECK-NEXT:    frintx z5.s, p0/m, z2.s
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z4.s
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z6.s, z29.s
-; CHECK-NEXT:    mov z1.d, p5/m, z9.d
-; CHECK-NEXT:    fcmgt p8.s, p0/z, z7.s, z29.s
-; CHECK-NEXT:    fcmuo p10.s, p0/z, z7.s, z7.s
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z8.d, p4/m, z25.s
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    sel z2.d, p6, z9.d, z26.d
-; CHECK-NEXT:    sel z3.d, p8, z9.d, z27.d
-; CHECK-NEXT:    fcmge p4.s, p0/z, z5.s, z4.s
-; CHECK-NEXT:    fcmgt p9.s, p0/z, z24.s, z29.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcvtzs z7.d, p4/m, z5.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    sel z4.d, p9, z9.d, z28.d
-; CHECK-NEXT:    fcmuo p7.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    sel z6.d, p6, z9.d, z8.d
-; CHECK-NEXT:    ldr z8, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p8.s, p0/z, z30.s, z30.s
-; CHECK-NEXT:    fcmuo p9.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    mov z7.d, p4/m, z9.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    sel z5.d, p5, z9.d, z31.d
-; CHECK-NEXT:    ldr z9, [sp, #1, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #3
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    movprfx z26, z2
+; CHECK-NEXT:    frintx z26.s, p0/m, z2.s
+; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
+; CHECK-NEXT:    movprfx z27, z3
+; CHECK-NEXT:    frintx z27.s, p0/m, z3.s
+; CHECK-NEXT:    movprfx z0, z4
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z4.s
+; CHECK-NEXT:    movprfx z1, z24
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z24.s
+; CHECK-NEXT:    movprfx z2, z5
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z5.s
+; CHECK-NEXT:    movprfx z3, z25
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z25.s
+; CHECK-NEXT:    movprfx z4, z6
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z6.s
+; CHECK-NEXT:    movprfx z5, z26
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z26.s
+; CHECK-NEXT:    movprfx z6, z7
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z7.s
+; CHECK-NEXT:    movprfx z7, z27
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z27.s
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.lrint.nxv16i64.nxv16f32(<vscale x 16 x float> %x)
   ret <vscale x 16 x i64> %a
@@ -762,251 +312,71 @@ define <vscale x 16 x i64> @lrint_v16f32(<vscale x 16 x float> %x) {
 define <vscale x 32 x i64> @lrint_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-LABEL: lrint_v32f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x98, 0x01, 0x1e, 0x22 // sp + 16 + 152 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    uunpklo z24.d, z0.s
-; CHECK-NEXT:    uunpklo z26.d, z1.s
-; CHECK-NEXT:    mov w9, #-553648128 // =0xdf000000
-; CHECK-NEXT:    uunpklo z28.d, z2.s
-; CHECK-NEXT:    uunpkhi z30.d, z2.s
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    uunpkhi z25.d, z0.s
-; CHECK-NEXT:    uunpkhi z13.d, z3.s
-; CHECK-NEXT:    uunpklo z14.d, z4.s
-; CHECK-NEXT:    uunpkhi z27.d, z1.s
-; CHECK-NEXT:    uunpklo z9.d, z3.s
-; CHECK-NEXT:    mov z29.s, w9
-; CHECK-NEXT:    movprfx z0, z24
-; CHECK-NEXT:    frintx z0.s, p0/m, z24.s
-; CHECK-NEXT:    movprfx z24, z26
-; CHECK-NEXT:    frintx z24.s, p0/m, z26.s
-; CHECK-NEXT:    mov w9, #1593835519 // =0x5effffff
-; CHECK-NEXT:    movprfx z10, z28
-; CHECK-NEXT:    frintx z10.s, p0/m, z28.s
-; CHECK-NEXT:    frintx z30.s, p0/m, z30.s
-; CHECK-NEXT:    uunpklo z17.d, z5.s
-; CHECK-NEXT:    movprfx z1, z25
-; CHECK-NEXT:    frintx z1.s, p0/m, z25.s
-; CHECK-NEXT:    movprfx z15, z13
-; CHECK-NEXT:    frintx z15.s, p0/m, z13.s
-; CHECK-NEXT:    movprfx z13, z14
-; CHECK-NEXT:    frintx z13.s, p0/m, z14.s
-; CHECK-NEXT:    uunpkhi z14.d, z4.s
-; CHECK-NEXT:    uunpkhi z18.d, z5.s
-; CHECK-NEXT:    uunpkhi z19.d, z6.s
-; CHECK-NEXT:    movprfx z25, z27
-; CHECK-NEXT:    frintx z25.s, p0/m, z27.s
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    mov z11.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p3.s, p0/z, z24.s, z29.s
-; CHECK-NEXT:    str z0, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p5.s, p0/z, z10.s, z29.s
-; CHECK-NEXT:    frintx z9.s, p0/m, z9.s
-; CHECK-NEXT:    uunpklo z20.d, z7.s
-; CHECK-NEXT:    movprfx z5, z14
-; CHECK-NEXT:    frintx z5.s, p0/m, z14.s
-; CHECK-NEXT:    movprfx z14, z17
-; CHECK-NEXT:    frintx z14.s, p0/m, z17.s
-; CHECK-NEXT:    movprfx z17, z18
-; CHECK-NEXT:    frintx z17.s, p0/m, z18.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    mov z31.s, w9
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z19.s, p0/m, z19.s
+; CHECK-NEXT:    uunpkhi z24.d, z7.s
+; CHECK-NEXT:    uunpkhi z25.d, z6.s
 ; CHECK-NEXT:    uunpklo z6.d, z6.s
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z24.s
-; CHECK-NEXT:    fcvtzs z11.d, p5/m, z10.s
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z22, z7
-; CHECK-NEXT:    frintx z22.s, p0/m, z7.s
-; CHECK-NEXT:    fcvtzs z12.d, p6/m, z30.s
-; CHECK-NEXT:    frintx z20.s, p0/m, z20.s
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x8000000000000000
+; CHECK-NEXT:    ptrue p0.d
+; CHECK-NEXT:    uunpklo z7.d, z7.s
+; CHECK-NEXT:    uunpkhi z26.d, z5.s
+; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    uunpkhi z27.d, z4.s
+; CHECK-NEXT:    uunpkhi z28.d, z1.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
+; CHECK-NEXT:    uunpkhi z29.d, z3.s
+; CHECK-NEXT:    uunpklo z3.d, z3.s
+; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
-; CHECK-NEXT:    mov z3.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z18.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z1.s, z29.s
-; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z29.s
-; CHECK-NEXT:    fcmgt p9.s, p0/z, z10.s, z31.s
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.s
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z1.s
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z25.s
-; CHECK-NEXT:    mov z11.d, p9/m, z3.d
-; CHECK-NEXT:    fcmuo p8.s, p0/z, z10.s, z10.s
-; CHECK-NEXT:    mov z10.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p5.s, p0/z, z9.s, z29.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z15.s, z29.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z13.s, z29.s
-; CHECK-NEXT:    mov z11.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z10.d, p5/m, z9.s
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z15.s
-; CHECK-NEXT:    fcvtzs z16.d, p6/m, z13.s
-; CHECK-NEXT:    fcmge p1.s, p0/z, z17.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z19.s, z29.s
-; CHECK-NEXT:    fcmgt p12.s, p0/z, z30.s, z31.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z15.s, z31.s
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z17.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
-; CHECK-NEXT:    fcvtzs z23.d, p2/m, z19.s
-; CHECK-NEXT:    sel z7.d, p12, z3.d, z12.d
-; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
-; CHECK-NEXT:    mov z4.d, p5/m, z3.d
-; CHECK-NEXT:    fcmge p4.s, p0/z, z22.s, z29.s
-; CHECK-NEXT:    fcvtzs z0.d, p3/m, z20.s
-; CHECK-NEXT:    fcmge p6.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    fcmge p7.s, p0/z, z14.s, z29.s
-; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
-; CHECK-NEXT:    fcvtzs z8.d, p4/m, z22.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z29.s
-; CHECK-NEXT:    mov z29.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z18.d, p7/m, z14.s
-; CHECK-NEXT:    fcmuo p10.s, p0/z, z15.s, z15.s
-; CHECK-NEXT:    mov z15.d, #0x8000000000000000
-; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z22.s, z31.s
-; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcvtzs z15.d, p6/m, z5.s
-; CHECK-NEXT:    mov z4.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z19.s, z31.s
-; CHECK-NEXT:    mov z8.d, p4/m, z3.d
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
-; CHECK-NEXT:    str z4, [x8, #7, mul vl]
-; CHECK-NEXT:    mov z0.d, p5/m, z3.d
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z19.s, z19.s
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z31.s
-; CHECK-NEXT:    mov z8.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z5.s, z5.s
-; CHECK-NEXT:    sel z5.d, p3, z3.d, z23.d
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z31.s
-; CHECK-NEXT:    str z8, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z17.s, z31.s
-; CHECK-NEXT:    str z0, [x8, #14, mul vl]
-; CHECK-NEXT:    mov z5.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z14.s, z31.s
-; CHECK-NEXT:    sel z0.d, p3, z3.d, z29.d
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    str z5, [x8, #13, mul vl]
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
-; CHECK-NEXT:    sel z5.d, p1, z3.d, z21.d
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
-; CHECK-NEXT:    sel z29.d, p2, z3.d, z18.d
-; CHECK-NEXT:    mov z6.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z14.s, z14.s
-; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z31.s
-; CHECK-NEXT:    str z6, [x8, #9, mul vl]
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z29.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    str z5, [x8, #11, mul vl]
-; CHECK-NEXT:    sel z5.d, p1, z3.d, z26.d
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
-; CHECK-NEXT:    str z29, [x8, #10, mul vl]
-; CHECK-NEXT:    ldr z4, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    str z11, [x8, #4, mul vl]
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
-; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
-; CHECK-NEXT:    fcmgt p6.s, p0/z, z9.s, z31.s
-; CHECK-NEXT:    fcmgt p1.s, p0/z, z4.s, z31.s
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    sel z0.d, p6, z3.d, z10.d
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    sel z1.d, p1, z3.d, z2.d
-; CHECK-NEXT:    str z7, [x8, #5, mul vl]
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
-; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z6.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z26.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #3, mul vl]
-; CHECK-NEXT:    str z26, [x8, #2, mul vl]
-; CHECK-NEXT:    str z5, [x8, #1, mul vl]
-; CHECK-NEXT:    str z1, [x8]
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    uunpklo z1.d, z1.s
+; CHECK-NEXT:    frintx z7.s, p0/m, z7.s
+; CHECK-NEXT:    frintx z25.s, p0/m, z25.s
+; CHECK-NEXT:    frintx z26.s, p0/m, z26.s
+; CHECK-NEXT:    frintx z5.s, p0/m, z5.s
+; CHECK-NEXT:    frintx z27.s, p0/m, z27.s
+; CHECK-NEXT:    frintx z28.s, p0/m, z28.s
+; CHECK-NEXT:    frintx z4.s, p0/m, z4.s
+; CHECK-NEXT:    frintx z29.s, p0/m, z29.s
+; CHECK-NEXT:    frintx z3.s, p0/m, z3.s
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.s
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-NEXT:    frintx z1.s, p0/m, z1.s
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.s
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.s
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.s
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.s
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.s
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.s
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.s
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.s
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.s
+; CHECK-NEXT:    str z24, [x8, #15, mul vl]
+; CHECK-NEXT:    uunpkhi z24.d, z2.s
+; CHECK-NEXT:    uunpklo z2.d, z2.s
+; CHECK-NEXT:    str z6, [x8, #12, mul vl]
+; CHECK-NEXT:    uunpkhi z6.d, z0.s
+; CHECK-NEXT:    uunpklo z0.d, z0.s
+; CHECK-NEXT:    str z7, [x8, #14, mul vl]
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.s
+; CHECK-NEXT:    str z25, [x8, #13, mul vl]
+; CHECK-NEXT:    str z26, [x8, #11, mul vl]
+; CHECK-NEXT:    frintx z24.s, p0/m, z24.s
+; CHECK-NEXT:    frintx z2.s, p0/m, z2.s
+; CHECK-NEXT:    str z5, [x8, #10, mul vl]
+; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
+; CHECK-NEXT:    frintx z0.s, p0/m, z0.s
+; CHECK-NEXT:    str z27, [x8, #9, mul vl]
+; CHECK-NEXT:    str z4, [x8, #8, mul vl]
+; CHECK-NEXT:    str z29, [x8, #7, mul vl]
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.s
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.s
+; CHECK-NEXT:    str z3, [x8, #6, mul vl]
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.s
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.s
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    str z1, [x8, #2, mul vl]
+; CHECK-NEXT:    str z24, [x8, #5, mul vl]
+; CHECK-NEXT:    str z2, [x8, #4, mul vl]
+; CHECK-NEXT:    str z6, [x8, #1, mul vl]
+; CHECK-NEXT:    str z0, [x8]
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.lrint.nxv32i64.nxv32f32(<vscale x 32 x float> %x)
   ret <vscale x 32 x i64> %a
@@ -1016,19 +386,8 @@ define <vscale x 1 x i64> @lrint_v1f64(<vscale x 1 x double> %x) {
 ; CHECK-LABEL: lrint_v1f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 1 x i64> @llvm.lrint.nxv1i64.nxv1f64(<vscale x 1 x double> %x)
   ret <vscale x 1 x i64> %a
@@ -1038,19 +397,8 @@ define <vscale x 2 x i64> @lrint_v2f64(<vscale x 2 x double> %x) {
 ; CHECK-LABEL: lrint_v2f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, x8
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z1.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z1.d, z2.d
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 2 x i64> @llvm.lrint.nxv2i64.nxv2f64(<vscale x 2 x double> %x)
   ret <vscale x 2 x i64> %a
@@ -1060,27 +408,10 @@ define <vscale x 4 x i64> @lrint_v4f64(<vscale x 4 x double> %x) {
 ; CHECK-LABEL: lrint_v4f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z3.d, #0x8000000000000000
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
-; CHECK-NEXT:    mov z5.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z2.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    mov z2.d, x8
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z0.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z2.d
-; CHECK-NEXT:    fcvtzs z3.d, p2/m, z1.d
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z1.d, z2.d
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    sel z0.d, p1, z5.d, z4.d
-; CHECK-NEXT:    sel z1.d, p2, z5.d, z3.d
-; CHECK-NEXT:    mov z0.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 4 x i64> @llvm.lrint.nxv4i64.nxv4f64(<vscale x 4 x double> %x)
   ret <vscale x 4 x i64> %a
@@ -1089,56 +420,15 @@ define <vscale x 4 x i64> @lrint_v4f64(<vscale x 4 x double> %x) {
 define <vscale x 8 x i64> @lrint_v8f64(<vscale x 8 x double> %x) {
 ; CHECK-LABEL: lrint_v8f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
-; CHECK-NEXT:    mov z5.d, x8
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
-; CHECK-NEXT:    mov z24.d, x8
 ; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-NEXT:    mov z7.d, #0x8000000000000000
-; CHECK-NEXT:    mov z25.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z5.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z5.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z2.d, z5.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z0.d, z24.d
-; CHECK-NEXT:    fcvtzs z4.d, p1/m, z0.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z3.d, z5.d
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z6.d, p2/m, z1.d
-; CHECK-NEXT:    fcvtzs z7.d, p3/m, z2.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z1.d, z24.d
-; CHECK-NEXT:    sel z0.d, p4, z25.d, z4.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z2.d, z24.d
-; CHECK-NEXT:    fcvtzs z5.d, p1/m, z3.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z24.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    sel z1.d, p3, z25.d, z6.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z2.d, z2.d
-; CHECK-NEXT:    sel z2.d, p4, z25.d, z7.d
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    sel z3.d, p1, z25.d, z5.d
-; CHECK-NEXT:    mov z1.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z2.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z3.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 8 x i64> @llvm.lrint.nxv8i64.nxv8f64(<vscale x 8 x double> %x)
   ret <vscale x 8 x i64> %a
@@ -1147,103 +437,23 @@ define <vscale x 8 x i64> @lrint_v8f64(<vscale x 8 x double> %x) {
 define <vscale x 16 x i64> @lrint_v16f64(<vscale x 16 x double> %x) {
 ; CHECK-LABEL: lrint_v16f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-3
-; CHECK-NEXT:    str p10, [sp, #1, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #2, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #3, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #4, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #5, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #6, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z9, [sp, #1, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x48, 0x1e, 0x22 // sp + 16 + 24 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x8, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z24, z0
-; CHECK-NEXT:    frintx z24.d, p0/m, z0.d
-; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
-; CHECK-NEXT:    mov z0.d, x8
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
-; CHECK-NEXT:    mov x8, #4890909195324358655 // =0x43dfffffffffffff
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
-; CHECK-NEXT:    mov z30.d, x8
-; CHECK-NEXT:    mov z29.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z5.d, p0/m, z5.d
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
 ; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    mov z8.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z9.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.d, p0/z, z24.d, z0.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z0.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z1.d, z0.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z2.d, z0.d
-; CHECK-NEXT:    fcvtzs z25.d, p1/m, z24.d
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z3.d
-; CHECK-NEXT:    fcvtzs z26.d, p2/m, z1.d
-; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z0.d
-; CHECK-NEXT:    fcvtzs z27.d, p3/m, z2.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z24.d, z30.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z24.d, z24.d
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p7.d, p0/z, z6.d, z0.d
-; CHECK-NEXT:    fcvtzs z29.d, p5/m, z4.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z5.d, z0.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z1.d, z30.d
-; CHECK-NEXT:    fcvtzs z24.d, p7/m, z6.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z2.d, z30.d
-; CHECK-NEXT:    fcmge p7.d, p0/z, z7.d, z0.d
-; CHECK-NEXT:    fcvtzs z31.d, p3/m, z5.d
-; CHECK-NEXT:    sel z0.d, p4, z8.d, z25.d
-; CHECK-NEXT:    fcmgt p8.d, p0/z, z3.d, z30.d
-; CHECK-NEXT:    fcmgt p9.d, p0/z, z4.d, z30.d
-; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z9.d, p7/m, z7.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z1.d, z1.d
-; CHECK-NEXT:    sel z1.d, p5, z8.d, z26.d
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z2.d, z2.d
-; CHECK-NEXT:    sel z2.d, p6, z8.d, z27.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z5.d, z30.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z6.d, z30.d
-; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z2.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p7.d, p0/z, z7.d, z30.d
-; CHECK-NEXT:    fcmuo p10.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    sel z3.d, p8, z8.d, z28.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    sel z4.d, p9, z8.d, z29.d
-; CHECK-NEXT:    fcmuo p8.d, p0/z, z5.d, z5.d
-; CHECK-NEXT:    sel z5.d, p5, z8.d, z31.d
-; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.d, p0/z, z6.d, z6.d
-; CHECK-NEXT:    sel z6.d, p6, z8.d, z24.d
-; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z4.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z7.d, z7.d
-; CHECK-NEXT:    sel z7.d, p7, z8.d, z9.d
-; CHECK-NEXT:    ldr z9, [sp, #1, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    mov z7.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    addvl sp, sp, #3
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.d
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.d
 ; CHECK-NEXT:    ret
   %a = call <vscale x 16 x i64> @llvm.lrint.nxv16i64.nxv16f64(<vscale x 16 x double> %x)
   ret <vscale x 16 x i64> %a
@@ -1252,242 +462,71 @@ define <vscale x 16 x i64> @lrint_v16f64(<vscale x 16 x double> %x) {
 define <vscale x 32 x i64> @lrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-LABEL: lrint_v32f64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-18
-; CHECK-NEXT:    str p12, [sp, #7, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p11, [sp, #8, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p10, [sp, #9, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p9, [sp, #10, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p8, [sp, #11, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p7, [sp, #12, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p6, [sp, #13, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p5, [sp, #14, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str p4, [sp, #15, mul vl] // 2-byte Spill
-; CHECK-NEXT:    str z23, [sp, #2, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z22, [sp, #3, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z21, [sp, #4, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z20, [sp, #5, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z19, [sp, #6, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z18, [sp, #7, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z17, [sp, #8, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z16, [sp, #9, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z15, [sp, #10, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z14, [sp, #11, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z13, [sp, #12, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z12, [sp, #13, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z11, [sp, #14, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
-; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4a, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x68, 0x1e, 0x22, 0x40, 0x1c // $d10 @ cfa - 24 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4b, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x60, 0x1e, 0x22, 0x40, 0x1c // $d11 @ cfa - 32 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4c, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x58, 0x1e, 0x22, 0x40, 0x1c // $d12 @ cfa - 40 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4d, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x50, 0x1e, 0x22, 0x40, 0x1c // $d13 @ cfa - 48 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
-; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
-; CHECK-NEXT:    ldr z0, [x0]
-; CHECK-NEXT:    ldr z7, [x0, #3, mul vl]
+; CHECK-NEXT:    ldr z5, [x0, #15, mul vl]
+; CHECK-NEXT:    ldr z4, [x0, #14, mul vl]
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
-; CHECK-NEXT:    ldr z4, [x0, #2, mul vl]
-; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, x9
-; CHECK-NEXT:    ldr z2, [x0, #1, mul vl]
-; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
-; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
-; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
-; CHECK-NEXT:    movprfx z14, z27
-; CHECK-NEXT:    frintx z14.d, p0/m, z27.d
+; CHECK-NEXT:    ldr z3, [x0, #13, mul vl]
+; CHECK-NEXT:    ldr z2, [x0, #12, mul vl]
+; CHECK-NEXT:    ldr z1, [x0, #11, mul vl]
+; CHECK-NEXT:    ldr z0, [x0, #10, mul vl]
+; CHECK-NEXT:    ldr z6, [x0, #9, mul vl]
+; CHECK-NEXT:    ldr z7, [x0, #8, mul vl]
+; CHECK-NEXT:    frintx z5.d, p0/m, z5.d
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    ldr z27, [x0, #5, mul vl]
-; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
-; CHECK-NEXT:    mov x9, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    movprfx z3, z2
-; CHECK-NEXT:    frintx z3.d, p0/m, z2.d
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z25.d
-; CHECK-NEXT:    movprfx z28, z27
-; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
+; CHECK-NEXT:    ldr z24, [x0, #7, mul vl]
+; CHECK-NEXT:    ldr z25, [x0, #6, mul vl]
+; CHECK-NEXT:    frintx z3.d, p0/m, z3.d
+; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    ldr z26, [x0, #5, mul vl]
+; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
+; CHECK-NEXT:    frintx z1.d, p0/m, z1.d
+; CHECK-NEXT:    ldr z28, [x0, #3, mul vl]
+; CHECK-NEXT:    ldr z29, [x0, #2, mul vl]
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
+; CHECK-NEXT:    ldr z30, [x0, #1, mul vl]
+; CHECK-NEXT:    ldr z31, [x0]
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
+; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
+; CHECK-NEXT:    frintx z24.d, p0/m, z24.d
+; CHECK-NEXT:    frintx z25.d, p0/m, z25.d
+; CHECK-NEXT:    frintx z26.d, p0/m, z26.d
+; CHECK-NEXT:    frintx z27.d, p0/m, z27.d
+; CHECK-NEXT:    frintx z28.d, p0/m, z28.d
 ; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
-; CHECK-NEXT:    mov z1.d, x9
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
-; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
-; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z25.d
-; CHECK-NEXT:    ldr z19, [x0, #9, mul vl]
-; CHECK-NEXT:    movprfx z20, z31
-; CHECK-NEXT:    frintx z20.d, p0/m, z31.d
-; CHECK-NEXT:    frintx z15.d, p0/m, z15.d
-; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
-; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
-; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
-; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
-; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
-; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
-; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z29.d, z25.d
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
-; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
-; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    frintx z8.d, p0/m, z8.d
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
-; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    fcmuo p8.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    movprfx z14, z19
-; CHECK-NEXT:    frintx z14.d, p0/m, z19.d
-; CHECK-NEXT:    movprfx z19, z11
-; CHECK-NEXT:    frintx z19.d, p0/m, z11.d
-; CHECK-NEXT:    mov z11.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, p10/m, z27.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
-; CHECK-NEXT:    fcmge p5.d, p0/z, z20.d, z25.d
-; CHECK-NEXT:    mov z30.d, p8/m, #0 // =0x0
-; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z3.d
-; CHECK-NEXT:    fcmge p1.d, p0/z, z18.d, z25.d
-; CHECK-NEXT:    str z30, [x8, #4, mul vl]
-; CHECK-NEXT:    fcvtzs z16.d, p5/m, z20.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
-; CHECK-NEXT:    fcvtzs z17.d, p6/m, z15.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z20.d, z1.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z10.d, z25.d
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
-; CHECK-NEXT:    fcmgt p11.d, p0/z, z15.d, z1.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z9.d, z25.d
-; CHECK-NEXT:    fcmge p6.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    fcvtzs z23.d, p3/m, z10.d
-; CHECK-NEXT:    fcmge p7.d, p0/z, z13.d, z25.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z15.d, z15.d
-; CHECK-NEXT:    sel z15.d, p5, z27.d, z16.d
-; CHECK-NEXT:    sel z16.d, p11, z27.d, z17.d
-; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
-; CHECK-NEXT:    fcvtzs z11.d, p6/m, z14.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z8.d, z25.d
-; CHECK-NEXT:    mov z25.d, #0x8000000000000000
-; CHECK-NEXT:    mov z16.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z9.d, z1.d
-; CHECK-NEXT:    fcmgt p5.d, p0/z, z10.d, z1.d
-; CHECK-NEXT:    str z16, [x8, #8, mul vl]
-; CHECK-NEXT:    fcvtzs z25.d, p2/m, z8.d
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z19.d, z1.d
-; CHECK-NEXT:    fcmuo p9.d, p0/z, z20.d, z20.d
-; CHECK-NEXT:    mov z20.d, #0x8000000000000000
-; CHECK-NEXT:    mov z26.d, p4/m, z27.d
-; CHECK-NEXT:    fcmuo p1.d, p0/z, z9.d, z9.d
-; CHECK-NEXT:    sel z9.d, p5, z27.d, z23.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z10.d, z10.d
-; CHECK-NEXT:    sel z10.d, p3, z27.d, z22.d
-; CHECK-NEXT:    fcvtzs z20.d, p7/m, z13.d
-; CHECK-NEXT:    mov z15.d, p9/m, #0 // =0x0
-; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z9.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    str z15, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z8.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
-; CHECK-NEXT:    str z9, [x8, #14, mul vl]
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z18.d, z1.d
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z13.d, z1.d
-; CHECK-NEXT:    sel z26.d, p4, z27.d, z11.d
-; CHECK-NEXT:    mov z25.d, p3/m, z27.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z18.d, z18.d
-; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z13.d, z13.d
-; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
-; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
-; CHECK-NEXT:    str z10, [x8, #13, mul vl]
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z8.d, z8.d
-; CHECK-NEXT:    sel z8.d, p1, z27.d, z21.d
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    mov z8.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    mov z12.d, p12/m, z27.d
-; CHECK-NEXT:    str z9, [x8, #10, mul vl]
-; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
-; CHECK-NEXT:    str z8, [x8, #11, mul vl]
-; CHECK-NEXT:    mov z5.d, p1/m, z27.d
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
-; CHECK-NEXT:    str z25, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
-; CHECK-NEXT:    mov z6.d, p2/m, z27.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #9, mul vl]
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
-; CHECK-NEXT:    mov z24.d, p4/m, z27.d
-; CHECK-NEXT:    mov z12.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z29.d, z29.d
-; CHECK-NEXT:    fcmuo p2.d, p0/z, z7.d, z7.d
-; CHECK-NEXT:    sel z25.d, p6, z27.d, z31.d
-; CHECK-NEXT:    str z12, [x8, #5, mul vl]
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    fcmuo p4.d, p0/z, z3.d, z3.d
-; CHECK-NEXT:    mov z25.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p1, z27.d, z2.d
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z6.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    frintx z30.d, p0/m, z30.d
+; CHECK-NEXT:    frintx z31.d, p0/m, z31.d
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.d
+; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.d
+; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.d
+; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.d
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.d
+; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.d
+; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.d
+; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.d
+; CHECK-NEXT:    fcvtzs z24.d, p0/m, z24.d
+; CHECK-NEXT:    fcvtzs z25.d, p0/m, z25.d
+; CHECK-NEXT:    fcvtzs z26.d, p0/m, z26.d
+; CHECK-NEXT:    fcvtzs z27.d, p0/m, z27.d
+; CHECK-NEXT:    fcvtzs z28.d, p0/m, z28.d
+; CHECK-NEXT:    fcvtzs z29.d, p0/m, z29.d
+; CHECK-NEXT:    fcvtzs z30.d, p0/m, z30.d
+; CHECK-NEXT:    fcvtzs z31.d, p0/m, z31.d
+; CHECK-NEXT:    str z5, [x8, #15, mul vl]
+; CHECK-NEXT:    str z4, [x8, #14, mul vl]
+; CHECK-NEXT:    str z3, [x8, #13, mul vl]
+; CHECK-NEXT:    str z2, [x8, #12, mul vl]
+; CHECK-NEXT:    str z1, [x8, #11, mul vl]
+; CHECK-NEXT:    str z0, [x8, #10, mul vl]
+; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    str z7, [x8, #8, mul vl]
+; CHECK-NEXT:    str z24, [x8, #7, mul vl]
 ; CHECK-NEXT:    str z25, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z24, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #2, mul vl]
-; CHECK-NEXT:    str z5, [x8, #1, mul vl]
-; CHECK-NEXT:    str z0, [x8]
-; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z20, [sp, #5, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z19, [sp, #6, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z18, [sp, #7, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z17, [sp, #8, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z16, [sp, #9, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z15, [sp, #10, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z14, [sp, #11, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z13, [sp, #12, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z12, [sp, #13, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z11, [sp, #14, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z10, [sp, #15, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z9, [sp, #16, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr z8, [sp, #17, mul vl] // 16-byte Folded Reload
-; CHECK-NEXT:    ldr p12, [sp, #7, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p11, [sp, #8, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p10, [sp, #9, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p9, [sp, #10, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p8, [sp, #11, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p7, [sp, #12, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p6, [sp, #13, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p5, [sp, #14, mul vl] // 2-byte Reload
-; CHECK-NEXT:    ldr p4, [sp, #15, mul vl] // 2-byte Reload
-; CHECK-NEXT:    addvl sp, sp, #18
-; CHECK-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    str z26, [x8, #5, mul vl]
+; CHECK-NEXT:    str z27, [x8, #4, mul vl]
+; CHECK-NEXT:    str z28, [x8, #3, mul vl]
+; CHECK-NEXT:    str z29, [x8, #2, mul vl]
+; CHECK-NEXT:    str z30, [x8, #1, mul vl]
+; CHECK-NEXT:    str z31, [x8]
 ; CHECK-NEXT:    ret
   %a = call <vscale x 32 x i64> @llvm.lrint.nxv32i64.nxv16f64(<vscale x 32 x double> %x)
   ret <vscale x 32 x i64> %a

--- a/llvm/test/CodeGen/AArch64/vector-lrint.ll
+++ b/llvm/test/CodeGen/AArch64/vector-lrint.ll
@@ -1313,29 +1313,18 @@ define <1 x iXLen> @lrint_v1f64(<1 x double> %x) nounwind {
 declare <1 x iXLen> @llvm.lrint.v1iXLen.v1f64(<1 x double>)
 
 define <2 x iXLen> @lrint_v2f64(<2 x double> %x) nounwind {
-; CHECK-i32-SD-LABEL: lrint_v2f64:
-; CHECK-i32-SD:       // %bb.0:
-; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
-; CHECK-i32-SD-NEXT:    mov d1, v0.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d0
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d1
-; CHECK-i32-SD-NEXT:    fmov s0, w8
-; CHECK-i32-SD-NEXT:    mov v0.s[1], w9
-; CHECK-i32-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; CHECK-i32-SD-NEXT:    ret
+; CHECK-i32-LABEL: lrint_v2f64:
+; CHECK-i32:       // %bb.0:
+; CHECK-i32-NEXT:    frintx v0.2d, v0.2d
+; CHECK-i32-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-NEXT:    xtn v0.2s, v0.2d
+; CHECK-i32-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v2f64:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    frintx v0.2d, v0.2d
 ; CHECK-i64-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-i64-NEXT:    ret
-;
-; CHECK-i32-GI-LABEL: lrint_v2f64:
-; CHECK-i32-GI:       // %bb.0:
-; CHECK-i32-GI-NEXT:    frintx v0.2d, v0.2d
-; CHECK-i32-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-i32-GI-NEXT:    xtn v0.2s, v0.2d
-; CHECK-i32-GI-NEXT:    ret
   %a = call <2 x iXLen> @llvm.lrint.v2iXLen.v2f64(<2 x double> %x)
   ret <2 x iXLen> %a
 }
@@ -1344,18 +1333,11 @@ declare <2 x iXLen> @llvm.lrint.v2iXLen.v2f64(<2 x double>)
 define <4 x iXLen> @lrint_v4f64(<4 x double> %x) nounwind {
 ; CHECK-i32-SD-LABEL: lrint_v4f64:
 ; CHECK-i32-SD:       // %bb.0:
-; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
 ; CHECK-i32-SD-NEXT:    frintx v1.2d, v1.2d
-; CHECK-i32-SD-NEXT:    mov d2, v0.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d0
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d2
-; CHECK-i32-SD-NEXT:    fmov s0, w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d1
-; CHECK-i32-SD-NEXT:    mov d1, v1.d[1]
-; CHECK-i32-SD-NEXT:    mov v0.s[1], w9
-; CHECK-i32-SD-NEXT:    mov v0.s[2], w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d1
-; CHECK-i32-SD-NEXT:    mov v0.s[3], w8
+; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
 ; CHECK-i32-SD-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v4f64:
@@ -1382,30 +1364,16 @@ declare <4 x iXLen> @llvm.lrint.v4iXLen.v4f64(<4 x double>)
 define <8 x iXLen> @lrint_v8f64(<8 x double> %x) nounwind {
 ; CHECK-i32-SD-LABEL: lrint_v8f64:
 ; CHECK-i32-SD:       // %bb.0:
-; CHECK-i32-SD-NEXT:    frintx v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    frintx v1.2d, v1.2d
 ; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
 ; CHECK-i32-SD-NEXT:    frintx v3.2d, v3.2d
-; CHECK-i32-SD-NEXT:    mov d4, v0.d[1]
-; CHECK-i32-SD-NEXT:    mov d5, v2.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d0
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d2
-; CHECK-i32-SD-NEXT:    frintx v2.2d, v1.2d
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d4
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d5
-; CHECK-i32-SD-NEXT:    fmov s0, w8
-; CHECK-i32-SD-NEXT:    fmov s1, w9
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d2
-; CHECK-i32-SD-NEXT:    mov d2, v2.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d3
-; CHECK-i32-SD-NEXT:    mov d3, v3.d[1]
-; CHECK-i32-SD-NEXT:    mov v0.s[1], w10
-; CHECK-i32-SD-NEXT:    mov v1.s[1], w11
-; CHECK-i32-SD-NEXT:    mov v0.s[2], w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d2
-; CHECK-i32-SD-NEXT:    mov v1.s[2], w9
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d3
-; CHECK-i32-SD-NEXT:    mov v0.s[3], w8
-; CHECK-i32-SD-NEXT:    mov v1.s[3], w9
+; CHECK-i32-SD-NEXT:    frintx v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v3.2d, v3.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
+; CHECK-i32-SD-NEXT:    uzp1 v1.4s, v2.4s, v3.4s
 ; CHECK-i32-SD-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v8f64:
@@ -1441,54 +1409,26 @@ declare <8 x iXLen> @llvm.lrint.v8iXLen.v8f64(<8 x double>)
 define <16 x iXLen> @lrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-i32-SD-LABEL: lrint_v16f64:
 ; CHECK-i32-SD:       // %bb.0:
+; CHECK-i32-SD-NEXT:    frintx v1.2d, v1.2d
 ; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    frintx v3.2d, v3.2d
 ; CHECK-i32-SD-NEXT:    frintx v2.2d, v2.2d
-; CHECK-i32-SD-NEXT:    frintx v4.2d, v4.2d
-; CHECK-i32-SD-NEXT:    frintx v6.2d, v6.2d
-; CHECK-i32-SD-NEXT:    frintx v17.2d, v1.2d
 ; CHECK-i32-SD-NEXT:    frintx v5.2d, v5.2d
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d0
-; CHECK-i32-SD-NEXT:    mov d16, v0.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d2
-; CHECK-i32-SD-NEXT:    mov d2, v2.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d4
-; CHECK-i32-SD-NEXT:    mov d4, v4.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d6
-; CHECK-i32-SD-NEXT:    mov d6, v6.d[1]
-; CHECK-i32-SD-NEXT:    fmov s0, w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d16
-; CHECK-i32-SD-NEXT:    frintx v16.2d, v3.2d
-; CHECK-i32-SD-NEXT:    fmov s1, w9
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d2
-; CHECK-i32-SD-NEXT:    fmov s2, w10
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d4
-; CHECK-i32-SD-NEXT:    frintx v4.2d, v7.2d
-; CHECK-i32-SD-NEXT:    fmov s3, w11
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d6
-; CHECK-i32-SD-NEXT:    mov d6, v17.d[1]
-; CHECK-i32-SD-NEXT:    mov v0.s[1], w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d17
-; CHECK-i32-SD-NEXT:    mov d7, v16.d[1]
-; CHECK-i32-SD-NEXT:    mov v1.s[1], w9
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d16
-; CHECK-i32-SD-NEXT:    mov v2.s[1], w10
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d5
-; CHECK-i32-SD-NEXT:    mov d5, v5.d[1]
-; CHECK-i32-SD-NEXT:    mov v3.s[1], w11
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d4
-; CHECK-i32-SD-NEXT:    mov d4, v4.d[1]
-; CHECK-i32-SD-NEXT:    mov v0.s[2], w8
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d6
-; CHECK-i32-SD-NEXT:    mov v1.s[2], w9
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d7
-; CHECK-i32-SD-NEXT:    mov v2.s[2], w10
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d5
-; CHECK-i32-SD-NEXT:    mov v3.s[2], w11
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d4
-; CHECK-i32-SD-NEXT:    mov v0.s[3], w8
-; CHECK-i32-SD-NEXT:    mov v1.s[3], w9
-; CHECK-i32-SD-NEXT:    mov v2.s[3], w10
-; CHECK-i32-SD-NEXT:    mov v3.s[3], w11
+; CHECK-i32-SD-NEXT:    frintx v4.2d, v4.2d
+; CHECK-i32-SD-NEXT:    frintx v7.2d, v7.2d
+; CHECK-i32-SD-NEXT:    frintx v6.2d, v6.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v3.2d, v3.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v5.2d, v5.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v4.2d, v4.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v7.2d, v7.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v6.2d, v6.2d
+; CHECK-i32-SD-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
+; CHECK-i32-SD-NEXT:    uzp1 v1.4s, v2.4s, v3.4s
+; CHECK-i32-SD-NEXT:    uzp1 v2.4s, v4.4s, v5.4s
+; CHECK-i32-SD-NEXT:    uzp1 v3.4s, v6.4s, v7.4s
 ; CHECK-i32-SD-NEXT:    ret
 ;
 ; CHECK-i64-LABEL: lrint_v16f64:
@@ -1542,106 +1482,50 @@ declare <16 x iXLen> @llvm.lrint.v16iXLen.v16f64(<16 x double>)
 define <32 x iXLen> @lrint_v32f64(<32 x double> %x) nounwind {
 ; CHECK-i32-SD-LABEL: lrint_v32f64:
 ; CHECK-i32-SD:       // %bb.0:
-; CHECK-i32-SD-NEXT:    frintx v17.2d, v0.2d
-; CHECK-i32-SD-NEXT:    frintx v19.2d, v2.2d
-; CHECK-i32-SD-NEXT:    frintx v0.2d, v1.2d
-; CHECK-i32-SD-NEXT:    frintx v1.2d, v4.2d
-; CHECK-i32-SD-NEXT:    frintx v2.2d, v3.2d
-; CHECK-i32-SD-NEXT:    frintx v3.2d, v5.2d
-; CHECK-i32-SD-NEXT:    ldp q16, q5, [sp]
-; CHECK-i32-SD-NEXT:    frintx v18.2d, v6.2d
-; CHECK-i32-SD-NEXT:    frintx v4.2d, v7.2d
-; CHECK-i32-SD-NEXT:    ldp q22, q6, [sp, #64]
-; CHECK-i32-SD-NEXT:    mov d20, v17.d[1]
-; CHECK-i32-SD-NEXT:    mov d21, v19.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d17
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d19
-; CHECK-i32-SD-NEXT:    ldp q17, q7, [sp, #32]
-; CHECK-i32-SD-NEXT:    fcvtzs w12, d0
-; CHECK-i32-SD-NEXT:    mov d19, v1.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w13, d1
-; CHECK-i32-SD-NEXT:    frintx v16.2d, v16.2d
-; CHECK-i32-SD-NEXT:    mov d23, v18.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w15, d18
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d20
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d21
-; CHECK-i32-SD-NEXT:    mov d21, v0.d[1]
-; CHECK-i32-SD-NEXT:    fmov s0, w8
-; CHECK-i32-SD-NEXT:    fmov s1, w9
-; CHECK-i32-SD-NEXT:    frintx v17.2d, v17.2d
-; CHECK-i32-SD-NEXT:    frintx v20.2d, v22.2d
-; CHECK-i32-SD-NEXT:    mov d22, v2.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w14, d19
-; CHECK-i32-SD-NEXT:    mov d18, v16.d[1]
+; CHECK-i32-SD-NEXT:    ldp q16, q17, [sp, #96]
+; CHECK-i32-SD-NEXT:    frintx v3.2d, v3.2d
+; CHECK-i32-SD-NEXT:    ldp q18, q19, [sp, #64]
+; CHECK-i32-SD-NEXT:    frintx v1.2d, v1.2d
+; CHECK-i32-SD-NEXT:    ldp q20, q21, [sp, #32]
+; CHECK-i32-SD-NEXT:    frintx v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    ldp q22, q23, [sp]
+; CHECK-i32-SD-NEXT:    frintx v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    frintx v5.2d, v5.2d
+; CHECK-i32-SD-NEXT:    frintx v4.2d, v4.2d
 ; CHECK-i32-SD-NEXT:    frintx v7.2d, v7.2d
-; CHECK-i32-SD-NEXT:    mov v0.s[1], w10
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d2
-; CHECK-i32-SD-NEXT:    mov v1.s[1], w11
-; CHECK-i32-SD-NEXT:    fcvtzs w8, d21
-; CHECK-i32-SD-NEXT:    ldp q21, q19, [sp, #96]
-; CHECK-i32-SD-NEXT:    fmov s2, w13
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d23
-; CHECK-i32-SD-NEXT:    mov d23, v3.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w9, d22
-; CHECK-i32-SD-NEXT:    mov d22, v17.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w13, d18
-; CHECK-i32-SD-NEXT:    mov v0.s[2], w12
-; CHECK-i32-SD-NEXT:    fcvtzs w12, d16
-; CHECK-i32-SD-NEXT:    mov v1.s[2], w10
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d3
-; CHECK-i32-SD-NEXT:    fmov s3, w15
+; CHECK-i32-SD-NEXT:    frintx v6.2d, v6.2d
 ; CHECK-i32-SD-NEXT:    frintx v21.2d, v21.2d
-; CHECK-i32-SD-NEXT:    mov v2.s[1], w14
-; CHECK-i32-SD-NEXT:    mov d16, v20.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w14, d17
-; CHECK-i32-SD-NEXT:    mov d17, v4.d[1]
-; CHECK-i32-SD-NEXT:    fcvtzs w15, d22
-; CHECK-i32-SD-NEXT:    frintx v22.2d, v5.2d
-; CHECK-i32-SD-NEXT:    mov v3.s[1], w11
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d4
-; CHECK-i32-SD-NEXT:    fmov s4, w12
-; CHECK-i32-SD-NEXT:    fcvtzs w12, d20
-; CHECK-i32-SD-NEXT:    mov d18, v21.d[1]
-; CHECK-i32-SD-NEXT:    mov d20, v7.d[1]
-; CHECK-i32-SD-NEXT:    fmov s5, w14
-; CHECK-i32-SD-NEXT:    fcvtzs w14, d21
-; CHECK-i32-SD-NEXT:    mov v2.s[2], w10
-; CHECK-i32-SD-NEXT:    mov v4.s[1], w13
-; CHECK-i32-SD-NEXT:    fcvtzs w13, d16
-; CHECK-i32-SD-NEXT:    frintx v16.2d, v6.2d
-; CHECK-i32-SD-NEXT:    fcvtzs w10, d23
-; CHECK-i32-SD-NEXT:    mov v3.s[2], w11
-; CHECK-i32-SD-NEXT:    fcvtzs w11, d17
-; CHECK-i32-SD-NEXT:    fmov s6, w12
-; CHECK-i32-SD-NEXT:    mov v5.s[1], w15
-; CHECK-i32-SD-NEXT:    fcvtzs w15, d18
-; CHECK-i32-SD-NEXT:    frintx v18.2d, v19.2d
-; CHECK-i32-SD-NEXT:    fcvtzs w12, d22
-; CHECK-i32-SD-NEXT:    mov d19, v22.d[1]
-; CHECK-i32-SD-NEXT:    mov v0.s[3], w8
-; CHECK-i32-SD-NEXT:    mov v1.s[3], w9
-; CHECK-i32-SD-NEXT:    mov v6.s[1], w13
-; CHECK-i32-SD-NEXT:    fcvtzs w13, d7
-; CHECK-i32-SD-NEXT:    fmov s7, w14
-; CHECK-i32-SD-NEXT:    fcvtzs w14, d16
-; CHECK-i32-SD-NEXT:    mov d16, v16.d[1]
-; CHECK-i32-SD-NEXT:    mov v2.s[3], w10
-; CHECK-i32-SD-NEXT:    mov v4.s[2], w12
-; CHECK-i32-SD-NEXT:    fcvtzs w12, d19
-; CHECK-i32-SD-NEXT:    mov v3.s[3], w11
-; CHECK-i32-SD-NEXT:    mov v7.s[1], w15
-; CHECK-i32-SD-NEXT:    fcvtzs w15, d18
-; CHECK-i32-SD-NEXT:    mov d18, v18.d[1]
-; CHECK-i32-SD-NEXT:    mov v5.s[2], w13
-; CHECK-i32-SD-NEXT:    fcvtzs w13, d20
-; CHECK-i32-SD-NEXT:    mov v6.s[2], w14
-; CHECK-i32-SD-NEXT:    fcvtzs w14, d16
-; CHECK-i32-SD-NEXT:    mov v4.s[3], w12
-; CHECK-i32-SD-NEXT:    mov v7.s[2], w15
-; CHECK-i32-SD-NEXT:    fcvtzs w15, d18
-; CHECK-i32-SD-NEXT:    mov v5.s[3], w13
-; CHECK-i32-SD-NEXT:    mov v6.s[3], w14
-; CHECK-i32-SD-NEXT:    mov v7.s[3], w15
+; CHECK-i32-SD-NEXT:    frintx v20.2d, v20.2d
+; CHECK-i32-SD-NEXT:    frintx v23.2d, v23.2d
+; CHECK-i32-SD-NEXT:    frintx v22.2d, v22.2d
+; CHECK-i32-SD-NEXT:    frintx v19.2d, v19.2d
+; CHECK-i32-SD-NEXT:    frintx v18.2d, v18.2d
+; CHECK-i32-SD-NEXT:    frintx v17.2d, v17.2d
+; CHECK-i32-SD-NEXT:    frintx v16.2d, v16.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v3.2d, v3.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v2.2d, v2.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v5.2d, v5.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v4.2d, v4.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v7.2d, v7.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v6.2d, v6.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v23.2d, v23.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v22.2d, v22.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v21.2d, v21.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v20.2d, v20.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v19.2d, v19.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v18.2d, v18.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v17.2d, v17.2d
+; CHECK-i32-SD-NEXT:    fcvtzs v16.2d, v16.2d
+; CHECK-i32-SD-NEXT:    uzp1 v0.4s, v0.4s, v1.4s
+; CHECK-i32-SD-NEXT:    uzp1 v1.4s, v2.4s, v3.4s
+; CHECK-i32-SD-NEXT:    uzp1 v2.4s, v4.4s, v5.4s
+; CHECK-i32-SD-NEXT:    uzp1 v3.4s, v6.4s, v7.4s
+; CHECK-i32-SD-NEXT:    uzp1 v4.4s, v22.4s, v23.4s
+; CHECK-i32-SD-NEXT:    uzp1 v5.4s, v20.4s, v21.4s
+; CHECK-i32-SD-NEXT:    uzp1 v6.4s, v18.4s, v19.4s
+; CHECK-i32-SD-NEXT:    uzp1 v7.4s, v16.4s, v17.4s
 ; CHECK-i32-SD-NEXT:    ret
 ;
 ; CHECK-i64-SD-LABEL: lrint_v32f64:


### PR DESCRIPTION
We don't need to use FP_TO_SINT_SAT, because according to the LangRef floating point values that don't fit the integer domain return a non-deterministic (freeze(poison)) value. The saturation code is quite verbose, so freezing the result seems like a better approach.

This was also discussed here:
https://github.com/llvm/llvm-project/pull/89035#discussion_r1595859634

We could even optimise away the freeze when we know that the operands to AArch64ISD::FCVTZS_MERGE_PASSTHRU are not poison.