### PR TITLE
[RISCV][CodeGen] Add initial vzip codegen support

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5672,7 +5672,8 @@ static SDValue lowerVZIP(unsigned Opc, SDValue Op0, SDValue Op1,
 
 static SDValue lowerZvzipVZIP(SDValue Op0, SDValue Op1, const SDLoc &DL,
                               SelectionDAG &DAG,
-                              const RISCVSubtarget &Subtarget, unsigned Part) {
+                              const RISCVSubtarget &Subtarget,
+                              std::optional<unsigned> Part = std::nullopt) {
   assert(Op0.getSimpleValueType() == Op1.getSimpleValueType());
   MVT VT = Op0.getSimpleValueType();
   MVT IntVT = VT.changeVectorElementTypeToInteger();
@@ -5689,12 +5690,19 @@ static SDValue lowerZvzipVZIP(SDValue Op0, SDValue Op1, const SDLoc &DL,
   SDValue Passthru = DAG.getUNDEF(ResVT);
   SDValue Res =
       DAG.getNode(RISCVISD::VZIP_VL, DL, ResVT, Op0, Op1, Passthru, Mask, VL);
-  Res = DAG.getExtractSubvector(
-      DL, ContainerVT, Res,
-      Part * ContainerVT.getVectorElementCount().getKnownMinValue());
+  if (Part) {
+    assert(*Part < 2 && "Unexpected VZIP part");
+    Res = DAG.getExtractSubvector(
+        DL, ContainerVT, Res,
+        *Part * ContainerVT.getVectorElementCount().getKnownMinValue());
+    if (IntVT.isFixedLengthVector())
+      Res = convertFromScalableVector(IntVT, Res, DAG, Subtarget);
+    return DAG.getBitcast(VT, Res);
+  }
   if (IntVT.isFixedLengthVector())
-    Res = convertFromScalableVector(IntVT, Res, DAG, Subtarget);
-  Res = DAG.getBitcast(VT, Res);
+    Res = convertFromScalableVector(IntVT.getDoubleNumVectorElementsVT(), Res,
+                                    DAG, Subtarget);
+  Res = DAG.getBitcast(VT.getDoubleNumVectorElementsVT(), Res);
   return Res;
 }
 
@@ -6474,11 +6482,8 @@ SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
 
     // Prefer vzip2a or vzip if available.
     // TODO: Extend to matching ri.vzip2b or vzip if EvenSrc and OddSrc allow.
-    if (Subtarget.hasStdExtZvzip() && isLegalVTForZvzip(VT, Subtarget, *this)) {
-      EvenV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), EvenV, 0);
-      OddV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), OddV, 0);
-      return lowerZvzipVZIP(EvenV, OddV, DL, DAG, Subtarget, /*Part=*/0);
-    }
+    if (Subtarget.hasStdExtZvzip() && isLegalVTForZvzip(VT, Subtarget, *this))
+      return lowerZvzipVZIP(EvenV, OddV, DL, DAG, Subtarget);
     if (Subtarget.hasVendorXRivosVizip()) {
       EvenV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), EvenV, 0);
       OddV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), OddV, 0);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5151,6 +5151,15 @@ static SDValue getSingleShuffleSrc(MVT VT, SDValue V1, SDValue V2) {
   return SDValue();
 }
 
+static bool isLegalVTForZvzip(MVT VT, const RISCVSubtarget &Subtarget,
+                              const TargetLowering &TLI) {
+  MVT ContainerVT = VT;
+  if (VT.isFixedLengthVector())
+    ContainerVT = getContainerForFixedLengthVector(TLI, VT, Subtarget);
+  // Determine LMUL of the container vector.
+  return RISCVTargetLowering::getLMUL(ContainerVT) != RISCVVType::LMUL_8;
+}
+
 /// Is this shuffle interleaving contiguous elements from one vector into the
 /// even elements and contiguous elements from another vector into the odd
 /// elements. \p EvenSrc will contain the element that should be in the first
@@ -5655,6 +5664,34 @@ static SDValue lowerVZIP(unsigned Opc, SDValue Op0, SDValue Op1,
   SDValue Res = DAG.getNode(Opc, DL, InnerVT, Op0, Op1, Passthru, Mask, VL);
   if (InnerVT.bitsLT(ContainerVT))
     Res = DAG.getInsertSubvector(DL, DAG.getUNDEF(ContainerVT), Res, 0);
+  if (IntVT.isFixedLengthVector())
+    Res = convertFromScalableVector(IntVT, Res, DAG, Subtarget);
+  Res = DAG.getBitcast(VT, Res);
+  return Res;
+}
+
+static SDValue lowerZvzipVZIP(SDValue Op0, SDValue Op1, const SDLoc &DL,
+                              SelectionDAG &DAG,
+                              const RISCVSubtarget &Subtarget, unsigned Part) {
+  assert(Op0.getSimpleValueType() == Op1.getSimpleValueType());
+  MVT VT = Op0.getSimpleValueType();
+  MVT IntVT = VT.changeVectorElementTypeToInteger();
+  Op0 = DAG.getBitcast(IntVT, Op0);
+  Op1 = DAG.getBitcast(IntVT, Op1);
+  MVT ContainerVT = IntVT;
+  if (VT.isFixedLengthVector()) {
+    ContainerVT = getContainerForFixedLengthVector(DAG, IntVT, Subtarget);
+    Op0 = convertToScalableVector(ContainerVT, Op0, DAG, Subtarget);
+    Op1 = convertToScalableVector(ContainerVT, Op1, DAG, Subtarget);
+  }
+  MVT ResVT = ContainerVT.getDoubleNumVectorElementsVT();
+  auto [Mask, VL] = getDefaultVLOps(IntVT, ContainerVT, DL, DAG, Subtarget);
+  SDValue Passthru = DAG.getUNDEF(ResVT);
+  SDValue Res =
+      DAG.getNode(RISCVISD::VZIP_VL, DL, ResVT, Op0, Op1, Passthru, Mask, VL);
+  Res = DAG.getExtractSubvector(
+      DL, ContainerVT, Res,
+      Part * ContainerVT.getVectorElementCount().getKnownMinValue());
   if (IntVT.isFixedLengthVector())
     Res = convertFromScalableVector(IntVT, Res, DAG, Subtarget);
   Res = DAG.getBitcast(VT, Res);
@@ -6435,8 +6472,13 @@ SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
       OddV = DAG.getExtractSubvector(DL, HalfVT, OddV, OddSrc % Size);
     }
 
-    // Prefer vzip2a if available.
-    // TODO: Extend to matching zip2b if EvenSrc and OddSrc allow.
+    // Prefer vzip2a or vzip if available.
+    // TODO: Extend to matching ri.vzip2b or vzip if EvenSrc and OddSrc allow.
+    if (Subtarget.hasStdExtZvzip() && isLegalVTForZvzip(VT, Subtarget, *this)) {
+      EvenV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), EvenV, 0);
+      OddV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), OddV, 0);
+      return lowerZvzipVZIP(EvenV, OddV, DL, DAG, Subtarget, /*Part=*/0);
+    }
     if (Subtarget.hasVendorXRivosVizip()) {
       EvenV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), EvenV, 0);
       OddV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), OddV, 0);
@@ -13025,6 +13067,19 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
     }
 
     return DAG.getMergeValues(Loads, DL);
+  }
+
+  if (Subtarget.hasStdExtZvzip() && !Op.getOperand(0).isUndef() &&
+      !Op.getOperand(1).isUndef()) {
+    MVT VT = Op->getSimpleValueType(0);
+    if (isLegalVTForZvzip(VT, Subtarget, *this)) {
+      // Freeze the sources so we can increase their use count.
+      SDValue V1 = DAG.getFreeze(Op->getOperand(0));
+      SDValue V2 = DAG.getFreeze(Op->getOperand(1));
+      SDValue Lo = lowerZvzipVZIP(V1, V2, DL, DAG, Subtarget, /*Part=*/0);
+      SDValue Hi = lowerZvzipVZIP(V1, V2, DL, DAG, Subtarget, /*Part=*/1);
+      return DAG.getMergeValues({Lo, Hi}, DL);
+    }
   }
 
   // Use ri.vzip2{a,b} if available

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5151,8 +5151,8 @@ static SDValue getSingleShuffleSrc(MVT VT, SDValue V1, SDValue V2) {
   return SDValue();
 }
 
