### PR TITLE
[AArch64][GlobalISel] Update fp legalization mir tests. NFC

### DIFF
--- a/llvm/test/CodeGen/AArch64/GlobalISel/fold-fp-select.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/fold-fp-select.mir
@@ -38,9 +38,9 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(oeq), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(oeq), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %2, %1
-    $w1 = COPY %5(f32)
+    $w1 = COPY %5(i32)
     $s0 = COPY %4(f32)
     RET_ReallyLR implicit $s0
 
@@ -71,7 +71,7 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(oeq), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(oeq), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %2, %1
     %7:fpr(f32) = G_SELECT %5, %1, %2
     $s0 = COPY %4(f32)
@@ -132,7 +132,7 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(oeq), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(oeq), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %2, %1
     $s0 = COPY %4(f32)
     RET_ReallyLR implicit $s0
@@ -165,7 +165,7 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(ueq), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(ueq), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %2, %1
     $s0 = COPY %4(f32)
     RET_ReallyLR implicit $s0
@@ -198,7 +198,7 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(one), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(one), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %1, %2
     $s0 = COPY %4(f32)
     RET_ReallyLR implicit $s0
@@ -227,7 +227,7 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(une), %0(f32), %2
+    %5:gpr(i32) = G_FCMP floatpred(une), %0(f32), %2
     %4:fpr(f32) = G_SELECT %5, %1, %2
     $s0 = COPY %4(f32)
     RET_ReallyLR implicit $s0
@@ -256,7 +256,7 @@ body:             |
     %0:fpr(f64) = COPY $d0
     %1:fpr(f64) = COPY $d1
     %2:fpr(f64) = G_FCONSTANT double 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(oeq), %0(f64), %2
+    %5:gpr(i32) = G_FCMP floatpred(oeq), %0(f64), %2
     %4:fpr(f64) = G_SELECT %5, %2, %1
     $d0 = COPY %4(f64)
     RET_ReallyLR implicit $d0
@@ -289,7 +289,7 @@ body:             |
     %0:fpr(f64) = COPY $d0
     %1:fpr(f64) = COPY $d1
     %2:fpr(f64) = G_FCONSTANT double 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(ueq), %0(f64), %2
+    %5:gpr(i32) = G_FCMP floatpred(ueq), %0(f64), %2
     %4:fpr(f64) = G_SELECT %5, %2, %1
     $d0 = COPY %4(f64)
     RET_ReallyLR implicit $d0
@@ -322,7 +322,7 @@ body:             |
     %0:fpr(f64) = COPY $d0
     %1:fpr(f64) = COPY $d1
     %2:fpr(f64) = G_FCONSTANT double 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(one), %0(f64), %2
+    %5:gpr(i32) = G_FCMP floatpred(one), %0(f64), %2
     %4:fpr(f64) = G_SELECT %5, %1, %2
     $d0 = COPY %4(f64)
     RET_ReallyLR implicit $d0
@@ -351,7 +351,7 @@ body:             |
     %0:fpr(f64) = COPY $d0
     %1:fpr(f64) = COPY $d1
     %2:fpr(f64) = G_FCONSTANT double 0.000000e+00
-    %5:gpr(f32) = G_FCMP floatpred(une), %0(f64), %2
+    %5:gpr(i32) = G_FCMP floatpred(une), %0(f64), %2
     %4:fpr(f64) = G_SELECT %5, %1, %2
     $d0 = COPY %4(f64)
     RET_ReallyLR implicit $d0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-acos.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-acos.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.acos
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &acosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &acosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &acosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &acosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FACOS %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FACOS %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &acosf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FACOS %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FACOS %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.acos
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FACOS %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FACOS %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.acos
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &acosf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FACOS %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FACOS %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.acos
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &acos
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &acos
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FACOS %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FACOS %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_acos_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &acosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FACOS %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FACOS %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-asin.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-asin.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.asin
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &asinf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &asinf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &asinf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &asinf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FASIN %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FASIN %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &asinf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FASIN %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FASIN %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.asin
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FASIN %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FASIN %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.asin
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &asinf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FASIN %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FASIN %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.asin
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &asin
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &asin
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FASIN %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FASIN %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_asin_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &asinf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FASIN %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FASIN %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-atan.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-atan.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.atan
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &atanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &atanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &atanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &atanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FATAN %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FATAN %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &atanf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FATAN %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FATAN %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.atan
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FATAN %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FATAN %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.atan
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &atanf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FATAN %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FATAN %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.atan
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &atan
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &atan
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FATAN %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FATAN %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_atan_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &atanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FATAN %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FATAN %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-atan2.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-atan2.mir
@@ -17,53 +17,53 @@ body:             |
     ; CHECK-LABEL: name: test_v4f16.atan2
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s16>) = COPY $d1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV4]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f16>) = COPY $d1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(f16), [[UV5:%[0-9]+]]:_(f16), [[UV6:%[0-9]+]]:_(f16), [[UV7:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY1]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV5]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV5]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(s32) = G_FPEXT [[UV6]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(f32) = G_FPEXT [[UV6]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
-    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(s32) = G_FPEXT [[UV7]](s16)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
+    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(f32) = G_FPEXT [[UV7]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY5]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = COPY $d1
-    %2:_(<4 x s16>) = G_FATAN2 %0, %1
-    $d0 = COPY %2(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = COPY $d1
+    %2:_(<4 x f16>) = G_FATAN2 %0, %1
+    $d0 = COPY %2(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -81,89 +81,89 @@ body:             |
     ; CHECK-LABEL: name: test_v8f16.atan2
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<8 x s16>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[UV8:%[0-9]+]]:_(s16), [[UV9:%[0-9]+]]:_(s16), [[UV10:%[0-9]+]]:_(s16), [[UV11:%[0-9]+]]:_(s16), [[UV12:%[0-9]+]]:_(s16), [[UV13:%[0-9]+]]:_(s16), [[UV14:%[0-9]+]]:_(s16), [[UV15:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV8]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<8 x f16>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16), [[UV4:%[0-9]+]]:_(f16), [[UV5:%[0-9]+]]:_(f16), [[UV6:%[0-9]+]]:_(f16), [[UV7:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[UV8:%[0-9]+]]:_(f16), [[UV9:%[0-9]+]]:_(f16), [[UV10:%[0-9]+]]:_(f16), [[UV11:%[0-9]+]]:_(f16), [[UV12:%[0-9]+]]:_(f16), [[UV13:%[0-9]+]]:_(f16), [[UV14:%[0-9]+]]:_(f16), [[UV15:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY1]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV8]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV9]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV9]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(s32) = G_FPEXT [[UV10]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(f32) = G_FPEXT [[UV10]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
-    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(s32) = G_FPEXT [[UV11]](s16)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
+    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(f32) = G_FPEXT [[UV11]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
-    ; CHECK-NEXT: [[FPEXT8:%[0-9]+]]:_(s32) = G_FPEXT [[UV4]](s16)
-    ; CHECK-NEXT: [[FPEXT9:%[0-9]+]]:_(s32) = G_FPEXT [[UV12]](s16)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY5]](f32)
+    ; CHECK-NEXT: [[FPEXT8:%[0-9]+]]:_(f32) = G_FPEXT [[UV4]](f16)
+    ; CHECK-NEXT: [[FPEXT9:%[0-9]+]]:_(f32) = G_FPEXT [[UV12]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT8]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT9]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT8]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT9]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY6]](s32)
-    ; CHECK-NEXT: [[FPEXT10:%[0-9]+]]:_(s32) = G_FPEXT [[UV5]](s16)
-    ; CHECK-NEXT: [[FPEXT11:%[0-9]+]]:_(s32) = G_FPEXT [[UV13]](s16)
+    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY6]](f32)
+    ; CHECK-NEXT: [[FPEXT10:%[0-9]+]]:_(f32) = G_FPEXT [[UV5]](f16)
+    ; CHECK-NEXT: [[FPEXT11:%[0-9]+]]:_(f32) = G_FPEXT [[UV13]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT10]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT11]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT10]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT11]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY7]](s32)
-    ; CHECK-NEXT: [[FPEXT12:%[0-9]+]]:_(s32) = G_FPEXT [[UV6]](s16)
-    ; CHECK-NEXT: [[FPEXT13:%[0-9]+]]:_(s32) = G_FPEXT [[UV14]](s16)
+    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY7]](f32)
+    ; CHECK-NEXT: [[FPEXT12:%[0-9]+]]:_(f32) = G_FPEXT [[UV6]](f16)
+    ; CHECK-NEXT: [[FPEXT13:%[0-9]+]]:_(f32) = G_FPEXT [[UV14]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT12]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT13]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT12]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT13]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY8]](s32)
-    ; CHECK-NEXT: [[FPEXT14:%[0-9]+]]:_(s32) = G_FPEXT [[UV7]](s16)
-    ; CHECK-NEXT: [[FPEXT15:%[0-9]+]]:_(s32) = G_FPEXT [[UV15]](s16)
+    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY8]](f32)
+    ; CHECK-NEXT: [[FPEXT14:%[0-9]+]]:_(f32) = G_FPEXT [[UV7]](f16)
+    ; CHECK-NEXT: [[FPEXT15:%[0-9]+]]:_(f32) = G_FPEXT [[UV15]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT14]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT15]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT14]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT15]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY9:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY9]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16), [[FPTRUNC4]](s16), [[FPTRUNC5]](s16), [[FPTRUNC6]](s16), [[FPTRUNC7]](s16)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x s16>)
+    ; CHECK-NEXT: [[COPY9:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY9]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16), [[FPTRUNC4]](f16), [[FPTRUNC5]](f16), [[FPTRUNC6]](f16), [[FPTRUNC7]](f16)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = COPY $q1
-    %2:_(<8 x s16>) = G_FATAN2 %0, %1
-    $q0 = COPY %2(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = COPY $q1
+    %2:_(<8 x f16>) = G_FATAN2 %0, %1
+    $q0 = COPY %2(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -181,29 +181,29 @@ body:             |
     ; CHECK-LABEL: name: test_v2f32.atan2
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<2 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV2]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV3]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[COPY2]](f32), [[COPY3]](f32)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = COPY $d1
-    %2:_(<2 x s32>) = G_FATAN2 %0, %1
-    $d0 = COPY %2(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = COPY $d1
+    %2:_(<2 x f32>) = G_FATAN2 %0, %1
+    $d0 = COPY %2(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -221,41 +221,41 @@ body:             |
     ; CHECK-LABEL: name: test_v4f32.atan2
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32), [[UV6:%[0-9]+]]:_(f32), [[UV7:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<4 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV4]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV4]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV5]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV6]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV6]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV3]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV3]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV7]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[COPY2]](f32), [[COPY3]](f32), [[COPY4]](f32), [[COPY5]](f32)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = COPY $q1
-    %2:_(<4 x s32>) = G_FATAN2 %0, %1
-    $q0 = COPY %2(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = COPY $q1
+    %2:_(<4 x f32>) = G_FATAN2 %0, %1
+    $q0 = COPY %2(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -273,29 +273,29 @@ body:             |
     ; CHECK-LABEL: name: test_v2f64.atan2
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s64), [[UV3:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY1]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f64), [[UV3:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY1]](<2 x f64>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[UV2]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[UV2]](f64)
     ; CHECK-NEXT: BL &atan2, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV1]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[UV3]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV1]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[UV3]](f64)
     ; CHECK-NEXT: BL &atan2, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[COPY2]](s64), [[COPY3]](s64)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[COPY2]](f64), [[COPY3]](f64)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<2 x s64>) = G_FATAN2 %0, %1
-    $q0 = COPY %2(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<2 x f64>) = G_FATAN2 %0, %1
+    $q0 = COPY %2(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -313,21 +313,21 @@ body:             |
     ; CHECK-LABEL: name: test_atan2_half
     ; CHECK: liveins: $h0, $h1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s16) = COPY $h1
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[COPY1]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f16) = COPY $h1
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[COPY1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &atan2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = COPY $h1
-    %2:_(s16) = G_FATAN2 %0, %1
-    $h0 = COPY %2(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = COPY $h1
+    %2:_(f16) = G_FATAN2 %0, %1
+    $h0 = COPY %2(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-ceil.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-ceil.mir
@@ -24,20 +24,20 @@ body:             |
     ; CHECK-LABEL: name: test_v8f16.ceil
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; CHECK-NEXT: [[FCEIL:%[0-9]+]]:_(<4 x s32>) = G_FCEIL [[FPEXT]]
-    ; CHECK-NEXT: [[FCEIL1:%[0-9]+]]:_(<4 x s32>) = G_FCEIL [[FPEXT1]]
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FCEIL]](<4 x s32>)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FCEIL1]](<4 x s32>)
-    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; CHECK-NEXT: [[FCEIL:%[0-9]+]]:_(<4 x f32>) = G_FCEIL [[FPEXT]]
+    ; CHECK-NEXT: [[FCEIL1:%[0-9]+]]:_(<4 x f32>) = G_FCEIL [[FPEXT1]]
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FCEIL]](<4 x f32>)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FCEIL1]](<4 x f32>)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FCEIL %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FCEIL %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -54,15 +54,15 @@ body:             |
     ; CHECK-LABEL: name: test_v4f16.ceil
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[FCEIL:%[0-9]+]]:_(<4 x s32>) = G_FCEIL [[FPEXT]]
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FCEIL]](<4 x s32>)
-    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[FCEIL:%[0-9]+]]:_(<4 x f32>) = G_FCEIL [[FPEXT]]
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FCEIL]](<4 x f32>)
+    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FCEIL %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FCEIL %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cos.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cos.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.cos
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &cosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &cosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &cosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &cosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FCOS %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FCOS %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &cosf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FCOS %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FCOS %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.cos
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FCOS %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FCOS %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.cos
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &cosf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FCOS %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FCOS %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.cos
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &cos
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &cos
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FCOS %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FCOS %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_cos_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &cosf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FCOS %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FCOS %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cosh.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cosh.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.cosh
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &coshf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &coshf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &coshf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &coshf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FCOSH %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FCOSH %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &coshf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FCOSH %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FCOSH %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.cosh
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FCOSH %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FCOSH %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.cosh
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &coshf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FCOSH %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FCOSH %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.cosh
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &cosh
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &cosh
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FCOSH %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FCOSH %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_cosh_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &coshf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FCOSH %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FCOSH %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fcmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fcmp.mir
@@ -5,22 +5,22 @@ name:            test_icmp
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_icmp
-    ; CHECK: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(s32) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: [[TRUNC1:%[0-9]+]]:_(s32) = G_TRUNC [[COPY1]](s64)
-    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(s32) = G_FCMP floatpred(oge), [[COPY]](s64), [[COPY1]]
-    ; CHECK-NEXT: $w0 = COPY [[FCMP]](s32)
-    ; CHECK-NEXT: [[FCMP1:%[0-9]+]]:_(s32) = G_FCMP floatpred(uno), [[TRUNC]](s32), [[TRUNC1]]
-    ; CHECK-NEXT: $w0 = COPY [[FCMP1]](s32)
-    %0:_(s64) = COPY $x0
-    %1:_(s64) = COPY $x0
-    %2:_(s32) = G_TRUNC %0(s64)
-    %3:_(s32) = G_TRUNC %1(s64)
-    %4:_(s32) = G_FCMP floatpred(oge), %0(s64), %1
-    $w0 = COPY %4(s32)
-    %5:_(s32) = G_FCMP floatpred(uno), %2(s32), %3
-    $w0 = COPY %5(s32)
+    ; CHECK: [[COPY:%[0-9]+]]:_(f64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f64) = COPY $x0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $w0
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $w0
+    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(i32) = G_FCMP floatpred(oge), [[COPY]](f64), [[COPY1]]
+    ; CHECK-NEXT: $w0 = COPY [[FCMP]](i32)
+    ; CHECK-NEXT: [[FCMP1:%[0-9]+]]:_(i32) = G_FCMP floatpred(uno), [[COPY2]](f32), [[COPY3]]
+    ; CHECK-NEXT: $w0 = COPY [[FCMP1]](i32)
+    %0:_(f64) = COPY $x0
+    %1:_(f64) = COPY $x0
+    %2:_(f32) = COPY $w0
+    %3:_(f32) = COPY $w0
+    %4:_(i32) = G_FCMP floatpred(oge), %0(f64), %1
+    $w0 = COPY %4(i32)
+    %5:_(i32) = G_FCMP floatpred(uno), %2(f32), %3
+    $w0 = COPY %5(i32)
 
 ...
 ---
@@ -34,25 +34,25 @@ body:             |
     ; CHECK-LABEL: name: legalize_v8s16
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %lhs:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: %rhs:_(<8 x s16>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES %lhs(<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(<4 x s16>), [[UV3:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES %rhs(<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV2]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV3]](<4 x s16>)
-    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(<4 x s32>) = G_FCMP floatpred(oeq), [[FPEXT]](<4 x s32>), [[FPEXT2]]
-    ; CHECK-NEXT: [[FCMP1:%[0-9]+]]:_(<4 x s32>) = G_FCMP floatpred(oeq), [[FPEXT1]](<4 x s32>), [[FPEXT3]]
-    ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(<4 x s16>) = G_TRUNC [[FCMP]](<4 x s32>)
-    ; CHECK-NEXT: [[TRUNC1:%[0-9]+]]:_(<4 x s16>) = G_TRUNC [[FCMP1]](<4 x s32>)
-    ; CHECK-NEXT: %fcmp:_(<8 x s16>) = G_CONCAT_VECTORS [[TRUNC]](<4 x s16>), [[TRUNC1]](<4 x s16>)
-    ; CHECK-NEXT: $q0 = COPY %fcmp(<8 x s16>)
+    ; CHECK-NEXT: %lhs:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: %rhs:_(<8 x f16>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES %lhs(<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(<4 x f16>), [[UV3:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES %rhs(<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV2]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV3]](<4 x f16>)
+    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(<4 x i32>) = G_FCMP floatpred(oeq), [[FPEXT]](<4 x f32>), [[FPEXT2]]
+    ; CHECK-NEXT: [[FCMP1:%[0-9]+]]:_(<4 x i32>) = G_FCMP floatpred(oeq), [[FPEXT1]](<4 x f32>), [[FPEXT3]]
+    ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(<4 x i16>) = G_TRUNC [[FCMP]](<4 x i32>)
+    ; CHECK-NEXT: [[TRUNC1:%[0-9]+]]:_(<4 x i16>) = G_TRUNC [[FCMP1]](<4 x i32>)
+    ; CHECK-NEXT: %fcmp:_(<8 x i16>) = G_CONCAT_VECTORS [[TRUNC]](<4 x i16>), [[TRUNC1]](<4 x i16>)
+    ; CHECK-NEXT: $q0 = COPY %fcmp(<8 x i16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %lhs:_(<8 x s16>) = COPY $q0
-    %rhs:_(<8 x s16>) = COPY $q1
-    %fcmp:_(<8 x s16>) = G_FCMP floatpred(oeq), %lhs(<8 x s16>), %rhs
-    $q0 = COPY %fcmp(<8 x s16>)
+    %lhs:_(<8 x f16>) = COPY $q0
+    %rhs:_(<8 x f16>) = COPY $q1
+    %fcmp:_(<8 x i16>) = G_FCMP floatpred(oeq), %lhs(<8 x f16>), %rhs
+    $q0 = COPY %fcmp(<8 x i16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -67,16 +67,16 @@ body:             |
     ; CHECK-LABEL: name: legalize_v4s16
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %lhs:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: %rhs:_(<4 x s16>) = COPY $d1
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT %lhs(<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT %rhs(<4 x s16>)
-    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(<4 x s32>) = G_FCMP floatpred(oeq), [[FPEXT]](<4 x s32>), [[FPEXT1]]
-    ; CHECK-NEXT: %fcmp:_(<4 x s16>) = G_TRUNC [[FCMP]](<4 x s32>)
-    ; CHECK-NEXT: $d0 = COPY %fcmp(<4 x s16>)
+    ; CHECK-NEXT: %lhs:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: %rhs:_(<4 x f16>) = COPY $d1
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT %lhs(<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT %rhs(<4 x f16>)
+    ; CHECK-NEXT: [[FCMP:%[0-9]+]]:_(<4 x i32>) = G_FCMP floatpred(oeq), [[FPEXT]](<4 x f32>), [[FPEXT1]]
+    ; CHECK-NEXT: %fcmp:_(<4 x i16>) = G_TRUNC [[FCMP]](<4 x i32>)
+    ; CHECK-NEXT: $d0 = COPY %fcmp(<4 x i16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %lhs:_(<4 x s16>) = COPY $d0
-    %rhs:_(<4 x s16>) = COPY $d1
-    %fcmp:_(<4 x s16>) = G_FCMP floatpred(oeq), %lhs(<4 x s16>), %rhs
-    $d0 = COPY %fcmp(<4 x s16>)
+    %lhs:_(<4 x f16>) = COPY $d0
+    %rhs:_(<4 x f16>) = COPY $d1
+    %fcmp:_(<4 x i16>) = G_FCMP floatpred(oeq), %lhs(<4 x f16>), %rhs
+    $d0 = COPY %fcmp(<4 x i16>)
     RET_ReallyLR implicit $d0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fcopysign.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fcopysign.mir
@@ -11,26 +11,29 @@ body:             |
     ; CHECK-LABEL: name: legalize_s32
     ; CHECK: liveins: $s0, $s1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %val:_(s32) = COPY $s0
-    ; CHECK-NEXT: %sign:_(s32) = COPY $s1
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR %val(s32), [[DEF]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR %sign(s32), [[DEF]](s32)
+    ; CHECK-NEXT: %val:_(f32) = COPY $s0
+    ; CHECK-NEXT: %sign:_(f32) = COPY $s1
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR %val(f32), [[DEF]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR %sign(f32), [[DEF]](f32)
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x i32>) = G_BITCAST [[BUILD_VECTOR]](<2 x f32>)
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x i32>) = G_BITCAST [[BUILD_VECTOR1]](<2 x f32>)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 -2147483648
     ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[C]](i32), [[C]](i32)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 2147483647
     ; CHECK-NEXT: [[BUILD_VECTOR3:%[0-9]+]]:_(<2 x i32>) = G_BUILD_VECTOR [[C1]](i32), [[C1]](i32)
-    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(<2 x i32>) = G_AND [[BUILD_VECTOR]], [[BUILD_VECTOR3]]
-    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(<2 x i32>) = G_AND [[BUILD_VECTOR1]], [[BUILD_VECTOR2]]
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(<2 x s32>) = disjoint G_OR [[AND]], [[AND1]]
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[OR]](<2 x s32>)
-    ; CHECK-NEXT: %fcopysign:_(s32) = COPY [[UV]](s32)
-    ; CHECK-NEXT: $s0 = COPY %fcopysign(s32)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(<2 x i32>) = G_AND [[BITCAST]], [[BUILD_VECTOR3]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(<2 x i32>) = G_AND [[BITCAST1]], [[BUILD_VECTOR2]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(<2 x i32>) = disjoint G_OR [[AND]], [[AND1]]
+    ; CHECK-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f32>) = G_BITCAST [[OR]](<2 x i32>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[BITCAST2]](<2 x f32>)
+    ; CHECK-NEXT: %fcopysign:_(f32) = COPY [[UV]](f32)
+    ; CHECK-NEXT: $s0 = COPY %fcopysign(f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %val:_(s32) = COPY $s0
-    %sign:_(s32) = COPY $s1
-    %fcopysign:_(s32) = G_FCOPYSIGN %val, %sign(s32)
-    $s0 = COPY %fcopysign(s32)
+    %val:_(f32) = COPY $s0
+    %sign:_(f32) = COPY $s1
+    %fcopysign:_(f32) = G_FCOPYSIGN %val, %sign(f32)
+    $s0 = COPY %fcopysign(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -43,24 +46,27 @@ body:             |
     ; CHECK-LABEL: name: legalize_s64
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %val:_(s64) = COPY $d0
-    ; CHECK-NEXT: %sign:_(s64) = COPY $d1
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s64) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR %val(s64), [[DEF]](s64)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR %sign(s64), [[DEF]](s64)
+    ; CHECK-NEXT: %val:_(f64) = COPY $d0
+    ; CHECK-NEXT: %sign:_(f64) = COPY $d1
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(f64) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR %val(f64), [[DEF]](f64)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR %sign(f64), [[DEF]](f64)
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BUILD_VECTOR]](<2 x f64>)
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BUILD_VECTOR1]](<2 x f64>)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 -9223372036854775808
     ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x i64>) = G_BUILD_VECTOR [[C]](i64), [[C]](i64)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 9223372036854775807
     ; CHECK-NEXT: [[BUILD_VECTOR3:%[0-9]+]]:_(<2 x i64>) = G_BUILD_VECTOR [[C1]](i64), [[C1]](i64)
-    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(<2 x i64>) = G_AND [[BUILD_VECTOR]], [[BUILD_VECTOR3]]
-    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(<2 x i64>) = G_AND [[BUILD_VECTOR1]], [[BUILD_VECTOR2]]
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(<2 x s64>) = disjoint G_OR [[AND]], [[AND1]]
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[OR]](<2 x s64>)
-    ; CHECK-NEXT: %fcopysign:_(s64) = COPY [[UV]](s64)
-    ; CHECK-NEXT: $d0 = COPY %fcopysign(s64)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(<2 x i64>) = G_AND [[BITCAST]], [[BUILD_VECTOR3]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(<2 x i64>) = G_AND [[BITCAST1]], [[BUILD_VECTOR2]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(<2 x i64>) = disjoint G_OR [[AND]], [[AND1]]
+    ; CHECK-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x f64>) = G_BITCAST [[OR]](<2 x i64>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[BITCAST2]](<2 x f64>)
+    ; CHECK-NEXT: %fcopysign:_(f64) = COPY [[UV]](f64)
+    ; CHECK-NEXT: $d0 = COPY %fcopysign(f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %val:_(s64) = COPY $d0
-    %sign:_(s64) = COPY $d1
-    %fcopysign:_(s64) = G_FCOPYSIGN %val, %sign(s64)
-    $d0 = COPY %fcopysign(s64)
+    %val:_(f64) = COPY $d0
+    %sign:_(f64) = COPY $d1
+    %fcopysign:_(f64) = G_FCOPYSIGN %val, %sign(f64)
+    $d0 = COPY %fcopysign(f64)
     RET_ReallyLR implicit $d0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fexp2.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fexp2.mir
@@ -13,42 +13,42 @@ body:             |
     ; CHECK-LABEL: name: test_v4f16.exp2
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FEXP2 %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FEXP2 %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -62,70 +62,70 @@ body:             |
     ; CHECK-LABEL: name: test_v8f16.exp2
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16), [[UV4:%[0-9]+]]:_(f16), [[UV5:%[0-9]+]]:_(f16), [[UV6:%[0-9]+]]:_(f16), [[UV7:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(s32) = G_FPEXT [[UV4]](s16)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(f32) = G_FPEXT [[UV4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(s32) = G_FPEXT [[UV5]](s16)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY5]](f32)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(f32) = G_FPEXT [[UV5]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT5]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY6]](s32)
-    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(s32) = G_FPEXT [[UV6]](s16)
+    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY6]](f32)
+    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(f32) = G_FPEXT [[UV6]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY7]](s32)
-    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(s32) = G_FPEXT [[UV7]](s16)
+    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY7]](f32)
+    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(f32) = G_FPEXT [[UV7]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT7]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY8]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16), [[FPTRUNC4]](s16), [[FPTRUNC5]](s16), [[FPTRUNC6]](s16), [[FPTRUNC7]](s16)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x s16>)
+    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY8]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16), [[FPTRUNC4]](f16), [[FPTRUNC5]](f16), [[FPTRUNC6]](f16), [[FPTRUNC7]](f16)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FEXP2 %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FEXP2 %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -139,24 +139,24 @@ body:             |
     ; CHECK-LABEL: name: test_v2f32.exp2
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY1]](s32), [[COPY2]](s32)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[COPY1]](f32), [[COPY2]](f32)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FEXP2 %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FEXP2 %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -170,34 +170,34 @@ body:             |
     ; CHECK-LABEL: name: test_v4f32.exp2
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV2]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV3]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[COPY1]](f32), [[COPY2]](f32), [[COPY3]](f32), [[COPY4]](f32)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FEXP2 %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FEXP2 %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -211,24 +211,24 @@ body:             |
     ; CHECK-LABEL: name: test_v2f64.exp2
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV]](f64)
     ; CHECK-NEXT: BL &exp2, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV1]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV1]](f64)
     ; CHECK-NEXT: BL &exp2, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[COPY1]](s64), [[COPY2]](s64)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[COPY1]](f64), [[COPY2]](f64)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FEXP2 %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FEXP2 %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -242,17 +242,17 @@ body:             |
     ; CHECK-LABEL: name: test_exp2_half
     ; CHECK: liveins: $h0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: BL &exp2f, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FEXP2 %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FEXP2 %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fma.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fma.mir
