### PR TITLE
[CIR] Fix LocalInitOp verifier to allow nested scopes

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3820,7 +3820,6 @@ def CIR_FuncOp : CIR_Op<"func", [
 
 def CIR_LocalInitOp : CIR_Op<"local_init", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>, NoRegionArguments,
-  ParentOneOf<["cir::FuncOp"]>,
   HasAtMostOneOfAttrs<["tls", "static_local"]>
 ]> {
   let summary = "initialize a static or thread local object";
@@ -3873,6 +3872,7 @@ def CIR_LocalInitOp : CIR_Op<"local_init", [
 }
 }];
 
+  let hasVerifier = 1;
   let hasLLVMLowering = false;
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -375,6 +375,13 @@ LogicalResult cir::BreakOp::verify() {
 // LocalInitOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult cir::LocalInitOp::verify() {
+  if (!getOperation()->getParentOfType<FuncOp>())
+    return emitOpError("must be within a function");
+
+  return success();
+}
+
 LogicalResult
 cir::LocalInitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   cir::GlobalOp global = getReferencedGlobal(symbolTable);

--- a/clang/test/CIR/CodeGen/static-local.cpp
+++ b/clang/test/CIR/CodeGen/static-local.cpp
@@ -740,3 +740,30 @@ int referenced_inside_const() {
 // OGCG-LABEL: define internal noundef i32 @"_ZZ23referenced_inside_constvENK3$_0clEv"(
 // OGCG:   load i32, ptr @_ZZ23referenced_inside_constvE12static_local
 }
+
+// Static local inside a nested scope (e.g., inside an if block).
+// The local_init op must be allowed inside scope ops, not just
+// directly under cir.func.
+void nested_scope_static_local(bool cond) {
+  if (cond) {
+    static A nested_a;
+  }
+}
+// CIR-BEFORE-LPP-LABEL: cir.func no_inline dso_local @_Z25nested_scope_static_localb(
+// CIR-BEFORE-LPP:   cir.scope
+// CIR-BEFORE-LPP:     cir.if
+// CIR-BEFORE-LPP:       cir.local_init static_local @_ZZ25nested_scope_static_localbE8nested_a
+//
+// CIR-LABEL: cir.func no_inline dso_local @_Z25nested_scope_static_localb(
+// CIR:   cir.scope
+// CIR:     cir.if
+// CIR:       cir.get_global @_ZGVZ25nested_scope_static_localbE8nested_a
+// CIR:       cir.call @__cxa_guard_acquire
+//
+// LLVM-CIR-LABEL: define dso_local void @_Z25nested_scope_static_localb(
+// LLVM-CIR:   load atomic i8, ptr @_ZGVZ25nested_scope_static_localbE8nested_a
+// LLVM-CIR:   call i32 @__cxa_guard_acquire(ptr @_ZGVZ25nested_scope_static_localbE8nested_a)
+//
+// OGCG-LABEL: define dso_local void @_Z25nested_scope_static_localb(
+// OGCG:   load atomic i8, ptr @_ZGVZ25nested_scope_static_localbE8nested_a
+// OGCG:   call i32 @__cxa_guard_acquire(ptr @_ZGVZ25nested_scope_static_localbE8nested_a)

--- a/clang/test/CIR/IR/invalid-static-local.cir
+++ b/clang/test/CIR/IR/invalid-static-local.cir
@@ -88,7 +88,7 @@ module {
 cir.global "private" internal static_local_guard<"_ZGVZ1fvE1y"> @_ZZ1fvE1y : !s32i
 
 cir.global "private" internal @_AnotherGlobal = ctor : !s32i {
-  // expected-error @below {{'cir.local_init' op expects parent op 'cir.func'}}
+  // expected-error @below {{'cir.local_init' op must be within a function}}
   cir.local_init @_ZZ1fvE1y ctor {
     cir.yield
   } dtor {


### PR DESCRIPTION
The `ParentOneOf<["cir::FuncOp"]>` trait on `LocalInitOp` checked only the immediate parent op, which fails when a static local variable is declared inside a nested scope (e.g., an `if` block) within a function. This is a regression from #193576.

Replace `ParentOneOf` with a custom verifier using `getParentOfType<FuncOp>()` that checks ancestors instead of just the immediate parent.

Fixes compilation of real-world code (e.g., Bullet physics engine's `btSoftBody.cpp` and `btSoftBodyHelpers.cpp`) where function-scope `static const` objects are declared inside `if` blocks.

Made with [Cursor](https://cursor.com)