### PR TITLE
[FunctionAttrs] Remove declaration check lines (NFC)

### DIFF
--- a/llvm/test/Transforms/FunctionAttrs/nosync.ll
+++ b/llvm/test/Transforms/FunctionAttrs/nosync.ll
@@ -203,8 +203,6 @@ define i32 @volatile_load(ptr %0) norecurse nounwind uwtable {
   ret i32 %2
 }
 
-; CHECK: Function Attrs: noinline nosync nounwind uwtable
-; CHECK-NEXT: declare void @nosync_function()
 declare void @nosync_function() noinline nounwind uwtable nosync
 
 define void @call_nosync_function() nounwind uwtable noinline {
@@ -217,8 +215,6 @@ define void @call_nosync_function() nounwind uwtable noinline {
   ret void
 }
 
-; CHECK: Function Attrs: noinline nounwind uwtable
-; CHECK-NEXT: declare void @might_sync()
 declare void @might_sync() noinline nounwind uwtable
 
 define void @call_might_sync() nounwind uwtable noinline {
@@ -279,8 +275,6 @@ define void @convergent_readnone(){
   ret void
 }
 
-; CHECK: Function Attrs: nounwind
-; CHECK-NEXT: declare void @llvm.x86.sse2.clflush(ptr)
 declare void @llvm.x86.sse2.clflush(ptr)
 @a = common global i32 0, align 4
 


### PR DESCRIPTION
These are annoying, because they get dropped by UTC. We're not
inferring attributes on declarations anyway.