@@ -14,31 +14,31 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f16.fma
     ; NO-FP16: liveins: $d0, $d1, $d2
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s16>) = COPY $d1
-    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x s16>) = COPY $d2
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY2]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x s32>) = G_FMA [[FPEXT]], [[FPEXT1]], [[FPEXT2]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FMA]](<4 x s32>)
-    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f16>) = COPY $d1
+    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x f16>) = COPY $d2
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY2]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x f32>) = G_FMA [[FPEXT]], [[FPEXT1]], [[FPEXT2]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FMA]](<4 x f32>)
+    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v4f16.fma
     ; FP16: liveins: $d0, $d1, $d2
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s16>) = COPY $d1
-    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x s16>) = COPY $d2
-    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x s16>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; FP16-NEXT: $d0 = COPY [[FMA]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f16>) = COPY $d1
+    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x f16>) = COPY $d2
+    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x f16>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; FP16-NEXT: $d0 = COPY [[FMA]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = COPY $d1
-    %2:_(<4 x s16>) = COPY $d2
-    %3:_(<4 x s16>) = G_FMA %0, %1, %2
-    $d0 = COPY %3(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = COPY $d1
+    %2:_(<4 x f16>) = COPY $d2
+    %3:_(<4 x f16>) = G_FMA %0, %1, %2
+    $d0 = COPY %3(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -54,40 +54,40 @@ body:             |
     ; NO-FP16-LABEL: name: test_v8f16.fma
     ; NO-FP16: liveins: $q0, $q1, $q2
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<8 x s16>) = COPY $q1
-    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<8 x s16>) = COPY $q2
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[UV2:%[0-9]+]]:_(<4 x s16>), [[UV3:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY1]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV2]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT3:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV3]](<4 x s16>)
-    ; NO-FP16-NEXT: [[UV4:%[0-9]+]]:_(<4 x s16>), [[UV5:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY2]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT4:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV4]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT5:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV5]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x s32>) = G_FMA [[FPEXT]], [[FPEXT2]], [[FPEXT4]]
-    ; NO-FP16-NEXT: [[FMA1:%[0-9]+]]:_(<4 x s32>) = G_FMA [[FPEXT1]], [[FPEXT3]], [[FPEXT5]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FMA]](<4 x s32>)
-    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FMA1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<8 x f16>) = COPY $q1
+    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<8 x f16>) = COPY $q2
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[UV2:%[0-9]+]]:_(<4 x f16>), [[UV3:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY1]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT2:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV2]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT3:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV3]](<4 x f16>)
+    ; NO-FP16-NEXT: [[UV4:%[0-9]+]]:_(<4 x f16>), [[UV5:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY2]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT4:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV4]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT5:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV5]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x f32>) = G_FMA [[FPEXT]], [[FPEXT2]], [[FPEXT4]]
+    ; NO-FP16-NEXT: [[FMA1:%[0-9]+]]:_(<4 x f32>) = G_FMA [[FPEXT1]], [[FPEXT3]], [[FPEXT5]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FMA]](<4 x f32>)
+    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FMA1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v8f16.fma
     ; FP16: liveins: $q0, $q1, $q2
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<8 x s16>) = COPY $q1
-    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<8 x s16>) = COPY $q2
-    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<8 x s16>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; FP16-NEXT: $q0 = COPY [[FMA]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<8 x f16>) = COPY $q1
+    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<8 x f16>) = COPY $q2
+    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<8 x f16>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; FP16-NEXT: $q0 = COPY [[FMA]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = COPY $q1
-    %2:_(<8 x s16>) = COPY $q2
-    %3:_(<8 x s16>) = G_FMA %0, %1, %2
-    $q0 = COPY %3(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = COPY $q1
+    %2:_(<8 x f16>) = COPY $q2
+    %3:_(<8 x f16>) = G_FMA %0, %1, %2
+    $q0 = COPY %3(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -103,27 +103,27 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f32.fma
     ; NO-FP16: liveins: $d0, $d1, $d2
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s32>) = COPY $d2
-    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x s32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; NO-FP16-NEXT: $d0 = COPY [[FMA]](<2 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f32>) = COPY $d2
+    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x f32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; NO-FP16-NEXT: $d0 = COPY [[FMA]](<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v2f32.fma
     ; FP16: liveins: $d0, $d1, $d2
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s32>) = COPY $d2
-    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x s32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; FP16-NEXT: $d0 = COPY [[FMA]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f32>) = COPY $d2
+    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x f32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; FP16-NEXT: $d0 = COPY [[FMA]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = COPY $d1
-    %2:_(<2 x s32>) = COPY $d2
-    %3:_(<2 x s32>) = G_FMA %0, %1, %2
-    $d0 = COPY %3(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = COPY $d1
+    %2:_(<2 x f32>) = COPY $d2
+    %3:_(<2 x f32>) = G_FMA %0, %1, %2
+    $d0 = COPY %3(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -139,27 +139,27 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f32.fma
     ; NO-FP16: liveins: $q0, $q1, $q2
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x s32>) = COPY $q2
-    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x s32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; NO-FP16-NEXT: $q0 = COPY [[FMA]](<4 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x f32>) = COPY $q2
+    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x f32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; NO-FP16-NEXT: $q0 = COPY [[FMA]](<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f32.fma
     ; FP16: liveins: $q0, $q1, $q2
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x s32>) = COPY $q2
-    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x s32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; FP16-NEXT: $q0 = COPY [[FMA]](<4 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<4 x f32>) = COPY $q2
+    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<4 x f32>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; FP16-NEXT: $q0 = COPY [[FMA]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = COPY $q1
-    %2:_(<4 x s32>) = COPY $q2
-    %3:_(<4 x s32>) = G_FMA %0, %1, %2
-    $q0 = COPY %3(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = COPY $q1
+    %2:_(<4 x f32>) = COPY $q2
+    %3:_(<4 x f32>) = G_FMA %0, %1, %2
+    $q0 = COPY %3(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -175,25 +175,25 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f64.fma
     ; NO-FP16: liveins: $q0, $q1, $q2
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s64>) = COPY $q2
-    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x s64>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; NO-FP16-NEXT: $q0 = COPY [[FMA]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; NO-FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f64>) = COPY $q2
+    ; NO-FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x f64>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; NO-FP16-NEXT: $q0 = COPY [[FMA]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v2f64.fma
     ; FP16: liveins: $q0, $q1, $q2
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s64>) = COPY $q2
-    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x s64>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
-    ; FP16-NEXT: $q0 = COPY [[FMA]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; FP16-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f64>) = COPY $q2
+    ; FP16-NEXT: [[FMA:%[0-9]+]]:_(<2 x f64>) = G_FMA [[COPY]], [[COPY1]], [[COPY2]]
+    ; FP16-NEXT: $q0 = COPY [[FMA]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<2 x s64>) = COPY $q2
-    %3:_(<2 x s64>) = G_FMA %0, %1, %2
-    $q0 = COPY %3(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<2 x f64>) = COPY $q2
+    %3:_(<2 x f64>) = G_FMA %0, %1, %2
+    $q0 = COPY %3(<2 x f64>)
     RET_ReallyLR implicit $q0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmad.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmad.mir
@@ -3,77 +3,77 @@
 
 ...
 ---
-name:            s16
+name:            f16
 tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $h0, $h1, $h2
-    ; CHECK-LABEL: name: s16
+    ; CHECK-LABEL: name: f16
     ; CHECK: liveins: $h0, $h1, $h2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(s16) = COPY $h0
-    ; CHECK-NEXT: %op1:_(s16) = COPY $h1
-    ; CHECK-NEXT: %op2:_(s16) = COPY $h2
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %op0(s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %op1(s16)
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FPEXT]], [[FPEXT1]]
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FMUL]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[FPTRUNC]](s16)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT %op2(s16)
-    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(s32) = G_FADD [[FPEXT2]], [[FPEXT3]]
-    ; CHECK-NEXT: %fmad:_(s16) = G_FPTRUNC [[FADD]](s32)
-    ; CHECK-NEXT: $h0 = COPY %fmad(s16)
+    ; CHECK-NEXT: %op0:_(f16) = COPY $h0
+    ; CHECK-NEXT: %op1:_(f16) = COPY $h1
+    ; CHECK-NEXT: %op2:_(f16) = COPY $h2
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %op0(f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %op1(f16)
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FPEXT]], [[FPEXT1]]
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FMUL]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[FPTRUNC]](f16)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT %op2(f16)
+    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[FPEXT2]], [[FPEXT3]]
+    ; CHECK-NEXT: %fmad:_(f16) = G_FPTRUNC [[FADD]](f32)
+    ; CHECK-NEXT: $h0 = COPY %fmad(f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %op0:_(s16) = COPY $h0
-    %op1:_(s16) = COPY $h1
-    %op2:_(s16) = COPY $h2
-    %fmad:_(s16) = G_FMAD %op0, %op1, %op2
+    %op0:_(f16) = COPY $h0
+    %op1:_(f16) = COPY $h1
+    %op2:_(f16) = COPY $h2
+    %fmad:_(f16) = G_FMAD %op0, %op1, %op2
     $h0 = COPY %fmad
     RET_ReallyLR implicit $h0
 ...
 ---
-name:            s32
+name:            f32
 tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $s0, $s1, $s2
-    ; CHECK-LABEL: name: s32
+    ; CHECK-LABEL: name: f32
     ; CHECK: liveins: $s0, $s1, $s2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(s32) = COPY $s0
-    ; CHECK-NEXT: %op1:_(s32) = COPY $s1
-    ; CHECK-NEXT: %op2:_(s32) = COPY $s2
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL %op0, %op1
-    ; CHECK-NEXT: %fmad:_(s32) = G_FADD [[FMUL]], %op2
-    ; CHECK-NEXT: $s0 = COPY %fmad(s32)
+    ; CHECK-NEXT: %op0:_(f32) = COPY $s0
+    ; CHECK-NEXT: %op1:_(f32) = COPY $s1
+    ; CHECK-NEXT: %op2:_(f32) = COPY $s2
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL %op0, %op1
+    ; CHECK-NEXT: %fmad:_(f32) = G_FADD [[FMUL]], %op2
+    ; CHECK-NEXT: $s0 = COPY %fmad(f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %op0:_(s32) = COPY $s0
-    %op1:_(s32) = COPY $s1
-    %op2:_(s32) = COPY $s2
-    %fmad:_(s32) = G_FMAD %op0, %op1, %op2
+    %op0:_(f32) = COPY $s0
+    %op1:_(f32) = COPY $s1
+    %op2:_(f32) = COPY $s2
+    %fmad:_(f32) = G_FMAD %op0, %op1, %op2
     $s0 = COPY %fmad
     RET_ReallyLR implicit $s0
 ...
 ---
-name:            s64
+name:            f64
 tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $d0, $d1, $d2
-    ; CHECK-LABEL: name: s64
+    ; CHECK-LABEL: name: f64
     ; CHECK: liveins: $d0, $d1, $d2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(s64) = COPY $d0
-    ; CHECK-NEXT: %op1:_(s64) = COPY $d1
-    ; CHECK-NEXT: %op2:_(s64) = COPY $d2
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(s64) = G_FMUL %op0, %op1
-    ; CHECK-NEXT: %fmad:_(s64) = G_FADD [[FMUL]], %op2
-    ; CHECK-NEXT: $d0 = COPY %fmad(s64)
+    ; CHECK-NEXT: %op0:_(f64) = COPY $d0
+    ; CHECK-NEXT: %op1:_(f64) = COPY $d1
+    ; CHECK-NEXT: %op2:_(f64) = COPY $d2
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(f64) = G_FMUL %op0, %op1
+    ; CHECK-NEXT: %fmad:_(f64) = G_FADD [[FMUL]], %op2
+    ; CHECK-NEXT: $d0 = COPY %fmad(f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %op0:_(s64) = COPY $d0
-    %op1:_(s64) = COPY $d1
-    %op2:_(s64) = COPY $d2
-    %fmad:_(s64) = G_FMAD %op0, %op1, %op2
+    %op0:_(f64) = COPY $d0
+    %op1:_(f64) = COPY $d1
+    %op2:_(f64) = COPY $d2
+    %fmad:_(f64) = G_FMAD %op0, %op1, %op2
     $d0 = COPY %fmad
     RET_ReallyLR implicit $d0
 ...
@@ -86,17 +86,17 @@ body:             |
     ; CHECK-LABEL: name: v2s32
     ; CHECK: liveins: $d0, $d1, $d2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: %op1:_(<2 x s32>) = COPY $d1
-    ; CHECK-NEXT: %op2:_(<2 x s32>) = COPY $d2
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x s32>) = G_FMUL %op0, %op1
-    ; CHECK-NEXT: %fmad:_(<2 x s32>) = G_FADD [[FMUL]], %op2
-    ; CHECK-NEXT: $d0 = COPY %fmad(<2 x s32>)
+    ; CHECK-NEXT: %op0:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: %op1:_(<2 x f32>) = COPY $d1
+    ; CHECK-NEXT: %op2:_(<2 x f32>) = COPY $d2
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x f32>) = G_FMUL %op0, %op1
+    ; CHECK-NEXT: %fmad:_(<2 x f32>) = G_FADD [[FMUL]], %op2
+    ; CHECK-NEXT: $d0 = COPY %fmad(<2 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %op0:_(<2 x s32>) = COPY $d0
-    %op1:_(<2 x s32>) = COPY $d1
-    %op2:_(<2 x s32>) = COPY $d2
-    %fmad:_(<2 x s32>) = G_FMAD %op0, %op1, %op2
+    %op0:_(<2 x f32>) = COPY $d0
+    %op1:_(<2 x f32>) = COPY $d1
+    %op2:_(<2 x f32>) = COPY $d2
+    %fmad:_(<2 x f32>) = G_FMAD %op0, %op1, %op2
     $d0 = COPY %fmad
     RET_ReallyLR implicit $d0
 ...
@@ -109,17 +109,17 @@ body:             |
     ; CHECK-LABEL: name: v4s32
     ; CHECK: liveins: $q0, $q1, $q2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: %op1:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: %op2:_(<4 x s32>) = COPY $q2
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x s32>) = G_FMUL %op0, %op1
-    ; CHECK-NEXT: %fmad:_(<4 x s32>) = G_FADD [[FMUL]], %op2
-    ; CHECK-NEXT: $q0 = COPY %fmad(<4 x s32>)
+    ; CHECK-NEXT: %op0:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: %op1:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: %op2:_(<4 x f32>) = COPY $q2
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x f32>) = G_FMUL %op0, %op1
+    ; CHECK-NEXT: %fmad:_(<4 x f32>) = G_FADD [[FMUL]], %op2
+    ; CHECK-NEXT: $q0 = COPY %fmad(<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %op0:_(<4 x s32>) = COPY $q0
-    %op1:_(<4 x s32>) = COPY $q1
-    %op2:_(<4 x s32>) = COPY $q2
-    %fmad:_(<4 x s32>) = G_FMAD %op0, %op1, %op2
+    %op0:_(<4 x f32>) = COPY $q0
+    %op1:_(<4 x f32>) = COPY $q1
+    %op2:_(<4 x f32>) = COPY $q2
+    %fmad:_(<4 x f32>) = G_FMAD %op0, %op1, %op2
     $q0 = COPY %fmad
     RET_ReallyLR implicit $q0
 ...
@@ -132,17 +132,17 @@ body:             |
     ; CHECK-LABEL: name: v2s64
     ; CHECK: liveins: $q0, $q1, $q2
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %op0:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: %op1:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: %op2:_(<2 x s64>) = COPY $q2
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x s64>) = G_FMUL %op0, %op1
-    ; CHECK-NEXT: %fmad:_(<2 x s64>) = G_FADD [[FMUL]], %op2
-    ; CHECK-NEXT: $q0 = COPY %fmad(<2 x s64>)
+    ; CHECK-NEXT: %op0:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: %op1:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: %op2:_(<2 x f64>) = COPY $q2
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x f64>) = G_FMUL %op0, %op1
+    ; CHECK-NEXT: %fmad:_(<2 x f64>) = G_FADD [[FMUL]], %op2
+    ; CHECK-NEXT: $q0 = COPY %fmad(<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %op0:_(<2 x s64>) = COPY $q0
-    %op1:_(<2 x s64>) = COPY $q1
-    %op2:_(<2 x s64>) = COPY $q2
-    %fmad:_(<2 x s64>) = G_FMAD %op0, %op1, %op2
+    %op0:_(<2 x f64>) = COPY $q0
+    %op1:_(<2 x f64>) = COPY $q1
+    %op2:_(<2 x f64>) = COPY $q2
+    %fmad:_(<2 x f64>) = G_FMAD %op0, %op1, %op2
     $q0 = COPY %fmad
     RET_ReallyLR implicit $q0
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmaximum.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmaximum.mir
@@ -11,27 +11,27 @@ body:             |
     ; FP16-LABEL: name: s16_legal_with_full_fp16
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s16) = COPY $h0
-    ; FP16-NEXT: %b:_(s16) = COPY $h1
-    ; FP16-NEXT: %legalize_me:_(s16) = G_FMAXIMUM %a, %b
-    ; FP16-NEXT: $h0 = COPY %legalize_me(s16)
+    ; FP16-NEXT: %a:_(f16) = COPY $h0
+    ; FP16-NEXT: %b:_(f16) = COPY $h1
+    ; FP16-NEXT: %legalize_me:_(f16) = G_FMAXIMUM %a, %b
+    ; FP16-NEXT: $h0 = COPY %legalize_me(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; NO-FP16-LABEL: name: s16_legal_with_full_fp16
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %b:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %a(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %b(s16)
-    ; NO-FP16-NEXT: [[FMAXIMUM:%[0-9]+]]:_(s32) = G_FMAXIMUM [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %legalize_me:_(s16) = G_FPTRUNC [[FMAXIMUM]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %legalize_me(s16)
+    ; NO-FP16-NEXT: %a:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %b:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %a(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %b(f16)
+    ; NO-FP16-NEXT: [[FMAXIMUM:%[0-9]+]]:_(f32) = G_FMAXIMUM [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %legalize_me:_(f16) = G_FPTRUNC [[FMAXIMUM]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %legalize_me(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
-    %a:_(s16) = COPY $h0
-    %b:_(s16) = COPY $h1
-    %legalize_me:_(s16) = G_FMAXIMUM %a, %b
-    $h0 = COPY %legalize_me(s16)
+    %a:_(f16) = COPY $h0
+    %b:_(f16) = COPY $h1
+    %legalize_me:_(f16) = G_FMAXIMUM %a, %b
+    $h0 = COPY %legalize_me(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -44,24 +44,24 @@ body:             |
     ; FP16-LABEL: name: s32_legal
     ; FP16: liveins: $s0, $s1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s32) = COPY $s0
-    ; FP16-NEXT: %b:_(s32) = COPY $s1
-    ; FP16-NEXT: %legalize_me:_(s32) = G_FMAXIMUM %a, %b
-    ; FP16-NEXT: $s0 = COPY %legalize_me(s32)
+    ; FP16-NEXT: %a:_(f32) = COPY $s0
+    ; FP16-NEXT: %b:_(f32) = COPY $s1
+    ; FP16-NEXT: %legalize_me:_(f32) = G_FMAXIMUM %a, %b
+    ; FP16-NEXT: $s0 = COPY %legalize_me(f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; NO-FP16-LABEL: name: s32_legal
     ; NO-FP16: liveins: $s0, $s1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: %b:_(s32) = COPY $s1
-    ; NO-FP16-NEXT: %legalize_me:_(s32) = G_FMAXIMUM %a, %b
-    ; NO-FP16-NEXT: $s0 = COPY %legalize_me(s32)
+    ; NO-FP16-NEXT: %a:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: %b:_(f32) = COPY $s1
+    ; NO-FP16-NEXT: %legalize_me:_(f32) = G_FMAXIMUM %a, %b
+    ; NO-FP16-NEXT: $s0 = COPY %legalize_me(f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
-    %a:_(s32) = COPY $s0
-    %b:_(s32) = COPY $s1
-    %legalize_me:_(s32) = G_FMAXIMUM %a, %b
-    $s0 = COPY %legalize_me(s32)
+    %a:_(f32) = COPY $s0
+    %b:_(f32) = COPY $s1
+    %legalize_me:_(f32) = G_FMAXIMUM %a, %b
+    $s0 = COPY %legalize_me(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -74,24 +74,24 @@ body:             |
     ; FP16-LABEL: name: s64_legal
     ; FP16: liveins: $d0, $d1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s64) = COPY $d0
-    ; FP16-NEXT: %b:_(s64) = COPY $d1
-    ; FP16-NEXT: %legalize_me:_(s64) = G_FMAXIMUM %a, %b
-    ; FP16-NEXT: $d0 = COPY %legalize_me(s64)
+    ; FP16-NEXT: %a:_(f64) = COPY $d0
+    ; FP16-NEXT: %b:_(f64) = COPY $d1
+    ; FP16-NEXT: %legalize_me:_(f64) = G_FMAXIMUM %a, %b
+    ; FP16-NEXT: $d0 = COPY %legalize_me(f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: s64_legal
     ; NO-FP16: liveins: $d0, $d1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: %b:_(s64) = COPY $d1
-    ; NO-FP16-NEXT: %legalize_me:_(s64) = G_FMAXIMUM %a, %b
-    ; NO-FP16-NEXT: $d0 = COPY %legalize_me(s64)
+    ; NO-FP16-NEXT: %a:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: %b:_(f64) = COPY $d1
+    ; NO-FP16-NEXT: %legalize_me:_(f64) = G_FMAXIMUM %a, %b
+    ; NO-FP16-NEXT: $d0 = COPY %legalize_me(f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %a:_(s64) = COPY $d0
-    %b:_(s64) = COPY $d1
-    %legalize_me:_(s64) = G_FMAXIMUM %a, %b
-    $d0 = COPY %legalize_me(s64)
+    %a:_(f64) = COPY $d0
+    %b:_(f64) = COPY $d1
+    %legalize_me:_(f64) = G_FMAXIMUM %a, %b
+    $d0 = COPY %legalize_me(f64)
     RET_ReallyLR implicit $d0
 ...
 ---
@@ -103,24 +103,24 @@ body:             |
     ; FP16-LABEL: name: v2s32
     ; FP16: liveins: $d0, $d1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: %b:_(<2 x s32>) = COPY $d1
-    ; FP16-NEXT: %maximum:_(<2 x s32>) = G_FMAXIMUM %a, %b
-    ; FP16-NEXT: $d0 = COPY %maximum(<2 x s32>)
+    ; FP16-NEXT: %a:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: %b:_(<2 x f32>) = COPY $d1
+    ; FP16-NEXT: %maximum:_(<2 x f32>) = G_FMAXIMUM %a, %b
+    ; FP16-NEXT: $d0 = COPY %maximum(<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: v2s32
     ; NO-FP16: liveins: $d0, $d1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: %b:_(<2 x s32>) = COPY $d1
-    ; NO-FP16-NEXT: %maximum:_(<2 x s32>) = G_FMAXIMUM %a, %b
-    ; NO-FP16-NEXT: $d0 = COPY %maximum(<2 x s32>)
+    ; NO-FP16-NEXT: %a:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: %b:_(<2 x f32>) = COPY $d1
+    ; NO-FP16-NEXT: %maximum:_(<2 x f32>) = G_FMAXIMUM %a, %b
+    ; NO-FP16-NEXT: $d0 = COPY %maximum(<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %a:_(<2 x s32>) = COPY $d0
-    %b:_(<2 x s32>) = COPY $d1
-    %maximum:_(<2 x s32>) = G_FMAXIMUM %a, %b
-    $d0 = COPY %maximum(<2 x s32>)
+    %a:_(<2 x f32>) = COPY $d0
+    %b:_(<2 x f32>) = COPY $d1
+    %maximum:_(<2 x f32>) = G_FMAXIMUM %a, %b
+    $d0 = COPY %maximum(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -133,24 +133,24 @@ body:             |
     ; FP16-LABEL: name: v4s32
     ; FP16: liveins: $q0, $q1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; FP16-NEXT: %maximum:_(<4 x s32>) = G_FMAXIMUM %a, %b
-    ; FP16-NEXT: $q0 = COPY %maximum(<4 x s32>)
+    ; FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; FP16-NEXT: %maximum:_(<4 x f32>) = G_FMAXIMUM %a, %b
+    ; FP16-NEXT: $q0 = COPY %maximum(<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; NO-FP16-LABEL: name: v4s32
     ; NO-FP16: liveins: $q0, $q1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; NO-FP16-NEXT: %maximum:_(<4 x s32>) = G_FMAXIMUM %a, %b
-    ; NO-FP16-NEXT: $q0 = COPY %maximum(<4 x s32>)
+    ; NO-FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; NO-FP16-NEXT: %maximum:_(<4 x f32>) = G_FMAXIMUM %a, %b
+    ; NO-FP16-NEXT: $q0 = COPY %maximum(<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
-    %a:_(<4 x s32>) = COPY $q0
-    %b:_(<4 x s32>) = COPY $q1
-    %maximum:_(<4 x s32>) = G_FMAXIMUM %a, %b
-    $q0 = COPY %maximum(<4 x s32>)
+    %a:_(<4 x f32>) = COPY $q0
+    %b:_(<4 x f32>) = COPY $q1
+    %maximum:_(<4 x f32>) = G_FMAXIMUM %a, %b
+    $q0 = COPY %maximum(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmaxnum.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fmaxnum.mir
@@ -11,27 +11,27 @@ body:             |
     ; FP16-LABEL: name: s16_legal_with_full_fp16
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s16) = COPY $h0
-    ; FP16-NEXT: %b:_(s16) = COPY $h1
-    ; FP16-NEXT: %maxnum:_(s16) = G_FMAXNUM %a, %b
-    ; FP16-NEXT: $h0 = COPY %maxnum(s16)
+    ; FP16-NEXT: %a:_(f16) = COPY $h0
+    ; FP16-NEXT: %b:_(f16) = COPY $h1
+    ; FP16-NEXT: %maxnum:_(f16) = G_FMAXNUM %a, %b
+    ; FP16-NEXT: $h0 = COPY %maxnum(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; NO-FP16-LABEL: name: s16_legal_with_full_fp16
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %b:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %a(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %b(s16)
-    ; NO-FP16-NEXT: [[FMAXNUM:%[0-9]+]]:_(s32) = G_FMAXNUM [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %maxnum:_(s16) = G_FPTRUNC [[FMAXNUM]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %maxnum(s16)
+    ; NO-FP16-NEXT: %a:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %b:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %a(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %b(f16)
+    ; NO-FP16-NEXT: [[FMAXNUM:%[0-9]+]]:_(f32) = G_FMAXNUM [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %maxnum:_(f16) = G_FPTRUNC [[FMAXNUM]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %maxnum(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
-    %a:_(s16) = COPY $h0
-    %b:_(s16) = COPY $h1
-    %maxnum:_(s16) = G_FMAXNUM %a, %b
-    $h0 = COPY %maxnum(s16)
+    %a:_(f16) = COPY $h0
+    %b:_(f16) = COPY $h1
+    %maxnum:_(f16) = G_FMAXNUM %a, %b
+    $h0 = COPY %maxnum(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -44,24 +44,24 @@ body:             |
     ; FP16-LABEL: name: s32_legal
     ; FP16: liveins: $s0, $s1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s32) = COPY $s0
-    ; FP16-NEXT: %b:_(s32) = COPY $s1
-    ; FP16-NEXT: %maxnum:_(s32) = G_FMAXNUM %a, %b
-    ; FP16-NEXT: $s0 = COPY %maxnum(s32)
+    ; FP16-NEXT: %a:_(f32) = COPY $s0
+    ; FP16-NEXT: %b:_(f32) = COPY $s1
+    ; FP16-NEXT: %maxnum:_(f32) = G_FMAXNUM %a, %b
+    ; FP16-NEXT: $s0 = COPY %maxnum(f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; NO-FP16-LABEL: name: s32_legal
     ; NO-FP16: liveins: $s0, $s1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: %b:_(s32) = COPY $s1
-    ; NO-FP16-NEXT: %maxnum:_(s32) = G_FMAXNUM %a, %b
-    ; NO-FP16-NEXT: $s0 = COPY %maxnum(s32)
+    ; NO-FP16-NEXT: %a:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: %b:_(f32) = COPY $s1
+    ; NO-FP16-NEXT: %maxnum:_(f32) = G_FMAXNUM %a, %b
+    ; NO-FP16-NEXT: $s0 = COPY %maxnum(f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
-    %a:_(s32) = COPY $s0
-    %b:_(s32) = COPY $s1
-    %maxnum:_(s32) = G_FMAXNUM %a, %b
-    $s0 = COPY %maxnum(s32)
+    %a:_(f32) = COPY $s0
+    %b:_(f32) = COPY $s1
+    %maxnum:_(f32) = G_FMAXNUM %a, %b
+    $s0 = COPY %maxnum(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -74,24 +74,24 @@ body:             |
     ; FP16-LABEL: name: s64_legal
     ; FP16: liveins: $d0, $d1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s64) = COPY $d0
-    ; FP16-NEXT: %b:_(s64) = COPY $d1
-    ; FP16-NEXT: %maxnum:_(s64) = G_FMAXNUM %a, %b
-    ; FP16-NEXT: $d0 = COPY %maxnum(s64)
+    ; FP16-NEXT: %a:_(f64) = COPY $d0
+    ; FP16-NEXT: %b:_(f64) = COPY $d1
+    ; FP16-NEXT: %maxnum:_(f64) = G_FMAXNUM %a, %b
+    ; FP16-NEXT: $d0 = COPY %maxnum(f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: s64_legal
     ; NO-FP16: liveins: $d0, $d1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: %b:_(s64) = COPY $d1
-    ; NO-FP16-NEXT: %maxnum:_(s64) = G_FMAXNUM %a, %b
-    ; NO-FP16-NEXT: $d0 = COPY %maxnum(s64)
+    ; NO-FP16-NEXT: %a:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: %b:_(f64) = COPY $d1
+    ; NO-FP16-NEXT: %maxnum:_(f64) = G_FMAXNUM %a, %b
+    ; NO-FP16-NEXT: $d0 = COPY %maxnum(f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %a:_(s64) = COPY $d0
-    %b:_(s64) = COPY $d1
-    %maxnum:_(s64) = G_FMAXNUM %a, %b
-    $d0 = COPY %maxnum(s64)
+    %a:_(f64) = COPY $d0
+    %b:_(f64) = COPY $d1
+    %maxnum:_(f64) = G_FMAXNUM %a, %b
+    $d0 = COPY %maxnum(f64)
     RET_ReallyLR implicit $d0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fminimum.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fminimum.mir
@@ -11,27 +11,27 @@ body:             |
     ; FP16-LABEL: name: s16_legal_with_full_fp16
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s16) = COPY $h0
-    ; FP16-NEXT: %b:_(s16) = COPY $h1
-    ; FP16-NEXT: %legalize_me:_(s16) = G_FMINIMUM %a, %b
-    ; FP16-NEXT: $h0 = COPY %legalize_me(s16)
+    ; FP16-NEXT: %a:_(f16) = COPY $h0
+    ; FP16-NEXT: %b:_(f16) = COPY $h1
+    ; FP16-NEXT: %legalize_me:_(f16) = G_FMINIMUM %a, %b
+    ; FP16-NEXT: $h0 = COPY %legalize_me(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; NO-FP16-LABEL: name: s16_legal_with_full_fp16
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %b:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %a(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %b(s16)
-    ; NO-FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(s32) = G_FMINIMUM [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %legalize_me:_(s16) = G_FPTRUNC [[FMINIMUM]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %legalize_me(s16)
+    ; NO-FP16-NEXT: %a:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %b:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %a(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %b(f16)
+    ; NO-FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(f32) = G_FMINIMUM [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %legalize_me:_(f16) = G_FPTRUNC [[FMINIMUM]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %legalize_me(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
-    %a:_(s16) = COPY $h0
-    %b:_(s16) = COPY $h1
-    %legalize_me:_(s16) = G_FMINIMUM %a, %b
-    $h0 = COPY %legalize_me(s16)
+    %a:_(f16) = COPY $h0
+    %b:_(f16) = COPY $h1
+    %legalize_me:_(f16) = G_FMINIMUM %a, %b
+    $h0 = COPY %legalize_me(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -44,24 +44,24 @@ body:             |
     ; FP16-LABEL: name: s32_legal
     ; FP16: liveins: $s0, $s1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s32) = COPY $s0
-    ; FP16-NEXT: %b:_(s32) = COPY $s1
-    ; FP16-NEXT: %legalize_me:_(s32) = G_FMINIMUM %a, %b
-    ; FP16-NEXT: $s0 = COPY %legalize_me(s32)
+    ; FP16-NEXT: %a:_(f32) = COPY $s0
+    ; FP16-NEXT: %b:_(f32) = COPY $s1
+    ; FP16-NEXT: %legalize_me:_(f32) = G_FMINIMUM %a, %b
+    ; FP16-NEXT: $s0 = COPY %legalize_me(f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; NO-FP16-LABEL: name: s32_legal
     ; NO-FP16: liveins: $s0, $s1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: %b:_(s32) = COPY $s1
-    ; NO-FP16-NEXT: %legalize_me:_(s32) = G_FMINIMUM %a, %b
-    ; NO-FP16-NEXT: $s0 = COPY %legalize_me(s32)
+    ; NO-FP16-NEXT: %a:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: %b:_(f32) = COPY $s1
+    ; NO-FP16-NEXT: %legalize_me:_(f32) = G_FMINIMUM %a, %b
+    ; NO-FP16-NEXT: $s0 = COPY %legalize_me(f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
-    %a:_(s32) = COPY $s0
-    %b:_(s32) = COPY $s1
-    %legalize_me:_(s32) = G_FMINIMUM %a, %b
-    $s0 = COPY %legalize_me(s32)
+    %a:_(f32) = COPY $s0
+    %b:_(f32) = COPY $s1
+    %legalize_me:_(f32) = G_FMINIMUM %a, %b
+    $s0 = COPY %legalize_me(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -74,24 +74,24 @@ body:             |
     ; FP16-LABEL: name: s64_legal
     ; FP16: liveins: $d0, $d1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(s64) = COPY $d0
-    ; FP16-NEXT: %b:_(s64) = COPY $d1
-    ; FP16-NEXT: %legalize_me:_(s64) = G_FMINIMUM %a, %b
-    ; FP16-NEXT: $d0 = COPY %legalize_me(s64)
+    ; FP16-NEXT: %a:_(f64) = COPY $d0
+    ; FP16-NEXT: %b:_(f64) = COPY $d1
+    ; FP16-NEXT: %legalize_me:_(f64) = G_FMINIMUM %a, %b
+    ; FP16-NEXT: $d0 = COPY %legalize_me(f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: s64_legal
     ; NO-FP16: liveins: $d0, $d1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: %b:_(s64) = COPY $d1
-    ; NO-FP16-NEXT: %legalize_me:_(s64) = G_FMINIMUM %a, %b
-    ; NO-FP16-NEXT: $d0 = COPY %legalize_me(s64)
+    ; NO-FP16-NEXT: %a:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: %b:_(f64) = COPY $d1
+    ; NO-FP16-NEXT: %legalize_me:_(f64) = G_FMINIMUM %a, %b
+    ; NO-FP16-NEXT: $d0 = COPY %legalize_me(f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %a:_(s64) = COPY $d0
-    %b:_(s64) = COPY $d1
-    %legalize_me:_(s64) = G_FMINIMUM %a, %b
-    $d0 = COPY %legalize_me(s64)
+    %a:_(f64) = COPY $d0
+    %b:_(f64) = COPY $d1
+    %legalize_me:_(f64) = G_FMINIMUM %a, %b
+    $d0 = COPY %legalize_me(f64)
     RET_ReallyLR implicit $d0
 ...
 ---
@@ -103,24 +103,24 @@ body:             |
     ; FP16-LABEL: name: v4s32
     ; FP16: liveins: $q0, $q1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; FP16-NEXT: %minimum:_(<4 x s32>) = G_FMINIMUM %a, %b
-    ; FP16-NEXT: $q0 = COPY %minimum(<4 x s32>)
+    ; FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; FP16-NEXT: %minimum:_(<4 x f32>) = G_FMINIMUM %a, %b
+    ; FP16-NEXT: $q0 = COPY %minimum(<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; NO-FP16-LABEL: name: v4s32
     ; NO-FP16: liveins: $q0, $q1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; NO-FP16-NEXT: %minimum:_(<4 x s32>) = G_FMINIMUM %a, %b
-    ; NO-FP16-NEXT: $q0 = COPY %minimum(<4 x s32>)
+    ; NO-FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; NO-FP16-NEXT: %minimum:_(<4 x f32>) = G_FMINIMUM %a, %b
+    ; NO-FP16-NEXT: $q0 = COPY %minimum(<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
-    %a:_(<4 x s32>) = COPY $q0
-    %b:_(<4 x s32>) = COPY $q1
-    %minimum:_(<4 x s32>) = G_FMINIMUM %a, %b
-    $q0 = COPY %minimum(<4 x s32>)
+    %a:_(<4 x f32>) = COPY $q0
+    %b:_(<4 x f32>) = COPY $q1
+    %minimum:_(<4 x f32>) = G_FMINIMUM %a, %b
+    $q0 = COPY %minimum(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -134,38 +134,38 @@ body:             |
     ; FP16-LABEL: name: v8s32
     ; FP16: liveins: $q0, $q1, $q2, $q3
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; FP16-NEXT: %c:_(<4 x s32>) = COPY $q2
-    ; FP16-NEXT: %d:_(<4 x s32>) = COPY $q3
-    ; FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(<4 x s32>) = G_FMINIMUM %a, %c
-    ; FP16-NEXT: [[FMINIMUM1:%[0-9]+]]:_(<4 x s32>) = G_FMINIMUM %b, %d
-    ; FP16-NEXT: $q0 = COPY [[FMINIMUM]](<4 x s32>)
-    ; FP16-NEXT: $q1 = COPY [[FMINIMUM1]](<4 x s32>)
+    ; FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; FP16-NEXT: %c:_(<4 x f32>) = COPY $q2
+    ; FP16-NEXT: %d:_(<4 x f32>) = COPY $q3
+    ; FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(<4 x f32>) = G_FMINIMUM %a, %c
+    ; FP16-NEXT: [[FMINIMUM1:%[0-9]+]]:_(<4 x f32>) = G_FMINIMUM %b, %d
+    ; FP16-NEXT: $q0 = COPY [[FMINIMUM]](<4 x f32>)
+    ; FP16-NEXT: $q1 = COPY [[FMINIMUM1]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; NO-FP16-LABEL: name: v8s32
     ; NO-FP16: liveins: $q0, $q1, $q2, $q3
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; NO-FP16-NEXT: %c:_(<4 x s32>) = COPY $q2
-    ; NO-FP16-NEXT: %d:_(<4 x s32>) = COPY $q3
-    ; NO-FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(<4 x s32>) = G_FMINIMUM %a, %c
-    ; NO-FP16-NEXT: [[FMINIMUM1:%[0-9]+]]:_(<4 x s32>) = G_FMINIMUM %b, %d
-    ; NO-FP16-NEXT: $q0 = COPY [[FMINIMUM]](<4 x s32>)
-    ; NO-FP16-NEXT: $q1 = COPY [[FMINIMUM1]](<4 x s32>)
+    ; NO-FP16-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; NO-FP16-NEXT: %c:_(<4 x f32>) = COPY $q2
+    ; NO-FP16-NEXT: %d:_(<4 x f32>) = COPY $q3
+    ; NO-FP16-NEXT: [[FMINIMUM:%[0-9]+]]:_(<4 x f32>) = G_FMINIMUM %a, %c
+    ; NO-FP16-NEXT: [[FMINIMUM1:%[0-9]+]]:_(<4 x f32>) = G_FMINIMUM %b, %d
+    ; NO-FP16-NEXT: $q0 = COPY [[FMINIMUM]](<4 x f32>)
+    ; NO-FP16-NEXT: $q1 = COPY [[FMINIMUM1]](<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
-    %a:_(<4 x s32>) = COPY $q0
-    %b:_(<4 x s32>) = COPY $q1
-    %c:_(<4 x s32>) = COPY $q2
-    %d:_(<4 x s32>) = COPY $q3
-    %v1:_(<8 x s32>) = G_CONCAT_VECTORS %a, %b
-    %v2:_(<8 x s32>) = G_CONCAT_VECTORS %c, %d
-    %minimum:_(<8 x s32>) = G_FMINIMUM %v1, %v2
-    %uv1:_(<4 x s32>), %uv2:_(<4 x s32>) = G_UNMERGE_VALUES %minimum
-    $q0 = COPY %uv1(<4 x s32>)
-    $q1 = COPY %uv2(<4 x s32>)
+    %a:_(<4 x f32>) = COPY $q0
+    %b:_(<4 x f32>) = COPY $q1
+    %c:_(<4 x f32>) = COPY $q2
+    %d:_(<4 x f32>) = COPY $q3
+    %v1:_(<8 x f32>) = G_CONCAT_VECTORS %a, %b
+    %v2:_(<8 x f32>) = G_CONCAT_VECTORS %c, %d
+    %minimum:_(<8 x f32>) = G_FMINIMUM %v1, %v2
+    %uv1:_(<4 x f32>), %uv2:_(<4 x f32>) = G_UNMERGE_VALUES %minimum
+    $q0 = COPY %uv1(<4 x f32>)
+    $q1 = COPY %uv2(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fminnum.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fminnum.mir
@@ -11,27 +11,27 @@ body:             |
     ; CHECK-FP16-LABEL: name: s16_legal_with_full_fp16
     ; CHECK-FP16: liveins: $h0, $h1
     ; CHECK-FP16-NEXT: {{  $}}
-    ; CHECK-FP16-NEXT: %a:_(s16) = COPY $h0
-    ; CHECK-FP16-NEXT: %b:_(s16) = COPY $h1
-    ; CHECK-FP16-NEXT: %minnum:_(s16) = G_FMINNUM %a, %b
-    ; CHECK-FP16-NEXT: $h0 = COPY %minnum(s16)
+    ; CHECK-FP16-NEXT: %a:_(f16) = COPY $h0
+    ; CHECK-FP16-NEXT: %b:_(f16) = COPY $h1
+    ; CHECK-FP16-NEXT: %minnum:_(f16) = G_FMINNUM %a, %b
+    ; CHECK-FP16-NEXT: $h0 = COPY %minnum(f16)
     ; CHECK-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; CHECK-NOFP16-LABEL: name: s16_legal_with_full_fp16
     ; CHECK-NOFP16: liveins: $h0, $h1
     ; CHECK-NOFP16-NEXT: {{  $}}
-    ; CHECK-NOFP16-NEXT: %a:_(s16) = COPY $h0
-    ; CHECK-NOFP16-NEXT: %b:_(s16) = COPY $h1
-    ; CHECK-NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %a(s16)
-    ; CHECK-NOFP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %b(s16)
-    ; CHECK-NOFP16-NEXT: [[FMINNUM:%[0-9]+]]:_(s32) = G_FMINNUM [[FPEXT]], [[FPEXT1]]
-    ; CHECK-NOFP16-NEXT: %minnum:_(s16) = G_FPTRUNC [[FMINNUM]](s32)
-    ; CHECK-NOFP16-NEXT: $h0 = COPY %minnum(s16)
+    ; CHECK-NOFP16-NEXT: %a:_(f16) = COPY $h0
+    ; CHECK-NOFP16-NEXT: %b:_(f16) = COPY $h1
+    ; CHECK-NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %a(f16)
+    ; CHECK-NOFP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %b(f16)
+    ; CHECK-NOFP16-NEXT: [[FMINNUM:%[0-9]+]]:_(f32) = G_FMINNUM [[FPEXT]], [[FPEXT1]]
+    ; CHECK-NOFP16-NEXT: %minnum:_(f16) = G_FPTRUNC [[FMINNUM]](f32)
+    ; CHECK-NOFP16-NEXT: $h0 = COPY %minnum(f16)
     ; CHECK-NOFP16-NEXT: RET_ReallyLR implicit $h0
-    %a:_(s16) = COPY $h0
-    %b:_(s16) = COPY $h1
-    %minnum:_(s16) = G_FMINNUM %a, %b
-    $h0 = COPY %minnum(s16)
+    %a:_(f16) = COPY $h0
+    %b:_(f16) = COPY $h1
+    %minnum:_(f16) = G_FMINNUM %a, %b
+    $h0 = COPY %minnum(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -44,15 +44,15 @@ body:             |
     ; CHECK-LABEL: name: s32_legal
     ; CHECK: liveins: $s0, $s1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %a:_(s32) = COPY $s0
-    ; CHECK-NEXT: %b:_(s32) = COPY $s1
-    ; CHECK-NEXT: %minnum:_(s32) = G_FMINNUM %a, %b
-    ; CHECK-NEXT: $s0 = COPY %minnum(s32)
+    ; CHECK-NEXT: %a:_(f32) = COPY $s0
+    ; CHECK-NEXT: %b:_(f32) = COPY $s1
+    ; CHECK-NEXT: %minnum:_(f32) = G_FMINNUM %a, %b
+    ; CHECK-NEXT: $s0 = COPY %minnum(f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %a:_(s32) = COPY $s0
-    %b:_(s32) = COPY $s1
-    %minnum:_(s32) = G_FMINNUM %a, %b
-    $s0 = COPY %minnum(s32)
+    %a:_(f32) = COPY $s0
+    %b:_(f32) = COPY $s1
+    %minnum:_(f32) = G_FMINNUM %a, %b
+    $s0 = COPY %minnum(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -65,15 +65,15 @@ body:             |
     ; CHECK-LABEL: name: s64_legal
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %a:_(s64) = COPY $d0
-    ; CHECK-NEXT: %b:_(s64) = COPY $d1
-    ; CHECK-NEXT: %minnum:_(s64) = G_FMINNUM %a, %b
-    ; CHECK-NEXT: $d0 = COPY %minnum(s64)
+    ; CHECK-NEXT: %a:_(f64) = COPY $d0
+    ; CHECK-NEXT: %b:_(f64) = COPY $d1
+    ; CHECK-NEXT: %minnum:_(f64) = G_FMINNUM %a, %b
+    ; CHECK-NEXT: $d0 = COPY %minnum(f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %a:_(s64) = COPY $d0
-    %b:_(s64) = COPY $d1
-    %minnum:_(s64) = G_FMINNUM %a, %b
-    $d0 = COPY %minnum(s64)
+    %a:_(f64) = COPY $d0
+    %b:_(f64) = COPY $d1
+    %minnum:_(f64) = G_FMINNUM %a, %b
+    $d0 = COPY %minnum(f64)
     RET_ReallyLR implicit $d0
 
 ...
@@ -112,15 +112,15 @@ body:             |
     ; CHECK-LABEL: name: v4s32_legal
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %a:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: %b:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: %minnum:_(<4 x s32>) = G_FMINNUM %a, %b
-    ; CHECK-NEXT: $q0 = COPY %minnum(<4 x s32>)
+    ; CHECK-NEXT: %a:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: %b:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: %minnum:_(<4 x f32>) = G_FMINNUM %a, %b
+    ; CHECK-NEXT: $q0 = COPY %minnum(<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %a:_(<4 x s32>) = COPY $q0
-    %b:_(<4 x s32>) = COPY $q1
-    %minnum:_(<4 x s32>) = G_FMINNUM %a, %b
-    $q0 = COPY %minnum(<4 x s32>)
+    %a:_(<4 x f32>) = COPY $q0
+    %b:_(<4 x f32>) = COPY $q1
+    %minnum:_(<4 x f32>) = G_FMINNUM %a, %b
+    $q0 = COPY %minnum(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -133,26 +133,26 @@ body:             |
     ; CHECK-LABEL: name: v3s32_widen
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s32>) = G_BITCAST [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<4 x s32>) = G_BITCAST [[COPY1]](<2 x s64>)
-    ; CHECK-NEXT: [[FMINNUM:%[0-9]+]]:_(<4 x s32>) = G_FMINNUM [[BITCAST]], [[BITCAST1]]
-    ; CHECK-NEXT: $q0 = COPY [[FMINNUM]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x f32>) = G_BITCAST [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<4 x f32>) = G_BITCAST [[COPY1]](<2 x f64>)
+    ; CHECK-NEXT: [[FMINNUM:%[0-9]+]]:_(<4 x f32>) = G_FMINNUM [[BITCAST]], [[BITCAST1]]
+    ; CHECK-NEXT: $q0 = COPY [[FMINNUM]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %2:_(<2 x s64>) = COPY $q0
-    %3:_(<4 x s32>) = G_BITCAST %2:_(<2 x s64>)
-    %4:_(s32), %5:_(s32), %6:_(s32), %7:_(s32) = G_UNMERGE_VALUES %3:_(<4 x s32>)
-    %0:_(<3 x s32>) = G_BUILD_VECTOR %4:_(s32), %5:_(s32), %6:_(s32)
-    %8:_(<2 x s64>) = COPY $q1
-    %9:_(<4 x s32>) = G_BITCAST %8:_(<2 x s64>)
-    %10:_(s32), %11:_(s32), %12:_(s32), %13:_(s32) = G_UNMERGE_VALUES %9:_(<4 x s32>)
-    %1:_(<3 x s32>) = G_BUILD_VECTOR %10:_(s32), %11:_(s32), %12:_(s32)
-    %14:_(<3 x s32>) = G_FMINNUM %0:_, %1:_
-    %15:_(s32), %16:_(s32), %17:_(s32) = G_UNMERGE_VALUES %14:_(<3 x s32>)
-    %18:_(s32) = G_IMPLICIT_DEF
-    %19:_(<4 x s32>) = G_BUILD_VECTOR %15:_(s32), %16:_(s32), %17:_(s32), %18:_(s32)
-    $q0 = COPY %19:_(<4 x s32>)
+    %2:_(<2 x f64>) = COPY $q0
+    %3:_(<4 x f32>) = G_BITCAST %2:_(<2 x f64>)
+    %4:_(f32), %5:_(f32), %6:_(f32), %7:_(f32) = G_UNMERGE_VALUES %3:_(<4 x f32>)
+    %0:_(<3 x f32>) = G_BUILD_VECTOR %4:_(f32), %5:_(f32), %6:_(f32)
+    %8:_(<2 x f64>) = COPY $q1
+    %9:_(<4 x f32>) = G_BITCAST %8:_(<2 x f64>)
+    %10:_(f32), %11:_(f32), %12:_(f32), %13:_(f32) = G_UNMERGE_VALUES %9:_(<4 x f32>)
+    %1:_(<3 x f32>) = G_BUILD_VECTOR %10:_(f32), %11:_(f32), %12:_(f32)
+    %14:_(<3 x f32>) = G_FMINNUM %0:_, %1:_
+    %15:_(f32), %16:_(f32), %17:_(f32) = G_UNMERGE_VALUES %14:_(<3 x f32>)
+    %18:_(f32) = G_IMPLICIT_DEF
+    %19:_(<4 x f32>) = G_BUILD_VECTOR %15:_(f32), %16:_(f32), %17:_(f32), %18:_(f32)
+    $q0 = COPY %19:_(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fp-arith-fp16.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fp-arith-fp16.mir
@@ -13,27 +13,27 @@ body:             |
     ; NO-FP16-LABEL: name: fadd
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %x:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %y:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %x(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %y(s16)
-    ; NO-FP16-NEXT: [[FADD:%[0-9]+]]:_(s32) = G_FADD [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %op:_(s16) = G_FPTRUNC [[FADD]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %op(s16)
+    ; NO-FP16-NEXT: %x:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %y:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %x(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %y(f16)
+    ; NO-FP16-NEXT: [[FADD:%[0-9]+]]:_(f32) = G_FADD [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %op:_(f16) = G_FPTRUNC [[FADD]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %op(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: fadd
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %x:_(s16) = COPY $h0
-    ; FP16-NEXT: %y:_(s16) = COPY $h1
-    ; FP16-NEXT: %op:_(s16) = G_FADD %x, %y
-    ; FP16-NEXT: $h0 = COPY %op(s16)
+    ; FP16-NEXT: %x:_(f16) = COPY $h0
+    ; FP16-NEXT: %y:_(f16) = COPY $h1
+    ; FP16-NEXT: %op:_(f16) = G_FADD %x, %y
+    ; FP16-NEXT: $h0 = COPY %op(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %x:_(s16) = COPY $h0
-    %y:_(s16) = COPY $h1
-    %op:_(s16) = G_FADD %x, %y
-    $h0 = COPY %op(s16)
+    %x:_(f16) = COPY $h0
+    %y:_(f16) = COPY $h1
+    %op:_(f16) = G_FADD %x, %y
+    $h0 = COPY %op(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -47,27 +47,27 @@ body:             |
     ; NO-FP16-LABEL: name: fsub
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %x:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %y:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %x(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %y(s16)
-    ; NO-FP16-NEXT: [[FSUB:%[0-9]+]]:_(s32) = G_FSUB [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %op:_(s16) = G_FPTRUNC [[FSUB]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %op(s16)
+    ; NO-FP16-NEXT: %x:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %y:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %x(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %y(f16)
+    ; NO-FP16-NEXT: [[FSUB:%[0-9]+]]:_(f32) = G_FSUB [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %op:_(f16) = G_FPTRUNC [[FSUB]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %op(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: fsub
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %x:_(s16) = COPY $h0
-    ; FP16-NEXT: %y:_(s16) = COPY $h1
-    ; FP16-NEXT: %op:_(s16) = G_FSUB %x, %y
-    ; FP16-NEXT: $h0 = COPY %op(s16)
+    ; FP16-NEXT: %x:_(f16) = COPY $h0
+    ; FP16-NEXT: %y:_(f16) = COPY $h1
+    ; FP16-NEXT: %op:_(f16) = G_FSUB %x, %y
+    ; FP16-NEXT: $h0 = COPY %op(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %x:_(s16) = COPY $h0
-    %y:_(s16) = COPY $h1
-    %op:_(s16) = G_FSUB %x, %y
-    $h0 = COPY %op(s16)
+    %x:_(f16) = COPY $h0
+    %y:_(f16) = COPY $h1
+    %op:_(f16) = G_FSUB %x, %y
+    $h0 = COPY %op(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -81,27 +81,27 @@ body:             |
     ; NO-FP16-LABEL: name: fmul
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %x:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %y:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %x(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %y(s16)
-    ; NO-FP16-NEXT: [[FMUL:%[0-9]+]]:_(s32) = G_FMUL [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %op:_(s16) = G_FPTRUNC [[FMUL]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %op(s16)
+    ; NO-FP16-NEXT: %x:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %y:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %x(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %y(f16)
+    ; NO-FP16-NEXT: [[FMUL:%[0-9]+]]:_(f32) = G_FMUL [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %op:_(f16) = G_FPTRUNC [[FMUL]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %op(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: fmul
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %x:_(s16) = COPY $h0
-    ; FP16-NEXT: %y:_(s16) = COPY $h1
-    ; FP16-NEXT: %op:_(s16) = G_FMUL %x, %y
-    ; FP16-NEXT: $h0 = COPY %op(s16)
+    ; FP16-NEXT: %x:_(f16) = COPY $h0
+    ; FP16-NEXT: %y:_(f16) = COPY $h1
+    ; FP16-NEXT: %op:_(f16) = G_FMUL %x, %y
+    ; FP16-NEXT: $h0 = COPY %op(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %x:_(s16) = COPY $h0
-    %y:_(s16) = COPY $h1
-    %op:_(s16) = G_FMUL %x, %y
-    $h0 = COPY %op(s16)
+    %x:_(f16) = COPY $h0
+    %y:_(f16) = COPY $h1
+    %op:_(f16) = G_FMUL %x, %y
+    $h0 = COPY %op(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -115,27 +115,27 @@ body:             |
     ; NO-FP16-LABEL: name: fdiv
     ; NO-FP16: liveins: $h0, $h1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %x:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: %y:_(s16) = COPY $h1
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT %x(s16)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT %y(s16)
-    ; NO-FP16-NEXT: [[FDIV:%[0-9]+]]:_(s32) = G_FDIV [[FPEXT]], [[FPEXT1]]
-    ; NO-FP16-NEXT: %op:_(s16) = G_FPTRUNC [[FDIV]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %op(s16)
+    ; NO-FP16-NEXT: %x:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: %y:_(f16) = COPY $h1
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT %x(f16)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT %y(f16)
+    ; NO-FP16-NEXT: [[FDIV:%[0-9]+]]:_(f32) = G_FDIV [[FPEXT]], [[FPEXT1]]
+    ; NO-FP16-NEXT: %op:_(f16) = G_FPTRUNC [[FDIV]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY %op(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: fdiv
     ; FP16: liveins: $h0, $h1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %x:_(s16) = COPY $h0
-    ; FP16-NEXT: %y:_(s16) = COPY $h1
-    ; FP16-NEXT: %op:_(s16) = G_FDIV %x, %y
-    ; FP16-NEXT: $h0 = COPY %op(s16)
+    ; FP16-NEXT: %x:_(f16) = COPY $h0
+    ; FP16-NEXT: %y:_(f16) = COPY $h1
+    ; FP16-NEXT: %op:_(f16) = G_FDIV %x, %y
+    ; FP16-NEXT: $h0 = COPY %op(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %x:_(s16) = COPY $h0
-    %y:_(s16) = COPY $h1
-    %op:_(s16) = G_FDIV %x, %y
-    $h0 = COPY %op(s16)
+    %x:_(f16) = COPY $h0
+    %y:_(f16) = COPY $h1
+    %op:_(f16) = G_FDIV %x, %y
+    $h0 = COPY %op(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -149,24 +149,26 @@ body:             |
     ; NO-FP16-LABEL: name: fneg
     ; NO-FP16: liveins: $h0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: %x:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT %x(s16)
-    ; NO-FP16-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 -32768
-    ; NO-FP16-NEXT: [[XOR:%[0-9]+]]:_(s32) = G_XOR [[ANYEXT]], [[C]]
-    ; NO-FP16-NEXT: %op:_(s16) = G_TRUNC [[XOR]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY %op(s16)
+    ; NO-FP16-NEXT: %x:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: [[BITCAST:%[0-9]+]]:_(i16) = G_BITCAST %x(f16)
+    ; NO-FP16-NEXT: [[ANYEXT:%[0-9]+]]:_(i32) = G_ANYEXT [[BITCAST]](i16)
+    ; NO-FP16-NEXT: [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 -32768
+    ; NO-FP16-NEXT: [[XOR:%[0-9]+]]:_(i32) = G_XOR [[ANYEXT]], [[C]]
+    ; NO-FP16-NEXT: [[TRUNC:%[0-9]+]]:_(i16) = G_TRUNC [[XOR]](i32)
+    ; NO-FP16-NEXT: %op:_(f16) = G_BITCAST [[TRUNC]](i16)
+    ; NO-FP16-NEXT: $h0 = COPY %op(f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: fneg
     ; FP16: liveins: $h0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: %x:_(s16) = COPY $h0
-    ; FP16-NEXT: %op:_(s16) = G_FNEG %x
-    ; FP16-NEXT: $h0 = COPY %op(s16)
+    ; FP16-NEXT: %x:_(f16) = COPY $h0
+    ; FP16-NEXT: %op:_(f16) = G_FNEG %x
+    ; FP16-NEXT: $h0 = COPY %op(f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %x:_(s16) = COPY $h0
-    %op:_(s16) = G_FNEG %x
-    $h0 = COPY %op(s16)
+    %x:_(f16) = COPY $h0
+    %op:_(f16) = G_FNEG %x
+    $h0 = COPY %op(f16)
     RET_ReallyLR implicit $h0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fp-arith.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fp-arith.mir
@@ -5,14 +5,14 @@ name:            test_fadd_v2s64
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fadd_v2s64
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(<2 x s64>) = G_FADD [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $q0 = COPY [[FADD]](<2 x s64>)
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<2 x s64>) = G_FADD %0, %1
-    $q0 = COPY %2(<2 x s64>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(<2 x f64>) = G_FADD [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $q0 = COPY [[FADD]](<2 x f64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<2 x f64>) = G_FADD %0, %1
+    $q0 = COPY %2(<2 x f64>)
 
 ...
 ---
@@ -20,14 +20,14 @@ name:            test_fdiv_v2s32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fdiv_v2s32
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; CHECK-NEXT: [[FDIV:%[0-9]+]]:_(<2 x s32>) = G_FDIV [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $d0 = COPY [[FDIV]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = COPY $d1
-    %2:_(<2 x s32>) = G_FDIV %0, %1
-    $d0 = COPY %2(<2 x s32>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; CHECK-NEXT: [[FDIV:%[0-9]+]]:_(<2 x f32>) = G_FDIV [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $d0 = COPY [[FDIV]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = COPY $d1
+    %2:_(<2 x f32>) = G_FDIV %0, %1
+    $d0 = COPY %2(<2 x f32>)
 
 ...
 ---
@@ -35,14 +35,14 @@ name:            test_fsub_v2s32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fsub_v2s32
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; CHECK-NEXT: [[FSUB:%[0-9]+]]:_(<2 x s32>) = G_FSUB [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $d0 = COPY [[FSUB]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = COPY $d1
-    %2:_(<2 x s32>) = G_FSUB %0, %1
-    $d0 = COPY %2(<2 x s32>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; CHECK-NEXT: [[FSUB:%[0-9]+]]:_(<2 x f32>) = G_FSUB [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $d0 = COPY [[FSUB]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = COPY $d1
+    %2:_(<2 x f32>) = G_FSUB %0, %1
+    $d0 = COPY %2(<2 x f32>)
 
 ...
 ---
@@ -50,12 +50,12 @@ name:            test_fneg_v2s32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fneg_v2s32
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(<2 x s32>) = G_FNEG [[COPY]]
-    ; CHECK-NEXT: $d0 = COPY [[FNEG]](<2 x s32>)
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FNEG %0
-    $d0 = COPY %1(<2 x s32>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[FNEG:%[0-9]+]]:_(<2 x f32>) = G_FNEG [[COPY]]
+    ; CHECK-NEXT: $d0 = COPY [[FNEG]](<2 x f32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FNEG %0
+    $d0 = COPY %1(<2 x f32>)
 
 ...
 ---
@@ -63,14 +63,14 @@ name:            test_fmul_v4s32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fmul_v4s32
-    ; CHECK: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x s32>) = G_FMUL [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<4 x s32>)
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = COPY $q1
-    %2:_(<4 x s32>) = G_FMUL %0, %1
-    $q0 = COPY %2(<4 x s32>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x f32>) = G_FMUL [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<4 x f32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = COPY $q1
+    %2:_(<4 x f32>) = G_FMUL %0, %1
+    $q0 = COPY %2(<4 x f32>)
 
 ...
 ---
@@ -78,17 +78,17 @@ name:            test_fmul_v4s64
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fmul_v4s64
-    ; CHECK: [[DEF:%[0-9]+]]:_(<2 x s64>) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x s64>) = G_FMUL [[DEF]], [[DEF]]
-    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<2 x s64>) = G_FMUL [[DEF]], [[DEF]]
-    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<2 x s64>)
-    ; CHECK-NEXT: $q1 = COPY [[FMUL1]](<2 x s64>)
-    %0:_(<4 x s64>) = G_IMPLICIT_DEF
-    %1:_(<4 x s64>) = G_IMPLICIT_DEF
-    %2:_(<4 x s64>) = G_FMUL %0, %1
-    %uv1:_(<2 x s64>), %uv2:_(<2 x s64>) = G_UNMERGE_VALUES %2
-    $q0 = COPY %uv1(<2 x s64>)
-    $q1 = COPY %uv2(<2 x s64>)
+    ; CHECK: [[DEF:%[0-9]+]]:_(<2 x f64>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<2 x f64>) = G_FMUL [[DEF]], [[DEF]]
+    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<2 x f64>) = G_FMUL [[DEF]], [[DEF]]
+    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<2 x f64>)
+    ; CHECK-NEXT: $q1 = COPY [[FMUL1]](<2 x f64>)
+    %0:_(<4 x f64>) = G_IMPLICIT_DEF
+    %1:_(<4 x f64>) = G_IMPLICIT_DEF
+    %2:_(<4 x f64>) = G_FMUL %0, %1
+    %uv1:_(<2 x f64>), %uv2:_(<2 x f64>) = G_UNMERGE_VALUES %2
+    $q0 = COPY %uv1(<2 x f64>)
+    $q1 = COPY %uv2(<2 x f64>)
 
 ...
 ---
@@ -96,15 +96,15 @@ name:            test_fmul_v8s32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_fmul_v8s32
-    ; CHECK: [[DEF:%[0-9]+]]:_(<4 x s32>) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x s32>) = G_FMUL [[DEF]], [[DEF]]
-    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<4 x s32>) = G_FMUL [[DEF]], [[DEF]]
-    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<4 x s32>)
-    ; CHECK-NEXT: $q1 = COPY [[FMUL1]](<4 x s32>)
-    %0:_(<8 x s32>) = G_IMPLICIT_DEF
-    %1:_(<8 x s32>) = G_IMPLICIT_DEF
-    %2:_(<8 x s32>) = G_FMUL %0, %1
-    %uv1:_(<4 x s32>), %uv2:_(<4 x s32>) = G_UNMERGE_VALUES %2
-    $q0 = COPY %uv1(<4 x s32>)
-    $q1 = COPY %uv2(<4 x s32>)
+    ; CHECK: [[DEF:%[0-9]+]]:_(<4 x f32>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x f32>) = G_FMUL [[DEF]], [[DEF]]
+    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<4 x f32>) = G_FMUL [[DEF]], [[DEF]]
+    ; CHECK-NEXT: $q0 = COPY [[FMUL]](<4 x f32>)
+    ; CHECK-NEXT: $q1 = COPY [[FMUL1]](<4 x f32>)
+    %0:_(<8 x f32>) = G_IMPLICIT_DEF
+    %1:_(<8 x f32>) = G_IMPLICIT_DEF
+    %2:_(<8 x f32>) = G_FMUL %0, %1
+    %uv1:_(<4 x f32>), %uv2:_(<4 x f32>) = G_UNMERGE_VALUES %2
+    $q0 = COPY %uv1(<4 x f32>)
+    $q1 = COPY %uv2(<4 x f32>)
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fpext.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fpext.mir
@@ -15,20 +15,20 @@ body:             |
     ; CHECK-LABEL: name: fpext_v4s64_v4s32
     ; CHECK: liveins: $q0, $x0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x s32>), [[UV1:%[0-9]+]]:_(<2 x s32>) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV]](<2 x s32>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV1]](<2 x s32>)
-    ; CHECK-NEXT: G_STORE [[FPEXT]](<2 x s64>), [[COPY1]](p0) :: (store (<2 x s64>), align 32)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x f32>), [[UV1:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV1]](<2 x f32>)
+    ; CHECK-NEXT: G_STORE [[FPEXT]](<2 x f64>), [[COPY1]](p0) :: (store (<2 x f64>), align 32)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 16
     ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C]](i64)
-    ; CHECK-NEXT: G_STORE [[FPEXT1]](<2 x s64>), [[PTR_ADD]](p0) :: (store (<2 x s64>) into unknown-address + 16)
+    ; CHECK-NEXT: G_STORE [[FPEXT1]](<2 x f64>), [[PTR_ADD]](p0) :: (store (<2 x f64>) into unknown-address + 16)
     ; CHECK-NEXT: RET_ReallyLR
-    %0:_(<4 x s32>) = COPY $q0
+    %0:_(<4 x f32>) = COPY $q0
     %1:_(p0) = COPY $x0
-    %2:_(<4 x s64>) = G_FPEXT %0(<4 x s32>)
-    G_STORE %2(<4 x s64>), %1(p0) :: (store (<4 x s64>))
+    %2:_(<4 x f64>) = G_FPEXT %0(<4 x f32>)
+    G_STORE %2(<4 x f64>), %1(p0) :: (store (<4 x f64>))
     RET_ReallyLR
 
 ...
@@ -41,13 +41,13 @@ body:             |
     ; CHECK-LABEL: name: fpext_f16_f64
     ; CHECK: liveins: $h0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s64) = G_FPEXT [[COPY]](s16)
-    ; CHECK-NEXT: $d0 = COPY [[FPEXT]](s64)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f64) = G_FPEXT [[COPY]](f16)
+    ; CHECK-NEXT: $d0 = COPY [[FPEXT]](f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(s16) = COPY $h0
-    %1:_(s64) = G_FPEXT %0(s16)
-    $d0 = COPY %1(s64)
+    %0:_(f16) = COPY $h0
+    %1:_(f64) = G_FPEXT %0(f16)
+    $d0 = COPY %1(f64)
     RET_ReallyLR implicit $d0
 ...
 
@@ -60,16 +60,16 @@ body:             |
     ; CHECK-LABEL: name: fpext_v2f16_v2f64
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
     ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x f32>), [[UV1:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x f32>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV]](<2 x f32>)
-    ; CHECK-NEXT: $q0 = COPY [[FPEXT1]](<2 x s64>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV]](<2 x f32>)
+    ; CHECK-NEXT: $q0 = COPY [[FPEXT1]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %1:_(<4 x s16>) = COPY $d0
-    %0:_(<2 x s16>), %2:_(<2 x s16>) = G_UNMERGE_VALUES %1(<4 x s16>)
-    %3:_(<2 x s64>) = G_FPEXT %0(<2 x s16>)
-    $q0 = COPY %3(<2 x s64>)
+    %1:_(<4 x f16>) = COPY $d0
+    %0:_(<2 x f16>), %2:_(<2 x f16>) = G_UNMERGE_VALUES %1(<4 x f16>)
+    %3:_(<2 x f64>) = G_FPEXT %0(<2 x f16>)
+    $q0 = COPY %3(<2 x f64>)
     RET_ReallyLR implicit $q0
 ...
 
@@ -82,25 +82,25 @@ body:             |
     ; CHECK-LABEL: name: fpext_v3f16_v3f64
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
     ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x f32>), [[UV1:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x f32>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV]](<2 x f32>)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV1]](<2 x f32>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s64), [[UV3:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[FPEXT1]](<2 x s64>)
-    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(s64), [[UV5:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[FPEXT2]](<2 x s64>)
-    ; CHECK-NEXT: $d0 = COPY [[UV2]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[UV3]](s64)
-    ; CHECK-NEXT: $d2 = COPY [[UV4]](s64)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV1]](<2 x f32>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f64), [[UV3:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[FPEXT1]](<2 x f64>)
+    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(f64), [[UV5:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[FPEXT2]](<2 x f64>)
+    ; CHECK-NEXT: $d0 = COPY [[UV2]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[UV3]](f64)
+    ; CHECK-NEXT: $d2 = COPY [[UV4]](f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0, implicit $d1, implicit $d2
-    %1:_(<4 x s16>) = COPY $d0
-    %2:_(s16), %3:_(s16), %4:_(s16), %5:_(s16) = G_UNMERGE_VALUES %1(<4 x s16>)
-    %0:_(<3 x s16>) = G_BUILD_VECTOR %2(s16), %3(s16), %4(s16)
-    %6:_(<3 x s64>) = G_FPEXT %0(<3 x s16>)
-    %7:_(s64), %8:_(s64), %9:_(s64) = G_UNMERGE_VALUES %6(<3 x s64>)
-    $d0 = COPY %7(s64)
-    $d1 = COPY %8(s64)
-    $d2 = COPY %9(s64)
+    %1:_(<4 x f16>) = COPY $d0
+    %2:_(f16), %3:_(f16), %4:_(f16), %5:_(f16) = G_UNMERGE_VALUES %1(<4 x f16>)
+    %0:_(<3 x f16>) = G_BUILD_VECTOR %2(f16), %3(f16), %4(f16)
+    %6:_(<3 x f64>) = G_FPEXT %0(<3 x f16>)
+    %7:_(f64), %8:_(f64), %9:_(f64) = G_UNMERGE_VALUES %6(<3 x f64>)
+    $d0 = COPY %7(f64)
+    $d1 = COPY %8(f64)
+    $d2 = COPY %9(f64)
     RET_ReallyLR implicit $d0, implicit $d1, implicit $d2
 ...
 
@@ -113,19 +113,19 @@ body:             |
     ; CHECK-LABEL: name: fpext_v4f16_v4f64
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
     ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x f32>), [[UV1:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x f32>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV]](<2 x f32>)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV1]](<2 x f32>)
-    ; CHECK-NEXT: $q0 = COPY [[FPEXT1]](<2 x s64>)
-    ; CHECK-NEXT: $q1 = COPY [[FPEXT2]](<2 x s64>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV1]](<2 x f32>)
+    ; CHECK-NEXT: $q0 = COPY [[FPEXT1]](<2 x f64>)
+    ; CHECK-NEXT: $q1 = COPY [[FPEXT2]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0, implicit $q1
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s64>) = G_FPEXT %0(<4 x s16>)
-    %2:_(<2 x s64>), %3:_(<2 x s64>) = G_UNMERGE_VALUES %1(<4 x s64>)
-    $q0 = COPY %2(<2 x s64>)
-    $q1 = COPY %3(<2 x s64>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f64>) = G_FPEXT %0(<4 x f16>)
+    %2:_(<2 x f64>), %3:_(<2 x f64>) = G_UNMERGE_VALUES %1(<4 x f64>)
+    $q0 = COPY %2(<2 x f64>)
+    $q1 = COPY %3(<2 x f64>)
     RET_ReallyLR implicit $q0, implicit $q1
 ...
 
@@ -138,27 +138,27 @@ body:             |
     ; CHECK-LABEL: name: fpext_v8f16_v8f64
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
     ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(<2 x f32>), [[UV3:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x f32>)
     ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(<2 x f32>), [[UV5:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT1]](<4 x f32>)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV2]](<2 x f32>)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV3]](<2 x f32>)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV4]](<2 x f32>)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(<2 x s64>) = G_FPEXT [[UV5]](<2 x f32>)
-    ; CHECK-NEXT: $q0 = COPY [[FPEXT2]](<2 x s64>)
-    ; CHECK-NEXT: $q1 = COPY [[FPEXT3]](<2 x s64>)
-    ; CHECK-NEXT: $q2 = COPY [[FPEXT4]](<2 x s64>)
-    ; CHECK-NEXT: $q3 = COPY [[FPEXT5]](<2 x s64>)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV2]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV3]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV4]](<2 x f32>)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(<2 x f64>) = G_FPEXT [[UV5]](<2 x f32>)
+    ; CHECK-NEXT: $q0 = COPY [[FPEXT2]](<2 x f64>)
+    ; CHECK-NEXT: $q1 = COPY [[FPEXT3]](<2 x f64>)
+    ; CHECK-NEXT: $q2 = COPY [[FPEXT4]](<2 x f64>)
+    ; CHECK-NEXT: $q3 = COPY [[FPEXT5]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0, implicit $q1, implicit $q2, implicit $q3
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s64>) = G_FPEXT %0(<8 x s16>)
-    %2:_(<2 x s64>), %3:_(<2 x s64>), %4:_(<2 x s64>), %5:_(<2 x s64>) = G_UNMERGE_VALUES %1(<8 x s64>)
-    $q0 = COPY %2(<2 x s64>)
-    $q1 = COPY %3(<2 x s64>)
-    $q2 = COPY %4(<2 x s64>)
-    $q3 = COPY %5(<2 x s64>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f64>) = G_FPEXT %0(<8 x f16>)
+    %2:_(<2 x f64>), %3:_(<2 x f64>), %4:_(<2 x f64>), %5:_(<2 x f64>) = G_UNMERGE_VALUES %1(<8 x f64>)
+    $q0 = COPY %2(<2 x f64>)
+    $q1 = COPY %3(<2 x f64>)
+    $q2 = COPY %4(<2 x f64>)
+    $q3 = COPY %5(<2 x f64>)
     RET_ReallyLR implicit $q0, implicit $q1, implicit $q2, implicit $q3
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fptrunc.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-fptrunc.mir
@@ -9,13 +9,13 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_s16_s32
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s32) = COPY $s0
-    %1:_(s16) = G_FPTRUNC %0
-    $h0 = COPY %1(s16)
+    %0:_(f32) = COPY $s0
+    %1:_(f16) = G_FPTRUNC %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 ...
 ---
@@ -27,13 +27,13 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_s16_s64
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY]](s64)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY]](f64)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s64) = COPY $d0
-    %1:_(s16) = G_FPTRUNC %0
-    $h0 = COPY %1(s16)
+    %0:_(f64) = COPY $d0
+    %1:_(f16) = G_FPTRUNC %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 ...
 ---
@@ -45,13 +45,13 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_s32_s64
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s32) = G_FPTRUNC [[COPY]](s64)
-    ; CHECK-NEXT: $s0 = COPY [[FPTRUNC]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f32) = G_FPTRUNC [[COPY]](f64)
+    ; CHECK-NEXT: $s0 = COPY [[FPTRUNC]](f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %0:_(s64) = COPY $d0
-    %1:_(s32) = G_FPTRUNC %0
-    $s0 = COPY %1(s32)
+    %0:_(f64) = COPY $d0
+    %1:_(f32) = G_FPTRUNC %0
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 ...
 ---
@@ -63,13 +63,13 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_v4s16_v4s32
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[COPY]](<4 x s32>)
-    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[COPY]](<4 x f32>)
+    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s16>) = G_FPTRUNC %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f16>) = G_FPTRUNC %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 ...
 ---
@@ -81,17 +81,17 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_v2s16_v2s32
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[UV]](s32), [[UV1]](s32), [[DEF]](s32), [[DEF]](s32)
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[BUILD_VECTOR]](<4 x s32>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(<2 x s16>), [[UV3:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[FPTRUNC]](<4 x s16>)
-    ; CHECK-NEXT: $s0 = COPY [[UV2]](<2 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[UV]](f32), [[UV1]](f32), [[DEF]](f32), [[DEF]](f32)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[BUILD_VECTOR]](<4 x f32>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(<2 x f16>), [[UV3:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[FPTRUNC]](<4 x f16>)
+    ; CHECK-NEXT: $s0 = COPY [[UV2]](<2 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s16>) = G_FPTRUNC %0
-    $s0 = COPY %1(<2 x s16>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f16>) = G_FPTRUNC %0
+    $s0 = COPY %1(<2 x f16>)
     RET_ReallyLR implicit $s0
 ...
 ---
@@ -100,15 +100,15 @@ body:             |
   bb.0:
 
     ; CHECK-LABEL: name: fptrunc_v4s32_v4s64
-    ; CHECK: [[DEF:%[0-9]+]]:_(<2 x s64>) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[DEF]](<2 x s64>)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[DEF]](<2 x s64>)
-    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s32>) = G_CONCAT_VECTORS [[FPTRUNC]](<2 x s32>), [[FPTRUNC1]](<2 x s32>)
-    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<4 x s32>)
+    ; CHECK: [[DEF:%[0-9]+]]:_(<2 x f64>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[DEF]](<2 x f64>)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[DEF]](<2 x f64>)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f32>) = G_CONCAT_VECTORS [[FPTRUNC]](<2 x f32>), [[FPTRUNC1]](<2 x f32>)
+    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s64>) = G_IMPLICIT_DEF
-    %1:_(<4 x s32>) = G_FPTRUNC %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f64>) = G_IMPLICIT_DEF
+    %1:_(<4 x f32>) = G_FPTRUNC %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 ...
 ---
@@ -121,31 +121,31 @@ body:             |
     ; CHECK-LABEL: name: fptrunc_v8s32_v8s64
     ; CHECK: liveins: $x0, $q0, $q1, $q2, $q3, $x0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s64>) = COPY $q2
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(<2 x s64>) = COPY $q3
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f64>) = COPY $q2
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(<2 x f64>) = COPY $q3
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[COPY1]](<2 x s64>)
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[COPY2]](<2 x s64>)
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(<2 x s32>) = G_FPTRUNC [[COPY3]](<2 x s64>)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[COPY1]](<2 x f64>)
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[COPY2]](<2 x f64>)
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(<2 x f32>) = G_FPTRUNC [[COPY3]](<2 x f64>)
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s32>) = G_CONCAT_VECTORS [[FPTRUNC]](<2 x s32>), [[FPTRUNC1]](<2 x s32>)
-    ; CHECK-NEXT: [[CONCAT_VECTORS1:%[0-9]+]]:_(<4 x s32>) = G_CONCAT_VECTORS [[FPTRUNC2]](<2 x s32>), [[FPTRUNC3]](<2 x s32>)
-    ; CHECK-NEXT: G_STORE [[CONCAT_VECTORS]](<4 x s32>), [[COPY5]](p0) :: (store (<4 x s32>), align 32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x f32>) = G_CONCAT_VECTORS [[FPTRUNC]](<2 x f32>), [[FPTRUNC1]](<2 x f32>)
+    ; CHECK-NEXT: [[CONCAT_VECTORS1:%[0-9]+]]:_(<4 x f32>) = G_CONCAT_VECTORS [[FPTRUNC2]](<2 x f32>), [[FPTRUNC3]](<2 x f32>)
+    ; CHECK-NEXT: G_STORE [[CONCAT_VECTORS]](<4 x f32>), [[COPY5]](p0) :: (store (<4 x f32>), align 32)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 16
     ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY5]], [[C]](i64)
-    ; CHECK-NEXT: G_STORE [[CONCAT_VECTORS1]](<4 x s32>), [[PTR_ADD]](p0) :: (store (<4 x s32>) into unknown-address + 16)
+    ; CHECK-NEXT: G_STORE [[CONCAT_VECTORS1]](<4 x f32>), [[PTR_ADD]](p0) :: (store (<4 x f32>) into unknown-address + 16)
     ; CHECK-NEXT: RET_ReallyLR
-    %2:_(<2 x s64>) = COPY $q0
-    %3:_(<2 x s64>) = COPY $q1
-    %4:_(<2 x s64>) = COPY $q2
-    %5:_(<2 x s64>) = COPY $q3
-    %0:_(<8 x s64>) = G_CONCAT_VECTORS %2(<2 x s64>), %3(<2 x s64>), %4(<2 x s64>), %5(<2 x s64>)
+    %2:_(<2 x f64>) = COPY $q0
+    %3:_(<2 x f64>) = COPY $q1
+    %4:_(<2 x f64>) = COPY $q2
+    %5:_(<2 x f64>) = COPY $q3
+    %0:_(<8 x f64>) = G_CONCAT_VECTORS %2(<2 x f64>), %3(<2 x f64>), %4(<2 x f64>), %5(<2 x f64>)
     %1:_(p0) = COPY $x0
-    %6:_(<8 x s32>) = G_FPTRUNC %0(<8 x s64>)
+    %6:_(<8 x f32>) = G_FPTRUNC %0(<8 x f64>)
     %7:_(p0) = COPY $x0
-    G_STORE %6(<8 x s32>), %7(p0) :: (store (<8 x s32>))
+    G_STORE %6(<8 x f32>), %7(p0) :: (store (<8 x f32>))
     RET_ReallyLR
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-frint.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-frint.mir
@@ -10,9 +10,9 @@ body:             |
   bb.0:
     liveins: $h0
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FRINT %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FRINT %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -28,21 +28,21 @@ body:             |
     ; NOFP16-LABEL: name: test_f32.rint
     ; NOFP16: liveins: $s0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(s32) = G_FRINT [[COPY]]
-    ; NOFP16-NEXT: $s0 = COPY [[FRINT]](s32)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(f32) = G_FRINT [[COPY]]
+    ; NOFP16-NEXT: $s0 = COPY [[FRINT]](f32)
     ; NOFP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; FP16-LABEL: name: test_f32.rint
     ; FP16: liveins: $s0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(s32) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $s0 = COPY [[FRINT]](s32)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(f32) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $s0 = COPY [[FRINT]](f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
-    %0:_(s32) = COPY $s0
-    %1:_(s32) = G_FRINT %0
-    $s0 = COPY %1(s32)
+    %0:_(f32) = COPY $s0
+    %1:_(f32) = G_FRINT %0
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -58,21 +58,21 @@ body:             |
     ; NOFP16-LABEL: name: test_f64.rint
     ; NOFP16: liveins: $d0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(s64) = G_FRINT [[COPY]]
-    ; NOFP16-NEXT: $d0 = COPY [[FRINT]](s64)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(f64) = G_FRINT [[COPY]]
+    ; NOFP16-NEXT: $d0 = COPY [[FRINT]](f64)
     ; NOFP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_f64.rint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(s64) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FRINT]](s64)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(f64) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FRINT]](f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(s64) = COPY $d0
-    %1:_(s64) = G_FRINT %0
-    $d0 = COPY %1(s64)
+    %0:_(f64) = COPY $d0
+    %1:_(f64) = G_FRINT %0
+    $d0 = COPY %1(f64)
     RET_ReallyLR implicit $d0
 
 ...
@@ -88,21 +88,21 @@ body:             |
     ; NOFP16-LABEL: name: test_v4f32.rint
     ; NOFP16: liveins: $q0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x s32>) = G_FRINT [[COPY]]
-    ; NOFP16-NEXT: $q0 = COPY [[FRINT]](<4 x s32>)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x f32>) = G_FRINT [[COPY]]
+    ; NOFP16-NEXT: $q0 = COPY [[FRINT]](<4 x f32>)
     ; NOFP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f32.rint
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x s32>) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[FRINT]](<4 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x f32>) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[FRINT]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FRINT %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FRINT %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -118,21 +118,21 @@ body:             |
     ; NOFP16-LABEL: name: test_v2f64.rint
     ; NOFP16: liveins: $q0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x s64>) = G_FRINT [[COPY]]
-    ; NOFP16-NEXT: $q0 = COPY [[FRINT]](<2 x s64>)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x f64>) = G_FRINT [[COPY]]
+    ; NOFP16-NEXT: $q0 = COPY [[FRINT]](<2 x f64>)
     ; NOFP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v2f64.rint
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x s64>) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[FRINT]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x f64>) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[FRINT]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FRINT %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FRINT %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -148,23 +148,23 @@ body:             |
     ; NOFP16-LABEL: name: test_v4f16.rint
     ; NOFP16: liveins: $d0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x s32>) = G_FRINT [[FPEXT]]
-    ; NOFP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FRINT]](<4 x s32>)
-    ; NOFP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x f32>) = G_FRINT [[FPEXT]]
+    ; NOFP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FRINT]](<4 x f32>)
+    ; NOFP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NOFP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v4f16.rint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x s16>) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FRINT]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x f16>) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FRINT]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FRINT %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FRINT %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -180,28 +180,28 @@ body:             |
     ; NOFP16-LABEL: name: test_v8f16.rint
     ; NOFP16: liveins: $q0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NOFP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NOFP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x s32>) = G_FRINT [[FPEXT]]
-    ; NOFP16-NEXT: [[FRINT1:%[0-9]+]]:_(<4 x s32>) = G_FRINT [[FPEXT1]]
-    ; NOFP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FRINT]](<4 x s32>)
-    ; NOFP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FRINT1]](<4 x s32>)
-    ; NOFP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NOFP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NOFP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NOFP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NOFP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<4 x f32>) = G_FRINT [[FPEXT]]
+    ; NOFP16-NEXT: [[FRINT1:%[0-9]+]]:_(<4 x f32>) = G_FRINT [[FPEXT1]]
+    ; NOFP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FRINT]](<4 x f32>)
+    ; NOFP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FRINT1]](<4 x f32>)
+    ; NOFP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NOFP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NOFP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v8f16.rint
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<8 x s16>) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[FRINT]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<8 x f16>) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[FRINT]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FRINT %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FRINT %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -217,21 +217,21 @@ body:             |
     ; NOFP16-LABEL: name: test_v2f32.rint
     ; NOFP16: liveins: $d0
     ; NOFP16-NEXT: {{  $}}
-    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x s32>) = G_FRINT [[COPY]]
-    ; NOFP16-NEXT: $d0 = COPY [[FRINT]](<2 x s32>)
+    ; NOFP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NOFP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x f32>) = G_FRINT [[COPY]]
+    ; NOFP16-NEXT: $d0 = COPY [[FRINT]](<2 x f32>)
     ; NOFP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v2f32.rint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x s32>) = G_FRINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FRINT]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[FRINT:%[0-9]+]]:_(<2 x f32>) = G_FRINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FRINT]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FRINT %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FRINT %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-round.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-round.mir
@@ -16,23 +16,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_f16.round
     ; NO-FP16: liveins: $h0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUND [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INTRINSIC_ROUND]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUND [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INTRINSIC_ROUND]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: test_f16.round
     ; FP16: liveins: $h0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s16) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_ROUND]](s16)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f16) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_ROUND]](f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_INTRINSIC_ROUND %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_INTRINSIC_ROUND %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -48,21 +48,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_f32.round
     ; NO-FP16: liveins: $s0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUND [[COPY]]
-    ; NO-FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUND]](s32)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUND [[COPY]]
+    ; NO-FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUND]](f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; FP16-LABEL: name: test_f32.round
     ; FP16: liveins: $s0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUND]](s32)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUND]](f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
-    %0:_(s32) = COPY $s0
-    %1:_(s32) = G_INTRINSIC_ROUND %0
-    $s0 = COPY %1(s32)
+    %0:_(f32) = COPY $s0
+    %1:_(f32) = G_INTRINSIC_ROUND %0
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -78,21 +78,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_f64.round
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s64) = G_INTRINSIC_ROUND [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](s64)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f64) = G_INTRINSIC_ROUND [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_f64.round
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(s64) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](s64)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(f64) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(s64) = COPY $d0
-    %1:_(s64) = G_INTRINSIC_ROUND %0
-    $d0 = COPY %1(s64)
+    %0:_(f64) = COPY $d0
+    %1:_(f64) = G_INTRINSIC_ROUND %0
+    $d0 = COPY %1(f64)
     RET_ReallyLR implicit $d0
 
 ...
