### PR TITLE
[clang][bytecode] Reject more constexpr-unknown pointers in CheckStore

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -894,7 +894,7 @@ bool CheckStore(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return false;
   if (!CheckVolatile(S, OpPC, Ptr, AK_Assign))
     return false;
-  if (!S.inConstantContext() && isConstexprUnknown(Ptr))
+  if (isConstexprUnknown(Ptr))
     return false;
   return true;
 }

--- a/clang/test/AST/ByteCode/openmp.cpp
+++ b/clang/test/AST/ByteCode/openmp.cpp
@@ -26,4 +26,11 @@ int test2() {
   }
 }
 
-
+void test3() {
+  char i = 0;
+  char &c = i;
+#pragma omp for collapse(2)
+  for (c = 0; c < 2; c++)
+    for (int j = 0; j < 4 + c; j++)
+      ;
+}


### PR DESCRIPTION
Even in constant contexts.