### PR TITLE
[lldb] Remove full stop from AppendErrorWithFormat format strings (part 2)

### DIFF
--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -164,7 +164,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
   }
 
   if (m_subcommand_dict.empty()) {
-    result.AppendErrorWithFormat("'%s' does not have any subcommands.",
+    result.AppendErrorWithFormat("'%s' does not have any subcommands",
                                  GetCommandName().str().c_str());
     return;
   }

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -731,12 +731,12 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.",
+        result.AppendErrorWithFormat("Failed to resume process: %s",
                                      error.AsCString());
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).",
+          "Process cannot be continued from its current state (%s)",
           StateAsCString(state));
     }
   }
@@ -1178,7 +1178,7 @@ protected:
         signo = process->GetUnixSignals()->GetSignalNumberFromName(signal_name);
 
       if (signo == LLDB_INVALID_SIGNAL_NUMBER) {
-        result.AppendErrorWithFormat("Invalid signal argument '%s'.",
+        result.AppendErrorWithFormat("Invalid signal argument '%s'",
                                      command.GetArgumentAtIndex(0));
       } else {
         Status error(process->Signal(signo));

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -214,7 +214,7 @@ protected:
                               print_flags))
               strm.Printf("%-12s = error: unavailable\n", reg_info->name);
           } else {
-            result.AppendErrorWithFormat("Invalid register name '%s'.",
+            result.AppendErrorWithFormat("Invalid register name '%s'",
                                          arg_str.str().c_str());
           }
         }
@@ -377,7 +377,7 @@ protected:
               reg_name.str().c_str(), value_str.str().c_str());
         }
       } else {
-        result.AppendErrorWithFormat("Register not found for '%s'.",
+        result.AppendErrorWithFormat("Register not found for '%s'",
                                      reg_name.str().c_str());
       }
     }
@@ -439,7 +439,7 @@ protected:
           GetCommandInterpreter().GetDebugger().GetTerminalWidth());
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else
-      result.AppendErrorWithFormat("No register found with name '%s'.",
+      result.AppendErrorWithFormat("No register found with name '%s'",
                                    reg_name.str().c_str());
   }
 };

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -403,7 +403,7 @@ protected:
       }
     }
     if (num_matches == 0) {
-      result.AppendErrorWithFormat("Could not find function named \'%s\'.",
+      result.AppendErrorWithFormat("Could not find function named \'%s\'",
                                    m_options.symbol_name.c_str());
       return false;
     }
@@ -464,15 +464,15 @@ protected:
     StreamString error_strm;
     if (!GetSymbolContextsForAddress(target.GetImages(), m_options.address,
                                      sc_list, error_strm)) {
-      result.AppendErrorWithFormat("%s.", error_strm.GetData());
+      result.AppendErrorWithFormat("%s", error_strm.GetData());
       return false;
     }
     ModuleList module_list;
     FileSpec file_spec;
     if (!DumpLinesInSymbolContexts(result.GetOutputStream(), sc_list,
                                    module_list, file_spec)) {
-      result.AppendErrorWithFormat(
-          "No modules contain load address 0x%" PRIx64 ".", m_options.address);
+      result.AppendErrorWithFormat("No modules contain load address 0x%" PRIx64,
+                                   m_options.address);
       return false;
     }
     return true;
@@ -834,7 +834,7 @@ protected:
           start_file, line_no, column, 0, m_options.num_lines, "",
           &result.GetOutputStream(), GetBreakpointLocations());
     } else {
-      result.AppendErrorWithFormat("Could not find function info for: \"%s\".",
+      result.AppendErrorWithFormat("Could not find function info for: \"%s\"",
                                    m_options.symbol_name.c_str());
     }
     return 0;
@@ -925,7 +925,7 @@ protected:
       }
 
       if (sc_list.GetSize() == 0) {
-        result.AppendErrorWithFormat("Could not find function named: \"%s\".",
+        result.AppendErrorWithFormat("Could not find function named: \"%s\"",
                                      m_options.symbol_name.c_str());
         return;
       }
@@ -972,8 +972,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules have source information for file address 0x%" PRIx64
-              ".",
+              "no modules have source information for file address 0x%" PRIx64,
               m_options.address);
           return;
         }
@@ -994,7 +993,7 @@ protected:
                            Address::DumpStyleModuleWithFileAddress);
               result.AppendErrorWithFormat("address resolves to %s, but there "
                                            "is no line table information "
-                                           "available for this address.",
+                                           "available for this address",
                                            error_strm.GetData());
               return;
             }
