### PR TITLE
[clang] Fix interaction of __ob_wrap with signed divide.

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -4230,7 +4230,7 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
   if (CGF.SanOpts.has(SanitizerKind::SignedIntegerOverflow) &&
       Ops.Ty->hasSignedIntegerRepresentation() &&
       !IsWidenedIntegerOp(CGF.getContext(), BO->getLHS()) &&
-      Ops.mayHaveIntegerOverflow() && !Ops.Ty.isWrapType() &&
+      Ops.mayHaveIntegerOverflow() &&
       !CGF.getContext().isTypeIgnoredBySanitizer(
           SanitizerKind::SignedIntegerOverflow, Ops.Ty)) {
     llvm::IntegerType *Ty = cast<llvm::IntegerType>(Zero->getType());

--- a/clang/test/CodeGen/overflow-behavior-types.c
+++ b/clang/test/CodeGen/overflow-behavior-types.c
@@ -62,11 +62,13 @@ void test1(int __ob_wrap a, int __ob_trap b) {
   // DEFAULT: llvm.sadd.with.overflow.i32
   ++b;
 
+  // Despite the fact that "a" is marked as "wrapping", we still perform an
+  // overflow check: an overflowing divide has undefined behavior at the
+  // LLVM IR level (and will trap on x86).
   volatile extern int divisor;
   // DEFAULT: %[[T0:.*]] = load i32, ptr %a
   // DEFAULT-NEXT: %[[T1:.*]] = load volatile i32, ptr @divisor
-  // DEFAULT-NOT: br {{.*}} %handler.divrem_overflow
-  // DEFAULT: sdiv i32 %[[T0]], %[[T1]]
+  // DEFAULT: br {{.*}} %handler.divrem_overflow
   a/divisor;
 
   // DEFAULT: %[[T0:.*]] = load i32, ptr %b


### PR DESCRIPTION
At first glance, signed divide overflow seems similar to other forms of signed overflow, but it's significantly different: it's the only form of signed overflow that is not affected by -fwrapv, it has undefined behavior at the LLVM IR level, and it can trigger trap on x86.

Given that, make ubsan trigger on signed divide overflow even if a type is marked __ob_wrap.