### PR TITLE
[MC] Make MCContext::getAsmInfo return a reference. NFC

### DIFF
--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -355,7 +355,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
   }
 
   MCContext &Context = Streamer.getContext();
-  const MCAsmInfo *MAI = Context.getAsmInfo();
+  const MCAsmInfo &MAI = Context.getAsmInfo();
 
   MCSymbol *const StartSymbol = Function.getSymbol(FF.getFragmentNum());
 
@@ -387,7 +387,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
     for (const MCCFIInstruction &CFIInstr : Function.cie()) {
       // Only write CIE CFI insns that LLVM will not already emit
       const std::vector<MCCFIInstruction> &FrameInstrs =
-          MAI->getInitialFrameState();
+          MAI.getInitialFrameState();
       if (!llvm::is_contained(FrameInstrs, CFIInstr))
         emitCFIInstruction(CFIInstr);
     }
@@ -413,7 +413,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
   if (size_t Padding = opts::padFunctionAfter(Function)) {
     LLVM_DEBUG(dbgs() << "BOLT-DEBUG: padding function " << Function << " with "
                       << Padding << " bytes\n");
-    Streamer.emitFill(Padding, MAI->getTextAlignFillValue());
+    Streamer.emitFill(Padding, MAI.getTextAlignFillValue());
   }
 
   if (opts::MarkFuncs)
@@ -426,7 +426,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
   MCSymbol *EndSymbol = Function.getFunctionEndLabel(FF.getFragmentNum());
   Streamer.emitLabel(EndSymbol);
 