@@ -1003,8 +1002,7 @@ protected:
 
         if (sc_list.GetSize() == 0) {
           result.AppendErrorWithFormat(
-              "no modules contain load address 0x%" PRIx64 ".",
-              m_options.address);
+              "no modules contain load address 0x%" PRIx64, m_options.address);
           return;
         }
       }
@@ -1138,7 +1136,7 @@ protected:
       }
 
       if (num_matches == 0) {
-        result.AppendErrorWithFormat("Could not find source file \"%s\".",
+        result.AppendErrorWithFormat("Could not find source file \"%s\"",
                                      m_options.file_name.c_str());
         return;
       }

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -450,7 +450,7 @@ protected:
       }
     } else {
       result.AppendErrorWithFormat("'%s' takes exactly one executable path "
-                                   "argument, or use the --core option.",
+                                   "argument, or use the --core option",
                                    m_cmd_name.c_str());
     }
   }
@@ -1162,7 +1162,7 @@ protected:
 
       if (!llvm::to_integer(command.GetArgumentAtIndex(0), insert_idx)) {
         result.AppendErrorWithFormat(
-            "<index> parameter is not an integer: '%s'.",
+            "<index> parameter is not an integer: '%s'",
             command.GetArgumentAtIndex(0));
         return;
       }
@@ -2180,7 +2180,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
-      result.AppendErrorWithFormat("'%s' takes exactly one pcm path argument.",
+      result.AppendErrorWithFormat("'%s' takes exactly one pcm path argument",
                                    m_cmd_name.c_str());
       return;
     }
@@ -3069,7 +3069,7 @@ protected:
           FileSpec *module_spec_file = module_spec.GetFileSpecPtr();
           if (module_spec_file) {
             module_spec_file->GetPath(path, sizeof(path));
-            result.AppendErrorWithFormat("invalid module '%s'.", path);
+            result.AppendErrorWithFormat("invalid module '%s'", path);
           } else
             result.AppendError("no module spec");
         }
@@ -3095,7 +3095,7 @@ protected:
           }
         } else {
           result.AppendErrorWithFormat(
-              "no modules were found  that match%s%s%s%s.",
+              "no modules were found  that match%s%s%s%s",
               path[0] ? " file=" : "", path, !uuid_str.empty() ? " uuid=" : "",
               uuid_str.c_str());
         }
@@ -3193,12 +3193,12 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
-              "Couldn't find module matching address: 0x%" PRIx64 ".",
+              "Couldn't find module matching address: 0x%" PRIx64,
               m_options.m_module_addr);
         }
       } else {
         result.AppendErrorWithFormat(
-            "Couldn't find module containing address: 0x%" PRIx64 ".",
+            "Couldn't find module containing address: 0x%" PRIx64,
             m_options.m_module_addr);
       }
       return;
