### PR TITLE
[Clang] Produce deterministic hash for anonymous namespaces.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -637,7 +637,7 @@ Windows Support
 - Clang now defines the ``_MSVC_TRADITIONAL`` macro as ``1`` when emulating MSVC
   19.15 (Visual Studio 2017 version 15.8) and later. (#GH47114)
 - ``-fmacro-prefix-map=`` (``-ffile-prefix-map=``) now affects an anonymous namespace hash generation
-  for the MSVC targets and allows deterministic symbol mangling for reproducible builds. (#GH194542)
+  for the MSVC targets and allows deterministic symbol mangling for reproducible builds.
 
 LoongArch Support
 ^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -636,6 +636,8 @@ Windows Support
 
 - Clang now defines the ``_MSVC_TRADITIONAL`` macro as ``1`` when emulating MSVC
   19.15 (Visual Studio 2017 version 15.8) and later. (#GH47114)
+- ``-fmacro-prefix-map=`` (``-ffile-prefix-map=``) now affects an anonymous namespace hash generation
+  for the MSVC targets and allows deterministic symbol mangling for reproducible builds. (#GH194542)
 
 LoongArch Support
 ^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -29,6 +29,7 @@
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CRC.h"
@@ -503,8 +504,13 @@ MicrosoftMangleContextImpl::MicrosoftMangleContextImpl(ASTContext &Context,
   // which are something like "?A0x01234567@".
   SourceManager &SM = Context.getSourceManager();
   if (OptionalFileEntryRef FE = SM.getFileEntryRefForID(SM.getMainFileID())) {
+    SmallString<256> Path(FE->getName());
+    // Do a path substitution from the MacroPrefixMap if needed.
+    clang::Preprocessor::processPathForFileMacro(Path, Context.getLangOpts(),
+                                                 Context.getTargetInfo());
+
     // Truncate the hash so we get 8 characters of hexadecimal.
-    uint32_t TruncatedHash = uint32_t(xxh3_64bits(FE->getName()));
+    uint32_t TruncatedHash = uint32_t(xxh3_64bits(Path));
     AnonymousNamespaceHash = llvm::utohexstr(TruncatedHash);
   } else {
     // If we don't have a path to the main file, we'll just use 0.

--- a/clang/test/AST/anon-ns-determ-hash.cpp
+++ b/clang/test/AST/anon-ns-determ-hash.cpp
@@ -1,0 +1,9 @@
+// Check anonymous namespace deterministic hash generation.
+// RUN: %clang_cc1 -std=c++2a -ast-dump=json -fmacro-prefix-map=%p=/static-path %s | FileCheck %s
+
+namespace {
+    int internal_ns_var = 0;
+} 
+
+// The 0xA110234F hash value must be identical on any system with proper path substitution.
+// CHECK: "mangledName": "?internal_ns_var@?A0xA110234F@@3HA",

--- a/clang/test/AST/anon-ns-determ-hash.cpp
+++ b/clang/test/AST/anon-ns-determ-hash.cpp
@@ -1,5 +1,8 @@
 // Check anonymous namespace deterministic hash generation.
-// RUN: %clang_cc1 -std=c++2a -ast-dump=json -fmacro-prefix-map=%p=/static-path %s | FileCheck %s
+// NOTE: applies to *-msvc targets only.
+
+// RUN: %clang_cc1 -triple=x86_64-pc-windows-msvc -std=c++2a -ast-dump=json -fmacro-prefix-map=%p=/static-path %s | FileCheck %s
+// REQUIRES: x86-registered-target
 
 namespace {
     int internal_ns_var = 0;


### PR DESCRIPTION
This change adds a path substitution for the main module file during anonymous namespace hash generation using the prefix map specified by -fmacro-prefix-map option. That ensures deterministic symbol mangling for reproducible builds.