-  if (MAI->hasDotTypeDotSizeDirective()) {
+  if (MAI.hasDotTypeDotSizeDirective()) {
     const MCExpr *SizeExpr = MCBinaryExpr::createSub(
         MCSymbolRefExpr::create(EndSymbol, Context),
         MCSymbolRefExpr::create(StartSymbol, Context), Context);

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -966,7 +966,7 @@ static inline void emitBinaryDwarfLineTable(
   unsigned Discriminator = 0;
   uint64_t LastAddress = InvalidAddress;
   uint64_t PrevEndOfSequence = InvalidAddress;
-  const MCAsmInfo *AsmInfo = MCOS->getContext().getAsmInfo();
+  const MCAsmInfo &AsmInfo = MCOS->getContext().getAsmInfo();
 
   auto emitEndOfSequence = [&](uint64_t Address) {
     MCDwarfLineAddr::Emit(MCOS, Params, INT64_MAX, Address - LastAddress);
@@ -1037,7 +1037,7 @@ static inline void emitBinaryDwarfLineTable(
       } else {
         if (LastAddress == InvalidAddress)
           emitDwarfSetLineAddrAbs(*MCOS, Params, LineDelta, Address,
-                                  AsmInfo->getCodePointerSize());
+                                  AsmInfo.getCodePointerSize());
         else
           MCDwarfLineAddr::Emit(MCOS, Params, LineDelta, Address - LastAddress);
 
@@ -1068,13 +1068,13 @@ static inline void emitDwarfLineTable(
   unsigned Isa = 0;
   unsigned Discriminator = 0;
   MCSymbol *LastLabel = nullptr;
-  const MCAsmInfo *AsmInfo = MCOS->getContext().getAsmInfo();
+  const MCAsmInfo &AsmInfo = MCOS->getContext().getAsmInfo();
 
   // Loop through each MCDwarfLineEntry and encode the dwarf line number table.
   for (const MCDwarfLineEntry &LineEntry : LineEntries) {
     if (LineEntry.getFlags() & DWARF2_FLAG_END_SEQUENCE) {
       MCOS->emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, LineEntry.getLabel(),
-                                     AsmInfo->getCodePointerSize());
+                                     AsmInfo.getCodePointerSize());
       FileNum = 1;
       LastLine = 1;
       Column = 0;
@@ -1128,7 +1128,7 @@ static inline void emitDwarfLineTable(
     // in line numbers and the increment of the address from the previous
     // Label and the current Label.
     MCOS->emitDwarfAdvanceLineAddr(LineDelta, LastLabel, Label,
-                                   AsmInfo->getCodePointerSize());
+                                   AsmInfo.getCodePointerSize());
     Discriminator = 0;
     LastLine = LineEntry.getLine();
     LastLabel = Label;

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -117,7 +117,7 @@ private:
   DiagHandlerTy DiagHandler;
 
   /// The MCAsmInfo for this target.
-  const MCAsmInfo *MAI = nullptr;
+  const MCAsmInfo &MAI;
 
   /// The MCRegisterInfo for this target.
   const MCRegisterInfo *MRI = nullptr;
@@ -406,7 +406,7 @@ public:
 
   void setObjectFileInfo(const MCObjectFileInfo *Mofi) { MOFI = Mofi; }
 
-  const MCAsmInfo *getAsmInfo() const { return MAI; }
+  const MCAsmInfo &getAsmInfo() const { return MAI; }
 
   const MCRegisterInfo *getRegisterInfo() const { return MRI; }
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCFIException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCFIException.cpp
@@ -91,7 +91,7 @@ void DwarfCFIException::beginFunction(const MachineFunction *MF) {
   shouldEmitLSDA = shouldEmitPersonality &&
     LSDAEncoding != dwarf::DW_EH_PE_omit;
 
-  const MCAsmInfo &MAI = *MF->getContext().getAsmInfo();
+  const MCAsmInfo &MAI = MF->getContext().getAsmInfo();
   if (MAI.getExceptionHandlingType() != ExceptionHandling::None)
     shouldEmitCFI =
         MAI.usesCFIForEH() && (shouldEmitPersonality || shouldEmitMoves);

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -130,7 +130,7 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
   case Triple::armeb:
   case Triple::thumb:
   case Triple::thumbeb:
-    if (Ctx.getAsmInfo()->getExceptionHandlingType() == ExceptionHandling::ARM)
+    if (Ctx.getAsmInfo().getExceptionHandlingType() == ExceptionHandling::ARM)
       break;
     // Fallthrough if not using EHABI
     [[fallthrough]];
@@ -726,8 +726,8 @@ calcUniqueIDUpdateFlagsAndSize(const GlobalObject *GO, StringRef SectionName,
   if (Retain) {
     if (TM.getTargetTriple().isOSSolaris())
       Flags |= ELF::SHF_SUNW_NODISCARD;
-    else if (Ctx.getAsmInfo()->useIntegratedAssembler() ||
-             Ctx.getAsmInfo()->binutilsIsAtLeast(2, 36))
+    else if (Ctx.getAsmInfo().useIntegratedAssembler() ||
+             Ctx.getAsmInfo().binutilsIsAtLeast(2, 36))
       Flags |= ELF::SHF_GNU_RETAIN;
     return NextUniqueID++;
   }
@@ -738,8 +738,8 @@ calcUniqueIDUpdateFlagsAndSize(const GlobalObject *GO, StringRef SectionName,
   // the same name. Doing so relies on the ",unique ," assembly feature. This
   // feature is not available until binutils version 2.35
   // (https://sourceware.org/bugzilla/show_bug.cgi?id=25380).
-  const bool SupportsUnique = Ctx.getAsmInfo()->useIntegratedAssembler() ||
-                              Ctx.getAsmInfo()->binutilsIsAtLeast(2, 35);
+  const bool SupportsUnique = Ctx.getAsmInfo().useIntegratedAssembler() ||
+                              Ctx.getAsmInfo().binutilsIsAtLeast(2, 35);
   if (!SupportsUnique) {
     Flags &= ~ELF::SHF_MERGE;
     EntrySize = 0;
@@ -848,8 +848,8 @@ static MCSection *selectExplicitSectionGlobal(const GlobalObject *GO,
   assert(Section->getLinkedToSymbol() == LinkedToSym &&
          "Associated symbol mismatch between sections");
 
-  if (!(Ctx.getAsmInfo()->useIntegratedAssembler() ||
-        Ctx.getAsmInfo()->binutilsIsAtLeast(2, 35))) {
+  if (!(Ctx.getAsmInfo().useIntegratedAssembler() ||
+        Ctx.getAsmInfo().binutilsIsAtLeast(2, 35))) {
     // If we are using GNU as before 2.35, then this symbol might have
     // been placed in an incompatible mergeable section. Emit an error if this
     // is the case to avoid creating broken output.
@@ -921,8 +921,8 @@ static MCSection *selectELFSectionForGlobal(
     if (TM.getTargetTriple().isOSSolaris()) {
       EmitUniqueSection = true;
       Flags |= ELF::SHF_SUNW_NODISCARD;
-    } else if (Ctx.getAsmInfo()->useIntegratedAssembler() ||
-               Ctx.getAsmInfo()->binutilsIsAtLeast(2, 36)) {
+    } else if (Ctx.getAsmInfo().useIntegratedAssembler() ||
+               Ctx.getAsmInfo().binutilsIsAtLeast(2, 36)) {
       EmitUniqueSection = true;
       Flags |= ELF::SHF_GNU_RETAIN;
     }
@@ -1011,8 +1011,8 @@ MCSection *TargetLoweringObjectFileELF::getSectionForLSDA(
   // Use SHF_LINK_ORDER to facilitate --gc-sections if we can use GNU ld>=2.36
   // or LLD, which support mixed SHF_LINK_ORDER & non-SHF_LINK_ORDER.
   if (TM.getFunctionSections() &&
-      (getContext().getAsmInfo()->useIntegratedAssembler() &&
-       getContext().getAsmInfo()->binutilsIsAtLeast(2, 36))) {
+      (getContext().getAsmInfo().useIntegratedAssembler() &&
+       getContext().getAsmInfo().binutilsIsAtLeast(2, 36))) {
     Flags |= ELF::SHF_LINK_ORDER;
     LinkedToSym = static_cast<const MCSymbolELF *>(&FnSym);
   }
@@ -2163,7 +2163,7 @@ MCSection *TargetLoweringObjectFileCOFF::getSectionForConstant(
     const DataLayout &DL, SectionKind Kind, const Constant *C, Align &Alignment,
     const Function *F) const {
   if (Kind.isMergeableConst() && C &&
-      getContext().getAsmInfo()->hasCOFFComdatConstants()) {
+      getContext().getAsmInfo().hasCOFFComdatConstants()) {
     // This creates comdat sections with the given symbol name, but unless
     // AsmPrinter::GetCPISymbol actually makes the symbol global, the symbol
     // will be created with a null storage class, which makes GNU binutils

--- a/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
+++ b/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
@@ -103,7 +103,7 @@ DWARFCFIAnalysis::DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII,
       nullptr, MCRI->getDwarfRegNum(MCRI->getProgramCounter(), IsEH)));
 
   for (auto &&InitialFrameStateCFIDirective :
-       Context->getAsmInfo()->getInitialFrameState())
+       Context->getAsmInfo().getInitialFrameState())
     State.update(InitialFrameStateCFIDirective);
 
   auto MaybeCurrentRow = State.getCurrentUnwindRow();

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -1366,7 +1366,7 @@ void ELFObjectWriter::recordRelocation(const MCFragment &F,
     UseSectionSym = RSS == RelocSectionSymType::All ||
                     (RSS == RelocSectionSymType::Internal &&
                      SymA->getName().starts_with(
-                         Ctx.getAsmInfo()->getInternalSymbolPrefix()));
+                         Ctx.getAsmInfo().getInternalSymbolPrefix()));
   }
   if (UseSectionSym && useSectionSymbol(Target, SymA, Addend, Type)) {
     Addend += Asm->getSymbolOffset(*SymA);

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -90,7 +90,7 @@ public:
                 std::unique_ptr<MCCodeEmitter> emitter,
                 std::unique_ptr<MCAsmBackend> asmbackend)
       : MCAsmBaseStreamer(Context), OSOwner(std::move(os)), OS(*OSOwner),
-        MAI(Context.getAsmInfo()), InstPrinter(std::move(printer)),
+        MAI(&Context.getAsmInfo()), InstPrinter(std::move(printer)),
         Assembler(std::make_unique<MCAssembler>(
             Context, std::move(asmbackend), std::move(emitter),
             (asmbackend) ? asmbackend->createObjectWriter(NullStream)
@@ -116,7 +116,7 @@ public:
       break;
     case MCTargetOptions::DefaultDwarfDirectory:
       UseDwarfDirectory =
-          Context.getAsmInfo()->enableDwarfFileDirectoryDefault();
+          Context.getAsmInfo().enableDwarfFileDirectoryDefault();
       break;
     }
   }
@@ -2703,9 +2703,9 @@ void MCAsmStreamer::emitDwarfLineEndEntry(MCSection *Section,
 
   if (!EndLabel)
     EndLabel = TextSection->getEndSymbol(Ctx);
-  const MCAsmInfo *AsmInfo = Ctx.getAsmInfo();
+  const MCAsmInfo &AsmInfo = Ctx.getAsmInfo();
   emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, EndLabel,
-                           AsmInfo->getCodePointerSize());
+                           AsmInfo.getCodePointerSize());
 }
 
 // Generate DWARF line sections for assembly mode without .loc/.file

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -68,7 +68,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo &mai,
                      StringRef Swift5ReflSegmentName)
     : Swift5ReflectionSegmentName(Swift5ReflSegmentName), TT(TheTriple),
       SrcMgr(mgr), InlineSrcMgr(nullptr), DiagHandler(defaultDiagHandler),
-      MAI(&mai), MRI(mri), MSTI(msti), Symbols(Allocator),
+      MAI(mai), MRI(mri), MSTI(msti), Symbols(Allocator),
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset) {
@@ -119,7 +119,7 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo &mai,
 }
 
 const MCTargetOptions &MCContext::getTargetOptions() const {
-  return MAI->getTargetOptions();
+  return MAI.getTargetOptions();
 }
 
 MCContext::~MCContext() {
@@ -213,7 +213,7 @@ MCSymbol *MCContext::getOrCreateSymbol(const Twine &Name) {
 
   MCSymbolTableEntry &Entry = getSymbolTableEntry(NameRef);
   if (!Entry.second.Symbol) {
-    bool IsRenamable = NameRef.starts_with(MAI->getInternalSymbolPrefix());
+    bool IsRenamable = NameRef.starts_with(MAI.getInternalSymbolPrefix());
     bool IsTemporary = IsRenamable && !SaveTempLabels;
     if (!Entry.second.Used) {
       Entry.second.Used = true;
@@ -258,17 +258,17 @@ MCSymbol *MCContext::parseSymbol(const Twine &Name) {
 
 MCSymbol *MCContext::getOrCreateFrameAllocSymbol(const Twine &FuncName,
                                                  unsigned Idx) {
-  return getOrCreateSymbol(MAI->getInternalSymbolPrefix() + FuncName +
+  return getOrCreateSymbol(MAI.getInternalSymbolPrefix() + FuncName +
                            "$frame_escape_" + Twine(Idx));
 }
 
 MCSymbol *MCContext::getOrCreateParentFrameOffsetSymbol(const Twine &FuncName) {
-  return getOrCreateSymbol(MAI->getInternalSymbolPrefix() + FuncName +
+  return getOrCreateSymbol(MAI.getInternalSymbolPrefix() + FuncName +
                            "$parent_frame_offset");
 }
 
 MCSymbol *MCContext::getOrCreateLSDASymbol(const Twine &FuncName) {
-  return getOrCreateSymbol(MAI->getInternalSymbolPrefix() + "__ehtable$" +
+  return getOrCreateSymbol(MAI.getInternalSymbolPrefix() + "__ehtable$" +
                            FuncName);
 }
 
@@ -365,23 +365,23 @@ MCSymbol *MCContext::createRenamableSymbol(const Twine &Name,
 MCSymbol *MCContext::createTempSymbol(const Twine &Name, bool AlwaysAddSuffix) {
   if (!UseNamesOnTempLabels)
     return createSymbolImpl(nullptr, /*IsTemporary=*/true);
-  return createRenamableSymbol(MAI->getInternalSymbolPrefix() + Name,
+  return createRenamableSymbol(MAI.getInternalSymbolPrefix() + Name,
                                AlwaysAddSuffix, /*IsTemporary=*/true);
 }
 
 MCSymbol *MCContext::createNamedTempSymbol(const Twine &Name) {
-  return createRenamableSymbol(MAI->getInternalSymbolPrefix() + Name, true,
+  return createRenamableSymbol(MAI.getInternalSymbolPrefix() + Name, true,
                                /*IsTemporary=*/!SaveTempLabels);
 }
 
 MCSymbol *MCContext::createBlockSymbol(const Twine &Name, bool AlwaysEmit) {
   if (AlwaysEmit)
-    return getOrCreateSymbol(MAI->getPrivateLabelPrefix() + Name);
+    return getOrCreateSymbol(MAI.getPrivateLabelPrefix() + Name);
 
   bool IsTemporary = !SaveTempLabels;
   if (IsTemporary && !UseNamesOnTempLabels)
     return createSymbolImpl(nullptr, IsTemporary);
-  return createRenamableSymbol(MAI->getPrivateLabelPrefix() + Name,
+  return createRenamableSymbol(MAI.getPrivateLabelPrefix() + Name,
                                /*AlwaysAddSuffix=*/false, IsTemporary);
 }
 
@@ -390,7 +390,7 @@ MCSymbol *MCContext::createLinkerPrivateTempSymbol() {
 }
 
 MCSymbol *MCContext::createLinkerPrivateSymbol(const Twine &Name) {
-  return createRenamableSymbol(MAI->getLinkerPrivateGlobalPrefix() + Name,
+  return createRenamableSymbol(MAI.getLinkerPrivateGlobalPrefix() + Name,
                                /*AlwaysAddSuffix=*/true,
                                /*IsTemporary=*/false);
 }
@@ -500,7 +500,7 @@ MCSymbolXCOFF *MCContext::createXCOFFSymbolImpl(const MCSymbolTableEntry *Name,
       OriginalName.starts_with("_Renamed.."))
     reportError(SMLoc(), "invalid symbol name from source");
 
-  if (MAI->isValidUnquotedName(OriginalName))
+  if (MAI.isValidUnquotedName(OriginalName))
     return new (Name, *this) MCSymbolXCOFF(Name, IsTemporary);
 
   // Now we have a name that contains invalid character(s) for XCOFF symbol.
@@ -518,7 +518,7 @@ MCSymbolXCOFF *MCContext::createXCOFFSymbolImpl(const MCSymbolTableEntry *Name,
   // Append the hex values of '_' and invalid characters with "_Renamed..";
   // at the same time replace invalid characters with '_'.
   for (char &C : InvalidName) {
-    if (!MAI->isAcceptableChar(C) || C == '_') {
+    if (!MAI.isAcceptableChar(C) || C == '_') {
       raw_svector_ostream(ValidName).write_hex(C);
       C = '_';
     }

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -56,14 +56,14 @@ MCSymbol *mcdwarf::emitListsTableHeaderStart(MCStreamer &S) {
   S.AddComment("Version");
   S.emitInt16(S.getContext().getDwarfVersion());
   S.AddComment("Address size");
-  S.emitInt8(S.getContext().getAsmInfo()->getCodePointerSize());
+  S.emitInt8(S.getContext().getAsmInfo().getCodePointerSize());
   S.AddComment("Segment selector size");
   S.emitInt8(0);
   return End;
 }
 
 static inline uint64_t ScaleAddrDelta(MCContext &Context, uint64_t AddrDelta) {
-  unsigned MinInsnLength = Context.getAsmInfo()->getMinInstAlignment();
+  unsigned MinInsnLength = Context.getAsmInfo().getMinInstAlignment();
   if (MinInsnLength == 1)
     return AddrDelta;
   if (AddrDelta % MinInsnLength != 0) {
@@ -74,7 +74,7 @@ static inline uint64_t ScaleAddrDelta(MCContext &Context, uint64_t AddrDelta) {
 }
 
 MCDwarfLineStr::MCDwarfLineStr(MCContext &Ctx) {
-  UseRelocs = Ctx.getAsmInfo()->doesDwarfUseRelocationsAcrossSections();
+  UseRelocs = Ctx.getAsmInfo().doesDwarfUseRelocationsAcrossSections();
   if (UseRelocs) {
     MCSection *DwarfLineStrSection =
         Ctx.getObjectFileInfo()->getDwarfLineStrSection();
@@ -199,7 +199,7 @@ void MCDwarfLineTable::emitOne(
   for (auto It = LineEntries.begin(); It != LineEntries.end(); ++It) {
     auto LineEntry = *It;
     MCSymbol *CurrLabel = LineEntry.getLabel();
-    const MCAsmInfo *asmInfo = MCOS->getContext().getAsmInfo();
+    const MCAsmInfo &asmInfo = MCOS->getContext().getAsmInfo();
 
     if (LineEntry.LineStreamLabel) {
       if (!IsAtStartSeq) {
@@ -222,7 +222,7 @@ void MCDwarfLineTable::emitOne(
 
     if (LineEntry.IsEndEntry) {
       MCOS->emitDwarfAdvanceLineAddr(INT64_MAX, PrevLabel, CurrLabel,
-                                     asmInfo->getCodePointerSize());
+                                     asmInfo.getCodePointerSize());
       init();
       EndEntryEmitted = true;
       continue;
@@ -269,7 +269,7 @@ void MCDwarfLineTable::emitOne(
     // line numbers and the increment of the address from the previous Label
     // and the current Label.
     MCOS->emitDwarfAdvanceLineAddr(LineDelta, PrevLabel, CurrLabel,
-                                   asmInfo->getCodePointerSize());
+                                   asmInfo.getCodePointerSize());
 
     Discriminator = 0;
     LastLine = LineEntry.getLine();
@@ -368,7 +368,7 @@ MCDwarfLineTableHeader::Emit(MCStreamer *MCOS, MCDwarfLineTableParams Params,
 static const MCExpr *forceExpAbs(MCStreamer &OS, const MCExpr* Expr) {
   MCContext &Context = OS.getContext();
   assert(!isa<MCSymbolRefExpr>(Expr));
-  if (!Context.getAsmInfo()->doesSetDirectiveSuppressReloc())
+  if (!Context.getAsmInfo().doesSetDirectiveSuppressReloc())
     return Expr;
 
   // On Mach-O, try to avoid a relocation by using a set directive.
@@ -410,7 +410,7 @@ void MCDwarfLineStr::emitRef(MCStreamer *MCOS, StringRef Path) {
   size_t Offset = addString(Path);
   if (UseRelocs) {
     MCContext &Ctx = MCOS->getContext();
-    if (Ctx.getAsmInfo()->needsDwarfSectionOffsetDirective()) {
+    if (Ctx.getAsmInfo().needsDwarfSectionOffsetDirective()) {
       MCOS->emitCOFFSecRel32(LineStrLabel, Offset);
     } else {
       MCOS->emitValue(makeStartPlusIntExpr(Ctx, *LineStrLabel, Offset),
@@ -570,7 +570,7 @@ MCDwarfLineTableHeader::Emit(MCStreamer *MCOS, MCDwarfLineTableParams Params,
 
   // In v5, we get address info next.
   if (LineTableVersion >= 5) {
-    MCOS->emitInt8(context.getAsmInfo()->getCodePointerSize());
+    MCOS->emitInt8(context.getAsmInfo().getCodePointerSize());
     MCOS->emitInt8(0); // Segment selector; same as EmitGenDwarfAranges.
   }
 
@@ -585,7 +585,7 @@ MCDwarfLineTableHeader::Emit(MCStreamer *MCOS, MCDwarfLineTableParams Params,
   MCOS->emitLabel(ProStartSym);
 
   // Parameters of the state machine, are next.
-  MCOS->emitInt8(context.getAsmInfo()->getMinInstAlignment());
+  MCOS->emitInt8(context.getAsmInfo().getMinInstAlignment());
   // maximum_operations_per_instruction
   // For non-VLIW architectures this field is always 1.
   // FIXME: VLIW architectures need to update this field accordingly.
@@ -904,8 +904,8 @@ static void EmitGenDwarfAranges(MCStreamer *MCOS,
 
   // Figure the padding after the header before the table of address and size
   // pairs who's values are PointerSize'ed.
-  const MCAsmInfo *asmInfo = context.getAsmInfo();
-  int AddrSize = asmInfo->getCodePointerSize();
+  const MCAsmInfo &asmInfo = context.getAsmInfo();
+  int AddrSize = asmInfo.getCodePointerSize();
   int Pad = 2 * AddrSize - (Length & (2 * AddrSize - 1));
   if (Pad == 2 * AddrSize)
     Pad = 0;
@@ -930,7 +930,7 @@ static void EmitGenDwarfAranges(MCStreamer *MCOS,
   // from the start of the .debug_info.
   if (InfoSectionSymbol)
     MCOS->emitSymbolValue(InfoSectionSymbol, OffsetSize,
-                          asmInfo->needsDwarfSectionOffsetDirective());
+                          asmInfo.needsDwarfSectionOffsetDirective());
   else
     MCOS->emitIntValue(0, OffsetSize);
   // The 1 byte size of an address.
@@ -999,7 +999,7 @@ static void EmitGenDwarfInfo(MCStreamer *MCOS,
 
   // The DWARF v5 header has unit type, address size, abbrev offset.
   // Earlier versions have abbrev offset, address size.
-  const MCAsmInfo &AsmInfo = *context.getAsmInfo();
+  const MCAsmInfo &AsmInfo = context.getAsmInfo();
   int AddrSize = AsmInfo.getCodePointerSize();
   if (context.getDwarfVersion() >= 5) {
     MCOS->emitInt8(dwarf::DW_UT_compile);
@@ -1145,8 +1145,8 @@ static MCSymbol *emitGenDwarfRanges(MCStreamer *MCOS) {
   MCContext &context = MCOS->getContext();
   auto &Sections = context.getGenDwarfSectionSyms();
 
-  const MCAsmInfo *AsmInfo = context.getAsmInfo();
-  int AddrSize = AsmInfo->getCodePointerSize();
+  const MCAsmInfo &AsmInfo = context.getAsmInfo();
+  int AddrSize = AsmInfo.getCodePointerSize();
   MCSymbol *RangesSymbol;
 
   if (MCOS->getContext().getDwarfVersion() >= 5) {
@@ -1206,9 +1206,9 @@ void MCGenDwarfInfo::Emit(MCStreamer *MCOS) {
   MCContext &context = MCOS->getContext();
 
   // Create the dwarf sections in this order (.debug_line already created).
-  const MCAsmInfo *AsmInfo = context.getAsmInfo();
+  const MCAsmInfo &AsmInfo = context.getAsmInfo();
   bool CreateDwarfSectionSymbols =
-      AsmInfo->doesDwarfUseRelocationsAcrossSections();
+      AsmInfo.doesDwarfUseRelocationsAcrossSections();
   MCSymbol *LineSectionSymbol = nullptr;
   if (CreateDwarfSectionSymbols)
     LineSectionSymbol = MCOS->getDwarfLineTableSymbol(0);
@@ -1304,9 +1304,9 @@ void MCGenDwarfLabelEntry::Make(MCSymbol *Symbol, MCStreamer *MCOS,
 
 static int getDataAlignmentFactor(MCStreamer &streamer) {
   MCContext &context = streamer.getContext();
-  const MCAsmInfo *asmInfo = context.getAsmInfo();
-  int size = asmInfo->getCalleeSaveStackSlotSize();
-  if (asmInfo->isStackGrowthDirectionUp())
+  const MCAsmInfo &asmInfo = context.getAsmInfo();
+  int size = asmInfo.getCalleeSaveStackSlotSize();
+  if (asmInfo.isStackGrowthDirectionUp())
     return size;
   else
     return -size;
@@ -1320,7 +1320,7 @@ static unsigned getSizeForEncoding(MCStreamer &streamer,
   default: llvm_unreachable("Unknown Encoding");
   case dwarf::DW_EH_PE_absptr:
   case dwarf::DW_EH_PE_signed:
-    return context.getAsmInfo()->getCodePointerSize();
+    return context.getAsmInfo().getCodePointerSize();
   case dwarf::DW_EH_PE_udata2:
   case dwarf::DW_EH_PE_sdata2:
     return 2;
@@ -1336,12 +1336,11 @@ static unsigned getSizeForEncoding(MCStreamer &streamer,
 static void emitFDESymbol(MCObjectStreamer &streamer, const MCSymbol &symbol,
                           unsigned symbolEncoding, bool isEH) {
   MCContext &context = streamer.getContext();
-  const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v = asmInfo->getExprForFDESymbol(&symbol,
-                                                 symbolEncoding,
-                                                 streamer);
+  const MCAsmInfo &asmInfo = context.getAsmInfo();
+  const MCExpr *v =
+      asmInfo.getExprForFDESymbol(&symbol, symbolEncoding, streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
-  if (asmInfo->doDwarfFDESymbolsUseAbsDiff() && isEH)
+  if (asmInfo.doDwarfFDESymbolsUseAbsDiff() && isEH)
     emitAbsValue(streamer, v, size);
   else
     streamer.emitValue(v, size);
@@ -1350,10 +1349,9 @@ static void emitFDESymbol(MCObjectStreamer &streamer, const MCSymbol &symbol,
 static void EmitPersonality(MCStreamer &streamer, const MCSymbol &symbol,
                             unsigned symbolEncoding) {
   MCContext &context = streamer.getContext();
-  const MCAsmInfo *asmInfo = context.getAsmInfo();
-  const MCExpr *v = asmInfo->getExprForPersonalitySymbol(&symbol,
-                                                         symbolEncoding,
-                                                         streamer);
+  const MCAsmInfo &asmInfo = context.getAsmInfo();
+  const MCExpr *v =
+      asmInfo.getExprForPersonalitySymbol(&symbol, symbolEncoding, streamer);
   unsigned size = getSizeForEncoding(streamer, symbolEncoding);
   streamer.emitValue(v, size);
 }
@@ -1710,14 +1708,14 @@ const MCSymbol &FrameEmitterImpl::EmitCIE(const MCDwarfFrameInfo &Frame) {
 
   if (CIEVersion >= 4) {
     // Address Size
-    Streamer.emitInt8(context.getAsmInfo()->getCodePointerSize());
+    Streamer.emitInt8(context.getAsmInfo().getCodePointerSize());
 
     // Segment Descriptor Size
     Streamer.emitInt8(0);
   }
 
   // Code Alignment Factor
-  Streamer.emitULEB128IntValue(context.getAsmInfo()->getMinInstAlignment());
+  Streamer.emitULEB128IntValue(context.getAsmInfo().getMinInstAlignment());
 
   // Data Alignment Factor
   Streamer.emitSLEB128IntValue(getDataAlignmentFactor(Streamer));
@@ -1769,17 +1767,17 @@ const MCSymbol &FrameEmitterImpl::EmitCIE(const MCDwarfFrameInfo &Frame) {
 
   // Initial Instructions
 
-  const MCAsmInfo *MAI = context.getAsmInfo();
+  const MCAsmInfo &MAI = context.getAsmInfo();
   if (!Frame.IsSimple) {
     const std::vector<MCCFIInstruction> &Instructions =
-        MAI->getInitialFrameState();
+        MAI.getInitialFrameState();
     emitCFIInstructions(Instructions, nullptr);
   }
 
   InitialCFAOffset = CFAOffset;
 
   // Padding
-  Streamer.emitValueToAlignment(Align(IsEH ? 4 : MAI->getCodePointerSize()));
+  Streamer.emitValueToAlignment(Align(IsEH ? 4 : MAI.getCodePointerSize()));
 
   Streamer.emitLabel(sectionEnd);
   return *sectionStart;
@@ -1810,18 +1808,18 @@ void FrameEmitterImpl::EmitFDE(const MCSymbol &cieStart,
   Streamer.emitLabel(fdeStart);
 
   // CIE Pointer
-  const MCAsmInfo *asmInfo = context.getAsmInfo();
+  const MCAsmInfo &asmInfo = context.getAsmInfo();
   if (IsEH) {
     const MCExpr *offset =
         makeEndMinusStartExpr(context, cieStart, *fdeStart, 0);
     emitAbsValue(Streamer, offset, OffsetSize);
-  } else if (!asmInfo->doesDwarfUseRelocationsAcrossSections()) {
+  } else if (!asmInfo.doesDwarfUseRelocationsAcrossSections()) {
     const MCExpr *offset =
         makeEndMinusStartExpr(context, SectionStart, cieStart, 0);
     emitAbsValue(Streamer, offset, OffsetSize);
   } else {
     Streamer.emitSymbolValue(&cieStart, OffsetSize,
-                             asmInfo->needsDwarfSectionOffsetDirective());
+                             asmInfo.needsDwarfSectionOffsetDirective());
   }
 
   // PC Begin
@@ -1856,7 +1854,7 @@ void FrameEmitterImpl::EmitFDE(const MCSymbol &cieStart,
   // The size of a .eh_frame section has to be a multiple of the alignment
   // since a null CIE is interpreted as the end. Old systems overaligned
   // .eh_frame, so we do too and account for it in the last FDE.
-  unsigned Alignment = LastInSection ? asmInfo->getCodePointerSize() : PCSize;
+  unsigned Alignment = LastInSection ? asmInfo.getCodePointerSize() : PCSize;
   Streamer.emitValueToAlignment(Align(Alignment));
 
   Streamer.emitLabel(fdeEnd);
@@ -1926,7 +1924,7 @@ struct CIEKey {
 void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   MCContext &Context = Streamer.getContext();
   const MCObjectFileInfo *MOFI = Context.getObjectFileInfo();
-  const MCAsmInfo *AsmInfo = Context.getAsmInfo();
+  const MCAsmInfo &AsmInfo = Context.getAsmInfo();
   FrameEmitterImpl Emitter(IsEH, Streamer);
   ArrayRef<MCDwarfFrameInfo> FrameArray = Streamer.getDwarfFrameInfos();
 
@@ -1939,7 +1937,7 @@ void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
       if (Frame.CompactUnwindEncoding == 0) continue;
       if (!SectionEmitted) {
         Streamer.switchSection(MOFI->getCompactUnwindSection());
-        Streamer.emitValueToAlignment(Align(AsmInfo->getCodePointerSize()));
+        Streamer.emitValueToAlignment(Align(AsmInfo.getCodePointerSize()));
         SectionEmitted = true;
       }
       NeedsEHFrameSection |=
@@ -2006,7 +2004,7 @@ void MCDwarfFrameEmitter::encodeAdvanceLoc(MCContext &Context,
   if (AddrDelta == 0)
     return;
 
-  llvm::endianness E = Context.getAsmInfo()->isLittleEndian()
+  llvm::endianness E = Context.getAsmInfo().isLittleEndian()
                            ? llvm::endianness::little
                            : llvm::endianness::big;
 

--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -360,8 +360,8 @@ void MCELFStreamer::finalizeCGProfile() {
 void MCELFStreamer::finishImpl() {
   // Emit .note.GNU-stack, similar to AsmPrinter::doFinalization.
   MCContext &Ctx = getContext();
-  auto *StackSec = Ctx.getAsmInfo()->getStackSection(Ctx,
-                                                     /*Exec=*/false);
+  auto *StackSec = Ctx.getAsmInfo().getStackSection(Ctx,
+                                                    /*Exec=*/false);
   if (StackSec && Ctx.getTargetOptions().MCNoExecStack)
     switchSection(StackSec);
 

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -226,7 +226,7 @@ MCSymbolRefExpr::MCSymbolRefExpr(const MCSymbol *Symbol, Spec specifier,
 const MCSymbolRefExpr *MCSymbolRefExpr::create(const MCSymbol *Sym,
                                                uint16_t specifier,
                                                MCContext &Ctx, SMLoc Loc) {
-  return new (Ctx) MCSymbolRefExpr(Sym, specifier, Ctx.getAsmInfo(), Loc);
+  return new (Ctx) MCSymbolRefExpr(Sym, specifier, &Ctx.getAsmInfo(), Loc);
 }
 
 /* *** */
@@ -487,7 +487,7 @@ bool MCExpr::evaluateAsRelocatableImpl(MCValue &Res, const MCAssembler *Asm,
       Sym.setIsResolving(true);
       llvm::scope_exit _([&] { Sym.setIsResolving(false); });
       bool IsMachO =
-          Asm && Asm->getContext().getAsmInfo()->hasSubsectionsViaSymbols();
+          Asm && Asm->getContext().getAsmInfo().hasSubsectionsViaSymbols();
       if (!Sym.getVariableValue()->evaluateAsRelocatableImpl(Res, Asm,
                                                              InSet || IsMachO))
         return false;
@@ -682,7 +682,7 @@ bool MCExpr::evaluateAsRelocatableImpl(MCValue &Res, const MCAssembler *Asm,
   case Specifier:
     // Fold the expression during relocation generation. As parse time Asm might
     // be null, and targets should not rely on the folding.
-    return Asm && Asm->getContext().getAsmInfo()->evaluateAsRelocatableImpl(
+    return Asm && Asm->getContext().getAsmInfo().evaluateAsRelocatableImpl(
                       cast<MCSpecifierExpr>(*this), Res, Asm);
   }
 

--- a/llvm/lib/MC/MCInst.cpp
+++ b/llvm/lib/MC/MCInst.cpp
@@ -39,7 +39,7 @@ void MCOperand::print(raw_ostream &OS, const MCContext *Ctx) const {
   else if (isExpr()) {
     OS << "Expr:";
     if (Ctx)
-      Ctx->getAsmInfo()->printExpr(OS, *getExpr());
+      Ctx->getAsmInfo().printExpr(OS, *getExpr());
     else
       getExpr()->print(OS, nullptr);
   } else if (isInst()) {

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -358,7 +358,7 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
     if (PositionIndependent)
       FDECFIEncoding = dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4;
     else
-      FDECFIEncoding = Ctx->getAsmInfo()->getCodePointerSize() == 4
+      FDECFIEncoding = Ctx->getAsmInfo().getCodePointerSize() == 4
                            ? dwarf::DW_EH_PE_sdata4
                            : dwarf::DW_EH_PE_sdata8;
     break;
@@ -1290,7 +1290,7 @@ MCObjectFileInfo::getBBAddrMapSection(const MCSection &TextSec) const {
                                COFF::IMAGE_SCN_MEM_READ;
     const auto &COFFSec = static_cast<const MCSectionCOFF &>(TextSec);
     if (const MCSymbol *COMDATSym = COFFSec.getCOMDATSymbol()) {
-      if (!Ctx->getAsmInfo()->hasCOFFAssociativeComdats())
+      if (!Ctx->getAsmInfo().hasCOFFAssociativeComdats())
         report_fatal_error("BB address map requires associative COMDAT "
                            "support for COMDAT functions");
       COMDATSymName = COMDATSym->getName();

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -580,9 +580,9 @@ void MCObjectStreamer::emitDwarfLineEndEntry(MCSection *Section,
   MCContext &Ctx = getContext();
   switchSection(Ctx.getObjectFileInfo()->getDwarfLineSection());
 
-  const MCAsmInfo *AsmInfo = Ctx.getAsmInfo();
+  const MCAsmInfo &AsmInfo = Ctx.getAsmInfo();
   emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, EndLabel,
-                           AsmInfo->getCodePointerSize());
+                           AsmInfo.getCodePointerSize());
 }
 
 void MCObjectStreamer::emitDwarfAdvanceFrameAddr(const MCSymbol *LastLabel,

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -1980,7 +1980,7 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
       return parseDirectiveValue(IDVal, 8);
     case DK_DC_A:
       return parseDirectiveValue(
-          IDVal, getContext().getAsmInfo()->getCodePointerSize());
+          IDVal, getContext().getAsmInfo().getCodePointerSize());
     case DK_OCTA:
       return parseDirectiveOctaValue(IDVal);
     case DK_SINGLE:
@@ -1991,11 +1991,11 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
     case DK_DC_D:
       return parseDirectiveRealValue(IDVal, APFloat::IEEEdouble());
     case DK_ALIGN: {
-      bool IsPow2 = !getContext().getAsmInfo()->getAlignmentIsInBytes();
+      bool IsPow2 = !getContext().getAsmInfo().getAlignmentIsInBytes();
       return parseDirectiveAlign(IsPow2, /*ExprSize=*/1);
     }
     case DK_ALIGN32: {
-      bool IsPow2 = !getContext().getAsmInfo()->getAlignmentIsInBytes();
+      bool IsPow2 = !getContext().getAsmInfo().getAlignmentIsInBytes();
       return parseDirectiveAlign(IsPow2, /*ExprSize=*/4);
     }
     case DK_BALIGN:
@@ -3592,7 +3592,7 @@ bool AsmParser::parseDirectiveFile(SMLoc DirectiveLoc) {
     // Ignore the directive if there is no number and the target doesn't support
     // numberless .file directives. This allows some portability of assembler
     // between different object file formats.
-    if (getContext().getAsmInfo()->hasSingleParameterDotFile())
+    if (getContext().getAsmInfo().hasSingleParameterDotFile())
       getStreamer().emitFileDirective(Filename);
   } else {
     // In case there is a -g option as well as debug info from directive .file,
@@ -6179,7 +6179,7 @@ bool AsmParser::parseMSInlineAsm(
         OS << "]";
       break;
     case AOK_Label:
-      OS << Ctx.getAsmInfo()->getPrivateLabelPrefix() << AR.Label;
+      OS << Ctx.getAsmInfo().getPrivateLabelPrefix() << AR.Label;
       break;
     case AOK_Input:
       if (AR.IntelExpRestricted)
@@ -6215,7 +6215,7 @@ bool AsmParser::parseMSInlineAsm(
       // MS alignment directives are measured in bytes. If the native assembler
       // measures alignment in bytes, we can pass it straight through.
       OS << ".align";
-      if (getContext().getAsmInfo()->getAlignmentIsInBytes())
+      if (getContext().getAsmInfo().getAlignmentIsInBytes())
         break;
 
       // Alignment is in log2 form, so print that instead and skip the original
@@ -6271,7 +6271,7 @@ bool HLASMAsmParser::parseAsHLASMLabel(ParseStatementInfo &Info,
                  "Cannot have just a label for an HLASM inline asm statement");
 
   MCSymbol *Sym = getContext().parseSymbol(
-      getContext().getAsmInfo()->isHLASM() ? LabelVal.upper() : LabelVal);
+      getContext().getAsmInfo().isHLASM() ? LabelVal.upper() : LabelVal);
 
   // Emit the label.
   Out.emitLabel(Sym, LabelLoc);

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -397,7 +397,7 @@ bool ELFAsmParser::maybeParseSectionType(StringRef &TypeName) {
   Lex();
   if (L.isNot(AsmToken::At) && L.isNot(AsmToken::Percent) &&
       L.isNot(AsmToken::String)) {
-    if (getContext().getAsmInfo()->getCommentString().starts_with('@'))
+    if (getContext().getAsmInfo().getCommentString().starts_with('@'))
       return TokError("expected '%<type>' or \"<type>\"");
     else
       return TokError("expected '@<type>', '%<type>' or \"<type>\"");
@@ -718,7 +718,7 @@ bool ELFAsmParser::parseDirectiveType(StringRef, SMLoc) {
 
   bool AllowAt = getLexer().getAllowAtInIdentifier();
   if (!AllowAt &&
-      !getContext().getAsmInfo()->getCommentString().starts_with("@"))
+      !getContext().getAsmInfo().getCommentString().starts_with("@"))
     getLexer().setAllowAtInIdentifier(true);
   llvm::scope_exit _([&]() { getLexer().setAllowAtInIdentifier(AllowAt); });
 

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -6070,7 +6070,7 @@ bool MasmParser::parseMSInlineAsm(
         OS << "]";
       break;
     case AOK_Label:
-      OS << Ctx.getAsmInfo()->getPrivateLabelPrefix() << AR.Label;
+      OS << Ctx.getAsmInfo().getPrivateLabelPrefix() << AR.Label;
       break;
     case AOK_Input:
       OS << '$' << InputIdx++;
@@ -6100,7 +6100,7 @@ bool MasmParser::parseMSInlineAsm(
       // MS alignment directives are measured in bytes. If the native assembler
       // measures alignment in bytes, we can pass it straight through.
       OS << ".align";
-      if (getContext().getAsmInfo()->getAlignmentIsInBytes())
+      if (getContext().getAsmInfo().getAlignmentIsInBytes())
         break;
 
       // Alignment is in log2 form, so print that instead and skip the original

--- a/llvm/lib/MC/MCSFrame.cpp
+++ b/llvm/lib/MC/MCSFrame.cpp
@@ -123,7 +123,7 @@ struct SFrameFDE {
     MCContext &C = S.getContext();
 
     // sfde_func_start_address
-    const MCExpr *V = C.getAsmInfo()->getExprForFDESymbol(
+    const MCExpr *V = C.getAsmInfo().getExprForFDESymbol(
         &(*DFrame.Begin), C.getObjectFileInfo()->getFDEEncoding(), S);
     S.emitValue(V, sizeof(int32_t));
 
@@ -223,9 +223,9 @@ class SFrameEmitterImpl {
   // Returns true if the CFI escape sequence is safe for sframes.
   bool isCFIEscapeSafe(SFrameFDE &FDE, const SFrameFRE &FRE,
                        const MCCFIInstruction &CFI) {
-    const MCAsmInfo *AI = Streamer.getContext().getAsmInfo();
-    DWARFDataExtractorSimple data(CFI.getValues(), AI->isLittleEndian(),
-                                  AI->getCodePointerSize());
+    const MCAsmInfo &AI = Streamer.getContext().getAsmInfo();
+    DWARFDataExtractorSimple data(CFI.getValues(), AI.isLittleEndian(),
+                                  AI.getCodePointerSize());
 
     // Normally, both alignment factors are extracted from the enclosing Dwarf
     // FDE or CIE. We don't have one here. Alignments are used for scaling
@@ -491,7 +491,7 @@ public:
     SFrameFRE BaseFRE(LastLabel);
     if (!DF.IsSimple) {
       for (const auto &CFI :
-           Streamer.getContext().getAsmInfo()->getInitialFrameState())
+           Streamer.getContext().getAsmInfo().getInitialFrameState())
         if (!handleCFI(FDE, BaseFRE, CFI))
           Valid = false;
     }
@@ -646,7 +646,7 @@ void MCSFrameEmitter::encodeFuncOffset(MCContext &C, uint64_t Offset,
   FDEInfo<endianness::native> I;
   I.Info = FDEData.back();
   FREType T = I.getFREType();
-  llvm::endianness E = C.getAsmInfo()->isLittleEndian()
+  llvm::endianness E = C.getAsmInfo().isLittleEndian()
                            ? llvm::endianness::little
                            : llvm::endianness::big;
   // sfre_start_address

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -58,7 +58,7 @@ void MCTargetStreamer::emitConstantPools() {}
 
 void MCTargetStreamer::changeSection(const MCSection *, MCSection *Sec,
                                      uint32_t Subsection, raw_ostream &OS) {
-  auto &MAI = *Streamer.getContext().getAsmInfo();
+  auto &MAI = Streamer.getContext().getAsmInfo();
   MAI.printSwitchToSection(*Sec, Subsection,
                            Streamer.getContext().getTargetTriple(), OS);
 }
@@ -71,13 +71,13 @@ void MCTargetStreamer::emitValue(const MCExpr *Value) {
   SmallString<128> Str;
   raw_svector_ostream OS(Str);
 
-  Streamer.getContext().getAsmInfo()->printExpr(OS, *Value);
+  Streamer.getContext().getAsmInfo().printExpr(OS, *Value);
   Streamer.emitRawText(OS.str());
 }
 
 void MCTargetStreamer::emitRawBytes(StringRef Data) {
-  const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
-  const char *Directive = MAI->getData8bitsDirective();
+  const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
+  const char *Directive = MAI.getData8bitsDirective();
   for (const unsigned char C : Data.bytes()) {
     SmallString<128> Str;
     raw_svector_ostream OS(Str);
@@ -131,7 +131,7 @@ void MCStreamer::emitIntValue(uint64_t Value, unsigned Size) {
   assert(1 <= Size && Size <= 8 && "Invalid size");
   assert((isUIntN(8 * Size, Value) || isIntN(8 * Size, Value)) &&
          "Invalid size");
-  const bool IsLittleEndian = Context.getAsmInfo()->isLittleEndian();
+  const bool IsLittleEndian = Context.getAsmInfo().isLittleEndian();
   uint64_t Swapped = support::endian::byte_swap(
       Value, IsLittleEndian ? llvm::endianness::little : llvm::endianness::big);
   unsigned Index = IsLittleEndian ? 0 : 8 - Size;
@@ -143,7 +143,7 @@ void MCStreamer::emitIntValue(const APInt &Value) {
     return;
   }
 
-  const bool IsLittleEndianTarget = Context.getAsmInfo()->isLittleEndian();
+  const bool IsLittleEndianTarget = Context.getAsmInfo().isLittleEndian();
   const bool ShouldSwap = sys::IsLittleEndianHost != IsLittleEndianTarget;
   const APInt Swapped = ShouldSwap ? Value.byteSwap() : Value;
   const unsigned Size = Value.getBitWidth() / 8;
@@ -249,7 +249,7 @@ void MCStreamer::emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) {
 MCSymbol *MCStreamer::getDwarfLineTableSymbol(unsigned CUID) {
   MCDwarfLineTable &Table = getContext().getMCDwarfLineTable(CUID);
   if (!Table.getLabel()) {
-    StringRef Prefix = Context.getAsmInfo()->getInternalSymbolPrefix();
+    StringRef Prefix = Context.getAsmInfo().getInternalSymbolPrefix();
     Table.setLabel(
         Context.getOrCreateSymbol(Prefix + "line_table_start" + Twine(CUID)));
   }
@@ -436,14 +436,12 @@ void MCStreamer::emitCFIStartProc(bool IsSimple, SMLoc Loc) {
   Frame.IsSimple = IsSimple;
   emitCFIStartProcImpl(Frame);
 
-  const MCAsmInfo* MAI = Context.getAsmInfo();
-  if (MAI) {
-    for (const MCCFIInstruction& Inst : MAI->getInitialFrameState()) {
-      if (Inst.getOperation() == MCCFIInstruction::OpDefCfa ||
-          Inst.getOperation() == MCCFIInstruction::OpDefCfaRegister ||
-          Inst.getOperation() == MCCFIInstruction::OpLLVMDefAspaceCfa) {
-        Frame.CurrentCfaRegister = Inst.getRegister();
-      }
+  const MCAsmInfo &MAI = Context.getAsmInfo();
+  for (const MCCFIInstruction &Inst : MAI.getInitialFrameState()) {
+    if (Inst.getOperation() == MCCFIInstruction::OpDefCfa ||
+        Inst.getOperation() == MCCFIInstruction::OpDefCfaRegister ||
+        Inst.getOperation() == MCCFIInstruction::OpLLVMDefAspaceCfa) {
+      Frame.CurrentCfaRegister = Inst.getRegister();
     }
   }
 
@@ -722,8 +720,8 @@ void MCStreamer::emitCFIValOffset(int64_t Register, int64_t Offset, SMLoc Loc) {
 }
 
 WinEH::FrameInfo *MCStreamer::EnsureValidWinFrameInfo(SMLoc Loc) {
-  const MCAsmInfo *MAI = Context.getAsmInfo();
-  if (!MAI->usesWindowsCFI()) {
+  const MCAsmInfo &MAI = Context.getAsmInfo();
+  if (!MAI.usesWindowsCFI()) {
     getContext().reportError(
         Loc, ".seh_* directives are not supported on this target");
     return nullptr;
@@ -737,8 +735,8 @@ WinEH::FrameInfo *MCStreamer::EnsureValidWinFrameInfo(SMLoc Loc) {
 }
 
 void MCStreamer::emitWinCFIStartProc(const MCSymbol *Symbol, SMLoc Loc) {
-  const MCAsmInfo *MAI = Context.getAsmInfo();
-  if (!MAI->usesWindowsCFI())
+  const MCAsmInfo &MAI = Context.getAsmInfo();
+  if (!MAI.usesWindowsCFI())
     return getContext().reportError(
         Loc, ".seh_* directives are not supported on this target");
   if (CurrentWinFrameInfo && !CurrentWinFrameInfo->End)
@@ -869,7 +867,7 @@ static MCSection *getWinCFISection(MCContext &Context, unsigned *NextWinCFIID,
     // In a GNU environment, we can't use associative comdats. Instead, do what
     // GCC does, which is to make plain comdat selectany section named like
     // ".[px]data$_Z3foov".
-    if (!Context.getAsmInfo()->hasCOFFAssociativeComdats()) {
+    if (!Context.getAsmInfo().hasCOFFAssociativeComdats()) {
       std::string SectionName = (MainCFISecCOFF->getName() + "$" +
                                  TextSecCOFF->getName().split('$').second)
                                     .str();
@@ -1250,8 +1248,8 @@ void MCStreamer::emitAbsoluteSymbolDiff(const MCSymbol *Hi, const MCSymbol *Lo,
       MCBinaryExpr::createSub(MCSymbolRefExpr::create(Hi, Context),
                               MCSymbolRefExpr::create(Lo, Context), Context);
 
-  const MCAsmInfo *MAI = Context.getAsmInfo();
-  if (!MAI->doesSetDirectiveSuppressReloc()) {
+  const MCAsmInfo &MAI = Context.getAsmInfo();
+  if (!MAI.doesSetDirectiveSuppressReloc()) {
     emitValue(Diff, Size);
     return;
   }

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -4693,7 +4693,7 @@ bool AArch64AsmParser::parseSymbolicImmVal(const MCExpr *&ImmVal) {
     ImmVal = MCSpecifierExpr::create(ImmVal, RefKind, getContext(), Loc);
 
   SMLoc EndLoc;
-  if (getContext().getAsmInfo()->hasSubsectionsViaSymbols()) {
+  if (getContext().getAsmInfo().hasSubsectionsViaSymbols()) {
     if (getParser().parseAtSpecifier(ImmVal, EndLoc))
       return true;
     const MCExpr *Term;

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCResourceInfo.cpp
@@ -28,7 +28,7 @@ using namespace llvm;
 MCSymbol *MCResourceInfo::getSymbol(StringRef FuncName, ResourceInfoKind RIK,
                                     MCContext &OutContext) {
   auto GOCS = [FuncName, &OutContext](StringRef Suffix) {
-    StringRef Prefix = OutContext.getAsmInfo()->getInternalSymbolPrefix();
+    StringRef Prefix = OutContext.getAsmInfo().getInternalSymbolPrefix();
     return OutContext.getOrCreateSymbol(Twine(Prefix) + FuncName +
                                         Twine(Suffix));
   };

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6630,7 +6630,7 @@ bool AMDGPUAsmParser::ParseToEndDirective(const char *AssemblerDirectiveBegin,
     }
 
     CollectStream << Parser.parseStringToEndOfStatement()
-                  << getContext().getAsmInfo()->getSeparatorString();
+                  << getContext().getAsmInfo().getSeparatorString();
 
     Parser.eatToEndOfStatement();
   }

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -57,7 +57,7 @@ static int64_t getInlineImmVal64(unsigned Imm);
 AMDGPUDisassembler::AMDGPUDisassembler(const MCSubtargetInfo &STI,
                                        MCContext &Ctx, MCInstrInfo const *MCII)
     : MCDisassembler(STI, Ctx), MCII(MCII), MRI(*Ctx.getRegisterInfo()),
-      MAI(*Ctx.getAsmInfo()),
+      MAI(Ctx.getAsmInfo()),
       HwModeRegClass(STI.getHwMode(MCSubtargetInfo::HwMode_RegInfo)),
       TargetMaxInstBytes(MAI.getMaxInstLength(&STI)),
       CodeObjectVersion(AMDGPU::getDefaultAMDHSACodeObjectVersion()) {

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -203,7 +203,7 @@ bool AMDGPUAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
   // be writing data into the text section (otherwise we have unaligned
   // instructions, and thus have far bigger problems), so just write zeros
   // instead.
-  unsigned MinInstAlignment = getContext().getAsmInfo()->getMinInstAlignment();
+  unsigned MinInstAlignment = getContext().getAsmInfo().getMinInstAlignment();
   OS.write_zeros(Count % MinInstAlignment);
 
   // We are properly aligned, so write NOPs as requested.

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -295,9 +295,9 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceInfo(
     const MCSymbol *HasRecursion, const MCSymbol *HasIndirectCall) {
 #define PRINT_RES_INFO(ARG)                                                    \
   OS << "\t.set ";                                                             \
-  ARG->print(OS, getContext().getAsmInfo());                                   \
+  ARG->print(OS, &getContext().getAsmInfo());                                  \
   OS << ", ";                                                                  \
-  getContext().getAsmInfo()->printExpr(OS, *ARG->getVariableValue());          \
+  getContext().getAsmInfo().printExpr(OS, *ARG->getVariableValue());           \
   Streamer.addBlankLine();
 
   PRINT_RES_INFO(NumVGPR);
@@ -318,9 +318,9 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(
     const MCSymbol *MaxNamedBarrier) {
 #define PRINT_RES_INFO(ARG)                                                    \
   OS << "\t.set ";                                                             \
-  ARG->print(OS, getContext().getAsmInfo());                                   \
+  ARG->print(OS, &getContext().getAsmInfo());                                  \
   OS << ", ";                                                                  \
-  getContext().getAsmInfo()->printExpr(OS, *ARG->getVariableValue());          \
+  getContext().getAsmInfo().printExpr(OS, *ARG->getVariableValue());           \
   Streamer.addBlankLine();
 
   PRINT_RES_INFO(MaxVGPR);
@@ -379,7 +379,7 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
     const MCExpr *NextSGPR, const MCExpr *ReserveVCC,
     const MCExpr *ReserveFlatScr) {
   IsaVersion IVersion = getIsaVersion(STI.getCPU());
-  const MCAsmInfo *MAI = getContext().getAsmInfo();
+  const MCAsmInfo &MAI = getContext().getAsmInfo();
 
   OS << "\t.amdhsa_kernel " << KernelName << '\n';
 
@@ -389,13 +389,13 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
     const MCExpr *ShiftedAndMaskedExpr =
         MCKernelDescriptor::bits_get(Expr, Shift, Mask, getContext());
     const MCExpr *New = foldAMDGPUMCExpr(ShiftedAndMaskedExpr, getContext());
-    printAMDGPUMCExpr(New, OS, MAI);
+    printAMDGPUMCExpr(New, OS, &MAI);
     OS << '\n';
   };
 
   auto EmitMCExpr = [&](const MCExpr *Value) {
     const MCExpr *NewExpr = foldAMDGPUMCExpr(Value, getContext());
-    printAMDGPUMCExpr(NewExpr, OS, MAI);
+    printAMDGPUMCExpr(NewExpr, OS, &MAI);
   };
 
   OS << "\t\t.amdhsa_group_segment_fixed_size ";
@@ -520,7 +520,7 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
         accum_bits, MCConstantExpr::create(4, getContext()), getContext());
     OS << "\t\t.amdhsa_accum_offset ";
     const MCExpr *New = foldAMDGPUMCExpr(accum_bits, getContext());
-    printAMDGPUMCExpr(New, OS, MAI);
+    printAMDGPUMCExpr(New, OS, &MAI);
     OS << '\n';
   }
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -214,7 +214,7 @@ public:
     if constexpr (!std::is_integral_v<T>) {
       OS << Name << " = ";
       const MCExpr *Value = C.*ptr;
-      Helper(Value, OS, Ctx.getAsmInfo());
+      Helper(Value, OS, &Ctx.getAsmInfo());
     } else {
       OS << Name << " = " << (int)(C.*ptr);
     }
@@ -253,7 +253,7 @@ getPrinterTable(AMDGPUMCKernelCodeT::PrintHelper Helper) {
       Value =                                                                  \
           maskShiftGet(C.compute_pgm_resource2_registers, Mask, Shift, Ctx);   \
     }                                                                          \
-    Helper(Value, OS, Ctx.getAsmInfo());                                       \
+    Helper(Value, OS, &Ctx.getAsmInfo());                                      \
   }
 #define RECORD(name, altName, print, parse) print
 #include "Utils/AMDKernelCodeTInfo.h"
@@ -445,7 +445,7 @@ void AMDGPUMCKernelCodeT::EmitKernelCodeT(raw_ostream &OS, MCContext &Ctx,
     if (hasMCExprVersionTable()[i]) {
       OS << get_amd_kernel_code_t_FldNames()[i + 1] << " = ";
       const MCExpr *Value = getMCExprForIndex(i);
-      Helper(Value, OS, Ctx.getAsmInfo());
+      Helper(Value, OS, &Ctx.getAsmInfo());
     } else {
       printAmdKernelCodeField(*this, i, OS, Ctx, Helper);
     }

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -12314,7 +12314,7 @@ bool ARMAsmParser::parseDirectiveEven(SMLoc L) {
   }
 
   assert(Section && "must have section to emit alignment");
-  if (getContext().getAsmInfo()->useCodeAlign(*Section))
+  if (getContext().getAsmInfo().useCodeAlign(*Section))
     getStreamer().emitCodeAlignment(Align(2), &getSTI());
   else
     getStreamer().emitValueToAlignment(Align(2));
@@ -12512,7 +12512,7 @@ bool ARMAsmParser::parseDirectiveAlign(SMLoc L) {
     // '.align' is target specifically handled to mean 2**2 byte alignment.
     const MCSection *Section = getStreamer().getCurrentSectionOnly();
     assert(Section && "must have section to emit alignment");
-    if (getContext().getAsmInfo()->useCodeAlign(*Section))
+    if (getContext().getAsmInfo().useCodeAlign(*Section))
       getStreamer().emitCodeAlignment(Align(4), &getSTI(), 0);
     else
       getStreamer().emitValueToAlignment(Align(4), 0, 1, 0);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -271,23 +271,23 @@ void ARMTargetAsmStreamer::emitCode16() { OS << "\t.code\t16\n"; }
 void ARMTargetAsmStreamer::emitCode32() { OS << "\t.code\t32\n"; }
 
 void ARMTargetAsmStreamer::emitThumbFunc(MCSymbol *Symbol) {
-  const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
+  const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
   OS << "\t.thumb_func";
   // Only Mach-O hasSubsectionsViaSymbols()
-  if (MAI->hasSubsectionsViaSymbols()) {
+  if (MAI.hasSubsectionsViaSymbols()) {
     OS << '\t';
-    Symbol->print(OS, MAI);
+    Symbol->print(OS, &MAI);
   }
   OS << '\n';
 }
 
 void ARMTargetAsmStreamer::emitThumbSet(MCSymbol *Symbol, const MCExpr *Value) {
-  const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
+  const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
 
   OS << "\t.thumb_set\t";
-  Symbol->print(OS, MAI);
+  Symbol->print(OS, &MAI);
   OS << ", ";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
@@ -531,7 +531,7 @@ public:
   void emitInst(uint32_t Inst, char Suffix) {
     unsigned Size;
     char Buffer[4];
-    const bool LittleEndian = getContext().getAsmInfo()->isLittleEndian();
+    const bool LittleEndian = getContext().getAsmInfo().isLittleEndian();
 
     switch (Suffix) {
     case '\0':

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
@@ -52,7 +52,7 @@ void ARMTargetStreamer::reset() {}
 void ARMTargetStreamer::emitInst(uint32_t Inst, char Suffix) {
   unsigned Size;
   char Buffer[4];
-  const bool LittleEndian = getContext().getAsmInfo()->isLittleEndian();
+  const bool LittleEndian = getContext().getAsmInfo().isLittleEndian();
 
   switch (Suffix) {
   case '\0':

--- a/llvm/lib/Target/BPF/Disassembler/BPFDisassembler.cpp
+++ b/llvm/lib/Target/BPF/Disassembler/BPFDisassembler.cpp
@@ -169,7 +169,7 @@ DecodeStatus BPFDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
                                              ArrayRef<uint8_t> Bytes,
                                              uint64_t Address,
                                              raw_ostream &CStream) const {
-  bool IsLittleEndian = getContext().getAsmInfo()->isLittleEndian();
+  bool IsLittleEndian = getContext().getAsmInfo().isLittleEndian();
   uint64_t Insn, Hi;
   DecodeStatus Result;
 

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
@@ -282,7 +282,7 @@ bool LoongArchAsmBackend::relaxDwarfLineAddr(MCFragment &F) const {
   // value is therefore 65535.  Set a conservative upper bound for relaxation.
   unsigned PCBytes;
   if (Value > 60000) {
-    unsigned PtrSize = C.getAsmInfo()->getCodePointerSize();
+    unsigned PtrSize = C.getAsmInfo().getCodePointerSize();
     assert((PtrSize == 4 || PtrSize == 8) && "Unexpected pointer size");
     PCBytes = PtrSize;
     OS << uint8_t(dwarf::DW_LNS_extended_op) << uint8_t(PtrSize + 1)
@@ -319,7 +319,7 @@ bool LoongArchAsmBackend::relaxDwarfCFA(MCFragment &F) const {
   assert(IsAbsolute && "CFA with invalid expression");
   (void)IsAbsolute;
 
-  assert(getContext().getAsmInfo()->getMinInstAlignment() == 1 &&
+  assert(getContext().getAsmInfo().getMinInstAlignment() == 1 &&
          "expected 1-byte alignment");
   if (Value == 0) {
     F.clearVarContents();

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsTargetStreamer.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsTargetStreamer.cpp
@@ -395,44 +395,44 @@ MipsTargetAsmStreamer::MipsTargetAsmStreamer(MCStreamer &S,
     : MipsTargetStreamer(S), OS(OS) {}
 
 void MipsTargetAsmStreamer::emitDTPRel32Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.dtprelword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
 void MipsTargetAsmStreamer::emitDTPRel64Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.dtpreldword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
 void MipsTargetAsmStreamer::emitTPRel32Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.tprelword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
 void MipsTargetAsmStreamer::emitTPRel64Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.tpreldword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
 void MipsTargetAsmStreamer::emitGPRel32Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.gpword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
 void MipsTargetAsmStreamer::emitGPRel64Value(const MCExpr *Value) {
-  auto *MAI = getStreamer().getContext().getAsmInfo();
+  auto &MAI = getStreamer().getContext().getAsmInfo();
   OS << "\t.gpdword\t";
-  MAI->printExpr(OS, *Value);
+  MAI.printExpr(OS, *Value);
   OS << '\n';
 }
 
@@ -970,7 +970,7 @@ void MipsTargetELFStreamer::finish() {
 
       Align Alignment = Section.getAlign();
       S.switchSection(&Section);
-      if (getContext().getAsmInfo()->useCodeAlign(Section))
+      if (getContext().getAsmInfo().useCodeAlign(Section))
         S.emitCodeAlignment(Alignment, &STI, Alignment.value());
       else
         S.emitValueToAlignment(Alignment, 0, 1, Alignment.value());

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
@@ -107,8 +107,8 @@ void NVPTXTargetStreamer::emitRawBytes(StringRef Data) {
   // resolved. Currently, (it is confirmed by NVidia) it causes a crash in
   // ptxas.
 #if 0
-  const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
-  const char *Directive = MAI->getData8bitsDirective();
+  const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
+  const char *Directive = MAI.getData8bitsDirective();
   unsigned NumElements = Data.size();
   const unsigned MaxLen = 40;
   unsigned NumChunks = 1 + ((NumElements - 1) / MaxLen);

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1983,7 +1983,7 @@ NVPTXAsmPrinter::lowerConstantForGV(const Constant *CV,
 }
 
 void NVPTXAsmPrinter::printMCExpr(const MCExpr &Expr, raw_ostream &OS) const {
-  OutContext.getAsmInfo()->printExpr(OS, Expr);
+  OutContext.getAsmInfo().printExpr(OS, Expr);
 }
 
 /// PrintAsmOperand - Print out an operand for an inline asm expression.

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.h
@@ -30,7 +30,7 @@ class PPCMCCodeEmitter : public MCCodeEmitter {
 public:
   PPCMCCodeEmitter(const MCInstrInfo &mcii, MCContext &ctx)
       : MCII(mcii), CTX(ctx),
-        IsLittleEndian(ctx.getAsmInfo()->isLittleEndian()) {}
+        IsLittleEndian(ctx.getAsmInfo().isLittleEndian()) {}
   PPCMCCodeEmitter(const PPCMCCodeEmitter &) = delete;
   void operator=(const PPCMCCodeEmitter &) = delete;
   ~PPCMCCodeEmitter() override = default;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
@@ -226,7 +226,7 @@ public:
           Kind == PPC::S_AIX_TLSIE || Kind == PPC::S_AIX_TLSLE ||
           Kind == PPC::S_AIX_TLSLD || Kind == PPC::S_AIX_TLSML)
         OS << "\t.tc " << TCSym->getName() << "," << S.getName() << "@"
-           << getContext().getAsmInfo()->getSpecifierName(Kind) << '\n';
+           << getContext().getAsmInfo().getSpecifierName(Kind) << '\n';
       else
         OS << "\t.tc " << TCSym->getName() << "," << S.getName() << '\n';
 
@@ -251,12 +251,12 @@ public:
   }
 
   void emitLocalEntry(MCSymbolELF *S, const MCExpr *LocalOffset) override {
-    const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
+    const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
 
     OS << "\t.localentry\t";
-    S->print(OS, MAI);
+    S->print(OS, &MAI);
     OS << ", ";
-    MAI->printExpr(OS, *LocalOffset);
+    MAI.printExpr(OS, *LocalOffset);
     OS << '\n';
   }
 };
@@ -396,8 +396,8 @@ public:
   PPCTargetXCOFFStreamer(MCStreamer &S) : PPCTargetStreamer(S) {}
 
   void emitTCEntry(const MCSymbol &S, PPCMCExpr::Specifier Kind) override {
-    const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
-    const unsigned PointerSize = MAI->getCodePointerSize();
+    const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
+    const unsigned PointerSize = MAI.getCodePointerSize();
     Streamer.emitValueToAlignment(Align(PointerSize));
     Streamer.emitValue(MCSymbolRefExpr::create(&S, Kind, Streamer.getContext()),
                        PointerSize);

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -373,7 +373,7 @@ bool RISCVAsmBackend::relaxDwarfLineAddr(MCFragment &F) const {
   // value is therefore 65535.  Set a conservative upper bound for relaxation.
   unsigned PCBytes;
   if (Value > 60000) {
-    PCBytes = getContext().getAsmInfo()->getCodePointerSize();
+    PCBytes = getContext().getAsmInfo().getCodePointerSize();
     OS << uint8_t(dwarf::DW_LNS_extended_op) << uint8_t(PCBytes + 1)
        << uint8_t(dwarf::DW_LNE_set_address);
     OS.write_zeros(PCBytes);
@@ -408,7 +408,7 @@ bool RISCVAsmBackend::relaxDwarfCFA(MCFragment &F) const {
       AddrDelta.evaluateKnownAbsolute(Value, *Asm);
   assert(IsAbsolute && "CFA with invalid expression");
 
-  assert(getContext().getAsmInfo()->getMinInstAlignment() == 1 &&
+  assert(getContext().getAsmInfo().getMinInstAlignment() == 1 &&
          "expected 1-byte alignment");
   if (Value == 0) {
     F.clearVarContents();

--- a/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
+++ b/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
@@ -322,7 +322,7 @@ DecodeStatus SparcDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
                                                uint64_t Address,
                                                raw_ostream &CStream) const {
   uint32_t Insn;
-  bool isLittleEndian = getContext().getAsmInfo()->isLittleEndian();
+  bool isLittleEndian = getContext().getAsmInfo().isLittleEndian();
   DecodeStatus Result =
       readInstruction32(Bytes, Address, Size, Insn, isLittleEndian);
   if (Result == MCDisassembler::Fail)

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
@@ -111,7 +111,7 @@ void SparcMCCodeEmitter::encodeInstruction(const MCInst &MI,
                                            const MCSubtargetInfo &STI) const {
   unsigned Bits = getBinaryCodeForInstr(MI, Fixups, STI);
   support::endian::write(CB, Bits,
-                         Ctx.getAsmInfo()->isLittleEndian()
+                         Ctx.getAsmInfo().isLittleEndian()
                              ? llvm::endianness::little
                              : llvm::endianness::big);
 

--- a/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
+++ b/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
@@ -481,7 +481,7 @@ private:
   // here, to get the "correct" assembler dialect, and use it in various
   // functions.
   unsigned getMAIAssemblerDialect() {
-    return Parser.getContext().getAsmInfo()->getAssemblerDialect();
+    return Parser.getContext().getAsmInfo().getAssemblerDialect();
   }
 
   // An alphabetic character in HLASM is a letter from 'A' through 'Z',

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.h
@@ -54,7 +54,7 @@ public:
                           std::unique_ptr<MCCodeEmitter> emitter,
                           std::unique_ptr<MCAsmBackend> asmbackend)
       : MCStreamer(Context), FOSOwner(std::move(os)), FOS(*FOSOwner), OS(Str),
-        MAI(Context.getAsmInfo()), InstPrinter(std::move(printer)),
+        MAI(&Context.getAsmInfo()), InstPrinter(std::move(printer)),
         Assembler(std::make_unique<MCAssembler>(
             Context, std::move(asmbackend), std::move(emitter),
             (asmbackend) ? asmbackend->createObjectWriter(NullStream)

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.cpp
@@ -47,7 +47,7 @@ const MCExpr *SystemZTargetHLASMStreamer::createWordDiffExpr(
   OS << Temp->getName() << " EQU ";
   const MCBinaryExpr *TempExpr = MCBinaryExpr::createSub(
       MCSymbolRefExpr::create(Hi, Ctx), MCSymbolRefExpr::create(Lo, Ctx), Ctx);
-  Ctx.getAsmInfo()->printExpr(OS, *TempExpr);
+  Ctx.getAsmInfo().printExpr(OS, *TempExpr);
   OS << "\n";
   return MCBinaryExpr::createLShr(MCSymbolRefExpr::create(Temp, Ctx),
                                   MCConstantExpr::create(1, Ctx), Ctx);

--- a/llvm/lib/Target/TargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/TargetLoweringObjectFile.cpp
@@ -61,7 +61,7 @@ unsigned TargetLoweringObjectFile::getCallSiteEncoding() const {
   // If target does not have LEB128 directives, we would need the
   // call site encoding to be udata4 so that the alternative path
   // for not having LEB128 directives could work.
-  if (!getContext().getAsmInfo()->hasLEB128Directives())
+  if (!getContext().getAsmInfo().hasLEB128Directives())
     return dwarf::DW_EH_PE_udata4;
   return CallSiteEncoding;
 }

--- a/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
+++ b/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
@@ -562,7 +562,7 @@ DecodeStatus VEDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
                                             uint64_t Address,
                                             raw_ostream &CStream) const {
   uint64_t Insn;
-  bool isLittleEndian = getContext().getAsmInfo()->isLittleEndian();
+  bool isLittleEndian = getContext().getAsmInfo().isLittleEndian();
   DecodeStatus Result =
       readInstruction64(Bytes, Address, Size, Insn, isLittleEndian);
   if (Result == MCDisassembler::Fail)

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
@@ -112,7 +112,7 @@ void WebAssemblyTargetAsmStreamer::emitExportName(const MCSymbolWasm *Sym,
 
 void WebAssemblyTargetAsmStreamer::emitIndIdx(const MCExpr *Value) {
   OS << "\t.indidx\t";
-  getContext().getAsmInfo()->printExpr(OS, *Value);
+  getContext().getAsmInfo().printExpr(OS, *Value);
   OS << '\n';
 }
 

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -4879,7 +4879,7 @@ bool X86AsmParser::parseDirectiveEven(SMLoc L) {
     getStreamer().initSections(getSTI());
     Section = getStreamer().getCurrentSectionOnly();
   }
-  if (getContext().getAsmInfo()->useCodeAlign(*Section))
+  if (getContext().getAsmInfo().useCodeAlign(*Section))
     getStreamer().emitCodeAlignment(Align(2), &getSTI(), 0);
   else
     getStreamer().emitValueToAlignment(Align(2), 0, 1, 0);

--- a/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
@@ -109,7 +109,7 @@ void X86WinCOFFAsmTargetStreamer::emitCode64() { OS << "\t.code64\n"; }
 bool X86WinCOFFAsmTargetStreamer::emitFPOProc(const MCSymbol *ProcSym,
                                               unsigned ParamsSize, SMLoc L) {
   OS << "\t.cv_fpo_proc\t";
-  ProcSym->print(OS, getContext().getAsmInfo());
+  ProcSym->print(OS, &getContext().getAsmInfo());
   OS << ' ' << ParamsSize << '\n';
   return false;
 }
@@ -127,7 +127,7 @@ bool X86WinCOFFAsmTargetStreamer::emitFPOEndProc(SMLoc L) {
 bool X86WinCOFFAsmTargetStreamer::emitFPOData(const MCSymbol *ProcSym,
                                               SMLoc L) {
   OS << "\t.cv_fpo_data\t";
-  ProcSym->print(OS, getStreamer().getContext().getAsmInfo());
+  ProcSym->print(OS, &getStreamer().getContext().getAsmInfo());
   OS << '\n';
   return false;
 }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2251,13 +2251,13 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           do {
             StringRef Line;
             std::tie(Line, ErrMsg) = ErrMsg.split('\n');
-            OS << DT->Context->getAsmInfo()->getCommentString()
+            OS << DT->Context->getAsmInfo().getCommentString()
                << " error decoding " << SymNamesHere[SHI] << ": " << Line
                << '\n';
           } while (!ErrMsg.empty());
 
           if (Size) {
-            OS << DT->Context->getAsmInfo()->getCommentString()
+            OS << DT->Context->getAsmInfo().getCommentString()
                << " decoding failed region as bytes\n";
             for (uint64_t I = 0; I < Size; ++I)
               OS << "\t.byte\t " << format_hex(Bytes[I], 1, /*Upper=*/true)
@@ -2621,8 +2621,7 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           }
         }
 
-        assert(DT->Context->getAsmInfo());
-        DT->Printer->emitPostInstructionInfo(FOS, *DT->Context->getAsmInfo(),
+        DT->Printer->emitPostInstructionInfo(FOS, DT->Context->getAsmInfo(),
                                              *DT->SubtargetInfo,
                                              CommentStream.str(), LEP);
         Comments.clear();

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -3831,7 +3831,7 @@ void AsmMatcherEmitter::run(raw_ostream &OS) {
   OS << "      if (ActualIdx < Operands.size())\n";
   OS << "        DEBUG_WITH_TYPE(\"asm-matcher\", dbgs() << \" (\";\n";
   OS << "                        Operands[ActualIdx]->print(dbgs(), "
-        "*getContext().getAsmInfo()); dbgs() << "
+        "getContext().getAsmInfo()); dbgs() << "
         "\"): \");\n";
   OS << "      else\n";
   OS << "        DEBUG_WITH_TYPE(\"asm-matcher\", dbgs() << \": \");\n";


### PR DESCRIPTION
The MAI member is non-null. #194280 made this clearer by making the
MCContext constructor take MCAsmInfo by reference. Convert getAsmInfo to
return const MCAsmInfo & and the member to a reference.