@@ -108,28 +108,28 @@ body:             |
     ; NO-FP16-LABEL: name: test_v8f16.round
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUND [[FPEXT]]
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND1:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUND [[FPEXT1]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUND]](<4 x s32>)
-    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUND1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUND [[FPEXT]]
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND1:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUND [[FPEXT1]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUND]](<4 x f32>)
+    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUND1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v8f16.round
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<8 x s16>) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<8 x f16>) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_INTRINSIC_ROUND %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_INTRINSIC_ROUND %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -148,23 +148,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f16.round
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUND [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUND]](<4 x s32>)
-    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUND [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUND]](<4 x f32>)
+    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v4f16.round
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x s16>) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x f16>) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_INTRINSIC_ROUND %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_INTRINSIC_ROUND %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -183,21 +183,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f32.round
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_ROUND [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<2 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_ROUND [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v2f32.round
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUND]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_INTRINSIC_ROUND %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_INTRINSIC_ROUND %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -216,21 +216,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f32.round
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUND [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<4 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUND [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f32.round
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<4 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_INTRINSIC_ROUND %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_INTRINSIC_ROUND %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -249,19 +249,19 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f64.round
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUND [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUND [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v2f64.round
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUND [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUND:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUND [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUND]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_INTRINSIC_ROUND %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_INTRINSIC_ROUND %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-roundeven.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-roundeven.mir
@@ -16,23 +16,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_f16.roundeven
     ; NO-FP16: liveins: $h0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: test_f16.roundeven
     ; FP16: liveins: $h0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s16) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_ROUNDEVEN]](s16)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f16) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_ROUNDEVEN]](f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_INTRINSIC_ROUNDEVEN %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_INTRINSIC_ROUNDEVEN %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -48,21 +48,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_f32.roundeven
     ; NO-FP16: liveins: $s0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUNDEVEN]](s32)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUNDEVEN]](f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; FP16-LABEL: name: test_f32.roundeven
     ; FP16: liveins: $s0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s32) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUNDEVEN]](s32)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f32) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $s0 = COPY [[INTRINSIC_ROUNDEVEN]](f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
-    %0:_(s32) = COPY $s0
-    %1:_(s32) = G_INTRINSIC_ROUNDEVEN %0
-    $s0 = COPY %1(s32)
+    %0:_(f32) = COPY $s0
+    %1:_(f32) = G_INTRINSIC_ROUNDEVEN %0
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -78,21 +78,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_f64.roundeven
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s64) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](s64)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f64) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_f64.roundeven
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(s64) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](s64)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(f64) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(s64) = COPY $d0
-    %1:_(s64) = G_INTRINSIC_ROUNDEVEN %0
-    $d0 = COPY %1(s64)
+    %0:_(f64) = COPY $d0
+    %1:_(f64) = G_INTRINSIC_ROUNDEVEN %0
+    $d0 = COPY %1(f64)
     RET_ReallyLR implicit $d0
 
 ...
