### PR TITLE
[offload] Un-XFAIL interop-print.c test for nvidia

### DIFF
--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -8,8 +8,6 @@
 // RUN:   %fcheck-spirv64-intel -check-prefixes=INTEL
 
 // REQUIRES: gpu
-// XFAIL: nvptx64-nvidia-cuda
-// XFAIL: nvptx64-nvidia-cuda-LTO
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
These tests are _unexpectedly passing_ in a NVIDIA H100. Seems that @adurang fixed the previous issue in #191969.