### PR TITLE
[libc++] Remove accidentally public `optional::__get()` method

### DIFF
--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -71,6 +71,8 @@ Deprecations and Removals
 - In ``__bit_reference`` (the proxy ``reference`` type of ``bitset`` and ``vector<bool>``), the overloaded ``operator&``
   is removed as it is non-standard and causes non-conforming behavior.
 
+- In ``optional``, an internal ``__get()`` method was mistakenly exposed, and has been moved to private.
+
 Potentially breaking changes
 ----------------------------
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -960,6 +960,10 @@ private:
            _CheckOptionalLikeConstructor<_QualUp>,
            __check_tuple_constructor_fail >;
 
+  template <class, bool>
+  friend struct __optional_storage_base;
+  using __base::__get;
+
 public:
   _LIBCPP_HIDE_FROM_ABI constexpr optional() noexcept {}
   _LIBCPP_HIDE_FROM_ABI constexpr optional(const optional&) = default;
@@ -1172,7 +1176,6 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return has_value(); }
 
-  using __base::__get;
   using __base::has_value;
   using __base::value;
 


### PR DESCRIPTION
- The internal `__get()` method was public since `std::optional<T>` was [implemented](https://godbolt.org/z/dj4Tdr5fj). So, make the `using` declaration private and grant `__optional_storage_base` friendship.