### PR TITLE
[flang][NFC] Converted five tests from old lowering to new lowering (part 51)

### DIFF
--- a/flang/test/Lower/associate-construct.f90
+++ b/flang/test/Lower/associate-construct.f90
@@ -1,39 +1,50 @@
-! RUN: bbc -emit-fir -hlfir=false -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
 
 ! CHECK-LABEL: func @_QQmain
 program p
-  ! CHECK-DAG: [[I:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QFEi"}
-  ! CHECK-DAG: [[N:%[0-9]+]] = fir.alloca i32 {{{.*}}uniq_name = "_QFEn"}
-  ! CHECK: [[T:%[0-9]+]] = fir.alloca !fir.array<3xi32> {bindc_name = "t", uniq_name = "_QFEt"}
+  ! CHECK-DAG: %[[I_ALLOC:.*]] = fir.alloca i32 {{{.*}}uniq_name = "_QFEi"}
+  ! CHECK-DAG: %[[I:.*]]:2 = hlfir.declare %[[I_ALLOC]] {uniq_name = "_QFEi"}
+  ! CHECK-DAG: %[[N_ALLOC:.*]] = fir.alloca i32 {{{.*}}uniq_name = "_QFEn"}
+  ! CHECK-DAG: %[[N:.*]]:2 = hlfir.declare %[[N_ALLOC]] {uniq_name = "_QFEn"}
+  ! CHECK: %[[T_ALLOC:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "t", uniq_name = "_QFEt"}
+  ! CHECK: %[[T:.*]]:2 = hlfir.declare %[[T_ALLOC]](%{{.*}}) {uniq_name = "_QFEt"}
   integer :: n, foo, t(3)
-  ! CHECK: [[N]]
-  ! CHECK-COUNT-3: fir.coordinate_of [[T]]
+  ! CHECK: hlfir.assign %c100{{.*}} to %[[N]]#0
+  ! CHECK-COUNT-3: hlfir.designate %[[T]]#0
   n = 100; t(1) = 111; t(2) = 222; t(3) = 333
-  ! CHECK: fir.load [[N]]
-  ! CHECK: addi {{.*}} %c5
-  ! CHECK: fir.store %{{[0-9]*}} to [[B:%[0-9]+]]
-  ! CHECK: [[C:%[0-9]+]] = fir.coordinate_of [[T]]
-  ! CHECK: fir.call @_QPfoo
-  ! CHECK: fir.store %{{[0-9]*}} to [[D:%[0-9]+]]
+  ! 'a' is associated to 'n' directly via hlfir.declare wrapping %[[N]]
+  ! CHECK: %[[A:.*]]:2 = hlfir.declare %[[N]]#0 {uniq_name = "_QFEa"}
+  ! 'b' = n+5: load n, addi 5, store to alloca, hlfir.declare it
+  ! CHECK: %[[NLOAD_B:.*]] = fir.load %[[N]]#0
+  ! CHECK: %[[NPLUS5:.*]] = arith.addi %[[NLOAD_B]], %c5{{.*}} : i32
+  ! CHECK: fir.store %[[NPLUS5]] to %[[B_ALLOC:.*]] : !fir.ref<i32>
+  ! CHECK: %[[B:.*]]:2 = hlfir.declare %[[B_ALLOC]] {uniq_name = "_QFEb"}
+  ! 'c' = t(2): designate, hlfir.declare it
+  ! CHECK: %[[C_DESIG:.*]] = hlfir.designate %[[T]]#0 (%c2{{.*}})
+  ! CHECK: %[[C:.*]]:2 = hlfir.declare %[[C_DESIG]] {uniq_name = "_QFEc"}
+  ! 'd' = foo(7): call foo, store result, hlfir.declare it
+  ! CHECK: %[[FOO_CALL:.*]] = fir.call @_QPfoo(%{{.*}})
+  ! CHECK: fir.store %[[FOO_CALL]] to %[[D_ALLOC:.*]] : !fir.ref<i32>
+  ! CHECK: %[[D:.*]]:2 = hlfir.declare %[[D_ALLOC]] {uniq_name = "_QFEd"}
   associate (a => n, b => n+5, c => t(2), d => foo(7))
-    ! CHECK: fir.load [[N]]
-    ! CHECK: addi %{{[0-9]*}}, %c1
-    ! CHECK: fir.store %{{[0-9]*}} to [[N]]
+    ! CHECK: fir.load %[[A]]#0
+    ! CHECK: arith.addi %{{.*}}, %c1
+    ! CHECK: hlfir.assign %{{.*}} to %[[A]]#0
     a = a + 1
-    ! CHECK: fir.load [[C]]
-    ! CHECK: addi %{{[0-9]*}}, %c1
-    ! CHECK: fir.store %{{[0-9]*}} to [[C]]
+    ! CHECK: fir.load %[[C]]#0
+    ! CHECK: arith.addi %{{.*}}, %c1
+    ! CHECK: hlfir.assign %{{.*}} to %[[C]]#0
     c = c + 1
-    ! CHECK: fir.load [[N]]
-    ! CHECK: addi %{{[0-9]*}}, %c1
-    ! CHECK: fir.store %{{[0-9]*}} to [[N]]
+    ! CHECK: fir.load %[[N]]#0
+    ! CHECK: arith.addi %{{.*}}, %c1
+    ! CHECK: hlfir.assign %{{.*}} to %[[N]]#0
     n = n + 1
-    ! CHECK: fir.load [[N]]
-    ! CHECK: fir.embox [[T]]
-    ! CHECK: fir.load [[N]]
-    ! CHECK: fir.load [[B]]
-    ! CHECK: fir.load [[C]]
-    ! CHECK: fir.load [[D]]
+    ! CHECK: fir.load %[[N]]#0
+    ! CHECK: fir.embox %[[T]]#0
+    ! CHECK: fir.load %[[A]]#0
+    ! CHECK: fir.load %[[B]]#0
+    ! CHECK: fir.load %[[C]]#0
+    ! CHECK: fir.load %[[D]]#0
     print*, n, t, a, b, c, d ! expect: 102 111 223 333 102 105 223 7
   end associate
 
@@ -41,14 +52,16 @@ program p
 
   do i=1,4
     associate (x=>i)
-      ! CHECK: [[IVAL:%[0-9]+]] = fir.load [[I]] : !fir.ref<i32>
-      ! CHECK: [[TWO:%.*]] = arith.constant 2 : i32
-      ! CHECK: arith.cmpi eq, [[IVAL]], [[TWO]] : i32
+      ! 'x' is associated to 'i' directly via hlfir.declare
+      ! CHECK: %[[X:.*]]:2 = hlfir.declare %[[I]]#0 {uniq_name = "_QFEx"}
+      ! CHECK: %[[XVAL:.*]] = fir.load %[[X]]#0 : !fir.ref<i32>
+      ! CHECK: %[[TWO:.*]] = arith.constant 2 : i32
+      ! CHECK: arith.cmpi eq, %[[XVAL]], %[[TWO]] : i32
       ! CHECK: ^bb
       if (x==2) goto 9
-      ! CHECK: [[IVAL:%[0-9]+]] = fir.load [[I]] : !fir.ref<i32>
-      ! CHECK: [[THREE:%.*]] = arith.constant 3 : i32
-      ! CHECK: arith.cmpi eq, [[IVAL]], [[THREE]] : i32
+      ! CHECK: %[[XVAL2:.*]] = fir.load %[[X]]#0 : !fir.ref<i32>
+      ! CHECK: %[[THREE:.*]] = arith.constant 3 : i32
+      ! CHECK: arith.cmpi eq, %[[XVAL2]], %[[THREE]] : i32
       ! CHECK: ^bb
       ! CHECK: fir.call @_FortranAStopStatementText
       ! CHECK: fir.unreachable

--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -1,5 +1,5 @@
 ! Test default initialization of local and dummy variables (dynamic initialization)
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 module test_dinit
   type t
@@ -21,9 +21,10 @@ contains
   ! Test local scalar is default initialized
   ! CHECK-LABEL: func @_QMtest_dinitPlocal()
   subroutine local
-    !CHECK: %[[x:.*]]  = fir.alloca !fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}> {bindc_name = "x", uniq_name = "_QMtest_dinitFlocalEx"}
+    !CHECK: %[[xalloc:.*]] = fir.alloca !fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}> {bindc_name = "x", uniq_name = "_QMtest_dinitFlocalEx"}
+    !CHECK: %[[x:.*]]:2 = hlfir.declare %[[xalloc]] {uniq_name = "_QMtest_dinitFlocalEx"}
     !CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTt.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
-    !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+    !CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
     type(t) :: x
     print *, x%i
   end subroutine
@@ -31,9 +32,9 @@ contains
   ! Test local array is default initialized
   ! CHECK-LABEL: func @_QMtest_dinitPlocal_array()
   subroutine local_array()
-    ! CHECK: %[[x:.*]] = fir.alloca !fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
-    ! CHECK: %[[xshape:.*]] = fir.shape %c4{{.*}} : (index) -> !fir.shape<1>
-    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]](%[[xshape]]) : (!fir.ref<!fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>>
+    ! CHECK: %[[xalloc:.*]] = fir.alloca !fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[xalloc]](%{{.*}}) {uniq_name = "_QMtest_dinitFlocal_arrayEx"}
+    ! CHECK: %[[xbox:.*]] = fir.embox %[[x]]#0(%{{.*}}) : (!fir.ref<!fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.array<4x!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>>
     ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
     ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32) -> ()
     type(t) :: x(4)
