### PR TITLE
[lldb][windows] fix a race condition in IO reader thread

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -740,9 +740,39 @@ ProcessWindows::OnDebugException(bool first_chance,
     return ExceptionResult::SendToApplication;
   }
 
+  // Drain any in-flight process output before announcing the stop. The I/O
+  // reader thread and this debug-event thread run concurrently. Without
+  // synchronization the eBroadcastBitStateChanged(Stopped) event can reach
+  // the Debugger event thread before the preceding eBroadcastBitSTDOUT
+  // events.
+  auto drain_stdout = [this] {
+    if (!m_stdio_communication.ReadThreadIsRunning())
+      return;
+    m_stdio_communication.SynchronizeWithReadThread();
+    if (!m_pty || m_pty->GetMode() != PseudoConsole::Mode::ConPTY)
+      return;
+
+    HANDLE pipe = m_pty->GetSTDOUTHandle();
+    for (int consec_empty = 0; consec_empty < 3;) {
+      DWORD avail = 0;
+      if (!::PeekNamedPipe(pipe, nullptr, 0, nullptr, &avail, nullptr))
+        break;
+      if (avail > 0) {
+        consec_empty = 0;
+        if (m_stdio_communication.ReadThreadIsRunning())
+          m_stdio_communication.SynchronizeWithReadThread();
+      } else {
+        ++consec_empty;
+        if (consec_empty < 3)
+          ::SleepEx(1, FALSE);
+      }
+    }
+  };
+
   if (!first_chance) {
     // Not any second chance exception is an application crash by definition.
     // It may be an expression evaluation crash.
+    drain_stdout();
     SetPrivateState(eStateStopped);
   }
 
@@ -763,10 +793,12 @@ ProcessWindows::OnDebugException(bool first_chance,
       LLDB_LOG(log, "Hit non-loader breakpoint at address {0:x}.",
                record.GetExceptionAddress());
     }
+    drain_stdout();
     SetPrivateState(eStateStopped);
     break;
   case EXCEPTION_SINGLE_STEP:
     result = ExceptionResult::BreakInDebugger;
+    drain_stdout();
     SetPrivateState(eStateStopped);
     break;
   default:

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -754,13 +754,15 @@ ProcessWindows::OnDebugException(bool first_chance,
 
     HANDLE pipe = m_pty->GetSTDOUTHandle();
     for (int consec_empty = 0; consec_empty < 3;) {
+      if (!m_stdio_communication.ReadThreadIsRunning())
+        break;
       DWORD avail = 0;
+      // PeekNamedPipe is thread safe.
       if (!::PeekNamedPipe(pipe, nullptr, 0, nullptr, &avail, nullptr))
         break;
       if (avail > 0) {
         consec_empty = 0;
-        if (m_stdio_communication.ReadThreadIsRunning())
-          m_stdio_communication.SynchronizeWithReadThread();
+        m_stdio_communication.SynchronizeWithReadThread();
       } else {
         ++consec_empty;
         if (consec_empty < 3)


### PR DESCRIPTION
The reader thread and the debug event thread run concurrently. They are currently not synced. When the debuggee pauses (hitting a breakpoint), there is no guarantee lldb is done printing the stdout from the debuggee.

This patch synchronizes the read thread and the debugger thread everytime the debuggee stops. lldb will try to read from the conpty until no more data arrives for 3 consecutive reads.

# Before

```
lldb.exe "main.exe" -o "break set -p 'break here'" -o r -o c -o q
(lldb) target create "C:\\Users\\charleszablit\\Developer\\testing\\main.exe"
Current executable set to 'C:\Users\charleszablit\Developer\testing\main.exe' (x86_64).
(lldb) break set -p 'break here'
Breakpoint 1: where = main.exe`main + 46 at main.cpp:15, address = 0x000000014000bfde
(lldb) r
Process 30936 launched: 'C:\Users\charleszablit\Developer\testing\main.exe' (x86_64)
Process 30936 stopped
* thread #1, stop reason = breakpoint 1.1
       frame #0: 0x00007ff7668abfde main.exe`main at main.cpp:15
   12  
   13   int main() {
   14     std::cout << "Hello World!" << std::endl;
-> 15     std::cout << "Hello World!" << std::endl; // break here
   16     return 0;
   17   }
(lldb) c
Hello World!
Hello World!
Process 30936 resuming
Process 30936 exited with status = 0 (0x00000000)
(lldb) q
```

# After

```
lldb.exe "main.exe" -o "break set -p 'break here'" -o r -o c -o qset -p 'break here'" -o r -o c -o q
(lldb) target create "C:\\Users\\charleszablit\\Developer\\testing\\main.exe"
Current executable set to 'C:\Users\charleszablit\Developer\testing\main.exe' (x86_64).
(lldb) break set -p 'break here'
Breakpoint 1: where = main.exe`main + 46 at main.cpp:15, address = 0x000000014000bfde
(lldb) r
Hello World!
Process 38076 launched: 'C:\Users\charleszablit\Developer\testing\main.exe' (x86_64)
Process 38076 stopped
* thread #1, stop reason = breakpoint 1.1
       frame #0: 0x00007ff7668abfde main.exe`main at main.cpp:15
   12  
   13   int main() {
   14     std::cout << "Hello World!" << std::endl;
-> 15     std::cout << "Hello World!" << std::endl; // break here
   16     return 0;
   17   }
(lldb) c
Hello World!
Process 38076 resuming
Process 38076 exited with status = 0 (0x00000000)
(lldb) q
```