@@ -108,28 +108,28 @@ body:             |
     ; NO-FP16-LABEL: name: test_v8f16.roundeven
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT1]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](<4 x s32>)
-    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT1]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](<4 x f32>)
+    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v8f16.roundeven
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<8 x s16>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<8 x f16>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_INTRINSIC_ROUNDEVEN %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_INTRINSIC_ROUNDEVEN %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -148,23 +148,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f16.roundeven
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](<4 x s32>)
-    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_ROUNDEVEN]](<4 x f32>)
+    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v4f16.roundeven
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s16>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f16>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_INTRINSIC_ROUNDEVEN %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_INTRINSIC_ROUNDEVEN %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -183,21 +183,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f32.roundeven
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v2f32.roundeven
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_INTRINSIC_ROUNDEVEN %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_INTRINSIC_ROUNDEVEN %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -216,21 +216,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f32.roundeven
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f32.roundeven
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_INTRINSIC_ROUNDEVEN %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_INTRINSIC_ROUNDEVEN %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -249,21 +249,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f64.roundeven
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v2f64.roundeven
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -278,31 +278,31 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f64.roundeven
     ; NO-FP16: liveins: $q0, $q1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY1]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s64>)
-    ; NO-FP16-NEXT: $q1 = COPY [[INTRINSIC_ROUNDEVEN1]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY1]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f64>)
+    ; NO-FP16-NEXT: $q1 = COPY [[INTRINSIC_ROUNDEVEN1]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f64.roundeven
     ; FP16: liveins: $q0, $q1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_ROUNDEVEN [[COPY1]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x s64>)
-    ; FP16-NEXT: $q1 = COPY [[INTRINSIC_ROUNDEVEN1]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY]]
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN1:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_ROUNDEVEN [[COPY1]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_ROUNDEVEN]](<2 x f64>)
+    ; FP16-NEXT: $q1 = COPY [[INTRINSIC_ROUNDEVEN1]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<4 x s64>) = G_CONCAT_VECTORS %0, %1
-    %3:_(<4 x s64>) = G_INTRINSIC_ROUNDEVEN %2
-    %4:_(<2 x s64>),  %5:_(<2 x s64>) = G_UNMERGE_VALUES %3
-    $q0 = COPY %4(<2 x s64>)
-    $q1 = COPY %5(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<4 x f64>) = G_CONCAT_VECTORS %0, %1
+    %3:_(<4 x f64>) = G_INTRINSIC_ROUNDEVEN %2
+    %4:_(<2 x f64>),  %5:_(<2 x f64>) = G_UNMERGE_VALUES %3
+    $q0 = COPY %4(<2 x f64>)
+    $q1 = COPY %5(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -317,33 +317,33 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f16.roundeven
     ; NO-FP16: liveins: $s0, $s1
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $s0
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<2 x s16>)
-    ; NO-FP16-NEXT: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; NO-FP16-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[DEF]](s16), [[DEF]](s16)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[BUILD_VECTOR]](<4 x s16>)
-    ; NO-FP16-NEXT: [[UV2:%[0-9]+]]:_(<2 x s32>), [[UV3:%[0-9]+]]:_(<2 x s32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x s32>)
-    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_ROUNDEVEN [[UV2]]
-    ; NO-FP16-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[INTRINSIC_ROUNDEVEN]](<2 x s32>)
-    ; NO-FP16-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; NO-FP16-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[UV4]](s32), [[UV5]](s32), [[DEF1]](s32), [[DEF1]](s32)
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[BUILD_VECTOR1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[UV6:%[0-9]+]]:_(<2 x s16>), [[UV7:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[FPTRUNC]](<4 x s16>)
-    ; NO-FP16-NEXT: $s0 = COPY [[UV6]](<2 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $s0
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<2 x f16>)
+    ; NO-FP16-NEXT: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; NO-FP16-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[UV]](f16), [[UV1]](f16), [[DEF]](f16), [[DEF]](f16)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[BUILD_VECTOR]](<4 x f16>)
+    ; NO-FP16-NEXT: [[UV2:%[0-9]+]]:_(<2 x f32>), [[UV3:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FPEXT]](<4 x f32>)
+    ; NO-FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_ROUNDEVEN [[UV2]]
+    ; NO-FP16-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[INTRINSIC_ROUNDEVEN]](<2 x f32>)
+    ; NO-FP16-NEXT: [[DEF1:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; NO-FP16-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[UV4]](f32), [[UV5]](f32), [[DEF1]](f32), [[DEF1]](f32)
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[BUILD_VECTOR1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[UV6:%[0-9]+]]:_(<2 x f16>), [[UV7:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[FPTRUNC]](<4 x f16>)
+    ; NO-FP16-NEXT: $s0 = COPY [[UV6]](<2 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; FP16-LABEL: name: test_v2f16.roundeven
     ; FP16: liveins: $s0, $s1
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $s0
-    ; FP16-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<2 x s16>)
-    ; FP16-NEXT: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; FP16-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[DEF]](s16), [[DEF]](s16)
-    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x s16>) = G_INTRINSIC_ROUNDEVEN [[BUILD_VECTOR]]
-    ; FP16-NEXT: [[UV2:%[0-9]+]]:_(<2 x s16>), [[UV3:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[INTRINSIC_ROUNDEVEN]](<4 x s16>)
-    ; FP16-NEXT: $s0 = COPY [[UV2]](<2 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f16>) = COPY $s0
+    ; FP16-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<2 x f16>)
+    ; FP16-NEXT: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; FP16-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[UV]](f16), [[UV1]](f16), [[DEF]](f16), [[DEF]](f16)
+    ; FP16-NEXT: [[INTRINSIC_ROUNDEVEN:%[0-9]+]]:_(<4 x f16>) = G_INTRINSIC_ROUNDEVEN [[BUILD_VECTOR]]
+    ; FP16-NEXT: [[UV2:%[0-9]+]]:_(<2 x f16>), [[UV3:%[0-9]+]]:_(<2 x f16>) = G_UNMERGE_VALUES [[INTRINSIC_ROUNDEVEN]](<4 x f16>)
+    ; FP16-NEXT: $s0 = COPY [[UV2]](<2 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
-    %0:_(<2 x s16>) = COPY $s0
-    %1:_(<2 x s16>) = G_INTRINSIC_ROUNDEVEN %0
-    $s0 = COPY %1(<2 x s16>)
+    %0:_(<2 x f16>) = COPY $s0
+    %1:_(<2 x f16>) = G_INTRINSIC_ROUNDEVEN %0
+    $s0 = COPY %1(<2 x f16>)
     RET_ReallyLR implicit $s0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-trunc.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-intrinsic-trunc.mir
@@ -13,23 +13,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_f16.intrinsic_trunc
     ; NO-FP16: liveins: $h0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s32) = G_INTRINSIC_TRUNC [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[INTRINSIC_TRUNC]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f32) = G_INTRINSIC_TRUNC [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[INTRINSIC_TRUNC]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; FP16-LABEL: name: test_f16.intrinsic_trunc
     ; FP16: liveins: $h0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(s16) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_TRUNC]](s16)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(f16) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $h0 = COPY [[INTRINSIC_TRUNC]](f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_INTRINSIC_TRUNC %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_INTRINSIC_TRUNC %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -45,23 +45,23 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f16.intrinsic_trunc
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_TRUNC [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_TRUNC]](<4 x s32>)
-    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_TRUNC [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_TRUNC]](<4 x f32>)
+    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v4f16.intrinsic_trunc
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x s16>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x f16>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_INTRINSIC_TRUNC %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_INTRINSIC_TRUNC %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -77,28 +77,28 @@ body:             |
     ; NO-FP16-LABEL: name: test_v8f16.intrinsic_trunc
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_TRUNC [[FPEXT]]
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_TRUNC [[FPEXT1]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_TRUNC]](<4 x s32>)
-    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[INTRINSIC_TRUNC1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_TRUNC [[FPEXT]]
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC1:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_TRUNC [[FPEXT1]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_TRUNC]](<4 x f32>)
+    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[INTRINSIC_TRUNC1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v8f16.intrinsic_trunc
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<8 x s16>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<8 x f16>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_INTRINSIC_TRUNC %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_INTRINSIC_TRUNC %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -114,21 +114,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f32.intrinsic_trunc
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<2 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; FP16-LABEL: name: test_v2f32.intrinsic_trunc
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x s32>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x f32>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[INTRINSIC_TRUNC]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_INTRINSIC_TRUNC %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_INTRINSIC_TRUNC %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -144,21 +144,21 @@ body:             |
     ; NO-FP16-LABEL: name: test_v4f32.intrinsic_trunc
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<4 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<4 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v4f32.intrinsic_trunc
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x s32>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<4 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<4 x f32>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<4 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_INTRINSIC_TRUNC %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_INTRINSIC_TRUNC %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -174,19 +174,19 @@ body:             |
     ; NO-FP16-LABEL: name: test_v2f64.intrinsic_trunc
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; FP16-LABEL: name: test_v2f64.intrinsic_trunc
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x s64>) = G_INTRINSIC_TRUNC [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[INTRINSIC_TRUNC:%[0-9]+]]:_(<2 x f64>) = G_INTRINSIC_TRUNC [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[INTRINSIC_TRUNC]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_INTRINSIC_TRUNC %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_INTRINSIC_TRUNC %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.log
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &logf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &logf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &logf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &logf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FLOG %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FLOG %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &logf
     ; CHECK-DAG: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FLOG %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FLOG %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.log
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FLOG %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FLOG %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.log
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &logf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FLOG %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FLOG %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.log
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &log
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &log
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FLOG %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FLOG %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_log_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &logf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FLOG %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FLOG %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log10.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log10.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.log10
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &log10
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &log10
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &log10
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &log10
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FLOG10 %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FLOG10 %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &log10
     ; CHECK-DAG: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FLOG10 %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FLOG10 %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.log10
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FLOG10 %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FLOG10 %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.log10
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FLOG10 %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FLOG10 %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.log10
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &log10
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FLOG10 %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FLOG10 %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_log10_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &log10
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FLOG10 %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FLOG10 %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log2.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-log2.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.log2
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &log2
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &log2
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &log2
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &log2
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FLOG2 %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FLOG2 %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK-DAG: BL &log2
     ; CHECK-DAG: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FLOG2 %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FLOG2 %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.log2
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FLOG2 %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FLOG2 %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.log2
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FLOG2 %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FLOG2 %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.log2
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &log2
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FLOG2 %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FLOG2 %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_log2_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &log2
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FLOG2 %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FLOG2 %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-modf.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-modf.mir
@@ -5,25 +5,25 @@ name:            test_modf_f16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_modf_f16
-    ; CHECK: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
+    ; CHECK: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[LOAD]](s32)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC1]](s16)
-    ; CHECK-NEXT: $h1 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.0)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[LOAD]](f32)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC1]](f16)
+    ; CHECK-NEXT: $h1 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0, implicit $h1
-    %0:_(s16) = COPY $h0
-    %1:_(s16), %2:_(s16) = G_FMODF %0
-    $h0 = COPY %1(s16)
-    $h1 = COPY %2(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16), %2:_(f16) = G_FMODF %0
+    $h0 = COPY %1(f16)
+    $h1 = COPY %2(f16)
     RET_ReallyLR implicit $h0, implicit $h1
 ...
 ---
