### PR TITLE
[LLVM] Disable IO sandbox in collectAddressSymbols

### DIFF
--- a/llvm/lib/Support/Signals.cpp
+++ b/llvm/lib/Support/Signals.cpp
@@ -155,6 +155,10 @@ std::optional<SmallVector<std::pair<unsigned, std::string>, 0>>
 collectAddressSymbols(void **AddressList, unsigned AddressCount,
                       const char *MainExecutableName,
                       const std::string &LLVMSymbolizerPath) {
+  // This function deals with temporary files for the purposes of symbolization
+  // only, not formal compiler output.
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   BumpPtrAllocator Allocator;
   StringSaver StrPool(Allocator);
   SmallVector<const char *, 0> Modules(AddressCount, nullptr);

--- a/llvm/lib/Support/Signals.cpp
+++ b/llvm/lib/Support/Signals.cpp
@@ -155,9 +155,6 @@ std::optional<SmallVector<std::pair<unsigned, std::string>, 0>>
 collectAddressSymbols(void **AddressList, unsigned AddressCount,
                       const char *MainExecutableName,
                       const std::string &LLVMSymbolizerPath) {
-  // This function deals with temporary files for the purposes of symbolization
-  // only, not formal compiler output.
-  auto BypassSandbox = sys::sandbox::scopedDisable();
 
   BumpPtrAllocator Allocator;
   StringSaver StrPool(Allocator);
@@ -305,6 +302,10 @@ void sys::symbolizeAddresses(AddressSet &Addresses,
                              SymbolizedAddressMap &SymbolizedAddresses) {
   assert(!DisableSymbolicationFlag && !getenv(DisableSymbolizationEnv) &&
          "Debugify origin stacktraces require symbolization to be enabled.");
+
+  // This function deals with temporary files for the purposes of symbolization
+  // only, not formal compiler output.
+  auto BypassSandbox = sys::sandbox::scopedDisable();
 
   // Convert Set of Addresses to ordered list.
   SmallVector<void *, 0> AddressList(Addresses.begin(), Addresses.end());

--- a/llvm/lib/Support/Signals.cpp
+++ b/llvm/lib/Support/Signals.cpp
@@ -155,7 +155,6 @@ std::optional<SmallVector<std::pair<unsigned, std::string>, 0>>
 collectAddressSymbols(void **AddressList, unsigned AddressCount,
                       const char *MainExecutableName,
                       const std::string &LLVMSymbolizerPath) {
-
   BumpPtrAllocator Allocator;
   StringSaver StrPool(Allocator);
   SmallVector<const char *, 0> Modules(AddressCount, nullptr);


### PR DESCRIPTION
The function `collectAddressSymbols` is used by debugify to symbolize addresses captured in the current invocation of LLVM, which it does by executing llvm-symbolizer with temporary input and output files. Creating the temporary files has an explicit sandbox exclusion, as temporary files are necessarily not part of the compiler's formal output, but attempting to read back the output file via MemoryBuffer triggers a sandbox violation. Since we are always only operating on temporary files within collectAddressSymbols, this patch disables the IO sandbox in that function.