### PR TITLE
[MachineVerifier] physical register should not be a live-in for non e…

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -893,6 +893,12 @@ MachineVerifier::visitMachineBasicBlockBefore(const MachineBasicBlock *MBB) {
   regsLive.clear();
   if (MRI->tracksLiveness()) {
     for (const auto &LI : MBB->liveins()) {
+      if (MRI->isSSA() && LI.PhysReg.isPhysical() && !MBB->isEntryBlock() &&
+          !MBB->isEHPad()) {
+        report("Physical registers should not be a live-in during SSA form",
+               MBB);
+        continue;
+      }
       if (!LI.PhysReg.isPhysical()) {
         report("MBB live-in list contains non-physical register", MBB);
         continue;

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -897,8 +897,7 @@ MachineVerifier::visitMachineBasicBlockBefore(const MachineBasicBlock *MBB) {
         report("MBB live-in list contains non-physical register", MBB);
         continue;
       }
-      if (MRI->isSSA() && LI.PhysReg.isPhysical() && !MBB->isEntryBlock() &&
-          !MBB->isEHPad()) {
+      if (MRI->isSSA() && !MBB->isEntryBlock() && !MBB->isEHPad()) {
         report("Physical registers should not be a live-in during SSA form",
                MBB);
         continue;

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -893,14 +893,14 @@ MachineVerifier::visitMachineBasicBlockBefore(const MachineBasicBlock *MBB) {
   regsLive.clear();
   if (MRI->tracksLiveness()) {
     for (const auto &LI : MBB->liveins()) {
+      if (!LI.PhysReg.isPhysical()) {
+        report("MBB live-in list contains non-physical register", MBB);
+        continue;
+      }
       if (MRI->isSSA() && LI.PhysReg.isPhysical() && !MBB->isEntryBlock() &&
           !MBB->isEHPad()) {
         report("Physical registers should not be a live-in during SSA form",
                MBB);
-        continue;
-      }
-      if (!LI.PhysReg.isPhysical()) {
-        report("MBB live-in list contains non-physical register", MBB);
         continue;
       }
       regsLive.insert_range(TRI->subregs_inclusive(LI.PhysReg));


### PR DESCRIPTION
This patch is to add a new validation check on the if MIR is with SSA format,
since the phi operand is not for physical registers, unless
- the block is the entry block due to respect forABI 
- EHPad(physical register is used for landing pad address)

The result of all lit-tests are:
```
Total Discovered Tests: 29735
  Unsupported      :   632 (2.13%)
  Passed           : 28662 (96.39%)
  Expectedly Failed:    73 (0.25%)
  Failed           :   368 (1.24%)
```
Except the AMDGPU ones which is fixed in https://github.com/llvm/llvm-project/pull/193143, typical errors are:
- X86: liveness-local-regalloc.ll $eflags
- AArch64: arm64-regress-f128csel-flags.ll $nzcv

and we will keep investigating these.