@@ -44,38 +45,42 @@ contains
   ! scalars.
   ! CHECK-LABEL: func @_QMtest_dinitPlocal_alloc_comp()
   subroutine local_alloc_comp
-    !CHECK: %[[x:.*]] = fir.alloca !fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "x", uniq_name = "_QMtest_dinitFlocal_alloc_compEx"}
+    !CHECK: %[[xalloc:.*]] = fir.alloca !fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "x", uniq_name = "_QMtest_dinitFlocal_alloc_compEx"}
+    !CHECK: %[[x:.*]]:2 = hlfir.declare %[[xalloc]] {uniq_name = "_QMtest_dinitFlocal_alloc_compEx"}
     !CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTt_alloc_comp.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-    !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+    !CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{{(,sequence)?}}{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
     type(t_alloc_comp) :: x
   end subroutine
 
   ! Test function results are default initialized.
   ! CHECK-LABEL: func @_QMtest_dinitPresult() -> !fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>
   function result()
-    !CHECK: %[[x:.*]] = fir.alloca !fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}> {bindc_name = "result", uniq_name = "_QMtest_dinitFresultEresult"}
+    !CHECK: %[[xalloc:.*]] = fir.alloca !fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}> {bindc_name = "result", uniq_name = "_QMtest_dinitFresultEresult"}
+    !CHECK: %[[x:.*]]:2 = hlfir.declare %[[xalloc]] {uniq_name = "_QMtest_dinitFresultEresult"}
     !CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTt.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
