### PR TITLE
[CodeGen] Fix incorrect index in rematerialization tracking

### DIFF
--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -310,11 +310,12 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
     deleteReg(RegIdx);
     if (isRematerializedRegister(RegIdx)) {
       // Delete rematerialized register from its origin's rematerializations.
-      RematsOf &OriginRemats = Rematerializations.at(getOriginOf(RegIdx));
+      const RegisterIdx OriginIdx = getOriginOf(RegIdx);
+      RematsOf &OriginRemats = Rematerializations.at(OriginIdx);
       assert(OriginRemats.contains(RegIdx) && "broken remat<->origin link");
       OriginRemats.erase(RegIdx);
       if (OriginRemats.empty())
-        Rematerializations.erase(RegIdx);
+        Rematerializations.erase(OriginIdx);
     }
     LLVM_DEBUG(dbgs() << "** Deleted " << printID(RegIdx) << "\n");
   }


### PR DESCRIPTION
When deleting the last rematerialization of a register, we should delete the rematerializer's remat tracking map's entry that corresponds to the index of the *original* register, not the rematerialized register.

The existing typo has no impact on correctness at the moment because entries with rematerialized register indices are never created (so there is nothing to erase), and having an empty set in a value does not break any code invariant; it just wastes memory.

Assisted-by: Claude Code
