### PR TITLE
[CodeGen] Make AsmPrinter::MAI a reference. NFC

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -235,12 +235,12 @@ private:
     // DWARF v5 reorders the address size and adds a unit type.
     if (Version >= 5) {
       Asm.emitInt8(UT);
-      Asm.emitInt8(Asm.MAI->getCodePointerSize());
+      Asm.emitInt8(Asm.MAI.getCodePointerSize());
     }
 
     Asm.emitInt32(0);
     if (Version <= 4) {
-      Asm.emitInt8(Asm.MAI->getCodePointerSize());
+      Asm.emitInt8(Asm.MAI.getCodePointerSize());
     }
   }
 

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -94,7 +94,7 @@ public:
   TargetMachine &TM;
 
   /// Target Asm Printer information.
-  const MCAsmInfo *MAI = nullptr;
+  const MCAsmInfo &MAI;
 
   /// This is the context for the output file that we are streaming. This owns
   /// all of the global MC-related objects for the generated translation unit.

--- a/llvm/include/llvm/MC/MCSymbol.h
+++ b/llvm/include/llvm/MC/MCSymbol.h
@@ -356,6 +356,7 @@ public:
 
   /// print - Print the value to the stream \p OS.
   LLVM_ABI void print(raw_ostream &OS, const MCAsmInfo *MAI) const;
+  void print(raw_ostream &OS, const MCAsmInfo &MAI) const { print(OS, &MAI); }
 
   /// dump - Print the value to stderr.
   LLVM_ABI void dump() const;

