### PR TITLE
Have LLVM_ENABLE_ZSTD defined as 0 in base select condition

### DIFF
--- a/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
@@ -23,7 +23,9 @@ cc_library_wrapper(
             "LLVM_ENABLE_ZSTD=1",
             "ZSTD_MULTITHREAD",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "LLVM_ENABLE_ZSTD=0",
+        ],
     }),
     deps = select({
         ":llvm_zstd_enabled": [


### PR DESCRIPTION
Very similar to https://github.com/llvm/llvm-project/pull/184525.  When this define is not present in the default select() condition, there is an issue building lldb using this build.bazel as a base for a BUCK file.