### PR TITLE
[clang][modules-driver] Further constrain import-std test

### DIFF
--- a/clang/test/Driver/modules-driver-import-std.cpp
+++ b/clang/test/Driver/modules-driver-import-std.cpp
@@ -1,8 +1,7 @@
 // Checks that -fmodules-driver correctly handles the import of Standard library
 // modules.
 
-// https://github.com/llvm/llvm-project/pull/194475#issuecomment-4331347690
-// UNSUPPORTED: target={{.*}}aarch64{{.*}}, {{.*}}arm64{{.*}}
+// REQUIRES: x86-registered-target
 
 // The standard library modules manifest (libc++.modules.json) is discovered
 // relative to the installed C++ standard library runtime libraries


### PR DESCRIPTION
The root cause for the failing test was found in https://github.com/llvm/llvm-project/pull/194475#issuecomment-4335023585. 
The test uses `--target=x86_64-linux-gnu` which is only available with `-DLLVM_TARGETS_TO_BUILD=all` or on native x86 targets.