@@ -31,21 +31,21 @@ name:            test_modf_f16_only_use_fractional_part
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_modf_f16_only_use_fractional_part
-    ; CHECK: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
+    ; CHECK: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16), %2:_(s16) = G_FMODF %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16), %2:_(f16) = G_FMODF %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 ...
 ---
@@ -53,46 +53,46 @@ name:            test_modf_v2f16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_modf_v2f16
-    ; CHECK: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.1
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.1)
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[LOAD]](s32)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY1]](s32)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.1)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[LOAD]](f32)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY1]](f32)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
     ; CHECK-NEXT: [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX1]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[LOAD1]](s32)
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[FPTRUNC1]](s16), [[FPTRUNC3]](s16), [[DEF]](s16), [[DEF]](s16)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC2]](s16), [[DEF]](s16), [[DEF]](s16)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x s16>)
-    ; CHECK-NEXT: $d1 = COPY [[BUILD_VECTOR1]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s32) from %stack.0)
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[LOAD1]](f32)
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(f16) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[FPTRUNC1]](f16), [[FPTRUNC3]](f16), [[DEF]](f16), [[DEF]](f16)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC2]](f16), [[DEF]](f16), [[DEF]](f16)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x f16>)
+    ; CHECK-NEXT: $d1 = COPY [[BUILD_VECTOR1]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0, implicit $d1
-    %1:_(<4 x s16>) = COPY $d0
-    %0:_(<2 x s16>), %2:_(<2 x s16>) = G_UNMERGE_VALUES %1(<4 x s16>)
-    %3:_(<2 x s16>), %4:_(<2 x s16>) = G_FMODF %0
-    %5:_(s16), %6:_(s16) = G_UNMERGE_VALUES %3(<2 x s16>)
-    %7:_(s16) = G_IMPLICIT_DEF
-    %8:_(<4 x s16>) = G_BUILD_VECTOR %5(s16), %6(s16), %7(s16), %7(s16)
-    %9:_(s16), %10:_(s16) = G_UNMERGE_VALUES %4(<2 x s16>)
-    %11:_(<4 x s16>) = G_BUILD_VECTOR %9(s16), %10(s16), %7(s16), %7(s16)
-    $d0 = COPY %8(<4 x s16>)
-    $d1 = COPY %11(<4 x s16>)
+    %1:_(<4 x f16>) = COPY $d0
+    %0:_(<2 x f16>), %2:_(<2 x f16>) = G_UNMERGE_VALUES %1(<4 x f16>)
+    %3:_(<2 x f16>), %4:_(<2 x f16>) = G_FMODF %0
+    %5:_(f16), %6:_(f16) = G_UNMERGE_VALUES %3(<2 x f16>)
+    %7:_(f16) = G_IMPLICIT_DEF
+    %8:_(<4 x f16>) = G_BUILD_VECTOR %5(f16), %6(f16), %7(f16), %7(f16)
+    %9:_(f16), %10:_(f16) = G_UNMERGE_VALUES %4(<2 x f16>)
+    %11:_(<4 x f16>) = G_BUILD_VECTOR %9(f16), %10(f16), %7(f16), %7(f16)
+    $d0 = COPY %8(<4 x f16>)
+    $d1 = COPY %11(<4 x f16>)
     RET_ReallyLR implicit $d0, implicit $d1
 ...
 ---
@@ -100,51 +100,51 @@ name:            test_modf_v3f32
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_modf_v3f32
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s32>) = G_BITCAST [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BITCAST]](<4 x s32>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x f32>) = G_BITCAST [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[BITCAST]](<4 x f32>)
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.2
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.2)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s32) from %stack.2)
     ; CHECK-NEXT: [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.1
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX1]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s32) from %stack.1)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s32) from %stack.1)
     ; CHECK-NEXT: [[FRAME_INDEX2:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV2]](f32)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX2]](p0)
     ; CHECK-NEXT: BL &modff, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $x0, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX2]](p0) :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[DEF]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[LOAD]](s32), [[LOAD1]](s32), [[LOAD2]](s32), [[DEF]](s32)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x s32>)
