### PR TITLE
[CIR][NFC] Upstream IR roundtrip tests for constants

### DIFF
--- a/clang/test/CIR/IR/constptrattr.cir
+++ b/clang/test/CIR/IR/constptrattr.cir
@@ -2,10 +2,9 @@
 
 !s32i = !cir.int<s, 32>
 
-cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
-cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
-cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
-
 // CHECK: cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
+cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
 // CHECK: cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
+cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
 // CHECK: cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
+cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>

--- a/clang/test/CIR/IR/constptrattr.cir
+++ b/clang/test/CIR/IR/constptrattr.cir
@@ -1,0 +1,11 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
+cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
+cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>
+
+// CHECK: cir.global external @const_ptr = #cir.ptr<4660 : i64> : !cir.ptr<!s32i>
+// CHECK: cir.global external @signed_ptr = #cir.ptr<-1 : i64> : !cir.ptr<!s32i>
+// CHECK: cir.global external @null_ptr = #cir.ptr<null> : !cir.ptr<!s32i>

--- a/clang/test/CIR/IR/float.cir
+++ b/clang/test/CIR/IR/float.cir
@@ -3,68 +3,64 @@
 // Exercise parser/printer roundtrip for floating-point values that require
 // exact hex spelling.
 
+// CHECK-LABEL: cir.func @f32_special_values
 cir.func @f32_special_values() {
+  // CHECK: cir.const #cir.fp<0x7F800001> : !cir.float
   %0 = cir.const #cir.fp<0x7F800001> : !cir.float
+  // CHECK: cir.const #cir.fp<0x7FBFFFFF> : !cir.float
   %1 = cir.const #cir.fp<0x7FBFFFFF> : !cir.float
+  // CHECK: cir.const #cir.fp<0x7FC00000> : !cir.float
   %2 = cir.const #cir.fp<0x7FC00000> : !cir.float
+  // CHECK: cir.const #cir.fp<0xFFFFFFFF> : !cir.float
   %3 = cir.const #cir.fp<0xFFFFFFFF> : !cir.float
+  // CHECK: cir.const #cir.fp<0x7F800000> : !cir.float
   %4 = cir.const #cir.fp<0x7F800000> : !cir.float
+  // CHECK: cir.const #cir.fp<0xFF800000> : !cir.float
   %5 = cir.const #cir.fp<0xFF800000> : !cir.float
   cir.return
 }
 
-// CHECK-LABEL: cir.func @f32_special_values
-// CHECK: cir.const #cir.fp<0x7F800001> : !cir.float
-// CHECK: cir.const #cir.fp<0x7FBFFFFF> : !cir.float
-// CHECK: cir.const #cir.fp<0x7FC00000> : !cir.float
-// CHECK: cir.const #cir.fp<0xFFFFFFFF> : !cir.float
-// CHECK: cir.const #cir.fp<0x7F800000> : !cir.float
-// CHECK: cir.const #cir.fp<0xFF800000> : !cir.float
-
+// CHECK-LABEL: cir.func @f64_special_values
 cir.func @f64_special_values() {
+  // CHECK: cir.const #cir.fp<0x7FF0000000000001> : !cir.double
   %0 = cir.const #cir.fp<0x7FF0000000000001> : !cir.double
+  // CHECK: cir.const #cir.fp<0x7FF8000000000000> : !cir.double
   %1 = cir.const #cir.fp<0x7FF8000000000000> : !cir.double
+  // CHECK: cir.const #cir.fp<0x7FF0000001000000> : !cir.double
   %2 = cir.const #cir.fp<0x7FF0000001000000> : !cir.double
+  // CHECK: cir.const #cir.fp<0xFFF0000001000000> : !cir.double
   %3 = cir.const #cir.fp<0xFFF0000001000000> : !cir.double
+  // CHECK: cir.const #cir.fp<0x7FF0000000000000> : !cir.double
   %4 = cir.const #cir.fp<0x7FF0000000000000> : !cir.double
+  // CHECK: cir.const #cir.fp<0xFFF0000000000000> : !cir.double
   %5 = cir.const #cir.fp<0xFFF0000000000000> : !cir.double
+  // CHECK: cir.const #cir.fp<0xC1CDC00000000000> : !cir.double
   %6 = cir.const #cir.fp<0xC1CDC00000000000> : !cir.double
   cir.return
 }
 
-// CHECK-LABEL: cir.func @f64_special_values
-// CHECK: cir.const #cir.fp<0x7FF0000000000001> : !cir.double
-// CHECK: cir.const #cir.fp<0x7FF8000000000000> : !cir.double
-// CHECK: cir.const #cir.fp<0x7FF0000001000000> : !cir.double
-// CHECK: cir.const #cir.fp<0xFFF0000001000000> : !cir.double
-// CHECK: cir.const #cir.fp<0x7FF0000000000000> : !cir.double
-// CHECK: cir.const #cir.fp<0xFFF0000000000000> : !cir.double
-// CHECK: cir.const #cir.fp<0xC1CDC00000000000> : !cir.double
-
+// CHECK-LABEL: cir.func @f80_special_values
 cir.func @f80_special_values() {
+  // CHECK: cir.const #cir.fp<0x7FFFE000000000000001> : !cir.long_double<!cir.f80>
   %0 = cir.const #cir.fp<0x7FFFE000000000000001> : !cir.long_double<!cir.f80>
+  // CHECK: cir.const #cir.fp<0x7FFFB000000000000011> : !cir.long_double<!cir.f80>
   %1 = cir.const #cir.fp<0x7FFFB000000000000011> : !cir.long_double<!cir.f80>
+  // CHECK: cir.const #cir.fp<0x7FFFC000000000100000> : !cir.long_double<!cir.f80>
   %2 = cir.const #cir.fp<0x7FFFC000000000100000> : !cir.long_double<!cir.f80>
+  // CHECK: cir.const #cir.fp<0x7FFFE000000001000000> : !cir.long_double<!cir.f80>
   %3 = cir.const #cir.fp<0x7FFFE000000001000000> : !cir.long_double<!cir.f80>
+  // CHECK: cir.const #cir.fp<0x7FFF8000000000000000> : !cir.long_double<!cir.f80>
   %4 = cir.const #cir.fp<0x7FFF8000000000000000> : !cir.long_double<!cir.f80>
+  // CHECK: cir.const #cir.fp<0xFFFF8000000000000000> : !cir.long_double<!cir.f80>
   %5 = cir.const #cir.fp<0xFFFF8000000000000000> : !cir.long_double<!cir.f80>
   cir.return
 }
 
-// CHECK-LABEL: cir.func @f80_special_values
-// CHECK: cir.const #cir.fp<0x7FFFE000000000000001> : !cir.long_double<!cir.f80>
-// CHECK: cir.const #cir.fp<0x7FFFB000000000000011> : !cir.long_double<!cir.f80>
-// CHECK: cir.const #cir.fp<0x7FFFC000000000100000> : !cir.long_double<!cir.f80>
-// CHECK: cir.const #cir.fp<0x7FFFE000000001000000> : !cir.long_double<!cir.f80>
-// CHECK: cir.const #cir.fp<0x7FFF8000000000000000> : !cir.long_double<!cir.f80>
-// CHECK: cir.const #cir.fp<0xFFFF8000000000000000> : !cir.long_double<!cir.f80>
-
 // Check that decimal values are preserved when exponential notation would lose
 // precision during roundtrip parsing.
+// CHECK-LABEL: cir.func @f32_potential_precision_loss
 cir.func @f32_potential_precision_loss() {
+  // CHECK: cir.const #cir.fp<1.23697901> : !cir.float
   %0 = cir.const #cir.fp<1.23697901> : !cir.float
   cir.return
 }
-
-// CHECK-LABEL: cir.func @f32_potential_precision_loss
-// CHECK: cir.const #cir.fp<1.23697901> : !cir.float

--- a/clang/test/CIR/IR/float.cir
+++ b/clang/test/CIR/IR/float.cir
@@ -1,0 +1,70 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+// Exercise parser/printer roundtrip for floating-point values that require
+// exact hex spelling.
+
+cir.func @f32_special_values() {
+  %0 = cir.const #cir.fp<0x7F800001> : !cir.float
+  %1 = cir.const #cir.fp<0x7FBFFFFF> : !cir.float
+  %2 = cir.const #cir.fp<0x7FC00000> : !cir.float
+  %3 = cir.const #cir.fp<0xFFFFFFFF> : !cir.float
+  %4 = cir.const #cir.fp<0x7F800000> : !cir.float
+  %5 = cir.const #cir.fp<0xFF800000> : !cir.float
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @f32_special_values
+// CHECK: cir.const #cir.fp<0x7F800001> : !cir.float
+// CHECK: cir.const #cir.fp<0x7FBFFFFF> : !cir.float
+// CHECK: cir.const #cir.fp<0x7FC00000> : !cir.float
+// CHECK: cir.const #cir.fp<0xFFFFFFFF> : !cir.float
+// CHECK: cir.const #cir.fp<0x7F800000> : !cir.float
+// CHECK: cir.const #cir.fp<0xFF800000> : !cir.float
+
+cir.func @f64_special_values() {
+  %0 = cir.const #cir.fp<0x7FF0000000000001> : !cir.double
+  %1 = cir.const #cir.fp<0x7FF8000000000000> : !cir.double
+  %2 = cir.const #cir.fp<0x7FF0000001000000> : !cir.double
+  %3 = cir.const #cir.fp<0xFFF0000001000000> : !cir.double
+  %4 = cir.const #cir.fp<0x7FF0000000000000> : !cir.double
+  %5 = cir.const #cir.fp<0xFFF0000000000000> : !cir.double
+  %6 = cir.const #cir.fp<0xC1CDC00000000000> : !cir.double
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @f64_special_values
+// CHECK: cir.const #cir.fp<0x7FF0000000000001> : !cir.double
+// CHECK: cir.const #cir.fp<0x7FF8000000000000> : !cir.double
+// CHECK: cir.const #cir.fp<0x7FF0000001000000> : !cir.double
+// CHECK: cir.const #cir.fp<0xFFF0000001000000> : !cir.double
+// CHECK: cir.const #cir.fp<0x7FF0000000000000> : !cir.double
+// CHECK: cir.const #cir.fp<0xFFF0000000000000> : !cir.double
+// CHECK: cir.const #cir.fp<0xC1CDC00000000000> : !cir.double
+
+cir.func @f80_special_values() {
+  %0 = cir.const #cir.fp<0x7FFFE000000000000001> : !cir.long_double<!cir.f80>
+  %1 = cir.const #cir.fp<0x7FFFB000000000000011> : !cir.long_double<!cir.f80>
+  %2 = cir.const #cir.fp<0x7FFFC000000000100000> : !cir.long_double<!cir.f80>
+  %3 = cir.const #cir.fp<0x7FFFE000000001000000> : !cir.long_double<!cir.f80>
+  %4 = cir.const #cir.fp<0x7FFF8000000000000000> : !cir.long_double<!cir.f80>
+  %5 = cir.const #cir.fp<0xFFFF8000000000000000> : !cir.long_double<!cir.f80>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @f80_special_values
+// CHECK: cir.const #cir.fp<0x7FFFE000000000000001> : !cir.long_double<!cir.f80>
+// CHECK: cir.const #cir.fp<0x7FFFB000000000000011> : !cir.long_double<!cir.f80>
+// CHECK: cir.const #cir.fp<0x7FFFC000000000100000> : !cir.long_double<!cir.f80>
+// CHECK: cir.const #cir.fp<0x7FFFE000000001000000> : !cir.long_double<!cir.f80>
+// CHECK: cir.const #cir.fp<0x7FFF8000000000000000> : !cir.long_double<!cir.f80>
+// CHECK: cir.const #cir.fp<0xFFFF8000000000000000> : !cir.long_double<!cir.f80>
+
+// Check that decimal values are preserved when exponential notation would lose
+// precision during roundtrip parsing.
+cir.func @f32_potential_precision_loss() {
+  %0 = cir.const #cir.fp<1.23697901> : !cir.float
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @f32_potential_precision_loss
+// CHECK: cir.const #cir.fp<1.23697901> : !cir.float

--- a/clang/test/CIR/IR/int.cir
+++ b/clang/test/CIR/IR/int.cir
@@ -1,0 +1,44 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u8i = !cir.int<u, 8>
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+
+cir.func @integer_boundary_constants() {
+  %0 = cir.const #cir.int<-128> : !s8i
+  %1 = cir.const #cir.int<127> : !s8i
+  %2 = cir.const #cir.int<255> : !u8i
+
+  %3 = cir.const #cir.int<-32768> : !s16i
+  %4 = cir.const #cir.int<32767> : !s16i
+  %5 = cir.const #cir.int<65535> : !u16i
+
+  %6 = cir.const #cir.int<-2147483648> : !s32i
+  %7 = cir.const #cir.int<2147483647> : !s32i
+  %8 = cir.const #cir.int<4294967295> : !u32i
+
+  %9 = cir.const #cir.int<9223372036854775807> : !s64i
+  %10 = cir.const #cir.int<18446744073709551615> : !u64i
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @integer_boundary_constants
+// CHECK:         cir.const #cir.int<-128> : !s8i
+// CHECK:         cir.const #cir.int<127> : !s8i
+// CHECK:         cir.const #cir.int<255> : !u8i
+
+// CHECK:         cir.const #cir.int<-32768> : !s16i
+// CHECK:         cir.const #cir.int<32767> : !s16i
+// CHECK:         cir.const #cir.int<65535> : !u16i
+
+// CHECK:         cir.const #cir.int<-2147483648> : !s32i
+// CHECK:         cir.const #cir.int<2147483647> : !s32i
+// CHECK:         cir.const #cir.int<4294967295> : !u32i
+
+// CHECK:         cir.const #cir.int<9223372036854775807> : !s64i
+// CHECK:         cir.const #cir.int<18446744073709551615> : !u64i

--- a/clang/test/CIR/IR/int.cir
+++ b/clang/test/CIR/IR/int.cir
@@ -9,36 +9,32 @@
 !u32i = !cir.int<u, 32>
 !u64i = !cir.int<u, 64>
 
+// CHECK-LABEL: cir.func @integer_boundary_constants
 cir.func @integer_boundary_constants() {
+  // CHECK:         cir.const #cir.int<-128> : !s8i
   %0 = cir.const #cir.int<-128> : !s8i
+  // CHECK:         cir.const #cir.int<127> : !s8i
   %1 = cir.const #cir.int<127> : !s8i
+  // CHECK:         cir.const #cir.int<255> : !u8i
   %2 = cir.const #cir.int<255> : !u8i
 
+  // CHECK:         cir.const #cir.int<-32768> : !s16i
   %3 = cir.const #cir.int<-32768> : !s16i
+  // CHECK:         cir.const #cir.int<32767> : !s16i
   %4 = cir.const #cir.int<32767> : !s16i
+  // CHECK:         cir.const #cir.int<65535> : !u16i
   %5 = cir.const #cir.int<65535> : !u16i
 
+  // CHECK:         cir.const #cir.int<-2147483648> : !s32i
   %6 = cir.const #cir.int<-2147483648> : !s32i
+  // CHECK:         cir.const #cir.int<2147483647> : !s32i
   %7 = cir.const #cir.int<2147483647> : !s32i
+  // CHECK:         cir.const #cir.int<4294967295> : !u32i
   %8 = cir.const #cir.int<4294967295> : !u32i
 
+  // CHECK:         cir.const #cir.int<9223372036854775807> : !s64i
   %9 = cir.const #cir.int<9223372036854775807> : !s64i
+  // CHECK:         cir.const #cir.int<18446744073709551615> : !u64i
   %10 = cir.const #cir.int<18446744073709551615> : !u64i
   cir.return
 }
-
-// CHECK-LABEL: cir.func @integer_boundary_constants
-// CHECK:         cir.const #cir.int<-128> : !s8i
-// CHECK:         cir.const #cir.int<127> : !s8i
-// CHECK:         cir.const #cir.int<255> : !u8i
-
-// CHECK:         cir.const #cir.int<-32768> : !s16i
-// CHECK:         cir.const #cir.int<32767> : !s16i
-// CHECK:         cir.const #cir.int<65535> : !u16i
-
-// CHECK:         cir.const #cir.int<-2147483648> : !s32i
-// CHECK:         cir.const #cir.int<2147483647> : !s32i
-// CHECK:         cir.const #cir.int<4294967295> : !u32i
-
-// CHECK:         cir.const #cir.int<9223372036854775807> : !s64i
-// CHECK:         cir.const #cir.int<18446744073709551615> : !u64i

--- a/clang/test/CIR/IR/int.cir
+++ b/clang/test/CIR/IR/int.cir
@@ -11,30 +11,30 @@
 
 // CHECK-LABEL: cir.func @integer_boundary_constants
 cir.func @integer_boundary_constants() {
-  // CHECK:         cir.const #cir.int<-128> : !s8i
+  // CHECK: cir.const #cir.int<-128> : !s8i
   %0 = cir.const #cir.int<-128> : !s8i
-  // CHECK:         cir.const #cir.int<127> : !s8i
+  // CHECK: cir.const #cir.int<127> : !s8i
   %1 = cir.const #cir.int<127> : !s8i
-  // CHECK:         cir.const #cir.int<255> : !u8i
+  // CHECK: cir.const #cir.int<255> : !u8i
   %2 = cir.const #cir.int<255> : !u8i
 
-  // CHECK:         cir.const #cir.int<-32768> : !s16i
+  // CHECK: cir.const #cir.int<-32768> : !s16i
   %3 = cir.const #cir.int<-32768> : !s16i
-  // CHECK:         cir.const #cir.int<32767> : !s16i
+  // CHECK: cir.const #cir.int<32767> : !s16i
   %4 = cir.const #cir.int<32767> : !s16i
-  // CHECK:         cir.const #cir.int<65535> : !u16i
+  // CHECK: cir.const #cir.int<65535> : !u16i
   %5 = cir.const #cir.int<65535> : !u16i
 
-  // CHECK:         cir.const #cir.int<-2147483648> : !s32i
+  // CHECK: cir.const #cir.int<-2147483648> : !s32i
   %6 = cir.const #cir.int<-2147483648> : !s32i
-  // CHECK:         cir.const #cir.int<2147483647> : !s32i
+  // CHECK: cir.const #cir.int<2147483647> : !s32i
   %7 = cir.const #cir.int<2147483647> : !s32i
-  // CHECK:         cir.const #cir.int<4294967295> : !u32i
+  // CHECK: cir.const #cir.int<4294967295> : !u32i
   %8 = cir.const #cir.int<4294967295> : !u32i
 
-  // CHECK:         cir.const #cir.int<9223372036854775807> : !s64i
+  // CHECK: cir.const #cir.int<9223372036854775807> : !s64i
   %9 = cir.const #cir.int<9223372036854775807> : !s64i
-  // CHECK:         cir.const #cir.int<18446744073709551615> : !u64i
+  // CHECK: cir.const #cir.int<18446744073709551615> : !u64i
   %10 = cir.const #cir.int<18446744073709551615> : !u64i
   cir.return
 }


### PR DESCRIPTION
Upstream `clang/test/CIR/IR` roundtrip tests for CIR constant attributes: integer boundary constants, floating-point special values that require exact hex spelling, and pointer constants with integer and null payloads.

Partially addresses #156747.