### PR TITLE
Exclude unsupported compiler-rt tests on z/OS.

### DIFF
--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
@@ -34,8 +34,11 @@ int test__compiler_rt_logbl(fp_t x) {
 }
 
 fp_t cases[] = {
-    1.e-6, -1.e-6, NAN, -NAN, INFINITY, -INFINITY, -1,
-    -0.0,  0.0,    1,   -2,   2,        -0.5,      0.5,
+    1.e-6, -1.e-6,
+#ifndef __MVS__
+    NAN, -NAN, INFINITY, -INFINITY,
+#endif
+    -1,  -0.0,  0.0,    1,   -2,   2,        -0.5,      0.5,
 };
 
 int main() {

--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
@@ -35,10 +35,10 @@ int test__compiler_rt_logbl(fp_t x) {
 
 fp_t cases[] = {
     1.e-6, -1.e-6,
-#ifndef __MVS__
-    NAN, -NAN, INFINITY, -INFINITY,
-#endif
-    -1,  -0.0,  0.0,    1,   -2,   2,        -0.5,      0.5,
+#  ifndef __MVS__
+    NAN,   -NAN,   INFINITY, -INFINITY,
+#  endif
+    -1,    -0.0,   0.0,      1,         -2, 2, -0.5, 0.5,
 };
 
 int main() {

--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
@@ -35,8 +35,8 @@ int test__compiler_rt_logbl(fp_t x) {
 
 fp_t cases[] = {
     1.e-6, -1.e-6,
-    // The logbl() function's behavior on the following values on z/OS
-    // differs from the C++ standard specification.
+// The logbl() function's behavior on the following values on z/OS
+// differs from the C++ standard specification.
 #  ifndef __MVS__
     NAN,   -NAN,   INFINITY, -INFINITY,
 #  endif

--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
@@ -35,6 +35,8 @@ int test__compiler_rt_logbl(fp_t x) {
 
 fp_t cases[] = {
     1.e-6, -1.e-6,
+    // The logbl() function's behavior on the following values on z/OS
+    // differs from the C++ standard specification.
 #  ifndef __MVS__
     NAN,   -NAN,   INFINITY, -INFINITY,
 #  endif

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
@@ -39,12 +39,12 @@ int test__compiler_rt_scalbnl(const char *mode, fp_t x, int y) {
 }
 
 fp_t cases[] = {
-#ifndef __MVS__
+#  ifndef __MVS__
     -NAN,
     NAN,
     -INFINITY,
     INFINITY,
-#endif
+#  endif
     -0.0,
     0.0,
     -1,

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
@@ -39,10 +39,12 @@ int test__compiler_rt_scalbnl(const char *mode, fp_t x, int y) {
 }
 
 fp_t cases[] = {
+#ifndef __MVS__
     -NAN,
     NAN,
     -INFINITY,
     INFINITY,
+#endif
     -0.0,
     0.0,
     -1,

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
@@ -39,8 +39,8 @@ int test__compiler_rt_scalbnl(const char *mode, fp_t x, int y) {
 }
 
 fp_t cases[] = {
-    // The scalbnl() function's behavior on the following values on z/OS
-    // differs from the C++ standard specification.
+// The scalbnl() function's behavior on the following values on z/OS
+// differs from the C++ standard specification.
 #  ifndef __MVS__
     -NAN,
     NAN,

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
@@ -39,6 +39,8 @@ int test__compiler_rt_scalbnl(const char *mode, fp_t x, int y) {
 }
 
 fp_t cases[] = {
+    // The scalbnl() function's behavior on the following values on z/OS
+    // differs from the C++ standard specification.
 #  ifndef __MVS__
     -NAN,
     NAN,


### PR DESCRIPTION
This PR excludes unsupported part (NAN, -NAN, INFINITY, -INFINITY) from the following 2 compiler-rt tests on z/OS.
```
compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
```