### PR TITLE
[flang] Do not mark CUDA device variables as dso_local

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3432,8 +3432,14 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
 
     // Mimic shouldAssumeDSOLocal in clang, marking external definitions as
     // dso_local if it is defined and is ELF, and either static or PIE.
+    // CUDA device/constant/managed/shared variables must not be marked
+    // dso_local because the CUDA runtime interposes on these symbols via
+    // cudaRegisterVar; using direct addressing instead of GOT indirection
+    // causes the wrong address to be registered, leading to segfaults.
     bool isDefinition = global.isInitialized();
-    if (isDefinition && linkage == mlir::LLVM::Linkage::External &&
+    bool isCUDADeviceVar = global.getDataAttr().has_value();
+    if (isDefinition && !isCUDADeviceVar &&
+        linkage == mlir::LLVM::Linkage::External &&
         fir::getTargetTriple(module).isOSBinFormatELF()) {
       llvm::Reloc::Model rm = fir::getRelocationModel(module);
       bool isPIE = fir::getIsPIE(module);

--- a/flang/test/Fir/dso-local.fir
+++ b/flang/test/Fir/dso-local.fir
@@ -82,3 +82,35 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "",
 // CHECK: llvm.mlir.global linkonce constant @linkonce_str()
 // CHECK-NOT: dso_local
 // CHECK-SAME: : !llvm.array<5 x i8>
+
+// -----
+
+// Static relocation model, ELF, CUDA constant variable: no dso_local
+// CUDA device/constant/managed variables need GOT indirection because the
+// CUDA runtime interposes on these symbols via cudaRegisterVar.
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "",
+    fir.relocation_model = 0 : i32,
+    llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+  fir.global @cuda_constant {data_attr = #cuf.cuda<constant>} : i32 {
+    %0 = arith.constant 4 : i32
+    fir.has_value %0 : i32
+  }
+}
+// CHECK: llvm.mlir.global external @cuda_constant()
+// CHECK-NOT: dso_local
+// CHECK-SAME: : i32
+
+// -----
+
+// Static relocation model, ELF, CUDA device variable: no dso_local
+module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "",
+    fir.relocation_model = 0 : i32,
+    llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+  fir.global @cuda_device {data_attr = #cuf.cuda<device>} : i32 {
+    %0 = fir.zero_bits i32
+    fir.has_value %0 : i32
+  }
+}
+// CHECK: llvm.mlir.global external @cuda_device()
+// CHECK-NOT: dso_local
+// CHECK-SAME: : i32


### PR DESCRIPTION
A follow-up to https://github.com/llvm/llvm-project/pull/189709.

```fortran
integer, constant :: zzz = 4
bind(c, name='zzz_from_c') :: zzz
```

In this code, `zzz` is a CUDA `constant` variable with an initializer. With PIE enabled, flang marks it as `dso_local`, causing LLVM to emit direct addressing (`leaq`) instead of GOT-indirect addressing (`movq @GOTPCREL`). The CUDA runtime interposes on these symbols via `cudaRegisterVar`, so the wrong address gets registered, leading to a segfault.

Fix: skip `dso_local` for globals with a CUDA data attribute.