### PR TITLE
[AMDGPU] Validate user SGPR count against HW range, not field width

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6357,6 +6357,8 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
     return TokError(".amdhsa_next_free_sgpr directive is required");
 
   unsigned UserSGPRCount = ExplicitUserSGPRCount.value_or(ImpliedUserSGPRCount);
+  if (UserSGPRCount > getMaxNumUserSGPRs())
+      return TokError("too many user SGPRs enabled");
 
   // Consider the case where the total number of UserSGPRs with trailing
   // allocated preload SGPRs, is greater than the number of explicitly
@@ -6404,17 +6406,12 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
                     "enabled user SGPRs");
 
   if (isGFX1250Plus()) {
-    if (!isUInt<COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_WIDTH>(UserSGPRCount))
-      return TokError("too many user SGPRs enabled");
     AMDGPU::MCKernelDescriptor::bits_set(
         KD.compute_pgm_rsrc2,
         MCConstantExpr::create(UserSGPRCount, getContext()),
         COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_SHIFT,
         COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT, getContext());
   } else {
-    if (!isUInt<COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_WIDTH>(
-            UserSGPRCount))
-      return TokError("too many user SGPRs enabled");
     AMDGPU::MCKernelDescriptor::bits_set(
         KD.compute_pgm_rsrc2,
         MCConstantExpr::create(UserSGPRCount, getContext()),

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6358,7 +6358,9 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
 
   unsigned UserSGPRCount = ExplicitUserSGPRCount.value_or(ImpliedUserSGPRCount);
   if (UserSGPRCount > getMaxNumUserSGPRs())
-      return TokError("too many user SGPRs enabled");
+    return TokError("too many user SGPRs enabled, found " +
+                    Twine(UserSGPRCount) + ", but only " +
+                    Twine(getMaxNumUserSGPRs()) + " are supported.");
 
   // Consider the case where the total number of UserSGPRs with trailing
   // allocated preload SGPRs, is greater than the number of explicitly

--- a/llvm/test/MC/AMDGPU/hsa-gfx12-v4-user-sgpr-err.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx12-v4-user-sgpr-err.s
@@ -1,0 +1,13 @@
+// RUN: not llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1200 -filetype=null %s 2>&1 | FileCheck --check-prefix=ERR %s
+
+.text
+
+.amdhsa_kernel complete
+// user_sgpr_count range: 0-16
+// ERR: error: too many user SGPRs enabled
+  .amdhsa_user_sgpr_count 17
+
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 27
+.end_amdhsa_kernel
+

--- a/llvm/test/MC/AMDGPU/hsa-gfx12-v4-user-sgpr-err.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx12-v4-user-sgpr-err.s
@@ -3,8 +3,7 @@
 .text
 
 .amdhsa_kernel complete
-// user_sgpr_count range: 0-16
-// ERR: error: too many user SGPRs enabled
+// ERR: error: too many user SGPRs enabled, found 17, but only 16 are supported.
   .amdhsa_user_sgpr_count 17
 
   .amdhsa_next_free_vgpr 9

--- a/llvm/test/MC/AMDGPU/hsa-gfx125x-v4-user-sgpr-err.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx125x-v4-user-sgpr-err.s
@@ -1,0 +1,14 @@
+// RUN: not llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1250 -filetype=null %s 2>&1 | FileCheck --check-prefix=ERR %s
+// RUN: not llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1251 -filetype=null %s 2>&1 | FileCheck --check-prefix=ERR %s
+
+.text
+
+.amdhsa_kernel complete
+// user_sgpr_count range: 0-32
+// ERR: error: too many user SGPRs enabled
+  .amdhsa_user_sgpr_count 33
+
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 27
+.end_amdhsa_kernel
+

--- a/llvm/test/MC/AMDGPU/hsa-gfx125x-v4-user-sgpr-err.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx125x-v4-user-sgpr-err.s
@@ -4,8 +4,7 @@
 .text
 
 .amdhsa_kernel complete
-// user_sgpr_count range: 0-32
-// ERR: error: too many user SGPRs enabled
+// ERR: error: too many user SGPRs enabled, found 33, but only 32 are supported.
   .amdhsa_user_sgpr_count 33
 
   .amdhsa_next_free_vgpr 9


### PR DESCRIPTION
The previous validation checked only the field width, allowing values that exceeded the actual hardware limits (e.g. 0–16 on gfx6-gfx120 and 0–32 on gfx125x) as long as they fit in the bit width.
Tighten validation to reject out-of-range user SGPR counts.