### PR TITLE
[mlir] Update CODEOWNERS after x86 dialects refactoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,14 +107,13 @@
 /mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp @MaheshRavishankar @nicolasvasilache
 
 # Vector Dialect in MLIR.
-/mlir/**/*AMX* @aartbik @dcaballe
 /mlir/**/*Neon* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*SME* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*SVE* @banach-space @dcaballe @nicolasvasilache
 /mlir/**/*VectorInterfaces* @dcaballe @nicolasvasilache
 /mlir/**/*VectorToSCF* @banach-space @dcaballe @matthias-springer @nicolasvasilache
 /mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*X86Vector* @aartbik @dcaballe @nicolasvasilache
+/mlir/**/*X86* @aartbik @dcaballe @nicolasvasilache
 /mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
 /mlir/include/mlir/Dialect/Vector/IR @kuhar
 /mlir/lib/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,7 +113,7 @@
 /mlir/**/*VectorInterfaces* @dcaballe @nicolasvasilache
 /mlir/**/*VectorToSCF* @banach-space @dcaballe @matthias-springer @nicolasvasilache
 /mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*X86* @aartbik @dcaballe @nicolasvasilache
+/mlir/**/*X86* @aartbik @dcaballe @nicolasvasilache @adam-smnk
 /mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
 /mlir/include/mlir/Dialect/Vector/IR @kuhar
 /mlir/lib/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss


### PR DESCRIPTION
The two separate x86 dialects ('amx' and 'x86vector') have been merged into a single 'x86' dialect.
Relevent paths are updated accordingly.

Also, adding myself to 'x86' dialect to enable notifications.