### PR TITLE
Fix UNSUPPORTED added to test in #194502.

### DIFF
--- a/clang/test/Driver/modules-driver-import-std.cpp
+++ b/clang/test/Driver/modules-driver-import-std.cpp
@@ -2,7 +2,7 @@
 // modules.
 
 // https://github.com/llvm/llvm-project/pull/194475#issuecomment-4331347690
-// UNSUPPORTED: aarch64
+// UNSUPPORTED: target={{.*}}aarch64{{.*}}, {{.*}}arm64{{.*}}
 
 // The standard library modules manifest (libc++.modules.json) is discovered
 // relative to the installed C++ standard library runtime libraries


### PR DESCRIPTION
The change in #194502 attempted to mark the test as UNSUPPORTED for AArch64, but it didn't work because it wasn't specified correctly. This fixes it.