### PR TITLE
[lldb][test] Delete obsolete cmds.txt

### DIFF
--- a/lldb/test/API/functionalities/dead-strip/cmds.txt
+++ b/lldb/test/API/functionalities/dead-strip/cmds.txt
@@ -1,4 +1,0 @@
-b main.c:21
-b main.c:41
-lines -shlib a.out main.c
-c

--- a/lldb/test/API/functionalities/load_unload/cmds.txt
+++ b/lldb/test/API/functionalities/load_unload/cmds.txt
@@ -1,2 +1,0 @@
-breakpoint set -n a_function
-run

--- a/lldb/test/API/lang/c/array_types/cmds.txt
+++ b/lldb/test/API/lang/c/array_types/cmds.txt
@@ -1,3 +1,0 @@
-break main.c:42
-continue
-var

--- a/lldb/test/API/lang/c/global_variables/cmds.txt
+++ b/lldb/test/API/lang/c/global_variables/cmds.txt
@@ -1,3 +1,0 @@
-break main.c:5
-continue
-var -global g_a -global g_global_int

--- a/lldb/test/API/lang/cpp/class_types/cmds.txt
+++ b/lldb/test/API/lang/cpp/class_types/cmds.txt
@@ -1,3 +1,0 @@
-b main.cpp:97
-c
-var

--- a/lldb/test/API/lang/cpp/namespace/cmds.txt
+++ b/lldb/test/API/lang/cpp/namespace/cmds.txt
@@ -1,3 +1,0 @@
-b main.cpp:54
-c
-var

--- a/lldb/test/API/lang/cpp/stl/cmds.txt
+++ b/lldb/test/API/lang/cpp/stl/cmds.txt
@@ -1,3 +1,0 @@
-b main.cpp:6
-continue
-var

--- a/lldb/test/API/macosx/order/cmds.txt
+++ b/lldb/test/API/macosx/order/cmds.txt
@@ -1,3 +1,0 @@
-b main.c:41
-c
-lines -shlib a.out main.c


### PR DESCRIPTION
Last time I asked about these files someone mentioned they were once used to replay a test.

However, I think by now these files are mostly out of sync with their tests and few people anyway know these files exist in the first place.