### PR TITLE
[offload][lit] Enable ctor_dtor.cpp on Intel GPUs

### DIFF
--- a/offload/test/offloading/ctor_dtor.cpp
+++ b/offload/test/offloading/ctor_dtor.cpp
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 struct S {


### PR DESCRIPTION
It was fixed with https://github.com/llvm/llvm-project/pull/192725 and https://github.com/llvm/llvm-project/pull/192730.