### PR TITLE
[libc][math] Refactor bf16subl family to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -57,6 +57,7 @@
 #include "math/bf16sub.h"
 #include "math/bf16subf.h"
 #include "math/bf16subf128.h"
+#include "math/bf16subl.h"
 #include "math/canonicalize.h"
 #include "math/canonicalizebf16.h"
 #include "math/canonicalizef.h"

--- a/libc/shared/math/bf16subl.h
+++ b/libc/shared/math/bf16subl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of bf16subl function -------------------------------===//
+//===-- Shared bf16subl function --------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/bf16subl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_BF16SUBL_H
+#define LLVM_LIBC_SHARED_MATH_BF16SUBL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16subl.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(bfloat16, bf16subl, (long double x, long double y)) {
-  return math::bf16subl(x, y);
-}
+using math::bf16subl;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_BF16SUBL_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -631,6 +631,15 @@ add_header_library(
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.generic.add_sub
 )
+add_header_library(
+  bf16subl
+  HDRS
+    bf16subl.h
+  DEPENDS
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.macros.config
+)
 
 add_header_library(
   canonicalize

--- a/libc/src/__support/math/bf16subl.h
+++ b/libc/src/__support/math/bf16subl.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for bf16subl ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_BF16SUBL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_BF16SUBL_H
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE constexpr bfloat16 bf16subl(long double x, long double y) {
+  return fputil::generic::sub<bfloat16>(x, y);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_BF16SUBL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5236,11 +5236,7 @@ add_entrypoint_object(
   HDRS
     ../bf16subl.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.generic.add_sub
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.bf16subl
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -54,6 +54,7 @@ add_fp_unittest(
     libc.src.__support.math.bf16sub
     libc.src.__support.math.bf16subf
     libc.src.__support.math.bf16subf128
+    libc.src.__support.math.bf16subl
     libc.src.__support.math.canonicalize
     libc.src.__support.math.canonicalizebf16
     libc.src.__support.math.canonicalizef
@@ -296,6 +297,7 @@ add_fp_unittest(
     shared_math_constexpr_test.cpp
   DEPENDS
     libc.src.__support.math.asinbf16
+    libc.src.__support.math.bf16subl
     libc.src.__support.math.ceil
     libc.src.__support.math.ceilbf16
     libc.src.__support.math.ceilf

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -64,6 +64,7 @@ static_assert(1.0L == LIBC_NAMESPACE::shared::fabsl(-1.0L));
 static_assert(1.0L == LIBC_NAMESPACE::shared::fdiml(1.0L, 0.0L));
 static_assert(0.0f == LIBC_NAMESPACE::shared::fdivl(0.0L, 1.0L));
 static_assert(0.0L == LIBC_NAMESPACE::shared::floorl(0.0L));
+static_assert(bfloat16(0.0) == LIBC_NAMESPACE::shared::bf16subl(0.0L, 0.0L));
 
 #endif
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -320,6 +320,7 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0.0L, canonicalizel_cx);
 
   EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16addl(2.0L, 3.0L));
+  EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16subl(0.0L, 0.0L));
   EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16divl(6.0L, 3.0L));
   EXPECT_FP_EQ(bfloat16(0.0), LIBC_NAMESPACE::shared::bf16mull(0.0L, 0.0L));
   EXPECT_FP_EQ(bfloat16(10.0),

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3711,6 +3711,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_bf16subl",
+    hdrs = ["src/__support/math/bf16subl.h"],
+    deps = [
+        ":__support_fputil_basic_operations",
+        ":__support_fputil_bfloat16",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_canonicalize",
     hdrs = ["src/__support/math/canonicalize.h"],
     deps = [
@@ -7080,6 +7090,11 @@ libc_math_function(
 libc_math_function(
     name = "bf16subf128",
     additional_deps = [":__support_math_bf16subf128"],
+)
+
+libc_math_function(
+    name = "bf16subl",
+    additional_deps = [":__support_math_bf16subl"],
 )
 
 libc_math_function(


### PR DESCRIPTION
Refactors the bf16subl math family to be header-only.