### PR TITLE
[llvm] Mark IOSandbox::ScopedSetting nodiscard and maybe_unused

### DIFF
--- a/llvm/include/llvm/Support/IOSandbox.h
+++ b/llvm/include/llvm/Support/IOSandbox.h
@@ -17,7 +17,7 @@
 
 namespace llvm::sys::sandbox {
 inline LLVM_THREAD_LOCAL bool Enabled = false;
-struct ScopedSetting {
+struct [[nodiscard, maybe_unused]] ScopedSetting {
   SaveAndRestore<bool> Impl;
 };
 inline ScopedSetting scopedEnable() { return {{Enabled, true}}; }
@@ -31,7 +31,7 @@ inline void violationIfEnabled() {
 #else
 
 namespace llvm::sys::sandbox {
-struct [[maybe_unused]] ScopedSetting {};
+struct [[nodiscard, maybe_unused]] ScopedSetting {};
 inline ScopedSetting scopedEnable() { return {}; }
 inline ScopedSetting scopedDisable() { return {}; }
 inline void violationIfEnabled() {}


### PR DESCRIPTION
The goal is to have the same attributes on ScopedSetting regardless if this cmake setting is enabled or not.

Both of these should have nodiscard and maybe_unused attributes.