### PR TITLE
[CIR] Add floating-point type descriptors to decodeFixedType

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -884,6 +884,16 @@ decodeFixedType(CIRGenFunction &cgf,
   switch (descriptor.Kind) {
   case IITDescriptor::Void:
     return cir::VoidType::get(context);
+  case IITDescriptor::Half:
+    return cir::FP16Type::get(context);
+  case IITDescriptor::BFloat:
+    return cir::BF16Type::get(context);
+  case IITDescriptor::Float:
+    return cir::SingleType::get(context);
+  case IITDescriptor::Double:
+    return cir::DoubleType::get(context);
+  case IITDescriptor::Quad:
+    return cir::FP128Type::get(context);
   // If the intrinsic expects unsigned integers, the signedness is corrected in
   // correctIntegerSignedness()
   case IITDescriptor::Integer:

--- a/clang/test/CIR/CodeGen/builtins-x86.c
+++ b/clang/test/CIR/CodeGen/builtins-x86.c
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-feature +avx512fp16 -target-feature +avx512bf16 -target-feature +avx512vl -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-feature +avx512fp16 -target-feature +avx512bf16 -target-feature +avx512vl -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t-ogcg.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-feature +avx512fp16 -target-feature +avx512bf16 -target-feature +avx512vl -emit-llvm %s -o %t-ogcg.ll
 // RUN: FileCheck --input-file=%t-ogcg.ll %s -check-prefix=OGCG
 
 void test_sfence(void) {
@@ -53,8 +53,11 @@ void test_clflush(void* a){
   __builtin_ia32_clflush(a);
 }
 
-typedef float v4f __attribute__((vector_size(16)));
-typedef int   v4i __attribute__((vector_size(16)));
+typedef float    v4f  __attribute__((vector_size(16)));
+typedef int      v4i  __attribute__((vector_size(16)));
+typedef double   v2d  __attribute__((vector_size(16)));
+typedef _Float16 v32h __attribute__((vector_size(64)));
+typedef __bf16   v8bf __attribute__((vector_size(16)));
 
 v4f test_cmpeqps(v4f a, v4f b) {
   // CIR-LABEL: @test_cmpeqps
@@ -133,6 +136,66 @@ v4f test_cmpneqps(v4f a, v4f b) {
   // OGCG-LABEL: @test_cmpneqps
   // OGCG: fcmp une <4 x float>
   return __builtin_ia32_cmpneqps(a, b);
+}
+
+v4f test_rsqrtps(v4f a) {
+  // CIR-LABEL: @test_rsqrtps
+  // CIR: cir.call_llvm_intrinsic "x86.sse.rsqrt.ps" {{.*}} : (!cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
+
+  // LLVM-LABEL: @test_rsqrtps
+  // LLVM: call <4 x float> @llvm.x86.sse.rsqrt.ps(<4 x float> {{.*}})
+
+  // OGCG-LABEL: @test_rsqrtps
+  // OGCG: call <4 x float> @llvm.x86.sse.rsqrt.ps(<4 x float> {{.*}})
+  return __builtin_ia32_rsqrtps(a);
+}
+
+v4f test_rcpps(v4f a) {
+  // CIR-LABEL: @test_rcpps
+  // CIR: cir.call_llvm_intrinsic "x86.sse.rcp.ps" {{.*}} : (!cir.vector<4 x !cir.float>) -> !cir.vector<4 x !cir.float>
+
+  // LLVM-LABEL: @test_rcpps
+  // LLVM: call <4 x float> @llvm.x86.sse.rcp.ps(<4 x float> {{.*}})
+
+  // OGCG-LABEL: @test_rcpps
+  // OGCG: call <4 x float> @llvm.x86.sse.rcp.ps(<4 x float> {{.*}})
+  return __builtin_ia32_rcpps(a);
+}
+
+v2d test_minpd(v2d a, v2d b) {
+  // CIR-LABEL: @test_minpd
+  // CIR: cir.call_llvm_intrinsic "x86.sse2.min.pd" {{.*}} : (!cir.vector<2 x !cir.double>, !cir.vector<2 x !cir.double>) -> !cir.vector<2 x !cir.double>
+
+  // LLVM-LABEL: @test_minpd
+  // LLVM: call <2 x double> @llvm.x86.sse2.min.pd(<2 x double> {{.*}}, <2 x double> {{.*}})
+
+  // OGCG-LABEL: @test_minpd
+  // OGCG: call <2 x double> @llvm.x86.sse2.min.pd(<2 x double> {{.*}}, <2 x double> {{.*}})
+  return __builtin_ia32_minpd(a, b);
+}
+
+v32h test_addph512(v32h a, v32h b) {
+  // CIR-LABEL: @test_addph512
+  // CIR: cir.call_llvm_intrinsic "x86.avx512fp16.add.ph.512" {{.*}} : (!cir.vector<32 x !cir.f16>, !cir.vector<32 x !cir.f16>, !s32i) -> !cir.vector<32 x !cir.f16>
+
+  // LLVM-LABEL: @test_addph512
+  // LLVM: call <32 x half> @llvm.x86.avx512fp16.add.ph.512(<32 x half> {{.*}}, <32 x half> {{.*}}, i32 4)
+
+  // OGCG-LABEL: @test_addph512
+  // OGCG: call <32 x half> @llvm.x86.avx512fp16.add.ph.512(<32 x half> {{.*}}, <32 x half> {{.*}}, i32 4)
+  return __builtin_ia32_addph512(a, b, 4);
+}
+
+v8bf test_cvtne2ps2bf16_128(v4f a, v4f b) {
+  // CIR-LABEL: @test_cvtne2ps2bf16_128
+  // CIR: cir.call_llvm_intrinsic "x86.avx512bf16.cvtne2ps2bf16.128" {{.*}} : (!cir.vector<4 x !cir.float>, !cir.vector<4 x !cir.float>) -> !cir.vector<8 x !cir.bf16>
+
+  // LLVM-LABEL: @test_cvtne2ps2bf16_128
+  // LLVM: call <8 x bfloat> @llvm.x86.avx512bf16.cvtne2ps2bf16.128(<4 x float> {{.*}}, <4 x float> {{.*}})
+
+  // OGCG-LABEL: @test_cvtne2ps2bf16_128
+  // OGCG: call <8 x bfloat> @llvm.x86.avx512bf16.cvtne2ps2bf16.128(<4 x float> {{.*}}, <4 x float> {{.*}})
+  return __builtin_ia32_cvtne2ps2bf16_128(a, b);
 }
 
 v4i test_convertvector(v4f a) {


### PR DESCRIPTION
`decodeFixedType` in `CIRGenBuiltin.cpp` only handled `Void`, `Integer`, `Vector`, and `Pointer` IIT descriptor kinds.  Any target builtin whose intrinsic signature includes a floating-point type (e.g. `__builtin_ia32_rsqrtps` → `<4 x float>`) hit the default `errorNYI` path, which returned `VoidType`.  `VectorType::get(VoidType, N)` then tripped the MLIR type verifier assertion.

Adds `Half`, `BFloat`, `Float`, `Double`, and `Quad` cases.

Found while building the Eigen test suite with CIR — this was crashing 21 of 135 test files.