-static bool isLegalVTForZvzip(MVT VT, const RISCVSubtarget &Subtarget,
-                              const TargetLowering &TLI) {
+static bool isLegalVTForZvzipOperand(MVT VT, const RISCVSubtarget &Subtarget,
+                                     const TargetLowering &TLI) {
   MVT ContainerVT = VT;
   if (VT.isFixedLengthVector())
     ContainerVT = getContainerForFixedLengthVector(TLI, VT, Subtarget);
@@ -6472,7 +6472,8 @@ SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
 
     // Prefer vzip2a or vzip if available.
     // TODO: Extend to matching ri.vzip2b or vzip if EvenSrc and OddSrc allow.
-    if (Subtarget.hasStdExtZvzip() && isLegalVTForZvzip(VT, Subtarget, *this))
+    if (Subtarget.hasStdExtZvzip() &&
+        isLegalVTForZvzipOperand(VT, Subtarget, *this))
       return lowerZvzipVZIP(EvenV, OddV, DL, DAG, Subtarget);
     if (Subtarget.hasVendorXRivosVizip()) {
       EvenV = DAG.getInsertSubvector(DL, DAG.getUNDEF(VT), EvenV, 0);
@@ -13067,7 +13068,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
   if (Subtarget.hasStdExtZvzip() && !Op.getOperand(0).isUndef() &&
       !Op.getOperand(1).isUndef()) {
     MVT VT = Op->getSimpleValueType(0);
-    if (isLegalVTForZvzip(VT, Subtarget, *this)) {
+    if (isLegalVTForZvzipOperand(VT, Subtarget, *this)) {
       // Freeze the sources so we can increase their use count.
       SDValue V1 = DAG.getFreeze(Op->getOperand(0));
       SDValue V2 = DAG.getFreeze(Op->getOperand(1));

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5672,8 +5672,7 @@ static SDValue lowerVZIP(unsigned Opc, SDValue Op0, SDValue Op1,
 
 static SDValue lowerZvzipVZIP(SDValue Op0, SDValue Op1, const SDLoc &DL,
                               SelectionDAG &DAG,
-                              const RISCVSubtarget &Subtarget,
-                              std::optional<unsigned> Part = std::nullopt) {
+                              const RISCVSubtarget &Subtarget) {
   assert(Op0.getSimpleValueType() == Op1.getSimpleValueType());
   MVT VT = Op0.getSimpleValueType();
   MVT IntVT = VT.changeVectorElementTypeToInteger();
@@ -5690,15 +5689,6 @@ static SDValue lowerZvzipVZIP(SDValue Op0, SDValue Op1, const SDLoc &DL,
   SDValue Passthru = DAG.getUNDEF(ResVT);
   SDValue Res =
       DAG.getNode(RISCVISD::VZIP_VL, DL, ResVT, Op0, Op1, Passthru, Mask, VL);
-  if (Part) {
-    assert(*Part < 2 && "Unexpected VZIP part");
-    Res = DAG.getExtractSubvector(
-        DL, ContainerVT, Res,
-        *Part * ContainerVT.getVectorElementCount().getKnownMinValue());
-    if (IntVT.isFixedLengthVector())
-      Res = convertFromScalableVector(IntVT, Res, DAG, Subtarget);
-    return DAG.getBitcast(VT, Res);
-  }
   if (IntVT.isFixedLengthVector())
     Res = convertFromScalableVector(IntVT.getDoubleNumVectorElementsVT(), Res,
                                     DAG, Subtarget);
@@ -13081,8 +13071,10 @@ SDValue RISCVTargetLowering::lowerVECTOR_INTERLEAVE(SDValue Op,
       // Freeze the sources so we can increase their use count.
       SDValue V1 = DAG.getFreeze(Op->getOperand(0));
       SDValue V2 = DAG.getFreeze(Op->getOperand(1));
-      SDValue Lo = lowerZvzipVZIP(V1, V2, DL, DAG, Subtarget, /*Part=*/0);
-      SDValue Hi = lowerZvzipVZIP(V1, V2, DL, DAG, Subtarget, /*Part=*/1);
+      SDValue Interleaved = lowerZvzipVZIP(V1, V2, DL, DAG, Subtarget);
+      SDValue Lo = DAG.getExtractSubvector(DL, VT, Interleaved, 0);
+      SDValue Hi = DAG.getExtractSubvector(DL, VT, Interleaved,
+                                           VT.getVectorMinNumElements());
       return DAG.getMergeValues({Lo, Hi}, DL);
     }
   }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -166,18 +166,12 @@ multiclass VPatVZIP<SDPatternOperator vop, string instruction_name> {
   foreach VtiToWti = AllZvzipVectors in {
     defvar vti = VtiToWti.Vti;
     defvar wti = VtiToWti.Wti;
-    let Predicates = !listconcat([HasStdExtZvzip], GetVTypePredicates<vti>.Predicates) in {
-      def : Pat<(wti.Vector (vop
-                       (vti.Vector vti.RegClass:$rs1),
-                       (vti.Vector vti.RegClass:$rs2),
-                       (wti.Vector wti.RegClass:$passthru),
-                       (vti.Mask VMV0:$vm),
-                       VLOpFrag)),
-                (!cast<Instruction>(instruction_name#"_VV_"#vti.LMul.MX#"_MASK")
-                             wti.RegClass:$passthru,
-                             vti.RegClass:$rs1,
-                             vti.RegClass:$rs2,
-                             (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
+    let Predicates = !listconcat([HasStdExtZvzip],
+                                 GetVTypeMinimalPredicates<vti>.Predicates) in {
+      def : VPatBinaryVL_V<vop, instruction_name, "VV",
+                           wti.Vector, vti.Vector, vti.Vector, vti.Mask,
+                           vti.Log2SEW, vti.LMul, wti.RegClass, vti.RegClass,
+                           vti.RegClass>;
     }
   }
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvzip.td
@@ -139,6 +139,15 @@ defm : VPatBinaryW_VV<"int_riscv_vzip", "PseudoVZIP", AllZvzipVectors,
                       ExtraPreds = [HasStdExtZvzip],
                       requireMinimal = true>;
 
+// (vd (op vs2, vs1, passthru, mask, vl))
+def SDT_RISCVZip_VL : SDTypeProfile<1, 5, [SDTCisVec<0>, SDTCisVec<1>,
+                                           SDTCisSubVecOfVec<1, 0>,
+                                           SDTCisSameAs<1, 2>,
+                                           SDTCisSameAs<0, 3>,
+                                           SDTCVecEltisVT<4, i1>,
+                                           SDTCisSameNumEltsAs<1, 4>,
+                                           SDTCisVT<5, XLenVT>]>;
+
 def SDT_RISCVVecBinOp_VL : SDTypeProfile<1, 5, [SDTCisSameAs<0, 1>,
                                                 SDTCisSameAs<0, 2>,
                                                 SDTCisVec<0>,
@@ -150,8 +159,30 @@ def SDT_RISCVVecBinOp_VL : SDTypeProfile<1, 5, [SDTCisSameAs<0, 1>,
 let HasPassthruOp = true, HasMaskOp = true in {
 def vpaire_vl  : RVSDNode<"VPAIRE_VL", SDT_RISCVVecBinOp_VL>;
 def vpairo_vl  : RVSDNode<"VPAIRO_VL", SDT_RISCVVecBinOp_VL>;
+def vzip_vl    : RVSDNode<"VZIP_VL", SDT_RISCVZip_VL>;
 } // HasPassthruOp = true, HasMaskOp = true
 
+multiclass VPatVZIP<SDPatternOperator vop, string instruction_name> {
+  foreach VtiToWti = AllZvzipVectors in {
+    defvar vti = VtiToWti.Vti;
+    defvar wti = VtiToWti.Wti;
+    let Predicates = !listconcat([HasStdExtZvzip], GetVTypePredicates<vti>.Predicates) in {
+      def : Pat<(wti.Vector (vop
+                       (vti.Vector vti.RegClass:$rs1),
+                       (vti.Vector vti.RegClass:$rs2),
+                       (wti.Vector wti.RegClass:$passthru),
+                       (vti.Mask VMV0:$vm),
+                       VLOpFrag)),
+                (!cast<Instruction>(instruction_name#"_VV_"#vti.LMul.MX#"_MASK")
+                             wti.RegClass:$passthru,
+                             vti.RegClass:$rs1,
+                             vti.RegClass:$rs2,
+                             (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
+    }
+  }
+}
+
+defm : VPatVZIP<vzip_vl, "PseudoVZIP">;
 defm : VPatBinaryVL_VV<vpaire_vl, "PseudoVPAIRE", AllVectors,
                        ExtraPreds = [HasStdExtZvzip],
                        requireMinimal = true>;

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
@@ -29,7 +29,7 @@ define <4 x i8> @interleave_v2i8(<2 x i8> %x, <2 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
@@ -56,7 +56,7 @@ define <4 x i16> @interleave_v2i16(<2 x i16> %x, <2 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
@@ -84,10 +84,9 @@ define <4 x i32> @interleave_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v10, v11
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v9, v8
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <2 x i32> %x, <2 x i32> %y, <4 x i32> <i32 2, i32 0, i32 3, i32 1>
   ret <4 x i32> %a
@@ -173,7 +172,7 @@ define <8 x i8> @interleave_v4i8(<4 x i8> %x, <4 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v10, v9, v8
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
@@ -210,10 +209,9 @@ define <8 x i16> @interleave_v4i16(<4 x i16> %x, <4 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i16> %x, <4 x i16> %y, <8 x i32> <i32 0, i32 4, i32 poison, i32 5, i32 2, i32 poison, i32 3, i32 7>
   ret <8 x i16> %a
@@ -249,10 +247,10 @@ define <8 x i32> @interleave_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
   ret <8 x i32> %a
@@ -293,10 +291,10 @@ define <4 x i32> @interleave_v4i32_offset_2(<4 x i32> %x, <4 x i32> %y) {
 ; ZVZIP-LABEL: interleave_v4i32_offset_2:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v8
-; ZVZIP-NEXT:    vslidedown.vi v11, v9, 2
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v10, v11
+; ZVZIP-NEXT:    vslidedown.vi v10, v9, 2
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v8, v10
+; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <4 x i32> <i32 0, i32 6, i32 1, i32 7>
   ret <4 x i32> %a
@@ -345,11 +343,13 @@ define <4 x i32> @interleave_v4i32_offset_1(<4 x i32> %x, <4 x i32> %y) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
 ; ZVZIP-NEXT:    vmv.v.i v0, 8
-; ZVZIP-NEXT:    vmv1r.v v12, v9
-; ZVZIP-NEXT:    vslideup.vi v12, v9, 1, v0.t
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vslideup.vi v10, v9, 1, v0.t
 ; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vzip.vv v10, v8, v9
-; ZVZIP-NEXT:    vmerge.vvm v8, v10, v12, v0
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v11, v8, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmerge.vvm v8, v11, v10, v0
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <4 x i32> <i32 0, i32 5, i32 1, i32 6>
   ret <4 x i32> %a
@@ -383,10 +383,9 @@ define <16 x i8> @interleave_v8i8(<8 x i8> %x, <8 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i8> %x, <8 x i8> %y, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
   ret <16 x i8> %a
@@ -423,10 +422,10 @@ define <16 x i16> @interleave_v8i16(<8 x i16> %x, <8 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v14, v12
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v10, v11
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i16> %x, <8 x i16> %y, <16 x i32> <i32 8, i32 0, i32 9, i32 1, i32 10, i32 2, i32 11, i32 3, i32 12, i32 4, i32 13, i32 5, i32 14, i32 6, i32 15, i32 7>
   ret <16 x i16> %a
@@ -462,10 +461,10 @@ define <16 x i32> @interleave_v8i32(<8 x i32> %x, <8 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v20, v10
-; ZVZIP-NEXT:    vmv2r.v v16, v8
-; ZVZIP-NEXT:    vzip.vv v8, v16, v20
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
+; ZVZIP-NEXT:    vmv2r.v v14, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i32> %x, <8 x i32> %y, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
   ret <16 x i32> %a
@@ -502,11 +501,10 @@ define <32 x i8> @interleave_v16i8(<16 x i8> %x, <16 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v16i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <16 x i8> %x, <16 x i8> %y, <32 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23, i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
   ret <32 x i8> %a
@@ -543,11 +541,10 @@ define <32 x i16> @interleave_v16i16(<16 x i16> %x, <16 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v16i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetvli zero, a0, e16, m4, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v20, v10
-; ZVZIP-NEXT:    vmv2r.v v16, v8
-; ZVZIP-NEXT:    vzip.vv v8, v16, v20
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
+; ZVZIP-NEXT:    vmv2r.v v14, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <16 x i16> %x, <16 x i16> %y, <32 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23, i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
   ret <32 x i16> %a
@@ -629,11 +626,11 @@ define <64 x i8> @interleave_v32i8(<32 x i8> %x, <32 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v32i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 64
-; ZVZIP-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v20, v10
-; ZVZIP-NEXT:    vmv2r.v v16, v8
-; ZVZIP-NEXT:    vzip.vv v8, v16, v20
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
+; ZVZIP-NEXT:    vmv2r.v v14, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <32 x i8> %x, <32 x i8> %y, <64 x i32> <i32 0, i32 32, i32 1, i32 33, i32 2, i32 34, i32 3, i32 35, i32 4, i32 36, i32 5, i32 37, i32 6, i32 38, i32 7, i32 39, i32 8, i32 40, i32 9, i32 41, i32 10, i32 42, i32 11, i32 43, i32 12, i32 44, i32 13, i32 45, i32 14, i32 46, i32 15, i32 47, i32 16, i32 48, i32 17, i32 49, i32 18, i32 50, i32 19, i32 51, i32 20, i32 52, i32 21, i32 53, i32 22, i32 54, i32 23, i32 55, i32 24, i32 56, i32 25, i32 57, i32 26, i32 58, i32 27, i32 59, i32 28, i32 60, i32 29, i32 61, i32 30, i32 62, i32 31, i32 63>
   ret <64 x i8> %a
@@ -898,7 +895,7 @@ define <4 x i8> @unary_interleave_v4i8(<4 x i8> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
@@ -990,7 +987,7 @@ define <4 x i16> @unary_interleave_v4i16(<4 x i16> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
@@ -1032,10 +1029,10 @@ define <4 x i32> @unary_interleave_v4i32(<4 x i32> %x) {
 ; ZVZIP-LABEL: unary_interleave_v4i32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v8
-; ZVZIP-NEXT:    vslidedown.vi v11, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v10, v11
+; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v8, v10
+; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
   ret <4 x i32> %a
@@ -1140,7 +1137,7 @@ define <8 x i8> @unary_interleave_v8i8(<8 x i8> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
@@ -1182,10 +1179,10 @@ define <8 x i16> @unary_interleave_v8i16(<8 x i16> %x) {
 ; ZVZIP-LABEL: unary_interleave_v8i16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v8
-; ZVZIP-NEXT:    vslidedown.vi v11, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vslidedown.vi v10, v8, 4
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v10, v8
+; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i16> %x, <8 x i16> poison, <8 x i32> <i32 4, i32 poison, i32 5, i32 1, i32 6, i32 2, i32 7, i32 3>
   ret <8 x i16> %a
@@ -1225,10 +1222,10 @@ define <8 x i32> @unary_interleave_v8i32(<8 x i32> %x) {
 ; ZVZIP-LABEL: unary_interleave_v8i32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m2, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v12, v8
-; ZVZIP-NEXT:    vslidedown.vi v14, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vslidedown.vi v12, v8, 4
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v12
+; ZVZIP-NEXT:    vmv2r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i32> %x, <8 x i32> poison, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
   ret <8 x i32> %a
@@ -1294,10 +1291,10 @@ define <16 x i16> @interleave_slp(<8 x i16> %v0, <8 x i16> %v1) {
 ;
 ; ZVZIP-LABEL: interleave_slp:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 entry:
   %v2 = shufflevector <8 x i16> %v0, <8 x i16> poison, <16 x i32> <i32 0, i32 poison, i32 1, i32 poison, i32 2, i32 poison, i32 3, i32 poison, i32 4, i32 poison, i32 5, i32 poison, i32 6, i32 poison, i32 7, i32 poison>

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
@@ -29,10 +29,8 @@ define <4 x i8> @interleave_v2i8(<2 x i8> %x, <2 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <2 x i8> %x, <2 x i8> %y, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
@@ -58,10 +56,8 @@ define <4 x i16> @interleave_v2i16(<2 x i16> %x, <2 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <2 x i16> %x, <2 x i16> %y, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
@@ -88,11 +84,10 @@ define <4 x i32> @interleave_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v9, v8
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v8
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v10, v11
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <2 x i32> %x, <2 x i32> %y, <4 x i32> <i32 2, i32 0, i32 3, i32 1>
   ret <4 x i32> %a
@@ -178,10 +173,8 @@ define <8 x i8> @interleave_v4i8(<4 x i8> %x, <4 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v9, v8
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v8
+; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v9, v8
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i8> %x, <4 x i8> %y, <8 x i32> <i32 4, i32 0, i32 5, i32 1, i32 6, i32 2, i32 7, i32 3>
@@ -217,11 +210,10 @@ define <8 x i16> @interleave_v4i16(<4 x i16> %x, <4 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i16> %x, <4 x i16> %y, <8 x i32> <i32 0, i32 4, i32 poison, i32 5, i32 2, i32 poison, i32 3, i32 7>
   ret <8 x i16> %a
@@ -257,12 +249,10 @@ define <8 x i32> @interleave_v4i32(<4 x i32> %x, <4 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v4i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
   ret <8 x i32> %a
@@ -303,12 +293,10 @@ define <4 x i32> @interleave_v4i32_offset_2(<4 x i32> %x, <4 x i32> %y) {
 ; ZVZIP-LABEL: interleave_v4i32_offset_2:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v10, v9, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v10
-; ZVZIP-NEXT:    vmv1r.v v8, v9
+; ZVZIP-NEXT:    vmv1r.v v10, v8
+; ZVZIP-NEXT:    vslidedown.vi v11, v9, 2
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v8, v10, v11
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <4 x i32> <i32 0, i32 6, i32 1, i32 7>
   ret <4 x i32> %a
@@ -357,13 +345,11 @@ define <4 x i32> @interleave_v4i32_offset_1(<4 x i32> %x, <4 x i32> %y) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
 ; ZVZIP-NEXT:    vmv.v.i v0, 8
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vslideup.vi v10, v9, 1, v0.t
+; ZVZIP-NEXT:    vmv1r.v v12, v9
+; ZVZIP-NEXT:    vslideup.vi v12, v9, 1, v0.t
 ; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; ZVZIP-NEXT:    vzext.vf2 v9, v8
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmerge.vvm v8, v9, v10, v0
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmerge.vvm v8, v10, v12, v0
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> %y, <4 x i32> <i32 0, i32 5, i32 1, i32 6>
   ret <4 x i32> %a
@@ -397,11 +383,10 @@ define <16 x i8> @interleave_v8i8(<8 x i8> %x, <8 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i8> %x, <8 x i8> %y, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
   ret <16 x i8> %a
@@ -438,12 +423,10 @@ define <16 x i16> @interleave_v8i16(<8 x i16> %x, <8 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v10, v11
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v11
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i16> %x, <8 x i16> %y, <16 x i32> <i32 8, i32 0, i32 9, i32 1, i32 10, i32 2, i32 11, i32 3, i32 12, i32 4, i32 13, i32 5, i32 14, i32 6, i32 15, i32 7>
   ret <16 x i16> %a
@@ -479,12 +462,10 @@ define <16 x i32> @interleave_v8i32(<8 x i32> %x, <8 x i32> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v8i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v12, v10
-; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v20, v10
+; ZVZIP-NEXT:    vmv2r.v v16, v8
+; ZVZIP-NEXT:    vzip.vv v8, v16, v20
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i32> %x, <8 x i32> %y, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
   ret <16 x i32> %a
@@ -521,12 +502,11 @@ define <32 x i8> @interleave_v16i8(<16 x i8> %x, <16 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v16i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <16 x i8> %x, <16 x i8> %y, <32 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23, i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
   ret <32 x i8> %a
@@ -563,12 +543,11 @@ define <32 x i16> @interleave_v16i16(<16 x i16> %x, <16 x i16> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v16i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v12, v10
-; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vsetvli zero, a0, e16, m4, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v20, v10
+; ZVZIP-NEXT:    vmv2r.v v16, v8
+; ZVZIP-NEXT:    vzip.vv v8, v16, v20
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <16 x i16> %x, <16 x i16> %y, <32 x i32> <i32 0, i32 16, i32 1, i32 17, i32 2, i32 18, i32 3, i32 19, i32 4, i32 20, i32 5, i32 21, i32 6, i32 22, i32 7, i32 23, i32 8, i32 24, i32 9, i32 25, i32 10, i32 26, i32 11, i32 27, i32 12, i32 28, i32 13, i32 29, i32 14, i32 30, i32 15, i32 31>
   ret <32 x i16> %a
@@ -650,13 +629,11 @@ define <64 x i8> @interleave_v32i8(<32 x i8> %x, <32 x i8> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v32i8:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v12, v10
-; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    li a0, 64
+; ZVZIP-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v20, v10
+; ZVZIP-NEXT:    vmv2r.v v16, v8
+; ZVZIP-NEXT:    vzip.vv v8, v16, v20
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <32 x i8> %x, <32 x i8> %y, <64 x i32> <i32 0, i32 32, i32 1, i32 33, i32 2, i32 34, i32 3, i32 35, i32 4, i32 36, i32 5, i32 37, i32 6, i32 38, i32 7, i32 39, i32 8, i32 40, i32 9, i32 41, i32 10, i32 42, i32 11, i32 43, i32 12, i32 44, i32 13, i32 45, i32 14, i32 46, i32 15, i32 47, i32 16, i32 48, i32 17, i32 49, i32 18, i32 50, i32 19, i32 51, i32 20, i32 52, i32 21, i32 53, i32 22, i32 54, i32 23, i32 55, i32 24, i32 56, i32 25, i32 57, i32 26, i32 58, i32 27, i32 59, i32 28, i32 60, i32 29, i32 61, i32 30, i32 62, i32 31, i32 63>
   ret <64 x i8> %a
@@ -921,10 +898,8 @@ define <4 x i8> @unary_interleave_v4i8(<4 x i8> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf4, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i8> %x, <4 x i8> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
@@ -1015,10 +990,8 @@ define <4 x i16> @unary_interleave_v4i16(<4 x i16> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i16> %x, <4 x i16> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
@@ -1059,12 +1032,10 @@ define <4 x i32> @unary_interleave_v4i32(<4 x i32> %x) {
 ; ZVZIP-LABEL: unary_interleave_v4i32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v10, v8, 2
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v10
-; ZVZIP-NEXT:    vmv1r.v v8, v9
+; ZVZIP-NEXT:    vmv1r.v v10, v8
+; ZVZIP-NEXT:    vslidedown.vi v11, v8, 2
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v8, v10, v11
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i32> %x, <4 x i32> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
   ret <4 x i32> %a
@@ -1169,10 +1140,8 @@ define <8 x i8> @unary_interleave_v8i8(<8 x i8> %x) {
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf2, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v10, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v9, v8, v10
 ; ZVZIP-NEXT:    vmv1r.v v8, v9
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i8> %x, <8 x i8> poison, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 poison, i32 6, i32 3, i32 7>
@@ -1213,12 +1182,10 @@ define <8 x i16> @unary_interleave_v8i16(<8 x i16> %x) {
 ; ZVZIP-LABEL: unary_interleave_v8i16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e16, m1, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v10, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v9, v10, v8
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v9, a0, v8
-; ZVZIP-NEXT:    vmv1r.v v8, v9
+; ZVZIP-NEXT:    vmv1r.v v10, v8
+; ZVZIP-NEXT:    vslidedown.vi v11, v8, 4
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i16> %x, <8 x i16> poison, <8 x i32> <i32 4, i32 poison, i32 5, i32 1, i32 6, i32 2, i32 7, i32 3>
   ret <8 x i16> %a
@@ -1258,12 +1225,10 @@ define <8 x i32> @unary_interleave_v8i32(<8 x i32> %x) {
 ; ZVZIP-LABEL: unary_interleave_v8i32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v12, v8, 4
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v12
-; ZVZIP-NEXT:    vmv2r.v v8, v10
+; ZVZIP-NEXT:    vmv2r.v v12, v8
+; ZVZIP-NEXT:    vslidedown.vi v14, v8, 4
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <8 x i32> %x, <8 x i32> poison, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
   ret <8 x i32> %a
@@ -1329,12 +1294,10 @@ define <16 x i16> @interleave_slp(<8 x i16> %v0, <8 x i16> %v1) {
 ;
 ; ZVZIP-LABEL: interleave_slp:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 entry:
   %v2 = shufflevector <8 x i16> %v0, <8 x i16> poison, <16 x i32> <i32 0, i32 poison, i32 1, i32 poison, i32 2, i32 poison, i32 3, i32 poison, i32 4, i32 poison, i32 5, i32 poison, i32 6, i32 poison, i32 7, i32 poison>

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
@@ -4119,13 +4119,11 @@ define { <8 x float>, <8 x float> } @interleave_deinterleave2(<8 x float> %a, <8
 ;
 ; ZVZIP-LABEL: interleave_deinterleave2:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vmv2r.v v12, v10
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vzip.vv v16, v8, v12
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vnsrl.wx v10, v16, a0
-; ZVZIP-NEXT:    vnsrl.wi v8, v16, 0
+; ZVZIP-NEXT:    vzip.vv v12, v8, v10
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vnsrl.wx v10, v12, a0
+; ZVZIP-NEXT:    vnsrl.wi v8, v12, 0
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = call <16 x float> @llvm.vector.interleave2.v16f32(<8 x float> %a, <8 x float> %b)
@@ -4157,12 +4155,11 @@ define <16 x float> @deinterleave_interleave2(<16 x float> %arg) {
 ;
 ; ZVZIP-LABEL: deinterleave_interleave2:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vnsrl.wi v16, v8, 0
 ; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vnsrl.wx v20, v8, a0
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v16, v20
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vnsrl.wx v12, v8, a0
+; ZVZIP-NEXT:    vnsrl.wi v14, v8, 0
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = call { <8 x float>, <8 x float> } @llvm.vector.deinterleave2.v16f32(<16 x float> %arg)

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
@@ -4119,13 +4119,13 @@ define { <8 x float>, <8 x float> } @interleave_deinterleave2(<8 x float> %a, <8
 ;
 ; ZVZIP-LABEL: interleave_deinterleave2:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v12, v8, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v12, a0, v10
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vnsrl.wx v10, v12, a0
-; ZVZIP-NEXT:    vnsrl.wi v8, v12, 0
+; ZVZIP-NEXT:    vzip.vv v16, v8, v12
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vnsrl.wx v10, v16, a0
+; ZVZIP-NEXT:    vnsrl.wi v8, v16, 0
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = call <16 x float> @llvm.vector.interleave2.v16f32(<8 x float> %a, <8 x float> %b)
@@ -4157,13 +4157,12 @@ define <16 x float> @deinterleave_interleave2(<16 x float> %arg) {
 ;
 ; ZVZIP-LABEL: deinterleave_interleave2:
 ; ZVZIP:       # %bb.0: # %entry
-; ZVZIP-NEXT:    li a0, 32
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vnsrl.wi v12, v8, 0
-; ZVZIP-NEXT:    vnsrl.wx v14, v8, a0
-; ZVZIP-NEXT:    vwaddu.vv v8, v12, v14
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v14
+; ZVZIP-NEXT:    vnsrl.wi v16, v8, 0
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vnsrl.wx v20, v8, a0
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v8, v16, v20
 ; ZVZIP-NEXT:    ret
 entry:
   %0 = call { <8 x float>, <8 x float> } @llvm.vector.deinterleave2.v16f32(<16 x float> %arg)

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
@@ -68,12 +68,13 @@ define <32 x i1> @vector_interleave_v32i1_v16i1(<16 x i1> %a, <16 x i1> %b) {
 ; ZVZIP-NEXT:    vslideup.vi v0, v8, 2
 ; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
 ; ZVZIP-NEXT:    vmv.v.i v8, 0
-; ZVZIP-NEXT:    vmerge.vim v12, v8, 1, v0
+; ZVZIP-NEXT:    vmerge.vim v8, v8, 1, v0
 ; ZVZIP-NEXT:    vsetivli zero, 16, e8, m2, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v14, v12, 16
+; ZVZIP-NEXT:    vslidedown.vi v10, v8, 16
+; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v12, v8, v10
 ; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
-; ZVZIP-NEXT:    vmsne.vi v0, v8, 0
+; ZVZIP-NEXT:    vmsne.vi v0, v12, 0
 ; ZVZIP-NEXT:    ret
 	   %res = call <32 x i1> @llvm.vector.interleave2.v32i1(<16 x i1> %a, <16 x i1> %b)
 	   ret <32 x i1> %res
@@ -109,10 +110,10 @@ define <16 x i16> @vector_interleave_v16i16_v8i16(<8 x i16> %a, <8 x i16> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v16i16_v8i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x i16> @llvm.vector.interleave2.v16i16(<8 x i16> %a, <8 x i16> %b)
 	   ret <16 x i16> %res
@@ -149,10 +150,10 @@ define <8 x i32> @vector_interleave_v8i32_v4i32(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v8i32_v4i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x i32> @llvm.vector.interleave2.v8i32(<4 x i32> %a, <4 x i32> %b)
 	   ret <8 x i32> %res
@@ -1080,7 +1081,7 @@ define <4 x half> @vector_interleave_v4f16_v2f16(<2 x half> %a, <2 x half> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v4f16_v2f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
@@ -1115,7 +1116,7 @@ define <4 x bfloat> @vector_interleave_v4bf16_v2bf16(<2 x bfloat> %a, <2 x bfloa
 ;
 ; ZVZIP-LABEL: vector_interleave_v4bf16_v2bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
@@ -1150,10 +1151,9 @@ define <8 x half> @vector_interleave_v8f16_v4f16(<4 x half> %a, <4 x half> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v8f16_v4f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x half> @llvm.vector.interleave2.v8f16(<4 x half> %a, <4 x half> %b)
 	   ret <8 x half> %res
@@ -1186,10 +1186,9 @@ define <8 x bfloat> @vector_interleave_v8bf16_v4bf16(<4 x bfloat> %a, <4 x bfloa
 ;
 ; ZVZIP-LABEL: vector_interleave_v8bf16_v4bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x bfloat> @llvm.vector.interleave2.v8bf16(<4 x bfloat> %a, <4 x bfloat> %b)
 	   ret <8 x bfloat> %res
@@ -1223,10 +1222,9 @@ define <4 x float> @vector_interleave_v4f32_v2f32(<2 x float> %a, <2 x float> %b
 ;
 ; ZVZIP-LABEL: vector_interleave_v4f32_v2f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vzip.vv v8, v11, v10
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
+; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x float> @llvm.vector.interleave2.v4f32(<2 x float> %a, <2 x float> %b)
 	   ret <4 x float> %res
@@ -1262,10 +1260,10 @@ define <16 x half> @vector_interleave_v16f16_v8f16(<8 x half> %a, <8 x half> %b)
 ;
 ; ZVZIP-LABEL: vector_interleave_v16f16_v8f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x half> @llvm.vector.interleave2.v16f16(<8 x half> %a, <8 x half> %b)
 	   ret <16 x half> %res
@@ -1301,10 +1299,10 @@ define <16 x bfloat> @vector_interleave_v16bf16_v8bf16(<8 x bfloat> %a, <8 x bfl
 ;
 ; ZVZIP-LABEL: vector_interleave_v16bf16_v8bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x bfloat> @llvm.vector.interleave2.v16bf16(<8 x bfloat> %a, <8 x bfloat> %b)
 	   ret <16 x bfloat> %res
@@ -1341,10 +1339,10 @@ define <8 x float> @vector_interleave_v8f32_v4f32(<4 x float> %a, <4 x float> %b
 ;
 ; ZVZIP-LABEL: vector_interleave_v8f32_v4f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v14, v9
-; ZVZIP-NEXT:    vmv1r.v v12, v8
-; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x float> @llvm.vector.interleave2.v8f32(<4 x float> %a, <4 x float> %b)
 	   ret <8 x float> %res

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
@@ -68,14 +68,12 @@ define <32 x i1> @vector_interleave_v32i1_v16i1(<16 x i1> %a, <16 x i1> %b) {
 ; ZVZIP-NEXT:    vslideup.vi v0, v8, 2
 ; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
 ; ZVZIP-NEXT:    vmv.v.i v8, 0
-; ZVZIP-NEXT:    vmerge.vim v8, v8, 1, v0
+; ZVZIP-NEXT:    vmerge.vim v12, v8, 1, v0
 ; ZVZIP-NEXT:    vsetivli zero, 16, e8, m2, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v10, v8, 16
-; ZVZIP-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; ZVZIP-NEXT:    vwsll.vi v12, v10, 8
-; ZVZIP-NEXT:    vwaddu.wv v12, v12, v8
+; ZVZIP-NEXT:    vslidedown.vi v14, v12, 16
 ; ZVZIP-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; ZVZIP-NEXT:    vmsne.vi v0, v12, 0
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
+; ZVZIP-NEXT:    vmsne.vi v0, v8, 0
 ; ZVZIP-NEXT:    ret
 	   %res = call <32 x i1> @llvm.vector.interleave2.v32i1(<16 x i1> %a, <16 x i1> %b)
 	   ret <32 x i1> %res
@@ -111,11 +109,10 @@ define <16 x i16> @vector_interleave_v16i16_v8i16(<8 x i16> %a, <8 x i16> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v16i16_v8i16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwsll.vi v8, v10, 16
-; ZVZIP-NEXT:    vwaddu.wv v8, v8, v11
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x i16> @llvm.vector.interleave2.v16i16(<8 x i16> %a, <8 x i16> %b)
 	   ret <16 x i16> %res
@@ -152,12 +149,10 @@ define <8 x i32> @vector_interleave_v8i32_v4i32(<4 x i32> %a, <4 x i32> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v8i32_v4i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vwsll.vx v8, v10, a0
-; ZVZIP-NEXT:    vwaddu.wv v8, v8, v11
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x i32> @llvm.vector.interleave2.v8i32(<4 x i32> %a, <4 x i32> %b)
 	   ret <8 x i32> %res
@@ -1085,9 +1080,8 @@ define <4 x half> @vector_interleave_v4f16_v2f16(<2 x half> %a, <2 x half> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v4f16_v2f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vwsll.vi v10, v9, 16
-; ZVZIP-NEXT:    vwaddu.wv v10, v10, v8
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x half> @llvm.vector.interleave2.v4f16(<2 x half> %a, <2 x half> %b)
@@ -1121,9 +1115,8 @@ define <4 x bfloat> @vector_interleave_v4bf16_v2bf16(<2 x bfloat> %a, <2 x bfloa
 ;
 ; ZVZIP-LABEL: vector_interleave_v4bf16_v2bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; ZVZIP-NEXT:    vwsll.vi v10, v9, 16
-; ZVZIP-NEXT:    vwaddu.wv v10, v10, v8
+; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    vmv1r.v v8, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x bfloat> @llvm.vector.interleave2.v4bf16(<2 x bfloat> %a, <2 x bfloat> %b)
@@ -1157,10 +1150,10 @@ define <8 x half> @vector_interleave_v8f16_v4f16(<4 x half> %a, <4 x half> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v8f16_v4f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwsll.vi v10, v9, 16
-; ZVZIP-NEXT:    vwaddu.wv v10, v10, v8
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x half> @llvm.vector.interleave2.v8f16(<4 x half> %a, <4 x half> %b)
 	   ret <8 x half> %res
@@ -1193,10 +1186,10 @@ define <8 x bfloat> @vector_interleave_v8bf16_v4bf16(<4 x bfloat> %a, <4 x bfloa
 ;
 ; ZVZIP-LABEL: vector_interleave_v8bf16_v4bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwsll.vi v10, v9, 16
-; ZVZIP-NEXT:    vwaddu.wv v10, v10, v8
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x bfloat> @llvm.vector.interleave2.v8bf16(<4 x bfloat> %a, <4 x bfloat> %b)
 	   ret <8 x bfloat> %res
@@ -1230,11 +1223,10 @@ define <4 x float> @vector_interleave_v4f32_v2f32(<2 x float> %a, <2 x float> %b
 ;
 ; ZVZIP-LABEL: vector_interleave_v4f32_v2f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vwsll.vx v10, v9, a0
-; ZVZIP-NEXT:    vwaddu.wv v10, v10, v8
-; ZVZIP-NEXT:    vmv1r.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v10, v9
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x float> @llvm.vector.interleave2.v4f32(<2 x float> %a, <2 x float> %b)
 	   ret <4 x float> %res
@@ -1270,11 +1262,10 @@ define <16 x half> @vector_interleave_v16f16_v8f16(<8 x half> %a, <8 x half> %b)
 ;
 ; ZVZIP-LABEL: vector_interleave_v16f16_v8f16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwsll.vi v8, v10, 16
-; ZVZIP-NEXT:    vwaddu.wv v8, v8, v11
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x half> @llvm.vector.interleave2.v16f16(<8 x half> %a, <8 x half> %b)
 	   ret <16 x half> %res
@@ -1310,11 +1301,10 @@ define <16 x bfloat> @vector_interleave_v16bf16_v8bf16(<8 x bfloat> %a, <8 x bfl
 ;
 ; ZVZIP-LABEL: vector_interleave_v16bf16_v8bf16:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwsll.vi v8, v10, 16
-; ZVZIP-NEXT:    vwaddu.wv v8, v8, v11
+; ZVZIP-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 	   %res = call <16 x bfloat> @llvm.vector.interleave2.v16bf16(<8 x bfloat> %a, <8 x bfloat> %b)
 	   ret <16 x bfloat> %res
@@ -1351,12 +1341,10 @@ define <8 x float> @vector_interleave_v8f32_v4f32(<4 x float> %a, <4 x float> %b
 ;
 ; ZVZIP-LABEL: vector_interleave_v8f32_v4f32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vwsll.vx v8, v10, a0
-; ZVZIP-NEXT:    vwaddu.wv v8, v8, v11
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v14, v9
+; ZVZIP-NEXT:    vmv1r.v v12, v8
+; ZVZIP-NEXT:    vzip.vv v8, v12, v14
 ; ZVZIP-NEXT:    ret
 	   %res = call <8 x float> @llvm.vector.interleave2.v8f32(<4 x float> %a, <4 x float> %b)
 	   ret <8 x float> %res

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave.ll
@@ -75,13 +75,11 @@ define <vscale x 32 x i1> @vector_interleave_nxv32i1_nxv16i1(<vscale x 16 x i1> 
 ; ZVZIP-NEXT:    vmv1r.v v9, v0
 ; ZVZIP-NEXT:    vmv1r.v v0, v8
 ; ZVZIP-NEXT:    vmv.v.i v10, 0
-; ZVZIP-NEXT:    li a0, -1
+; ZVZIP-NEXT:    csrr a0, vlenb
 ; ZVZIP-NEXT:    vmerge.vim v12, v10, 1, v0
 ; ZVZIP-NEXT:    vmv1r.v v0, v9
 ; ZVZIP-NEXT:    vmerge.vim v14, v10, 1, v0
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
-; ZVZIP-NEXT:    csrr a0, vlenb
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    vmsne.vi v12, v10, 0
 ; ZVZIP-NEXT:    vmsne.vi v0, v8, 0
 ; ZVZIP-NEXT:    srli a0, a0, 2
@@ -126,9 +124,7 @@ define <vscale x 32 x i8> @vector_interleave_nxv32i8_nxv16i8(<vscale x 16 x i8> 
 ; ZVZIP-NEXT:    vsetvli a0, zero, e8, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 32 x i8> @llvm.vector.interleave2.nxv32i8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b)
   ret <vscale x 32 x i8> %res
@@ -168,9 +164,7 @@ define <vscale x 16 x i16> @vector_interleave_nxv16i16_nxv8i16(<vscale x 8 x i16
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 16 x i16> @llvm.vector.interleave2.nxv16i16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b)
   ret <vscale x 16 x i16> %res
@@ -211,9 +205,7 @@ define <vscale x 8 x i32> @vector_interleave_nxv8i32_nxv4i32(<vscale x 4 x i32> 
 ; ZVZIP-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 8 x i32> @llvm.vector.interleave2.nxv8i32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b)
   ret <vscale x 8 x i32> %res
@@ -261,17 +253,10 @@ define <vscale x 4 x i64> @vector_interleave_nxv4i64_nxv2i64(<vscale x 2 x i64> 
 ;
 ; ZVZIP-LABEL: vector_interleave_nxv4i64_nxv2i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, mu
-; ZVZIP-NEXT:    vid.v v12
-; ZVZIP-NEXT:    srli a0, a0, 2
-; ZVZIP-NEXT:    vand.vi v13, v12, 1
-; ZVZIP-NEXT:    vmsne.vi v0, v13, 0
-; ZVZIP-NEXT:    vsrl.vi v16, v12, 1
-; ZVZIP-NEXT:    vadd.vx v16, v16, a0, v0.t
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m4, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v12, v8, v16
-; ZVZIP-NEXT:    vmv.v.v v8, v12
+; ZVZIP-NEXT:    vsetvli a0, zero, e64, m2, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
+; ZVZIP-NEXT:    vmv2r.v v14, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 4 x i64> @llvm.vector.interleave2.nxv4i64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b)
   ret <vscale x 4 x i64> %res
@@ -344,19 +329,16 @@ define <vscale x 128 x i1> @vector_interleave_nxv128i1_nxv64i1(<vscale x 64 x i1
 ; ZVZIP-NEXT:    vmv1r.v v9, v0
 ; ZVZIP-NEXT:    vmv1r.v v0, v8
 ; ZVZIP-NEXT:    vmv.v.i v24, 0
-; ZVZIP-NEXT:    li a0, -1
 ; ZVZIP-NEXT:    vmerge.vim v16, v24, 1, v0
 ; ZVZIP-NEXT:    vmv1r.v v0, v9
-; ZVZIP-NEXT:    vmerge.vim v24, v24, 1, v0
-; ZVZIP-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vmerge.vim v8, v24, 1, v0
+; ZVZIP-NEXT:    vsetvli a0, zero, e8, m4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v0, v8, v16
+; ZVZIP-NEXT:    vzip.vv v24, v12, v20
 ; ZVZIP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
-; ZVZIP-NEXT:    vmsne.vi v16, v8, 0
-; ZVZIP-NEXT:    vmsne.vi v8, v0, 0
-; ZVZIP-NEXT:    vmv1r.v v0, v16
+; ZVZIP-NEXT:    vmsne.vi v9, v0, 0
+; ZVZIP-NEXT:    vmsne.vi v8, v24, 0
+; ZVZIP-NEXT:    vmv1r.v v0, v9
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 128 x i1> @llvm.vector.interleave2.nxv128i1(<vscale x 64 x i1> %a, <vscale x 64 x i1> %b)
   ret <vscale x 128 x i1> %res
@@ -400,12 +382,9 @@ define <vscale x 128 x i8> @vector_interleave_nxv128i8_nxv64i8(<vscale x 64 x i8
 ; ZVZIP-LABEL: vector_interleave_nxv128i8_nxv64i8:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e8, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 128 x i8> @llvm.vector.interleave2.nxv128i8(<vscale x 64 x i8> %a, <vscale x 64 x i8> %b)
@@ -450,12 +429,9 @@ define <vscale x 64 x i16> @vector_interleave_nxv64i16_nxv32i16(<vscale x 32 x i
 ; ZVZIP-LABEL: vector_interleave_nxv64i16_nxv32i16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 64 x i16> @llvm.vector.interleave2.nxv64i16(<vscale x 32 x i16> %a, <vscale x 32 x i16> %b)
@@ -501,12 +477,9 @@ define <vscale x 32 x i32> @vector_interleave_nxv32i32_nxv16i32(<vscale x 16 x i
 ; ZVZIP-LABEL: vector_interleave_nxv32i32_nxv16i32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 32 x i32> @llvm.vector.interleave2.nxv32i32(<vscale x 16 x i32> %a, <vscale x 16 x i32> %b)
@@ -565,21 +538,11 @@ define <vscale x 16 x i64> @vector_interleave_nxv16i64_nxv8i64(<vscale x 8 x i64
 ;
 ; ZVZIP-LABEL: vector_interleave_nxv16i64_nxv8i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, m2, ta, mu
-; ZVZIP-NEXT:    vid.v v6
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    srli a0, a0, 1
-; ZVZIP-NEXT:    vmv4r.v v28, v16
-; ZVZIP-NEXT:    vmv4r.v v16, v12
-; ZVZIP-NEXT:    vand.vi v8, v6, 1
-; ZVZIP-NEXT:    vmsne.vi v0, v8, 0
-; ZVZIP-NEXT:    vsrl.vi v6, v6, 1
-; ZVZIP-NEXT:    vadd.vx v6, v6, a0, v0.t
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v8, v24, v6
-; ZVZIP-NEXT:    vrgatherei16.vv v24, v16, v6
-; ZVZIP-NEXT:    vmv.v.v v16, v24
+; ZVZIP-NEXT:    vsetvli a0, zero, e64, m4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
+; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 16 x i64> @llvm.vector.interleave2.nxv16i64(<vscale x 8 x i64> %a, <vscale x 8 x i64> %b)
   ret <vscale x 16 x i64> %res
@@ -7167,9 +7130,7 @@ define <vscale x 4 x bfloat> @vector_interleave_nxv4bf16_nxv2bf16(<vscale x 2 x 
 ; ZVZIP-LABEL: vector_interleave_nxv4bf16_nxv2bf16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    csrr a0, vlenb
 ; ZVZIP-NEXT:    srli a0, a0, 2
 ; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
@@ -7215,9 +7176,7 @@ define <vscale x 8 x bfloat> @vector_interleave_nxv8bf16_nxv4bf16(<vscale x 4 x 
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
 ; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 8 x bfloat> @llvm.vector.interleave2.nxv8bf16(<vscale x 4 x bfloat> %a, <vscale x 4 x bfloat> %b)
   ret <vscale x 8 x bfloat> %res
@@ -7266,9 +7225,7 @@ define <vscale x 4 x half> @vector_interleave_nxv4f16_nxv2f16(<vscale x 2 x half
 ; ZVZIP-LABEL: vector_interleave_nxv4f16_nxv2f16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vwaddu.vv v10, v8, v9
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v10, a0, v9
+; ZVZIP-NEXT:    vzip.vv v10, v8, v9
 ; ZVZIP-NEXT:    csrr a0, vlenb
 ; ZVZIP-NEXT:    srli a0, a0, 2
 ; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
@@ -7314,9 +7271,7 @@ define <vscale x 8 x half> @vector_interleave_nxv8f16_nxv4f16(<vscale x 4 x half
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
 ; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 8 x half> @llvm.vector.interleave2.nxv8f16(<vscale x 4 x half> %a, <vscale x 4 x half> %b)
   ret <vscale x 8 x half> %res
@@ -7357,9 +7312,7 @@ define <vscale x 4 x float> @vector_interleave_nxv4f32_nxv2f32(<vscale x 2 x flo
 ; ZVZIP-NEXT:    vsetvli a0, zero, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
 ; ZVZIP-NEXT:    vmv1r.v v11, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v11, v10
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 4 x float> @llvm.vector.interleave2.nxv4f32(<vscale x 2 x float> %a, <vscale x 2 x float> %b)
   ret <vscale x 4 x float> %res
@@ -7399,9 +7352,7 @@ define <vscale x 16 x bfloat> @vector_interleave_nxv16bf16_nxv8bf16(<vscale x 8 
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 16 x bfloat> @llvm.vector.interleave2.nxv16bf16(<vscale x 8 x bfloat> %a, <vscale x 8 x bfloat> %b)
   ret <vscale x 16 x bfloat> %res
@@ -7441,9 +7392,7 @@ define <vscale x 16 x half> @vector_interleave_nxv16f16_nxv8f16(<vscale x 8 x ha
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 16 x half> @llvm.vector.interleave2.nxv16f16(<vscale x 8 x half> %a, <vscale x 8 x half> %b)
   ret <vscale x 16 x half> %res
@@ -7484,9 +7433,7 @@ define <vscale x 8 x float> @vector_interleave_nxv8f32_nxv4f32(<vscale x 4 x flo
 ; ZVZIP-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vmv2r.v v12, v10
 ; ZVZIP-NEXT:    vmv2r.v v14, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v14, v12
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v12
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 8 x float> @llvm.vector.interleave2.nxv8f32(<vscale x 4 x float> %a, <vscale x 4 x float> %b)
   ret <vscale x 8 x float> %res
@@ -7534,17 +7481,10 @@ define <vscale x 4 x double> @vector_interleave_nxv4f64_nxv2f64(<vscale x 2 x do
 ;
 ; ZVZIP-LABEL: vector_interleave_nxv4f64_nxv2f64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, mu
-; ZVZIP-NEXT:    vid.v v12
-; ZVZIP-NEXT:    srli a0, a0, 2
-; ZVZIP-NEXT:    vand.vi v13, v12, 1
-; ZVZIP-NEXT:    vmsne.vi v0, v13, 0
-; ZVZIP-NEXT:    vsrl.vi v16, v12, 1
-; ZVZIP-NEXT:    vadd.vx v16, v16, a0, v0.t
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m4, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v12, v8, v16
-; ZVZIP-NEXT:    vmv.v.v v8, v12
+; ZVZIP-NEXT:    vsetvli a0, zero, e64, m2, ta, ma
+; ZVZIP-NEXT:    vmv2r.v v12, v10
+; ZVZIP-NEXT:    vmv2r.v v14, v8
+; ZVZIP-NEXT:    vzip.vv v8, v14, v12
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 4 x double> @llvm.vector.interleave2.nxv4f64(<vscale x 2 x double> %a, <vscale x 2 x double> %b)
   ret <vscale x 4 x double> %res
@@ -7590,12 +7530,9 @@ define <vscale x 64 x bfloat> @vector_interleave_nxv64bf16_nxv32bf16(<vscale x 3
 ; ZVZIP-LABEL: vector_interleave_nxv64bf16_nxv32bf16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 64 x bfloat> @llvm.vector.interleave2.nxv64bf16(<vscale x 32 x bfloat> %a, <vscale x 32 x bfloat> %b)
@@ -7640,12 +7577,9 @@ define <vscale x 64 x half> @vector_interleave_nxv64f16_nxv32f16(<vscale x 32 x 
 ; ZVZIP-LABEL: vector_interleave_nxv64f16_nxv32f16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 64 x half> @llvm.vector.interleave2.nxv64f16(<vscale x 32 x half> %a, <vscale x 32 x half> %b)
@@ -7691,12 +7625,9 @@ define <vscale x 32 x float> @vector_interleave_nxv32f32_nxv16f32(<vscale x 16 x
 ; ZVZIP-LABEL: vector_interleave_nxv32f32_nxv16f32:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    vwaddu.vv v8, v24, v16
-; ZVZIP-NEXT:    li a0, -1
-; ZVZIP-NEXT:    vwaddu.vv v0, v28, v20
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v16
-; ZVZIP-NEXT:    vwmaccu.vx v0, a0, v20
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
 ; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 32 x float> @llvm.vector.interleave2.nxv32f32(<vscale x 16 x float> %a, <vscale x 16 x float> %b)
@@ -7755,21 +7686,11 @@ define <vscale x 16 x double> @vector_interleave_nxv16f64_nxv8f64(<vscale x 8 x 
 ;
 ; ZVZIP-LABEL: vector_interleave_nxv16f64_nxv8f64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    vsetvli a1, zero, e16, m2, ta, mu
-; ZVZIP-NEXT:    vid.v v6
-; ZVZIP-NEXT:    vmv8r.v v24, v8
-; ZVZIP-NEXT:    srli a0, a0, 1
-; ZVZIP-NEXT:    vmv4r.v v28, v16
-; ZVZIP-NEXT:    vmv4r.v v16, v12
-; ZVZIP-NEXT:    vand.vi v8, v6, 1
-; ZVZIP-NEXT:    vmsne.vi v0, v8, 0
-; ZVZIP-NEXT:    vsrl.vi v6, v6, 1
-; ZVZIP-NEXT:    vadd.vx v6, v6, a0, v0.t
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m8, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v8, v24, v6
-; ZVZIP-NEXT:    vrgatherei16.vv v24, v16, v6
-; ZVZIP-NEXT:    vmv.v.v v16, v24
+; ZVZIP-NEXT:    vsetvli a0, zero, e64, m4, ta, ma
+; ZVZIP-NEXT:    vzip.vv v24, v8, v16
+; ZVZIP-NEXT:    vzip.vv v0, v12, v20
+; ZVZIP-NEXT:    vmv8r.v v8, v24
+; ZVZIP-NEXT:    vmv8r.v v16, v0
 ; ZVZIP-NEXT:    ret
   %res = call <vscale x 16 x double> @llvm.vector.interleave2.nxv16f64(<vscale x 8 x double> %a, <vscale x 8 x double> %b)
   ret <vscale x 16 x double> %res
@@ -16891,12 +16812,10 @@ define <vscale x 4 x i16> @interleave2_diff_const_splat_nxv4i16() {
 ; ZVZIP-LABEL: interleave2_diff_const_splat_nxv4i16:
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vmv.v.i v9, 3
-; ZVZIP-NEXT:    li a0, 4
-; ZVZIP-NEXT:    vmv.v.i v10, -1
-; ZVZIP-NEXT:    vwaddu.vx v8, v9, a0
-; ZVZIP-NEXT:    vwmaccu.vx v8, a0, v10
+; ZVZIP-NEXT:    vmv.v.i v9, 4
+; ZVZIP-NEXT:    vmv.v.i v10, 3
 ; ZVZIP-NEXT:    csrr a0, vlenb
+; ZVZIP-NEXT:    vzip.vv v8, v10, v9
 ; ZVZIP-NEXT:    srli a0, a0, 2
 ; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vx v9, v8, a0
@@ -16969,10 +16888,9 @@ define <vscale x 4 x i16> @interleave2_diff_nonconst_splat_nxv4i16(i16 %a, i16 %
 ; ZVZIP:       # %bb.0:
 ; ZVZIP-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
 ; ZVZIP-NEXT:    vmv.v.x v9, a0
-; ZVZIP-NEXT:    vmv.v.i v10, -1
+; ZVZIP-NEXT:    vmv.v.x v10, a1
 ; ZVZIP-NEXT:    csrr a0, vlenb
-; ZVZIP-NEXT:    vwaddu.vx v8, v9, a1
-; ZVZIP-NEXT:    vwmaccu.vx v8, a1, v10
+; ZVZIP-NEXT:    vzip.vv v8, v9, v10
 ; ZVZIP-NEXT:    srli a0, a0, 2
 ; ZVZIP-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vx v9, v8, a0


### PR DESCRIPTION
Add initial support for vzip instruction, which is included in zvzip extension. It is used to lower VECTOR_SHUFFLE with interleave pattern and VECTOR_INTERLEAVE.