### PR TITLE
[libc] Enable socket entrypoints in overlay mode on x86_64 and aarch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -278,8 +278,19 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.resource.getrlimit
     libc.src.sys.resource.setrlimit
 
-    # sys/sendfile entrypoints
+    # sys/sendfile.h entrypoints
     libc.src.sys.sendfile.sendfile
+
+    # sys/socket.h entrypoints
+    libc.src.sys.socket.accept
+    libc.src.sys.socket.accept4
+    libc.src.sys.socket.bind
+    libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.listen
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socket
 
     # sys/stat.h entrypoints
     libc.src.sys.stat.chmod
@@ -1218,17 +1229,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/select.h entrypoints
     libc.src.sys.select.select
-
-    # sys/socket.h entrypoints
-    libc.src.sys.socket.accept
-    libc.src.sys.socket.accept4
-    libc.src.sys.socket.bind
-    libc.src.sys.socket.connect
-    libc.src.sys.socket.getsockopt
-    libc.src.sys.socket.listen
-    libc.src.sys.socket.setsockopt
-    libc.src.sys.socket.shutdown
-    libc.src.sys.socket.socket
   )
 endif()
 

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -294,8 +294,26 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.sem.semctl
     libc.src.sys.sem.semop
 
-    # sys/sendfile entrypoints
+    # sys/sendfile.h entrypoints
     libc.src.sys.sendfile.sendfile
+
+    # sys/socket.h entrypoints
+    libc.src.sys.socket.accept
+    libc.src.sys.socket.accept4
+    libc.src.sys.socket.bind
+    libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.listen
+    libc.src.sys.socket.recv
+    libc.src.sys.socket.recvfrom
+    libc.src.sys.socket.recvmsg
+    libc.src.sys.socket.send
+    libc.src.sys.socket.sendmsg
+    libc.src.sys.socket.sendto
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socket
+    libc.src.sys.socket.socketpair
 
     # sys/stat.h entrypoints
     libc.src.sys.stat.chmod
@@ -1428,24 +1446,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/select.h entrypoints
     libc.src.sys.select.select
-
-    # sys/socket.h entrypoints
-    libc.src.sys.socket.accept
-    libc.src.sys.socket.accept4
-    libc.src.sys.socket.socket
-    libc.src.sys.socket.bind
-    libc.src.sys.socket.connect
-    libc.src.sys.socket.getsockopt
-    libc.src.sys.socket.listen
-    libc.src.sys.socket.shutdown
-    libc.src.sys.socket.socketpair
-    libc.src.sys.socket.setsockopt
-    libc.src.sys.socket.send
-    libc.src.sys.socket.sendto
-    libc.src.sys.socket.sendmsg
-    libc.src.sys.socket.recv
-    libc.src.sys.socket.recvfrom
-    libc.src.sys.socket.recvmsg
 
     # wchar.h entrypoints
     libc.src.wchar.mblen

--- a/libc/test/src/sys/socket/linux/socketopt_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketopt_test.cpp
@@ -48,7 +48,7 @@ TEST_F(LlvmLibcSocketOptTest, BasicSocketOpt) {
   ASSERT_THAT(
       LIBC_NAMESPACE::getsockopt(sock, SOL_SOCKET, SO_TYPE, &optval, &optlen),
       Succeeds(0));
-  ASSERT_EQ(optval, SOCK_STREAM);
+  ASSERT_EQ(optval, static_cast<int>(SOCK_STREAM));
   ASSERT_EQ(optlen, static_cast<socklen_t>(sizeof(optval)));
 
   optval = SOCK_DGRAM;


### PR DESCRIPTION
This is slightly tricky in that many of these functions depend on types (struct sockaddrs, msghdr, ...) and we cannot overlay types. However, this works because these functions are simple syscall wrappers which simply forward the data to the kernel -- so it's really the kernel that's defining these structures.

This approach is compatible with libraries which implement these functions the same way, which includes at least glibc (on all architectures) and musl (on 64-bit architectures). 32-bit musl repacks the [c]msghdr structures to zero out padding fields, and overlaying that could lead to very subtle bugs. I don't know if anyone uses the overlay mode with musl, but I'm playing it safe and enabling the entrypoints on 64-bit architectures only.