### PR TITLE
[Offload] Make kernel dynamic memory handling more generic

### DIFF
--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -249,13 +249,17 @@ Error GenericKernelTy::launch(GenericDeviceTy &GenericDevice, void **ArgPtrs,
   uint32_t NumBlocks[3] = {KernelArgs.NumTeams[0], KernelArgs.NumTeams[1],
                            KernelArgs.NumTeams[2]};
   if (!isBareMode()) {
+    assert(
+        NumThreads[1] == 1 && NumThreads[2] == 1 && NumBlocks[1] == 1 &&
+        NumBlocks[2] == 1 &&
+        "Non-bare mode should only use the first thread and block dimensions");
     NumThreads[0] = getNumThreads(GenericDevice, NumThreads);
     NumBlocks[0] = getNumBlocks(GenericDevice, NumBlocks, KernelArgs.Tripcount,
                                 NumThreads[0], KernelArgs.ThreadLimit[0] > 0);
   }
 
-  auto DynBlockMemConfOrErr =
-      prepareBlockMemory(GenericDevice, KernelArgs, NumBlocks[0]);
+  auto DynBlockMemConfOrErr = prepareBlockMemory(
+      GenericDevice, KernelArgs, NumBlocks[0] * NumBlocks[1] * NumBlocks[2]);
   if (!DynBlockMemConfOrErr)
     return DynBlockMemConfOrErr.takeError();
 


### PR DESCRIPTION
Make sure we do not get unexpected NumThreads and NumBlocks values when launching non-bare kernels, and generalize the computation of the dynamic block memory allocation to handle multi-dimensional blocks.

The DynBlockMem fallback is never used in a non-bare context where `NumBlocks[1]` and `NumBlocks[2]` are not 1 so the code was correct, but this patch makes sure that assumption is made explicit, and also future-proofs the code in case we decide to allow multi-dimensional blocks for fallback dyn block mem in some path. 