### PR TITLE
[CUDA/HIP] Do not check function calls in discarded statement

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -470,6 +470,9 @@ Improvements to Clang's diagnostics
 
 - Removed the body of lambdas from some diagnostic messages.
 
+- Fixed false positive host-device mismatch errors in discarded `if constexpr` branches for CUDA/HIP;
+  such calls are now correctly skipped.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -990,7 +990,8 @@ bool SemaCUDA::CheckCall(SourceLocation Loc, FunctionDecl *Callee) {
   assert(Callee && "Callee may not be null.");
 
   const auto &ExprEvalCtx = SemaRef.currentEvaluationContext();
-  if (ExprEvalCtx.isUnevaluated() || ExprEvalCtx.isConstantEvaluated())
+  if (ExprEvalCtx.isUnevaluated() || ExprEvalCtx.isConstantEvaluated() ||
+      ExprEvalCtx.isDiscardedStatementContext())
     return true;
 
   // C++ deduction guides participate in overload resolution but are not

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -84,10 +84,6 @@ ExprResult SemaCUDA::ActOnExecConfigExpr(Scope *S, SourceLocation LLLLoc,
     return ExprError(
         Diag(LLLLoc, diag::err_cuda_device_kernel_launch_not_supported));
 
-  if (IsDeviceKernelCall && !getLangOpts().GPURelocatableDeviceCode)
-    return ExprError(
-        Diag(LLLLoc, diag::err_cuda_device_kernel_launch_require_rdc));
-
   FunctionDecl *ConfigDecl = IsDeviceKernelCall
                                  ? getASTContext().getcudaLaunchDeviceDecl()
                                  : getASTContext().getcudaConfigureCallDecl();
@@ -1027,9 +1023,20 @@ bool SemaCUDA::CheckCall(SourceLocation Loc, FunctionDecl *Callee) {
     }
   }();
 
+  bool IsDeviceKernelCall = Callee == getASTContext().getcudaLaunchDeviceDecl();
+  bool CallerHD = Caller && Caller->hasAttr<CUDAHostAttr>() &&
+                  Caller->hasAttr<CUDADeviceAttr>();
+  bool CallerDiscard = SemaRef.getEmissionStatus(Caller) ==
+                       Sema::FunctionEmissionStatus::TemplateDiscarded;
+  bool RDC = getLangOpts().GPURelocatableDeviceCode;
+  if (IsDeviceKernelCall && !(CallerHD && CallerDiscard) && !RDC) {
+    Diag(Loc, diag::err_cuda_device_kernel_launch_require_rdc);
+    return false;
+  }
+
   if (DiagKind == SemaDiagnosticBuilder::K_Nop) {
     // For -fgpu-rdc, keep track of external kernels used by host functions.
-    if (getLangOpts().CUDAIsDevice && getLangOpts().GPURelocatableDeviceCode &&
+    if (getLangOpts().CUDAIsDevice && RDC &&
         Callee->hasAttr<CUDAGlobalAttr>() && !Callee->isDefined() &&
         (!Caller || (!Caller->getDescribedFunctionTemplate() &&
                      getASTContext().GetGVALinkageForFunction(Caller) ==

--- a/clang/test/SemaCUDA/call-device-fn-from-host.cu
+++ b/clang/test/SemaCUDA/call-device-fn-from-host.cu
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 %s --std=c++11 -triple x86_64-unknown-linux -emit-llvm -o - \
+// RUN: %clang_cc1 %s --std=c++17 -triple x86_64-unknown-linux -emit-llvm -o - \
 // RUN:   -verify -verify-ignore-unexpected=note
-// RUN: %clang_cc1 %s --std=c++11 -triple x86_64-unknown-linux -emit-llvm -o - \
+// RUN: %clang_cc1 %s --std=c++17 -triple x86_64-unknown-linux -emit-llvm -o - \
 // RUN:   -verify=expected,omp -verify-ignore-unexpected=note -fopenmp
 
 // Note: This test won't work with -fsyntax-only, because some of these errors
@@ -97,3 +97,18 @@ void host_func(void) { kernel<<<1, 1>>>(); }
 __device__ void f();
 template<void(*F)()> __global__ void t() { F(); }
 __host__ void g() { t<f><<<1,1>>>(); }
+
+namespace template_if_constexpr {
+  template<bool B>
+  __host__ __device__ void fn() {
+    if constexpr (!B)
+      device_fn();
+
+    if constexpr (B)
+      device_fn(); // expected-error {{reference to __device__ function 'device_fn' in __host__ __device__ function}}
+  }
+
+  void call() {
+    fn<true>();
+  }
+}

--- a/clang/test/SemaCUDA/call-device-fn-from-host.cu
+++ b/clang/test/SemaCUDA/call-device-fn-from-host.cu
@@ -1,3 +1,8 @@
+// RUN: %clang_cc1 %s --std=c++11 -triple x86_64-unknown-linux -emit-llvm -o - \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 %s --std=c++11 -triple x86_64-unknown-linux -emit-llvm -o - \
+// RUN:   -verify=expected,omp -verify-ignore-unexpected=note -fopenmp
+
 // RUN: %clang_cc1 %s --std=c++17 -triple x86_64-unknown-linux -emit-llvm -o - \
 // RUN:   -verify -verify-ignore-unexpected=note
 // RUN: %clang_cc1 %s --std=c++17 -triple x86_64-unknown-linux -emit-llvm -o - \
@@ -98,6 +103,7 @@ __device__ void f();
 template<void(*F)()> __global__ void t() { F(); }
 __host__ void g() { t<f><<<1,1>>>(); }
 
+#if __cplusplus >= 201703L
 namespace template_if_constexpr {
   template<bool B>
   __host__ __device__ void fn() {
@@ -110,3 +116,4 @@ namespace template_if_constexpr {
     fn<true>(); // expected-error@-5 {{reference to __device__ function 'device_fn' in __host__ __device__ function}}
   }
 }
+#endif

--- a/clang/test/SemaCUDA/call-device-fn-from-host.cu
+++ b/clang/test/SemaCUDA/call-device-fn-from-host.cu
@@ -101,14 +101,12 @@ __host__ void g() { t<f><<<1,1>>>(); }
 namespace template_if_constexpr {
   template<bool B>
   __host__ __device__ void fn() {
-    if constexpr (!B)
-      device_fn();
-
     if constexpr (B)
-      device_fn(); // expected-error {{reference to __device__ function 'device_fn' in __host__ __device__ function}}
+      device_fn();
   }
 
   void call() {
-    fn<true>();
+    fn<false>();
+    fn<true>(); // expected-error@-5 {{reference to __device__ function 'device_fn' in __host__ __device__ function}}
   }
 }

--- a/clang/test/SemaCUDA/call-host-fn-from-device.cu
+++ b/clang/test/SemaCUDA/call-host-fn-from-device.cu
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s --std=c++11 -triple nvptx-unknown-unknown -fcuda-is-device \
+// RUN: %clang_cc1 %s --std=c++17 -triple nvptx-unknown-unknown -fcuda-is-device \
 // RUN:   -emit-llvm -o /dev/null -verify -verify-ignore-unexpected=note
 
 // Note: This test won't work with -fsyntax-only, because some of these errors
@@ -138,3 +138,18 @@ __host__ __device__ void TmplStruct<int>::fn<int>() { host_fn(); }
 // expected-error@-1 {{reference to __host__ function 'host_fn' in __host__ __device__ function}}
 
 __device__ void double_specialization() { TmplStruct<int>().fn<int>(); }
+
+namespace template_if_constexpr {
+  template<bool B>
+  __host__ __device__ void fn() {
+    if constexpr (!B)
+      host_fn();
+
+    if constexpr (B)
+      host_fn(); // expected-error {{reference to __host__ function 'host_fn' in __host__ __device__ function}}
+  }
+
+  __device__ void call() {
+    fn<true>();
+  }
+}

--- a/clang/test/SemaCUDA/call-host-fn-from-device.cu
+++ b/clang/test/SemaCUDA/call-host-fn-from-device.cu
@@ -1,3 +1,6 @@
+// RUN: %clang_cc1 %s --std=c++11 -triple nvptx-unknown-unknown -fcuda-is-device \
+// RUN:   -emit-llvm -o /dev/null -verify -verify-ignore-unexpected=note
+
 // RUN: %clang_cc1 %s --std=c++17 -triple nvptx-unknown-unknown -fcuda-is-device \
 // RUN:   -emit-llvm -o /dev/null -verify -verify-ignore-unexpected=note
 
@@ -139,6 +142,7 @@ __host__ __device__ void TmplStruct<int>::fn<int>() { host_fn(); }
 
 __device__ void double_specialization() { TmplStruct<int>().fn<int>(); }
 
+#if __cplusplus >= 201703L
 namespace template_if_constexpr {
   template<bool B>
   __host__ __device__ void fn() {
@@ -151,3 +155,4 @@ namespace template_if_constexpr {
     fn<true>(); // expected-error@-5 {{reference to __host__ function 'host_fn' in __host__ __device__ function}}
   }
 }
+#endif

--- a/clang/test/SemaCUDA/call-host-fn-from-device.cu
+++ b/clang/test/SemaCUDA/call-host-fn-from-device.cu
@@ -142,14 +142,12 @@ __device__ void double_specialization() { TmplStruct<int>().fn<int>(); }
 namespace template_if_constexpr {
   template<bool B>
   __host__ __device__ void fn() {
-    if constexpr (!B)
-      host_fn();
-
     if constexpr (B)
-      host_fn(); // expected-error {{reference to __host__ function 'host_fn' in __host__ __device__ function}}
+      host_fn();
   }
 
   __device__ void call() {
-    fn<true>();
+    fn<false>();
+    fn<true>(); // expected-error@-5 {{reference to __host__ function 'host_fn' in __host__ __device__ function}}
   }
 }

--- a/clang/test/SemaCUDA/device-kernel-call.cu
+++ b/clang/test/SemaCUDA/device-kernel-call.cu
@@ -13,3 +13,19 @@ __global__ void g1(void) {
   // nordc-error@-1 {{kernel launch from __device__ or __global__ function requires relocatable device code (i.e. requires -fgpu-rdc)}}
   // hip-error@-2 {{device-side kernel call/launch is not supported}}
 }
+
+namespace template_if_constexpr {
+  template<bool B>
+  __host__ __device__ void fn() {
+    if constexpr (B)
+      g2<<<1, 1>>>(42);
+    // hip-error@-1 {{device-side kernel call/launch is not supported}}
+  }
+
+  void call() {
+    fn<false>();
+    fn<true>();
+    // nordc-error@-7 {{kernel launch from __device__ or __global__ function requires relocatable device code (i.e. requires -fgpu-rdc)}}
+    // nordc-note@-2 {{in instantiation of function template specialization 'template_if_constexpr::fn<true>' requested here}}
+  }
+}


### PR DESCRIPTION
Previously, calling a host-device mismatch function inside a discarded `if constexpr` branch would trigger an error. This patch recognizes that discarded statements are never instantiated and allows such code.