### PR TITLE
[libclc] Fix using normalized triple for the directory name

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -74,7 +74,7 @@ endfunction()
 function(link_libclc_builtin_library target_name)
   cmake_parse_arguments(ARG
     ""
-    "ARCH;TRIPLE;FOLDER;OUTPUT_FILENAME"
+    "ARCH;TRIPLE;TARGET_TRIPLE;FOLDER;OUTPUT_FILENAME"
     "LIBRARIES;INTERNALIZE_LIBRARIES;OPT_FLAGS"
     ${ARGN}
   )
@@ -86,7 +86,7 @@ function(link_libclc_builtin_library target_name)
     message(FATAL_ERROR "LIBRARIES is required for link_libclc_builtin_library")
   endif()
 
-  set(library_dir ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TRIPLE})
+  set(library_dir ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TARGET_TRIPLE})
   file(MAKE_DIRECTORY ${library_dir})
 
   set(linked_bc ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.linked.bc)
@@ -179,6 +179,7 @@ function(add_libclc_library target_name)
   link_libclc_builtin_library(${target_name}
     ARCH ${ARG_ARCH}
     TRIPLE ${ARG_TRIPLE}
+    TARGET_TRIPLE ${ARG_TARGET_TRIPLE}
     LIBRARIES ${builtins_target}
     INTERNALIZE_LIBRARIES ${ARG_INTERNALIZE_LIBRARIES}
     OPT_FLAGS ${ARG_OPT_FLAGS}
@@ -190,7 +191,7 @@ function(add_libclc_library target_name)
   set(builtins_file $<TARGET_PROPERTY:${target_name},TARGET_FILE>)
 
   install(FILES ${builtins_file}
-    DESTINATION ${LIBCLC_INSTALL_DIR}/${ARG_TRIPLE}
+    DESTINATION ${LIBCLC_INSTALL_DIR}/${ARG_TARGET_TRIPLE}
     COMPONENT ${ARG_PARENT_TARGET}
   )
 endfunction()


### PR DESCRIPTION
Summary:
libclc needs to normalize triples, mostly on account of the fact that
things like spv and clspv aren't real triples but are used anyway. That
is, we convert the user-value to whatever is passed to `--target=`. The
problem is that we were not using the normal triple for the installation
directory, so something like `spirv64-mesa32-unknown` would be installed
in `spirv64--`.

This *might* have the side effect of putting these in
`spirv64-unknown-unknown`. I actually do not know if that's a problem
with the clang handling, I'll double check.