-    ; CHECK-NEXT: $q1 = COPY [[BUILD_VECTOR1]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(f32) = G_LOAD [[FRAME_INDEX2]](p0) :: (load (s32) from %stack.0)
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(f32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[COPY1]](f32), [[COPY2]](f32), [[COPY3]](f32), [[DEF]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[LOAD]](f32), [[LOAD1]](f32), [[LOAD2]](f32), [[DEF]](f32)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x f32>)
+    ; CHECK-NEXT: $q1 = COPY [[BUILD_VECTOR1]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0, implicit $q1
-    %1:_(<2 x s64>) = COPY $q0
-    %2:_(<4 x s32>) = G_BITCAST %1(<2 x s64>)
-    %3:_(s32), %4:_(s32), %5:_(s32), %6:_(s32) = G_UNMERGE_VALUES %2(<4 x s32>)
-    %0:_(<3 x s32>) = G_BUILD_VECTOR %3(s32), %4(s32), %5(s32)
-    %7:_(<3 x s32>), %8:_(<3 x s32>) = G_FMODF %0
-    %9:_(s32), %10:_(s32), %11:_(s32) = G_UNMERGE_VALUES %7(<3 x s32>)
-    %12:_(s32) = G_IMPLICIT_DEF
-    %13:_(<4 x s32>) = G_BUILD_VECTOR %9(s32), %10(s32), %11(s32), %12(s32)
-    %14:_(s32), %15:_(s32), %16:_(s32) = G_UNMERGE_VALUES %8(<3 x s32>)
-    %17:_(<4 x s32>) = G_BUILD_VECTOR %14(s32), %15(s32), %16(s32), %12(s32)
-    $q0 = COPY %13(<4 x s32>)
-    $q1 = COPY %17(<4 x s32>)
+    %1:_(<2 x f64>) = COPY $q0
+    %2:_(<4 x f32>) = G_BITCAST %1(<2 x f64>)
+    %3:_(f32), %4:_(f32), %5:_(f32), %6:_(f32) = G_UNMERGE_VALUES %2(<4 x f32>)
+    %0:_(<3 x f32>) = G_BUILD_VECTOR %3(f32), %4(f32), %5(f32)
+    %7:_(<3 x f32>), %8:_(<3 x f32>) = G_FMODF %0
+    %9:_(f32), %10:_(f32), %11:_(f32) = G_UNMERGE_VALUES %7(<3 x f32>)
+    %12:_(f32) = G_IMPLICIT_DEF
+    %13:_(<4 x f32>) = G_BUILD_VECTOR %9(f32), %10(f32), %11(f32), %12(f32)
+    %14:_(f32), %15:_(f32), %16:_(f32) = G_UNMERGE_VALUES %8(<3 x f32>)
+    %17:_(<4 x f32>) = G_BUILD_VECTOR %14(f32), %15(f32), %16(f32), %12(f32)
+    $q0 = COPY %13(<4 x f32>)
+    $q1 = COPY %17(<4 x f32>)
     RET_ReallyLR implicit $q0, implicit $q1
 ...
 ---
@@ -152,33 +152,33 @@ name:            test_modf_v2f64
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_modf_v2f64
-    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
+    ; CHECK: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
     ; CHECK-NEXT: [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.1
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV]](f64)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX]](p0)
     ; CHECK-NEXT: BL &modf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $x0, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s64) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s64) from %stack.1)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(f64) = G_LOAD [[FRAME_INDEX]](p0) :: (load (s64) from %stack.1)
     ; CHECK-NEXT: [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %stack.0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV1]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV1]](f64)
     ; CHECK-NEXT: $x0 = COPY [[FRAME_INDEX1]](p0)
     ; CHECK-NEXT: BL &modf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $x0, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(s64) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s64) from %stack.0)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[COPY1]](s64), [[COPY2]](s64)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[LOAD]](s64), [[LOAD1]](s64)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x s64>)
