### PR TITLE
[MLIR][ExecutionEngine] Revert stream/event teardown error suppressions

### DIFF
--- a/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
+++ b/mlir/lib/ExecutionEngine/CudaRuntimeWrappers.cpp
@@ -45,29 +45,6 @@
     fprintf(stderr, "'%s' failed with '%s'\n", #expr, name);                   \
   }(expr)
 
-/// Helper to check if a CUDA error is due to the context being destroyed
-/// during program shutdown. Both CUDA_ERROR_DEINITIALIZED and
-/// CUDA_ERROR_CONTEXT_IS_DESTROYED indicate that the CUDA context has been
-/// torn down and any associated resources are already freed.
-static bool isCudaContextShutdownError(CUresult result) {
-  return result == CUDA_ERROR_DEINITIALIZED ||
-         result == CUDA_ERROR_CONTEXT_IS_DESTROYED;
-}
-
-/// Like CUDA_REPORT_IF_ERROR, but silences errors caused by CUDA context
-/// shutdown. These errors are benign when they occur during program exit,
-/// as all resources are freed with the context.
-#define CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(expr)                             \
-  [](CUresult result) {                                                        \
-    if (!result || isCudaContextShutdownError(result))                         \
-      return;                                                                  \
-    const char *name = nullptr;                                                \
-    cuGetErrorName(result, &name);                                             \
-    if (!name)                                                                 \
-      name = "<unknown>";                                                      \
-    fprintf(stderr, "'%s' failed with '%s'\n", #expr, name);                   \
-  }(expr)
-
 #define CUSPARSE_REPORT_IF_ERROR(expr)                                         \
   {                                                                            \
     cusparseStatus_t status = (expr);                                          \
@@ -169,7 +146,11 @@ mgpuModuleLoadJIT(void *data, int optLevel, size_t /*assmeblySize*/) {
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuModuleUnload(CUmodule module) {
-  CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(cuModuleUnload(module));
+  // Tolerate CUDA_ERROR_DEINITIALIZED: this can run from a global destructor
+  // after the CUDA primary context has already been torn down.
+  CUresult result = cuModuleUnload(module);
+  if (result != CUDA_SUCCESS && result != CUDA_ERROR_DEINITIALIZED)
+    CUDA_REPORT_IF_ERROR(result);
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUfunction
@@ -222,7 +203,7 @@ extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUstream mgpuStreamCreate() {
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuStreamDestroy(CUstream stream) {
-  CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(cuStreamDestroy(stream));
+  CUDA_REPORT_IF_ERROR(cuStreamDestroy(stream));
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void
@@ -232,8 +213,7 @@ mgpuStreamSynchronize(CUstream stream) {
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuStreamWaitEvent(CUstream stream,
                                                               CUevent event) {
-  CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(
-      cuStreamWaitEvent(stream, event, /*flags=*/0));
+  CUDA_REPORT_IF_ERROR(cuStreamWaitEvent(stream, event, /*flags=*/0));
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUevent mgpuEventCreate() {
@@ -244,11 +224,11 @@ extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUevent mgpuEventCreate() {
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuEventDestroy(CUevent event) {
-  CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(cuEventDestroy(event));
+  CUDA_REPORT_IF_ERROR(cuEventDestroy(event));
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuEventSynchronize(CUevent event) {
-  CUDA_REPORT_IF_ERROR_IGNORE_SHUTDOWN(cuEventSynchronize(event));
+  CUDA_REPORT_IF_ERROR(cuEventSynchronize(event));
 }
 
 extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuEventRecord(CUevent event,


### PR DESCRIPTION
#190717 fixed the race that produced CUDA_ERROR_CONTEXT_IS_DESTROYED on mgpuStreamDestroy, mgpuStreamWaitEvent, mgpuEventDestroy, and mgpuEventSynchronize. This changes restores CUDA_REPORT_IF_ERROR on those four sites.

Keep the CUDA_ERROR_DEINITIALIZED tolerance on mgpuModuleUnload because that's a separate global-destructor ordering issue, and an error on module unload is benign anyway.

This is a partial revert of #190563.

Assisted-by: Claude