### PR TITLE
[clang][bytecode] Rework APValue visiting

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2434,17 +2434,19 @@ bool Compiler<Emitter>::VisitSubstNonTypeTemplateParmExpr(
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitConstantExpr(const ConstantExpr *E) {
-  OptPrimType T = classify(E->getType());
-  if (T && E->hasAPValueResult()) {
+  if (!E->hasAPValueResult())
+    return this->delegate(E->getSubExpr());
+
+  if (OptPrimType T = classify(E)) {
     // Try to emit the APValue directly, without visiting the subexpr.
     // This will only fail if we can't emit the APValue, so won't emit any
     // diagnostics or any double values.
     if (DiscardResult)
       return true;
-
-    if (this->visitAPValue(E->getAPValueResult(), *T, E))
-      return true;
+    return this->visitAPValue(E->getAPValueResult(), *T, E);
   }
+
+  // Fall back to the subexpr for non-primitive APValues.
   return this->delegate(E->getSubExpr());
 }
 
@@ -5313,18 +5315,63 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
     return this->emitFloat(F, E);
   }
 
-  if (Val.isLValue()) {
-    if (Val.isNullPointer())
-      return this->emitNull(ValType, 0, nullptr, E);
-    APValue::LValueBase Base = Val.getLValueBase();
-    if (const Expr *BaseExpr = Base.dyn_cast<const Expr *>())
-      return this->visit(BaseExpr);
-    if (const auto *VD = Base.dyn_cast<const ValueDecl *>())
-      return this->visitDeclRef(VD, E);
-  } else if (Val.isMemberPointer()) {
+  if (Val.isMemberPointer()) {
     if (const ValueDecl *MemberDecl = Val.getMemberPointerDecl())
       return this->emitGetMemberPtr(MemberDecl, E);
     return this->emitNullMemberPtr(0, nullptr, E);
+  }
+
+  if (Val.isLValue()) {
+    if (Val.isNullPointer())
+      return this->emitNull(ValType, 0, nullptr, E);
+
+    APValue::LValueBase Base = Val.getLValueBase();
+    ArrayRef<APValue::LValuePathEntry> Path = Val.getLValuePath();
+
+    if (const Expr *BaseExpr = Base.dyn_cast<const Expr *>())
+      return this->visit(BaseExpr);
+    if (const auto *VD = Base.dyn_cast<const ValueDecl *>()) {
+      if (!this->visitDeclRef(VD, E))
+        return false;
+
+      QualType EntryType = VD->getType();
+      for (auto &Entry : Path) {
+        if (EntryType->isArrayType()) {
+          uint64_t Index = Entry.getAsArrayIndex();
+          QualType ElemType =
+              EntryType->getAsArrayTypeUnsafe()->getElementType();
+          if (!this->emitConst(Index, PT_Uint64, E))
+            return false;
+          if (!this->emitArrayElemPtrPop(PT_Uint64, E))
+            return false;
+          EntryType = ElemType;
+        } else {
+          assert(EntryType->isRecordType());
+          const Record *EntryRecord = getRecord(EntryType);
+          if (!EntryRecord) {
+            assert(false);
+
+            return false;
+          }
+
+          const Decl *BaseOrMember = Entry.getAsBaseOrMember().getPointer();
+          if (const auto *FD = dyn_cast<FieldDecl>(BaseOrMember)) {
+            unsigned EntryOffset = EntryRecord->getField(FD)->Offset;
+            if (!this->emitGetPtrFieldPop(EntryOffset, E))
+              return false;
+            EntryType = FD->getType();
+          } else {
+            const auto *Base = cast<CXXRecordDecl>(BaseOrMember);
+            unsigned BaseOffset = EntryRecord->getBase(Base)->Offset;
+            if (!this->emitGetPtrBasePop(BaseOffset, /*NullOK=*/false, E))
+              return false;
+            EntryType = Ctx.getASTContext().getCanonicalTagType(Base);
+          }
+        }
+      }
+
+      return true;
+    }
   }
 
   return false;
@@ -5341,6 +5388,7 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
       const Record::Field *RF = R->getField(I);
       QualType FieldType = RF->Decl->getType();
 
+      // Fields.
       if (OptPrimType PT = classify(FieldType)) {
         if (!this->visitAPValue(F, *PT, E))
           return false;
@@ -5351,10 +5399,25 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
           return false;
         if (!this->visitAPValueInitializer(F, E, FieldType))
           return false;
-        if (!this->emitPopPtr(E))
+        if (!this->emitFinishInitPop(E))
           return false;
       }
     }
+
+    // Bases.
+    for (unsigned I = 0, N = Val.getStructNumBases(); I != N; ++I) {
+      const APValue &B = Val.getStructBase(I);
+      const Record::Base *RB = R->getBase(I);
+      QualType BaseType = Ctx.getASTContext().getCanonicalTagType(RB->Decl);
+
+      if (!this->emitGetPtrBase(RB->Offset, E))
+        return false;
+      if (!this->visitAPValueInitializer(B, E, BaseType))
+        return false;
+      if (!this->emitFinishInitPop(E))
+        return false;
+    }
+
     return true;
   }
   if (Val.isUnion()) {
@@ -7442,13 +7505,14 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
   }
   if (const auto *TPOD = dyn_cast<TemplateParamObjectDecl>(D)) {
     if (UnsignedOrNone Index = P.getOrCreateGlobal(D)) {
-      if (!this->emitGetPtrGlobal(*Index, E))
-        return false;
-      if (OptPrimType T = classify(E->getType())) {
+      if (OptPrimType T = classify(D->getType())) {
         if (!this->visitAPValue(TPOD->getValue(), *T, E))
           return false;
         return this->emitInitGlobal(*T, *Index, E);
       }
+
+      if (!this->emitGetPtrGlobal(*Index, E))
+        return false;
       if (!this->visitAPValueInitializer(TPOD->getValue(), E, TPOD->getType()))
         return false;
       return this->emitFinishInit(E);

--- a/clang/test/AST/ByteCode/libcxx/apvalue-initializer.cpp
+++ b/clang/test/AST/ByteCode/libcxx/apvalue-initializer.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -std=c++2c -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -std=c++2c  -verify=ref,both                                             %s
+
+// both-no-diagnostics
+
+namespace std {
+
+class SomeBase {
+public:
+  int k = 20;
+};
+
+template <class, class... _Args>
+constexpr bool is_nothrow_invocable_v = noexcept(__builtin_invoke(_Args()...));
+template <class _Tp> struct __cw_fixed_value : public SomeBase {
+  constexpr __cw_fixed_value(_Tp) {}
+  _Tp __data = 0;
+  int a[3]{1,1,1};
+};
+template <__cw_fixed_value> struct constant_wrapper;
+template <auto &_Callable>
+concept __constexpr_callable =
+    requires { typename constant_wrapper<_Callable>; };
+template <__cw_fixed_value _Xp> struct constant_wrapper {
+  static constexpr auto &value = _Xp.__data;
+  static constexpr auto &value2 = _Xp.a[1];
+  static constexpr auto &value3 = _Xp.k;
+  template <class...>
+    requires __constexpr_callable<value> && __constexpr_callable<value2> && __constexpr_callable<value3>
+  constant_wrapper operator()() noexcept;
+};
+} // namespace std
+void throwing_call();
+static_assert(
+    std::is_nothrow_invocable_v<std::constant_wrapper<throwing_call>,
+                                std::constant_wrapper<42>>,
+    "the call expression is still nothrow because the constexpr path is taken");
+
+

--- a/clang/test/AST/ByteCode/libcxx/lvalue-constantexpr.cpp
+++ b/clang/test/AST/ByteCode/libcxx/lvalue-constantexpr.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -std=c++2c -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -std=c++2c  -verify=ref,both                                             %s
+
+// both-no-diagnostics
+
+template <class _Tp, _Tp __v> struct integral_constant {
+  static const _Tp value = __v;
+};
+template <bool _Val> using _BoolConstant = integral_constant<bool, _Val>;
+namespace std {
+template <class _Tp, class _Up>
+using _IsSame = _BoolConstant<__is_same(_Tp, _Up)>;
+template <class _Tp, class _Up>
+concept __same_as_impl = _IsSame<_Tp, _Up>::value;
+template <class _Tp, class _Up>
+concept same_as = __same_as_impl<_Up, _Tp>;
+template <class _Tp> _Tp forward;
+template <class, class... _Args> struct __invoke_result_impl {
+  using type = decltype(__builtin_invoke(_Args()...));
+};
+template <class... _Args>
+using __invoke_result = __invoke_result_impl<void, _Args...>;
+template <class... _Args>
+using __invoke_result_t = __invoke_result<_Args...>::type;
+template <class... _Args>
+constexpr __invoke_result_t<_Args...> __invoke(_Args... __args) {
+  return __builtin_invoke(__args...);
+}
+template <class _Fn, class... _Args>
+using invoke_result_t = __invoke_result_t<_Fn, _Args...>;
+template <class _Fn, class... _Args>
+constexpr invoke_result_t<_Fn, _Args...> invoke(_Fn __f, _Args... __args) {
+  return __invoke(__f, __args...);
+}
+template <class _Tp> struct __cw_fixed_value {
+  constexpr __cw_fixed_value(_Tp) : __data() {}
+  _Tp __data;
+};
+template <__cw_fixed_value> struct constant_wrapper;
+template <__cw_fixed_value _Xp> auto cw = constant_wrapper<_Xp>{};
+template <auto &_Callable, class... _Args>
+concept __constexpr_callable = requires {
+  typename constant_wrapper<invoke(_Callable, _Args ::value...)>;
+};
+template <__cw_fixed_value _Xp> struct constant_wrapper {
+  static constexpr auto &value = _Xp.__data;
+  void operator()(...);
+  template <class... _Args>
+    requires(!__constexpr_callable<value, _Args...>)
+  auto operator()(_Args...) noexcept(invoke(value, forward<_Args>...)) {}
+};
+} // namespace std
+template <class T> struct MustBeInt {
+  static_assert(std::same_as<T, int>);
+};
+
+struct Poison {
+  template <class T> constexpr auto operator()(T) -> MustBeInt<T> { return {}; }
+};
+
+bool test() {
+  using T = std::constant_wrapper<Poison{}>;
+  T()(std::cw<5>);
+  return true;
+}


### PR DESCRIPTION
First, we can't just ignore the LValuePath of an lvalue APValue. Add code to handle that and a test case exercising the newly added code.

We also didn't look at APValue bases when initializing from an APValue.