### PR TITLE
[SLP] Add tests for boundary case with MinProfitableStridedOps

### DIFF
--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
@@ -1003,3 +1003,31 @@ define void @rt_stride_widen_no_reordering_i16(ptr %pl, i64 %stride, ptr %ps) {
 
   ret void
 }
+
+define void @two_wide(ptr %pl, ptr %ps, i64 %stride) {
+; CHECK-LABEL: define void @two_wide(
+; CHECK-SAME: ptr [[PL:%.*]], ptr [[PS:%.*]], i64 [[STRIDE:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[GEP_L0:%.*]] = getelementptr i8, ptr [[PL]], i64 0
+; CHECK-NEXT:    [[GEP_L1:%.*]] = getelementptr i8, ptr [[PL]], i64 [[STRIDE]]
+; CHECK-NEXT:    [[LOAD0:%.*]] = load i8, ptr [[GEP_L0]], align 1
+; CHECK-NEXT:    [[LOAD1:%.*]] = load i8, ptr [[GEP_L1]], align 1
+; CHECK-NEXT:    [[GEP_S0:%.*]] = getelementptr i8, ptr [[PS]], i64 0
+; CHECK-NEXT:    [[GEP_S1:%.*]] = getelementptr i8, ptr [[PS]], i64 1
+; CHECK-NEXT:    store i8 [[LOAD0]], ptr [[GEP_S0]], align 1
+; CHECK-NEXT:    store i8 [[LOAD1]], ptr [[GEP_S1]], align 1
+; CHECK-NEXT:    ret void
+;
+  %gep_l0 = getelementptr i8, ptr %pl, i64 0
+  %gep_l1 = getelementptr i8, ptr %pl, i64 %stride
+
+  %load0  = load i8, ptr %gep_l0
+  %load1  = load i8, ptr %gep_l1
+
+  %gep_s0 = getelementptr i8, ptr %ps, i64 0
+  %gep_s1 = getelementptr i8, ptr %ps, i64 1
+
+  store i8 %load0, ptr %gep_s0
+  store i8 %load1, ptr %gep_s1
+
+  ret void
+}


### PR DESCRIPTION
Currently we don't vectorize runtime strided loads when `VF == MinProfitableStridedOps`.