--- a/llvm/lib/CodeGen/AsmPrinter/ARMException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/ARMException.cpp
@@ -29,7 +29,7 @@ ARMTargetStreamer &ARMException::getTargetStreamer() {
 }
 
 void ARMException::beginFunction(const MachineFunction *MF) {
-  if (Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+  if (Asm->MAI.getExceptionHandlingType() == ExceptionHandling::ARM)
     getTargetStreamer().emitFnStart();
   // See if we need call frame info.
   AsmPrinter::CFISection CFISecType = Asm->getFunctionCFISectionType(*MF);
@@ -83,7 +83,7 @@ void ARMException::endFunction(const MachineFunction *MF) {
     emitExceptionTable();
   }
 
-  if (Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+  if (Asm->MAI.getExceptionHandlingType() == ExceptionHandling::ARM)
     ATS.emitFnEnd();
 }
 

--- a/llvm/lib/CodeGen/AsmPrinter/AddressPool.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AddressPool.cpp
@@ -22,7 +22,7 @@ unsigned AddressPool::getIndex(const MCSymbol *Sym, bool TLS) {
 }
 
 MCSymbol *AddressPool::emitHeader(AsmPrinter &Asm, MCSection *Section) {
-  static const uint8_t AddrSize = Asm.MAI->getCodePointerSize();
+  static const uint8_t AddrSize = Asm.MAI.getCodePointerSize();
 
   MCSymbol *EndLabel =
       Asm.emitDwarfUnitLength("debug_addr", "Length of contribution");
@@ -63,7 +63,7 @@ void AddressPool::emit(AsmPrinter &Asm, MCSection *AddrSection) {
             : MCSymbolRefExpr::create(I.first, Asm.OutContext);
 
   for (const MCExpr *Entry : Entries)
-    Asm.OutStreamer->emitValue(Entry, Asm.MAI->getCodePointerSize());
+    Asm.OutStreamer->emitValue(Entry, Asm.MAI.getCodePointerSize());
 
   if (EndLabel)
     Asm.OutStreamer->emitLabel(EndLabel);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -409,12 +409,12 @@ Align AsmPrinter::getGVAlignment(const GlobalObject *GV, const DataLayout &DL,
 
 AsmPrinter::AsmPrinter(TargetMachine &tm, std::unique_ptr<MCStreamer> Streamer,
                        char &ID)
-    : MachineFunctionPass(ID), TM(tm), MAI(&tm.getMCAsmInfo()),
+    : MachineFunctionPass(ID), TM(tm), MAI(tm.getMCAsmInfo()),
       OutContext(Streamer->getContext()), OutStreamer(std::move(Streamer)),
       SM(*this) {
   VerboseAsm = OutStreamer->isVerboseAsm();
   DwarfUsesRelocationsAcrossSections =
-      MAI->doesDwarfUseRelocationsAcrossSections();
+      MAI.doesDwarfUseRelocationsAcrossSections();
   GetMMI = [this]() {
     auto *MMIWP = getAnalysisIfAvailable<MachineModuleInfoWrapperPass>();
     return MMIWP ? &MMIWP->getMMI() : nullptr;
@@ -581,9 +581,9 @@ bool AsmPrinter::doInitialization(Module &M) {
 
   // Very minimal debug info. It is ignored if we emit actual debug info. If we
   // don't, this at least helps the user find where a global came from.
-  if (MAI->hasSingleParameterDotFile()) {
+  if (MAI.hasSingleParameterDotFile()) {
     // .file "foo.c"
-    if (MAI->isAIX()) {
+    if (MAI.isAIX()) {
       const char VerStr[] =
 #ifdef PACKAGE_VENDOR
           PACKAGE_VENDOR " "
@@ -634,7 +634,7 @@ bool AsmPrinter::doInitialization(Module &M) {
     OutStreamer->addBlankLine();
   }
 
-  if (MAI->doesSupportDebugInformation()) {
+  if (MAI.doesSupportDebugInformation()) {
     bool EmitCodeView = M.getCodeViewFlag();
     // On Windows targets, emit minimal CodeView compiler info even when debug
     // info is disabled.
@@ -652,7 +652,7 @@ bool AsmPrinter::doInitialization(Module &M) {
   if (M.getNamedMetadata(PseudoProbeDescMetadataName))
     PP = std::make_unique<PseudoProbeHandler>(this);
 
-  switch (MAI->getExceptionHandlingType()) {
+  switch (MAI.getExceptionHandlingType()) {
   case ExceptionHandling::None:
     // We may want to emit CFI for debug.
     [[fallthrough]];
@@ -667,7 +667,7 @@ bool AsmPrinter::doInitialization(Module &M) {
       if (ModuleCFISection == CFISection::EH)
         break;
     }
-    assert(MAI->getExceptionHandlingType() == ExceptionHandling::DwarfCFI ||
+    assert(MAI.getExceptionHandlingType() == ExceptionHandling::DwarfCFI ||
            usesCFIWithoutEH() || ModuleCFISection != CFISection::EH);
     break;
   default:
@@ -675,7 +675,7 @@ bool AsmPrinter::doInitialization(Module &M) {
   }
 
   EHStreamer *ES = nullptr;
-  switch (MAI->getExceptionHandlingType()) {
+  switch (MAI.getExceptionHandlingType()) {
   case ExceptionHandling::None:
     if (!usesCFIWithoutEH())
       break;
@@ -689,7 +689,7 @@ bool AsmPrinter::doInitialization(Module &M) {
     ES = new ARMException(this);
     break;
   case ExceptionHandling::WinEH:
-    switch (MAI->getWinEHEncodingType()) {
+    switch (MAI.getWinEHEncodingType()) {
     default: llvm_unreachable("unsupported unwinding information encoding");
     case WinEH::EncodingType::Invalid:
       break;
@@ -736,16 +736,16 @@ void AsmPrinter::emitLinkage(const GlobalValue *GV, MCSymbol *GVSym) const {
   case GlobalValue::LinkOnceODRLinkage:
   case GlobalValue::WeakAnyLinkage:
   case GlobalValue::WeakODRLinkage:
-    if (MAI->isMachO()) {
+    if (MAI.isMachO()) {
       // .globl _foo
       OutStreamer->emitSymbolAttribute(GVSym, MCSA_Global);
 
-      if (!canBeHidden(GV, *MAI))
+      if (!canBeHidden(GV, MAI))
         // .weak_definition _foo
         OutStreamer->emitSymbolAttribute(GVSym, MCSA_WeakDefinition);
       else
         OutStreamer->emitSymbolAttribute(GVSym, MCSA_WeakDefAutoPrivate);
-    } else if (MAI->avoidWeakIfComdat() && GV->hasComdat()) {
+    } else if (MAI.avoidWeakIfComdat() && GV->hasComdat()) {
       // .globl _foo
       OutStreamer->emitSymbolAttribute(GVSym, MCSA_Global);
       //NOTE: linkonce is handled by the section the symbol was assigned to.
@@ -850,7 +850,7 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
     OutContext.reportError(SMLoc(), "symbol '" + Twine(GVSym->getName()) +
                                         "' is already defined");
 
-  if (MAI->hasDotTypeDotSizeDirective())
+  if (MAI.hasDotTypeDotSizeDirective())
     OutStreamer->emitSymbolAttribute(EmittedSym, MCSA_ELF_TypeObject);
 
   SectionKind GVKind = TargetLoweringObjectFile::getKindForGlobal(GV, TM);
@@ -879,7 +879,7 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
 
   // If we have a bss global going to a section that supports the
   // zerofill directive, do so here.
-  if (GVKind.isBSS() && MAI->isMachO() && TheSection->isBssSection()) {
+  if (GVKind.isBSS() && MAI.isMachO() && TheSection->isBssSection()) {
     if (Size == 0)
       Size = 1; // zerofill of 0 bytes is undefined.
     emitLinkage(GV, GVSym);
@@ -901,7 +901,7 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
     // some -unknown- default alignment behavior, which could cause
     // spurious differences between external and integrated assembler.
     // Prefer to simply fall back to .local / .comm in this case.
-    if (MAI->getLCOMMDirectiveAlignmentType() != LCOMM::NoAlignment) {
+    if (MAI.getLCOMMDirectiveAlignmentType() != LCOMM::NoAlignment) {
       // .lcomm _foo, 42
       OutStreamer->emitLocalCommonSymbol(GVSym, Size, Alignment);
       return;
@@ -924,7 +924,7 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   // TLOF class.  This will also make it more obvious that stuff like
   // MCStreamer::EmitTBSSSymbol is macho specific and only called from macho
   // specific code.
-  if (GVKind.isThreadLocal() && MAI->isMachO()) {
+  if (GVKind.isThreadLocal() && MAI.isMachO()) {
     // Emit the .tbss symbol
     MCSymbol *MangSym =
         OutContext.getOrCreateSymbol(GVSym->getName() + Twine("$tlv$init"));
@@ -980,7 +980,7 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
 
   emitGlobalConstant(GV->getDataLayout(), GV->getInitializer());
 
-  if (MAI->hasDotTypeDotSizeDirective())
+  if (MAI.hasDotTypeDotSizeDirective())
     // .size foo, 42
     OutStreamer->emitELFSize(EmittedInitSym,
                              MCConstantExpr::create(Size, OutContext));
@@ -1000,7 +1000,7 @@ void AsmPrinter::emitFunctionHeaderComment() {}
 
 void AsmPrinter::emitFunctionPrefix(ArrayRef<const Constant *> Prefix) {
   const Function &F = MF->getFunction();
-  if (!MAI->hasSubsectionsViaSymbols()) {
+  if (!MAI.hasSubsectionsViaSymbols()) {
     for (auto &C : Prefix)
       emitGlobalConstant(F.getDataLayout(), C);
     return;
@@ -1041,15 +1041,15 @@ void AsmPrinter::emitFunctionHeader() {
     MF->setSection(getObjFileLowering().SectionForGlobal(&F, TM));
   OutStreamer->switchSection(MF->getSection());
 
-  if (MAI->isAIX())
+  if (MAI.isAIX())
     emitLinkage(&F, CurrentFnDescSym);
   else
     emitVisibility(CurrentFnSym, F.getVisibility());
 
   emitLinkage(&F, CurrentFnSym);
-  if (MAI->hasFunctionAlignment()) {
+  if (MAI.hasFunctionAlignment()) {
     Align PrefAlign = MF->getPreferredAlignment();
-    if (MAI->useIntegratedAssembler() && MAI->hasPreferredAlignment()) {
+    if (MAI.useIntegratedAssembler() && MAI.hasPreferredAlignment()) {
       // Emit .p2align for the effective minimum alignment (which accounts for
       // F's own align attribute via getGVAlignment), then emit .prefalign only
       // when the preferred alignment is greater. The end symbol must be
@@ -1068,7 +1068,7 @@ void AsmPrinter::emitFunctionHeader() {
     }
   }
 
-  if (MAI->hasDotTypeDotSizeDirective())
+  if (MAI.hasDotTypeDotSizeDirective())
     OutStreamer->emitSymbolAttribute(CurrentFnSym, MCSA_ELF_TypeFunction);
 
   if (F.hasFnAttribute(Attribute::Cold))
@@ -1122,7 +1122,7 @@ void AsmPrinter::emitFunctionHeader() {
   // to emit their specific function descriptor. Right now it is only used by
   // the AIX target. The PowerPC 64-bit V1 ELF target also uses function
   // descriptors and should be converted to use this hook as well.
-  if (MAI->isAIX())
+  if (MAI.isAIX())
     emitFunctionDescriptor();
 
   // Emit the CurrentFnSym. This is a virtual function to allow targets to do
@@ -1140,7 +1140,7 @@ void AsmPrinter::emitFunctionHeader() {
   }
 
   if (CurrentFnBegin) {
-    if (MAI->useAssignmentForEHBegin()) {
+    if (MAI.useAssignmentForEHBegin()) {
       MCSymbol *CurPos = OutContext.createTempSymbol();
       OutStreamer->emitLabel(CurPos);
       OutStreamer->emitAssignment(CurrentFnBegin,
@@ -1404,11 +1404,11 @@ AsmPrinter::getFunctionCFISectionType(const Function &F) const {
   if (F.isDeclarationForLinker())
     return CFISection::None;
 
-  if (MAI->getExceptionHandlingType() == ExceptionHandling::DwarfCFI &&
+  if (MAI.getExceptionHandlingType() == ExceptionHandling::DwarfCFI &&
       F.needsUnwindTableEntry())
     return CFISection::EH;
 
-  if (MAI->usesCFIWithoutEH() && F.hasUWTable())
+  if (MAI.usesCFIWithoutEH() && F.hasUWTable())
     return CFISection::EH;
 
   if (hasDebugInfo() || TM.Options.ForceDwarfFrameSection)
@@ -1423,15 +1423,15 @@ AsmPrinter::getFunctionCFISectionType(const MachineFunction &MF) const {
 }
 
 bool AsmPrinter::needsSEHMoves() {
-  return MAI->usesWindowsCFI() && MF->getFunction().needsUnwindTableEntry();
+  return MAI.usesWindowsCFI() && MF->getFunction().needsUnwindTableEntry();
 }
 
 bool AsmPrinter::usesCFIWithoutEH() const {
-  return MAI->usesCFIWithoutEH() && ModuleCFISection != CFISection::None;
+  return MAI.usesCFIWithoutEH() && ModuleCFISection != CFISection::None;
 }
 
 void AsmPrinter::emitCFIInstruction(const MachineInstr &MI) {
-  ExceptionHandling ExceptionHandlingType = MAI->getExceptionHandlingType();
+  ExceptionHandling ExceptionHandlingType = MAI.getExceptionHandlingType();
   if (!usesCFIWithoutEH() &&
       ExceptionHandlingType != ExceptionHandling::DwarfCFI &&
       ExceptionHandlingType != ExceptionHandling::ARM)
@@ -2357,14 +2357,14 @@ void AsmPrinter::emitFunctionBody() {
     // we have BBLabels enabled or if this basic blocks marks the end of a
     // section.
     if (MF->getTarget().Options.BBAddrMap ||
-        (MAI->hasDotTypeDotSizeDirective() && MBB.isEndSection()))
+        (MAI.hasDotTypeDotSizeDirective() && MBB.isEndSection()))
       OutStreamer->emitLabel(MBB.getEndSymbol());
 
     if (MBB.isEndSection()) {
       // The size directive for the section containing the entry block is
       // handled separately by the function section.
       if (!MBB.sameSection(&MF->front())) {
-        if (MAI->hasDotTypeDotSizeDirective()) {
+        if (MAI.hasDotTypeDotSizeDirective()) {
           // Emit the size directive for the basic block section.
           const MCExpr *SizeExp = MCBinaryExpr::createSub(
               MCSymbolRefExpr::create(MBB.getEndSymbol(), OutContext),
@@ -2428,7 +2428,7 @@ void AsmPrinter::emitFunctionBody() {
   // https://developercommunity.visualstudio.com/content/problem/45366/vc-linker-creates-invalid-dll-with-clang-cl.html
   // FIXME: Hide this behind some API in e.g. MCAsmInfo or MCTargetStreamer.
   const Triple &TT = TM.getTargetTriple();
-  if (!HasAnyRealCode && (MAI->hasSubsectionsViaSymbols() ||
+  if (!HasAnyRealCode && (MAI.hasSubsectionsViaSymbols() ||
                           (TT.isOSWindows() && TT.isOSBinFormatCOFF()))) {
     MCInst Noop = MF->getSubtarget().getInstrInfo()->getNop();
 
@@ -2459,7 +2459,7 @@ void AsmPrinter::emitFunctionBody() {
 
   // Even though wasm supports .type and .size in general, function symbols
   // are automatically sized.
-  bool EmitFunctionSize = MAI->hasDotTypeDotSizeDirective() && !TT.isWasm();
+  bool EmitFunctionSize = MAI.hasDotTypeDotSizeDirective() && !TT.isWasm();
 
   // SPIR-V supports label instructions only inside a block, not after the
   // function body.
@@ -2657,7 +2657,7 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
     return;
   }
 
-  if (GA.hasExternalLinkage() || !MAI->getWeakRefDirective())
+  if (GA.hasExternalLinkage() || !MAI.getWeakRefDirective())
     OutStreamer->emitSymbolAttribute(Name, MCSA_Global);
   else if (GA.hasWeakLinkage() || GA.hasLinkOnceLinkage())
     OutStreamer->emitSymbolAttribute(Name, MCSA_WeakReference);
@@ -2683,7 +2683,7 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
 
   const MCExpr *Expr = lowerConstant(GA.getAliasee());
 
-  if (MAI->isMachO() && isa<MCBinaryExpr>(Expr))
+  if (MAI.isMachO() && isa<MCBinaryExpr>(Expr))
     OutStreamer->emitSymbolAttribute(Name, MCSA_AltEntry);
 
   // Emit the directives as assignments aka .set:
@@ -2697,7 +2697,7 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
   // size of the alias symbol from the type of the alias. We don't do this in
   // other situations as the alias and aliasee having differing types but same
   // size may be intentional.
-  if (MAI->hasDotTypeDotSizeDirective() && GA.getValueType()->isSized() &&
+  if (MAI.hasDotTypeDotSizeDirective() && GA.getValueType()->isSized() &&
       (!BaseObject || BaseObject->hasPrivateLinkage())) {
     const DataLayout &DL = M.getDataLayout();
     uint64_t Size = DL.getTypeAllocSize(GA.getValueType());
@@ -2707,7 +2707,7 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
 
 void AsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
   auto EmitLinkage = [&](MCSymbol *Sym) {
-    if (GI.hasExternalLinkage() || !MAI->getWeakRefDirective())
+    if (GI.hasExternalLinkage() || !MAI.getWeakRefDirective())
       OutStreamer->emitSymbolAttribute(Sym, MCSA_Global);
     else if (GI.hasWeakLinkage() || GI.hasLinkOnceLinkage())
       OutStreamer->emitSymbolAttribute(Sym, MCSA_WeakReference);
@@ -3074,7 +3074,7 @@ bool AsmPrinter::doFinalization(Module &M) {
   DD = nullptr;
 
   // If the target wants to know about weak references, print them all.
-  if (MAI->getWeakRefDirective()) {
+  if (MAI.getWeakRefDirective()) {
     // FIXME: This is not lazy, it would be nice to only print weak references
     // to stuff that is actually used.  Note that doing so would require targets
     // to notice uses in operands (due to constant exprs etc).  This should
@@ -3124,7 +3124,7 @@ bool AsmPrinter::doFinalization(Module &M) {
   Function *InitTrampolineIntrinsic = M.getFunction("llvm.init.trampoline");
   bool HasTrampolineUses =
       InitTrampolineIntrinsic && !InitTrampolineIntrinsic->use_empty();
-  MCSection *S = MAI->getStackSection(OutContext, /*Exec=*/HasTrampolineUses);
+  MCSection *S = MAI.getStackSection(OutContext, /*Exec=*/HasTrampolineUses);
   if (S)
     OutStreamer->switchSection(S);
 
@@ -3155,7 +3155,7 @@ bool AsmPrinter::doFinalization(Module &M) {
       OutStreamer->emitZeros(1);
       OutStreamer->emitValue(
           MCSymbolRefExpr::create(getSymbol(&GV), OutContext),
-          MAI->getCodePointerSize());
+          MAI.getCodePointerSize());
     }
   }
 
@@ -3204,7 +3204,7 @@ void AsmPrinter::SetupMachineFunction(MachineFunction &MF) {
     HasNoSplitStack = true;
 
   // Get the function symbol.
-  if (!MAI->isAIX()) {
+  if (!MAI.isAIX()) {
     CurrentFnSym = getSymbol(&MF.getFunction());
   } else {
     assert(TM.getTargetTriple().isOSAIX() &&
@@ -3227,7 +3227,7 @@ void AsmPrinter::SetupMachineFunction(MachineFunction &MF) {
   CurrentFnCallsiteEndSymbols.clear();
   MBBSectionRanges.clear();
   MBBSectionExceptionSyms.clear();
-  bool NeedsLocalForSize = MAI->needsLocalForSize();
+  bool NeedsLocalForSize = MAI.needsLocalForSize();
   if (F.hasFnAttribute("patchable-function-entry") ||
       F.hasFnAttribute("function-instrument") ||
       F.hasFnAttribute("xray-instruction-threshold") ||
@@ -3418,7 +3418,7 @@ void AsmPrinter::emitJumpTableImpl(const MachineJumpTableInfo &MJTI,
     // For the EK_LabelDifference32 entry, if using .set avoids a relocation,
     /// emit a .set directive for each unique entry.
     if (MJTI.getEntryKind() == MachineJumpTableInfo::EK_LabelDifference32 &&
-        MAI->doesSetDirectiveSuppressReloc()) {
+        MAI.doesSetDirectiveSuppressReloc()) {
       SmallPtrSet<const MachineBasicBlock *, 16> EmittedSets;
       const TargetLowering *TLI = MF->getSubtarget().getTargetLowering();
       const MCExpr *Base =
@@ -3543,7 +3543,7 @@ void AsmPrinter::emitJumpTableEntry(const MachineJumpTableInfo &MJTI,
     //      .set L4_5_set_123, LBB123 - LJTI1_2
     //      .word L4_5_set_123
     if (MJTI.getEntryKind() == MachineJumpTableInfo::EK_LabelDifference32 &&
-        MAI->doesSetDirectiveSuppressReloc()) {
+        MAI.doesSetDirectiveSuppressReloc()) {
       Value = MCSymbolRefExpr::create(GetJTSetSymbol(UID, MBB->getNumber()),
                                       OutContext);
       break;
@@ -3567,7 +3567,7 @@ void AsmPrinter::emitJumpTableEntry(const MachineJumpTableInfo &MJTI,
 /// do nothing and return false.
 bool AsmPrinter::emitSpecialLLVMGlobal(const GlobalVariable *GV) {
   if (GV->getName() == "llvm.used") {
-    if (MAI->hasNoDeadStrip())    // No need to emit this at all.
+    if (MAI.hasNoDeadStrip()) // No need to emit this at all.
       emitLLVMUsedList(cast<ConstantArray>(GV->getInitializer()));
     return true;
   }
@@ -3724,7 +3724,7 @@ void AsmPrinter::emitXXStructorList(const DataLayout &DL, const Constant *List,
 }
 
 void AsmPrinter::emitModuleIdents(Module &M) {
-  if (!MAI->hasIdentDirective())
+  if (!MAI.hasIdentDirective())
     return;
 
   if (const NamedMDNode *NMD = M.getNamedMetadata("llvm.ident")) {
@@ -3814,7 +3814,7 @@ void AsmPrinter::emitLabelDifferenceAsULEB128(const MCSymbol *Hi,
 void AsmPrinter::emitLabelPlusOffset(const MCSymbol *Label, uint64_t Offset,
                                      unsigned Size,
                                      bool IsSectionRelative) const {
-  if (MAI->needsDwarfSectionOffsetDirective() && IsSectionRelative) {
+  if (MAI.needsDwarfSectionOffsetDirective() && IsSectionRelative) {
     OutStreamer->emitCOFFSecRel32(Label, Offset);
     if (Size > 4)
       OutStreamer->emitZeros(Size - 4);
@@ -4590,7 +4590,7 @@ void AsmPrinter::emitGlobalConstant(const DataLayout &DL, const Constant *CV,
   uint64_t Size = DL.getTypeAllocSize(CV->getType());
   if (Size)
     emitGlobalConstantImpl(DL, CV, *this, nullptr, 0, AliasList);
-  else if (MAI->hasSubsectionsViaSymbols()) {
+  else if (MAI.hasSubsectionsViaSymbols()) {
     // If the global has zero size, emit a single byte so that two labels don't
     // look like they are at the same location.
     OutStreamer->emitIntValue(0, 1);
@@ -4843,7 +4843,7 @@ void AsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
   }
 
   if (MBB.isEHContTarget() &&
-      MAI->getExceptionHandlingType() == ExceptionHandling::WinEH) {
+      MAI.getExceptionHandlingType() == ExceptionHandling::WinEH) {
     OutStreamer->emitLabel(MBB.getEHContSymbol());
   }
 
@@ -4877,12 +4877,12 @@ void AsmPrinter::emitVisibility(MCSymbol *Sym, unsigned Visibility,
   default: break;
   case GlobalValue::HiddenVisibility:
     if (IsDefinition)
-      Attr = MAI->getHiddenVisibilityAttr();
+      Attr = MAI.getHiddenVisibilityAttr();
     else
-      Attr = MAI->getHiddenDeclarationVisibilityAttr();
+      Attr = MAI.getHiddenDeclarationVisibilityAttr();
     break;
   case GlobalValue::ProtectedVisibility:
-    Attr = MAI->getProtectedVisibilityAttr();
+    Attr = MAI.getProtectedVisibilityAttr();
     break;
   }
 
@@ -5034,7 +5034,7 @@ void AsmPrinter::emitXRayTable() {
     llvm_unreachable("Unsupported target");
   }
 
-  auto WordSizeBytes = MAI->getCodePointerSize();
+  auto WordSizeBytes = MAI.getCodePointerSize();
 
   // Now we switch to the instrumentation map section. Because this is done
   // per-function, we are able to create an index entry that will represent the
@@ -5124,7 +5124,7 @@ void AsmPrinter::emitPatchableFunctionEntries() {
 
     // GNU as < 2.35 did not support section flag 'o'. GNU ld < 2.36 did not
     // support mixed SHF_LINK_ORDER and non-SHF_LINK_ORDER sections.
-    if (MAI->useIntegratedAssembler() || MAI->binutilsIsAtLeast(2, 36)) {
+    if (MAI.useIntegratedAssembler() || MAI.binutilsIsAtLeast(2, 36)) {
       Flags |= ELF::SHF_LINK_ORDER;
       if (F.hasComdat()) {
         Flags |= ELF::SHF_GROUP;
@@ -5158,7 +5158,7 @@ unsigned int AsmPrinter::getDwarfOffsetByteSize() const {
 }
 
 dwarf::FormParams AsmPrinter::getDwarfFormParams() const {
-  return {getDwarfVersion(), uint8_t(MAI->getCodePointerSize()),
+  return {getDwarfVersion(), uint8_t(MAI.getCodePointerSize()),
           OutStreamer->getContext().getDwarfFormat(),
           doesDwarfUseRelocationsAcrossSections()};
 }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
@@ -107,7 +107,7 @@ unsigned AsmPrinter::GetSizeOfEncodedValue(unsigned Encoding) const {
   default:
     llvm_unreachable("Invalid encoded value.");
   case dwarf::DW_EH_PE_absptr:
-    return MAI->getCodePointerSize();
+    return MAI.getCodePointerSize();
   case dwarf::DW_EH_PE_udata2:
     return 2;
   case dwarf::DW_EH_PE_udata4:
@@ -132,7 +132,7 @@ void AsmPrinter::emitDwarfSymbolReference(const MCSymbol *Label,
                                           bool ForceOffset) const {
   if (!ForceOffset) {
     // On COFF targets, we have to emit the special .secrel32 directive.
-    if (MAI->needsDwarfSectionOffsetDirective()) {
+    if (MAI.needsDwarfSectionOffsetDirective()) {
       assert(!isDwarf64() &&
              "emitting DWARF64 is not implemented for COFF targets");
       OutStreamer->emitCOFFSecRel32(Label, /*Offset=*/0);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterInlineAsm.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterInlineAsm.cpp
@@ -106,7 +106,7 @@ void AsmPrinter::emitInlineAsm(StringRef Str, const MCSubtargetInfo &STI,
   }());
 
   std::unique_ptr<MCAsmParser> Parser(
-      createMCAsmParser(SrcMgr, OutContext, *OutStreamer, *MAI, BufNum));
+      createMCAsmParser(SrcMgr, OutContext, *OutStreamer, MAI, BufNum));
 
   // We create a new MCInstrInfo here since we might be at the module level
   // and not have a MachineFunction to initialize the TargetInstrInfo from and
@@ -138,7 +138,7 @@ void AsmPrinter::emitInlineAsm(StringRef Str, const MCSubtargetInfo &STI,
 }
 
 static void EmitInlineAsmStr(const char *AsmStr, const MachineInstr *MI,
-                             MachineModuleInfo *MMI, const MCAsmInfo *MAI,
+                             MachineModuleInfo *MMI, const MCAsmInfo &MAI,
                              AsmPrinter *AP, uint64_t LocCookie,
                              raw_ostream &OS) {
   bool InputIsIntelDialect = MI->getInlineAsmDialect() == InlineAsm::AD_Intel;
@@ -159,7 +159,7 @@ static void EmitInlineAsmStr(const char *AsmStr, const MachineInstr *MI,
     AsmPrinterVariant = MMI->getTarget().unqualifiedInlineAsmVariant();
 
   // FIXME: Should this happen for `asm inteldialect` as well?
-  if (!InputIsIntelDialect && !MAI->isHLASM())
+  if (!InputIsIntelDialect && !MAI.isHLASM())
     OS << '\t';
 
   while (*LastEmitted) {
@@ -344,14 +344,14 @@ void AsmPrinter::emitInlineAsm(const MachineInstr *MI) {
   // If this asmstr is empty, just print the #APP/#NOAPP markers.
   // These are useful to see where empty asm's wound up.
   if (AsmStr[0] == 0) {
-    OutStreamer->emitRawComment(MAI->getInlineAsmStart());
-    OutStreamer->emitRawComment(MAI->getInlineAsmEnd());
+    OutStreamer->emitRawComment(MAI.getInlineAsmStart());
+    OutStreamer->emitRawComment(MAI.getInlineAsmEnd());
     return;
   }
 
   // Emit the #APP start marker.  This has to happen even if verbose-asm isn't
   // enabled, so we use emitRawComment.
-  OutStreamer->emitRawComment(MAI->getInlineAsmStart());
+  OutStreamer->emitRawComment(MAI.getInlineAsmStart());
 
   const MDNode *LocMD = MI->getLocCookieMD();
   uint64_t LocCookie =
@@ -420,7 +420,7 @@ void AsmPrinter::emitInlineAsm(const MachineInstr *MI) {
 
   // Emit the #NOAPP end marker.  This has to happen even if verbose-asm isn't
   // enabled, so we use emitRawComment.
-  OutStreamer->emitRawComment(MAI->getInlineAsmEnd());
+  OutStreamer->emitRawComment(MAI.getInlineAsmEnd());
 }
 
 /// PrintSpecial - Print information related to the specified machine instr
@@ -435,7 +435,7 @@ void AsmPrinter::PrintSpecial(const MachineInstr *MI, raw_ostream &OS,
     const DataLayout &DL = MF->getDataLayout();
     OS << DL.getInternalSymbolPrefix();
   } else if (Code == "comment") {
-    OS << MAI->getCommentString();
+    OS << MAI.getCommentString();
   } else if (Code == "uid") {
     // Comparing the address of MI isn't sufficient, because machineinstrs may
     // be allocated to the same address across functions.

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -2149,7 +2149,7 @@ TypeIndex CodeViewDebug::lowerTypeMemberFunction(const DISubroutineType *Ty,
 
 TypeIndex CodeViewDebug::lowerTypeVFTableShape(const DIDerivedType *Ty) {
   unsigned VSlotCount =
-      Ty->getSizeInBits() / (8 * Asm->MAI->getCodePointerSize());
+      Ty->getSizeInBits() / (8 * Asm->MAI.getCodePointerSize());
   SmallVector<VFTableSlotKind, 4> Slots(VSlotCount, VFTableSlotKind::Near);
 
   VFTableShapeRecord VFTSR(Slots);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCFIException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCFIException.cpp
@@ -37,7 +37,7 @@ void DwarfCFIException::addPersonality(const GlobalValue *Personality) {
 /// content.
 void DwarfCFIException::endModule() {
   // SjLj uses this pass and it doesn't need this info.
-  if (!Asm->MAI->usesCFIForEH())
+  if (!Asm->MAI.usesCFIForEH())
     return;
 
   const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -274,7 +274,7 @@ void DwarfCompileUnit::addLocationAttribute(
       // 16-bit platforms like MSP430 and AVR take this path, so sink this
       // assert to platforms that use it.
       auto GetPointerSizedFormAndOp = [this]() {
-        unsigned PointerSize = Asm->MAI->getCodePointerSize();
+        unsigned PointerSize = Asm->MAI.getCodePointerSize();
         assert((PointerSize == 4 || PointerSize == 8) &&
                "Add support for other sizes if necessary");
         struct FormAndOp {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -3186,7 +3186,7 @@ void DwarfDebug::emitDebugLocEntry(ByteStreamer &Streamer,
   // need to reference a base_type DIE the offset of that DIE is not yet known.
   // To deal with this we instead insert a placeholder early and then extract
   // it here and replace it with the real reference.
-  unsigned PtrSize = Asm->MAI->getCodePointerSize();
+  unsigned PtrSize = Asm->MAI.getCodePointerSize();
   DWARFDataExtractor Data(StringRef(DebugLocs.getBytes(Entry).data(),
                                     DebugLocs.getBytes(Entry).size()),
                           Asm->getDataLayout().isLittleEndian(), PtrSize);
@@ -3409,7 +3409,7 @@ emitRangeList(DwarfDebug &DD, AsmPrinter *Asm, MCSymbol *Sym, const Ranges &R,
               unsigned OffsetPair, unsigned StartxLength, unsigned StartxEndx,
               unsigned EndOfList, StringRef (*StringifyEnum)(unsigned),
               bool ShouldUseBaseAddress, PayloadEmitter EmitPayload) {
-  auto Size = Asm->MAI->getCodePointerSize();
+  auto Size = Asm->MAI.getCodePointerSize();
   bool UseDwarf5 = DD.getDwarfVersion() >= 5;
 
   // Emit our symbol so we can find the beginning of the range.
@@ -3660,7 +3660,7 @@ void DwarfDebug::emitDebugARanges() {
   Asm->OutStreamer->switchSection(
       Asm->getObjFileLowering().getDwarfARangesSection());
 
-  unsigned PtrSize = Asm->MAI->getCodePointerSize();
+  unsigned PtrSize = Asm->MAI.getCodePointerSize();
 
   // Build a list of CUs used.
   std::vector<DwarfCompileUnit *> CUs;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -569,7 +569,7 @@ bool DwarfExpression::addExpression(
       unsigned DerefSize = 0;
       //  Operations are done in the DWARF "generic type" whose size
       // is the size of a pointer.
-      unsigned PtrSizeInBytes = CU.getAsmPrinter()->MAI->getCodePointerSize();
+      unsigned PtrSizeInBytes = CU.getAsmPrinter()->MAI.getCodePointerSize();
 
       // If we have a memory location then dereference to get the value, though
       // we have to make sure we don't dereference any bytes past the end of the

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -2086,7 +2086,7 @@ void DwarfUnit::emitCommonHeader(bool UseOffsets, dwarf::UnitType UT) {
     Asm->OutStreamer->AddComment("DWARF Unit Type");
     Asm->emitInt8(UT);
     Asm->OutStreamer->AddComment("Address Size (in bytes)");
-    Asm->emitInt8(Asm->MAI->getCodePointerSize());
+    Asm->emitInt8(Asm->MAI.getCodePointerSize());
   }
 
   // We share one abbreviations table across all units so it's always at the
@@ -2102,7 +2102,7 @@ void DwarfUnit::emitCommonHeader(bool UseOffsets, dwarf::UnitType UT) {
 
   if (Version <= 4) {
     Asm->OutStreamer->AddComment("Address Size (in bytes)");
-    Asm->emitInt8(Asm->MAI->getCodePointerSize());
+    Asm->emitInt8(Asm->MAI.getCodePointerSize());
   }
 }
 

--- a/llvm/lib/CodeGen/AsmPrinter/EHStreamer.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/EHStreamer.cpp
@@ -244,7 +244,7 @@ void EHStreamer::computeCallSiteTable(
   // Whether the last CallSite entry was for an invoke.
   bool PreviousIsInvoke = false;
 
-  bool IsSJLJ = Asm->MAI->getExceptionHandlingType() == ExceptionHandling::SjLj;
+  bool IsSJLJ = Asm->MAI.getExceptionHandlingType() == ExceptionHandling::SjLj;
 
   // Visit all instructions in order of address.
   for (const auto &MBB : *Asm->MF) {
@@ -291,8 +291,8 @@ void EHStreamer::computeCallSiteTable(
       // throw, create a call-site entry with no landing pad for the region
       // between the try-ranges.
       if (SawPotentiallyThrowing &&
-          (Asm->MAI->usesCFIForEH() ||
-           Asm->MAI->getExceptionHandlingType() == ExceptionHandling::AIX)) {
+          (Asm->MAI.usesCFIForEH() ||
+           Asm->MAI.getExceptionHandlingType() == ExceptionHandling::AIX)) {
         CallSites.push_back({LastLabel, BeginLabel, nullptr, 0});
         PreviousIsInvoke = false;
       }
@@ -415,9 +415,9 @@ MCSymbol *EHStreamer::emitExceptionTable() {
   SmallVector<CallSiteRange, 4> CallSiteRanges;
   computeCallSiteTable(CallSites, CallSiteRanges, LandingPads, FirstActions);
 
-  bool IsSJLJ = Asm->MAI->getExceptionHandlingType() == ExceptionHandling::SjLj;
-  bool IsWasm = Asm->MAI->getExceptionHandlingType() == ExceptionHandling::Wasm;
-  bool HasLEB128Directives = Asm->MAI->hasLEB128Directives();
+  bool IsSJLJ = Asm->MAI.getExceptionHandlingType() == ExceptionHandling::SjLj;
+  bool IsWasm = Asm->MAI.getExceptionHandlingType() == ExceptionHandling::Wasm;
+  bool HasLEB128Directives = Asm->MAI.hasLEB128Directives();
   unsigned CallSiteEncoding =
       IsSJLJ ? static_cast<unsigned>(dwarf::DW_EH_PE_udata4) :
                Asm->getObjFileLowering().getCallSiteEncoding();
@@ -684,7 +684,7 @@ MCSymbol *EHStreamer::emitExceptionTable() {
         // For non-PIC we can simply use the absolute value.
         Asm->emitEncodingByte(dwarf::DW_EH_PE_absptr, "@LPStart");
         Asm->OutStreamer->emitSymbolValue(LandingPadRange->FragmentBeginLabel,
-                                          Asm->MAI->getCodePointerSize());
+                                          Asm->MAI.getCodePointerSize());
       } else {
         // For PIC mode, we Emit a PC-relative address for LPStart.
         Asm->emitEncodingByte(dwarf::DW_EH_PE_pcrel, "@LPStart");
@@ -696,7 +696,7 @@ MCSymbol *EHStreamer::emitExceptionTable() {
                 MCSymbolRefExpr::create(LandingPadRange->FragmentBeginLabel,
                                         Context),
                 MCSymbolRefExpr::create(Dot, Context), Context),
-            Asm->MAI->getCodePointerSize());
+            Asm->MAI.getCodePointerSize());
       }
 
       if (HasLEB128Directives)

--- a/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -95,7 +95,7 @@ void WinException::beginFunction(const MachineFunction *MF) {
 
   // If we're not using CFI, we don't want the CFI or the personality, but we
   // might want EH tables if we had EH pads.
-  if (!Asm->MAI->usesWindowsCFI()) {
+  if (!Asm->MAI.usesWindowsCFI()) {
     if (Per == EHPersonality::MSVC_X86SEH && !hasEHFunclets) {
       // If this is 32-bit SEH and we don't have any funclets (really invokes),
       // make sure we emit the parent offset label. Some unreferenced filter
@@ -341,7 +341,7 @@ int WinException::getFrameIndexOffset(int FrameIndex,
                                       const WinEHFuncInfo &FuncInfo) {
   const TargetFrameLowering &TFI = *Asm->MF->getSubtarget().getFrameLowering();
   Register UnusedReg;
-  if (Asm->MAI->usesWindowsCFI()) {
+  if (Asm->MAI.usesWindowsCFI()) {
     StackOffset Offset =
         TFI.getFrameIndexReferencePreferSP(*Asm->MF, FrameIndex, UnusedReg,
                                            /*IgnoreSPUpdates*/ true);
@@ -685,7 +685,7 @@ void WinException::emitCXXFrameHandler3Table(const MachineFunction *MF) {
   // second check further below) can be removed if MS C++ unwinding is
   // implemented for ARM, when test/CodeGen/ARM/Windows/wineh-basic.ll
   // passes without the check.
-  if (Asm->MAI->usesWindowsCFI() &&
+  if (Asm->MAI.usesWindowsCFI() &&
       FuncInfo.UnwindHelpFrameIdx != std::numeric_limits<int>::max())
     UnwindHelpOffset =
         getFrameIndexOffset(FuncInfo.UnwindHelpFrameIdx, FuncInfo);
@@ -748,7 +748,7 @@ void WinException::emitCXXFrameHandler3Table(const MachineFunction *MF) {
   AddComment("IPToStateXData");
   OS.emitValue(create32bitRef(IPToStateXData), 4);
 
-  if (Asm->MAI->usesWindowsCFI() &&
+  if (Asm->MAI.usesWindowsCFI() &&
       FuncInfo.UnwindHelpFrameIdx != std::numeric_limits<int>::max()) {
     AddComment("UnwindHelp");
     OS.emitInt32(UnwindHelpOffset);

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1321,7 +1321,7 @@ void AArch64AsmPrinter::PrintDebugValueComment(const MachineInstr *MI,
                                                raw_ostream &OS) {
   unsigned NOps = MI->getNumOperands();
   assert(NOps == 4);
-  OS << '\t' << MAI->getCommentString() << "DEBUG_VALUE: ";
+  OS << '\t' << MAI.getCommentString() << "DEBUG_VALUE: ";
   // cast away const; DIetc do not take const operands for some reason.
   OS << MI->getDebugVariable()->getName();
   OS << " <- ";
@@ -3259,20 +3259,20 @@ void AArch64AsmPrinter::emitInstruction(const MachineInstr *MI) {
     return;
 
   case AArch64::EMITBKEY: {
-      ExceptionHandling ExceptionHandlingType = MAI->getExceptionHandlingType();
-      if (ExceptionHandlingType != ExceptionHandling::DwarfCFI &&
-          ExceptionHandlingType != ExceptionHandling::ARM)
-        return;
-
-      if (getFunctionCFISectionType(*MF) == CFISection::None)
-        return;
-
-      OutStreamer->emitCFIBKeyFrame();
+    ExceptionHandling ExceptionHandlingType = MAI.getExceptionHandlingType();
+    if (ExceptionHandlingType != ExceptionHandling::DwarfCFI &&
+        ExceptionHandlingType != ExceptionHandling::ARM)
       return;
+
+    if (getFunctionCFISectionType(*MF) == CFISection::None)
+      return;
+
+    OutStreamer->emitCFIBKeyFrame();
+    return;
   }
 
   case AArch64::EMITMTETAGGED: {
-    ExceptionHandling ExceptionHandlingType = MAI->getExceptionHandlingType();
+    ExceptionHandling ExceptionHandlingType = MAI.getExceptionHandlingType();
     if (ExceptionHandlingType != ExceptionHandling::DwarfCFI &&
         ExceptionHandlingType != ExceptionHandling::ARM)
       return;

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -581,7 +581,7 @@ SmallString<128> AMDGPUAsmPrinter::getMCExprStr(const MCExpr *Value) {
   auto &Streamer = getTargetStreamer()->getStreamer();
   auto &Context = Streamer.getContext();
   const MCExpr *New = foldAMDGPUMCExpr(Value, Context);
-  printAMDGPUMCExpr(New, OSS, MAI);
+  printAMDGPUMCExpr(New, OSS, &MAI);
   return Str;
 }
 

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -1366,7 +1366,7 @@ void ARMAsmPrinter::EmitUnwindingInstruction(const MachineInstr *MI) {
       PadBefore = -MI->getOperand(4).getImm() - 8;
       break;
     }
-    if (MAI->getExceptionHandlingType() == ExceptionHandling::ARM) {
+    if (MAI.getExceptionHandlingType() == ExceptionHandling::ARM) {
       if (PadBefore)
         ATS.emitPad(PadBefore);
       ATS.emitRegSave(RegList, Opc == ARM::VSTMDDB_UPD);
@@ -1417,7 +1417,7 @@ void ARMAsmPrinter::EmitUnwindingInstruction(const MachineInstr *MI) {
         break;
       }
 
-      if (MAI->getExceptionHandlingType() == ExceptionHandling::ARM) {
+      if (MAI.getExceptionHandlingType() == ExceptionHandling::ARM) {
         if (DstReg == FramePtr && FramePtr != ARM::SP)
           // Set-up of the frame pointer. Positive values correspond to "add"
           // instruction.

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -276,7 +276,7 @@ void ARMTargetAsmStreamer::emitThumbFunc(MCSymbol *Symbol) {
   // Only Mach-O hasSubsectionsViaSymbols()
   if (MAI.hasSubsectionsViaSymbols()) {
     OS << '\t';
-    Symbol->print(OS, &MAI);
+    Symbol->print(OS, MAI);
   }
   OS << '\n';
 }
@@ -285,7 +285,7 @@ void ARMTargetAsmStreamer::emitThumbSet(MCSymbol *Symbol, const MCExpr *Value) {
   const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
 
   OS << "\t.thumb_set\t";
-  Symbol->print(OS, &MAI);
+  Symbol->print(OS, MAI);
   OS << ", ";
   MAI.printExpr(OS, *Value);
   OS << '\n';

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -46,7 +46,7 @@ bool BPFAsmPrinter::doInitialization(Module &M) {
   AsmPrinter::doInitialization(M);
 
   // Only emit BTF when debuginfo available.
-  if (MAI->doesSupportDebugInformation() && !M.debug_compile_units().empty()) {
+  if (MAI.doesSupportDebugInformation() && !M.debug_compile_units().empty()) {
     BTF = new BTFDebug(this);
     Handlers.push_back(std::unique_ptr<BTFDebug>(BTF));
   }

--- a/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
+++ b/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
@@ -72,8 +72,8 @@ void CSKYAsmPrinter::expandTLSLA(const MachineInstr *MI) {
   DebugLoc DL = MI->getDebugLoc();
 
   MCSymbol *PCLabel = OutContext.getOrCreateSymbol(
-      Twine(MAI->getInternalSymbolPrefix()) + "PC" +
-      Twine(getFunctionNumber()) + "_" + Twine(MI->getOperand(3).getImm()));
+      Twine(MAI.getInternalSymbolPrefix()) + "PC" + Twine(getFunctionNumber()) +
+      "_" + Twine(MI->getOperand(3).getImm()));
 
   OutStreamer->emitLabel(PCLabel);
 
@@ -223,7 +223,7 @@ void CSKYAsmPrinter::emitMachineConstantPoolValue(
   if (CCPV->getPCAdjustment()) {
 
     MCSymbol *PCLabel = OutContext.getOrCreateSymbol(
-        Twine(MAI->getInternalSymbolPrefix()) + "PC" +
+        Twine(MAI.getInternalSymbolPrefix()) + "PC" +
         Twine(getFunctionNumber()) + "_" + Twine(CCPV->getLabelID()));
 
     const MCExpr *PCRelExpr = MCSymbolRefExpr::create(PCLabel, OutContext);

--- a/llvm/lib/Target/Lanai/LanaiAsmPrinter.cpp
+++ b/llvm/lib/Target/Lanai/LanaiAsmPrinter.cpp
@@ -91,12 +91,12 @@ void LanaiAsmPrinter::printOperand(const MachineInstr *MI, int OpNum,
     break;
 
   case MachineOperand::MO_JumpTableIndex:
-    O << MAI->getInternalSymbolPrefix() << "JTI" << getFunctionNumber() << '_'
+    O << MAI.getInternalSymbolPrefix() << "JTI" << getFunctionNumber() << '_'
       << MO.getIndex();
     break;
 
   case MachineOperand::MO_ConstantPoolIndex:
-    O << MAI->getInternalSymbolPrefix() << "CPI" << getFunctionNumber() << '_'
+    O << MAI.getInternalSymbolPrefix() << "CPI" << getFunctionNumber() << '_'
       << MO.getIndex();
     return;
 

--- a/llvm/lib/Target/Lanai/LanaiMCInstLower.cpp
+++ b/llvm/lib/Target/Lanai/LanaiMCInstLower.cpp
@@ -46,7 +46,7 @@ LanaiMCInstLower::GetExternalSymbolSymbol(const MachineOperand &MO) const {
 MCSymbol *LanaiMCInstLower::GetJumpTableSymbol(const MachineOperand &MO) const {
   SmallString<256> Name;
   raw_svector_ostream(Name)
-      << Printer.MAI->getInternalSymbolPrefix() << "JTI"
+      << Printer.MAI.getInternalSymbolPrefix() << "JTI"
       << Printer.getFunctionNumber() << '_' << MO.getIndex();
   // Create a symbol for the name.
   return Ctx.getOrCreateSymbol(Name.str());
@@ -56,7 +56,7 @@ MCSymbol *
 LanaiMCInstLower::GetConstantPoolIndexSymbol(const MachineOperand &MO) const {
   SmallString<256> Name;
   raw_svector_ostream(Name)
-      << Printer.MAI->getInternalSymbolPrefix() << "CPI"
+      << Printer.MAI.getInternalSymbolPrefix() << "CPI"
       << Printer.getFunctionNumber() << '_' << MO.getIndex();
   // Create a symbol for the name.
   return Ctx.getOrCreateSymbol(Name.str());

--- a/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.cpp
@@ -164,7 +164,7 @@ bool LoongArchAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
   else if (OffsetMO.isGlobal() || OffsetMO.isBlockAddress() ||
            OffsetMO.isMCSymbol() || OffsetMO.isCPI()) {
     OS << ", ";
-    MAI->printExpr(OS, *MCO.getExpr());
+    MAI.printExpr(OS, *MCO.getExpr());
   } else
     return true;
 

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1060,7 +1060,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
           AggBuffer aggBuffer(ElementSize, *this);
           bufferAggregateConstant(Initializer, &aggBuffer);
           if (aggBuffer.numSymbols()) {
-            const unsigned int ptrSize = MAI->getCodePointerSize();
+            const unsigned int ptrSize = MAI.getCodePointerSize();
             if (ElementSize % ptrSize ||
                 !aggBuffer.allSymbolsAligned(ptrSize)) {
               // Print in bytes and use the mask() operator for pointers.
@@ -1132,7 +1132,7 @@ void NVPTXAsmPrinter::AggBuffer::printSymbol(unsigned nSym, raw_ostream &os) {
 }
 
 void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
-  unsigned int ptrSize = AP.MAI->getCodePointerSize();
+  unsigned int ptrSize = AP.MAI.getCodePointerSize();
   // Do not emit trailing zero initializers. They will be zero-initialized by
   // ptxas. This saves on both space requirements for the generated PTX and on
   // memory use by ptxas. (See:
@@ -1174,7 +1174,7 @@ void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
 }
 
 void NVPTXAsmPrinter::AggBuffer::printWords(raw_ostream &os) {
-  unsigned int ptrSize = AP.MAI->getCodePointerSize();
+  unsigned int ptrSize = AP.MAI.getCodePointerSize();
   symbolPosInBuffer.push_back(Size);
   unsigned int nSym = 0;
   unsigned int nextSymbolPos = symbolPosInBuffer[nSym];

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
@@ -254,7 +254,7 @@ public:
     const MCAsmInfo &MAI = Streamer.getContext().getAsmInfo();
 
     OS << "\t.localentry\t";
-    S->print(OS, &MAI);
+    S->print(OS, MAI);
     OS << ", ";
     MAI.printExpr(OS, *LocalOffset);
     OS << '\n';

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -283,7 +283,7 @@ public:
 
   PPCAIXAsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer)
       : PPCAsmPrinter(TM, std::move(Streamer), ID) {
-    if (MAI->isLittleEndian())
+    if (MAI.isLittleEndian())
       report_fatal_error(
           "cannot create AIX PPC Assembly Printer for a little-endian target");
   }
@@ -1822,7 +1822,7 @@ void PPCLinuxAsmPrinter::emitInstruction(const MachineInstr *MI) {
         .getValueAsString()
         .getAsInteger(10, Num);
 
-    if (!MAI->isLittleEndian() || Num)
+    if (!MAI.isLittleEndian() || Num)
       break;
     MCSymbol *BeginOfSled = OutContext.createTempSymbol();
     MCSymbol *EndOfSled = OutContext.createTempSymbol();
@@ -2064,7 +2064,7 @@ void PPCLinuxAsmPrinter::emitEndOfAsmFile(Module &M) {
   if (static_cast<const PPCTargetMachine &>(TM).hasGlibcHWCAPAccess())
     OutStreamer->emitSymbolValue(
         GetExternalSymbolSymbol("__parse_hwcap_and_convert_at_platform"),
-        MAI->getCodePointerSize());
+        MAI.getCodePointerSize());
   emitGNUAttributes(M);
 
   if (!TOC.empty()) {
@@ -2286,13 +2286,13 @@ void PPCAIXAsmPrinter::emitLinkage(const GlobalValue *GV,
     // TODO: "internal" Visibility needs to go here.
     case GlobalValue::DefaultVisibility:
       if (GV->hasDLLExportStorageClass())
-        VisibilityAttr = MAI->getExportedVisibilityAttr();
+        VisibilityAttr = MAI.getExportedVisibilityAttr();
       break;
     case GlobalValue::HiddenVisibility:
-      VisibilityAttr = MAI->getHiddenVisibilityAttr();
+      VisibilityAttr = MAI.getHiddenVisibilityAttr();
       break;
     case GlobalValue::ProtectedVisibility:
-      VisibilityAttr = MAI->getProtectedVisibilityAttr();
+      VisibilityAttr = MAI.getProtectedVisibilityAttr();
       break;
     }
   }

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -444,7 +444,7 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
   if (Offset.isImm())
     OS << MCO.getImm();
   else if (Offset.isGlobal() || Offset.isBlockAddress() || Offset.isMCSymbol())
-    MAI->printExpr(OS, *MCO.getExpr());
+    MAI.printExpr(OS, *MCO.getExpr());
 
   if (Offset.isMCSymbol())
     MMI->getContext().registerInlineAsmLabel(Offset.getMCSymbol());

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1195,7 +1195,7 @@ bool SystemZAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
     SystemZMCInstLower Lower(MF->getContext(), *this);
     MCOp = Lower.lowerOperand(MO);
   }
-  printOperand(MCOp, MAI, OS);
+  printOperand(MCOp, &MAI, OS);
   return false;
 }
 
@@ -1214,11 +1214,11 @@ bool SystemZAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
       OS << MI->getOperand(OpNo + 1).getImm();
       return false;
     case 'R':
-      ::printReg(MI->getOperand(OpNo).getReg(), MAI, OS);
+      ::printReg(MI->getOperand(OpNo).getReg(), &MAI, OS);
       return false;
     }
   }
-  printAddress(MAI, MI->getOperand(OpNo).getReg(),
+  printAddress(&MAI, MI->getOperand(OpNo).getReg(),
                MCOperand::createImm(MI->getOperand(OpNo + 1).getImm()),
                MI->getOperand(OpNo + 2).getReg(), OS);
   return false;

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -192,7 +192,7 @@ void X86AsmPrinter::emitKCFITypeId(const MachineFunction &MF) {
   // symbols for weak parent functions.
   MCSymbol *FnSym = OutContext.getOrCreateSymbol("__cfi_" + MF.getName());
   emitLinkage(&MF.getFunction(), FnSym);
-  if (MAI->hasDotTypeDotSizeDirective())
+  if (MAI.hasDotTypeDotSizeDirective())
     OutStreamer->emitSymbolAttribute(FnSym, MCSA_ELF_TypeFunction);
   OutStreamer->emitLabel(FnSym);
 
@@ -237,7 +237,7 @@ void X86AsmPrinter::emitKCFITypeId(const MachineFunction &MF) {
                               .addReg(DestReg)
                               .addImm(MaskKCFIType(Type->getZExtValue())));
 
-  if (MAI->hasDotTypeDotSizeDirective()) {
+  if (MAI.hasDotTypeDotSizeDirective()) {
     MCSymbol *EndSym = OutContext.createTempSymbol("cfi_func_end");
     OutStreamer->emitLabel(EndSym);
 
@@ -964,7 +964,7 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
 
   // TODO: Support prefixed registers for the Intel syntax.
   const bool IntelSyntax =
-      MAI->getOutputAssemblerDialect() == InlineAsm::AD_Intel;
+      MAI.getOutputAssemblerDialect() == InlineAsm::AD_Intel;
   OutStreamer->emitSyntaxDirective(IntelSyntax ? "intel" : "att",
                                    IntelSyntax ? "noprefix" : "");
 
@@ -1132,7 +1132,7 @@ void X86AsmPrinter::emitEndOfAsmFile(Module &M) {
       OutStreamer->switchSection(ReadOnlySection);
       OutStreamer->emitLabel(AddrSymbol);
 
-      unsigned PtrSize = MAI->getCodePointerSize();
+      unsigned PtrSize = MAI.getCodePointerSize();
       OutStreamer->emitSymbolValue(GetExternalSymbolSymbol("__morestack"),
                                    PtrSize);
     }

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -2743,8 +2743,8 @@ void X86AsmPrinter::maybeEmitNopAfterCallForWindowsEH(const MachineInstr *MI) {
   // We only need to insert NOPs after CALLs when targeting Windows on AMD64.
   // (Don't let the name fool you: Itanium refers to table-based exception
   // handling, not the Itanium architecture.)
-  if (MAI->getExceptionHandlingType() != ExceptionHandling::WinEH ||
-      MAI->getWinEHEncodingType() != WinEH::EncodingType::Itanium) {
+  if (MAI.getExceptionHandlingType() != ExceptionHandling::WinEH ||
+      MAI.getWinEHEncodingType() != WinEH::EncodingType::Itanium) {
     return;
   }
 

--- a/llvm/lib/Target/XCore/XCoreAsmPrinter.cpp
+++ b/llvm/lib/Target/XCore/XCoreAsmPrinter.cpp
@@ -145,7 +145,7 @@ void XCoreAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
     report_fatal_error("TLS is not supported by this target!");
   }
   unsigned Size = DL.getTypeAllocSize(C->getType());
-  if (MAI->hasDotTypeDotSizeDirective()) {
+  if (MAI.hasDotTypeDotSizeDirective()) {
     OutStreamer->emitSymbolAttribute(GVSym, MCSA_ELF_TypeObject);
     OutStreamer->emitELFSize(GVSym, MCConstantExpr::create(Size, OutContext));
   }

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
@@ -146,7 +146,7 @@ void dwarfgen::DIE::addStrOffsetsBaseAttribute() {
   const MCExpr *Expr =
       MCSymbolRefExpr::create(DG.getStringOffsetsStartSym(), MC);
 
-  if (!Asm->MAI->doesDwarfUseRelocationsAcrossSections())
+  if (!Asm->MAI.doesDwarfUseRelocationsAcrossSections())
     Expr = MCBinaryExpr::createSub(
         Expr, MCSymbolRefExpr::create(SectionStart, MC), MC);
 
@@ -164,7 +164,7 @@ void dwarfgen::DIE::addAddrBaseAttribute() {
 
   const MCExpr *Expr = MCSymbolRefExpr::create(DG.getAddrTableStartSym(), MC);
 
-  if (!Asm->MAI->doesDwarfUseRelocationsAcrossSections())
+  if (!Asm->MAI.doesDwarfUseRelocationsAcrossSections())
     Expr = MCBinaryExpr::createSub(
         Expr, MCSymbolRefExpr::create(SectionStart, MC), MC);
 


### PR DESCRIPTION
AsmPrinter::MAI is non-null. This is made more explicit after
PR #194523 changed TargetMachine::getMCAsmInfo to return a reference
with recent MCAsmInfo/MCTargetOptions related refactoring.

Convert the member from const MCAsmInfo * to const MCAsmInfo & and
update all consumers.