### PR TITLE
Hash.cpp: include ErrorHandling.h

### DIFF
--- a/llvm/lib/Support/Hash.cpp
+++ b/llvm/lib/Support/Hash.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Hash.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/xxhash.h"
 
 using namespace llvm;


### PR DESCRIPTION
Hash.cpp uses llvm_unreachable but currently picks up ErrorHandling.h
only transitively through xxhash.h -> ArrayRef.h -> Hashing.h.