### PR TITLE
[Clang][HLSL] Fix -Wunused-variable

### DIFF
--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -1658,10 +1658,9 @@ class HLSLBufferCopyEmitter {
                             llvm::ArrayType *DstTy) {
     // Those assumptions are checked by isBufferLayoutArray.
     auto *SrcPaddedArrayTy = cast<llvm::ArrayType>(SrcTy->getElementType(0));
-    auto *SrcPaddedEltTy =
-        cast<llvm::StructType>(SrcPaddedArrayTy->getElementType());
     assert(SrcPaddedArrayTy->getNumElements() + 1 == DstTy->getNumElements());
-    assert(SrcPaddedEltTy->getElementType(0) == SrcTy->getElementType(1));
+    assert(cast<llvm::StructType>(SrcPaddedArrayTy->getElementType())
+               ->getElementType(0) == SrcTy->getElementType(1));
 
     auto *SrcDataTy = SrcTy->getElementType(1);
     auto Zero = llvm::ConstantInt::get(CGF.IntTy, 0);


### PR DESCRIPTION
Inline the variable definition into the assert given it is side effect
free and the variable name does not make the code much more clear.