### PR TITLE
[BOLT][AArch64] Refuse to run IndirectCallPromotion pass

### DIFF
--- a/bolt/lib/Passes/IndirectCallPromotion.cpp
+++ b/bolt/lib/Passes/IndirectCallPromotion.cpp
@@ -1142,6 +1142,11 @@ Error IndirectCallPromotion::runOnFunctions(BinaryContext &BC) {
   if (opts::ICP == ICP_NONE)
     return Error::success();
 
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   auto &BFs = BC.getBinaryFunctions();
 
   const bool OptimizeCalls = (opts::ICP == ICP_CALLS || opts::ICP == ICP_ALL);

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -6,10 +6,12 @@ RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
+RUN: not llvm-bolt %t -o %t.bolt --indirect-call-promotion=all 2>&1 | FileCheck %s --check-prefix=CHECK-INDIRECT-CALL-PROMOTION
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
+CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported only on X86
 
 // Passes specific to X86 arch
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV

--- a/bolt/test/assume-abi.test
+++ b/bolt/test/assume-abi.test
@@ -1,7 +1,7 @@
 # Validate the usage of the `--assume-abi` option in conjunction with
 # options related to the RegAnalysis Pass.
 
-REQUIRES: system-linux
+REQUIRES: system-linux, target-x86_64
 
 RUN: %clang %cflags %p/Inputs/hello.c -o %t -Wl,-q
 RUN: llvm-bolt %t -o %t.bolt --assume-abi --indirect-call-promotion=all


### PR DESCRIPTION
`--icp=<value>`/`--indirect-call-promotion=<value>` results in an `UNIMPLEMENTED` crash when invoked as it is unimplemented in AArch64.

- Guard IndirectCallPromotion for non-X86
- Update unsupported-passes.test with expected error