### PR TITLE
[clang-sycl-linker] Add FrontendOffloading dependency to clang-sycl-linker

### DIFF
--- a/clang/tools/clang-sycl-linker/CMakeLists.txt
+++ b/clang/tools/clang-sycl-linker/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   BinaryFormat
   BitWriter
   Core
+  FrontendOffloading
   IRReader
   Linker
   MC


### PR DESCRIPTION
This PR fixes the build after https://github.com/llvm/llvm-project/commit/b862554a70eeb9a8315f45406a7e13c771af1eb7

Fixes missing dependency in `clang-sycl-linker/CMakeLists.txt`