### PR TITLE
[SandboxIR] Implement getPointerOperandType() and getPointerAddressSpace()

### DIFF
--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -1258,6 +1258,10 @@ public:
   /// For isa/dyn_cast.
   LLVM_ABI static bool classof(const Value *From);
   LLVM_ABI Value *getPointerOperand() const;
+  Type *getPointerOperandType() const { return getPointerOperand()->getType(); }
+  unsigned getPointerAddressSpace() const {
+    return getPointerOperandType()->getPointerAddressSpace();
+  }
   Align getAlign() const { return cast<llvm::LoadInst>(Val)->getAlign(); }
   bool isUnordered() const { return cast<llvm::LoadInst>(Val)->isUnordered(); }
   bool isSimple() const { return cast<llvm::LoadInst>(Val)->isSimple(); }
@@ -1287,6 +1291,10 @@ public:
   LLVM_ABI static bool classof(const Value *From);
   LLVM_ABI Value *getValueOperand() const;
   LLVM_ABI Value *getPointerOperand() const;
+  Type *getPointerOperandType() const { return getPointerOperand()->getType(); }
+  unsigned getPointerAddressSpace() const {
+    return getPointerOperandType()->getPointerAddressSpace();
+  }
   Align getAlign() const { return cast<llvm::StoreInst>(Val)->getAlign(); }
   bool isSimple() const { return cast<llvm::StoreInst>(Val)->isSimple(); }
   bool isUnordered() const { return cast<llvm::StoreInst>(Val)->isUnordered(); }

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -3224,6 +3224,11 @@ define void @foo(ptr %arg0, ptr %arg1) {
   EXPECT_FALSE(NewLd->isVolatile());
   EXPECT_EQ(NewLd->getType(), Ld->getType());
   EXPECT_EQ(NewLd->getPointerOperand(), Arg1);
+  // Check getPointerOperandType()
+  EXPECT_EQ(NewLd->getPointerOperandType(), Arg1->getType());
+  // Check getPointerAddressSpace()
+  EXPECT_EQ(NewLd->getPointerAddressSpace(),
+            Arg1->getType()->getPointerAddressSpace());
   EXPECT_EQ(NewLd->getAlign(), 8);
   EXPECT_EQ(NewLd->getName(), "NewLd");
   // Check create(InsertBefore, IsVolatile=true)
@@ -3289,6 +3294,11 @@ define void @foo(i8 %val, ptr %ptr) {
   // Check getPointerOperand()
   EXPECT_EQ(St->getValueOperand(), Val);
   EXPECT_EQ(St->getPointerOperand(), Ptr);
+  // Check getPointerOperandType()
+  EXPECT_EQ(St->getPointerOperandType(), Ptr->getType());
+  // Check getPointerAddressSpace()
+  EXPECT_EQ(St->getPointerAddressSpace(),
+            Ptr->getType()->getPointerAddressSpace());
   // Check getAlign()
   EXPECT_EQ(St->getAlign(), 64);
   // Check create(InsertBefore)


### PR DESCRIPTION
This patch implements `getPointerOperandType()` and `getPointerAddressSpace()` member functions for both `LoadInst` and `StoreInst`, mirroring LLVM IR.