### PR TITLE
[libc][math] Refactor llogbbf16 to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -206,6 +206,7 @@
 #include "math/ldexpf128.h"
 #include "math/ldexpf16.h"
 #include "math/llogb.h"
+#include "math/llogbbf16.h"
 #include "math/llogbf.h"
 #include "math/llogbf128.h"
 #include "math/llogbf16.h"

--- a/libc/shared/math/llogbbf16.h
+++ b/libc/shared/math/llogbbf16.h
@@ -1,4 +1,4 @@
-//===-- Implementation of llogbbf16 function ------------------------------===//
+//===-- Shared llogbbf16 function -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/llogbbf16.h"
+#ifndef LLVM_LIBC_SHARED_MATH_LLOGBBF16_H
+#define LLVM_LIBC_SHARED_MATH_LLOGBBF16_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/llogbbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(long, llogbbf16, (bfloat16 x)) { return math::llogbbf16(x); }
+using math::llogbbf16;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_LLOGBBF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -819,6 +819,17 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.__support.number_pair
 )
+
+add_header_library(
+  llogbbf16
+  HDRS
+    llogbbf16.h
+  DEPENDS
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.config
+)
+
 add_header_library(
   ilogbbf16
   HDRS

--- a/libc/src/__support/math/llogbbf16.h
+++ b/libc/src/__support/math/llogbbf16.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for llogbbf16 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBBF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBBF16_H
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE constexpr long llogbbf16(bfloat16 x) {
+  return fputil::intlogb<long>(x);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_LLOGBBF16_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1720,11 +1720,7 @@ add_entrypoint_object(
   HDRS
     ../llogbbf16.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.manipulation_functions
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.llogbbf16
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -201,6 +201,7 @@ add_fp_unittest(
     libc.src.__support.math.ilogbl
     libc.src.__support.math.ldexpf
     libc.src.__support.math.llogb
+    libc.src.__support.math.llogbbf16
     libc.src.__support.math.log
     libc.src.__support.math.log10
     libc.src.__support.math.log10f16
@@ -339,6 +340,7 @@ add_fp_unittest(
     libc.src.__support.math.fmaximum_mag_num
     libc.src.__support.math.fmaximum_mag_numbf16
     libc.src.__support.math.fmaximum_mag_numf
+    libc.src.__support.math.llogbbf16
     libc.src.__support.math.log
     libc.src.__support.math.logbbf16
     libc.src.__support.math.ilogbbf16

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -114,6 +114,6 @@ static_assert(bfloat16(0.0) ==
 static_assert(bfloat16(0.0) ==
               LIBC_NAMESPACE::shared::logbbf16(bfloat16(1.0f)));
 static_assert(0 == LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
-static_assert(0.0L == LIBC_NAMESPACE::shared::llogbbf16(bfloat16(1.0)));
+static_assert(0L == LIBC_NAMESPACE::shared::llogbbf16(bfloat16(1.0)));
 
 TEST(LlvmLibcSharedMathTest, ConstantEvaluation) {}

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -114,5 +114,6 @@ static_assert(bfloat16(0.0) ==
 static_assert(bfloat16(0.0) ==
               LIBC_NAMESPACE::shared::logbbf16(bfloat16(1.0f)));
 static_assert(0 == LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
+static_assert(0.0L == LIBC_NAMESPACE::shared::llogbbf16(bfloat16(1.0)));
 
 TEST(LlvmLibcSharedMathTest, ConstantEvaluation) {}

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -537,6 +537,6 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   EXPECT_FP_EQ(bfloat16(0.0),
                LIBC_NAMESPACE::shared::nexttowardbf16(bfloat16(0.0), 0.0L));
 #endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
-
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
+  EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbbf16(bfloat16(1.0)));
 }

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -537,6 +537,7 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   EXPECT_FP_EQ(bfloat16(0.0),
                LIBC_NAMESPACE::shared::nexttowardbf16(bfloat16(0.0), 0.0L));
 #endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbbf16(bfloat16(1.0)));
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbbf16(bfloat16(1.0)));
 }

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3957,6 +3957,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_llogbbf16",
+    hdrs = ["src/__support/math/llogbbf16.h"],
+    deps = [
+        ":__support_fputil_bfloat16",
+        ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_sincos_integer_utils",
     hdrs = ["src/__support/math/sincos_integer_utils.h"],
     deps = [
@@ -8395,6 +8405,13 @@ libc_math_function(
     name = "llogb",
     additional_deps = [
         ":__support_math_llogb",
+    ],
+)
+
+libc_math_function(
+    name = "llogbbf16",
+    additional_deps = [
+        ":__support_math_llogbbf16",
     ],
 )
 


### PR DESCRIPTION
Refactors llogbbf16 to be header-only.

part of: #147386