### PR TITLE
[flang][cuda] Restore constructor for global only module

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFAddConstructor.cpp
@@ -76,6 +76,37 @@ static fir::GlobalOp createManagedPointerGlobal(fir::FirOpBuilder &builder,
   return ptrGlobal;
 }
 
+static bool hasRegisteredGlobals(mlir::ModuleOp mod,
+                                 mlir::SymbolTable gpuSymTable) {
+  for (fir::GlobalOp globalOp : mod.getOps<fir::GlobalOp>()) {
+    auto attr = globalOp.getDataAttrAttr();
+    if (!attr)
+      continue;
+    if (!gpuSymTable.lookup(globalOp.getSymName()))
+      continue;
+    if (attr.getValue() == cuf::DataAttribute::Managed &&
+        !mlir::isa<fir::BaseBoxType>(globalOp.getType()))
+      return true;
+    switch (attr.getValue()) {
+    case cuf::DataAttribute::Device:
+    case cuf::DataAttribute::Constant:
+    case cuf::DataAttribute::Managed: {
+      return true;
+    } break;
+    default:
+      break;
+    }
+  }
+  return false;
+}
+
+static bool hasKernel(mlir::gpu::GPUModuleOp gpuMod) {
+  for (auto func : gpuMod.getOps<mlir::gpu::GPUFuncOp>())
+    if (func.isKernel())
+      return true;
+  return false;
+}
+
 struct CUFAddConstructor
     : public fir::impl::CUFAddConstructorBase<CUFAddConstructor> {
 
@@ -118,16 +149,11 @@ struct CUFAddConstructor
 
     auto gpuMod = symTab.lookup<mlir::gpu::GPUModuleOp>(cudaDeviceModuleName);
     if (gpuMod) {
-      bool hasKernel = false;
-      for (auto func : gpuMod.getOps<mlir::gpu::GPUFuncOp>()) {
-        if (func.isKernel()) {
-          hasKernel = true;
-          break;
-        }
-      }
-      if (!hasKernel) {
-        // No kernels means no GPU binary to register. This happens for host
-        // TUs that USE a kernel module but don't define any device code.
+      mlir::SymbolTable gpuSymTable(gpuMod);
+      if (!hasKernel(gpuMod) && !hasRegisteredGlobals(mod, gpuSymTable)) {
+        // No kernels and no globals to register means no GPU binary to
+        // register. This happens for host TUs that USE a kernel module but
+        // don't define any device code.
         mlir::LLVM::ReturnOp::create(builder, loc, mlir::ValueRange{});
         return;
       }
@@ -151,7 +177,6 @@ struct CUFAddConstructor
       }
 
       // Register variables
-      mlir::SymbolTable gpuSymTable(gpuMod);
       bool hasNonAllocManagedGlobal = false;
       for (fir::GlobalOp globalOp : mod.getOps<fir::GlobalOp>()) {
         auto attr = globalOp.getDataAttrAttr();

--- a/flang/test/Fir/CUDA/cuda-constructor-2.f90
+++ b/flang/test/Fir/CUDA/cuda-constructor-2.f90
@@ -170,3 +170,32 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 // CHECK: llvm.func internal @__cudaFortranConstructor()
 // CHECK-NEXT: llvm.call @_FortranACUFRegisterAllocator()
 // CHECK-NEXT: llvm.return
+
+// -----
+
+// Test that when the gpu.module has no kernels but a device global, the
+// constructor registers the global.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>>, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+
+  fir.global @_QMkernels_mEdev_var {data_attr = #cuf.cuda<device>} : f32 {
+    %0 = arith.constant 0.0 : f32
+    fir.has_value %0 : f32
+  }
+
+  gpu.module @cuda_device_mod {
+    gpu.func @_QMkernels_mPnot_a_kernel() {
+      gpu.return
+    }
+    fir.global @_QMkernels_mEdev_var {data_attr = #cuf.cuda<device>} : f32 {
+      %0 = arith.constant 0.0 : f32
+      fir.has_value %0 : f32
+    }
+  }
+}
+
+// CHECK: llvm.func internal @__cudaFortranConstructor()
+// CHECK: llvm.call @_FortranACUFRegisterAllocator()
+// CHECK: cuf.register_module @cuda_device_mod -> !llvm.ptr 
+// CHECK: fir.address_of(@_QMkernels_mEdev_var) : !fir.ref<f32> 
+// CHECK: fir.call @_FortranACUFRegisterVariable(%3, %4, %5, %6) : (!fir.ref<!fir.llvm_ptr<i8>>, !fir.ref<i8>, !fir.ref<i8>, i64) -> () 


### PR DESCRIPTION
When the module has no kernel but device global, the constructor still need to register the module and register the globals otherwise it will fail at runtime with `cudaErrorInvalidSymbol`. Fix a regression from https://github.com/llvm/llvm-project/pull/194290