### PR TITLE
[CodeGen] Lower vector llvm.sincos to AMDLIBM vector calls

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -4431,6 +4431,7 @@ defset list<RuntimeLibcallImpl> AMDLIBM_VECFUNCS = {
   def amd_vrd2_log2 : RuntimeLibcallImpl<LOG2_V2F64>;
   def amd_vrd2_pow : RuntimeLibcallImpl<POW_V2F64>;
   def amd_vrd2_sin : RuntimeLibcallImpl<SIN_V2F64>;
+  def amd_vrd2_sincos : RuntimeLibcallImpl<SINCOS_V2F64>;
   def amd_vrd2_tan : RuntimeLibcallImpl<TAN_V2F64>;
   def amd_vrd4_atan : RuntimeLibcallImpl<ATAN_V4F64>;
   def amd_vrd4_cos : RuntimeLibcallImpl<COS_V4F64>;

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -586,8 +586,16 @@ RTLIB::Libcall RTLIB::getSINCOS(EVT RetVT) {
     switch (RetVT.getSimpleVT().SimpleTy) {
     case MVT::v4f32:
       return RTLIB::SINCOS_V4F32;
+    case MVT::v8f32:
+      return RTLIB::SINCOS_V8F32;
+    case MVT::v16f32:
+      return RTLIB::SINCOS_V16F32;
     case MVT::v2f64:
       return RTLIB::SINCOS_V2F64;
+    case MVT::v4f64:
+      return RTLIB::SINCOS_V4F64;
+    case MVT::v8f64:
+      return RTLIB::SINCOS_V8F64;
     case MVT::nxv4f32:
       return RTLIB::SINCOS_NXV4F32;
     case MVT::nxv2f64:

--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -89,6 +89,13 @@ RuntimeLibcallsInfo::RuntimeLibcallsInfo(const Triple &TT,
           RTLIB::impl_armpl_vcbrtq_f32, RTLIB::impl_armpl_vcbrtq_f64})
       setLibcallImplCallingConv(Impl, CallingConv::AArch64_VectorCall);
     break;
+  case VectorLibrary::AMDLIBM:
+    for (RTLIB::LibcallImpl Impl :
+         {RTLIB::impl_amd_vrd2_sincos, RTLIB::impl_amd_vrd4_sincos,
+          RTLIB::impl_amd_vrd8_sincos, RTLIB::impl_amd_vrs4_sincosf,
+          RTLIB::impl_amd_vrs8_sincosf, RTLIB::impl_amd_vrs16_sincosf})
+      setAvailable(Impl);
+    break;
   default:
     break;
   }

--- a/llvm/test/CodeGen/X86/veclib-llvm.sincos.ll
+++ b/llvm/test/CodeGen/X86/veclib-llvm.sincos.ll
@@ -9,11 +9,14 @@
 ; RUN: llc -mtriple=x86_64-unknown-linux-gnu -mcpu=x86-64-v4 -vector-library=LIBMVEC < %s | FileCheck %s --check-prefixes=CHECK,GLIBC,GLIBC-AVX512
 
 define void @test_sincos_v4f32(<4 x float> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v4f32:
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
+; AMD-LABEL: test_sincos_v4f32:
+; AMD:    callq amd_vrs4_sincosf@PLT
+;
+; GLIBC-LABEL: test_sincos_v4f32:
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
   %result = call { <4 x float>, <4 x float> } @llvm.sincos.v4f32(<4 x float> %x)
   %result.0 = extractvalue { <4 x float>, <4 x float> } %result, 0
   %result.1 = extractvalue { <4 x float>, <4 x float> } %result, 1
@@ -23,15 +26,29 @@ define void @test_sincos_v4f32(<4 x float> %x, ptr noalias %out_sin, ptr noalias
 }
 
 define void @test_sincos_v8f32(<8 x float> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v8f32:
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
+; AMD-SSE-LABEL: test_sincos_v8f32:
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+;
+; AMD-AVX-LABEL: test_sincos_v8f32:
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+;
+; AMD-AVX2-LABEL: test_sincos_v8f32:
+; AMD-AVX2:    callq amd_vrs8_sincosf@PLT
+;
+; AMD-AVX512-LABEL: test_sincos_v8f32:
+; AMD-AVX512:    callq amd_vrs8_sincosf@PLT
+;
+; GLIBC-LABEL: test_sincos_v8f32:
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
   %result = call { <8 x float>, <8 x float> } @llvm.sincos.v8f32(<8 x float> %x)
   %result.0 = extractvalue { <8 x float>, <8 x float> } %result, 0
   %result.1 = extractvalue { <8 x float>, <8 x float> } %result, 1
@@ -41,23 +58,42 @@ define void @test_sincos_v8f32(<8 x float> %x, ptr noalias %out_sin, ptr noalias
 }
 
 define void @test_sincos_v16f32(<16 x float> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v16f32:
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
-; CHECK:    callq sincosf@PLT
+; AMD-SSE-LABEL: test_sincos_v16f32:
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+; AMD-SSE:    callq amd_vrs4_sincosf@PLT
+;
+; AMD-AVX-LABEL: test_sincos_v16f32:
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+; AMD-AVX:    callq amd_vrs4_sincosf@PLT
+;
+; AMD-AVX2-LABEL: test_sincos_v16f32:
+; AMD-AVX2:    callq amd_vrs8_sincosf@PLT
+; AMD-AVX2:    callq amd_vrs8_sincosf@PLT
+;
+; AMD-AVX512-LABEL: test_sincos_v16f32:
+; AMD-AVX512:    callq amd_vrs16_sincosf@PLT
+;
+; GLIBC-LABEL: test_sincos_v16f32:
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
+; GLIBC:    callq sincosf@PLT
   %result = call { <16 x float>, <16 x float> } @llvm.sincos.v16f32(<16 x float> %x)
   %result.0 = extractvalue { <16 x float>, <16 x float> } %result, 0
   %result.1 = extractvalue { <16 x float>, <16 x float> } %result, 1
@@ -67,9 +103,12 @@ define void @test_sincos_v16f32(<16 x float> %x, ptr noalias %out_sin, ptr noali
 }
 
 define void @test_sincos_v2f64(<2 x double> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v2f64:
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
+; AMD-LABEL: test_sincos_v2f64:
+; AMD:    callq amd_vrd2_sincos@PLT
+;
+; GLIBC-LABEL: test_sincos_v2f64:
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
   %result = call { <2 x double>, <2 x double> } @llvm.sincos.v2f64(<2 x double> %x)
   %result.0 = extractvalue { <2 x double>, <2 x double> } %result, 0
   %result.1 = extractvalue { <2 x double>, <2 x double> } %result, 1
@@ -79,11 +118,25 @@ define void @test_sincos_v2f64(<2 x double> %x, ptr noalias %out_sin, ptr noalia
 }
 
 define void @test_sincos_v4f64(<4 x double> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v4f64:
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
+; AMD-SSE-LABEL: test_sincos_v4f64:
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+;
+; AMD-AVX-LABEL: test_sincos_v4f64:
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+;
+; AMD-AVX2-LABEL: test_sincos_v4f64:
+; AMD-AVX2:    callq amd_vrd4_sincos@PLT
+;
+; AMD-AVX512-LABEL: test_sincos_v4f64:
+; AMD-AVX512:    callq amd_vrd4_sincos@PLT
+;
+; GLIBC-LABEL: test_sincos_v4f64:
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
   %result = call { <4 x double>, <4 x double> } @llvm.sincos.v4f64(<4 x double> %x)
   %result.0 = extractvalue { <4 x double>, <4 x double> } %result, 0
   %result.1 = extractvalue { <4 x double>, <4 x double> } %result, 1
@@ -93,15 +146,34 @@ define void @test_sincos_v4f64(<4 x double> %x, ptr noalias %out_sin, ptr noalia
 }
 
 define void @test_sincos_v8f64(<8 x double> %x, ptr noalias %out_sin, ptr noalias %out_cos) {
-; CHECK-LABEL: test_sincos_v8f64:
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
-; CHECK:    callq sincos@PLT
+; AMD-SSE-LABEL: test_sincos_v8f64:
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+; AMD-SSE:    callq amd_vrd2_sincos@PLT
+;
+; AMD-AVX-LABEL: test_sincos_v8f64:
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+; AMD-AVX:    callq amd_vrd2_sincos@PLT
+;
+; AMD-AVX2-LABEL: test_sincos_v8f64:
+; AMD-AVX2:    callq amd_vrd4_sincos@PLT
+; AMD-AVX2:    callq amd_vrd4_sincos@PLT
+;
+; AMD-AVX512-LABEL: test_sincos_v8f64:
+; AMD-AVX512:    callq amd_vrd8_sincos@PLT
+;
+; GLIBC-LABEL: test_sincos_v8f64:
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
+; GLIBC:    callq sincos@PLT
   %result = call { <8 x double>, <8 x double> } @llvm.sincos.v8f64(<8 x double> %x)
   %result.0 = extractvalue { <8 x double>, <8 x double> } %result, 0
   %result.1 = extractvalue { <8 x double>, <8 x double> } %result, 1
@@ -110,12 +182,7 @@ define void @test_sincos_v8f64(<8 x double> %x, ptr noalias %out_sin, ptr noalia
   ret void
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; AMD: {{.*}}
-; AMD-AVX: {{.*}}
-; AMD-AVX2: {{.*}}
-; AMD-AVX512: {{.*}}
-; AMD-SSE: {{.*}}
-; GLIBC: {{.*}}
+; CHECK: {{.*}}
 ; GLIBC-AVX: {{.*}}
 ; GLIBC-AVX2: {{.*}}
 ; GLIBC-AVX512: {{.*}}


### PR DESCRIPTION
- Adds amd_vrd2_sincos to RuntimeLibcalls.td.
- Adds v8f32, v16f32, v4f64, and v8f64 cases to getSINCOS().
- Enables the AMDLIBM sincos in RuntimeLibcallsInfo.