-    ; CHECK-NEXT: $q1 = COPY [[BUILD_VECTOR1]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(f64) = G_LOAD [[FRAME_INDEX1]](p0) :: (load (s64) from %stack.0)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[COPY1]](f64), [[COPY2]](f64)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[LOAD]](f64), [[LOAD1]](f64)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x f64>)
+    ; CHECK-NEXT: $q1 = COPY [[BUILD_VECTOR1]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0, implicit $q1
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>), %2:_(<2 x s64>) = G_FMODF %0
-    $q0 = COPY %1(<2 x s64>)
-    $q1 = COPY %2(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>), %2:_(<2 x f64>) = G_FMODF %0
+    $q0 = COPY %1(<2 x f64>)
+    $q1 = COPY %2(<2 x f64>)
     RET_ReallyLR implicit $q0, implicit $q1
 ...
 ---

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-nearbyint.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-nearbyint.mir
@@ -15,23 +15,23 @@ body:             |
     ; FP16-LABEL: name: test_v4f16.nearbyint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x s16>) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<4 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x f16>) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<4 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: test_v4f16.nearbyint
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x s32>) = G_FNEARBYINT [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FNEARBYINT]](<4 x s32>)
-    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x f32>) = G_FNEARBYINT [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FNEARBYINT]](<4 x f32>)
+    ; NO-FP16-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FNEARBYINT %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FNEARBYINT %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -47,28 +47,28 @@ body:             |
     ; FP16-LABEL: name: test_v8f16.nearbyint
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<8 x s16>) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<8 x s16>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<8 x f16>) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<8 x f16>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; NO-FP16-LABEL: name: test_v8f16.nearbyint
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x s32>) = G_FNEARBYINT [[FPEXT]]
-    ; NO-FP16-NEXT: [[FNEARBYINT1:%[0-9]+]]:_(<4 x s32>) = G_FNEARBYINT [[FPEXT1]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FNEARBYINT]](<4 x s32>)
-    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FNEARBYINT1]](<4 x s32>)
-    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; NO-FP16-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<4 x f32>) = G_FNEARBYINT [[FPEXT]]
+    ; NO-FP16-NEXT: [[FNEARBYINT1:%[0-9]+]]:_(<4 x f32>) = G_FNEARBYINT [[FPEXT1]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FNEARBYINT]](<4 x f32>)
+    ; NO-FP16-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FNEARBYINT1]](<4 x f32>)
+    ; NO-FP16-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; NO-FP16-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FNEARBYINT %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FNEARBYINT %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -84,21 +84,21 @@ body:             |
     ; FP16-LABEL: name: test_v2f32.nearbyint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x s32>) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<2 x s32>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x f32>) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<2 x f32>)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: test_v2f32.nearbyint
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x s32>) = G_FNEARBYINT [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<2 x s32>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x f32>) = G_FNEARBYINT [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[FNEARBYINT]](<2 x f32>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FNEARBYINT %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FNEARBYINT %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -114,21 +114,21 @@ body:             |
     ; FP16-LABEL: name: test_v2f64.nearbyint
     ; FP16: liveins: $q0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x s64>) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<2 x s64>)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x f64>) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<2 x f64>)
     ; FP16-NEXT: RET_ReallyLR implicit $q0
     ;
     ; NO-FP16-LABEL: name: test_v2f64.nearbyint
     ; NO-FP16: liveins: $q0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x s64>) = G_FNEARBYINT [[COPY]]
-    ; NO-FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<2 x s64>)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(<2 x f64>) = G_FNEARBYINT [[COPY]]
+    ; NO-FP16-NEXT: $q0 = COPY [[FNEARBYINT]](<2 x f64>)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FNEARBYINT %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FNEARBYINT %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -144,21 +144,21 @@ body:             |
     ; FP16-LABEL: name: test_f32.nearbyint
     ; FP16: liveins: $s0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s32) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $s0 = COPY [[FNEARBYINT]](s32)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f32) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $s0 = COPY [[FNEARBYINT]](f32)
     ; FP16-NEXT: RET_ReallyLR implicit $s0
     ;
     ; NO-FP16-LABEL: name: test_f32.nearbyint
     ; NO-FP16: liveins: $s0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $s0
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s32) = G_FNEARBYINT [[COPY]]
-    ; NO-FP16-NEXT: $s0 = COPY [[FNEARBYINT]](s32)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f32) = COPY $s0
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f32) = G_FNEARBYINT [[COPY]]
+    ; NO-FP16-NEXT: $s0 = COPY [[FNEARBYINT]](f32)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $s0
-    %0:_(s32) = COPY $s0
-    %1:_(s32) = G_FNEARBYINT %0
-    $s0 = COPY %1(s32)
+    %0:_(f32) = COPY $s0
+    %1:_(f32) = G_FNEARBYINT %0
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -174,21 +174,21 @@ body:             |
     ; FP16-LABEL: name: test_f64.nearbyint
     ; FP16: liveins: $d0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s64) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](s64)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f64) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $d0 = COPY [[FNEARBYINT]](f64)
     ; FP16-NEXT: RET_ReallyLR implicit $d0
     ;
     ; NO-FP16-LABEL: name: test_f64.nearbyint
     ; NO-FP16: liveins: $d0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s64) = G_FNEARBYINT [[COPY]]
-    ; NO-FP16-NEXT: $d0 = COPY [[FNEARBYINT]](s64)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f64) = G_FNEARBYINT [[COPY]]
+    ; NO-FP16-NEXT: $d0 = COPY [[FNEARBYINT]](f64)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $d0
-    %0:_(s64) = COPY $d0
-    %1:_(s64) = G_FNEARBYINT %0
-    $d0 = COPY %1(s64)
+    %0:_(f64) = COPY $d0
+    %1:_(f64) = G_FNEARBYINT %0
+    $d0 = COPY %1(f64)
     RET_ReallyLR implicit $d0
 
 ...
@@ -204,23 +204,23 @@ body:             |
     ; FP16-LABEL: name: test_f16.nearbyint
     ; FP16: liveins: $h0
     ; FP16-NEXT: {{  $}}
-    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s16) = G_FNEARBYINT [[COPY]]
-    ; FP16-NEXT: $h0 = COPY [[FNEARBYINT]](s16)
+    ; FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f16) = G_FNEARBYINT [[COPY]]
+    ; FP16-NEXT: $h0 = COPY [[FNEARBYINT]](f16)
     ; FP16-NEXT: RET_ReallyLR implicit $h0
     ;
     ; NO-FP16-LABEL: name: test_f16.nearbyint
     ; NO-FP16: liveins: $h0
     ; NO-FP16-NEXT: {{  $}}
-    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(s16) = COPY $h0
-    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[COPY]](s16)
-    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(s32) = G_FNEARBYINT [[FPEXT]]
-    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[FNEARBYINT]](s32)
-    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; NO-FP16-NEXT: [[COPY:%[0-9]+]]:_(f16) = COPY $h0
+    ; NO-FP16-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[COPY]](f16)
+    ; NO-FP16-NEXT: [[FNEARBYINT:%[0-9]+]]:_(f32) = G_FNEARBYINT [[FPEXT]]
+    ; NO-FP16-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[FNEARBYINT]](f32)
+    ; NO-FP16-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; NO-FP16-NEXT: RET_ReallyLR implicit $h0
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FNEARBYINT %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FNEARBYINT %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-pow.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-pow.mir
@@ -5,32 +5,32 @@ name:            test_pow
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_pow
-    ; CHECK: [[COPY:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s64) = COPY $d1
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s2
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s3
+    ; CHECK: [[COPY:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(f64) = COPY $d1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s2
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s3
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[COPY]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[COPY1]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[COPY]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[COPY1]](f64)
     ; CHECK-NEXT: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: $x0 = COPY [[COPY4]](s64)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: $x0 = COPY [[COPY4]](f64)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[COPY2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[COPY3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[COPY2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[COPY3]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: $w0 = COPY [[COPY5]](s32)
-    %0:_(s64) = COPY $d0
-    %1:_(s64) = COPY $d1
-    %2:_(s32) = COPY $s2
-    %3:_(s32) = COPY $s3
-    %4:_(s64) = G_FPOW %0, %1
-    $x0 = COPY %4(s64)
-    %5:_(s32) = G_FPOW %2, %3
-    $w0 = COPY %5(s32)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: $w0 = COPY [[COPY5]](f32)
+    %0:_(f64) = COPY $d0
+    %1:_(f64) = COPY $d1
+    %2:_(f32) = COPY $s2
+    %3:_(f32) = COPY $s3
+    %4:_(f64) = G_FPOW %0, %1
+    $x0 = COPY %4(f64)
+    %5:_(f32) = G_FPOW %2, %3
+    $w0 = COPY %5(f32)
 
 ...
 ---
@@ -44,53 +44,53 @@ body:             |
     ; CHECK-LABEL: name: test_v4f16.pow
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s16>) = COPY $d1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV4]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f16>) = COPY $d1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(f16), [[UV5:%[0-9]+]]:_(f16), [[UV6:%[0-9]+]]:_(f16), [[UV7:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY1]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV5]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV5]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(s32) = G_FPEXT [[UV6]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(f32) = G_FPEXT [[UV6]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
-    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(s32) = G_FPEXT [[UV7]](s16)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
+    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(f32) = G_FPEXT [[UV7]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY5]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = COPY $d1
-    %2:_(<4 x s16>) = G_FPOW %0, %1
-    $d0 = COPY %2(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = COPY $d1
+    %2:_(<4 x f16>) = G_FPOW %0, %1
+    $d0 = COPY %2(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -105,89 +105,89 @@ body:             |
     ; CHECK-LABEL: name: test_v8f16.pow
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<8 x s16>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[UV8:%[0-9]+]]:_(s16), [[UV9:%[0-9]+]]:_(s16), [[UV10:%[0-9]+]]:_(s16), [[UV11:%[0-9]+]]:_(s16), [[UV12:%[0-9]+]]:_(s16), [[UV13:%[0-9]+]]:_(s16), [[UV14:%[0-9]+]]:_(s16), [[UV15:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(s32) = G_FPEXT [[UV]](s16)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(s32) = G_FPEXT [[UV8]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<8 x f16>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f16), [[UV1:%[0-9]+]]:_(f16), [[UV2:%[0-9]+]]:_(f16), [[UV3:%[0-9]+]]:_(f16), [[UV4:%[0-9]+]]:_(f16), [[UV5:%[0-9]+]]:_(f16), [[UV6:%[0-9]+]]:_(f16), [[UV7:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[UV8:%[0-9]+]]:_(f16), [[UV9:%[0-9]+]]:_(f16), [[UV10:%[0-9]+]]:_(f16), [[UV11:%[0-9]+]]:_(f16), [[UV12:%[0-9]+]]:_(f16), [[UV13:%[0-9]+]]:_(f16), [[UV14:%[0-9]+]]:_(f16), [[UV15:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES [[COPY1]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(f32) = G_FPEXT [[UV]](f16)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(f32) = G_FPEXT [[UV8]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT1]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY2]](s32)
-    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(s32) = G_FPEXT [[UV1]](s16)
-    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(s32) = G_FPEXT [[UV9]](s16)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY2]](f32)
+    ; CHECK-NEXT: [[FPEXT2:%[0-9]+]]:_(f32) = G_FPEXT [[UV1]](f16)
+    ; CHECK-NEXT: [[FPEXT3:%[0-9]+]]:_(f32) = G_FPEXT [[UV9]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT3]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY3]](s32)
-    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(s32) = G_FPEXT [[UV2]](s16)
-    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(s32) = G_FPEXT [[UV10]](s16)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY3]](f32)
+    ; CHECK-NEXT: [[FPEXT4:%[0-9]+]]:_(f32) = G_FPEXT [[UV2]](f16)
+    ; CHECK-NEXT: [[FPEXT5:%[0-9]+]]:_(f32) = G_FPEXT [[UV10]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT4]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT5]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY4]](s32)
-    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(s32) = G_FPEXT [[UV3]](s16)
-    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(s32) = G_FPEXT [[UV11]](s16)
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC2:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY4]](f32)
+    ; CHECK-NEXT: [[FPEXT6:%[0-9]+]]:_(f32) = G_FPEXT [[UV3]](f16)
+    ; CHECK-NEXT: [[FPEXT7:%[0-9]+]]:_(f32) = G_FPEXT [[UV11]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT6]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT7]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY5]](s32)
-    ; CHECK-NEXT: [[FPEXT8:%[0-9]+]]:_(s32) = G_FPEXT [[UV4]](s16)
-    ; CHECK-NEXT: [[FPEXT9:%[0-9]+]]:_(s32) = G_FPEXT [[UV12]](s16)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC3:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY5]](f32)
+    ; CHECK-NEXT: [[FPEXT8:%[0-9]+]]:_(f32) = G_FPEXT [[UV4]](f16)
+    ; CHECK-NEXT: [[FPEXT9:%[0-9]+]]:_(f32) = G_FPEXT [[UV12]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT8]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT9]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT8]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT9]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY6]](s32)
-    ; CHECK-NEXT: [[FPEXT10:%[0-9]+]]:_(s32) = G_FPEXT [[UV5]](s16)
-    ; CHECK-NEXT: [[FPEXT11:%[0-9]+]]:_(s32) = G_FPEXT [[UV13]](s16)
+    ; CHECK-NEXT: [[COPY6:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC4:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY6]](f32)
+    ; CHECK-NEXT: [[FPEXT10:%[0-9]+]]:_(f32) = G_FPEXT [[UV5]](f16)
+    ; CHECK-NEXT: [[FPEXT11:%[0-9]+]]:_(f32) = G_FPEXT [[UV13]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT10]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT11]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT10]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT11]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY7]](s32)
-    ; CHECK-NEXT: [[FPEXT12:%[0-9]+]]:_(s32) = G_FPEXT [[UV6]](s16)
-    ; CHECK-NEXT: [[FPEXT13:%[0-9]+]]:_(s32) = G_FPEXT [[UV14]](s16)
+    ; CHECK-NEXT: [[COPY7:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC5:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY7]](f32)
+    ; CHECK-NEXT: [[FPEXT12:%[0-9]+]]:_(f32) = G_FPEXT [[UV6]](f16)
+    ; CHECK-NEXT: [[FPEXT13:%[0-9]+]]:_(f32) = G_FPEXT [[UV14]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT12]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT13]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT12]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT13]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY8]](s32)
-    ; CHECK-NEXT: [[FPEXT14:%[0-9]+]]:_(s32) = G_FPEXT [[UV7]](s16)
-    ; CHECK-NEXT: [[FPEXT15:%[0-9]+]]:_(s32) = G_FPEXT [[UV15]](s16)
+    ; CHECK-NEXT: [[COPY8:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC6:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY8]](f32)
+    ; CHECK-NEXT: [[FPEXT14:%[0-9]+]]:_(f32) = G_FPEXT [[UV7]](f16)
+    ; CHECK-NEXT: [[FPEXT15:%[0-9]+]]:_(f32) = G_FPEXT [[UV15]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[FPEXT14]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[FPEXT15]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[FPEXT14]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[FPEXT15]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY9:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(s16) = G_FPTRUNC [[COPY9]](s32)
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[FPTRUNC]](s16), [[FPTRUNC1]](s16), [[FPTRUNC2]](s16), [[FPTRUNC3]](s16), [[FPTRUNC4]](s16), [[FPTRUNC5]](s16), [[FPTRUNC6]](s16), [[FPTRUNC7]](s16)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x s16>)
+    ; CHECK-NEXT: [[COPY9:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[FPTRUNC7:%[0-9]+]]:_(f16) = G_FPTRUNC [[COPY9]](f32)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x f16>) = G_BUILD_VECTOR [[FPTRUNC]](f16), [[FPTRUNC1]](f16), [[FPTRUNC2]](f16), [[FPTRUNC3]](f16), [[FPTRUNC4]](f16), [[FPTRUNC5]](f16), [[FPTRUNC6]](f16), [[FPTRUNC7]](f16)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<8 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = COPY $q1
-    %2:_(<8 x s16>) = G_FPOW %0, %1
-    $q0 = COPY %2(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = COPY $q1
+    %2:_(<8 x f16>) = G_FPOW %0, %1
+    $q0 = COPY %2(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -202,29 +202,29 @@ body:             |
     ; CHECK-LABEL: name: test_v2f32.pow
     ; CHECK: liveins: $d0, $d1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s32>) = COPY $d1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f32>) = COPY $d1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<2 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV2]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV2]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV3]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV3]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32)
