### PR TITLE
lldb] Fix two issues causing TestEvents.py flakiness

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4481,7 +4481,9 @@ bool Process::ProcessEventData::ForwardEventToPendingListeners(
 
   // For state changed events, if the update state is zero, we are handling
   // this on the private state thread.  We should wait for the public event.
-  return m_update_state == 1;
+  // After the primary listener processes it, m_update_state becomes 2, which
+  // is when we forward to pending (secondary) listeners.
+  return m_update_state >= 1;
 }
 
 void Process::ProcessEventData::DoOnRemoval(Event *event_ptr) {
@@ -4498,12 +4500,14 @@ void Process::ProcessEventData::DoOnRemoval(Event *event_ptr) {
   // pulled off of the private process event queue, and then any number of
   // times, first when it gets pulled off of the public event queue, then other
   // times when we're pretending that this is where we stopped at the end of
-  // expression evaluation.  m_update_state is used to distinguish these three
-  // cases; it is 0 when we're just pulling it off for private handling, and >
-  // 1 for expression evaluation, and we don't want to do the breakpoint
-  // command handling then.
+  // expression evaluation.  m_update_state is used to distinguish these
+  // cases; it is 0 when we're just pulling it off for private handling, 1
+  // when the primary public listener consumes it, and > 1 after that (e.g.
+  // secondary listeners or expression evaluation) where we don't want to
+  // redo the breakpoint command handling or stop hooks.
   if (m_update_state != 1)
     return;
+  m_update_state++;
 
   process_sp->SetPublicState(
       m_state, Process::ProcessEventData::GetRestartedFromEvent(event_ptr));

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4481,9 +4481,10 @@ bool Process::ProcessEventData::ForwardEventToPendingListeners(
 
   // For state changed events, if the update state is zero, we are handling
   // this on the private state thread.  We should wait for the public event.
-  // After the primary listener processes it, m_update_state becomes 2, which
-  // is when we forward to pending (secondary) listeners.
-  return m_update_state >= 1;
+  // After the primary listener processes it in DoOnRemoval, m_update_state
+  // is incremented from 1 to 2, which is when we forward to pending
+  // (secondary) listeners.
+  return m_update_state > 1;
 }
 
 void Process::ProcessEventData::DoOnRemoval(Event *event_ptr) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3162,8 +3162,6 @@ bool Target::RunStopHooks(bool at_initial_stop) {
   if (last_natural_stop != 0 && m_latest_stop_hook_id == last_natural_stop)
     return false;
 
-  m_latest_stop_hook_id = last_natural_stop;
-
   std::vector<ExecutionContext> exc_ctx_with_reasons;
 
   ThreadList &cur_threadlist = m_process_sp->GetThreadList();
@@ -3194,6 +3192,8 @@ bool Target::RunStopHooks(bool at_initial_stop) {
       return false;
     }
   }
+
+  m_latest_stop_hook_id = last_natural_stop;
 
   StreamSP output_sp = m_debugger.GetAsyncOutputStream();
   llvm::scope_exit on_exit([output_sp] { output_sp->Flush(); });


### PR DESCRIPTION
This PR fixes two issues that contribute to `TestEvents.py` being flaky in CI:

1. `ProcessEventData::DoOnRemoval` runs the full stop-handling logic (like `ShouldStop` and `RunStopHooks`) every time an event is consumed from any listener. When the primary listener consumes an event and then the shadow listener consumes the same event, the logic runs twice. The second execution can race with subsequent event processing. Fix this by incrementing `m_update_state` after the first successful run so secondary listeners skip the full logic.

2. Target::RunStopHooks updates `m_latest_stop_hook_id` (marking a stop as "handled") before checking whether any threads have stop reasons. If the check fails and hooks don't run, the stop ID is already consumed, preventing hooks from ever running for that stop. Fix this by deferring the update until we're certain we'll actually run hooks.