### PR TITLE
[mlir][SPIR-V] Use ToolSubst for spirv-tools lit substitutions

### DIFF
--- a/mlir/test/Target/SPIRV/lit.local.cfg
+++ b/mlir/test/Target/SPIRV/lit.local.cfg
@@ -1,4 +1,4 @@
 if config.spirv_tools_tests:
     config.available_features.add("spirv-tools")
-    config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
-    config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
+    from lit.llvm import llvm_config
+    llvm_config.add_tool_substitutions(["spirv-as", "spirv-val"])


### PR DESCRIPTION
Bare-string substitutions match as substrings and the replacement path contains the tool name, causing corrupted RUN lines

Mirrors the LLVM-side fix from #192462