### PR TITLE
[clang][modules-driver] Fix failing import-std regression test

### DIFF
--- a/clang/test/Driver/modules-driver-import-std.cpp
+++ b/clang/test/Driver/modules-driver-import-std.cpp
@@ -1,6 +1,9 @@
 // Checks that -fmodules-driver correctly handles the import of Standard library
 // modules.
 
+// https://github.com/llvm/llvm-project/pull/194475#issuecomment-4331347690
+// UNSUPPORTED: aarch64
+
 // The standard library modules manifest (libc++.modules.json) is discovered
 // relative to the installed C++ standard library runtime libraries
 // We need to create them in order for Clang to find the manifest.


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/194475#issuecomment-4331347690. 
This constrains the test to not run on aarch64, where it fails on `clang-aarch64-quick` and `llvm-clang-aarch64-darwin` builders.
The failing builders don't show any output, and the test will be re-enabled for aarch64 in a later follow-up.