### PR TITLE
[clang-tidy] Add note about the removal of `hicpp` module

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -49,6 +49,10 @@ Major New Features
 Potentially Breaking Changes
 ----------------------------
 
+- Deprecated the :program:`clang-tidy` ``hicpp`` module. All checks have been
+  moved to other modules instead. The ``hicpp`` module will be removed
+  for the 23.x release.
+
 - Deprecated the :program:`clang-tidy` ``zircon`` module. All checks have been
   moved to the ``fuchsia`` module instead. The ``zircon`` module will be removed
   in the 24th release.


### PR DESCRIPTION
From the discussion [here](https://github.com/llvm/llvm-project/issues/183462#issuecomment-4305159993), we would remove the `hicpp` module in 23 release due to license issues. So we need to add a notice in release 22 branch to alert the users in advance.