### PR TITLE
[MLIR][OpenMP] Fix sanitizer issue related to stack-to-shared pass

### DIFF
--- a/mlir/lib/Dialect/OpenMP/Transforms/StackToShared.cpp
+++ b/mlir/lib/Dialect/OpenMP/Transforms/StackToShared.cpp
@@ -114,8 +114,9 @@ public:
       // Create a new omp.free_shared_mem for the allocated buffer prior to
       // exiting the region.
       insertDeviceSharedMemDeallocation(
-          builder, allocaOp.getElemTypeAttr(), allocaOp.getArraySize(),
-          allocaOp.getAlignmentAttr(), sharedAllocOp.getResult());
+          builder, sharedAllocOp.getMemElemTypeAttr(),
+          sharedAllocOp.getMemArraySize(), sharedAllocOp.getMemAlignmentAttr(),
+          sharedAllocOp.getResult());
     });
     for (Operation *op : toBeDeleted)
       op->erase();


### PR DESCRIPTION
The OpenMP dialect stack-to-shared pass could try to access attributes from a deleted operation. This updates it to get that information from the operation created to replace it.