### PR TITLE
[C++20] [Modules] Don't check redeclaration for TagUseKind::Referencekind declaration

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18933,7 +18933,7 @@ CreateNewDecl:
   if (!Invalid && SearchDC->isRecord())
     SetMemberAccessSpecifier(New, PrevDecl, AS);
 
-  if (PrevDecl)
+  if (PrevDecl && TUK != TagUseKind::Reference)
     CheckRedeclarationInModule(New, PrevDecl);
 
   if (TUK == TagUseKind::Definition) {

--- a/clang/test/Modules/pr72038.cppm
+++ b/clang/test/Modules/pr72038.cppm
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 %s -fsyntax-only -verify
+
+// expected-no-diagnostics
+module;
+struct kevent { };
+void kevent(int x);
+export module my_mod;
+struct kevent evt;


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/72038

The reason of the issue is ISO forbids redeclaration between GMF and the module purview.

But "struct kevent evt;" was thought to be declaration than triggers the above issue.

In this patch, we simply not checking for cases of TagUseKind::Reference declaration.