@@ -3580,7 +3580,7 @@ protected:
     }
 
     if (sc_list.GetSize() == 0) {
-      result.AppendErrorWithFormat("no unwind data found that matches '%s'.",
+      result.AppendErrorWithFormat("no unwind data found that matches '%s'",
                                    m_options.m_str.c_str());
       return;
     }
@@ -4336,7 +4336,7 @@ protected:
     if (matching_modules.GetSize() > 1) {
       result.AppendErrorWithFormat("multiple modules match symbol file '%s', "
                                    "use the --uuid option to resolve the "
-                                   "ambiguity.",
+                                   "ambiguity",
                                    symfile_path);
       return false;
     }
@@ -5118,12 +5118,12 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         if (!target.RemoveStopHookByID(user_id)) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
@@ -5169,13 +5169,13 @@ protected:
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
-          result.AppendErrorWithFormat("invalid stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("invalid stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }
         success = target.SetStopHookActiveStateByID(user_id, m_enable);
         if (!success) {
-          result.AppendErrorWithFormat("unknown stop hook id: \"%s\".",
+          result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
         }

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -613,7 +613,7 @@ protected:
       uint32_t step_thread_idx;
 
       if (!llvm::to_integer(thread_idx_cstr, step_thread_idx)) {
-        result.AppendErrorWithFormat("invalid thread index '%s'.",
+        result.AppendErrorWithFormat("invalid thread index '%s'",
                                      thread_idx_cstr);
         return;
       }
@@ -621,7 +621,7 @@ protected:
           process->GetThreadList().FindThreadByIndexID(step_thread_idx).get();
       if (thread == nullptr) {
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).",
+            "Thread index %u is out of range (valid values are 0 - %u)",
             step_thread_idx, num_threads);
         return;
       }
@@ -629,12 +629,12 @@ protected:
 
     if (m_step_type == eStepTypeScripted) {
       if (m_class_options.GetName().empty()) {
-        result.AppendErrorWithFormat("empty class name for scripted step.");
+        result.AppendErrorWithFormat("empty class name for scripted step");
         return;
       } else if (!GetDebugger().GetScriptInterpreter()->CheckObjectExists(
                      m_class_options.GetName().c_str())) {
         result.AppendErrorWithFormat(
-            "class for scripted step: \"%s\" does not exist.",
+            "class for scripted step: \"%s\" does not exist",
             m_class_options.GetName().c_str());
         return;
       }
@@ -682,7 +682,7 @@ protected:
           Status error;
           Block *block = frame->GetSymbolContext(eSymbolContextBlock).block;
           if (!block) {
-            result.AppendErrorWithFormat("Could not find the current block.");
+            result.AppendErrorWithFormat("Could not find the current block");
             return;
           }
 
@@ -691,7 +691,7 @@ protected:
           block->GetRangeContainingAddress(pc_address, block_range);
           if (!block_range.GetBaseAddress().IsValid()) {
             result.AppendErrorWithFormat(
-                "Could not find the current block address.");
+                "Could not find the current block address");
             return;
           }
           lldb::addr_t pc_offset_in_block =
@@ -857,7 +857,7 @@ public:
           uint32_t thread_idx;
           if (entry.ref().getAsInteger(0, thread_idx)) {
             result.AppendErrorWithFormat(
-                "invalid thread index argument: \"%s\".", entry.c_str());
+                "invalid thread index argument: \"%s\"", entry.c_str());
             return;
           }
           Thread *thread =
@@ -866,8 +866,7 @@ public:
           if (thread) {
             resume_threads.push_back(thread);
           } else {
-            result.AppendErrorWithFormat("invalid thread index %u.",
-                                         thread_idx);
+            result.AppendErrorWithFormat("invalid thread index %u", thread_idx);
             return;
           }
         }
@@ -958,7 +957,7 @@ public:
       }
     } else {
       result.AppendErrorWithFormat(
-          "Process cannot be continued from its current state (%s).",
+          "Process cannot be continued from its current state (%s)",
           StateAsCString(state));
     }
   }
@@ -1082,7 +1081,7 @@ protected:
         for (size_t i = 0; i < num_args; i++) {
           uint32_t line_number;
           if (!llvm::to_integer(command.GetArgumentAtIndex(i), line_number)) {
-            result.AppendErrorWithFormat("invalid line number: '%s'.",
+            result.AppendErrorWithFormat("invalid line number: '%s'",
                                          command.GetArgumentAtIndex(i));
             return;
           } else
@@ -1105,7 +1104,7 @@ protected:
       if (thread == nullptr) {
         const uint32_t num_threads = process->GetThreadList().GetSize();
         result.AppendErrorWithFormat(
-            "Thread index %u is out of range (valid values are 0 - %u).",
+            "Thread index %u is out of range (valid values are 0 - %u)",
             m_options.m_thread_idx, num_threads);
         return;
       }
@@ -1116,7 +1115,7 @@ protected:
           thread->GetStackFrameAtIndex(m_options.m_frame_idx).get();
       if (frame == nullptr) {
         result.AppendErrorWithFormat(
-            "Frame index %u is out of range for thread id %" PRIu64 ".",
+            "Frame index %u is out of range for thread id %" PRIu64,
             m_options.m_frame_idx, thread->GetID());
         return;
       }
@@ -1134,7 +1133,7 @@ protected:
 
         if (line_table == nullptr) {
           result.AppendErrorWithFormat("Failed to resolve the line table for "
-                                       "frame %u of thread id %" PRIu64 ".",
+                                       "frame %u of thread id %" PRIu64,
                                        m_options.m_frame_idx, thread->GetID());
           return;
         }
@@ -1146,7 +1145,7 @@ protected:
         // sure it is valid:
         if (!sc.function) {
           result.AppendErrorWithFormat("Have debug information but no "
-                                       "function info - can't get until range.");
+                                       "function info - can't get until range");
           return;
         }
 
@@ -1199,10 +1198,10 @@ protected:
         if (address_list.empty()) {
           if (found_something)
             result.AppendErrorWithFormat(
-                "Until target outside of the current function.");
+                "Until target outside of the current function");
           else
             result.AppendErrorWithFormat(
-                "No line entries matching until target.");
+                "No line entries matching until target");
 
           return;
         }
