### PR TITLE
[FLANG] [DOCS] Update current status details of DO CONCURRENT support

### DIFF
--- a/flang/docs/DoConcurrentConversionToOpenMP.md
+++ b/flang/docs/DoConcurrentConversionToOpenMP.md
@@ -47,11 +47,18 @@ See `-fopenmp-targets` and `--offload-arch` for more info.
 
 ## Current status
 
-Under the hood, `do concurrent` mapping is implemented in the
-`DoConcurrentConversionPass`. This is still an experimental pass which means
-that:
-* It has been tested in a very limited way so far.
-* It has been tested mostly on simple synthetic inputs.
+As of LLVM 22, flang adds more extensive support for parallelizing `do concurrent` loops
+on the CPU and the GPU. In particular, the local specifier, partial support for reduce,
+and automatic mapping of user-defined types are now supported.
+On the CPU, we validated the feature using [FIATS](https://github.com/BerkeleyLab/fiats)
+inference and training codes where `do concurrent` and OpenMP had very similar 
+acceleration results (for more information, see: [1]).
+On the GPU, we have basic support that is still in progress. We have offload tests for 
+1D and 2D saxpy. We also validated using codes that do not make extensive use of user-defined
+types and allocatables.
+
+[1] Automatically Parallelizing Batch Inference on Deep Neural Networks Using Fiats
+and Fortran 2023 “Do Concurrent” (https://link.springer.com/chapter/10.1007/978-3-032-07612-0_11)
 
 ### Loop nest detection
 


### PR DESCRIPTION
To maintain consistency, updated the status of DO CONCURRENT support based on the LLVM 22 release notes.