### PR TITLE
[lldb] Fix has_lldb_codesign check

### DIFF
--- a/lldb/test/API/macosx/dsym_codesign/TestdSYMCodesign.py
+++ b/lldb/test/API/macosx/dsym_codesign/TestdSYMCodesign.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbtest import *
 def has_lldb_codesign():
     """Check if the lldb_codesign certificate is available."""
     try:
+        if lldbplatformutil.getPlatform() not in lldbplatformutil.getDarwinOSTriples():
+            return False
         result = subprocess.run(
             [
                 "security",

--- a/lldb/test/API/macosx/dsym_codesign/TestdSYMCodesign.py
+++ b/lldb/test/API/macosx/dsym_codesign/TestdSYMCodesign.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 
 import lldb
 from lldbsuite.test.decorators import *
@@ -10,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 def has_lldb_codesign():
     """Check if the lldb_codesign certificate is available."""
     try:
-        if lldbplatformutil.getPlatform() not in lldbplatformutil.getDarwinOSTriples():
+        if sys.platform != "darwin":
             return False
         result = subprocess.run(
             [


### PR DESCRIPTION
I met a problem with this test on WSL. WSL has access to Windows's files. Windows distribution has `security` dir ( `/mnt/c/Windows/security` from WSL point of view). So when we try to run `security` command we get `PermissionError` instead of `FileNotFoundError`. It is would not be a problem, but Python firstly calls decorators for methods (see example below), so we call `has_lldb_codesign()` not only on Darwin platform. Also I think some Linux distros might have `security` command, so  the current check is not robust enough.

```python
import unittest

def checker():
    raise Exception("test")

@unittest.skipUnless(False, "")
class Tests(unittest.TestCase):

    @unittest.skipUnless(checker(), ())
    def test():
        pass
```