### PR TITLE
[CtxProf] emit fatal usage error when flatten-prethinlink runs without guid metadata

### DIFF
--- a/llvm/lib/Analysis/CtxProfAnalysis.cpp
+++ b/llvm/lib/Analysis/CtxProfAnalysis.cpp
@@ -441,7 +441,9 @@ GlobalValue::GUID AssignGUIDPass::getGUID(const Function &F) {
     return F.getGUID();
   }
   auto *MD = F.getMetadata(GUIDMetadataName);
-  assert(MD && "guid not found for defined function");
+  if (!MD)
+    reportFatalUsageError(
+        "this pass requires the GUID metadata to be available.");
   return cast<ConstantInt>(cast<ConstantAsMetadata>(MD->getOperand(0))
                                ->getValue()
                                ->stripPointerCasts())

--- a/llvm/lib/Analysis/CtxProfAnalysis.cpp
+++ b/llvm/lib/Analysis/CtxProfAnalysis.cpp
@@ -442,8 +442,7 @@ GlobalValue::GUID AssignGUIDPass::getGUID(const Function &F) {
   }
   auto *MD = F.getMetadata(GUIDMetadataName);
   if (!MD)
-    reportFatalUsageError(
-        "this pass requires the GUID metadata to be available.");
+    reportFatalUsageError("this pass requires GUID metadata to be available.");
   return cast<ConstantInt>(cast<ConstantAsMetadata>(MD->getOperand(0))
                                ->getValue()
                                ->stripPointerCasts())

--- a/llvm/test/Analysis/CtxProfAnalysis/flatten-prethinlink-requires-guid-metadata.ll
+++ b/llvm/test/Analysis/CtxProfAnalysis/flatten-prethinlink-requires-guid-metadata.ll
@@ -1,0 +1,7 @@
+; RUN: not opt -passes='ctx-prof-flatten-prethinlink' %s -disable-output 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: this pass requires the GUID metadata to be available.
+
+define void @test() {
+  ret void
+}

--- a/llvm/test/Analysis/CtxProfAnalysis/flatten-prethinlink-requires-guid-metadata.ll
+++ b/llvm/test/Analysis/CtxProfAnalysis/flatten-prethinlink-requires-guid-metadata.ll
@@ -1,6 +1,6 @@
 ; RUN: not opt -passes='ctx-prof-flatten-prethinlink' %s -disable-output 2>&1 | FileCheck %s
 
-; CHECK: LLVM ERROR: this pass requires the GUID metadata to be available.
+; CHECK: LLVM ERROR: this pass requires GUID metadata to be available.
 
 define void @test() {
   ret void


### PR DESCRIPTION
`ctx-prof-flatten-prethinlink` can call `AssignGUIDPass::getGUID()` on defined functions even when the GUID metadata is missing. In that case, LLVM currently asserts on missing `!guid` metadata.

Replace the assertion with `reportFatalUsageError()` so the pass fails with a clear user-facing error, and add a regression test for invoking only `ctx-prof-flatten-prethinlink`.

Fixes #194185