### PR TITLE
[CIR] Add implicit return zero handling

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -514,6 +514,21 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
     }
     emitAndUpdateRetAlloca(returnType, getLoc(bodyEndLoc),
                            getContext().getTypeAlignInChars(returnType));
+
+    // If this is an implicit-return-zero function, initialize the return
+    // value. This mirrors the implicit-return-zero handling in classic
+    // codegen's EmitFunctionProlog (CGCall.cpp). It is done here, after
+    // emitAndUpdateRetAlloca, because in CIR the return slot is created
+    // after the prolog (the opposite of classic codegen, where ReturnValue
+    // is set up before EmitFunctionProlog runs).
+    // TODO(cir): Align prolog handling with classic codegen.
+    if (fd && fd->hasImplicitReturnZero()) {
+      mlir::Type cirRetTy = convertType(returnType.getUnqualifiedType());
+      mlir::Location bodyBeginMLIRLoc = getLoc(bodyBeginLoc);
+      mlir::Value zero = builder.getNullValue(cirRetTy, bodyBeginMLIRLoc);
+      builder.CIRBaseBuilderTy::createStore(bodyBeginMLIRLoc, zero,
+                                            returnValue.getPointer());
+    }
   }
 
   if (isa_and_nonnull<CXXMethodDecl>(d) &&

--- a/clang/test/CIR/CodeGen/implicit-return-zero.c
+++ b/clang/test/CIR/CodeGen/implicit-return-zero.c
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// 'main' implicitly returns 0 if it falls off the end of the function. CIR
+// must initialize the return slot to 0 in the prologue so that loading it for
+// the implicit return does not yield an undefined value.
+
+int main(void) {
+}
+
+// CIR-LABEL: cir.func{{.*}} @main
+// CIR:         %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR-NEXT:    %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR-NEXT:    cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR:         %[[LOAD:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:    cir.return %[[LOAD]] : !s32i
+
+// LLVM-LABEL: define{{.*}} i32 @main(
+// LLVM:         %[[RET:.*]] = alloca i32
+// LLVM:         store i32 0, ptr %[[RET]]
+// LLVM:         %[[LOAD:.*]] = load i32, ptr %[[RET]]
+// LLVM:         ret i32 %[[LOAD]]
+
+// OGCG-LABEL: define{{.*}} i32 @main(
+// OGCG:         ret i32 0

--- a/clang/test/CIR/CodeGen/implicit-return-zero.c
+++ b/clang/test/CIR/CodeGen/implicit-return-zero.c
@@ -1,23 +1,28 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+// RUN: split-file %s %t
 
 // 'main' implicitly returns 0 if it falls off the end of the function. CIR
 // must initialize the return slot to 0 in the prologue so that loading it for
 // the implicit return does not yield an undefined value.
+
+
+//--- empty_body.c
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %t/empty_body.c -o %t/empty_body.cir
+// RUN: FileCheck --input-file=%t/empty_body.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %t/empty_body.c -o %t/empty_body-cir.ll
+// RUN: FileCheck --input-file=%t/empty_body-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %t/empty_body.c -o %t/empty_body.ll
+// RUN: FileCheck --input-file=%t/empty_body.ll %s --check-prefix=OGCG
 
 int main(void) {
 }
 
 // CIR-LABEL: cir.func{{.*}} @main
 // CIR:         %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
-// CIR-NEXT:    %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
-// CIR-NEXT:    cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR:         %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:         cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
 // CIR:         %[[LOAD:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:    cir.return %[[LOAD]] : !s32i
+// CIR:         cir.return %[[LOAD]] : !s32i
 
 // LLVM-LABEL: define{{.*}} i32 @main(
 // LLVM:         %[[RET:.*]] = alloca i32
@@ -27,3 +32,53 @@ int main(void) {
 
 // OGCG-LABEL: define{{.*}} i32 @main(
 // OGCG:         ret i32 0
+
+
+//--- nonempty_body.c
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %t/nonempty_body.c -o %t/nonempty_body.cir
+// RUN: FileCheck --input-file=%t/nonempty_body.cir %s --check-prefix=CIR2
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %t/nonempty_body.c -o %t/nonempty_body-cir.ll
+// RUN: FileCheck --input-file=%t/nonempty_body-cir.ll %s --check-prefix=LLVM2
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %t/nonempty_body.c -o %t/nonempty_body.ll
+// RUN: FileCheck --input-file=%t/nonempty_body.ll %s --check-prefix=OGCG2
+
+int g;
+
+int main(void) {
+  if (g != 0)
+    return g;
+}
+
+// CIR2-LABEL: cir.func{{.*}} @main
+// CIR2:         %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR2:         %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR2:         cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR2:         cir.if
+// CIR2:           %[[G_ADDR:.*]] = cir.get_global @g
+// CIR2:           %[[G:.*]] = cir.load{{.*}} %[[G_ADDR]] : !cir.ptr<!s32i>, !s32i
+// CIR2:           cir.store %[[G]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR2:           %[[EXPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR2:           cir.return %[[EXPL]] : !s32i
+// CIR2:         %[[IMPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR2:         cir.return %[[IMPL]] : !s32i
+
+// LLVM2-LABEL: define{{.*}} i32 @main(
+// LLVM2:         %[[RET:.*]] = alloca i32
+// LLVM2:         store i32 0, ptr %[[RET]]
+// LLVM2:         icmp ne
+// LLVM2:         %[[G:.*]] = load i32, ptr @g
+// LLVM2:         store i32 %[[G]], ptr %[[RET]]
+// LLVM2:         %[[EXPL:.*]] = load i32, ptr %[[RET]]
+// LLVM2:         ret i32 %[[EXPL]]
+// LLVM2:         %[[IMPL:.*]] = load i32, ptr %[[RET]]
+// LLVM2:         ret i32 %[[IMPL]]
+
+// OGCG2-LABEL: define{{.*}} i32 @main(
+// OGCG2:         %[[RET:.*]] = alloca i32
+// OGCG2:         store i32 0, ptr %[[RET]]
+// OGCG2:         icmp ne
+// OGCG2:         %[[G:.*]] = load i32, ptr @g
+// OGCG2:         store i32 %[[G]], ptr %[[RET]]
+// OGCG2:         %[[VAL:.*]] = load i32, ptr %[[RET]]
+// OGCG2:         ret i32 %[[VAL]]

--- a/clang/test/CIR/CodeGen/implicit-return-zero.c
+++ b/clang/test/CIR/CodeGen/implicit-return-zero.c
@@ -8,11 +8,11 @@
 //--- empty_body.c
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %t/empty_body.c -o %t/empty_body.cir
-// RUN: FileCheck --input-file=%t/empty_body.cir %s --check-prefix=CIR
+// RUN: FileCheck --input-file=%t/empty_body.cir %t/empty_body.c --check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %t/empty_body.c -o %t/empty_body-cir.ll
-// RUN: FileCheck --input-file=%t/empty_body-cir.ll %s --check-prefix=LLVM
+// RUN: FileCheck --input-file=%t/empty_body-cir.ll %t/empty_body.c --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %t/empty_body.c -o %t/empty_body.ll
-// RUN: FileCheck --input-file=%t/empty_body.ll %s --check-prefix=OGCG
+// RUN: FileCheck --input-file=%t/empty_body.ll %t/empty_body.c --check-prefix=OGCG
 
 int main(void) {
 }
@@ -37,11 +37,11 @@ int main(void) {
 //--- nonempty_body.c
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %t/nonempty_body.c -o %t/nonempty_body.cir
-// RUN: FileCheck --input-file=%t/nonempty_body.cir %s --check-prefix=CIR2
+// RUN: FileCheck --input-file=%t/nonempty_body.cir %t/nonempty_body.c --check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %t/nonempty_body.c -o %t/nonempty_body-cir.ll
-// RUN: FileCheck --input-file=%t/nonempty_body-cir.ll %s --check-prefix=LLVM2
+// RUN: FileCheck --input-file=%t/nonempty_body-cir.ll %t/nonempty_body.c --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %t/nonempty_body.c -o %t/nonempty_body.ll
-// RUN: FileCheck --input-file=%t/nonempty_body.ll %s --check-prefix=OGCG2
+// RUN: FileCheck --input-file=%t/nonempty_body.ll %t/nonempty_body.c --check-prefix=OGCG
 
 int g;
 
@@ -50,35 +50,35 @@ int main(void) {
     return g;
 }
 
-// CIR2-LABEL: cir.func{{.*}} @main
-// CIR2:         %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
-// CIR2:         %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
-// CIR2:         cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
-// CIR2:         cir.if
-// CIR2:           %[[G_ADDR:.*]] = cir.get_global @g
-// CIR2:           %[[G:.*]] = cir.load{{.*}} %[[G_ADDR]] : !cir.ptr<!s32i>, !s32i
-// CIR2:           cir.store %[[G]], %[[RET]] : !s32i, !cir.ptr<!s32i>
-// CIR2:           %[[EXPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
-// CIR2:           cir.return %[[EXPL]] : !s32i
-// CIR2:         %[[IMPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
-// CIR2:         cir.return %[[IMPL]] : !s32i
+// CIR-LABEL: cir.func{{.*}} @main
+// CIR:         %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:         %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:         cir.store %[[ZERO]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR:         cir.if
+// CIR:           %[[G_ADDR:.*]] = cir.get_global @g
+// CIR:           %[[G:.*]] = cir.load{{.*}} %[[G_ADDR]] : !cir.ptr<!s32i>, !s32i
+// CIR:           cir.store %[[G]], %[[RET]] : !s32i, !cir.ptr<!s32i>
+// CIR:           %[[EXPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR:           cir.return %[[EXPL]] : !s32i
+// CIR:         %[[IMPL:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR:         cir.return %[[IMPL]] : !s32i
 
-// LLVM2-LABEL: define{{.*}} i32 @main(
-// LLVM2:         %[[RET:.*]] = alloca i32
-// LLVM2:         store i32 0, ptr %[[RET]]
-// LLVM2:         icmp ne
-// LLVM2:         %[[G:.*]] = load i32, ptr @g
-// LLVM2:         store i32 %[[G]], ptr %[[RET]]
-// LLVM2:         %[[EXPL:.*]] = load i32, ptr %[[RET]]
-// LLVM2:         ret i32 %[[EXPL]]
-// LLVM2:         %[[IMPL:.*]] = load i32, ptr %[[RET]]
-// LLVM2:         ret i32 %[[IMPL]]
+// LLVM-LABEL: define{{.*}} i32 @main(
+// LLVM:         %[[RET:.*]] = alloca i32
+// LLVM:         store i32 0, ptr %[[RET]]
+// LLVM:         icmp ne
+// LLVM:         %[[G:.*]] = load i32, ptr @g
+// LLVM:         store i32 %[[G]], ptr %[[RET]]
+// LLVM:         %[[EXPL:.*]] = load i32, ptr %[[RET]]
+// LLVM:         ret i32 %[[EXPL]]
+// LLVM:         %[[IMPL:.*]] = load i32, ptr %[[RET]]
+// LLVM:         ret i32 %[[IMPL]]
 
-// OGCG2-LABEL: define{{.*}} i32 @main(
-// OGCG2:         %[[RET:.*]] = alloca i32
-// OGCG2:         store i32 0, ptr %[[RET]]
-// OGCG2:         icmp ne
-// OGCG2:         %[[G:.*]] = load i32, ptr @g
-// OGCG2:         store i32 %[[G]], ptr %[[RET]]
-// OGCG2:         %[[VAL:.*]] = load i32, ptr %[[RET]]
-// OGCG2:         ret i32 %[[VAL]]
+// OGCG-LABEL: define{{.*}} i32 @main(
+// OGCG:         %[[RET:.*]] = alloca i32
+// OGCG:         store i32 0, ptr %[[RET]]
+// OGCG:         icmp ne
+// OGCG:         %[[G:.*]] = load i32, ptr @g
+// OGCG:         store i32 %[[G]], ptr %[[RET]]
+// OGCG:         %[[VAL:.*]] = load i32, ptr %[[RET]]
+// OGCG:         ret i32 %[[VAL]]


### PR DESCRIPTION
This adds code to emit a store of zero to the return value for functions that are identified as having the implicit return zero propery (such as main() in C programs).

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh