### PR TITLE
[clang-tidy] Fix UB in SuspiciousIncludeCheck when IgnoredRegex is not set

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousIncludeCheck.cpp
@@ -39,7 +39,7 @@ private:
 SuspiciousIncludeCheck::SuspiciousIncludeCheck(StringRef Name,
                                                ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      IgnoredRegexString(Options.get("IgnoredRegex").value_or(StringRef{})),
+      IgnoredRegexString(Options.get("IgnoredRegex").value_or("")),
       IgnoredRegex(IgnoredRegexString) {}
 
 void SuspiciousIncludeCheck::registerPPCallbacks(


### PR DESCRIPTION
When the "IgnoredRegex" option is not set, `IgnoredRegexString` is default-constructed, i.e. initialized with a null data pointer. This is passed to `llvm_regcomp` as the pattern argument, causing a nullptr+0 UB in regcomp.c:327 (caught by UBSan). Fix by initializing `IgnoredRegexString` with an empty string literal instead.