### PR TITLE
[Lit] Open sub-processes with text=`False`

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -475,8 +475,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     stderr=stderr,
                     env=cmd_shenv.env,
                     close_fds=kUseCloseFDs,
-                    universal_newlines=True,
-                    errors="replace",
+                    text=False,
                 )
             )
             if old_umask != -1:


### PR DESCRIPTION
This PR is part of a series of patches upgrading Lit's in-process built-ins to be able to run with piped input/output and full redirection support, and to allow custom in-process builtns to be provided via the Lit config. The remaining patches to Lit's test runner can be found [here](https://github.com/BStott6/llvm-project/compare/lit-inproc-builtins). This is part of the [Lit daemonized testing project](https://discourse.llvm.org/t/rfc-reducing-process-creation-overhead-in-llvm-regression-tests/88612/9).

This PR makes Lit open all sub-processes with `text=False`, so that the Python code will be able to read and write binary data to and from their IO streams. This currently causes no functional change, as when Lit reads output from the sub-processes, it already handles the case that the read output is `bytes` by decoding it, but we will need to be able to read binary data from a sub-process's STDIN if its output, which may be binary, is piped into an in-process built-in, and we will need to be able to write binary data to a sub-process's STDOUT if its input is piped from an in-process builtin.

I have made sure that on Windows, when a sub-process invoked by Lit has its output redirected to a file by Lit, the `\n -> \r\n` conversion is performed as usual when writing to the file from the process - this change only affects how the Python code interacts with the streams.