### PR TITLE
[compiler-rt][builtins] Fix GCC build warnings for unsupported flags

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -18,7 +18,8 @@ builtin_check_c_compiler_flag(-fno-lto              COMPILER_RT_HAS_FNO_LTO_FLAG
 builtin_check_c_compiler_flag(-fno-profile-generate COMPILER_RT_HAS_FNO_PROFILE_GENERATE_FLAG)
 builtin_check_c_compiler_flag(-fno-profile-instr-generate COMPILER_RT_HAS_FNO_PROFILE_INSTR_GENERATE_FLAG)
 builtin_check_c_compiler_flag(-fno-profile-instr-use COMPILER_RT_HAS_FNO_PROFILE_INSTR_USE_FLAG)
-builtin_check_c_compiler_flag(-Wno-c2y-extensions   COMPILER_RT_HAS_WNO_C2Y_EXTENSIONS)
+# gcc returns 0 for -Wno-* if unknown but 1 for the -W* version
+builtin_check_c_compiler_flag(-Wc2y-extensions      COMPILER_RT_HAS_WC2Y_EXTENSIONS)
 builtin_check_c_compiler_flag(-Wno-pedantic         COMPILER_RT_HAS_WNO_PEDANTIC)
 builtin_check_c_compiler_flag(-nogpulib             COMPILER_RT_HAS_NOGPULIB_FLAG)
 builtin_check_c_compiler_flag(-flto                 COMPILER_RT_HAS_FLTO_FLAG)

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -945,7 +945,7 @@ else ()
   append_list_if(COMPILER_RT_HAS_WBUILTIN_DECLARATION_MISMATCH_FLAG -Werror=builtin-declaration-mismatch BUILTIN_CFLAGS)
 
   # Builtins use __COUNTER__
-  append_list_if(COMPILER_RT_HAS_WNO_C2Y_EXTENSIONS -Wno-c2y-extensions BUILTIN_CFLAGS)
+  append_list_if(COMPILER_RT_HAS_WC2Y_EXTENSIONS -Wno-c2y-extensions BUILTIN_CFLAGS)
 
   # Don't embed directives for picking any specific CRT
   if (MSVC)


### PR DESCRIPTION
Fix the following warnings when building compiler-rt builtins with GCC:

  cc1: note: unrecognized command-line option '-Wno-c2y-extensions' may
  have been intended to silence earlier diagnostics


The builtin_check_c_compiler_flag() checks for these flags pass under GCC because GCC exits with code 0 for -Wno-* if unknown but code 1 for the -W* case. Check for the positive case instead.

Here is a demo with Clang & GCC both doing this : https://godbolt.org/z/eY3688KEM
