### PR TITLE
[llvm][ABI] Add NonTrivialCopyConstructor and NonTrivialDestructor RecordFlags

### DIFF
--- a/llvm/include/llvm/ABI/Types.h
+++ b/llvm/include/llvm/ABI/Types.h
@@ -257,7 +257,9 @@ enum RecordFlags : unsigned {
   IsCXXRecord = 1 << 3,
   IsPolymorphic = 1 << 4,
   HasFlexibleArrayMember = 1 << 5,
-  LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ HasFlexibleArrayMember),
+  HasNonTrivialCopyConstructor = 1 << 6,
+  HasNonTrivialDestructor = 1 << 7,
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ HasNonTrivialDestructor),
 };
 
 class RecordType : public Type {
@@ -294,6 +296,14 @@ public:
   bool hasFlexibleArrayMember() const {
     return static_cast<unsigned>(Flags & RecordFlags::HasFlexibleArrayMember) !=
            0;
+  }
+  bool hasNonTrivialCopyConstructor() const {
+    return static_cast<unsigned>(
+               Flags & RecordFlags::HasNonTrivialCopyConstructor) != 0;
+  }
+  bool hasNonTrivialDestructor() const {
+    return static_cast<unsigned>(Flags &
+                                 RecordFlags::HasNonTrivialDestructor) != 0;
   }
   uint32_t getNumBaseClasses() const { return BaseClasses.size(); }
   uint32_t getNumVirtualBaseClasses() const {

--- a/llvm/unittests/ABI/CMakeLists.txt
+++ b/llvm/unittests/ABI/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  ABI
+  Support
+  )
+
+add_llvm_unittest(ABITests
+  TypesTest.cpp
+  )

--- a/llvm/unittests/ABI/TypesTest.cpp
+++ b/llvm/unittests/ABI/TypesTest.cpp
@@ -1,0 +1,79 @@
+//===- TypesTest.cpp - Unit tests for ABI Types ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::abi;
+
+namespace {
+
+class ABITypesTest : public ::testing::Test {
+protected:
+  BumpPtrAllocator Alloc;
+  TypeBuilder TB{Alloc};
+};
+
+TEST_F(ABITypesTest, RecordFlagsNonTrivialCopyConstructor) {
+  RecordFlags Flags =
+      RecordFlags::IsCXXRecord | RecordFlags::HasNonTrivialCopyConstructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->hasNonTrivialDestructor());
+  EXPECT_TRUE(RT->isCXXRecord());
+}
+
+TEST_F(ABITypesTest, RecordFlagsNonTrivialDestructor) {
+  RecordFlags Flags =
+      RecordFlags::IsCXXRecord | RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+}
+
+TEST_F(ABITypesTest, RecordFlagsBothNonTrivial) {
+  RecordFlags Flags = RecordFlags::IsCXXRecord |
+                      RecordFlags::HasNonTrivialCopyConstructor |
+                      RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+}
+
+TEST_F(ABITypesTest, RecordFlagsNoneSet) {
+  const RecordType *RT = TB.getRecordType({}, TypeSize::getFixed(64), Align(8));
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->hasNonTrivialDestructor());
+  EXPECT_FALSE(RT->isCXXRecord());
+  EXPECT_FALSE(RT->isUnion());
+  EXPECT_FALSE(RT->isPolymorphic());
+}
+
+TEST_F(ABITypesTest, RecordFlagsCombineWithExisting) {
+  RecordFlags Flags = RecordFlags::CanPassInRegisters |
+                      RecordFlags::IsCXXRecord |
+                      RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->canPassInRegisters());
+  EXPECT_TRUE(RT->isCXXRecord());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->isUnion());
+}
+
+} // namespace

--- a/llvm/unittests/CMakeLists.txt
+++ b/llvm/unittests/CMakeLists.txt
@@ -29,6 +29,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif ()
 
 add_subdirectory(ADT)
+add_subdirectory(ABI)
 add_subdirectory(Analysis)
 add_subdirectory(AsmParser)
 add_subdirectory(BinaryFormat)


### PR DESCRIPTION
Breakout from @vortex73's PR #140112.

Add HasNonTrivialCopyConstructor and HasNonTrivialDestructor flags to RecordFlags, with accessor methods on RecordType. These flags are needed by target-specific ABI classifiers (e.g. X86_64) to determine whether a C++ record type must be passed indirectly per the Itanium ABI.

Also adds unit test infrastructure for the ABI library (llvm/unittests/ABI/) with tests for the new flags and their interaction with existing flags.

This is Narayan's design and logic from the LLVM ABI Lowering Library, adapted to the current upstream API.

Made with [Cursor](https://cursor.com)