### PR TITLE
[LLD][COFF] Move Archive::create call to LinkerDriver::addBuffer (NFC)

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -291,10 +291,10 @@ void LinkerDriver::addBuffer(std::unique_ptr<MemoryBuffer> mb,
   case file_magic::windows_resource:
     resources.push_back(mbref);
     break;
-  case file_magic::archive:
+  case file_magic::archive: {
+    std::unique_ptr<Archive> file =
+        CHECK(Archive::create(mbref), filename + ": failed to parse archive");
     if (wholeArchive) {
-      std::unique_ptr<Archive> file =
-          CHECK(Archive::create(mbref), filename + ": failed to parse archive");
       Archive *archive = file.get();
       make<std::unique_ptr<Archive>>(std::move(file)); // take ownership
 
@@ -308,8 +308,9 @@ void LinkerDriver::addBuffer(std::unique_ptr<MemoryBuffer> mb,
 
       return;
     }
-    addFile(make<ArchiveFile>(ctx, mbref));
+    addFile(make<ArchiveFile>(ctx, mbref, file));
     break;
+  }
   case file_magic::bitcode:
     addFile(BitcodeFile::create(ctx, mbref, "", 0, lazy));
     break;

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -150,15 +150,15 @@ static bool fixupDllMain(COFFLinkerContext &ctx, llvm::object::Archive *file,
   return false;
 }
 
-ArchiveFile::ArchiveFile(COFFLinkerContext &ctx, MemoryBufferRef m)
-    : InputFile(ctx.symtab, ArchiveKind, m) {}
+ArchiveFile::ArchiveFile(COFFLinkerContext &ctx, MemoryBufferRef m,
+                         std::unique_ptr<Archive> &f)
+    : InputFile(ctx.symtab, ArchiveKind, m) {
+  file.swap(f);
+}
 
 void ArchiveFile::parse() {
   COFFLinkerContext &ctx = symtab.ctx;
   SymbolTable *archiveSymtab = &symtab;
-
-  // Parse a MemoryBufferRef as an archive file.
-  file = CHECK(Archive::create(mb), this);
 
   // Try to read symbols from ECSYMBOLS section on ARM64EC.
   if (ctx.symtab.isEC()) {

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -118,7 +118,8 @@ public:
 // .lib or .a file.
 class ArchiveFile : public InputFile {
 public:
-  explicit ArchiveFile(COFFLinkerContext &ctx, MemoryBufferRef m);
+  explicit ArchiveFile(COFFLinkerContext &ctx, MemoryBufferRef mb,
+                       std::unique_ptr<Archive> &f);
   static bool classof(const InputFile *f) { return f->kind() == ArchiveKind; }
   void parse() override;
 


### PR DESCRIPTION
This allows an upcoming change to Archive::create() to make decisions based on the archive type.