@@ -1224,14 +1223,14 @@ protected:
         }
       } else {
         result.AppendErrorWithFormat("Frame index %u of thread id %" PRIu64
-                                     " has no debug information.",
+                                     " has no debug information",
                                      m_options.m_frame_idx, thread->GetID());
         return;
       }
 
       if (!process->GetThreadList().SetSelectedThreadByID(thread->GetID())) {
         result.AppendErrorWithFormat(
-            "Failed to set the selected thread to thread id %" PRIu64 ".",
+            "Failed to set the selected thread to thread id %" PRIu64,
             thread->GetID());
         return;
       }
@@ -1258,7 +1257,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessContinuingNoResult);
         }
       } else {
-        result.AppendErrorWithFormat("Failed to resume process: %s.",
+        result.AppendErrorWithFormat("Failed to resume process: %s",
                                      error.AsCString());
       }
     }
@@ -1383,7 +1382,7 @@ protected:
       }
       new_thread = process->GetThreadList().FindThreadByIndexID(index_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread index #%s.",
+        result.AppendErrorWithFormat("Invalid thread index #%s",
                                      command.GetArgumentAtIndex(0));
         return;
       }
@@ -1391,7 +1390,7 @@ protected:
       new_thread =
           process->GetThreadList().FindThreadByID(m_options.m_thread_id).get();
       if (new_thread == nullptr) {
-        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64 ".",
+        result.AppendErrorWithFormat("Invalid thread ID %" PRIu64,
                                      m_options.m_thread_id);
         return;
       }
@@ -1725,7 +1724,7 @@ protected:
       Status error;
       error = thread->UnwindInnermostExpression();
       if (!error.Success()) {
-        result.AppendErrorWithFormat("Unwinding expression failed - %s.",
+        result.AppendErrorWithFormat("Unwinding expression failed - %s",
                                      error.AsCString());
       } else {
         bool success =
@@ -1736,7 +1735,7 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
-              "Could not select 0th frame after unwinding expression.");
+              "Could not select 0th frame after unwinding expression");
         }
       }
       return;
@@ -1769,7 +1768,7 @@ protected:
               return_valobj_sp->GetError().AsCString());
         else
           result.AppendErrorWithFormat(
-              "Unknown error evaluating result expression.");
+              "Unknown error evaluating result expression");
         return;
       }
     }
@@ -1780,7 +1779,7 @@ protected:
     error = thread_sp->ReturnFromFrame(frame_sp, return_valobj_sp, broadcast);
     if (!error.Success()) {
       result.AppendErrorWithFormat(
-          "Error returning from frame %d of thread %d: %s.", frame_idx,
+          "Error returning from frame %d of thread %d: %s", frame_idx,
           thread_sp->GetIndexID(), error.AsCString());
       return;
     }
@@ -1885,12 +1884,12 @@ protected:
 
       lldb::addr_t callAddr = dest.GetCallableLoadAddress(target);
       if (callAddr == LLDB_INVALID_ADDRESS) {
-        result.AppendErrorWithFormat("Invalid destination address.");
+        result.AppendErrorWithFormat("Invalid destination address");
         return;
       }
 
       if (!reg_ctx->SetPC(callAddr)) {
-        result.AppendErrorWithFormat("Error changing PC value for thread %d.",
+        result.AppendErrorWithFormat("Error changing PC value for thread %d",
                                      thread->GetIndexID());
         return;
       }
@@ -2095,7 +2094,7 @@ public:
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (args.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat("Too many arguments, expected one - the "
-                                   "thread plan index - but got %zu.",
+                                   "thread plan index - but got %zu",
                                    args.GetArgumentCount());
       return;
     }
@@ -2103,14 +2102,14 @@ public:
     uint32_t thread_plan_idx;
     if (!llvm::to_integer(args.GetArgumentAtIndex(0), thread_plan_idx)) {
       result.AppendErrorWithFormat(
-          "Invalid thread index: \"%s\" - should be unsigned int.",
+          "Invalid thread index: \"%s\" - should be unsigned int",
           args.GetArgumentAtIndex(0));
       return;
     }
 
     if (thread_plan_idx == 0) {
       result.AppendErrorWithFormat(
-          "You wouldn't really want me to discard the base thread plan.");
+          "You wouldn't really want me to discard the base thread plan");
       return;
     }
 