-    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x s32>)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f32>) = G_BUILD_VECTOR [[COPY2]](f32), [[COPY3]](f32)
+    ; CHECK-NEXT: $d0 = COPY [[BUILD_VECTOR]](<2 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = COPY $d1
-    %2:_(<2 x s32>) = G_FPOW %0, %1
-    $d0 = COPY %2(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = COPY $d1
+    %2:_(<2 x f32>) = G_FPOW %0, %1
+    $d0 = COPY %2(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -239,41 +239,41 @@ body:             |
     ; CHECK-LABEL: name: test_v4f32.pow
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY]](<4 x s32>)
-    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[COPY1]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f32), [[UV1:%[0-9]+]]:_(f32), [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY]](<4 x f32>)
+    ; CHECK-NEXT: [[UV4:%[0-9]+]]:_(f32), [[UV5:%[0-9]+]]:_(f32), [[UV6:%[0-9]+]]:_(f32), [[UV7:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[COPY1]](<4 x f32>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV4]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV4]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV1]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV5]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV1]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV5]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV2]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV6]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV2]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV6]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-NEXT: [[COPY4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $s0 = COPY [[UV3]](s32)
-    ; CHECK-NEXT: $s1 = COPY [[UV7]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[UV3]](f32)
+    ; CHECK-NEXT: $s1 = COPY [[UV7]](f32)
     ; CHECK-NEXT: BL &powf, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $s0, implicit $s1, implicit-def $s0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x s32>)
+    ; CHECK-NEXT: [[COPY5:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<4 x f32>) = G_BUILD_VECTOR [[COPY2]](f32), [[COPY3]](f32), [[COPY4]](f32), [[COPY5]](f32)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<4 x f32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = COPY $q1
-    %2:_(<4 x s32>) = G_FPOW %0, %1
-    $q0 = COPY %2(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = COPY $q1
+    %2:_(<4 x f32>) = G_FPOW %0, %1
+    $q0 = COPY %2(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -288,27 +288,27 @@ body:             |
     ; CHECK-LABEL: name: test_v2f64.pow
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(s64), [[UV1:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s64), [[UV3:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES [[COPY1]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(f64), [[UV1:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f64), [[UV3:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES [[COPY1]](<2 x f64>)
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[UV2]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[UV2]](f64)
     ; CHECK-NEXT: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-NEXT: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: $d0 = COPY [[UV1]](s64)
-    ; CHECK-NEXT: $d1 = COPY [[UV3]](s64)
+    ; CHECK-NEXT: $d0 = COPY [[UV1]](f64)
+    ; CHECK-NEXT: $d1 = COPY [[UV3]](f64)
     ; CHECK-NEXT: BL &pow, csr_aarch64_aapcs, implicit-def $lr, implicit $sp, implicit $d0, implicit $d1, implicit-def $d0
     ; CHECK-NEXT: ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s64) = COPY $d0
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[COPY2]](s64), [[COPY3]](s64)
-    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x s64>)
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(f64) = COPY $d0
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x f64>) = G_BUILD_VECTOR [[COPY2]](f64), [[COPY3]](f64)
+    ; CHECK-NEXT: $q0 = COPY [[BUILD_VECTOR]](<2 x f64>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<2 x s64>) = G_FPOW %0, %1
-    $q0 = COPY %2(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<2 x f64>) = G_FPOW %0, %1
+    $q0 = COPY %2(<2 x f64>)
     RET_ReallyLR implicit $q0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fadd.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fadd.mir
@@ -11,13 +11,13 @@ body:             |
     ; CHECK-LABEL: name: fadd_v2s32
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(s32) = G_VECREDUCE_FADD [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: $w0 = COPY [[VECREDUCE_FADD]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(f32) = G_VECREDUCE_FADD [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: $w0 = COPY [[VECREDUCE_FADD]](f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(s32) = G_VECREDUCE_FADD %0(<2 x s32>)
-    $w0 = COPY %1(s32)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(f32) = G_VECREDUCE_FADD %0(<2 x f32>)
+    $w0 = COPY %1(f32)
     RET_ReallyLR implicit $w0
 
 ...
@@ -31,13 +31,13 @@ body:             |
     ; CHECK-LABEL: name: fadd_v2s64
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(s64) = G_VECREDUCE_FADD [[COPY]](<2 x s64>)
-    ; CHECK-NEXT: $x0 = COPY [[VECREDUCE_FADD]](s64)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(f64) = G_VECREDUCE_FADD [[COPY]](<2 x f64>)
+    ; CHECK-NEXT: $x0 = COPY [[VECREDUCE_FADD]](f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $x0
-    %0:_(<2 x s64>) = COPY $q0
-    %2:_(s64) = G_VECREDUCE_FADD %0(<2 x s64>)
-    $x0 = COPY %2(s64)
+    %0:_(<2 x f64>) = COPY $q0
+    %2:_(f64) = G_VECREDUCE_FADD %0(<2 x f64>)
+    $x0 = COPY %2(f64)
     RET_ReallyLR implicit $x0
 
 ...
@@ -52,25 +52,25 @@ body:             |
     ; CHECK-LABEL: name: fadd_v8s64
     ; CHECK: liveins: $q0, $q1, $q2, $q3
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s64>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s64>) = COPY $q1
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(<2 x s64>) = COPY $q2
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(<2 x s64>) = COPY $q3
-    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(<2 x s64>) = G_FADD [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: [[FADD1:%[0-9]+]]:_(<2 x s64>) = G_FADD [[COPY2]], [[COPY3]]
-    ; CHECK-NEXT: [[FADD2:%[0-9]+]]:_(<2 x s64>) = G_FADD [[FADD]], [[FADD1]]
-    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(s64) = G_VECREDUCE_FADD [[FADD2]](<2 x s64>)
-    ; CHECK-NEXT: $x0 = COPY [[VECREDUCE_FADD]](s64)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f64>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x f64>) = COPY $q1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(<2 x f64>) = COPY $q2
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(<2 x f64>) = COPY $q3
+    ; CHECK-NEXT: [[FADD:%[0-9]+]]:_(<2 x f64>) = G_FADD [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[FADD1:%[0-9]+]]:_(<2 x f64>) = G_FADD [[COPY2]], [[COPY3]]
+    ; CHECK-NEXT: [[FADD2:%[0-9]+]]:_(<2 x f64>) = G_FADD [[FADD]], [[FADD1]]
+    ; CHECK-NEXT: [[VECREDUCE_FADD:%[0-9]+]]:_(f64) = G_VECREDUCE_FADD [[FADD2]](<2 x f64>)
+    ; CHECK-NEXT: $x0 = COPY [[VECREDUCE_FADD]](f64)
     ; CHECK-NEXT: RET_ReallyLR implicit $x0
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = COPY $q1
-    %2:_(<2 x s64>) = COPY $q2
-    %3:_(<2 x s64>) = COPY $q3
-    %4:_(<4 x s64>) = G_CONCAT_VECTORS %0(<2 x s64>), %1(<2 x s64>)
-    %5:_(<4 x s64>) = G_CONCAT_VECTORS %2(<2 x s64>), %3(<2 x s64>)
-    %6:_(<8 x s64>) = G_CONCAT_VECTORS %4(<4 x s64>), %5(<4 x s64>)
-    %7:_(s64) = G_VECREDUCE_FADD %6(<8 x s64>)
-    $x0 = COPY %7(s64)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = COPY $q1
+    %2:_(<2 x f64>) = COPY $q2
+    %3:_(<2 x f64>) = COPY $q3
+    %4:_(<4 x f64>) = G_CONCAT_VECTORS %0(<2 x f64>), %1(<2 x f64>)
+    %5:_(<4 x f64>) = G_CONCAT_VECTORS %2(<2 x f64>), %3(<2 x f64>)
+    %6:_(<8 x f64>) = G_CONCAT_VECTORS %4(<4 x f64>), %5(<4 x f64>)
+    %7:_(f64) = G_VECREDUCE_FADD %6(<8 x f64>)
+    $x0 = COPY %7(f64)
     RET_ReallyLR implicit $x0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fminmax.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fminmax.mir
@@ -11,13 +11,13 @@ body:             |
     ; CHECK-LABEL: name: fmin_v2s32
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[VECREDUCE_FMIN:%[0-9]+]]:_(s32) = G_VECREDUCE_FMIN [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: $s0 = COPY [[VECREDUCE_FMIN]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[VECREDUCE_FMIN:%[0-9]+]]:_(f32) = G_VECREDUCE_FMIN [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: $s0 = COPY [[VECREDUCE_FMIN]](f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(s32) = G_VECREDUCE_FMIN %0(<2 x s32>)
-    $s0 = COPY %1(s32)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(f32) = G_VECREDUCE_FMIN %0(<2 x f32>)
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -31,18 +31,18 @@ body:             |
     ; CHECK-LABEL: name: fmax_v8s16
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; CHECK-NEXT: [[FMAXNUM:%[0-9]+]]:_(<4 x s32>) = G_FMAXNUM [[FPEXT]], [[FPEXT1]]
-    ; CHECK-NEXT: [[VECREDUCE_FMAX:%[0-9]+]]:_(s32) = G_VECREDUCE_FMAX [[FMAXNUM]](<4 x s32>)
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[VECREDUCE_FMAX]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; CHECK-NEXT: [[FMAXNUM:%[0-9]+]]:_(<4 x f32>) = G_FMAXNUM [[FPEXT]], [[FPEXT1]]
+    ; CHECK-NEXT: [[VECREDUCE_FMAX:%[0-9]+]]:_(f32) = G_VECREDUCE_FMAX [[FMAXNUM]](<4 x f32>)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[VECREDUCE_FMAX]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(s16) = G_VECREDUCE_FMAX %0(<8 x s16>)
-    $h0 = COPY %1(s16)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(f16) = G_VECREDUCE_FMAX %0(<8 x f16>)
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...
@@ -56,13 +56,13 @@ body:             |
     ; CHECK-LABEL: name: fminimum_v2s32
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s32>) = COPY $d0
-    ; CHECK-NEXT: [[VECREDUCE_FMINIMUM:%[0-9]+]]:_(s32) = G_VECREDUCE_FMINIMUM [[COPY]](<2 x s32>)
-    ; CHECK-NEXT: $s0 = COPY [[VECREDUCE_FMINIMUM]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x f32>) = COPY $d0
+    ; CHECK-NEXT: [[VECREDUCE_FMINIMUM:%[0-9]+]]:_(f32) = G_VECREDUCE_FMINIMUM [[COPY]](<2 x f32>)
+    ; CHECK-NEXT: $s0 = COPY [[VECREDUCE_FMINIMUM]](f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(s32) = G_VECREDUCE_FMINIMUM %0(<2 x s32>)
-    $s0 = COPY %1(s32)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(f32) = G_VECREDUCE_FMINIMUM %0(<2 x f32>)
+    $s0 = COPY %1(f32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -76,18 +76,18 @@ body:             |
     ; CHECK-LABEL: name: fmaximum_v8s16
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; CHECK-NEXT: [[FMAXIMUM:%[0-9]+]]:_(<4 x s32>) = G_FMAXIMUM [[FPEXT]], [[FPEXT1]]
-    ; CHECK-NEXT: [[VECREDUCE_FMAXIMUM:%[0-9]+]]:_(s32) = G_VECREDUCE_FMAXIMUM [[FMAXIMUM]](<4 x s32>)
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(s16) = G_FPTRUNC [[VECREDUCE_FMAXIMUM]](s32)
-    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](s16)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; CHECK-NEXT: [[FMAXIMUM:%[0-9]+]]:_(<4 x f32>) = G_FMAXIMUM [[FPEXT]], [[FPEXT1]]
+    ; CHECK-NEXT: [[VECREDUCE_FMAXIMUM:%[0-9]+]]:_(f32) = G_VECREDUCE_FMAXIMUM [[FMAXIMUM]](<4 x f32>)
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(f16) = G_FPTRUNC [[VECREDUCE_FMAXIMUM]](f32)
+    ; CHECK-NEXT: $h0 = COPY [[FPTRUNC]](f16)
     ; CHECK-NEXT: RET_ReallyLR implicit $h0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(s16) = G_VECREDUCE_FMAXIMUM %0(<8 x s16>)
-    $h0 = COPY %1(s16)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(f16) = G_VECREDUCE_FMAXIMUM %0(<8 x f16>)
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fmul.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-reduce-fmul.mir
@@ -11,21 +11,21 @@ body:             |
     ; CHECK-LABEL: name: mul_2H
     ; CHECK: liveins: $q0, $q1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s32>) = COPY $q0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x s32>) = COPY $q1
-    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x s32>) = G_FMUL [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x s32>), [[UV1:%[0-9]+]]:_(<2 x s32>) = G_UNMERGE_VALUES [[FMUL]](<4 x s32>)
-    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<2 x s32>) = G_FMUL [[UV]], [[UV1]]
-    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[FMUL1]](<2 x s32>)
-    ; CHECK-NEXT: [[FMUL2:%[0-9]+]]:_(s32) = G_FMUL [[UV2]], [[UV3]]
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY [[FMUL2]](s32)
-    ; CHECK-NEXT: $s0 = COPY [[COPY2]](s32)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f32>) = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<4 x f32>) = COPY $q1
+    ; CHECK-NEXT: [[FMUL:%[0-9]+]]:_(<4 x f32>) = G_FMUL [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<2 x f32>), [[UV1:%[0-9]+]]:_(<2 x f32>) = G_UNMERGE_VALUES [[FMUL]](<4 x f32>)
+    ; CHECK-NEXT: [[FMUL1:%[0-9]+]]:_(<2 x f32>) = G_FMUL [[UV]], [[UV1]]
+    ; CHECK-NEXT: [[UV2:%[0-9]+]]:_(f32), [[UV3:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES [[FMUL1]](<2 x f32>)
+    ; CHECK-NEXT: [[FMUL2:%[0-9]+]]:_(f32) = G_FMUL [[UV2]], [[UV3]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(f32) = COPY [[FMUL2]](f32)
+    ; CHECK-NEXT: $s0 = COPY [[COPY2]](f32)
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %1:_(<4 x s32>) = COPY $q0
-    %2:_(<4 x s32>) = COPY $q1
-    %0:_(<8 x s32>) = G_CONCAT_VECTORS %1(<4 x s32>), %2(<4 x s32>)
-    %5:_(s32) = nnan ninf nsz arcp contract afn reassoc G_VECREDUCE_FMUL %0(<8 x s32>)
-    $s0 = COPY %5(s32)
+    %1:_(<4 x f32>) = COPY $q0
+    %2:_(<4 x f32>) = COPY $q1
+    %0:_(<8 x f32>) = G_CONCAT_VECTORS %1(<4 x f32>), %2(<4 x f32>)
+    %5:_(f32) = nnan ninf nsz arcp contract afn reassoc G_VECREDUCE_FMUL %0(<8 x f32>)
+    $s0 = COPY %5(f32)
     RET_ReallyLR implicit $s0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-sqrt.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-sqrt.mir
@@ -24,20 +24,20 @@ body:             |
     ; CHECK-LABEL: name: test_v8f16.sqrt
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s16>), [[UV1:%[0-9]+]]:_(<4 x s16>) = G_UNMERGE_VALUES [[COPY]](<8 x s16>)
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV]](<4 x s16>)
-    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[UV1]](<4 x s16>)
-    ; CHECK-NEXT: [[FSQRT:%[0-9]+]]:_(<4 x s32>) = G_FSQRT [[FPEXT]]
-    ; CHECK-NEXT: [[FSQRT1:%[0-9]+]]:_(<4 x s32>) = G_FSQRT [[FPEXT1]]
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FSQRT]](<4 x s32>)
-    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FSQRT1]](<4 x s32>)
-    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x s16>), [[FPTRUNC1]](<4 x s16>)
-    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x f16>) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x f16>), [[UV1:%[0-9]+]]:_(<4 x f16>) = G_UNMERGE_VALUES [[COPY]](<8 x f16>)
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV]](<4 x f16>)
+    ; CHECK-NEXT: [[FPEXT1:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[UV1]](<4 x f16>)
+    ; CHECK-NEXT: [[FSQRT:%[0-9]+]]:_(<4 x f32>) = G_FSQRT [[FPEXT]]
+    ; CHECK-NEXT: [[FSQRT1:%[0-9]+]]:_(<4 x f32>) = G_FSQRT [[FPEXT1]]
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FSQRT]](<4 x f32>)
+    ; CHECK-NEXT: [[FPTRUNC1:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FSQRT1]](<4 x f32>)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x f16>) = G_CONCAT_VECTORS [[FPTRUNC]](<4 x f16>), [[FPTRUNC1]](<4 x f16>)
+    ; CHECK-NEXT: $q0 = COPY [[CONCAT_VECTORS]](<8 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FSQRT %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FSQRT %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -54,15 +54,15 @@ body:             |
     ; CHECK-LABEL: name: test_v4f16.sqrt
     ; CHECK: liveins: $d0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s16>) = COPY $d0
-    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x s32>) = G_FPEXT [[COPY]](<4 x s16>)
-    ; CHECK-NEXT: [[FSQRT:%[0-9]+]]:_(<4 x s32>) = G_FSQRT [[FPEXT]]
-    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x s16>) = G_FPTRUNC [[FSQRT]](<4 x s32>)
-    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x s16>)
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x f16>) = COPY $d0
+    ; CHECK-NEXT: [[FPEXT:%[0-9]+]]:_(<4 x f32>) = G_FPEXT [[COPY]](<4 x f16>)
+    ; CHECK-NEXT: [[FSQRT:%[0-9]+]]:_(<4 x f32>) = G_FSQRT [[FPEXT]]
+    ; CHECK-NEXT: [[FPTRUNC:%[0-9]+]]:_(<4 x f16>) = G_FPTRUNC [[FSQRT]](<4 x f32>)
+    ; CHECK-NEXT: $d0 = COPY [[FPTRUNC]](<4 x f16>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FSQRT %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FSQRT %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-tan.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-tan.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.tan
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &tanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &tanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &tanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &tanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FTAN %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FTAN %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &tanf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FTAN %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FTAN %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.tan
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FTAN %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FTAN %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.tan
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &tanf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FTAN %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FTAN %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.tan
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &tan
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &tan
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FTAN %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FTAN %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_tan_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &tanf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FTAN %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FTAN %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-tanh.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-tanh.mir
@@ -13,45 +13,45 @@ body:             |
   bb.0:
     liveins: $d0
     ; CHECK-LABEL: name:            test_v4f16.tanh
-    ; CHECK: [[V1:%[0-9]+]]:_(s16), [[V2:%[0-9]+]]:_(s16), [[V3:%[0-9]+]]:_(s16), [[V4:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s16>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f16), [[V2:%[0-9]+]]:_(f16), [[V3:%[0-9]+]]:_(f16), [[V4:%[0-9]+]]:_(f16) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f16>)
 
-    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V1]](s16)
+    ; CHECK-DAG: [[V1_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V1]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V1_S32]](f32)
     ; CHECK-NEXT: BL &tanhf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT1_S32]](s32)
+    ; CHECK-NEXT: [[ELT1_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT1:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT1_S32]](f32)
 
-    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V2]](s16)
+    ; CHECK-DAG: [[V2_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V2]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V2_S32]](f32)
     ; CHECK-NEXT: BL &tanhf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT2_S32]](s32)
+    ; CHECK-NEXT: [[ELT2_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT2:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT2_S32]](f32)
 
-    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V3]](s16)
+    ; CHECK-DAG: [[V3_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V3]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V3_S32]](f32)
     ; CHECK-NEXT: BL &tanhf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT3_S32]](s32)
+    ; CHECK-NEXT: [[ELT3_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT3:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT3_S32]](f32)
 
-    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(s32) = G_FPEXT [[V4]](s16)
+    ; CHECK-DAG: [[V4_S32:%[0-9]+]]:_(f32) = G_FPEXT [[V4]](f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[V4_S32]](f32)
     ; CHECK-NEXT: BL &tanhf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(s16) = G_FPTRUNC [[ELT4_S32]](s32)
+    ; CHECK-NEXT: [[ELT4_S32:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[ELT4:%[0-9]+]]:_(f16) = G_FPTRUNC [[ELT4_S32]](f32)
 
-    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x s16>) = G_BUILD_VECTOR [[ELT1]](s16), [[ELT2]](s16), [[ELT3]](s16), [[ELT4]](s16)
+    ; CHECK-DAG: %{{[0-9]+}}:_(<4 x f16>) = G_BUILD_VECTOR [[ELT1]](f16), [[ELT2]](f16), [[ELT3]](f16), [[ELT4]](f16)
 
-    %0:_(<4 x s16>) = COPY $d0
-    %1:_(<4 x s16>) = G_FTANH %0
-    $d0 = COPY %1(<4 x s16>)
+    %0:_(<4 x f16>) = COPY $d0
+    %1:_(<4 x f16>) = G_FTANH %0
+    $d0 = COPY %1(<4 x f16>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -83,9 +83,9 @@ body:             |
     ; CHECK: BL &tanhf
     ; CHECK: G_BUILD_VECTOR
 
-    %0:_(<8 x s16>) = COPY $q0
-    %1:_(<8 x s16>) = G_FTANH %0
-    $q0 = COPY %1(<8 x s16>)
+    %0:_(<8 x f16>) = COPY $q0
+    %1:_(<8 x f16>) = G_FTANH %0
+    $q0 = COPY %1(<8 x f16>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -101,25 +101,25 @@ body:             |
     liveins: $d0
 
     ; CHECK-LABEL: name:            test_v2f32.tanh
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32)
+    ; CHECK-DAG: %1:_(<2 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32)
 
-    %0:_(<2 x s32>) = COPY $d0
-    %1:_(<2 x s32>) = G_FTANH %0
-    $d0 = COPY %1(<2 x s32>)
+    %0:_(<2 x f32>) = COPY $d0
+    %1:_(<2 x f32>) = G_FTANH %0
+    $d0 = COPY %1(<2 x f32>)
     RET_ReallyLR implicit $d0
 
 ...
@@ -134,37 +134,37 @@ body:             |
   bb.0:
     liveins: $q0
     ; CHECK-LABEL: name:            test_v4f32.tanh
-    ; CHECK: [[V1:%[0-9]+]]:_(s32), [[V2:%[0-9]+]]:_(s32), [[V3:%[0-9]+]]:_(s32), [[V4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x s32>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f32), [[V2:%[0-9]+]]:_(f32), [[V3:%[0-9]+]]:_(f32), [[V4:%[0-9]+]]:_(f32) = G_UNMERGE_VALUES %{{[0-9]+}}(<4 x f32>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V1]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V1]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V2]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V2]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V3]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V3]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT3:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $s0 = COPY [[V4]](s32)
+    ; CHECK-DAG: $s0 = COPY [[V4]](f32)
     ; CHECK-DAG: BL &tanhf
-    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(s32) = COPY $s0
+    ; CHECK-DAG: [[ELT4:%[0-9]+]]:_(f32) = COPY $s0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<4 x s32>) = G_BUILD_VECTOR [[ELT1]](s32), [[ELT2]](s32), [[ELT3]](s32), [[ELT4]](s32)
+    ; CHECK-DAG: %1:_(<4 x f32>) = G_BUILD_VECTOR [[ELT1]](f32), [[ELT2]](f32), [[ELT3]](f32), [[ELT4]](f32)
 
-    %0:_(<4 x s32>) = COPY $q0
-    %1:_(<4 x s32>) = G_FTANH %0
-    $q0 = COPY %1(<4 x s32>)
+    %0:_(<4 x f32>) = COPY $q0
+    %1:_(<4 x f32>) = G_FTANH %0
+    $q0 = COPY %1(<4 x f32>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -180,25 +180,25 @@ body:             |
     liveins: $q0
 
     ; CHECK-LABEL: name:            test_v2f64.tanh
-    ; CHECK: [[V1:%[0-9]+]]:_(s64), [[V2:%[0-9]+]]:_(s64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x s64>)
+    ; CHECK: [[V1:%[0-9]+]]:_(f64), [[V2:%[0-9]+]]:_(f64) = G_UNMERGE_VALUES %{{[0-9]+}}(<2 x f64>)
 
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V1]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V1]](f64)
     ; CHECK-DAG: BL &tanh
-    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT1:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
     ; CHECK-DAG: ADJCALLSTACKDOWN
-    ; CHECK-DAG: $d0 = COPY [[V2]](s64)
+    ; CHECK-DAG: $d0 = COPY [[V2]](f64)
     ; CHECK-DAG: BL &tanh
-    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(s64) = COPY $d0
+    ; CHECK-DAG: [[ELT2:%[0-9]+]]:_(f64) = COPY $d0
     ; CHECK-DAG: ADJCALLSTACKUP
 
-    ; CHECK-DAG: %1:_(<2 x s64>) = G_BUILD_VECTOR [[ELT1]](s64), [[ELT2]](s64)
+    ; CHECK-DAG: %1:_(<2 x f64>) = G_BUILD_VECTOR [[ELT1]](f64), [[ELT2]](f64)
 
-    %0:_(<2 x s64>) = COPY $q0
-    %1:_(<2 x s64>) = G_FTANH %0
-    $q0 = COPY %1(<2 x s64>)
+    %0:_(<2 x f64>) = COPY $q0
+    %1:_(<2 x f64>) = G_FTANH %0
+    $q0 = COPY %1(<2 x f64>)
     RET_ReallyLR implicit $q0
 
 ...
@@ -213,15 +213,15 @@ body:             |
   bb.0:
     liveins: $h0
     ; CHECK-LABEL: name:            test_tanh_half
-    ; CHECK: [[REG1:%[0-9]+]]:_(s32) = G_FPEXT %0(s16)
+    ; CHECK: [[REG1:%[0-9]+]]:_(f32) = G_FPEXT %0(f16)
     ; CHECK-NEXT: ADJCALLSTACKDOWN
-    ; CHECK-NEXT: $s0 = COPY [[REG1]](s32)
+    ; CHECK-NEXT: $s0 = COPY [[REG1]](f32)
     ; CHECK-NEXT: BL &tanhf
     ; CHECK-NEXT: ADJCALLSTACKUP
-    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(s32) = COPY $s0
-    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(s16) = G_FPTRUNC [[REG2]](s32)
+    ; CHECK-NEXT: [[REG2:%[0-9]+]]:_(f32) = COPY $s0
+    ; CHECK-NEXT: [[RES:%[0-9]+]]:_(f16) = G_FPTRUNC [[REG2]](f32)
 
-    %0:_(s16) = COPY $h0
-    %1:_(s16) = G_FTANH %0
-    $h0 = COPY %1(s16)
+    %0:_(f16) = COPY $h0
+    %1:_(f16) = G_FTANH %0
+    $h0 = COPY %1(f16)
     RET_ReallyLR implicit $h0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-fcmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-fcmp.mir
@@ -22,11 +22,11 @@ body:             |
     ; CHECK-NEXT: [[CSINCWr:%[0-9]+]]:gpr32 = CSINCWr $wzr, $wzr, 1, implicit $nzcv
     ; CHECK-NEXT: $s0 = COPY [[CSINCWr]]
     ; CHECK-NEXT: RET_ReallyLR implicit $s0
-    %0:fpr(s32) = COPY $s0
-    %1:fpr(s32) = COPY $s1
-    %2:fpr(s32) = G_FCONSTANT float 0.000000e+00
-    %3:gpr(s32) = G_FCMP floatpred(oeq), %0(s32), %2
-    $s0 = COPY %3(s32)
+    %0:fpr(f32) = COPY $s0
+    %1:fpr(f32) = COPY $s1
+    %2:fpr(f32) = G_FCONSTANT float 0.000000e+00
+    %3:gpr(i32) = G_FCMP floatpred(oeq), %0(f32), %2
+    $s0 = COPY %3(i32)
     RET_ReallyLR implicit $s0
 
 ...
@@ -53,8 +53,8 @@ body:             |
     %0:fpr(f32) = COPY $s0
     %1:fpr(f32) = COPY $s1
     %2:fpr(f32) = G_FCONSTANT float 1.000000e+00
-    %3:gpr(f32) = G_FCMP floatpred(oeq), %0(f32), %2
-    $s0 = COPY %3(f32)
+    %3:gpr(i32) = G_FCMP floatpred(oeq), %0(f32), %2
+    $s0 = COPY %3(i32)
     RET_ReallyLR implicit $s0
 
 ...


### PR DESCRIPTION
This updates a number of the floating point mir legalization tests to use f
types instead of generic s types.