### PR TITLE
[libc] Validate against LC_ALL_MASK in newlocale

### DIFF
--- a/libc/src/locale/newlocale.cpp
+++ b/libc/src/locale/newlocale.cpp
@@ -18,7 +18,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(locale_t, newlocale,
                    (int category_mask, const char *locale_name, locale_t)) {
   cpp::string_view name(locale_name);
-  if (category_mask > LC_ALL || (!name.empty() && name != "C"))
+  if ((category_mask & ~LC_ALL_MASK) != 0 || (!name.empty() && name != "C"))
     return nullptr;
 
   return &c_locale;

--- a/libc/test/src/locale/locale_test.cpp
+++ b/libc/test/src/locale/locale_test.cpp
@@ -13,7 +13,7 @@
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcLocale, DefaultLocale) {
-  locale_t new_locale = LIBC_NAMESPACE::newlocale(LC_ALL, "C", nullptr);
+  locale_t new_locale = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "C", nullptr);
   EXPECT_NE(new_locale, static_cast<locale_t>(nullptr));
 
   locale_t old_locale = LIBC_NAMESPACE::uselocale(new_locale);
@@ -22,4 +22,26 @@ TEST(LlvmLibcLocale, DefaultLocale) {
   LIBC_NAMESPACE::freelocale(new_locale);
 
   LIBC_NAMESPACE::uselocale(old_locale);
+}
+
+TEST(LlvmLibcLocale, NewLocaleValidation) {
+  // Choosing masks within LC_*_MASK is OK.
+  locale_t loc =
+      LIBC_NAMESPACE::newlocale(LC_CTYPE_MASK | LC_NUMERIC_MASK, "C", nullptr);
+  EXPECT_NE(loc, static_cast<locale_t>(nullptr));
+  LIBC_NAMESPACE::freelocale(loc);
+
+  // Empty locale name is implementation-defined,
+  // defaults to C locale.
+  loc = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "", nullptr);
+  EXPECT_NE(loc, static_cast<locale_t>(nullptr));
+  LIBC_NAMESPACE::freelocale(loc);
+
+  // Masks outside the valid range are rejected.
+  loc = LIBC_NAMESPACE::newlocale(~0, "C", nullptr);
+  EXPECT_EQ(loc, static_cast<locale_t>(nullptr));
+
+  // Invalid locale name is rejected.
+  loc = LIBC_NAMESPACE::newlocale(LC_ALL_MASK, "does-not-exist", nullptr);
+  EXPECT_EQ(loc, static_cast<locale_t>(nullptr));
 }


### PR DESCRIPTION
Currently, `newlocale` uses `LC_ALL` for validation, but it's supposed to the `LC_*_MASK` category of constants (https://pubs.opengroup.org/onlinepubs/9699919799/functions/newlocale.html). Pretty inconsequential since LLVM-libc doesn't actually support locales, but this popped up since libc++ wants to be able to call `newlocale` and not receive a `nullptr`.