### PR TITLE
[lldb][test] Introduce build_and_run test utility

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -46,7 +46,7 @@ import sys
 import time
 import datetime
 import traceback
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 # Third-party modules
 import unittest
@@ -1578,6 +1578,38 @@ class Base(unittest.TestCase):
             raise Exception("Don't know how to build binary")
 
         self.runBuildCommand(command)
+
+    def build_and_run(
+        self,
+        build_dictionary: dict[str, str] | None = None,
+        file_name: str = "",
+        comment: str = "// break here",
+    ) -> Tuple[lldb.SBTarget, lldb.SBProcess, lldb.SBThread, lldb.SBBreakpoint]:
+        """
+        Builds the target binary, launches it and runs to the breakpoint
+        location specified by the '// break here' comment.
+
+        Returns the target/process/thread/breakpoint returned from
+        lldbutil.run_to_name_breakpoint
+        """
+        self.build(dictionary=build_dictionary)
+
+        if file_name:
+            main_candidates = [file_name]
+        else:
+            main_candidates = ["main.c", "main.cpp", "main.m", "main.mm"]
+
+        for candidate in main_candidates:
+            if os.path.exists(candidate):
+                return lldbutil.run_to_source_breakpoint(
+                    self, comment, lldb.SBFileSpec(candidate, False)
+                )
+
+        self.fail(
+            f"Could not find any main file in {self.mydir}."
+            + "Searched: "
+            + ", ".join(main_candidates)
+        )
 
     def runBuildCommand(self, command):
         self.trace(shlex.join(command))

--- a/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
+++ b/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
@@ -16,8 +16,5 @@ from lldbsuite.test import lldbutil
 class TestExprLookupAnonStructTypedef(TestBase):
     def test(self):
         """Test typedeffed untagged struct arguments for function call expressions"""
-        self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "// break here", lldb.SBFileSpec("main.cpp")
-        )
+        self.build_and_run()
         self.expect_expr("multiply(&s)", result_type="double", result_value="1")

--- a/lldb/test/API/commands/expression/dollar-in-variable/TestDollarInVariable.py
+++ b/lldb/test/API/commands/expression/dollar-in-variable/TestDollarInVariable.py
@@ -6,10 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     def test(self):
-        self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "// break here", lldb.SBFileSpec("main.c")
-        )
+        self.build_and_run()
 
         self.expect_expr("$__lldb_expr_result", result_type="int", result_value="11")
         self.expect_expr("$foo", result_type="int", result_value="12")

--- a/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
+++ b/lldb/test/API/lang/objc/bitfield_ivars/TestBitfieldIvars.py
@@ -6,10 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestBitfieldIvars(TestBase):
     def test(self):
-        self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "// break here", lldb.SBFileSpec("main.m")
-        )
+        self.build_and_run()
 
         self.expect_expr(
             "chb->hb->field1", result_type="unsigned int", result_value="0"

--- a/lldb/test/API/lang/objcxx/conflicting-names-class-update-utility-expr/TestObjCConflictingNamesForClassUpdateExpr.py
+++ b/lldb/test/API/lang/objcxx/conflicting-names-class-update-utility-expr/TestObjCConflictingNamesForClassUpdateExpr.py
@@ -17,10 +17,7 @@ class TestCase(TestBase):
         function.
         """
 
-        self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "// break here", lldb.SBFileSpec("main.mm")
-        )
+        self.build_and_run()
 
         # First check our side effect variable is in its initial state.
         self.expect_expr("called_function", result_summary='"none"')


### PR DESCRIPTION
We currently have several hundred tests require a running process in a given state, and therefore perform the same three tasks:

* compile a test executable
* set a breakpoint by finding a source regex
* then launch the test process to hit that breakpoint.

A large chunk of these tests do this exact same setup with various versions of copied boilerplate code. The different versions we have all have different conventions of naming the breakpoint comment, the main file (and whether it should be resolved), and different generated error messages if things go wrong.

We already have a standardized and much shorter way of doing this in LLDB (see below), but this still encourages test writers to specify non-standard file names and non-standard breakpoint comment names.

```
    self.build()
    lldbutil.run_to_source_breakpoint(
        self, "break here", lldb.SBFileSpec("main.cpp")
    )
```

This patch introduces a simple `build_and_run` wrapper that takes care of all of these things in one go. It also forces the standard naming scheme that most tests have adoped with a breakpoint comment called `break here` and a `main.*` file.

I already adapted a few tests to this new format so that all added code in this patch is tested. I'll do the updating of the other tests in a several follow up PRs so that downstream folks can easily temporarily revert it if it causes issues.