### PR TITLE
[CIR] Add token type and none token attribute for coroutine intrinsics

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -200,6 +200,13 @@ public:
   cir::BoolAttr getTrueAttr() { return getCIRBoolAttr(true); }
   cir::BoolAttr getFalseAttr() { return getCIRBoolAttr(false); }
 
+  cir::TokenType getTokenTy() { return cir::TokenType::get(getContext()); }
+
+  cir::ConstantOp getTokenNone(mlir::Location loc) {
+    return cir::ConstantOp::create(
+        *this, loc, cir::TokenNoneAttr::get(cir::TokenType::get(getContext())));
+  }
+
   mlir::Value createComplexCreate(mlir::Location loc, mlir::Value real,
                                   mlir::Value imag) {
     auto resultComplexTy = cir::ComplexType::get(real.getType());

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -283,6 +283,18 @@ def CIR_PoisonAttr : CIR_TypedAttr<"Poison", "poison"> {
 }
 
 //===----------------------------------------------------------------------===//
+// TokenNone
+//===----------------------------------------------------------------------===//
+
+def CIR_TokenNoneAttr : CIR_TypedAttr<"TokenNone", "token_none"> {
+  let summary = "Represents an empty token constant";
+  let description = [{
+    The TokenNoneAttr represents an empty token constant. It corresponds to
+    LLVM's 'none' token and must have token type.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // IntegerAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -843,6 +843,18 @@ def CIR_CatchTokenType : CIR_Type<"CatchToken", "catch_token"> {
 }
 
 //===----------------------------------------------------------------------===//
+//  Token Types
+//===----------------------------------------------------------------------===//
+
+def CIR_TokenType : CIR_Type<"Token", "token"> {
+  let summary = "CIR token type";
+  let description = [{
+    The Token type is an opaque type used to represent dependencies between
+    operations, without carrying meaningful data.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Global type constraints
 //===----------------------------------------------------------------------===//
 
@@ -850,7 +862,7 @@ def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
   CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_RecordType,
   CIR_ComplexType, CIR_VPtrType, CIR_DataMemberType, CIR_MethodType,
-  CIR_EhTokenType, CIR_CleanupTokenType, CIR_CatchTokenType
+  CIR_EhTokenType, CIR_CleanupTokenType, CIR_CatchTokenType, CIR_TokenType
 ]>;
 
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPES_TD

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -383,6 +383,8 @@ public:
   cir::ConstantOp getConstFP(mlir::Location loc, mlir::Type t,
                              llvm::APFloat fpVal);
 
+  cir::TokenType getTokenTy() { return typeCache.tokenTy; }
+
   bool isInt8Ty(mlir::Type i) {
     return i == typeCache.uInt8Ty || i == typeCache.sInt8Ty;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -847,41 +847,6 @@ static RValue tryEmitFPMathIntrinsic(CIRGenFunction &cgf, const CallExpr *e,
   return RValue::getIgnored();
 }
 
-// FIXME: Remove cgf parameter when all descriptor kinds are implemented
-static mlir::Type
-decodeFixedType(CIRGenFunction &cgf,
-                ArrayRef<llvm::Intrinsic::IITDescriptor> &infos,
-                mlir::MLIRContext *context) {
-  using namespace llvm::Intrinsic;
-
-  IITDescriptor descriptor = infos.front();
-  infos = infos.slice(1);
-
-  switch (descriptor.Kind) {
-  case IITDescriptor::Void:
-    return cir::VoidType::get(context);
-  // If the intrinsic expects unsigned integers, the signedness is corrected in
-  // correctIntegerSignedness()
-  case IITDescriptor::Integer:
-    return cir::IntType::get(context, descriptor.IntegerWidth,
-                             /*isSigned=*/true);
-  case IITDescriptor::Vector: {
-    mlir::Type elementType = decodeFixedType(cgf, infos, context);
-    unsigned numElements = descriptor.VectorWidth.getFixedValue();
-    return cir::VectorType::get(elementType, numElements);
-  }
-  case IITDescriptor::Pointer: {
-    mlir::Builder builder(context);
-    auto addrSpace = cir::TargetAddressSpaceAttr::get(
-        context, descriptor.PointerAddressSpace);
-    return cir::PointerType::get(cir::VoidType::get(context), addrSpace);
-  }
-  default:
-    cgf.cgm.errorNYI("Unimplemented intrinsic type descriptor");
-    return cir::VoidType::get(context);
-  }
-}
-
 /// Helper function to correct integer signedness for intrinsic arguments and
 /// return type. IIT always returns signed integers, but the actual intrinsic
 /// may expect unsigned integers based on the AST FunctionDecl parameter types.
@@ -913,37 +878,6 @@ static mlir::Value getCorrectedPtr(mlir::Value argValue, mlir::Type expectedTy,
   }
 
   return builder.createBitcast(argValue, expectedTy);
-}
-
-static cir::FuncType getIntrinsicType(CIRGenFunction &cgf,
-                                      mlir::MLIRContext *context,
-                                      llvm::Intrinsic::ID id) {
-  using namespace llvm::Intrinsic;
-
-  SmallVector<IITDescriptor, 8> table;
-  getIntrinsicInfoTableEntries(id, table);
-
-  ArrayRef<IITDescriptor> tableRef = table;
-  mlir::Type resultTy = decodeFixedType(cgf, tableRef, context);
-
-  SmallVector<mlir::Type, 8> argTypes;
-  bool isVarArg = false;
-  while (!tableRef.empty()) {
-    llvm::Intrinsic::IITDescriptor::IITDescriptorKind kind =
-        tableRef.front().Kind;
-    if (kind == IITDescriptor::VarArg) {
-      isVarArg = true;
-      break; // VarArg is last
-    }
-    argTypes.push_back(decodeFixedType(cgf, tableRef, context));
-  }
-
-  // CIR convention: no explicit void return type
-  if (isa<cir::VoidType>(resultTy))
-    return cir::FuncType::get(context, argTypes, /*optionalReturnType=*/nullptr,
-                              isVarArg);
-
-  return cir::FuncType::get(context, argTypes, resultTy, isVarArg);
 }
 
 RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
@@ -2365,8 +2299,10 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     assert(name.starts_with("llvm.") && "expected llvm. prefix");
     name = name.drop_front(/*strlen("llvm.")=*/5);
 
+    IntrinsicTypeOptions opts;
+    opts.addAddrSpace = true;
     cir::FuncType intrinsicType =
-        getIntrinsicType(*this, &getMLIRContext(), intrinsicID);
+        getIntrinsicType(&getMLIRContext(), intrinsicID, opts);
 
     SmallVector<mlir::Value> args;
     const FunctionDecl *fd = e->getDirectCallee();

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -15,8 +15,8 @@
 #include "clang/AST/StmtCXX.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/TargetInfo.h"
-#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "llvm/IR/Intrinsics.h"
 
 using namespace clang;
 using namespace clang::CIRGen;
@@ -208,7 +208,6 @@ emitBodyAndFallthrough(CIRGenFunction &cgf, const CoroutineBodyStmt &s,
 
 cir::CallOp CIRGenFunction::emitCoroIDBuiltinCall(mlir::Location loc,
                                                   mlir::Value nullPtr) {
-  cir::IntType int32Ty = builder.getUInt32Ty();
 
   const TargetInfo &ti = cgm.getASTContext().getTargetInfo();
   unsigned newAlign = ti.getNewAlign() / ti.getCharWidth();
@@ -217,9 +216,11 @@ cir::CallOp CIRGenFunction::emitCoroIDBuiltinCall(mlir::Location loc,
 
   cir::FuncOp fnOp;
   if (!builtin) {
+    IntrinsicTypeOptions opts;
+    opts.isSigned = false;
     fnOp = cgm.createCIRBuiltinFunction(
         loc, cgm.builtinCoroId,
-        cir::FuncType::get({int32Ty, voidPtrTy, voidPtrTy, voidPtrTy}, int32Ty),
+        getIntrinsicType(&getMLIRContext(), llvm::Intrinsic::coro_id, opts),
         /*FD=*/nullptr);
     assert(fnOp && "should always succeed");
   } else {
@@ -232,15 +233,17 @@ cir::CallOp CIRGenFunction::emitCoroIDBuiltinCall(mlir::Location loc,
 }
 
 cir::CallOp CIRGenFunction::emitCoroAllocBuiltinCall(mlir::Location loc) {
-  cir::BoolType boolTy = builder.getBoolTy();
 
   mlir::Operation *builtin = cgm.getGlobalValue(cgm.builtinCoroAlloc);
 
   cir::FuncOp fnOp;
   if (!builtin) {
-    fnOp = cgm.createCIRBuiltinFunction(loc, cgm.builtinCoroAlloc,
-                                        cir::FuncType::get({uInt32Ty}, boolTy),
-                                        /*fd=*/nullptr);
+    IntrinsicTypeOptions opts;
+    opts.treatInt1AsBool = true;
+    fnOp = cgm.createCIRBuiltinFunction(
+        loc, cgm.builtinCoroAlloc,
+        getIntrinsicType(&getMLIRContext(), llvm::Intrinsic::coro_alloc, opts),
+        /*fd=*/nullptr);
     assert(fnOp && "should always succeed");
   } else {
     fnOp = cast<cir::FuncOp>(builtin);
@@ -259,7 +262,7 @@ CIRGenFunction::emitCoroBeginBuiltinCall(mlir::Location loc,
   if (!builtin) {
     fnOp = cgm.createCIRBuiltinFunction(
         loc, cgm.builtinCoroBegin,
-        cir::FuncType::get({uInt32Ty, voidPtrTy}, voidPtrTy),
+        getIntrinsicType(&getMLIRContext(), llvm::Intrinsic::coro_begin, {}),
         /*fd=*/nullptr);
     assert(fnOp && "should always succeed");
   } else {
@@ -272,15 +275,17 @@ CIRGenFunction::emitCoroBeginBuiltinCall(mlir::Location loc,
 }
 
 cir::CallOp CIRGenFunction::emitCoroEndBuiltinCall(mlir::Location loc,
-                                                   mlir::Value nullPtr) {
-  cir::BoolType boolTy = builder.getBoolTy();
+                                                   mlir::Value nullPtr,
+                                                   cir::ConstantOp unwind) {
   mlir::Operation *builtin = cgm.getGlobalValue(cgm.builtinCoroEnd);
 
   cir::FuncOp fnOp;
   if (!builtin) {
+    IntrinsicTypeOptions opts;
+    opts.treatInt1AsBool = true;
     fnOp = cgm.createCIRBuiltinFunction(
         loc, cgm.builtinCoroEnd,
-        cir::FuncType::get({voidPtrTy, boolTy}, boolTy),
+        getIntrinsicType(&getMLIRContext(), llvm::Intrinsic::coro_end, opts),
         /*fd=*/nullptr);
     assert(fnOp && "should always succeed");
   } else {
@@ -288,7 +293,7 @@ cir::CallOp CIRGenFunction::emitCoroEndBuiltinCall(mlir::Location loc,
   }
 
   return builder.createCallOp(
-      loc, fnOp, mlir::ValueRange{nullPtr, builder.getBool(false, loc)});
+      loc, fnOp, mlir::ValueRange{nullPtr, unwind, builder.getTokenNone(loc)});
 }
 
 cir::CallOp CIRGenFunction::emitCoroFreeBuiltin(const CallExpr *e) {
@@ -298,7 +303,8 @@ cir::CallOp CIRGenFunction::emitCoroFreeBuiltin(const CallExpr *e) {
   if (!builtin) {
     fnOp = cgm.createCIRBuiltinFunction(
         loc, cgm.builtinCoroFree,
-        cir::FuncType::get({uInt32Ty, voidPtrTy}, voidPtrTy),
+        getIntrinsicType(&getMLIRContext(), llvm::Intrinsic::coro_free,
+                         /*opts*/ {}),
         /*fd=*/nullptr);
     assert(fnOp && "should always succeed");
   } else {
@@ -454,7 +460,8 @@ CIRGenFunction::emitCoroutineBody(const CoroutineBodyStmt &s) {
   }
 
   emitCoroEndBuiltinCall(
-      openCurlyLoc, builder.getNullPtr(builder.getVoidPtrTy(), openCurlyLoc));
+      openCurlyLoc, builder.getNullPtr(builder.getVoidPtrTy(), openCurlyLoc),
+      builder.getBool(false, openCurlyLoc));
   if (auto *ret = cast_or_null<ReturnStmt>(s.getReturnStmt())) {
     // Since we already emitted the return value above, so we shouldn't
     // emit it again here.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1640,4 +1640,80 @@ Address CIRGenFunction::emitVAListRef(const Expr *e) {
   return emitLValue(e).getAddress();
 }
 
+cir::FuncType
+CIRGenFunction::getIntrinsicType(mlir::MLIRContext *context,
+                                 llvm::Intrinsic::ID id,
+                                 const IntrinsicTypeOptions &opts) {
+  using namespace llvm::Intrinsic;
+
+  SmallVector<IITDescriptor, 8> table;
+  getIntrinsicInfoTableEntries(id, table);
+
+  ArrayRef<IITDescriptor> tableRef = table;
+  mlir::Type resultTy = decodeFixedType(tableRef, context, opts);
+
+  SmallVector<mlir::Type, 8> argTypes;
+  bool isVarArg = false;
+  while (!tableRef.empty()) {
+    llvm::Intrinsic::IITDescriptor::IITDescriptorKind kind =
+        tableRef.front().Kind;
+    if (kind == IITDescriptor::VarArg) {
+      isVarArg = true;
+      break; // VarArg is last
+    }
+    argTypes.push_back(decodeFixedType(tableRef, context, opts));
+  }
+
+  // CIR convention: no explicit void return type
+  if (isa<cir::VoidType>(resultTy))
+    return cir::FuncType::get(context, argTypes, /*optionalReturnType=*/nullptr,
+                              isVarArg);
+
+  return cir::FuncType::get(context, argTypes, resultTy, isVarArg);
+}
+
+mlir::Type
+CIRGenFunction::decodeFixedType(ArrayRef<llvm::Intrinsic::IITDescriptor> &infos,
+                                mlir::MLIRContext *context,
+                                const IntrinsicTypeOptions &opts) {
+  using namespace llvm::Intrinsic;
+
+  IITDescriptor descriptor = infos.front();
+  infos = infos.slice(1);
+
+  switch (descriptor.Kind) {
+  case IITDescriptor::Void:
+    return cir::VoidType::get(context);
+  // If the intrinsic expects unsigned integers, the signedness is corrected in
+  // correctIntegerSignedness()
+  case IITDescriptor::Integer: {
+    unsigned width = descriptor.IntegerWidth;
+
+    if (opts.treatInt1AsBool && width == 1)
+      return cir::BoolType::get(context);
+
+    return cir::IntType::get(context, width, opts.isSigned);
+  }
+  case IITDescriptor::Vector: {
+    mlir::Type elementType = decodeFixedType(infos, context, opts);
+    unsigned numElements = descriptor.VectorWidth.getFixedValue();
+    return cir::VectorType::get(elementType, numElements);
+  }
+  case IITDescriptor::Pointer: {
+
+    if (opts.addAddrSpace) {
+      auto addrSpace = cir::TargetAddressSpaceAttr::get(
+          context, descriptor.PointerAddressSpace);
+      return cir::PointerType::get(cir::VoidType::get(context), addrSpace);
+    }
+    return voidPtrTy;
+  }
+  case IITDescriptor::Token:
+    return tokenTy;
+  default:
+    cgm.errorNYI("Unimplemented intrinsic type descriptor");
+    return voidTy;
+  }
+}
+
 } // namespace clang::CIRGen

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1672,7 +1672,8 @@ public:
   void emitConstructorBody(FunctionArgList &args);
 
   mlir::LogicalResult emitCoroutineBody(const CoroutineBodyStmt &s);
-  cir::CallOp emitCoroEndBuiltinCall(mlir::Location loc, mlir::Value nullPtr);
+  cir::CallOp emitCoroEndBuiltinCall(mlir::Location loc, mlir::Value nullPtr,
+                                     cir::ConstantOp unwind);
   cir::CallOp emitCoroIDBuiltinCall(mlir::Location loc, mlir::Value nullPtr);
   cir::CallOp emitCoroAllocBuiltinCall(mlir::Location loc);
   cir::CallOp emitCoroBeginBuiltinCall(mlir::Location loc,
@@ -2286,6 +2287,23 @@ public:
       cgm.errorNYI("Global op addrspace cast");
     return builder.createAddrSpaceCast(v, destTy);
   }
+  /// ----------------------
+  /// Intrinsic helpers
+  /// -
+public:
+  struct IntrinsicTypeOptions {
+    bool treatInt1AsBool = false;
+    bool addAddrSpace = false;
+    bool isSigned = true;
+  };
+
+  cir::FuncType getIntrinsicType(mlir::MLIRContext *context,
+                                 llvm::Intrinsic::ID id,
+                                 const IntrinsicTypeOptions &opts);
+
+  mlir::Type decodeFixedType(ArrayRef<llvm::Intrinsic::IITDescriptor> &infos,
+                             mlir::MLIRContext *context,
+                             const IntrinsicTypeOptions &opts);
 
   //===--------------------------------------------------------------------===//
   //                         OpenMP Emission

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -102,6 +102,7 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
   doubleTy = cir::DoubleType::get(&getMLIRContext());
   fP80Ty = cir::FP80Type::get(&getMLIRContext());
   fP128Ty = cir::FP128Type::get(&getMLIRContext());
+  tokenTy = cir::TokenType::get(&getMLIRContext());
 
   allocaInt8PtrTy = cir::PointerType::get(uInt8Ty, cirAllocaAddressSpace);
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypeCache.h
@@ -51,6 +51,8 @@ struct CIRGenTypeCache {
   cir::FP80Type fP80Ty;
   cir::FP128Type fP128Ty;
 
+  cir::TokenType tokenTy;
+
   /// ClangIR char
   mlir::Type uCharTy;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -466,8 +466,8 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
 
   if (mlir::isa<cir::ConstArrayAttr, cir::ConstVectorAttr,
                 cir::ConstComplexAttr, cir::ConstRecordAttr,
-                cir::GlobalViewAttr, cir::PoisonAttr, cir::TypeInfoAttr,
-                cir::VTableAttr>(attrType))
+                cir::GlobalViewAttr, cir::PoisonAttr, cir::TokenNoneAttr,
+                cir::TypeInfoAttr, cir::VTableAttr>(attrType))
     return success();
 
   assert(isa<TypedAttr>(attrType) && "What else could we be looking at here?");

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -76,6 +76,8 @@ bool isCXXABIAttributeLegal(const mlir::TypeConverter &tc,
           [&tc](cir::ZeroAttr za) { return tc.isLegal(za.getType()); })
       .Case<cir::PoisonAttr>(
           [&tc](cir::PoisonAttr pa) { return tc.isLegal(pa.getType()); })
+      .Case<cir::TokenNoneAttr>(
+          [&tc](cir::TokenNoneAttr tka) { return tc.isLegal(tka.getType()); })
       .Case<cir::UndefAttr>(
           [&tc](cir::UndefAttr uda) { return tc.isLegal(uda.getType()); })
       .Case<mlir::TypeAttr>(
@@ -156,6 +158,9 @@ mlir::Attribute rewriteAttribute(const mlir::TypeConverter &tc,
       })
       .Case<cir::PoisonAttr>([&tc](cir::PoisonAttr pa) {
         return cir::PoisonAttr::get(tc.convertType(pa.getType()));
+      })
+      .Case<cir::TokenNoneAttr>([&tc](cir::TokenNoneAttr tkn) {
+        return cir::TokenNoneAttr::get(tc.convertType(tkn.getType()));
       })
       .Case<cir::UndefAttr>([&tc](cir::UndefAttr uda) {
         return cir::UndefAttr::get(tc.convertType(uda.getType()));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -677,6 +677,13 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ZeroAttr attr) {
                                     converter->convertType(attr.getType()));
 }
 
+/// TokenNoneAttr visitor.
+mlir::Value CIRAttrToValue::visitCirAttr(cir::TokenNoneAttr attr) {
+  mlir::Location loc = parentOp->getLoc();
+  return mlir::LLVM::NoneTokenOp::create(
+      rewriter, loc, converter->convertType(attr.getType()));
+}
+
 // This class handles rewriting initializer attributes for types that do not
 // require region initialization.
 class GlobalInitAttrRewriter {

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -138,10 +138,10 @@ co_invoke_fn co_invoke;
 // CIR: module {{.*}} {
 // CIR-NEXT: cir.global external @_ZN5folly4coro9co_invokeE = #cir.zero : !rec_folly3A3Acoro3A3Aco_invoke_fn
 
-// CIR: cir.func builtin private @__builtin_coro_id(!u32i, !cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>) -> !u32i
-// CIR:  cir.func builtin private @__builtin_coro_alloc(!u32i) -> !cir.bool
+// CIR: cir.func builtin private @__builtin_coro_id(!u32i, !cir.ptr<!void>, !cir.ptr<!void>, !cir.ptr<!void>) -> !cir.token
+// CIR:  cir.func builtin private @__builtin_coro_alloc(!cir.token) -> !cir.bool
 // CIR:  cir.func builtin private @__builtin_coro_size() -> !u64i
-// CIR:  cir.func builtin private @__builtin_coro_begin(!u32i, !cir.ptr<!void>) -> !cir.ptr<!void>
+// CIR:  cir.func builtin private @__builtin_coro_begin(!cir.token, !cir.ptr<!void>) -> !cir.ptr<!void>
 
 using VoidTask = folly::coro::Task<void>;
 
@@ -172,7 +172,7 @@ VoidTask silly_task() {
 // Perform allocation calling operator 'new' depending on __builtin_coro_alloc and
 // call __builtin_coro_begin for the final coroutine frame address.
 
-// CIR: %[[ShouldAlloc:.*]] = cir.call @__builtin_coro_alloc(%[[CoroId]]) : (!u32i) -> !cir.bool
+// CIR: %[[ShouldAlloc:.*]] = cir.call @__builtin_coro_alloc(%[[CoroId]]) : (!cir.token) -> !cir.bool
 // CIR: cir.store{{.*}} %[[NullPtr]], %[[SavedFrameAddr]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR: cir.if %[[ShouldAlloc]] {
 // CIR:   %[[CoroSize:.*]] = cir.call @__builtin_coro_size() : () -> (!u64i {llvm.noundef})
@@ -334,9 +334,10 @@ VoidTask silly_task() {
 
 // Call builtin coro end and return
 
-// CIR: %[[CoroEndArg0:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!void>
-// CIR: %[[CoroEndArg1:.*]] = cir.const #false
-// CIR: = cir.call @__builtin_coro_end(%[[CoroEndArg0]], %[[CoroEndArg1]])
+// CIR-DAG: %[[CoroEndArg0:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!void>
+// CIR-DAG: %[[CoroEndArg1:.*]] = cir.const #false
+// CIR-DAG: %[[CoroEndArg2:.*]] = cir.const #cir.token_none : !cir.token
+// CIR: cir.call @__builtin_coro_end(%[[CoroEndArg0]], %[[CoroEndArg1]], %[[CoroEndArg2]])
 
 // CIR: %[[Tmp1:.*]] = cir.load{{.*}} %[[VoidTaskAddr]]
 // CIR: cir.return %[[Tmp1]]
@@ -524,7 +525,7 @@ folly::coro::Task<void> yield1() {
 // CIR:   cir.yield
 // CIR: } cleanup  normal {
 // CIR: }
-// CIR: = cir.call @__builtin_coro_end(%{{.*}}, %{{.*}}){{.*}}
+// CIR: cir.call @__builtin_coro_end(%{{.*}}, %{{.*}}, %{{.*}}){{.*}}
 // CIR: %[[RETLOAD:.*]] = cir.load{{.*}} %[[RETVAL]]
 // CIR: cir.return %[[RETLOAD]]
 // CIR: }


### PR DESCRIPTION
This PR adds a `cir.token` type and a `token.none` attribute used by coroutine intrinsics. Before this, we were using `!u32i` to represent the LLVM token type. This change replaces that with a dedicated type. It also moves some functions that were `static` in `CIRGenBuiltin.cpp` into helpers to make the code easier to reuse.