### PR TITLE
[libc][math] Refactor ilogbbf16 family to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -197,6 +197,7 @@
 #include "math/hypotf.h"
 #include "math/hypotf16.h"
 #include "math/ilogb.h"
+#include "math/ilogbbf16.h"
 #include "math/ilogbf.h"
 #include "math/ilogbf128.h"
 #include "math/ilogbf16.h"

--- a/libc/shared/math/ilogbbf16.h
+++ b/libc/shared/math/ilogbbf16.h
@@ -1,4 +1,4 @@
-//===-- Implementation of ilogbbf16 function ------------------------------===//
+//===-- Shared ilogbbf16 function -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/ilogbbf16.h"
+#ifndef LLVM_LIBC_SHARED_MATH_ILOGBBF16_H
+#define LLVM_LIBC_SHARED_MATH_ILOGBBF16_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/ilogbbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(int, ilogbbf16, (bfloat16 x)) { return math::ilogbbf16(x); }
+using math::ilogbbf16;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_ILOGBBF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -819,6 +819,15 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.__support.number_pair
 )
+add_header_library(
+  ilogbbf16
+  HDRS
+    ilogbbf16.h
+  DEPENDS
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.config
+)
 
 add_header_library(
   sincos_integer_utils

--- a/libc/src/__support/math/ilogbbf16.h
+++ b/libc/src/__support/math/ilogbbf16.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for ilogbbf16 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBBF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBBF16_H
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE constexpr int ilogbbf16(bfloat16 x) {
+  return fputil::intlogb<int>(x);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBBF16_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1659,11 +1659,7 @@ add_entrypoint_object(
   HDRS
     ../ilogbbf16.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.manipulation_functions
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.ilogbbf16
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -194,6 +194,7 @@ add_fp_unittest(
     libc.src.__support.math.hypotbf16
     libc.src.__support.math.hypotf16
     libc.src.__support.math.ilogb
+    libc.src.__support.math.ilogbbf16
     libc.src.__support.math.ilogbf
     libc.src.__support.math.ilogbf16
     libc.src.__support.math.ilogbf128
@@ -340,6 +341,7 @@ add_fp_unittest(
     libc.src.__support.math.fmaximum_mag_numf
     libc.src.__support.math.log
     libc.src.__support.math.logbbf16
+    libc.src.__support.math.ilogbbf16
 )
 
 add_fp_unittest(

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -113,5 +113,6 @@ static_assert(bfloat16(0.0) ==
               LIBC_NAMESPACE::shared::floorbf16(bfloat16(0.0f)));
 static_assert(bfloat16(0.0) ==
               LIBC_NAMESPACE::shared::logbbf16(bfloat16(1.0f)));
+static_assert(0 == LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
 
 TEST(LlvmLibcSharedMathTest, ConstantEvaluation) {}

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -537,4 +537,6 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   EXPECT_FP_EQ(bfloat16(0.0),
                LIBC_NAMESPACE::shared::nexttowardbf16(bfloat16(0.0), 0.0L));
 #endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
 }

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3947,6 +3947,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_ilogbbf16",
+    hdrs = ["src/__support/math/ilogbbf16.h"],
+    deps = [
+        ":__support_fputil_bfloat16",
+        ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_sincos_integer_utils",
     hdrs = ["src/__support/math/sincos_integer_utils.h"],
     deps = [
@@ -7191,6 +7201,13 @@ libc_math_function(
     name = "canonicalizef16",
     additional_deps = [
         ":__support_math_canonicalizef16",
+    ],
+)
+
+libc_math_function(
+    name = "ilogbbf16",
+    additional_deps = [
+        ":__support_math_ilogbbf16",
     ],
 )
 


### PR DESCRIPTION
Refactors ilogbbf16 to be header-only.