### PR TITLE
[libc][math] Refactor sqrtl family to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -284,6 +284,7 @@
 #include "math/sqrtf.h"
 #include "math/sqrtf128.h"
 #include "math/sqrtf16.h"
+#include "math/sqrtl.h"
 #include "math/tan.h"
 #include "math/tanf.h"
 #include "math/tanf16.h"

--- a/libc/shared/math/sqrtl.h
+++ b/libc/shared/math/sqrtl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of sqrtl function ----------------------------------===//
+//===-- Shared sqrtl function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/sqrtl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_SQRTL_H
+#define LLVM_LIBC_SHARED_MATH_SQRTL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/sqrtl.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(long double, sqrtl, (long double x)) {
-  return math::sqrtl(x);
-}
+using math::sqrtl;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_SQRTL_H

--- a/libc/shared/math/sqrtl.h
+++ b/libc/shared/math/sqrtl.h
@@ -10,6 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_SQRTL_H
 
 #include "shared/libc_common.h"
+#include "src/__support/macros/properties/types.h"
+
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
 #include "src/__support/math/sqrtl.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -19,5 +23,7 @@ using math::sqrtl;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #endif // LLVM_LIBC_SHARED_MATH_SQRTL_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3500,6 +3500,14 @@ add_header_library(
     libc.src.__support.uint128
     libc.include.llvm-libc-types.float128
 )
+add_header_library(
+  sqrtl
+  HDRS
+    sqrtl.h
+  DEPENDS
+    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.macros.config
+)
 
 add_header_library(
   tan

--- a/libc/src/__support/math/sqrtl.h
+++ b/libc/src/__support/math/sqrtl.h
@@ -12,6 +12,8 @@
 #include "src/__support/FPUtil/sqrt.h"
 #include "src/__support/macros/config.h"
 
+#ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
+
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
@@ -21,5 +23,7 @@ LIBC_INLINE LIBC_CONSTEXPR long double sqrtl(long double x) {
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_SQRTL_H

--- a/libc/src/__support/math/sqrtl.h
+++ b/libc/src/__support/math/sqrtl.h
@@ -15,7 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr long double sqrtl(long double x) {
+LIBC_INLINE LIBC_CONSTEXPR long double sqrtl(long double x) {
   return fputil::sqrt<long double>(x);
 }
 

--- a/libc/src/__support/math/sqrtl.h
+++ b/libc/src/__support/math/sqrtl.h
@@ -1,0 +1,25 @@
+//===-- Implementation header for sqrtl -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SQRTL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SQRTL_H
+
+#include "src/__support/FPUtil/sqrt.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE constexpr long double sqrtl(long double x) {
+  return fputil::sqrt<long double>(x);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SQRTL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2841,7 +2841,7 @@ add_entrypoint_object(
   HDRS
     ../sqrtl.h
   DEPENDS
-    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.math.sqrtl
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -282,6 +282,7 @@ add_fp_unittest(
     libc.src.__support.math.sqrt
     libc.src.__support.math.sqrtbf16
     libc.src.__support.math.sqrtf
+    libc.src.__support.math.sqrtl
     libc.src.__support.math.tan
     libc.src.__support.math.tanf
     libc.src.__support.math.tanf16
@@ -344,6 +345,7 @@ add_fp_unittest(
     libc.src.__support.math.log
     libc.src.__support.math.logbbf16
     libc.src.__support.math.ilogbbf16
+    libc.src.__support.math.sqrtl
 )
 
 add_fp_unittest(

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -65,6 +65,7 @@ static_assert(1.0L == LIBC_NAMESPACE::shared::fdiml(1.0L, 0.0L));
 static_assert(0.0f == LIBC_NAMESPACE::shared::fdivl(0.0L, 1.0L));
 static_assert(0.0L == LIBC_NAMESPACE::shared::floorl(0.0L));
 static_assert(bfloat16(0.0) == LIBC_NAMESPACE::shared::bf16subl(0.0L, 0.0L));
+static_assert(0.0L == LIBC_NAMESPACE::shared::sqrtl(0.0L));
 
 #endif
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -365,7 +365,7 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmal(2.0L, 3.0L, 4.0L));
 #endif // LIBC_TYPES_HAS_FLOAT16
 
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::sqrtl(0.0L));
+  EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::sqrtl(0.0L));
 }
 
 #endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -364,6 +364,8 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(1.0f16, LIBC_NAMESPACE::shared::f16sqrtl(1.0L));
   EXPECT_FP_EQ(10.0f16, LIBC_NAMESPACE::shared::f16fmal(2.0L, 3.0L, 4.0L));
 #endif // LIBC_TYPES_HAS_FLOAT16
+
+  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::sqrtl(0.0L));
 }
 
 #endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6150,6 +6150,15 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_sqrtl",
+    hdrs = ["src/__support/math/sqrtl.h"],
+    deps = [
+        ":__support_fputil_sqrt",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_logf16",
     hdrs = ["src/__support/math/logf16.h"],
     deps = [
@@ -9182,7 +9191,9 @@ libc_math_function(
 
 libc_math_function(
     name = "sqrtl",
-    additional_deps = [":__support_fputil_sqrt"],
+    additional_deps = [
+        ":__support_math_sqrtl",
+    ],
 )
 
 libc_math_function(


### PR DESCRIPTION
Refactors the sqrtl math family to be header-only.

part of: #147386

Target Functions:
  - sqrtl