### PR TITLE
[TableGen] Emit constexpr versions of some directive/clause functions

### DIFF
--- a/llvm/test/TableGen/directive1.td
+++ b/llvm/test/TableGen/directive1.td
@@ -58,6 +58,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  #include "llvm/Frontend/Directive/Spelling.h"
 // CHECK-NEXT:  #include "llvm/Support/Compiler.h"
 // CHECK-NEXT:  #include <cstddef>
+// CHECK-NEXT:  #include <optional>
 // CHECK-NEXT:  #include <utility>
 // CHECK-EMPTY:
 // CHECK-NEXT:  namespace llvm {
@@ -134,6 +135,32 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  constexpr auto TDLCV_vala = AKind::TDLCV_vala;
 // CHECK-NEXT:  constexpr auto TDLCV_valb = AKind::TDLCV_valb;
 // CHECK-NEXT:  constexpr auto TDLCV_valc = AKind::TDLCV_valc;
+// CHECK-EMPTY:
+// CHECK-NEXT:  // Constexpr functions.
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<Association> getDirectiveAssociationOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return Association::None;
+// CHECK-NEXT:    } // switch (D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<Category> getDirectiveCategoryOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return Category::Executable;
+// CHECK-NEXT:    } // switch (D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<SourceLanguage> getDirectiveLanguagesOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
+// CHECK-NEXT:    } // switch(D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions
 // CHECK-NEXT:  LLVM_ABI std::pair<Directive, directive::VersionRange> getTdlDirectiveKindAndVersions(StringRef Str);
