### PR TITLE
[clang][bytecode] Add a missing fallthrough() call

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -629,6 +629,7 @@ public:
         if (!this->Ctx->emitDestructionPop(Local.Desc, Local.Desc->getLoc()))
           return false;
 
+        this->Ctx->fallthrough(EndLabel);
         this->Ctx->emitLabel(EndLabel);
       } else {
         if (!this->Ctx->emitGetPtrLocal(Local.Offset, E))

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -466,7 +466,14 @@ namespace ConditionalInit {
 
   static_assert(getS(true).a == 12, "");
   static_assert(getS(false).a == 13, "");
-};
+
+  struct T {
+    virtual ~T() = default;
+  };
+  struct D : T {};
+  void foo() { const T &t = true ? (const T)(D()) : D(); }
+}
+
 namespace DeclRefs {
   struct A{ int m; const int &f = m; };
 


### PR DESCRIPTION
When the local variable is enabled but we don't emit any dtor instructions, we need to fallthrough to the `EndLabel`.