### PR TITLE
[MLIR][NVVM] Add `NVVM_F32UnaryApproxOp` Base Class (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -302,8 +302,7 @@ class NVVM_SingleResultIntrinsicOp<string mnemonic, list<Trait> traits = [], str
   }];
 }
 
-// Base class for unary NVVM operations.
-class NVVM_UnaryOp<string mnemonic, list<Trait> traits = []> :
+class NVVM_F32UnaryApproxOp<string mnemonic, list<Trait> traits = []> :
     NVVM_SingleResultIntrinsicOp<mnemonic,
         traits # [Pure, SameOperandsAndResultType]> {
   let arguments = (ins F32:$src,
@@ -537,8 +536,7 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
 // keeps the NVVM dialect self-contained -- users don't need to reach for
 // `math.*` ops for something that already has a PTX instruction.
 
-def NVVM_SinOp : NVVM_UnaryOp<"sin",
-    [Pure, SameOperandsAndResultType]> {
+def NVVM_SinOp : NVVM_F32UnaryApproxOp<"sin"> {
   let summary = "Sine (fast approximation)";
   let description = [{
     Computes a fast approximation of the sine of the input value (in radians).
@@ -550,7 +548,7 @@ def NVVM_SinOp : NVVM_UnaryOp<"sin",
   }];
 }
 
-def NVVM_CosOp : NVVM_UnaryOp<"cos"> {
+def NVVM_CosOp : NVVM_F32UnaryApproxOp<"cos"> {
   let summary = "Cosine (fast approximation)";
   let description = [{
     Computes a fast approximation of the cosine of the input value (in
@@ -559,8 +557,7 @@ def NVVM_CosOp : NVVM_UnaryOp<"cos"> {
   }];
 }
 
-def NVVM_Log2Op : NVVM_UnaryOp<"log2",
-    [Pure, SameOperandsAndResultType]> {
+def NVVM_Log2Op : NVVM_F32UnaryApproxOp<"log2"> {
   let summary = "Base-2 logarithm (fast approximation)";
   let description = [{
     Computes a fast approximation of the base-2 logarithm of the input
@@ -569,7 +566,7 @@ def NVVM_Log2Op : NVVM_UnaryOp<"log2",
   }];
 }
 
-def NVVM_Ex2Op : NVVM_UnaryOp<"ex2"> {
+def NVVM_Ex2Op : NVVM_F32UnaryApproxOp<"ex2"> {
   let summary = "Base-2 exponential (fast approximation)";
   let description = [{
     Computes a fast approximation of 2 raised to the power of the input

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -302,6 +302,17 @@ class NVVM_SingleResultIntrinsicOp<string mnemonic, list<Trait> traits = [], str
   }];
 }
 
+// Base class for unary NVVM operations.
+class NVVM_UnaryOp<string mnemonic, list<Trait> traits = []> :
+    NVVM_SingleResultIntrinsicOp<mnemonic,
+        traits # [Pure, SameOperandsAndResultType]> {
+  let arguments = (ins F32:$src,
+                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
+  let results = (outs F32:$res);
+  let assemblyFormat = "$src attr-dict `:` type($src)";
+}
+
+
 //===----------------------------------------------------------------------===//
 // NVVM special register op definitions
 //===----------------------------------------------------------------------===//
@@ -526,39 +537,29 @@ def NVVM_RcpApproxFtzF32Op : NVVM_IntrOp<"rcp.approx.ftz.f", [Pure], 1> {
 // keeps the NVVM dialect self-contained -- users don't need to reach for
 // `math.*` ops for something that already has a PTX instruction.
 
-def NVVM_SinOp : NVVM_SingleResultIntrinsicOp<"sin",
+def NVVM_SinOp : NVVM_UnaryOp<"sin",
     [Pure, SameOperandsAndResultType]> {
   let summary = "Sine (fast approximation)";
   let description = [{
     Computes a fast approximation of the sine of the input value (in radians).
-    The `ftz` attribute, when set, flushes subnormal inputs and results to 
+    The `ftz` attribute, when set, flushes subnormal inputs and results to
     sign-preserving zero.
 
     For more information, see PTX ISA:
     [sin](https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions-sin)
   }];
-  let arguments = (ins F32:$src,
-                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
-  let results = (outs F32:$res);
-  let assemblyFormat = "$src attr-dict `:` type($src)";
 }
 
-
-def NVVM_CosOp : NVVM_SingleResultIntrinsicOp<"cos",
-    [Pure, SameOperandsAndResultType]> {
+def NVVM_CosOp : NVVM_UnaryOp<"cos"> {
   let summary = "Cosine (fast approximation)";
   let description = [{
     Computes a fast approximation of the cosine of the input value (in
     radians). The `ftz` attribute, when set, flushes subnormal inputs
     and results to sign-preserving zero.
   }];
-  let arguments = (ins F32:$src,
-                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
-  let results = (outs F32:$res);
-  let assemblyFormat = "$src attr-dict `:` type($src)";
 }
 
-def NVVM_Log2Op : NVVM_SingleResultIntrinsicOp<"log2",
+def NVVM_Log2Op : NVVM_UnaryOp<"log2",
     [Pure, SameOperandsAndResultType]> {
   let summary = "Base-2 logarithm (fast approximation)";
   let description = [{
@@ -566,24 +567,15 @@ def NVVM_Log2Op : NVVM_SingleResultIntrinsicOp<"log2",
     value. The `ftz` attribute, when set, flushes subnormal inputs and
     results to sign-preserving zero.
   }];
-  let arguments = (ins F32:$src,
-                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
-  let results = (outs F32:$res);
-  let assemblyFormat = "$src attr-dict `:` type($src)";
 }
 
-def NVVM_Ex2Op : NVVM_SingleResultIntrinsicOp<"ex2",
-    [Pure, SameOperandsAndResultType]> {
+def NVVM_Ex2Op : NVVM_UnaryOp<"ex2"> {
   let summary = "Base-2 exponential (fast approximation)";
   let description = [{
     Computes a fast approximation of 2 raised to the power of the input
     value. The `ftz` attribute, when set, flushes subnormal inputs and
     results to sign-preserving zero.
   }];
-  let arguments = (ins F32:$src,
-                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
-  let results = (outs F32:$res);
-  let assemblyFormat = "$src attr-dict `:` type($src)";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Add `NVVM_F32UnaryApproxOp` tablegen class to unify implementation