### PR TITLE
[libc][docs] Add sys/sem.h POSIX header documentation (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -68,6 +68,7 @@ if (SPHINX_FOUND)
       sys/mman
       sys/resource
       sys/select
+      sys/sem
       sys/socket
       sys/stat
       sys/statvfs

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -36,6 +36,7 @@ Implementation Status
    sys/mman
    sys/resource
    sys/select
+   sys/sem
    sys/socket
    sys/stat
    sys/statvfs

--- a/libc/utils/docgen/sys/sem.yaml
+++ b/libc/utils/docgen/sys/sem.yaml
@@ -1,0 +1,25 @@
+functions:
+  semctl:
+    in-latest-posix: ''
+  semget:
+    in-latest-posix: ''
+  semop:
+    in-latest-posix: ''
+
+macros:
+  GETALL:
+    in-latest-posix: ''
+  GETNCNT:
+    in-latest-posix: ''
+  GETPID:
+    in-latest-posix: ''
+  GETVAL:
+    in-latest-posix: ''
+  GETZCNT:
+    in-latest-posix: ''
+  SEM_UNDO:
+    in-latest-posix: ''
+  SETALL:
+    in-latest-posix: ''
+  SETVAL:
+    in-latest-posix: ''


### PR DESCRIPTION
Add sys/sem.h implementation-status docs to llvm-libc.