### PR TITLE
[compiler-rt] Respect CMAKE_INSTALL_LIBDIR for runtime install path

### DIFF
--- a/compiler-rt/cmake/base-config-ix.cmake
+++ b/compiler-rt/cmake/base-config-ix.cmake
@@ -125,14 +125,14 @@ endif()
 # TODO: Use common runtimes infrastructure for output and install paths
 if(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR AND NOT APPLE)
   set(COMPILER_RT_OUTPUT_LIBRARY_DIR
-    ${COMPILER_RT_OUTPUT_DIR}/lib)
-  extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" lib)
+    ${COMPILER_RT_OUTPUT_DIR}/lib${LLVM_LIBDIR_SUFFIX})
+  extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "lib${LLVM_LIBDIR_SUFFIX}")
   set(COMPILER_RT_INSTALL_LIBRARY_DIR "${default_install_path}" CACHE PATH
     "Path where built compiler-rt libraries should be installed.")
 else(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR AND NOT APPLE)
   set(COMPILER_RT_OUTPUT_LIBRARY_DIR
-    ${COMPILER_RT_OUTPUT_DIR}/lib/${COMPILER_RT_OS_DIR})
-  extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "lib/${COMPILER_RT_OS_DIR}")
+    ${COMPILER_RT_OUTPUT_DIR}/lib${LLVM_LIBDIR_SUFFIX}/${COMPILER_RT_OS_DIR})
+  extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "lib${LLVM_LIBDIR_SUFFIX}/${COMPILER_RT_OS_DIR}")
   set(COMPILER_RT_INSTALL_LIBRARY_DIR "${default_install_path}" CACHE PATH
     "Path where built compiler-rt libraries should be installed.")
 endif()


### PR DESCRIPTION
compiler-rt currently hardcodes "lib" when forming the default COMPILER_RT_INSTALL_LIBRARY_DIR in base-config-ix.cmake.

In multilib environments, LLVM_LIBDIR_SUFFIX may be "32" (or "64").
With the hardcoded path, runtimes are installed under /usr/lib/linux instead of /usr/lib${LLVM_LIBDIR_SUFFIX}/linux, which breaks downstream packaging and install logic expecting ${libdir}/linux.

Use LLVM_LIBDIR_SUFFIX when computing the default install lib path. This preserves behavior for non-multilib builds and fixes multilib installs.