-    !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+    !CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
     type(t) :: result
   end function
 
   ! Test intent(out) dummies are default initialized
   ! CHECK-LABEL: func @_QMtest_dinitPintent_out(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+  ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
   subroutine intent_out(x)
+    !CHECK: %[[x:.*]]:2 = hlfir.declare %[[arg0]] {{.*}} {fortran_attrs = #fir.var_attrs<intent_out>, uniq_name = "_QMtest_dinitFintent_outEx"}
     !CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTt.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
-    !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+    !CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
     type(t), intent(out) :: x
   end subroutine
 
   ! Test that optional intent(out) are default initialized only when
   ! present.
   ! CHECK-LABEL: func @_QMtest_dinitPintent_out_optional(
-  ! CHECK-SAME: %[[x:.*]]: !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>> {fir.bindc_name = "x", fir.optional})
+  ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>> {fir.bindc_name = "x", fir.optional})
   subroutine intent_out_optional(x)
-    ! CHECK: %[[isPresent:.*]] = fir.is_present %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>) -> i1
+    ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[arg0]] {{.*}} {fortran_attrs = #fir.var_attrs<intent_out, optional>, uniq_name = "_QMtest_dinitFintent_out_optionalEx"}
+    ! CHECK: %[[isPresent:.*]] = fir.is_present %[[x]]#0 : (!fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>) -> i1
     ! CHECK: fir.if %[[isPresent]] {
-      ! CHECK: %[[xbox:.*]] = fir.embox %[[x]] : (!fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
+      ! CHECK: %[[xbox:.*]] = fir.embox %[[x]]#0 : (!fir.ref<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>) -> !fir.box<!fir.type<_QMtest_dinitTt{{(,sequence)?}}{i:i32}>>
       ! CHECK: %[[xboxNone:.*]] = fir.convert %[[xbox]]
       ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32) -> ()
     ! CHECK: }
@@ -89,9 +94,10 @@ contains
     integer :: zi
     ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[xptr:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[xptr]] storage(%[[equiv]][0]) {uniq_name = "_QMtest_dinitFlocal_eqEx"}
     ! CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
-    ! CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
     equivalence (x, zi)
     print *, i
   end subroutine
@@ -106,15 +112,17 @@ contains
     type(tseq) :: y
     ! CHECK: %[[equiv:.*]] = fir.alloca !fir.array<4xi8>
     ! CHECK: %[[xcoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[x:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[xptr:.*]] = fir.convert %[[xcoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[xptr]] storage(%[[equiv]][0]) {uniq_name = "_QMtest_dinitFlocal_eq2Ex"}
     ! CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
-    ! CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: fir.copy %[[ADDR]] to %[[x]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
 
 
     ! CHECK: %[[ycoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
-    ! CHECK: %[[y:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
-    ! CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
-    ! CHECK: fir.copy %[[ADDR]] to %[[y]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[yptr:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: %[[y:.*]]:2 = hlfir.declare %[[yptr]] storage(%[[equiv]][0]) {uniq_name = "_QMtest_dinitFlocal_eq2Ey"}
+    ! CHECK: %[[ADDR2:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
+    ! CHECK: fir.copy %[[ADDR2]] to %[[y]]#0 no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{{(,sequence)?}}{i:i32}>>
     equivalence (x, y)
     print *, y%i
   end subroutine

--- a/flang/test/Lower/select-type-2.f90
+++ b/flang/test/Lower/select-type-2.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | fir-opt --fir-polymorphic-op | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | fir-opt --fir-polymorphic-op | FileCheck %s
 module select_type_2
   type p1
     integer :: a
@@ -30,10 +30,11 @@ contains
 
 ! CHECK-LABEL: func.func @_QMselect_type_2Pselect_type1(
 ! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.type<_QMselect_type_2Tp1{a:i32,b:i32}>> {fir.bindc_name = "a"}) {
+! CHECK:      %[[A:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope {{.*}} {fortran_attrs = #fir.var_attrs<intent_in>, uniq_name = "_QMselect_type_2Fselect_type1Ea"}
 ! CHECK:      %[[TDESC_P3_ADDR:.*]] = fir.type_desc !fir.type<_QMselect_type_2Tp3
 ! CHECK:      %[[TDESC_P3_CONV:.*]] = fir.convert %[[TDESC_P3_ADDR]] : (!fir.tdesc{{.*}}>) -> !fir.ref<none>
-! CHECK:      %[[BOX_NONE:.*]] = fir.convert %[[ARG0]] : (!fir.class<!fir.type<_QMselect_type_2Tp1{a:i32,b:i32}>>) -> !fir.box<none>
-! CHECK:      %[[CLASS_IS_CMP:.*]] = fir.call @_FortranAClassIs(%[[BOX_NONE]], %[[TDESC_P3_CONV]]) : (!fir.box<none>, !fir.ref<none>) -> i1
+! CHECK:      %[[BOX_NONE:.*]] = fir.convert %[[A]]#1 : (!fir.class<!fir.type<_QMselect_type_2Tp1{a:i32,b:i32}>>) -> !fir.box<none>
+! CHECK:      %[[CLASS_IS_CMP:.*]] = fir.call @_FortranAClassIs(%[[BOX_NONE]], %[[TDESC_P3_CONV]]) {{.*}}: (!fir.box<none>, !fir.ref<none>) -> i1
 ! CHECK:      cf.cond_br %[[CLASS_IS_CMP]], ^[[CLASS_IS_P3_BLK:.*]], ^[[NOT_CLASS_IS_P3_BLK:.*]]
 ! CHECK:    ^bb[[NOT_CLASS_IS_P1:[0-9]]]:
 ! CHECK:      cf.br ^bb[[DEFAULT_BLK:[0-9]]]
@@ -42,8 +43,8 @@ contains
 ! CHECK:    ^[[NOT_CLASS_IS_P3_BLK]]:
 ! CHECK:      %[[TDESC_P1_ADDR:.*]] = fir.type_desc !fir.type<_QMselect_type_2Tp1
 ! CHECK:      %[[TDESC_P1_CONV:.*]] = fir.convert %[[TDESC_P1_ADDR]] : (!fir.tdesc{{.*}}>) -> !fir.ref<none>
-! CHECK:      %[[BOX_NONE:.*]] = fir.convert %[[ARG0]] : (!fir.class<!fir.type<_QMselect_type_2Tp1{a:i32,b:i32}>>) -> !fir.box<none>
-! CHECK:      %[[CLASS_IS_CMP:.*]] = fir.call @_FortranAClassIs(%[[BOX_NONE]], %[[TDESC_P1_CONV]]) : (!fir.box<none>, !fir.ref<none>) -> i1
+! CHECK:      %[[BOX_NONE:.*]] = fir.convert %[[A]]#1 : (!fir.class<!fir.type<_QMselect_type_2Tp1{a:i32,b:i32}>>) -> !fir.box<none>
+! CHECK:      %[[CLASS_IS_CMP:.*]] = fir.call @_FortranAClassIs(%[[BOX_NONE]], %[[TDESC_P1_CONV]]) {{.*}}: (!fir.box<none>, !fir.ref<none>) -> i1
 ! CHECK:      cf.cond_br %[[CLASS_IS_CMP]], ^bb[[CLASS_IS_P1]], ^bb[[NOT_CLASS_IS_P1]]
 ! CHECK:    ^[[CLASS_IS_P3_BLK]]:
 ! CHECK:      cf.br ^bb[[END_SELECT_BLK]]

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false -outline-intrinsics %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -outline-intrinsics %s -o - | FileCheck %s
 
 ! Test statement function lowering
 
@@ -9,14 +9,16 @@ real function test_stmt_0(x)
   real :: x, func, arg
   func(arg) = arg + 0.123456
 
-  ! CHECK-DAG: %[[x:.*]] = fir.load %arg0
-  ! CHECK-DAG: %[[cst:.*]] = arith.constant 1.234560e-01
+  ! CHECK: %[[res:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFtest_stmt_0Etest_stmt_0"}
+  ! CHECK: %[[xdecl:.*]]:2 = hlfir.declare %arg0 {{.*}} {uniq_name = "_QFtest_stmt_0Ex"}
+  ! CHECK: %[[x:.*]] = fir.load %[[xdecl]]#0
+  ! CHECK: %[[cst:.*]] = arith.constant 1.234560e-01
   ! CHECK: %[[eval:.*]] = arith.addf %[[x]], %[[cst]]
-  ! CHECK: fir.store %[[eval]] to %[[resmem:.*]] : !fir.ref<f32>
+  ! CHECK: hlfir.assign %[[eval]] to %[[res]]#0 : f32, !fir.ref<f32>
   test_stmt_0 = func(x)
 
-  ! CHECK: %[[res:.*]] = fir.load %[[resmem]]
-  ! CHECK: return %[[res]]
+  ! CHECK: %[[resval:.*]] = fir.load %[[res]]#0
+  ! CHECK: return %[[resval]]
 end function
 
 ! Check this is not lowered as a simple macro: e.g. argument is only
@@ -26,11 +28,11 @@ end function
 real(4) function test_stmt_only_eval_arg_once()
   real(4) :: only_once, x1
   func(x1) = x1 + x1
-  ! CHECK: %[[x2:.*]] = fir.alloca f32 {adapt.valuebyref}
-  ! CHECK: %[[x1:.*]] = fir.call @_QPonly_once()
-  ! Note: using -emit-fir, so the faked pass-by-reference is exposed
-  ! CHECK: fir.store %[[x1]] to %[[x2]]
-  ! CHECK: addf %{{.*}}, %{{.*}}
+  ! CHECK: %[[call:.*]] = fir.call @_QPonly_once()
+  ! CHECK: %[[assoc:.*]]:3 = hlfir.associate %[[call]]
+  ! CHECK: %[[v1:.*]] = fir.load %[[assoc]]#0
+  ! CHECK: %[[v2:.*]] = fir.load %[[assoc]]#0
+  ! CHECK: arith.addf %[[v1]], %[[v2]]
   test_stmt_only_eval_arg_once = func(only_once())
 end function
 
@@ -42,30 +44,35 @@ real function test_stmt_1(x, a)
   real :: res1, res2
   func1(arg1) = a + foo(arg1)
   func2(arg2) = func1(arg2) + b
-  ! CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eb"}
-  ! CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eres1"}
-  ! CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {{{.*}}uniq_name = "{{.*}}Eres2"}
+  ! CHECK-DAG: %[[adecl:.*]]:2 = hlfir.declare %arg1 {{.*}} {uniq_name = "_QFtest_stmt_1Ea"}
+  ! CHECK-DAG: %[[bmem:.*]] = fir.alloca f32 {{{.*}}uniq_name = "_QFtest_stmt_1Eb"}
+  ! CHECK-DAG: %[[bdecl:.*]]:2 = hlfir.declare %[[bmem]] {uniq_name = "_QFtest_stmt_1Eb"}
+  ! CHECK-DAG: %[[res1:.*]] = fir.alloca f32 {{{.*}}uniq_name = "_QFtest_stmt_1Eres1"}
+  ! CHECK-DAG: %[[res1decl:.*]]:2 = hlfir.declare %[[res1]] {uniq_name = "_QFtest_stmt_1Eres1"}
+  ! CHECK-DAG: %[[res2:.*]] = fir.alloca f32 {{{.*}}uniq_name = "_QFtest_stmt_1Eres2"}
+  ! CHECK-DAG: %[[res2decl:.*]]:2 = hlfir.declare %[[res2]] {uniq_name = "_QFtest_stmt_1Eres2"}
+  ! CHECK-DAG: %[[xdecl:.*]]:2 = hlfir.declare %arg0 {{.*}} {uniq_name = "_QFtest_stmt_1Ex"}
 
   b = 5
 
   ! CHECK-DAG: %[[cst_8:.*]] = arith.constant 8.000000e+00
-  ! CHECK-DAG: fir.store %[[cst_8]] to %[[tmp1:.*]] : !fir.ref<f32>
-  ! CHECK-DAG: %[[foocall1:.*]] = fir.call @_QPfoo(%[[tmp1]])
-  ! CHECK-DAG: %[[aload1:.*]] = fir.load %arg1
+  ! CHECK-DAG: %[[assoc1:.*]]:3 = hlfir.associate %[[cst_8]]
+  ! CHECK-DAG: %[[aload1:.*]] = fir.load %[[adecl]]#0
+  ! CHECK-DAG: %[[foocall1:.*]] = fir.call @_QPfoo(%[[assoc1]]#0)
   ! CHECK: %[[add1:.*]] = arith.addf %[[aload1]], %[[foocall1]]
-  ! CHECK: fir.store %[[add1]] to %[[res1]]
+  ! CHECK: hlfir.assign %[[add1]] to %[[res1decl]]#0
   res1 =  func1(8.)
 
-  ! CHECK-DAG: %[[a2:.*]] = fir.load %arg1
-  ! CHECK-DAG: %[[foocall2:.*]] = fir.call @_QPfoo(%arg0)
+  ! CHECK-DAG: %[[a2:.*]] = fir.load %[[adecl]]#0
+  ! CHECK-DAG: %[[foocall2:.*]] = fir.call @_QPfoo(%[[xdecl]]#0)
   ! CHECK-DAG: %[[add2:.*]] = arith.addf %[[a2]], %[[foocall2]]
-  ! CHECK-DAG: %[[b:.*]] = fir.load %[[bmem]]
+  ! CHECK-DAG: %[[b:.*]] = fir.load %[[bdecl]]#0
   ! CHECK: %[[add3:.*]] = arith.addf %[[add2]], %[[b]]
-  ! CHECK: fir.store %[[add3]] to %[[res2]]
+  ! CHECK: hlfir.assign %[[add3]] to %[[res2decl]]#0
   res2 = func2(x)
 
-  ! CHECK-DAG: %[[res12:.*]] = fir.load %[[res1]]
-  ! CHECK-DAG: %[[res22:.*]] = fir.load %[[res2]]
+  ! CHECK-DAG: %[[res12:.*]] = fir.load %[[res1decl]]#0
+  ! CHECK-DAG: %[[res22:.*]] = fir.load %[[res2decl]]#0
   ! CHECK: = arith.addf %[[res12]], %[[res22]] {{.*}}: f32
   test_stmt_1 = res1 + res2
   ! CHECK: return %{{.*}} : f32
@@ -91,12 +98,10 @@ end function
 integer function test_stmt_character(c, j)
   integer :: i, j, func, argj
   character(10) :: c, argc
-  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
-  ! CHECK-DAG: %[[ref:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,10>>
-  ! CHECK-DAG: %[[c10:.*]] = arith.constant 10 :
-  ! CHECK-DAG: %[[ref_cast:.*]] = fir.convert %[[ref]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
-  ! CHECK: %[[c10_cast:.*]] = fir.convert %[[c10]] : (i32) -> index
-  ! CHECK: %[[c:.*]] = fir.emboxchar %[[ref_cast]], %[[c10_cast]]
+  ! CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %arg0 :
+  ! CHECK: %[[ref:.*]] = fir.convert %[[unboxed]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[cdecl:.*]]:2 = hlfir.declare %[[ref]] typeparams %{{.*}} {{.*}} {uniq_name = "_QFtest_stmt_characterEc"}
+  ! CHECK: %[[funcArgcDecl:.*]]:2 = hlfir.declare %[[cdecl]]#0 typeparams %{{.*}} {uniq_name = "_QFtest_stmt_characterFfuncEargc"}
 
   func(argc, argj) = len_trim(argc, 4) + argj
   ! CHECK: addi %{{.*}}, %{{.*}} : i
@@ -113,10 +118,13 @@ integer function test_stmt_character_with_different_length(c)
   integer :: func, ifoo
   character(10) :: argc
   character(*) :: c
-  ! CHECK-DAG: %[[unboxed:.*]]:2 = fir.unboxchar %[[arg0]] :
-  ! CHECK-DAG: %[[c10:.*]] = arith.constant 10 :
-  ! CHECK: %[[c10_cast:.*]] = fir.convert %[[c10]] : (i32) -> index
-  ! CHECK: %[[argc:.*]] = fir.emboxchar %[[unboxed]]#0, %[[c10_cast]]
+  ! CHECK: %[[unboxedC:.*]]:2 = fir.unboxchar %[[arg0]] :
+  ! CHECK: %[[cdecl:.*]]:2 = hlfir.declare %[[unboxedC]]#0 typeparams %[[unboxedC]]#1 {{.*}} {uniq_name = "_QFtest_stmt_character_with_different_lengthEc"}
+  ! CHECK: %[[unboxedArg:.*]]:2 = fir.unboxchar %[[cdecl]]#0 :
+  ! CHECK: %[[ref:.*]] = fir.convert %[[unboxedArg]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[c10:.*]] = arith.constant 10 : index
+  ! CHECK: %[[funcArgc:.*]]:2 = hlfir.declare %[[ref]] typeparams %[[c10]] {uniq_name = "_QFtest_stmt_character_with_different_lengthFfuncEargc"}
+  ! CHECK: %[[argc:.*]] = fir.emboxchar %[[funcArgc]]#0, %[[c10]]
   ! CHECK: fir.call @_QPifoo(%[[argc]]) {{.*}}: (!fir.boxchar<1>) -> i32
   func(argc) = ifoo(argc)
   test_stmt_character = func(c)
@@ -128,13 +136,15 @@ integer function test_stmt_character_with_different_length_2(c, n)
   integer :: func, ifoo
   character(n) :: argc
   character(*) :: c
-  ! CHECK: %[[unboxed:.*]]:2 = fir.unboxchar %[[arg0]] :
-  ! CHECK: %[[n:.*]] = fir.load %[[arg1]] : !fir.ref<i32>
+  ! CHECK: %[[ndecl:.*]]:2 = hlfir.declare %[[arg1]] {{.*}} {uniq_name = "_QFtest_stmt_character_with_different_length_2En"}
+  ! CHECK: %[[unboxedC:.*]]:2 = fir.unboxchar %[[arg0]] :
+  ! CHECK: %[[cdecl:.*]]:2 = hlfir.declare %[[unboxedC]]#0 typeparams %[[unboxedC]]#1 {{.*}} {uniq_name = "_QFtest_stmt_character_with_different_length_2Ec"}
+  ! CHECK: %[[unboxedArg:.*]]:2 = fir.unboxchar %[[cdecl]]#0 :
+  ! CHECK: %[[n:.*]] = fir.load %[[ndecl]]#0 : !fir.ref<i32>
   ! CHECK: %[[n_is_positive:.*]] = arith.cmpi sgt, %[[n]], %c0{{.*}} : i32
   ! CHECK: %[[len:.*]] = arith.select %[[n_is_positive]], %[[n]], %c0{{.*}} : i32
-  ! CHECK: %[[lenCast:.*]] = fir.convert %[[len]] : (i32) -> index
-  ! CHECK: %[[argc:.*]] = fir.emboxchar %[[unboxed]]#0, %[[lenCast]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-  ! CHECK: fir.call @_QPifoo(%[[argc]]) {{.*}}: (!fir.boxchar<1>) -> i32
+  ! CHECK: %[[funcArgc:.*]]:2 = hlfir.declare %[[unboxedArg]]#0 typeparams %[[len]] {uniq_name = "_QFtest_stmt_character_with_different_length_2FfuncEargc"} : (!fir.ref<!fir.char<1,?>>, i32) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
+  ! CHECK: fir.call @_QPifoo(%[[funcArgc]]#0) {{.*}}: (!fir.boxchar<1>) -> i32
   func(argc) = ifoo(argc)
   test_stmt_character = func(c)
 end function
@@ -157,24 +167,14 @@ subroutine truncate_arg
 end subroutine
 
 ! CHECK-LABEL: @_QPtruncate_arg
-! CHECK: %[[c4:.*]] = arith.constant 4 : i32
 ! CHECK: %[[arg:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,10>>
-! CHECK: %[[cast_arg:.*]] = fir.convert %[[arg]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
-! CHECK: %[[c10:.*]] = arith.constant 10 : i64
-! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,10> {bindc_name = ".chrtmp"}
-! CHECK: %[[c10_index:.*]] = fir.convert %[[c10]] : (i64) -> index
-! CHECK: %[[c4_index:.*]] = fir.convert %[[c4]] : (i32) -> index
-! CHECK: %[[cmpi:.*]] = arith.cmpi slt, %[[c10_index]], %[[c4_index]] : index
-! CHECK: %[[select:.*]] = arith.select %[[cmpi]], %[[c10_index]], %[[c4_index]] : index
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[select_i64:.*]] = fir.convert %[[select]] : (index) -> i64
-! CHECK: %[[length:.*]] = arith.muli %[[c1]], %[[select_i64]] : i64
-! CHECK: %[[cast_temp_i8:.*]] = fir.convert %[[temp]] : (!fir.ref<!fir.char<1,10>>) -> !llvm.ptr
-! CHECK: %[[cast_arg_i8:.*]] = fir.convert %[[cast_arg]] : (!fir.ref<!fir.char<1,?>>) -> !llvm.ptr
-! CHECK: "llvm.intr.memmove"(%[[cast_temp_i8]], %[[cast_arg_i8]], %[[length]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-! CHECK: %[[c1_i64:.*]] = arith.constant 1 : i64
-! CHECK: %[[ub:.*]] = arith.subi %[[c10]], %[[c1_i64]] : i64
-! CHECK: %[[ub_index:.*]] = fir.convert %[[ub]] : (i64) -> index
-! CHECK: fir.do_loop %{{.*}} = %[[select]] to %[[ub_index]] step %{{.*}} {
-! CHECK: %[[cast_temp:.*]] = fir.convert %[[temp:.*]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK: %{{.*}} = fir.call @_FortranAioOutputAscii(%{{.*}}, %[[cast_temp]], %[[c10]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK: %[[c10:.*]] = arith.constant 10 : index
+! CHECK: %[[argDecl:.*]]:2 = hlfir.declare %[[arg]] typeparams %[[c10]]
+! CHECK: %[[castArg:.*]] = fir.convert %[[argDecl]]#0 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,4>>
+! CHECK: %[[c4:.*]] = arith.constant 4 : index
+! CHECK: %[[fctArg:.*]]:2 = hlfir.declare %[[castArg]] typeparams %[[c4]] {uniq_name = "_QFtruncate_argFstmt_fctEarg"}
+! CHECK: %[[c10_i64:.*]] = arith.constant 10 : i64
+! CHECK: %[[setlen:.*]] = hlfir.set_length %[[fctArg]]#0 len %[[c10_i64]] : (!fir.ref<!fir.char<1,4>>, i64) -> !hlfir.expr<!fir.char<1,10>>
+! CHECK: %[[assoc:.*]]:3 = hlfir.associate %[[setlen]] typeparams %[[c10_i64]] {{.*}} : (!hlfir.expr<!fir.char<1,10>>, i64) -> (!fir.ref<!fir.char<1,10>>, !fir.ref<!fir.char<1,10>>, i1)
+! CHECK: %[[castTemp:.*]] = fir.convert %[[assoc]]#0 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
+! CHECK: %{{.*}} = fir.call @_FortranAioOutputAscii(%{{.*}}, %[[castTemp]], %[[c10_i64]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1

--- a/flang/test/Lower/submodule.f90
+++ b/flang/test/Lower/submodule.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 module mm
   integer :: vv = 20
@@ -24,24 +24,20 @@ submodule(mm) ss1
   end interface
 contains
   ! CHECK-LABEL: func @_QMmmPff2
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK:     %[[V_1:[0-9]+]] = arith.addi %[[V_0]], %c2{{.*}} : i32
-  ! CHECK:     %[[V_2:[0-9]+]] = fir.convert %[[V_1]] : (i32) -> i64
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.convert %[[V_2]] : (i64) -> index
-  ! CHECK:     %[[V_4:[0-9]+]] = arith.cmpi sgt, %[[V_3]], %c0{{.*}} : index
-  ! CHECK:     %[[V_5:[0-9]+]] = arith.select %[[V_4]], %[[V_3]], %c0{{.*}} : index
-  ! CHECK:     %[[V_6:[0-9]+]] = fir.alloca !fir.array<?xi32>, %[[V_5]] {bindc_name = "ff2", uniq_name = "_QMmmSss1Fff2Eff2"}
-  ! CHECK:     %[[V_7:[0-9]+]] = fir.shape %[[V_5]] : (index) -> !fir.shape<1>
-  ! CHECK:     %[[V_8:[0-9]+]] = fir.array_load %[[V_6]](%[[V_7]]) : (!fir.ref<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.array<?xi32>
-  ! CHECK:     %[[V_9:[0-9]+]] = fir.call @_QMmmSss1Pfff(%arg0) {{.*}} : (!fir.ref<i32>) -> i32
-  ! CHECK:     %[[V_10:[0-9]+]] = arith.subi %[[V_5]], %c1{{.*}} : index
-  ! CHECK:     %[[V_11:[0-9]+]] = fir.do_loop %arg1 = %c0{{.*}} to %[[V_10]] step %c1{{.*}} unordered iter_args(%arg2 = %[[V_8]]) -> (!fir.array<?xi32>) {
-  ! CHECK:       %[[V_13:[0-9]+]] = fir.array_update %arg2, %[[V_9]], %arg1 : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
-  ! CHECK:       fir.result %[[V_13]] : !fir.array<?xi32>
-  ! CHECK:     }
-  ! CHECK:     fir.array_merge_store %[[V_8]], %[[V_11]] to %[[V_6]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.ref<!fir.array<?xi32>>
-  ! CHECK:     %[[V_12:[0-9]+]] = fir.load %[[V_6]] : !fir.ref<!fir.array<?xi32>>
-  ! CHECK:     return %[[V_12]] : !fir.array<?xi32>
+  ! CHECK:     %[[V_0:.*]]:2 = hlfir.declare %arg0 {{.*}} {uniq_name = "_QMmmSss1Fff2Enn"}
+  ! CHECK:     %[[V_1:.*]] = fir.load %[[V_0]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_2:.*]] = arith.addi %[[V_1]], %c2{{.*}} : i32
+  ! CHECK:     %[[V_3:.*]] = fir.convert %[[V_2]] : (i32) -> i64
+  ! CHECK:     %[[V_4:.*]] = fir.convert %[[V_3]] : (i64) -> index
+  ! CHECK:     %[[V_5:.*]] = arith.cmpi sgt, %[[V_4]], %c0{{.*}} : index
+  ! CHECK:     %[[V_6:.*]] = arith.select %[[V_5]], %[[V_4]], %c0{{.*}} : index
+  ! CHECK:     %[[V_7:.*]] = fir.alloca !fir.array<?xi32>, %[[V_6]] {bindc_name = "ff2", uniq_name = "_QMmmSss1Fff2Eff2"}
+  ! CHECK:     %[[V_8:.*]] = fir.shape %[[V_6]] : (index) -> !fir.shape<1>
+  ! CHECK:     %[[V_9:.*]]:2 = hlfir.declare %[[V_7]](%[[V_8]]) {uniq_name = "_QMmmSss1Fff2Eff2"}
+  ! CHECK:     %[[V_10:.*]] = fir.call @_QMmmSss1Pfff(%[[V_0]]#0) {{.*}} : (!fir.ref<i32>) -> i32
+  ! CHECK:     hlfir.assign %[[V_10]] to %[[V_9]]#0 : i32, !fir.box<!fir.array<?xi32>>
+  ! CHECK:     %[[V_11:.*]] = fir.load %[[V_9]]#1 : !fir.ref<!fir.array<?xi32>>
+  ! CHECK:     return %[[V_11]] : !fir.array<?xi32>
   ! CHECK:   }
   module procedure ff2
     ff2 = fff(nn)
@@ -51,25 +47,22 @@ end submodule ss1
 submodule(mm:ss1) ss2
 contains
   ! CHECK-LABEL: func @_QMmmPff1
-  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK:     %[[V_2:[0-9]+]] = arith.addi %[[V_1]], %c1{{.*}} : i32
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.convert %[[V_2]] : (i32) -> i64
-  ! CHECK:     %[[V_4:[0-9]+]] = fir.convert %[[V_3]] : (i64) -> index
-  ! CHECK:     %[[V_5:[0-9]+]] = arith.cmpi sgt, %[[V_4]], %c0{{.*}} : index
-  ! CHECK:     %[[V_6:[0-9]+]] = arith.select %[[V_5]], %[[V_4]], %c0{{.*}} : index
-  ! CHECK:     %[[V_7:[0-9]+]] = fir.alloca !fir.array<?xi32>, %[[V_6]] {bindc_name = "ff1", uniq_name = "_QMmmSss1Sss2Fff1Eff1"}
-  ! CHECK:     %[[V_8:[0-9]+]] = fir.shape %[[V_6]] : (index) -> !fir.shape<1>
-  ! CHECK:     %[[V_9:[0-9]+]] = fir.array_load %[[V_7]](%[[V_8]]) : (!fir.ref<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.array<?xi32>
-  ! CHECK:     %[[V_10:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<i32>
-  ! CHECK:     %[[V_11:[0-9]+]] = arith.addi %[[V_10]], %c2{{.*}} : i32
-  ! CHECK:     %[[V_12:[0-9]+]] = arith.subi %[[V_6]], %c1{{.*}} : index
-  ! CHECK:     %[[V_13:[0-9]+]] = fir.do_loop %arg1 = %c0{{.*}} to %[[V_12]] step %c1{{.*}} unordered iter_args(%arg2 = %[[V_9]]) -> (!fir.array<?xi32>) {
-  ! CHECK:       %[[V_15:[0-9]+]] = fir.array_update %arg2, %[[V_11]], %arg1 : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
-  ! CHECK:       fir.result %[[V_15]] : !fir.array<?xi32>
-  ! CHECK:     }
-  ! CHECK:     fir.array_merge_store %[[V_9]], %[[V_13]] to %[[V_7]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.ref<!fir.array<?xi32>>
-  ! CHECK:     %[[V_14:[0-9]+]] = fir.load %[[V_7]] : !fir.ref<!fir.array<?xi32>>
+  ! CHECK-DAG: %[[V_0:.*]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_1:.*]]:2 = hlfir.declare %[[V_0]] {uniq_name = "_QMmmEvv"}
+  ! CHECK-DAG: %[[V_2:.*]]:2 = hlfir.declare %arg0 {{.*}} {uniq_name = "_QMmmSss1Sss2Fff1Enn"}
+  ! CHECK:     %[[V_3:.*]] = fir.load %[[V_2]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_4:.*]] = arith.addi %[[V_3]], %c1{{.*}} : i32
+  ! CHECK:     %[[V_5:.*]] = fir.convert %[[V_4]] : (i32) -> i64
+  ! CHECK:     %[[V_6:.*]] = fir.convert %[[V_5]] : (i64) -> index
+  ! CHECK:     %[[V_7:.*]] = arith.cmpi sgt, %[[V_6]], %c0{{.*}} : index
+  ! CHECK:     %[[V_8:.*]] = arith.select %[[V_7]], %[[V_6]], %c0{{.*}} : index
+  ! CHECK:     %[[V_9:.*]] = fir.alloca !fir.array<?xi32>, %[[V_8]] {bindc_name = "ff1", uniq_name = "_QMmmSss1Sss2Fff1Eff1"}
+  ! CHECK:     %[[V_10:.*]] = fir.shape %[[V_8]] : (index) -> !fir.shape<1>
+  ! CHECK:     %[[V_11:.*]]:2 = hlfir.declare %[[V_9]](%[[V_10]]) {uniq_name = "_QMmmSss1Sss2Fff1Eff1"}
+  ! CHECK:     %[[V_12:.*]] = fir.load %[[V_1]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_13:.*]] = arith.addi %[[V_12]], %c2{{.*}} : i32
+  ! CHECK:     hlfir.assign %[[V_13]] to %[[V_11]]#0 : i32, !fir.box<!fir.array<?xi32>>
+  ! CHECK:     %[[V_14:.*]] = fir.load %[[V_11]]#1 : !fir.ref<!fir.array<?xi32>>
   ! CHECK:     return %[[V_14]] : !fir.array<?xi32>
   ! CHECK:   }
   module function ff1(nn)
@@ -78,16 +71,19 @@ contains
   end function ff1
 
   ! CHECK-LABEL: func @_QMmmSss1Pfff
-  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.address_of(@_QMmmSss1Eww) : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca i32 {bindc_name = "fff", uniq_name = "_QMmmSss1Sss2FfffEfff"}
-  ! CHECK-DAG: %[[V_3:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_4:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<i32>
-  ! CHECK:     %[[V_5:[0-9]+]] = arith.addi %[[V_3]], %[[V_4]] : i32
-  ! CHECK:     %[[V_6:[0-9]+]] = arith.addi %[[V_5]], %c4{{.*}} : i32
-  ! CHECK:     fir.store %[[V_6]] to %[[V_2]] : !fir.ref<i32>
-  ! CHECK:     %[[V_7:[0-9]+]] = fir.load %[[V_2]] : !fir.ref<i32>
-  ! CHECK:     return %[[V_7]] : i32
+  ! CHECK-DAG: %[[V_0:.*]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_1:.*]]:2 = hlfir.declare %[[V_0]] {uniq_name = "_QMmmEvv"}
+  ! CHECK-DAG: %[[V_2:.*]] = fir.address_of(@_QMmmSss1Eww) : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_3:.*]]:2 = hlfir.declare %[[V_2]] {uniq_name = "_QMmmSss1Eww"}
+  ! CHECK-DAG: %[[V_4:.*]] = fir.alloca i32 {bindc_name = "fff", uniq_name = "_QMmmSss1Sss2FfffEfff"}
+  ! CHECK-DAG: %[[V_5:.*]]:2 = hlfir.declare %[[V_4]] {uniq_name = "_QMmmSss1Sss2FfffEfff"}
+  ! CHECK-DAG: %[[V_6:.*]] = fir.load %[[V_1]]#0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_7:.*]] = fir.load %[[V_3]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_8:.*]] = arith.addi %[[V_6]], %[[V_7]] : i32
+  ! CHECK:     %[[V_9:.*]] = arith.addi %[[V_8]], %c4{{.*}} : i32
+  ! CHECK:     hlfir.assign %[[V_9]] to %[[V_5]]#0 : i32, !fir.ref<i32>
+  ! CHECK:     %[[V_10:.*]] = fir.load %[[V_5]]#0 : !fir.ref<i32>
+  ! CHECK:     return %[[V_10]] : i32
   ! CHECK:   }
   module procedure fff
     fff = vv + ww + 4
@@ -97,27 +93,24 @@ end submodule ss2
 submodule(mm) sss
 contains
   ! CHECK-LABEL: func @_QMmmPff3
-  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK:     %[[V_2:[0-9]+]] = arith.addi %[[V_1]], %c3{{.*}} : i32
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.convert %[[V_2]] : (i32) -> i64
-  ! CHECK:     %[[V_4:[0-9]+]] = fir.convert %[[V_3]] : (i64) -> index
-  ! CHECK:     %[[V_5:[0-9]+]] = arith.cmpi sgt, %[[V_4]], %c0{{.*}} : index
-  ! CHECK:     %[[V_6:[0-9]+]] = arith.select %[[V_5]], %[[V_4]], %c0{{.*}} : index
-  ! CHECK:     %[[V_7:[0-9]+]] = fir.alloca !fir.array<?xi32>, %[[V_6]] {bindc_name = "ff3", uniq_name = "_QMmmSsssFff3Eff3"}
-  ! CHECK:     %[[V_8:[0-9]+]] = fir.shape %[[V_6]] : (index) -> !fir.shape<1>
-  ! CHECK:     %[[V_9:[0-9]+]] = fir.array_load %[[V_7]](%[[V_8]]) : (!fir.ref<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.array<?xi32>
-  ! CHECK-DAG: %[[V_10:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK-DAG: %[[V_11:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<i32>
-  ! CHECK:     %[[V_12:[0-9]+]] = arith.muli %[[V_10]], %[[V_11]] : i32
-  ! CHECK:     %[[V_13:[0-9]+]] = arith.addi %[[V_12]], %c6{{.*}} : i32
-  ! CHECK:     %[[V_14:[0-9]+]] = arith.subi %[[V_6]], %c1{{.*}} : index
-  ! CHECK:     %[[V_15:[0-9]+]] = fir.do_loop %arg1 = %c0{{.*}} to %[[V_14]] step %c1{{.*}} unordered iter_args(%arg2 = %[[V_9]]) -> (!fir.array<?xi32>) {
-  ! CHECK:       %[[V_17:[0-9]+]] = fir.array_update %arg2, %[[V_13]], %arg1 : (!fir.array<?xi32>, i32, index) -> !fir.array<?xi32>
-  ! CHECK:       fir.result %[[V_17]] : !fir.array<?xi32>
-  ! CHECK:     }
-  ! CHECK:     fir.array_merge_store %[[V_9]], %[[V_15]] to %[[V_7]] : !fir.array<?xi32>, !fir.array<?xi32>, !fir.ref<!fir.array<?xi32>>
-  ! CHECK:     %[[V_16:[0-9]+]] = fir.load %[[V_7]] : !fir.ref<!fir.array<?xi32>>
+  ! CHECK-DAG: %[[V_0:.*]] = fir.address_of(@_QMmmEvv) : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_1:.*]]:2 = hlfir.declare %[[V_0]] {uniq_name = "_QMmmEvv"}
+  ! CHECK-DAG: %[[V_2:.*]]:2 = hlfir.declare %arg0 {{.*}} {uniq_name = "_QMmmSsssFff3Enn"}
+  ! CHECK:     %[[V_3:.*]] = fir.load %[[V_2]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_4:.*]] = arith.addi %[[V_3]], %c3{{.*}} : i32
+  ! CHECK:     %[[V_5:.*]] = fir.convert %[[V_4]] : (i32) -> i64
+  ! CHECK:     %[[V_6:.*]] = fir.convert %[[V_5]] : (i64) -> index
+  ! CHECK:     %[[V_7:.*]] = arith.cmpi sgt, %[[V_6]], %c0{{.*}} : index
+  ! CHECK:     %[[V_8:.*]] = arith.select %[[V_7]], %[[V_6]], %c0{{.*}} : index
+  ! CHECK:     %[[V_9:.*]] = fir.alloca !fir.array<?xi32>, %[[V_8]] {bindc_name = "ff3", uniq_name = "_QMmmSsssFff3Eff3"}
+  ! CHECK:     %[[V_10:.*]] = fir.shape %[[V_8]] : (index) -> !fir.shape<1>
+  ! CHECK:     %[[V_11:.*]]:2 = hlfir.declare %[[V_9]](%[[V_10]]) {uniq_name = "_QMmmSsssFff3Eff3"}
+  ! CHECK-DAG: %[[V_12:.*]] = fir.load %[[V_2]]#0 : !fir.ref<i32>
+  ! CHECK-DAG: %[[V_13:.*]] = fir.load %[[V_1]]#0 : !fir.ref<i32>
+  ! CHECK:     %[[V_14:.*]] = arith.muli %[[V_12]], %[[V_13]] : i32
+  ! CHECK:     %[[V_15:.*]] = arith.addi %[[V_14]], %c6{{.*}} : i32
+  ! CHECK:     hlfir.assign %[[V_15]] to %[[V_11]]#0 : i32, !fir.box<!fir.array<?xi32>>
+  ! CHECK:     %[[V_16:.*]] = fir.load %[[V_11]]#1 : !fir.ref<!fir.array<?xi32>>
   ! CHECK:     return %[[V_16]] : !fir.array<?xi32>
   ! CHECK:   }
   module function ff3(nn)
@@ -129,10 +122,10 @@ end submodule sss
 ! CHECK-LABEL: func @_QQmain
 program pp
   use mm
-  ! CHECK:     fir.call @_QMmmPff1(%{{[0-9]+}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
+  ! CHECK:     fir.call @_QMmmPff1(%{{.*}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
   print*, ff1(1) ! expect: 22 22
-  ! CHECK:     fir.call @_QMmmPff2(%{{[0-9]+}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
+  ! CHECK:     fir.call @_QMmmPff2(%{{.*}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
   print*, ff2(2) ! expect: 44 44 44 44
-  ! CHECK:     fir.call @_QMmmPff3(%{{[0-9]+}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
+  ! CHECK:     fir.call @_QMmmPff3(%{{.*}}) {{.*}} : (!fir.ref<i32>) -> !fir.array<?xi32>
   print*, ff3(3) ! expect: 66 66 66 66 66 66
 end program pp


### PR DESCRIPTION
Converted Lower/associate-construct.f90, Lower/default-initialization.f90, Lower/select-type-2.f90, Lower/statement-function.f90, and Lower/submodule.f90 from legacy lowering (-hlfir=false) to new lowering (-emit-hlfir).