@@ -2118,7 +2117,7 @@ public:
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       result.AppendErrorWithFormat(
-          "Could not find User thread plan with index %s.",
+          "Could not find User thread plan with index %s",
           args.GetArgumentAtIndex(0));
     }
   }

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -666,7 +666,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.",
+      result.AppendErrorWithFormat("%s takes one or more args",
                                    m_cmd_name.c_str());
       return;
     }
@@ -674,7 +674,7 @@ protected:
     const Format format = m_format_options.GetFormat();
     if (format == eFormatInvalid &&
         m_command_options.m_custom_type_name.empty()) {
-      result.AppendErrorWithFormat("%s needs a valid format.",
+      result.AppendErrorWithFormat("%s needs a valid format",
                                    m_cmd_name.c_str());
       return;
     }
@@ -836,7 +836,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc != 1) {
-      result.AppendErrorWithFormat("%s takes 1 arg.", m_cmd_name.c_str());
+      result.AppendErrorWithFormat("%s takes 1 arg", m_cmd_name.c_str());
       return;
     }
 
@@ -880,7 +880,7 @@ protected:
     if (delete_category || extra_deletion) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
-      result.AppendErrorWithFormat("no custom formatter for %s.", typeA);
+      result.AppendErrorWithFormat("no custom formatter for %s", typeA);
     }
   }
 };
@@ -1266,7 +1266,7 @@ bool CommandObjectTypeSummaryAdd::Execute_ScriptSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1381,7 +1381,7 @@ bool CommandObjectTypeSummaryAdd::Execute_StringSummary(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1 && !m_options.m_name) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -1753,7 +1753,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more args.",
+      result.AppendErrorWithFormat("%s takes 1 or more args",
                                    m_cmd_name.c_str());
       return;
     }
@@ -1889,7 +1889,7 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes 1 or more arg.",
+      result.AppendErrorWithFormat("%s takes 1 or more arg",
                                    m_cmd_name.c_str());
       return;
     }
@@ -2046,8 +2046,7 @@ protected:
         return;
       }
     } else if (argc != 0) {
-      result.AppendErrorWithFormat("%s takes 0 or one arg.",
-                                   m_cmd_name.c_str());
+      result.AppendErrorWithFormat("%s takes 0 or one arg", m_cmd_name.c_str());
       return;
     }
 