@@ -431,27 +458,24 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive Dir) {
-// IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return Association::None;
-// IMPL-NEXT:    } // switch (Dir)
+// IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive D) {
+// IMPL-NEXT:    if (auto X = getDirectiveAssociationOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive Dir) {
-// IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return Category::Executable;
-// IMPL-NEXT:    } // switch (Dir)
+// IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive D) {
+// IMPL-NEXT:    if (auto X = getDirectiveCategoryOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::SourceLanguage llvm::tdl::getDirectiveLanguages(llvm::tdl::Directive D) {
-// IMPL-NEXT:    switch (D) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
-// IMPL-NEXT:    } // switch(D)
+// IMPL-NEXT:    if (auto X = getDirectiveLanguagesOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:

--- a/llvm/test/TableGen/directive2.td
+++ b/llvm/test/TableGen/directive2.td
@@ -51,6 +51,7 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  #include "llvm/Frontend/Directive/Spelling.h"
 // CHECK-NEXT:  #include "llvm/Support/Compiler.h"
 // CHECK-NEXT:  #include <cstddef>
+// CHECK-NEXT:  #include <optional>
 // CHECK-NEXT:  #include <utility>
 // CHECK-EMPTY:
 // CHECK-NEXT:  namespace llvm {
@@ -110,6 +111,32 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
 // CHECK-NEXT:  static constexpr std::size_t Clause_enumSize = 4;
+// CHECK-EMPTY:
+// CHECK-NEXT:  // Constexpr functions.
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<Association> getDirectiveAssociationOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return Association::Block;
+// CHECK-NEXT:    } // switch (D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<Category> getDirectiveCategoryOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return Category::Declarative;
+// CHECK-NEXT:    } // switch (D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  constexpr std::optional<SourceLanguage> getDirectiveLanguagesOpt(Directive D) {
+// CHECK-NEXT:    switch (D) {
+// CHECK-NEXT:    case TDLD_dira:
+// CHECK-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
+// CHECK-NEXT:    } // switch(D)
+// CHECK-NEXT:    return std::nullopt;
+// CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions
 // CHECK-NEXT:  LLVM_ABI std::pair<Directive, directive::VersionRange> getTdlDirectiveKindAndVersions(StringRef Str);
@@ -356,27 +383,24 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // IMPL-NEXT:    llvm_unreachable("Invalid Tdl Directive kind");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive Dir) {
-// IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return Association::Block;
-// IMPL-NEXT:    } // switch (Dir)
+// IMPL-NEXT:  llvm::tdl::Association llvm::tdl::getDirectiveAssociation(llvm::tdl::Directive D) {
+// IMPL-NEXT:    if (auto X = getDirectiveAssociationOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
-// IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive Dir) {
-// IMPL-NEXT:    switch (Dir) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return Category::Declarative;
-// IMPL-NEXT:    } // switch (Dir)
+// IMPL-NEXT:  llvm::tdl::Category llvm::tdl::getDirectiveCategory(llvm::tdl::Directive D) {
+// IMPL-NEXT:    if (auto X = getDirectiveCategoryOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:
 // IMPL-NEXT:  llvm::tdl::SourceLanguage llvm::tdl::getDirectiveLanguages(llvm::tdl::Directive D) {
-// IMPL-NEXT:    switch (D) {
-// IMPL-NEXT:    case TDLD_dira:
-// IMPL-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
-// IMPL-NEXT:    } // switch(D)
+// IMPL-NEXT:    if (auto X = getDirectiveLanguagesOpt(D)) {
+// IMPL-NEXT:      return *X;
+// IMPL-NEXT:    }
 // IMPL-NEXT:    llvm_unreachable("Unexpected directive");
 // IMPL-NEXT:  }
 // IMPL-EMPTY:

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -34,6 +34,9 @@ namespace {
 enum class Frontend { LLVM, Flang, Clang };
 } // namespace
 
+static void emitDirectivesConstexprImpl(const DirectiveLanguage &DirLang,
+                                        raw_ostream &OS);
+
 static StringRef getFESpelling(Frontend FE) {
   switch (FE) {
   case Frontend::LLVM:
@@ -272,8 +275,9 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
   OS << "#include \"llvm/ADT/StringRef.h\"\n";
   OS << "#include \"llvm/Frontend/Directive/Spelling.h\"\n";
   OS << "#include \"llvm/Support/Compiler.h\"\n";
-  OS << "#include <cstddef>\n"; // for size_t
-  OS << "#include <utility>\n"; // for std::pair
+  OS << "#include <cstddef>\n";  // Needed for size_t
+  OS << "#include <optional>\n"; // Needed for constexpr functions
+  OS << "#include <utility>\n";  // Needed for std::pair
   OS << "\n";
   NamespaceEmitter LlvmNS(OS, "llvm");
   {
@@ -311,7 +315,11 @@ static void emitDirectivesDecl(const RecordKeeper &Records, raw_ostream &OS) {
     std::string EnumHelperFuncs;
     generateClauseEnumVal(DirLang.getClauses(), OS, DirLang, EnumHelperFuncs);
 
+    // Emit constexpr functions
+    emitDirectivesConstexprImpl(DirLang, OS);
+
     // Generic function signatures
+    OS << "\n";
     OS << "// Enumeration helper functions\n";
 
     OS << "LLVM_ABI std::pair<Directive, directive::VersionRange> get" << Lang
@@ -542,7 +550,6 @@ static void generateIsAllowedClause(const DirectiveLanguage &DirLang,
                                     raw_ostream &OS) {
   std::string Qual = getQualifier(DirLang);
 
-  OS << "\n";
   OS << "bool " << Qual << "isAllowedClauseForDirective(" << Qual
      << "Directive D, " << Qual << "Clause C, unsigned Version) {\n";
   OS << "  assert(unsigned(D) <= Directive_enumSize);\n";
@@ -726,8 +733,9 @@ static void emitLeafTable(const DirectiveLanguage &DirLang, raw_ostream &OS,
   OS << "\n};\n";
 }
 
-static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
-                                            raw_ostream &OS) {
+static void
+generateGetDirectiveAssociationConstexpr(const DirectiveLanguage &DirLang,
+                                         raw_ostream &OS) {
   enum struct Association {
     None = 0,    // None should be the smallest value.
     Block,       // If the order of the rest of these changes, update the
@@ -834,33 +842,41 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
   for (const Record *R : DirLang.getDirectives())
     CompAssocImpl(R, CompAssocImpl); // Updates AsMap.
 
-  OS << '\n';
-
   StringRef Prefix = DirLang.getDirectivePrefix();
-  std::string Qual = getQualifier(DirLang);
 
-  OS << Qual << "Association " << Qual << "getDirectiveAssociation(" << Qual
-     << "Directive Dir) {\n";
-  OS << "  switch (Dir) {\n";
+  OS << "constexpr std::optional<Association> ";
+  OS << "getDirectiveAssociationOpt(Directive D) {\n";
+  OS << "  switch (D) {\n";
   for (const Record *R : DirLang.getDirectives()) {
     if (auto F = AsMap.find(R); F != AsMap.end()) {
       OS << "  case " << getIdentifierName(R, Prefix) << ":\n";
       OS << "    return Association::" << GetAssocName(F->second) << ";\n";
     }
   }
-  OS << "  } // switch (Dir)\n";
+  OS << "  } // switch (D)\n";
+  OS << "  return std::nullopt;\n";
+  OS << "}\n";
+}
+
+static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
+                                            raw_ostream &OS) {
+  std::string Qual = getQualifier(DirLang);
+
+  OS << Qual << "Association ";
+  OS << Qual << "getDirectiveAssociation(" << Qual << "Directive D) {\n";
+  OS << "  if (auto X = getDirectiveAssociationOpt(D)) {\n";
+  OS << "    return *X;\n";
+  OS << "  }\n";
   OS << "  llvm_unreachable(\"Unexpected directive\");\n";
   OS << "}\n";
 }
 
-static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
-                                         raw_ostream &OS) {
-  std::string Qual = getQualifier(DirLang);
-
-  OS << '\n';
-  OS << Qual << "Category " << Qual << "getDirectiveCategory(" << Qual
-     << "Directive Dir) {\n";
-  OS << "  switch (Dir) {\n";
+static void
+generateGetDirectiveCategoryConstexpr(const DirectiveLanguage &DirLang,
+                                      raw_ostream &OS) {
+  OS << "constexpr std::optional<Category> ";
+  OS << "getDirectiveCategoryOpt(Directive D) {\n";
+  OS << "  switch (D) {\n";
 
   StringRef Prefix = DirLang.getDirectivePrefix();
 
@@ -870,18 +886,29 @@ static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
     OS << "    return Category::" << D.getCategory()->getValueAsString("name")
        << ";\n";
   }
-  OS << "  } // switch (Dir)\n";
+  OS << "  } // switch (D)\n";
+  OS << "  return std::nullopt;\n";
+  OS << "}\n";
+}
+
+static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
+                                         raw_ostream &OS) {
+  std::string Qual = getQualifier(DirLang);
+
+  OS << Qual << "Category ";
+  OS << Qual << "getDirectiveCategory(" << Qual << "Directive D) {\n";
+  OS << "  if (auto X = getDirectiveCategoryOpt(D)) {\n";
+  OS << "    return *X;\n";
+  OS << "  }\n";
   OS << "  llvm_unreachable(\"Unexpected directive\");\n";
   OS << "}\n";
 }
 
-static void generateGetDirectiveLanguages(const DirectiveLanguage &DirLang,
-                                          raw_ostream &OS) {
-  std::string Qual = getQualifier(DirLang);
-
-  OS << '\n';
-  OS << Qual << "SourceLanguage " << Qual << "getDirectiveLanguages(" << Qual
-     << "Directive D) {\n";
+static void
+generateGetDirectiveLanguagesConstexpr(const DirectiveLanguage &DirLang,
+                                       raw_ostream &OS) {
+  OS << "constexpr std::optional<SourceLanguage> ";
+  OS << "getDirectiveLanguagesOpt(Directive D) {\n";
   OS << "  switch (D) {\n";
 
   StringRef Prefix = DirLang.getDirectivePrefix();
@@ -900,6 +927,19 @@ static void generateGetDirectiveLanguages(const DirectiveLanguage &DirLang,
     OS << ";\n";
   }
   OS << "  } // switch(D)\n";
+  OS << "  return std::nullopt;\n";
+  OS << "}\n";
+}
+
+static void generateGetDirectiveLanguages(const DirectiveLanguage &DirLang,
+                                          raw_ostream &OS) {
+  std::string Qual = getQualifier(DirLang);
+
+  OS << Qual << "SourceLanguage " << Qual;
+  OS << "getDirectiveLanguages(" << Qual << "Directive D) {\n";
+  OS << "  if (auto X = getDirectiveLanguagesOpt(D)) {\n";
+  OS << "    return *X;\n";
+  OS << "  }\n";
   OS << "  llvm_unreachable(\"Unexpected directive\");\n";
   OS << "}\n";
 }
@@ -1310,6 +1350,17 @@ static void generateClauseClassMacro(const DirectiveLanguage &DirLang,
   OS << "#undef CLAUSE\n";
 }
 
+static void emitDirectivesConstexprImpl(const DirectiveLanguage &DirLang,
+                                        raw_ostream &OS) {
+  OS << "// Constexpr functions.\n";
+  OS << "\n";
+  generateGetDirectiveAssociationConstexpr(DirLang, OS);
+  OS << "\n";
+  generateGetDirectiveCategoryConstexpr(DirLang, OS);
+  OS << "\n";
+  generateGetDirectiveLanguagesConstexpr(DirLang, OS);
+}
+
 // Generate the implemenation for the enumeration in the directive
 // language. This code can be included in library.
 void emitDirectivesBasicImpl(const DirectiveLanguage &DirLang,
@@ -1342,15 +1393,19 @@ void emitDirectivesBasicImpl(const DirectiveLanguage &DirLang,
   generateGetClauseVal(DirLang, OS);
 
   // isAllowedClauseForDirective(Directive D, Clause C, unsigned Version)
+  OS << "\n";
   generateIsAllowedClause(DirLang, OS);
 
   // getDirectiveAssociation(Directive D)
+  OS << "\n";
   generateGetDirectiveAssociation(DirLang, OS);
 
   // getDirectiveCategory(Directive D)
+  OS << "\n";
   generateGetDirectiveCategory(DirLang, OS);
 
   // getDirectiveLanguages(Directive D)
+  OS << "\n";
   generateGetDirectiveLanguages(DirLang, OS);
 
   // Leaf table for getLeafConstructs, etc.


### PR DESCRIPTION
Reland https://github.com/llvm/llvm-project/pull/176253 with a change to reduce compile-time impact.

Several of the functions that TableGen emits into the .cpp files for OpenACC or OpenMP could be constexpr. They can't just be emitted into the header files as constexpr as they are because they use "assert" and "llvm_unreachable".
To preserve the existing functionality, this patch will cause TableGen to emit the constexpr variants that return the value as std::optional, where std::nullopt indicates an error. The exisiting functions will invoke the constexpr versions and call assert/llvm_unreachable if nullopt is returned. E.g.

```
// .h
constexpr std::optional<Association>
getDirectiveAssociationOpt(Directive D) {
  switch (D) {
    case ...:
      return Association::Block;
    ...
  } // switch (D)
  return std::nullopt;
}

// .cpp
Association getDirectiveAssociation(Directive D) {
  if (auto X = getDirectiveAssociationOpt(D)) {
    return *X;
  }
  llvm_unreachable("Unexpected directive");
}
```

In the previous PR the `isAllowedClauseForDirective` function was made constexpr, but since it was very long it has a significant impact on compilation time. In this PR that function is no longer constexpr.