### PR TITLE
[llvm][ABI] Add X86_64 ABI classifier

### DIFF
--- a/llvm/include/llvm/ABI/TargetInfo.h
+++ b/llvm/include/llvm/ABI/TargetInfo.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ABI/FunctionInfo.h"
 #include "llvm/ABI/Types.h"
+#include "llvm/TargetParser/Triple.h"
 #include <cassert>
 
 namespace llvm {
@@ -82,6 +83,19 @@ protected:
 };
 
 std::unique_ptr<TargetInfo> createBPFTargetInfo(TypeBuilder &TB);
+
+/// The AVX ABI level for X86 targets.
+enum class X86AVXABILevel {
+  None,
+  AVX,
+  AVX512,
+};
+
+std::unique_ptr<TargetInfo> createX8664TargetInfo(TypeBuilder &TB,
+                                                  const Triple &Triple,
+                                                  X86AVXABILevel AVXLevel,
+                                                  bool Has64BitPointers,
+                                                  const ABICompatInfo &Compat);
 
 } // namespace abi
 } // namespace llvm

--- a/llvm/include/llvm/ABI/Types.h
+++ b/llvm/include/llvm/ABI/Types.h
@@ -257,7 +257,9 @@ enum RecordFlags : unsigned {
   IsCXXRecord = 1 << 3,
   IsPolymorphic = 1 << 4,
   HasFlexibleArrayMember = 1 << 5,
-  LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ HasFlexibleArrayMember),
+  HasNonTrivialCopyConstructor = 1 << 6,
+  HasNonTrivialDestructor = 1 << 7,
+  LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ HasNonTrivialDestructor),
 };
 
 class RecordType : public Type {
@@ -294,6 +296,14 @@ public:
   bool hasFlexibleArrayMember() const {
     return static_cast<unsigned>(Flags & RecordFlags::HasFlexibleArrayMember) !=
            0;
+  }
+  bool hasNonTrivialCopyConstructor() const {
+    return static_cast<unsigned>(
+               Flags & RecordFlags::HasNonTrivialCopyConstructor) != 0;
+  }
+  bool hasNonTrivialDestructor() const {
+    return static_cast<unsigned>(Flags &
+                                 RecordFlags::HasNonTrivialDestructor) != 0;
   }
   uint32_t getNumBaseClasses() const { return BaseClasses.size(); }
   uint32_t getNumVirtualBaseClasses() const {

--- a/llvm/lib/ABI/CMakeLists.txt
+++ b/llvm/lib/ABI/CMakeLists.txt
@@ -3,6 +3,7 @@ add_llvm_component_library(LLVMABI
   FunctionInfo.cpp
   TargetInfo.cpp
   Targets/BPF.cpp
+  Targets/X86.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/ABI
@@ -13,5 +14,6 @@ add_llvm_component_library(LLVMABI
   LINK_COMPONENTS
   Core
   Support
+  TargetParser
 )
 

--- a/llvm/lib/ABI/Targets/X86.cpp
+++ b/llvm/lib/ABI/Targets/X86.cpp
@@ -1,0 +1,1335 @@
+//===- X86.cpp ------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/FunctionInfo.h"
+#include "llvm/ABI/TargetInfo.h"
+#include "llvm/ABI/Types.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/TypeSize.h"
+#include "llvm/TargetParser/Triple.h"
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+namespace llvm {
+namespace abi {
+
+static bool isEmptyForABI(const Type *Ty) {
+  if (auto *RT = dyn_cast<RecordType>(Ty))
+    return RT->isEmpty();
+  return Ty->getSizeInBits().getFixedValue() == 0;
+}
+
+static const FieldInfo *getElementContainingOffset(const RecordType *RT,
+                                                   unsigned OffsetInBits) {
+  SmallVector<std::pair<unsigned, const FieldInfo *>> AllElements;
+  for (const auto &Base : RT->getBaseClasses())
+    if (!isEmptyForABI(Base.FieldType))
+      AllElements.emplace_back(Base.OffsetInBits, &Base);
+  for (const auto &VBase : RT->getVirtualBaseClasses())
+    if (!isEmptyForABI(VBase.FieldType))
+      AllElements.emplace_back(VBase.OffsetInBits, &VBase);
+  for (const auto &Field : RT->getFields()) {
+    if (Field.IsUnnamedBitfield)
+      continue;
+    AllElements.emplace_back(Field.OffsetInBits, &Field);
+  }
+  llvm::stable_sort(AllElements, [](const auto &A, const auto &B) {
+    return A.first < B.first;
+  });
+  auto It = llvm::upper_bound(
+      AllElements, OffsetInBits,
+      [](unsigned Offset, const auto &E) { return Offset < E.first; });
+  if (It == AllElements.begin())
+    return nullptr;
+  --It;
+  return It->second;
+}
+
+static unsigned getNativeVectorSizeForAVXABI(X86AVXABILevel AVXLevel) {
+  switch (AVXLevel) {
+  case X86AVXABILevel::AVX512:
+    return 512;
+  case X86AVXABILevel::AVX:
+    return 256;
+  case X86AVXABILevel::None:
+    return 128;
+  }
+  llvm_unreachable("Unknown AVXLevel");
+}
+
+class X86_64ABIInfo : public TargetInfo {
+public:
+  enum Class {
+    Integer = 0,
+    SSE,
+    SSEUp,
+    X87,
+    X87UP,
+    Complex_X87,
+    NoClass,
+    Memory
+  };
+
+private:
+  TypeBuilder &TB;
+  X86AVXABILevel AVXLevel;
+  bool Has64BitPointers;
+  const llvm::Triple &TargetTriple;
+
+  static Class merge(Class Accum, Class Field);
+
+  void postMerge(unsigned AggregateSize, Class &Lo, Class &Hi) const;
+
+  void classify(const Type *T, uint64_t OffsetBase, Class &Lo, Class &Hi,
+                bool IsNamedArg, bool IsRegCall = false) const;
+
+  const Type *getIntegerTypeAtOffset(const Type *IRType, unsigned IROffset,
+                                     const Type *SourceTy,
+                                     unsigned SourceOffset,
+                                     bool InMemory = false) const;
+
+  const Type *getSSETypeAtOffset(const Type *ABIType, unsigned ABIOffset,
+                                 const Type *SourceTy,
+                                 unsigned SourceOffset) const;
+  bool isIllegalVectorType(const Type *Ty) const;
+  bool containsMatrixField(const RecordType *RT) const;
+
+  void computeInfo(FunctionInfo &FI) const override;
+  ArgInfo getIndirectReturnResult(const Type *Ty) const;
+  const Type *getFPTypeAtOffset(const Type *Ty, unsigned Offset) const;
+
+  const Type *isSingleElementStruct(const Type *Ty) const;
+  const Type *getByteVectorType(const Type *Ty) const;
+
+  const Type *createPairType(const Type *Lo, const Type *Hi) const;
+  ArgInfo getIndirectResult(const Type *Ty, unsigned FreeIntRegs) const;
+
+  ArgInfo classifyReturnType(const Type *RetTy) const;
+  const char *getClassName(Class C) const;
+
+  ArgInfo classifyArgumentType(const Type *Ty, unsigned FreeIntRegs,
+                               unsigned &NeededInt, unsigned &NeededSse,
+                               bool IsNamedArg, bool IsRegCall = false) const;
+  const Type *useFirstFieldIfTransparentUnion(const Type *Ty) const;
+
+public:
+  X86_64ABIInfo(TypeBuilder &TypeBuilder, const Triple &Triple,
+                X86AVXABILevel AVXABILevel, bool Has64BitPtrs,
+                const ABICompatInfo &Compat)
+      : TargetInfo(Compat), TB(TypeBuilder), AVXLevel(AVXABILevel),
+        Has64BitPointers(Has64BitPtrs), TargetTriple(Triple) {}
+
+  bool has64BitPointers() const { return Has64BitPointers; }
+};
+
+static const Type *reduceUnionForX8664(const RecordType *UnionType,
+                                       TypeBuilder &TB) {
+  assert(UnionType->isUnion() && "Expected union type");
+
+  ArrayRef<FieldInfo> Fields = UnionType->getFields();
+  if (Fields.empty()) {
+    return nullptr;
+  }
+
+  const Type *StorageType = nullptr;
+
+  for (const auto &Field : Fields) {
+    if (Field.IsBitField && Field.IsUnnamedBitfield &&
+        Field.BitFieldWidth == 0) {
+      continue;
+    }
+
+    const Type *FieldType = Field.FieldType;
+
+    if (UnionType->isTransparentUnion() && !StorageType) {
+      StorageType = FieldType;
+      break;
+    }
+
+    if (!StorageType ||
+        FieldType->getAlignment() > StorageType->getAlignment() ||
+        (FieldType->getAlignment() == StorageType->getAlignment() &&
+         TypeSize::isKnownGT(FieldType->getSizeInBits(),
+                             StorageType->getSizeInBits()))) {
+      StorageType = FieldType;
+    }
+  }
+  return StorageType;
+}
+
+void X86_64ABIInfo::postMerge(unsigned AggregateSize, Class &Lo,
+                              Class &Hi) const {
+  // AMD64-ABI 3.2.3p2: Rule 5. Then a post merger cleanup is done:
+  //
+  // (a) If one of the classes is Memory, the whole argument is passed in
+  //     memory.
+  //
+  // (b) If X87UP is not preceded by X87, the whole argument is passed in
+  //     memory.
+  //
+  // (c) If the size of the aggregate exceeds two eightbytes and the first
+  //     eightbyte isn't SSE or any other eightbyte isn't SSEUP, the whole
+  //     argument is passed in memory. NOTE: This is necessary to keep the
+  //     ABI working for processors that don't support the __m256 type.
+  //
+  // (d) If SSEUP is not preceded by SSE or SSEUP, it is converted to SSE.
+  //
+  // Some of these are enforced by the merging logic.  Others can arise
+  // only with unions; for example:
+  //   union { _Complex double; unsigned; }
+  //
+  // Note that clauses (b) and (c) were added in 0.98.
+
+  if (Hi == Memory)
+    Lo = Memory;
+  if (Hi == X87UP && Lo != X87 && getABICompatInfo().HonorsRevision98)
+    Lo = Memory;
+  if (AggregateSize > 128 && (Lo != SSE || Hi != SSEUp))
+    Lo = Memory;
+  if (Hi == SSEUp && Lo != SSE)
+    Hi = SSE;
+}
+X86_64ABIInfo::Class X86_64ABIInfo::merge(Class Accum, Class Field) {
+  // AMD64-ABI 3.2.3p2: Rule 4. Each field of an object is
+  // classified recursively so that always two fields are
+  // considered. The resulting class is calculated according to
+  // the classes of the fields in the eightbyte:
+  //
+  // (a) If both classes are equal, this is the resulting class.
+  //
+  // (b) If one of the classes is NO_CLASS, the resulting class is
+  // the other class.
+  //
+  // (c) If one of the classes is MEMORY, the result is the MEMORY
+  // class.
+  //
+  // (d) If one of the classes is INTEGER, the result is the
+  // INTEGER.
+  //
+  // (e) If one of the classes is X87, X87UP, COMPLEX_X87 class,
+  // MEMORY is used as class.
+  //
+  // (f) Otherwise class SSE is used.
+
+  // Accum should never be memory (we should have returned) or
+  // ComplexX87 (because this cannot be passed in a structure).
+  assert((Accum != Memory && Accum != Complex_X87) &&
+         "Invalid accumulated classification during merge.");
+
+  if (Accum == Field || Field == NoClass)
+    return Accum;
+  if (Accum == NoClass)
+    return Field;
+  if (Field == Memory)
+    return Memory;
+  if (Accum == Integer || Field == Integer)
+    return Integer;
+  if (Field == X87 || Field == X87UP || Field == Complex_X87 || Accum == X87 ||
+      Accum == X87UP)
+    return Memory;
+
+  return SSE;
+}
+
+bool X86_64ABIInfo::containsMatrixField(const RecordType *RT) const {
+  for (const auto &Field : RT->getFields()) {
+    const Type *FieldType = Field.FieldType;
+
+    if (const auto *AT = dyn_cast<ArrayType>(FieldType))
+      return AT->isMatrixType();
+
+    if (const auto *NestedRT = dyn_cast<RecordType>(FieldType))
+      return containsMatrixField(NestedRT);
+  }
+  return false;
+}
+
+void X86_64ABIInfo::classify(const Type *T, uint64_t OffsetBase, Class &Lo,
+                             Class &Hi, bool IsNamedArg, bool IsRegCall) const {
+  Lo = Hi = NoClass;
+  Class &Current = OffsetBase < 64 ? Lo : Hi;
+  Current = Memory;
+
+  if (T->isVoid()) {
+    Current = NoClass;
+    return;
+  }
+
+  if (const auto *IT = dyn_cast<IntegerType>(T)) {
+    uint64_t BitWidth = IT->getSizeInBits().getFixedValue();
+
+    if (BitWidth == 128 ||
+        (IT->isBitInt() && BitWidth > 64 && BitWidth <= 128)) {
+      Lo = Integer;
+      Hi = Integer;
+    } else if (BitWidth <= 64)
+      Current = Integer;
+
+    return;
+  }
+
+  if (const auto *FT = dyn_cast<FloatType>(T)) {
+    const fltSemantics *FltSem = FT->getSemantics();
+
+    if (FltSem == &llvm::APFloat::IEEEsingle() ||
+        FltSem == &llvm::APFloat::IEEEdouble() ||
+        FltSem == &llvm::APFloat::IEEEhalf() ||
+        FltSem == &llvm::APFloat::BFloat()) {
+      Current = SSE;
+    } else if (FltSem == &llvm::APFloat::IEEEquad()) {
+      Lo = SSE;
+      Hi = SSEUp;
+    } else if (FltSem == &llvm::APFloat::x87DoubleExtended()) {
+      Lo = X87;
+      Hi = X87UP;
+    } else
+      Current = SSE;
+    return;
+  }
+  if (T->isPointer()) {
+    Current = Integer;
+    return;
+  }
+
+  if (const auto *MPT = dyn_cast<MemberPointerType>(T)) {
+    if (MPT->isFunctionPointer()) {
+      if (Has64BitPointers) {
+        Lo = Hi = Integer;
+      } else {
+        uint64_t EbFuncPtr = OffsetBase / 64;
+        uint64_t EbThisAdj = (OffsetBase + 64 - 1) / 64;
+        if (EbFuncPtr != EbThisAdj) {
+          Lo = Hi = Integer;
+        } else
+          Current = Integer;
+      }
+    } else
+      Current = Integer;
+    return;
+  }
+
+  if (const auto *VT = dyn_cast<VectorType>(T)) {
+    uint64_t Size = VT->getSizeInBits().getFixedValue();
+    const Type *ElementType = VT->getElementType();
+
+    if (Size == 1 || Size == 8 || Size == 16 || Size == 32) {
+      Current = Integer;
+      uint64_t EbLo = (OffsetBase) / 64;
+      uint64_t EbHi = (OffsetBase + Size - 1) / 64;
+      if (EbLo != EbHi)
+        Hi = Lo;
+    } else if (Size == 64) {
+      if (const auto *FT = dyn_cast<FloatType>(ElementType)) {
+        if (FT->getSemantics() == &llvm::APFloat::IEEEdouble())
+          return;
+      }
+
+      if (const auto *IT = dyn_cast<IntegerType>(ElementType)) {
+        uint64_t ElemBits = IT->getSizeInBits().getFixedValue();
+        if (!getABICompatInfo().ClassifyIntegerMMXAsSSE &&
+            (ElemBits == 64 || ElemBits == 32)) {
+          Current = Integer;
+        } else
+          Current = SSE;
+      } else
+        Current = SSE;
+      if (OffsetBase && OffsetBase != 64)
+        Hi = Lo;
+    } else if (Size == 128 ||
+               (IsNamedArg && Size <= getNativeVectorSizeForAVXABI(AVXLevel))) {
+      if (const auto *IT = dyn_cast<IntegerType>(ElementType)) {
+        uint64_t ElemBits = IT->getSizeInBits().getFixedValue();
+        if (getABICompatInfo().PassInt128VectorsInMem && Size != 128 &&
+            ElemBits == 128)
+          return;
+      }
+
+      // Arguments of 256-bits are split into four eightbyte chunks.
+      // The least significant one belongs to class SSE and all the
+      // others to class SSEUP.  The original Lo and Hi design
+      // considers that types can't be greater than 128-bits, so a
+      // 64-bit split in Hi and Lo makes sense.  This design isn't
+      // correct for 256-bits, but since there're no cases where the
+      // upper parts would need to be inspected, avoid adding
+      // complexity and just consider Hi to match the 64-256 part.
+      //
+      // Note that per 3.5.7 of AMD64-ABI, 256-bit args are only
+      // passed in registers if they are "named", i.e. not part of
+      // the "..." of a variadic function.
+      //
+      // Similarly, per 3.2.3. of the AVX512 draft, 512-bits
+      // ("named") args are split into eight eightbyte chunks, one
+      // SSE and seven SSEUP.
+      Lo = SSE;
+      Hi = SSEUp;
+    }
+    return;
+  }
+
+  if (const auto *CT = dyn_cast<ComplexType>(T)) {
+    const Type *ElementType = CT->getElementType();
+    uint64_t Size = T->getSizeInBits().getFixedValue();
+
+    if (isa<IntegerType>(ElementType)) {
+      if (Size <= 64)
+        Current = Integer;
+      else if (Size <= 128)
+        Lo = Hi = Integer;
+    } else if (const auto *EFT = dyn_cast<FloatType>(ElementType)) {
+      const fltSemantics *FltSem = EFT->getSemantics();
+      if (FltSem == &llvm::APFloat::IEEEhalf() ||
+          FltSem == &llvm::APFloat::IEEEsingle() ||
+          FltSem == &llvm::APFloat::BFloat())
+        Current = SSE;
+      else if (FltSem == &llvm::APFloat::IEEEquad())
+        Current = Memory;
+      else if (FltSem == &llvm::APFloat::x87DoubleExtended())
+        Current = Complex_X87;
+      else if (FltSem == &llvm::APFloat::IEEEdouble())
+        Lo = Hi = SSE;
+      else
+        llvm_unreachable("Unexpected long double representation!");
+    }
+
+    uint64_t ElementSize = ElementType->getSizeInBits().getFixedValue();
+    uint64_t EbReal = OffsetBase / 64;
+    uint64_t EbImag = (OffsetBase + ElementSize) / 64;
+    if (Hi == NoClass && EbReal != EbImag)
+      Hi = Lo;
+
+    return;
+  }
+
+  if (const auto *AT = dyn_cast<ArrayType>(T)) {
+    uint64_t Size = AT->getSizeInBits().getFixedValue();
+
+    if (!IsRegCall && Size > 512)
+      return;
+
+    const Type *ElementType = AT->getElementType();
+    uint64_t ElemAlign = ElementType->getAlignment().value() * 8;
+    if (OffsetBase % ElemAlign)
+      return;
+
+    Current = NoClass;
+    uint64_t EltSize = ElementType->getSizeInBits().getFixedValue();
+    uint64_t ArraySize = AT->getNumElements();
+
+    if (Size > 128 &&
+        (Size != EltSize || Size > getNativeVectorSizeForAVXABI(AVXLevel)))
+      return;
+
+    for (uint64_t I = 0, Offset = OffsetBase; I < ArraySize;
+         ++I, Offset += EltSize) {
+      Class FieldLo, FieldHi;
+      classify(ElementType, Offset, FieldLo, FieldHi, IsNamedArg);
+      Lo = merge(Lo, FieldLo);
+      Hi = merge(Hi, FieldHi);
+      if (Lo == Memory || Hi == Memory)
+        break;
+    }
+    postMerge(Size, Lo, Hi);
+    assert((Hi != SSEUp || Lo == SSE) && "Invalid SSEUp array classification.");
+    return;
+  }
+  if (const auto *RT = dyn_cast<RecordType>(T)) {
+    uint64_t Size = RT->getSizeInBits().getFixedValue();
+
+    if (containsMatrixField(RT)) {
+      Lo = Memory;
+      return;
+    }
+
+    // AMD64-ABI 3.2.3p2: Rule 1. If the size of an object is
+    // larger than eight eightbytes, ..., it has class MEMORY.
+    if (Size > 512)
+      return;
+
+    // AMD64-ABI 3.2.3p2: Rule 2. If a C++ object has either a
+    // non-trivial copy constructor or a non-trivial destructor, it
+    // is passed by invisible reference.
+    if (getRecordArgABI(RT))
+      return;
+
+    if (RT->hasFlexibleArrayMember())
+      return;
+
+    Current = NoClass;
+
+    if (RT->isCXXRecord()) {
+      for (const auto &Base : RT->getBaseClasses()) {
+
+        // Classify this field.
+        //
+        // AMD64-ABI 3.2.3p2: Rule 3. If the size of the aggregate
+        // exceeds a single eightbyte, each is classified
+        // separately.  Each eightbyte gets initialized to class
+        // NO_CLASS.
+        Class FieldLo, FieldHi;
+        uint64_t Offset = OffsetBase + Base.OffsetInBits;
+        classify(Base.FieldType, Offset, FieldLo, FieldHi, IsNamedArg);
+        Lo = merge(Lo, FieldLo);
+        Hi = merge(Hi, FieldHi);
+
+        if (getABICompatInfo().ReturnCXXRecordGreaterThan128InMem &&
+            (Size > 128 &&
+             (Size != Base.FieldType->getSizeInBits().getFixedValue() ||
+              Size > getNativeVectorSizeForAVXABI(AVXLevel)))) {
+          Lo = Memory;
+          postMerge(Size, Lo, Hi);
+          return;
+        }
+
+        if (Lo == Memory || Hi == Memory) {
+          postMerge(Size, Lo, Hi);
+          return;
+        }
+      }
+    }
+
+    bool IsUnion = RT->isUnion() && !getABICompatInfo().Clang11Compat;
+    for (const auto &Field : RT->getFields()) {
+      uint64_t Offset = OffsetBase + Field.OffsetInBits;
+      bool BitField = Field.IsBitField;
+
+      if (BitField && Field.IsUnnamedBitfield)
+        continue;
+
+      if (Size > 128 &&
+          ((!IsUnion &&
+            Size != Field.FieldType->getSizeInBits().getFixedValue()) ||
+           Size > getNativeVectorSizeForAVXABI(AVXLevel))) {
+        Lo = Memory;
+        postMerge(Size, Lo, Hi);
+        return;
+      }
+
+      bool IsInMemory = Offset % (Field.FieldType->getAlignment().value() * 8);
+      if (!BitField && IsInMemory) {
+        Lo = Memory;
+        postMerge(Size, Lo, Hi);
+        return;
+      }
+
+      Class FieldLo, FieldHi;
+
+      if (BitField) {
+        uint64_t BitFieldSize = Field.BitFieldWidth;
+        uint64_t EbLo = Offset / 64;
+        uint64_t EbHi = (Offset + BitFieldSize - 1) / 64;
+
+        if (EbLo) {
+          assert(EbHi == EbLo && "Invalid classification, type > 16 bytes.");
+          FieldLo = NoClass;
+          FieldHi = Integer;
+        } else {
+          FieldLo = Integer;
+          FieldHi = EbHi ? Integer : NoClass;
+        }
+      } else
+        classify(Field.FieldType, Offset, FieldLo, FieldHi, IsNamedArg);
+
+      Lo = merge(Lo, FieldLo);
+      Hi = merge(Hi, FieldHi);
+      if (Lo == Memory || Hi == Memory)
+        break;
+    }
+    postMerge(Size, Lo, Hi);
+    return;
+  }
+
+  Lo = Memory;
+  Hi = NoClass;
+}
+
+const Type *
+X86_64ABIInfo::useFirstFieldIfTransparentUnion(const Type *Ty) const {
+  if (const auto *RT = dyn_cast<RecordType>(Ty)) {
+    if (RT->isUnion() && RT->isTransparentUnion()) {
+      ArrayRef<FieldInfo> Fields = RT->getFields();
+      assert(!Fields.empty() && "sema created an empty transparent union");
+      return Fields.front().FieldType;
+    }
+  }
+  return Ty;
+}
+
+ArgInfo
+X86_64ABIInfo::classifyArgumentType(const Type *Ty, unsigned FreeIntRegs,
+                                    unsigned &NeededInt, unsigned &NeededSSE,
+                                    bool IsNamedArg, bool IsRegCall) const {
+
+  Ty = useFirstFieldIfTransparentUnion(Ty);
+
+  X86_64ABIInfo::Class Lo, Hi;
+  classify(Ty, 0, Lo, Hi, IsNamedArg, IsRegCall);
+
+  assert((Hi != Memory || Lo == Memory) && "Invalid memory classification.");
+  assert((Hi != SSEUp || Lo == SSE) && "Invalid SSEUp classification.");
+
+  NeededInt = 0;
+  NeededSSE = 0;
+  const Type *ResType = nullptr;
+
+  switch (Lo) {
+  case NoClass:
+    if (Hi == NoClass)
+      return ArgInfo::getIgnore();
+    assert((Hi == SSE || Hi == Integer || Hi == X87UP) &&
+           "Unknown missing lo part");
+    break;
+
+    // AMD64-ABI 3.2.3p3: Rule 1. If the class is MEMORY, pass the
+    // argument on the stack.
+  case Memory:
+    // AMD64-ABI 3.2.3p3: Rule 5. If the class is X87, X87UP or
+    // COMPLEX_X87, it is passed in memory.
+  case X87:
+  case Complex_X87:
+    if (getRecordArgABI(dyn_cast<RecordType>(Ty)) == RAA_Indirect)
+      ++NeededInt;
+    return getIndirectResult(Ty, FreeIntRegs);
+
+  case SSEUp:
+  case X87UP:
+    llvm_unreachable("Invalid classification for lo word.");
+
+    // AMD64-ABI 3.2.3p3: Rule 2. If the class is INTEGER, the
+    // next available register of the sequence %rdi, %rsi, %rdx,
+    // %rcx, %r8 and %r9 is used.
+  case Integer:
+    ++NeededInt;
+
+    ResType = getIntegerTypeAtOffset(Ty, 0, Ty, 0);
+
+    if (Hi == NoClass && ResType->isInteger()) {
+      if (Ty->isInteger() && isPromotableInteger(cast<IntegerType>(Ty)))
+        return ArgInfo::getExtend(Ty);
+    }
+
+    if (ResType->isInteger() && ResType->getSizeInBits() == 128) {
+      assert(Hi == Integer);
+      ++NeededInt;
+      return ArgInfo::getDirect(ResType);
+    }
+    break;
+
+    // AMD64-ABI 3.2.3p3: Rule 3. If the class is SSE, the next
+    // available SSE register is used, the registers are taken in
+    // the order from %xmm0 to %xmm7.
+  case SSE:
+    ResType = getSSETypeAtOffset(Ty, 0, Ty, 0);
+    ++NeededSSE;
+    break;
+  }
+
+  const Type *HighPart = nullptr;
+  switch (Hi) {
+  case Memory:
+  case X87:
+  case Complex_X87:
+    llvm_unreachable("Invalid classification for hi word.");
+
+  case NoClass:
+    break;
+
+  case Integer:
+    ++NeededInt;
+    HighPart = getIntegerTypeAtOffset(Ty, 8, Ty, 8);
+
+    if (Lo == NoClass)
+      return ArgInfo::getDirect(HighPart, 8);
+    break;
+
+    // X87UP generally doesn't occur here (long double is passed in
+    // memory), except in situations involving unions.
+  case X87UP:
+  case SSE:
+    ++NeededSSE;
+    HighPart = getSSETypeAtOffset(Ty, 8, Ty, 8);
+
+    if (Lo == NoClass)
+      return ArgInfo::getDirect(HighPart, 8);
+    break;
+
+    // AMD64-ABI 3.2.3p3: Rule 4. If the class is SSEUP, the
+    // eightbyte is passed in the upper half of the last used SSE
+    // register.  This only happens when 128-bit vectors are
+    // passed.
+  case SSEUp:
+    assert(Lo == SSE && "Unexpected SSEUp classification");
+    ResType = getByteVectorType(Ty);
+    break;
+  }
+
+  if (HighPart)
+    ResType = createPairType(ResType, HighPart);
+
+  return ArgInfo::getDirect(ResType);
+}
+
+ArgInfo X86_64ABIInfo::classifyReturnType(const Type *RetTy) const {
+  // AMD64-ABI 3.2.3p4: Rule 1. Classify the return type with the
+  // classification algorithm.
+
+  X86_64ABIInfo::Class Lo, Hi;
+  classify(RetTy, 0, Lo, Hi, /*isNamedArg*/ true);
+
+  assert((Hi != Memory || Lo == Memory) && "Invalid memory classification.");
+  assert((Hi != SSEUp || Lo == SSE) && "Invalid SSEUp classification.");
+
+  const Type *ResType = nullptr;
+  switch (Lo) {
+  case NoClass:
+    if (Hi == NoClass)
+      return ArgInfo::getIgnore();
+    assert((Hi == SSE || Hi == Integer || Hi == X87UP) &&
+           "Unknown missing lo part");
+    break;
+  case SSEUp:
+  case X87UP:
+    llvm_unreachable("Invalid classification for lo word.");
+
+    // AMD64-ABI 3.2.3p4: Rule 2. Types of class memory are
+    // returned via hidden argument.
+  case Memory:
+    return getIndirectReturnResult(RetTy);
+
+    // AMD64-ABI 3.2.3p4: Rule 3. If the class is INTEGER, the
+    // next available register of the sequence %rax, %rdx is used.
+  case Integer:
+    ResType = getIntegerTypeAtOffset(RetTy, 0, RetTy, 0);
+    if (Hi == NoClass && ResType->isInteger()) {
+      if (const IntegerType *IntTy = dyn_cast<IntegerType>(RetTy)) {
+        if (isPromotableInteger(IntTy)) {
+          ArgInfo Info = ArgInfo::getExtend(RetTy);
+          return Info;
+        }
+      }
+    }
+    if (ResType->isInteger() && ResType->getSizeInBits() == 128) {
+      assert(Hi == Integer);
+      return ArgInfo::getDirect(ResType);
+    }
+    break;
+
+    // AMD64-ABI 3.2.3p4: Rule 4. If the class is SSE, the next
+    // available SSE register of the sequence %xmm0, %xmm1 is
+    // used.
+  case SSE:
+    ResType = getSSETypeAtOffset(RetTy, 0, RetTy, 0);
+    break;
+
+    // AMD64-ABI 3.2.3p4: Rule 6. If the class is X87, the value
+    // is returned on the X87 stack in %st0 as 80-bit x87 number.
+  case X87:
+    ResType = TB.getFloatType(APFloat::x87DoubleExtended(), Align(16));
+    break;
+
+    // AMD64-ABI 3.2.3p4: Rule 8. If the class is COMPLEX_X87,
+    // the real part of the value is returned in %st0 and the
+    // imaginary part in %st1.
+  case Complex_X87:
+    assert(Hi == Complex_X87 && "Unexpected ComplexX87 classification.");
+    {
+      const Type *X87Type =
+          TB.getFloatType(APFloat::x87DoubleExtended(), Align(16));
+      FieldInfo Fields[] = {FieldInfo(X87Type, 0), FieldInfo(X87Type, 128)};
+      ResType = TB.getRecordType(Fields, TypeSize::getFixed(256), Align(16),
+                                 StructPacking::Default, {}, {},
+                                 RecordFlags::CanPassInRegisters);
+    }
+    break;
+  }
+
+  const Type *HighPart = nullptr;
+  switch (Hi) {
+  case Memory:
+  case X87:
+    llvm_unreachable("Invalid classification for hi word.");
+
+  case Complex_X87:
+  case NoClass:
+    break;
+
+  case Integer:
+    HighPart = getIntegerTypeAtOffset(RetTy, 8, RetTy, 8);
+    if (Lo == NoClass)
+      return ArgInfo::getDirect(HighPart, 8);
+    break;
+
+  case SSE:
+    HighPart = getSSETypeAtOffset(RetTy, 8, RetTy, 8);
+    if (Lo == NoClass)
+      return ArgInfo::getDirect(HighPart, 8);
+    break;
+
+    // AMD64-ABI 3.2.3p4: Rule 5. If the class is SSEUP, the
+    // eightbyte is passed in the next available eightbyte chunk if
+    // the last used vector register.
+    //
+    // SSEUP should always be preceded by SSE, just widen.
+  case SSEUp:
+    assert(Lo == SSE && "Unexpected SSEUp classification.");
+    ResType = getByteVectorType(RetTy);
+    break;
+
+    // AMD64-ABI 3.2.3p4: Rule 7. If the class is X87UP, the
+    // value is returned together with the previous X87 value in
+    // %st0.
+  case X87UP:
+    if (Lo != X87) {
+      HighPart = getSSETypeAtOffset(RetTy, 8, RetTy, 8);
+      if (Lo == NoClass)
+        return ArgInfo::getDirect(HighPart, 8);
+    }
+    break;
+  }
+
+  if (HighPart)
+    ResType = createPairType(ResType, HighPart);
+
+  return ArgInfo::getDirect(ResType);
+}
+
+const Type *X86_64ABIInfo::createPairType(const Type *Lo,
+                                          const Type *Hi) const {
+  unsigned LoSize = (unsigned)Lo->getTypeAllocSize();
+  Align HiAlign = Hi->getAlignment();
+  unsigned HiStart = alignTo(LoSize, HiAlign);
+
+  assert(HiStart != 0 && HiStart <= 8 && "Invalid x86-64 argument pair!");
+
+  const Type *AdjustedLo = Lo;
+  if (HiStart != 8) {
+    if (Lo->isFloat()) {
+      const FloatType *FT = cast<FloatType>(Lo);
+      if (FT->getSemantics() == &APFloat::IEEEhalf() ||
+          FT->getSemantics() == &APFloat::IEEEsingle() ||
+          FT->getSemantics() == &APFloat::BFloat())
+        AdjustedLo = TB.getFloatType(APFloat::IEEEdouble(), Align(8));
+    } else if (Lo->isInteger() || Lo->isPointer())
+      AdjustedLo = TB.getIntegerType(64, Align(8), /*Signed=*/false);
+    else
+      assert((Lo->isInteger() || Lo->isPointer()) &&
+             "Invalid/unknown low type in pair");
+    unsigned AdjustedLoSize = AdjustedLo->getSizeInBits().getFixedValue() / 8;
+    HiStart = alignTo(AdjustedLoSize, HiAlign);
+  }
+
+  FieldInfo Fields[] = {FieldInfo(AdjustedLo, 0), FieldInfo(Hi, HiStart * 8)};
+
+  assert((8 * 8) == Fields[1].OffsetInBits &&
+         "High part must be at offset 8 bytes");
+
+  return TB.getRecordType(Fields, TypeSize::getFixed(128), Align(8),
+                          StructPacking::Default, {}, {},
+                          RecordFlags::CanPassInRegisters);
+}
+
+static bool bitsContainNoUserData(const Type *Ty, unsigned StartBit,
+                                  unsigned EndBit) {
+  unsigned TySize = Ty->getSizeInBits().getFixedValue();
+  if (TySize <= StartBit)
+    return true;
+
+  if (const ArrayType *AT = dyn_cast<ArrayType>(Ty)) {
+    const Type *EltTy = AT->getElementType();
+    unsigned EltSize = EltTy->getSizeInBits().getFixedValue();
+
+    for (unsigned I = 0; I < AT->getNumElements(); ++I) {
+      unsigned EltOffset = I * EltSize;
+      if (EltOffset >= EndBit)
+        break;
+
+      unsigned EltStart = (EltOffset < StartBit) ? StartBit - EltOffset : 0;
+      if (!bitsContainNoUserData(EltTy, EltStart, EndBit - EltOffset))
+        return false;
+    }
+    return true;
+  }
+
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (RT->isUnion()) {
+      for (const auto &Field : RT->getFields()) {
+        if (Field.IsUnnamedBitfield)
+          continue;
+
+        unsigned FieldStart =
+            (Field.OffsetInBits < StartBit) ? StartBit - Field.OffsetInBits : 0;
+        unsigned FieldEnd =
+            FieldStart + Field.FieldType->getSizeInBits().getFixedValue();
+
+        if (FieldStart < EndBit && FieldEnd > StartBit) {
+          unsigned RelativeStart =
+              (StartBit > FieldStart) ? StartBit - FieldStart : 0;
+          unsigned RelativeEnd =
+              (EndBit < FieldEnd)
+                  ? EndBit - FieldStart
+                  : Field.FieldType->getSizeInBits().getFixedValue();
+
+          if (!bitsContainNoUserData(Field.FieldType, RelativeStart,
+                                     RelativeEnd)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+    if (RT->isCXXRecord()) {
+      for (unsigned I = 0; I < RT->getNumBaseClasses(); ++I) {
+        const FieldInfo &Base = RT->getBaseClasses()[I];
+        if (Base.OffsetInBits >= EndBit)
+          continue;
+
+        unsigned BaseStart =
+            (Base.OffsetInBits < StartBit) ? StartBit - Base.OffsetInBits : 0;
+        if (!bitsContainNoUserData(Base.FieldType, BaseStart,
+                                   EndBit - Base.OffsetInBits))
+          return false;
+      }
+    }
+
+    for (unsigned I = 0; I < RT->getNumFields(); ++I) {
+      const FieldInfo &Field = RT->getFields()[I];
+      if (Field.OffsetInBits >= EndBit)
+        break;
+
+      unsigned FieldStart =
+          (Field.OffsetInBits < StartBit) ? StartBit - Field.OffsetInBits : 0;
+      if (!bitsContainNoUserData(Field.FieldType, FieldStart,
+                                 EndBit - Field.OffsetInBits))
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+const Type *X86_64ABIInfo::getIntegerTypeAtOffset(const Type *ABIType,
+                                                  unsigned ABIOffset,
+                                                  const Type *SourceTy,
+                                                  unsigned SourceOffset,
+                                                  bool InMemory) const {
+
+  const Type *WorkingType = ABIType;
+  if (InMemory && ABIType->isInteger()) {
+    const auto *IT = cast<IntegerType>(ABIType);
+    unsigned OriginalBitWidth = IT->getSizeInBits().getFixedValue();
+
+    unsigned WidenedBitWidth = OriginalBitWidth;
+    if (OriginalBitWidth <= 8) {
+      WidenedBitWidth = 8;
+    } else {
+      WidenedBitWidth = llvm::bit_ceil(OriginalBitWidth);
+    }
+
+    if (WidenedBitWidth != OriginalBitWidth) {
+      WorkingType = TB.getIntegerType(WidenedBitWidth, ABIType->getAlignment(),
+                                      IT->isSigned());
+    }
+  }
+  if (ABIOffset == 0) {
+    if ((WorkingType->isPointer() && Has64BitPointers) ||
+        (WorkingType->isInteger() &&
+         cast<IntegerType>(WorkingType)->getSizeInBits() == 64))
+      return ABIType;
+
+    if ((WorkingType->isInteger() &&
+         (cast<IntegerType>(WorkingType)->getSizeInBits() == 1 ||
+          cast<IntegerType>(WorkingType)->getSizeInBits() == 8 ||
+          cast<IntegerType>(WorkingType)->getSizeInBits() == 16 ||
+          cast<IntegerType>(WorkingType)->getSizeInBits() == 32)) ||
+        (WorkingType->isPointer() && !Has64BitPointers)) {
+
+      unsigned BitWidth = WorkingType->isPointer()
+                              ? 32
+                              : cast<IntegerType>(WorkingType)->getSizeInBits();
+
+      if (bitsContainNoUserData(SourceTy, SourceOffset * 8 + BitWidth,
+                                SourceOffset * 8 + 64))
+        return WorkingType;
+    }
+  }
+
+  if (const auto *RTy = dyn_cast<RecordType>(ABIType)) {
+    if (RTy->isUnion()) {
+      const Type *ReducedType = reduceUnionForX8664(RTy, TB);
+      if (ReducedType)
+        return getIntegerTypeAtOffset(ReducedType, ABIOffset, SourceTy,
+                                      SourceOffset, true);
+    }
+    if (const FieldInfo *Element =
+            getElementContainingOffset(RTy, ABIOffset * 8)) {
+
+      unsigned ElementOffsetBytes = Element->OffsetInBits / 8;
+      return getIntegerTypeAtOffset(Element->FieldType,
+                                    ABIOffset - ElementOffsetBytes, SourceTy,
+                                    SourceOffset, true);
+    }
+  }
+
+  if (const auto *ATy = dyn_cast<ArrayType>(ABIType)) {
+    const Type *EltTy = ATy->getElementType();
+    unsigned EltSize = EltTy->getSizeInBits() / 8;
+    if (EltSize > 0) {
+      unsigned EltOffset = (ABIOffset / EltSize) * EltSize;
+      return getIntegerTypeAtOffset(EltTy, ABIOffset - EltOffset, SourceTy,
+                                    SourceOffset, true);
+    }
+  }
+
+  if (ABIType->isInteger() && ABIType->getSizeInBits() == 128) {
+    assert(ABIOffset == 0);
+    return ABIType;
+  }
+
+  unsigned TySizeInBytes =
+      llvm::divideCeil(SourceTy->getSizeInBits().getFixedValue(), 8);
+  if (auto *IT = dyn_cast<IntegerType>(SourceTy)) {
+    if (IT->isBitInt())
+      TySizeInBytes =
+          alignTo(SourceTy->getSizeInBits().getFixedValue(), 64) / 8;
+  }
+  assert(TySizeInBytes != SourceOffset && "Empty field?");
+  unsigned AvailableSize = TySizeInBytes - SourceOffset;
+  return TB.getIntegerType(std::min(AvailableSize, 8U) * 8, Align(1), false);
+}
+
+const Type *X86_64ABIInfo::getFPTypeAtOffset(const Type *Ty,
+                                             unsigned Offset) const {
+  if (Offset == 0 && Ty->isFloat())
+    return Ty;
+
+  if (const ComplexType *CT = dyn_cast<ComplexType>(Ty)) {
+    const Type *ElementType = CT->getElementType();
+    unsigned ElementSize = ElementType->getSizeInBits().getFixedValue() / 8;
+
+    if (Offset == 0 || Offset == ElementSize)
+      return ElementType;
+    return nullptr;
+  }
+
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (const FieldInfo *Element = getElementContainingOffset(RT, Offset * 8)) {
+      unsigned ElementOffsetBytes = Element->OffsetInBits / 8;
+      return getFPTypeAtOffset(Element->FieldType, Offset - ElementOffsetBytes);
+    }
+  }
+
+  if (const ArrayType *AT = dyn_cast<ArrayType>(Ty)) {
+    const Type *EltTy = AT->getElementType();
+    unsigned EltSize = EltTy->getSizeInBits() / 8;
+    unsigned EltIndex = Offset / EltSize;
+
+    return getFPTypeAtOffset(EltTy, Offset - (EltIndex * EltSize));
+  }
+
+  return nullptr;
+}
+
+static bool isFloatTypeWithSemantics(const Type *Ty,
+                                     const fltSemantics &Semantics) {
+  if (!Ty->isFloat())
+    return false;
+  const FloatType *FT = cast<FloatType>(Ty);
+  return FT->getSemantics() == &Semantics;
+}
+
+const Type *X86_64ABIInfo::getSSETypeAtOffset(const Type *ABIType,
+                                              unsigned ABIOffset,
+                                              const Type *SourceTy,
+                                              unsigned SourceOffset) const {
+
+  if (const auto *RTy = dyn_cast<RecordType>(ABIType)) {
+    if (RTy->isUnion()) {
+      const Type *ReducedType = reduceUnionForX8664(RTy, TB);
+      if (ReducedType) {
+        return getSSETypeAtOffset(ReducedType, ABIOffset, SourceTy,
+                                  SourceOffset);
+      }
+    }
+  }
+
+  auto Is16bitFpTy = [](const Type *T) {
+    return isFloatTypeWithSemantics(T, APFloat::IEEEhalf()) ||
+           isFloatTypeWithSemantics(T, APFloat::BFloat());
+  };
+
+  const Type *T0 = getFPTypeAtOffset(ABIType, ABIOffset);
+  if (!T0 || isFloatTypeWithSemantics(T0, APFloat::IEEEdouble()))
+    return TB.getFloatType(APFloat::IEEEdouble(), Align(8));
+
+  unsigned SourceSize =
+      (SourceTy->getSizeInBits().getFixedValue() / 8) - SourceOffset;
+
+  const Type *T1 = nullptr;
+  unsigned T0Size =
+      alignTo(T0->getSizeInBits().getFixedValue(), T0->getAlignment().value()) /
+      8;
+  if (SourceSize > T0Size)
+    T1 = getFPTypeAtOffset(ABIType, ABIOffset + T0Size);
+
+  if (T1 == nullptr) {
+    if (Is16bitFpTy(T0) && SourceSize > 4)
+      T1 = getFPTypeAtOffset(ABIType, ABIOffset + 4);
+
+    if (T1 == nullptr)
+      return T0;
+  }
+  if (isFloatTypeWithSemantics(T0, APFloat::IEEEsingle()) &&
+      isFloatTypeWithSemantics(T1, APFloat::IEEEsingle()))
+    return TB.getVectorType(T0, ElementCount::getFixed(2), Align(8));
+
+  if (Is16bitFpTy(T0) && Is16bitFpTy(T1)) {
+    const Type *T2 = nullptr;
+    if (SourceSize > 4)
+      T2 = getFPTypeAtOffset(ABIType, ABIOffset + 4);
+    if (!T2)
+      return TB.getVectorType(T0, ElementCount::getFixed(2), Align(8));
+    return TB.getVectorType(T0, ElementCount::getFixed(4), Align(8));
+  }
+
+  if (Is16bitFpTy(T0) || Is16bitFpTy(T1))
+    return TB.getVectorType(TB.getFloatType(APFloat::IEEEhalf(), Align(2)),
+                            ElementCount::getFixed(4), Align(8));
+
+  return TB.getFloatType(APFloat::IEEEdouble(), Align(8));
+}
+
+const Type *X86_64ABIInfo::getByteVectorType(const Type *Ty) const {
+  if (const Type *InnerTy = isSingleElementStruct(Ty))
+    Ty = InnerTy;
+
+  if (const VectorType *VT = dyn_cast<VectorType>(Ty)) {
+    if (getABICompatInfo().PassInt128VectorsInMem &&
+        VT->getElementType()->isInteger() &&
+        cast<IntegerType>(VT->getElementType())->getSizeInBits() == 128) {
+      unsigned Size = VT->getSizeInBits().getFixedValue();
+      return TB.getVectorType(TB.getIntegerType(64, Align(8), /*Signed=*/false),
+                              ElementCount::getFixed(Size / 64),
+                              Align(Size / 8));
+    }
+    return VT;
+  }
+
+  if (isFloatTypeWithSemantics(Ty, APFloat::IEEEquad()))
+    return Ty;
+
+  unsigned Size = Ty->getSizeInBits().getFixedValue();
+  assert((Size == 128 || Size == 256 || Size == 512) && "Invalid vector size");
+
+  return TB.getVectorType(TB.getFloatType(APFloat::IEEEdouble(), Align(8)),
+                          ElementCount::getFixed(Size / 64), Align(Size / 8));
+}
+
+const Type *X86_64ABIInfo::isSingleElementStruct(const Type *Ty) const {
+  const auto *RT = dyn_cast<RecordType>(Ty);
+  if (!RT)
+    return nullptr;
+
+  if (RT->isPolymorphic() || RT->hasNonTrivialCopyConstructor() ||
+      RT->hasNonTrivialDestructor() || RT->hasFlexibleArrayMember() ||
+      RT->getNumVirtualBaseClasses() != 0)
+    return nullptr;
+
+  const Type *Found = nullptr;
+
+  for (const auto &Base : RT->getBaseClasses()) {
+    const Type *BaseTy = Base.FieldType;
+    auto *BaseRT = dyn_cast<RecordType>(BaseTy);
+
+    if (!BaseRT || BaseRT->isEmpty())
+      continue;
+
+    const Type *Elem = isSingleElementStruct(BaseTy);
+    if (!Elem || Found)
+      return nullptr;
+    Found = Elem;
+  }
+
+  for (const auto &FI : RT->getFields()) {
+    if (FI.isEmpty())
+      continue;
+
+    const Type *FTy = FI.FieldType;
+
+    while (auto *AT = dyn_cast<ArrayType>(FTy)) {
+      if (AT->getNumElements() != 1)
+        break;
+      FTy = AT->getElementType();
+    }
+
+    const Type *Elem;
+    if (auto *InnerRT = dyn_cast<RecordType>(FTy))
+      Elem = isSingleElementStruct(InnerRT);
+    else
+      Elem = FTy;
+    if (!Elem || Found)
+      return nullptr;
+    Found = Elem;
+  }
+
+  if (!Found)
+    return nullptr;
+  if (Found->getSizeInBits() != Ty->getSizeInBits())
+    return nullptr;
+
+  return Found;
+}
+
+bool X86_64ABIInfo::isIllegalVectorType(const Type *Ty) const {
+  if (const auto *VecTy = dyn_cast<VectorType>(Ty)) {
+    uint64_t Size = VecTy->getSizeInBits().getFixedValue();
+    unsigned LargestVector = getNativeVectorSizeForAVXABI(AVXLevel);
+
+    if (Size <= 64 || Size > LargestVector)
+      return true;
+
+    const Type *EltTy = VecTy->getElementType();
+    if (getABICompatInfo().PassInt128VectorsInMem && EltTy->isInteger()) {
+      const auto *IntTy = cast<IntegerType>(EltTy);
+      if (IntTy->getSizeInBits().getFixedValue() == 128)
+        return true;
+    }
+  }
+  return false;
+}
+
+ArgInfo X86_64ABIInfo::getIndirectResult(const Type *Ty,
+                                         unsigned FreeIntRegs) const {
+  if (!isAggregateTypeForABI(Ty) && !isIllegalVectorType(Ty) &&
+      !(Ty->isInteger() && cast<IntegerType>(Ty)->isBitInt())) {
+    return (Ty->isInteger() && isPromotableInteger(cast<IntegerType>(Ty))
+                ? ArgInfo::getExtend(Ty)
+                : ArgInfo::getDirect());
+  }
+
+  if (RecordArgABI RecordRAA = getRecordArgABI(Ty))
+    return getNaturalAlignIndirect(Ty, RecordRAA ==
+                                           RecordArgABI::RAA_DirectInMemory);
+
+  llvm::Align AlignVal = std::max(Ty->getAlignment(), llvm::Align(8));
+
+  if (FreeIntRegs == 0) {
+    uint64_t Size = Ty->getSizeInBits().getFixedValue();
+
+    if (AlignVal == llvm::Align(8) && Size <= 64) {
+      const Type *IntTy =
+          TB.getIntegerType(Size, llvm::Align(8), /*Signed=*/false);
+      return ArgInfo::getDirect(IntTy);
+    }
+  }
+
+  return ArgInfo::getIndirect(AlignVal, true);
+}
+
+ArgInfo X86_64ABIInfo::getIndirectReturnResult(const Type *Ty) const {
+  if (!isAggregateTypeForABI(Ty)) {
+    if (Ty->isInteger()) {
+      const IntegerType *IntTy = cast<IntegerType>(Ty);
+      if (isPromotableInteger(IntTy)) {
+        ArgInfo Info = ArgInfo::getExtend(Ty);
+        return Info;
+      }
+      if (IntTy->isBitInt())
+        return getNaturalAlignIndirect(IntTy);
+    }
+    return ArgInfo::getDirect();
+  }
+
+  return getNaturalAlignIndirect(Ty);
+}
+
+static bool classifyCXXReturnType(FunctionInfo &FI, const TargetInfo &Info) {
+  const abi::Type *Ty = FI.getReturnType();
+
+  if (const auto *RT = llvm::dyn_cast<abi::RecordType>(Ty)) {
+    if (!RT->isCXXRecord() && !RT->canPassInRegisters()) {
+      ArgInfo IndirectInfo = ArgInfo::getIndirect(RT->getAlignment(), true);
+      FI.getReturnInfo() = IndirectInfo;
+      return true;
+    }
+    if (!RT->canPassInRegisters()) {
+      ArgInfo IndirectInfo =
+          ArgInfo::getIndirect(Ty->getAlignment(), false, 0, false);
+      FI.getReturnInfo() = IndirectInfo;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void X86_64ABIInfo::computeInfo(FunctionInfo &FI) const {
+  CallingConv::ID CallingConv = FI.getCallingConvention();
+
+  if (CallingConv == CallingConv::Win64 ||
+      CallingConv == CallingConv::X86_RegCall)
+    return;
+
+  bool IsRegCall = false;
+
+  unsigned FreeIntRegs = 6;
+  unsigned FreeSSERegs = 8;
+  unsigned NeededInt = 0, NeededSSE = 0;
+
+  if (!classifyCXXReturnType(FI, *this)) {
+    const Type *RetTy = FI.getReturnType();
+    ArgInfo RetInfo = classifyReturnType(RetTy);
+    FI.getReturnInfo() = RetInfo;
+  }
+
+  if (FI.getReturnInfo().isIndirect())
+    --FreeIntRegs;
+
+  unsigned NumRequiredArgs = FI.getNumRequiredArgs();
+
+  unsigned ArgNo = 0;
+  for (auto IT = FI.arg_begin(), IE = FI.arg_end(); IT != IE; ++IT, ++ArgNo) {
+    bool IsNamedArg = ArgNo < NumRequiredArgs;
+    const Type *ArgTy = IT->ABIType;
+    NeededInt = 0;
+    NeededSSE = 0;
+
+    ArgInfo AI = classifyArgumentType(ArgTy, FreeIntRegs, NeededInt, NeededSSE,
+                                      IsNamedArg, IsRegCall);
+
+    // AMD64-ABI 3.2.3p3: If there are no registers available for
+    // any eightbyte of an argument, the whole argument is passed
+    // on the stack.  If registers have already been assigned for
+    // some eightbytes of such an argument, the assignments get
+    // reverted.
+    if (FreeIntRegs >= NeededInt && FreeSSERegs >= NeededSSE) {
+      FreeIntRegs -= NeededInt;
+      FreeSSERegs -= NeededSSE;
+      IT->Info = AI;
+    } else {
+      ArgInfo IndirectInfo = getIndirectResult(ArgTy, FreeIntRegs);
+      IT->Info = IndirectInfo;
+    }
+  }
+}
+
+std::unique_ptr<TargetInfo> createX8664TargetInfo(TypeBuilder &TB,
+                                                  const Triple &Triple,
+                                                  X86AVXABILevel AVXLevel,
+                                                  bool Has64BitPointers,
+                                                  const ABICompatInfo &Compat) {
+  return std::make_unique<X86_64ABIInfo>(TB, Triple, AVXLevel, Has64BitPointers,
+                                         Compat);
+}
+} // namespace abi
+} // namespace llvm

--- a/llvm/unittests/ABI/CMakeLists.txt
+++ b/llvm/unittests/ABI/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(LLVM_LINK_COMPONENTS
   ABI
   Support
+  TargetParser
   )
 
 add_llvm_unittest(ABITests
   TypesTest.cpp
+  X86Test.cpp
   )

--- a/llvm/unittests/ABI/CMakeLists.txt
+++ b/llvm/unittests/ABI/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  ABI
+  Support
+  )
+
+add_llvm_unittest(ABITests
+  TypesTest.cpp
+  )

--- a/llvm/unittests/ABI/TypesTest.cpp
+++ b/llvm/unittests/ABI/TypesTest.cpp
@@ -1,0 +1,79 @@
+//===- TypesTest.cpp - Unit tests for ABI Types ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::abi;
+
+namespace {
+
+class ABITypesTest : public ::testing::Test {
+protected:
+  BumpPtrAllocator Alloc;
+  TypeBuilder TB{Alloc};
+};
+
+TEST_F(ABITypesTest, RecordFlagsNonTrivialCopyConstructor) {
+  RecordFlags Flags =
+      RecordFlags::IsCXXRecord | RecordFlags::HasNonTrivialCopyConstructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->hasNonTrivialDestructor());
+  EXPECT_TRUE(RT->isCXXRecord());
+}
+
+TEST_F(ABITypesTest, RecordFlagsNonTrivialDestructor) {
+  RecordFlags Flags =
+      RecordFlags::IsCXXRecord | RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+}
+
+TEST_F(ABITypesTest, RecordFlagsBothNonTrivial) {
+  RecordFlags Flags = RecordFlags::IsCXXRecord |
+                      RecordFlags::HasNonTrivialCopyConstructor |
+                      RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+}
+
+TEST_F(ABITypesTest, RecordFlagsNoneSet) {
+  const RecordType *RT = TB.getRecordType({}, TypeSize::getFixed(64), Align(8));
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->hasNonTrivialDestructor());
+  EXPECT_FALSE(RT->isCXXRecord());
+  EXPECT_FALSE(RT->isUnion());
+  EXPECT_FALSE(RT->isPolymorphic());
+}
+
+TEST_F(ABITypesTest, RecordFlagsCombineWithExisting) {
+  RecordFlags Flags = RecordFlags::CanPassInRegisters |
+                      RecordFlags::IsCXXRecord |
+                      RecordFlags::HasNonTrivialDestructor;
+  const RecordType *RT =
+      TB.getRecordType({}, TypeSize::getFixed(64), Align(8),
+                       StructPacking::Default, {}, {}, Flags);
+  EXPECT_TRUE(RT->canPassInRegisters());
+  EXPECT_TRUE(RT->isCXXRecord());
+  EXPECT_TRUE(RT->hasNonTrivialDestructor());
+  EXPECT_FALSE(RT->hasNonTrivialCopyConstructor());
+  EXPECT_FALSE(RT->isUnion());
+}
+
+} // namespace

--- a/llvm/unittests/ABI/X86Test.cpp
+++ b/llvm/unittests/ABI/X86Test.cpp
@@ -1,0 +1,297 @@
+//===- X86Test.cpp - Unit tests for X86_64 ABI classifier -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/FunctionInfo.h"
+#include "llvm/ABI/TargetInfo.h"
+#include "llvm/ABI/Types.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::abi;
+
+namespace {
+
+class X86_64ABITest : public ::testing::Test {
+protected:
+  BumpPtrAllocator Alloc;
+  TypeBuilder TB{Alloc};
+  Triple TargetTriple{"x86_64-unknown-linux-gnu"};
+
+  std::unique_ptr<TargetInfo>
+  createTarget(X86AVXABILevel AVX = X86AVXABILevel::None,
+               bool Has64BitPtrs = true) {
+    return createX8664TargetInfo(TB, TargetTriple, AVX, Has64BitPtrs,
+                                 ABICompatInfo());
+  }
+
+  FunctionInfo *makeFI(const Type *RetTy,
+                       ArrayRef<const Type *> ArgTypes = {}) {
+    return FunctionInfo::create(CallingConv::C, RetTy, ArgTypes);
+  }
+};
+
+TEST_F(X86_64ABITest, VoidReturn) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isIgnore());
+}
+
+TEST_F(X86_64ABITest, IntegerReturnDirect) {
+  auto TI = createTarget();
+  const IntegerType *I32 = TB.getIntegerType(32, Align(4), true);
+  std::unique_ptr<FunctionInfo> FI(makeFI(I32));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, Int64ReturnDirect) {
+  auto TI = createTarget();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), true);
+  std::unique_ptr<FunctionInfo> FI(makeFI(I64));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, FloatReturnSSE) {
+  auto TI = createTarget();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  std::unique_ptr<FunctionInfo> FI(makeFI(F32));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, DoubleReturnSSE) {
+  auto TI = createTarget();
+  const FloatType *F64 = TB.getFloatType(APFloat::IEEEdouble(), Align(8));
+  std::unique_ptr<FunctionInfo> FI(makeFI(F64));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, SmallStructDirect) {
+  auto TI = createTarget();
+  const IntegerType *I32 = TB.getIntegerType(32, Align(4), true);
+  FieldInfo Fields[] = {FieldInfo(I32, 0), FieldInfo(I32, 32)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(64),
+                                          Align(4), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  std::unique_ptr<FunctionInfo> FI(makeFI(RT));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, LargeStructIndirect) {
+  auto TI = createTarget();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), false);
+  FieldInfo Fields[] = {FieldInfo(I64, 0), FieldInfo(I64, 64),
+                        FieldInfo(I64, 128)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(192),
+                                          Align(8), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  std::unique_ptr<FunctionInfo> FI(makeFI(RT));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isIndirect());
+}
+
+TEST_F(X86_64ABITest, IntegerArgDirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), true);
+  SmallVector<const Type *> Args = {I64};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, SmallIntegerArgExtend) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I16 = TB.getIntegerType(16, Align(2), true);
+  SmallVector<const Type *> Args = {I16};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isExtend());
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isSignExt());
+}
+
+TEST_F(X86_64ABITest, UnsignedSmallIntegerArgZeroExt) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *U8 = TB.getIntegerType(8, Align(1), false);
+  SmallVector<const Type *> Args = {U8};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isExtend());
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isZeroExt());
+}
+
+TEST_F(X86_64ABITest, PointerArgDirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const PointerType *PtrTy = TB.getPointerType(64, Align(8));
+  SmallVector<const Type *> Args = {PtrTy};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, SmallStructArgDirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I32 = TB.getIntegerType(32, Align(4), true);
+  FieldInfo Fields[] = {FieldInfo(I32, 0), FieldInfo(I32, 32)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(64),
+                                          Align(4), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  SmallVector<const Type *> Args = {RT};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, TwoEightbyteStructArgDirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), false);
+  FieldInfo Fields[] = {FieldInfo(I64, 0), FieldInfo(I64, 64)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(128),
+                                          Align(8), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  SmallVector<const Type *> Args = {RT};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, LargeStructArgIndirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), false);
+  FieldInfo Fields[] = {FieldInfo(I64, 0), FieldInfo(I64, 64),
+                        FieldInfo(I64, 128)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(192),
+                                          Align(8), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  SmallVector<const Type *> Args = {RT};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isIndirect());
+}
+
+TEST_F(X86_64ABITest, NTCStructArgIndirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I32 = TB.getIntegerType(32, Align(4), true);
+  FieldInfo Fields[] = {FieldInfo(I32, 0)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(32),
+                                          Align(4), StructPacking::Default, {},
+                                          {}, RecordFlags::IsCXXRecord);
+  SmallVector<const Type *> Args = {RT};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isIndirect());
+}
+
+TEST_F(X86_64ABITest, SSEFloatArgDirect) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  SmallVector<const Type *> Args = {F32};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, X87LongDoubleReturn) {
+  auto TI = createTarget();
+  const FloatType *LDTy =
+      TB.getFloatType(APFloat::x87DoubleExtended(), Align(16));
+  std::unique_ptr<FunctionInfo> FI(makeFI(LDTy));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+}
+
+TEST_F(X86_64ABITest, VectorSSE128Direct) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  const VectorType *V4F32 =
+      TB.getVectorType(F32, ElementCount::getFixed(4), Align(16));
+  SmallVector<const Type *> Args = {V4F32};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, Vector256NoAVXIndirect) {
+  auto TI = createTarget(X86AVXABILevel::None);
+  const VoidType *VoidTy = TB.getVoidType();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  const VectorType *V8F32 =
+      TB.getVectorType(F32, ElementCount::getFixed(8), Align(32));
+  SmallVector<const Type *> Args = {V8F32};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isIndirect());
+}
+
+TEST_F(X86_64ABITest, Vector256WithAVXDirect) {
+  auto TI = createTarget(X86AVXABILevel::AVX);
+  const VoidType *VoidTy = TB.getVoidType();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  const VectorType *V8F32 =
+      TB.getVectorType(F32, ElementCount::getFixed(8), Align(32));
+  SmallVector<const Type *> Args = {V8F32};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, RegisterExhaustion) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const IntegerType *I64 = TB.getIntegerType(64, Align(8), false);
+  SmallVector<const Type *> Args(7, I64);
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  for (unsigned I = 0; I < 6; ++I)
+    EXPECT_TRUE(FI->getArgInfo(I).Info.isDirect());
+  EXPECT_TRUE(FI->getArgInfo(6).Info.isDirect());
+}
+
+TEST_F(X86_64ABITest, FloatStructCoercion) {
+  auto TI = createTarget();
+  const FloatType *F32 = TB.getFloatType(APFloat::IEEEsingle(), Align(4));
+  FieldInfo Fields[] = {FieldInfo(F32, 0), FieldInfo(F32, 32)};
+  const RecordType *RT = TB.getRecordType(Fields, TypeSize::getFixed(64),
+                                          Align(4), StructPacking::Default, {},
+                                          {}, RecordFlags::CanPassInRegisters);
+  std::unique_ptr<FunctionInfo> FI(makeFI(RT));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getReturnInfo().isDirect());
+  const Type *CoerceTy = FI->getReturnInfo().getCoerceToType();
+  ASSERT_NE(CoerceTy, nullptr);
+  EXPECT_TRUE(CoerceTy->isVector());
+}
+
+TEST_F(X86_64ABITest, EmptyStructIgnored) {
+  auto TI = createTarget();
+  const VoidType *VoidTy = TB.getVoidType();
+  const RecordType *EmptyRT = TB.getRecordType(
+      {}, TypeSize::getFixed(0), Align(1), StructPacking::Default, {}, {},
+      RecordFlags::CanPassInRegisters);
+  SmallVector<const Type *> Args = {EmptyRT};
+  std::unique_ptr<FunctionInfo> FI(makeFI(VoidTy, Args));
+  TI->computeInfo(*FI);
+  EXPECT_TRUE(FI->getArgInfo(0).Info.isIgnore());
+}
+
+} // namespace

--- a/llvm/unittests/CMakeLists.txt
+++ b/llvm/unittests/CMakeLists.txt
@@ -29,6 +29,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif ()
 
 add_subdirectory(ADT)
+add_subdirectory(ABI)
 add_subdirectory(Analysis)
 add_subdirectory(AsmParser)
 add_subdirectory(BinaryFormat)


### PR DESCRIPTION
Breakout from @vortex73's PR #140112. This is Narayan's design and logic from the LLVM ABI Lowering Library, adapted to the current upstream TargetInfo API.

Add the X86_64 ABI classifier implementing the System V AMD64 ABI classification algorithm. The classifier extends TargetInfo (matching the BPF pattern established in #194031) and handles all x86_64 type classifications: integer, SSE, X87, complex, vectors (SSE/AVX/AVX512), arrays, records, member pointers, and bit-fields.

Adds the X86AVXABILevel enum and createX8664TargetInfo factory function declaration to TargetInfo.h, and 23 unit tests covering scalar types, struct coercion, indirect passing, AVX level handling, register exhaustion, and empty struct classification.

Depends on #194427 for HasNonTrivialCopyConstructor and HasNonTrivialDestructor RecordFlags.

Made with [Cursor](https://cursor.com)