@@ -2168,14 +2167,14 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
   const size_t argc = command.GetArgumentCount();
 
   if (argc < 1) {
-    result.AppendErrorWithFormat("%s takes one or more args.",
+    result.AppendErrorWithFormat("%s takes one or more args",
                                  m_cmd_name.c_str());
     return false;
   }
 
   if (m_options.m_class_name.empty() && !m_options.m_input_python) {
     result.AppendErrorWithFormat("%s needs either a Python class name or -P to "
-                                 "directly input Python code.",
+                                 "directly input Python code",
                                  m_cmd_name.c_str());
     return false;
   }
@@ -2477,13 +2476,13 @@ protected:
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
-      result.AppendErrorWithFormat("%s takes one or more args.",
+      result.AppendErrorWithFormat("%s takes one or more args",
                                    m_cmd_name.c_str());
       return;
     }
 
     if (m_options.m_expr_paths.empty()) {
-      result.AppendErrorWithFormat("%s needs one or more children.",
+      result.AppendErrorWithFormat("%s needs one or more children",
                                    m_cmd_name.c_str());
       return;
     }

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -906,7 +906,7 @@ protected:
     if (!watch_sp) {
       result.AppendErrorWithFormat(
           "Watchpoint creation failed (addr=0x%" PRIx64 ", size=%" PRIu64
-          ", variable expression='%s').",
+          ", variable expression='%s')",
           addr, static_cast<uint64_t>(size), command.GetArgumentAtIndex(0));
       if (const char *error_message = error.AsCString(nullptr))
         result.AppendError(error_message);
@@ -1104,7 +1104,7 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
       result.AppendErrorWithFormat("Watchpoint creation failed (addr=0x%" PRIx64
-                                   ", size=%" PRIu64 ").",
+                                   ", size=%" PRIu64 ")",
                                    addr, (uint64_t)size);
       if (error.AsCString(nullptr))
         result.AppendError(error.AsCString());

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -483,7 +483,7 @@ protected:
         if (wp)
           wp->ClearCallback();
       } else {
-        result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
+        result.AppendErrorWithFormat("Invalid watchpoint ID: %u", cur_wp_id);
         return;
       }
     }
@@ -555,7 +555,7 @@ protected:
           }
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          result.AppendErrorWithFormat("Invalid watchpoint ID: %u.", cur_wp_id);
+          result.AppendErrorWithFormat("Invalid watchpoint ID: %u", cur_wp_id);
         }
       }
     }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1883,7 +1883,7 @@ CommandObject *CommandInterpreter::BuildAliasResult(
 
       result.AppendErrorWithFormat("Not enough arguments provided; you "
                                    "need at least %d arguments to use "
-                                   "this alias.",
+                                   "this alias",
                                    index);
       return nullptr;
     } else {
@@ -2520,7 +2520,7 @@ void CommandInterpreter::BuildAliasCommandArgs(CommandObject *alias_cmd_obj,
       } else if (static_cast<size_t>(index) >= cmd_args.GetArgumentCount()) {
         result.AppendErrorWithFormat("Not enough arguments provided; you "
                                      "need at least %d arguments to use "
-                                     "this alias.",
+                                     "this alias",
                                      index);
         return;
       } else {
@@ -2889,7 +2889,7 @@ void CommandInterpreter::HandleCommands(
         if (idx != num_lines - 1)
           result.AppendErrorWithFormat(
               "Aborting reading of commands after command #%" PRIu64
-              ": '%s' continued the target.",
+              ": '%s' continued the target",
               (uint64_t)idx + 1, cmd);
         else
           result.AppendMessageWithFormatv(
@@ -2909,7 +2909,7 @@ void CommandInterpreter::HandleCommands(
       if (idx != num_lines - 1)
         result.AppendErrorWithFormat(
             "Aborting reading of commands after command #%" PRIu64
-            ": '%s' stopped with a signal or exception.",
+            ": '%s' stopped with a signal or exception",
             (uint64_t)idx + 1, cmd);
       else
         result.AppendMessageWithFormatv(
@@ -2953,7 +2953,7 @@ void CommandInterpreter::HandleCommandsFromFile(
     CommandReturnObject &result) {
   if (!FileSystem::Instance().Exists(cmd_file)) {
     result.AppendErrorWithFormat(
-        "Error reading commands from file %s - file not found.",
+        "Error reading commands from file %s - file not found",
         cmd_file.GetFilename().AsCString("<Unknown>"));
     return;
   }
@@ -3818,7 +3818,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       } else {
         // We didn't have only one match, otherwise we wouldn't get here.
         lldbassert(num_matches == 0);
-        result.AppendErrorWithFormat("'%s' is not a valid command.",
+        result.AppendErrorWithFormat("'%s' is not a valid command",
                                      next_word.c_str());
       }
       if (!done)
@@ -3829,7 +3829,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
       if (!suffix.empty()) {
         result.AppendErrorWithFormat(
             "command '%s' did not recognize '%s%s%s' as valid (subcommand "
-            "might be invalid).",
+            "might be invalid)",
             cmd_obj->GetCommandName().str().c_str(),
             next_word.empty() ? "" : next_word.c_str(),
             next_word.empty() ? " -- " : " ", suffix.c_str());

--- a/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
+++ b/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
@@ -32,4 +32,4 @@ class UnknownCommandTestCase(TestBase):
 
         command_interpreter.HandleCommand("qbert", result)
         self.assertFalse(result.Succeeded())
-        self.assertEqual(result.GetError(), "error: 'qbert' is not a valid command.\n")
+        self.assertEqual(result.GetError(), "error: 'qbert' is not a valid command\n")

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -162,7 +162,7 @@ class CommandInterpreterAPICase(TestBase):
                 "command": "an-unknown-command",
                 # Unresolved commands don't have "commandName"/"commandArguments"
                 "output": "",
-                "error": "error: 'an-unknown-command' is not a valid command.\n",
+                "error": "error: 'an-unknown-command' is not a valid command\n",
             },
         )
 


### PR DESCRIPTION
To fit the style guide: https://llvm.org/docs/CodingStandards.html#error-and-warning-messages

I found these with:
* Find `(\.AppendErrorWithFormat\(([\s\r\n]+)?"(?:(?:\\.|[^"\\])*))\."` and replace with `$1"` using Visual Studio Code.
* Putting a call to `validate_diagnostic` in `AppendErrorWithFormat`.
* Manual inspection.

Note that this change *does not* include a call to `validate_diagnostic` because I do not know what's going to crash on platforms that I haven't tested on.