### PR TITLE
[libc][math] Refactor dsqrt family to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -94,6 +94,7 @@
 #include "math/dfmal.h"
 #include "math/dmulf128.h"
 #include "math/dmull.h"
+#include "math/dsqrtf128.h"
 #include "math/dsqrtl.h"
 #include "math/dsubf128.h"
 #include "math/dsubl.h"

--- a/libc/shared/math/dsqrtf128.h
+++ b/libc/shared/math/dsqrtf128.h
@@ -1,0 +1,29 @@
+//===-- Shared dsqrtf128 function -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_DSQRTF128_H
+#define LLVM_LIBC_SHARED_MATH_DSQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "shared/libc_common.h"
+#include "src/__support/math/dsqrtf128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::dsqrtf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_DSQRTF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -820,6 +820,16 @@ add_header_library(
     libc.src.__support.number_pair
 )
 add_header_library(
+  dsqrtf128
+  HDRS
+    dsqrtf128.h
+  DEPENDS
+    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.macros.config
+)
+
+add_header_library(
   fmaximum
   HDRS
     fmaximum.h

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -819,6 +819,7 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.__support.number_pair
 )
+
 add_header_library(
   dsqrtf128
   HDRS

--- a/libc/src/__support/math/dsqrtf128.h
+++ b/libc/src/__support/math/dsqrtf128.h
@@ -1,0 +1,31 @@
+//===-- Implementation header for dsqrtf128 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/generic/sqrt.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE constexpr double dsqrtf128(float128 x) {
+  return fputil::sqrt<double>(x);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTF128_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -255,8 +255,7 @@ add_entrypoint_object(
   HDRS
     ../dsqrtf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.math.dsqrtf128
 )
 
 

--- a/libc/src/math/generic/dsqrtf128.cpp
+++ b/libc/src/math/generic/dsqrtf128.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/dsqrtf128.h"
-#include "src/__support/FPUtil/generic/sqrt.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/math/dsqrtf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(double, dsqrtf128, (float128 x)) {
-  return fputil::sqrt<double>(x);
+  return math::dsqrtf128(x);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -91,6 +91,7 @@ add_fp_unittest(
     libc.src.__support.math.dfmal
     libc.src.__support.math.dmulf128
     libc.src.__support.math.dmull
+    libc.src.__support.math.dsqrtf128
     libc.src.__support.math.dsqrtl
     libc.src.__support.math.dsubf128
     libc.src.__support.math.dsubl
@@ -335,6 +336,7 @@ add_fp_unittest(
     libc.src.__support.math.ddivl
     libc.src.__support.math.dmulf128
     libc.src.__support.math.dmull
+    libc.src.__support.math.dsqrtf128
     libc.src.__support.math.fdim
     libc.src.__support.math.fdimbf16
     libc.src.__support.math.fdimf

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -111,6 +111,7 @@ static_assert(float128(0.0) ==
                                                    float128(0.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::fminf128(float128(0.0), float128(0.0)));
+static_assert(0.0 == LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));
 
 #endif // LIBC_TYPES_HAS_FLOAT128
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -409,6 +409,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dfmaf128(
                         float128(0.0), float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(1.0), LIBC_NAMESPACE::shared::sqrtf128(float128(1.0)));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsqrtf128(float128(0.0)));
 
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(float128(1.0)));
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3947,6 +3947,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_dsqrtf128",
+    hdrs = ["src/__support/math/dsqrtf128.h"],
+    deps = [
+        ":__support_fputil_normal_float",
+        ":__support_macros_config",
+        ":llvm_libc_types_float128",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_fmaximum",
     hdrs = ["src/__support/math/fmaximum.h"],
     deps = [
@@ -7657,7 +7667,7 @@ libc_math_function(
 libc_math_function(
     name = "dsqrtf128",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_dsqrtf128",
     ],
 )
 


### PR DESCRIPTION
Refactors the dsqrt math family to be header-only.

part of: #147386

Target Functions:
  - dsqrtf128