### PR TITLE
[libc][docs] Add nl_types.h POSIX header documentation (#122006)

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -54,6 +54,7 @@ if (SPHINX_FOUND)
       glob
       inttypes
       locale
+      nl_types
       net/if
       netinet/in
       poll

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -23,6 +23,7 @@ Implementation Status
    math/index.rst
    net/if
    netinet/in
+   nl_types
    poll
    search
    setjmp

--- a/libc/utils/docgen/nl_types.yaml
+++ b/libc/utils/docgen/nl_types.yaml
@@ -1,0 +1,13 @@
+functions:
+  catclose:
+    in-latest-posix: ""
+  catgets:
+    in-latest-posix: ""
+  catopen:
+    in-latest-posix: ""
+
+macros:
+  NL_CAT_LOCALE:
+    in-latest-posix: ""
+  NL_SETD:
+    in-latest-posix: ""


### PR DESCRIPTION
Add nl_types.h implementation-status docs to llvm-libc.

Depends on PR #194367. That change fixes docgen lookup for underscored headers, without it, the macros of nl_types.h implementation status is not reported accurately.