### PR TITLE
[clang-tidy] Migrate explicit-constructor check from google to misc and add relative aliases

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/CppCoreGuidelinesTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/CppCoreGuidelinesTidyModule.cpp
@@ -9,6 +9,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../bugprone/NarrowingConversionsCheck.h"
+#include "../misc/ExplicitConstructorCheck.h"
 #include "../misc/NonPrivateMemberVariablesInClassesCheck.h"
 #include "../misc/UnconventionalAssignOperatorCheck.h"
 #include "../modernize/AvoidCArraysCheck.h"
@@ -75,6 +76,8 @@ public:
         "cppcoreguidelines-avoid-non-const-global-variables");
     CheckFactories.registerCheck<AvoidReferenceCoroutineParametersCheck>(
         "cppcoreguidelines-avoid-reference-coroutine-parameters");
+    CheckFactories.registerCheck<misc::ExplicitConstructorCheck>(
+        "cppcoreguidelines-explicit-constructor");
     CheckFactories.registerCheck<modernize::UseOverrideCheck>(
         "cppcoreguidelines-explicit-virtual-functions");
     CheckFactories.registerCheck<InitVariablesCheck>(

--- a/clang-tools-extra/clang-tidy/google/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/google/CMakeLists.txt
@@ -8,7 +8,6 @@ add_clang_library(clangTidyGoogleModule STATIC
   AvoidThrowingObjCExceptionCheck.cpp
   AvoidUnderscoreInGoogletestNameCheck.cpp
   DefaultArgumentsCheck.cpp
-  ExplicitConstructorCheck.cpp
   ExplicitMakePairCheck.cpp
   FloatTypesCheck.cpp
   FunctionNamingCheck.cpp

--- a/clang-tools-extra/clang-tidy/google/GoogleTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/google/GoogleTidyModule.cpp
@@ -17,7 +17,7 @@
 #include "AvoidThrowingObjCExceptionCheck.h"
 #include "AvoidUnderscoreInGoogletestNameCheck.h"
 #include "DefaultArgumentsCheck.h"
-#include "ExplicitConstructorCheck.h"
+#include "../misc/ExplicitConstructorCheck.h"
 #include "ExplicitMakePairCheck.h"
 #include "FloatTypesCheck.h"
 #include "FunctionNamingCheck.h"
@@ -46,7 +46,7 @@ public:
         "google-build-using-namespace");
     CheckFactories.registerCheck<DefaultArgumentsCheck>(
         "google-default-arguments");
-    CheckFactories.registerCheck<ExplicitConstructorCheck>(
+    CheckFactories.registerCheck<misc::ExplicitConstructorCheck>(
         "google-explicit-constructor");
     CheckFactories.registerCheck<readability::GlobalNamesInHeadersCheck>(
         "google-global-names-in-headers");

--- a/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
@@ -19,7 +19,7 @@
 #include "../cppcoreguidelines/ProTypeMemberInitCheck.h"
 #include "../cppcoreguidelines/ProTypeVarargCheck.h"
 #include "../cppcoreguidelines/SpecialMemberFunctionsCheck.h"
-#include "../google/ExplicitConstructorCheck.h"
+#include "../misc/ExplicitConstructorCheck.h"
 #include "../misc/NewDeleteOverloadsCheck.h"
 #include "../misc/StaticAssertCheck.h"
 #include "../modernize/AvoidCArraysCheck.h"
@@ -63,7 +63,7 @@ public:
         "hicpp-multiway-paths-covered");
     CheckFactories.registerCheck<bugprone::SignedBitwiseCheck>(
         "hicpp-signed-bitwise");
-    CheckFactories.registerCheck<google::ExplicitConstructorCheck>(
+    CheckFactories.registerCheck<misc::ExplicitConstructorCheck>(
         "hicpp-explicit-conversions");
     CheckFactories.registerCheck<readability::FunctionSizeCheck>(
         "hicpp-function-size");

--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -22,6 +22,7 @@ add_clang_library(clangTidyMiscModule STATIC
   ConstCorrectnessCheck.cpp
   CoroutineHostileRAIICheck.cpp
   DefinitionsInHeadersCheck.cpp
+  ExplicitConstructorCheck.cpp
   ConfusableIdentifierCheck.cpp
   HeaderIncludeCycleCheck.cpp
   IncludeCleanerCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/ExplicitConstructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ExplicitConstructorCheck.cpp
@@ -14,7 +14,7 @@
 
 using namespace clang::ast_matchers;
 
-namespace clang::tidy::google {
+namespace clang::tidy::misc {
 
 void ExplicitConstructorCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
@@ -136,4 +136,4 @@ void ExplicitConstructorCheck::check(const MatchFinder::MatchResult &Result) {
     Diag << FixItHint::CreateInsertion(Loc, "explicit ");
 }
 
-} // namespace clang::tidy::google
+} // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/misc/ExplicitConstructorCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/ExplicitConstructorCheck.h
@@ -6,19 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_GOOGLE_EXPLICITCONSTRUCTORCHECK_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_GOOGLE_EXPLICITCONSTRUCTORCHECK_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_EXPLICITCONSTRUCTORCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_EXPLICITCONSTRUCTORCHECK_H
 
 #include "../ClangTidyCheck.h"
 
-namespace clang::tidy::google {
+namespace clang::tidy::misc {
 
 /// Checks that all single-argument constructors are explicit.
 ///
-/// See https://google.github.io/styleguide/cppguide.html#Explicit_Constructors
-///
 /// For the user-facing documentation see:
-/// https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html
+/// https://clang.llvm.org/extra/clang-tidy/checks/misc/explicit-constructor.html
 class ExplicitConstructorCheck : public ClangTidyCheck {
 public:
   ExplicitConstructorCheck(StringRef Name, ClangTidyContext *Context)
@@ -30,6 +28,6 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 };
 
-} // namespace clang::tidy::google
+} // namespace clang::tidy::misc
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_GOOGLE_EXPLICITCONSTRUCTORCHECK_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_EXPLICITCONSTRUCTORCHECK_H

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -13,6 +13,7 @@
 #include "ConstCorrectnessCheck.h"
 #include "CoroutineHostileRAIICheck.h"
 #include "DefinitionsInHeadersCheck.h"
+#include "ExplicitConstructorCheck.h"
 #include "HeaderIncludeCycleCheck.h"
 #include "IncludeCleanerCheck.h"
 #include "MisleadingBidirectionalCheck.h"
@@ -53,6 +54,8 @@ public:
         "misc-coroutine-hostile-raii");
     CheckFactories.registerCheck<DefinitionsInHeadersCheck>(
         "misc-definitions-in-headers");
+    CheckFactories.registerCheck<ExplicitConstructorCheck>(
+        "misc-explicit-constructor");
     CheckFactories.registerCheck<HeaderIncludeCycleCheck>(
         "misc-header-include-cycle");
     CheckFactories.registerCheck<IncludeCleanerCheck>("misc-include-cleaner");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -199,11 +199,26 @@ New check aliases
   to :doc:`bugprone-assignment-in-selection-statement
   <clang-tidy/checks/bugprone/assignment-in-selection-statement>`.
 
+- Renamed :doc:`cppcoreguidelines-explicit-constructor <clang-tidy/checks/cppcoreguidelines/explicit-constructor>`
+  to :doc:`misc-explicit-constructor
+  <clang-tidy/checks/misc/explicit-constructor>`. The `cppcoreguidelines-explicit-constructor`
+  name is kept as an alias.
+
+- Renamed :doc:`google-explicit-constructor <clang-tidy/checks/google/explicit-constructor>`
+  to :doc:`misc-explicit-constructor
+  <clang-tidy/checks/misc/explicit-constructor>`. The `google-explicit-constructor`
+  name is kept as an alias.
+
 - Renamed :doc:`hicpp-exception-baseclass
   <clang-tidy/checks/hicpp/exception-baseclass>`
   to :doc:`bugprone-std-exception-baseclass
   <clang-tidy/checks/bugprone/std-exception-baseclass>`.
   The `hicpp-exception-baseclass` name is kept as an alias.
+
+- Renamed :doc:`hicpp-explicit-conversions <clang-tidy/checks/hicpp/explicit-conversions>`
+  to :doc:`misc-explicit-constructor
+  <clang-tidy/checks/misc/explicit-constructor>`. The `hicpp-explicit-conversions`
+  name is kept as an alias.
 
 - Renamed :doc:`hicpp-ignored-remove-result
   <clang-tidy/checks/hicpp/ignored-remove-result>`

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/explicit-constructor.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - cppcoreguidelines-explicit-constructor
+
+cppcoreguidelines-explicit-constructor
+======================================
+
+This check is an alias, please see
+`misc-explicit-constructor <../misc/explicit-constructor.html>`_
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/google/explicit-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/explicit-constructor.rst
@@ -3,54 +3,6 @@
 google-explicit-constructor
 ===========================
 
-
-Checks that constructors callable with a single argument and conversion
-operators are marked explicit to avoid the risk of unintentional implicit
-conversions.
-
-Consider this example:
-
-.. code-block:: c++
-
-  struct S {
-    int x;
-    operator bool() const { return true; }
-  };
-
-  bool f() {
-    S a{1};
-    S b{2};
-    return a == b;
-  }
-
-The function will return ``true``, since the objects are implicitly converted
-to ``bool`` before comparison, which is unlikely to be the intent.
-
-The check will suggest inserting ``explicit`` before the constructor or
-conversion operator declaration. However, copy and move constructors should not
-be explicit, as well as constructors taking a single ``initializer_list``
-argument.
-
-This code:
-
-.. code-block:: c++
-
-  struct S {
-    S(int a);
-    explicit S(const S&);
-    operator bool() const;
-    ...
-
-will become
-
-.. code-block:: c++
-
-  struct S {
-    explicit S(int a);
-    S(const S&);
-    explicit operator bool() const;
-    ...
-
-
-
-See https://google.github.io/styleguide/cppguide.html#Explicit_Constructors
+This check is an alias, please see
+`misc-explicit-constructor <../misc/explicit-constructor.html>`_
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
@@ -4,7 +4,7 @@ hicpp-explicit-conversions
 ==========================
 
 This check is an alias for
-:doc:`google-explicit-constructor <../google/explicit-constructor>`.
+:doc:`misc-explicit-constructor <../misc/explicit-constructor>`.
 
 Used to enforce parts of `rule 5.4.1
 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -193,6 +193,7 @@ Clang-Tidy Checks
    :doc:`cppcoreguidelines-avoid-goto <cppcoreguidelines/avoid-goto>`,
    :doc:`cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines/avoid-non-const-global-variables>`,
    :doc:`cppcoreguidelines-avoid-reference-coroutine-parameters <cppcoreguidelines/avoid-reference-coroutine-parameters>`,
+   :doc:`cppcoreguidelines-explicit-constructor <cppcoreguidelines/explicit-constructor>`,
    :doc:`cppcoreguidelines-init-variables <cppcoreguidelines/init-variables>`, "Yes"
    :doc:`cppcoreguidelines-interfaces-global-init <cppcoreguidelines/interfaces-global-init>`,
    :doc:`cppcoreguidelines-macro-usage <cppcoreguidelines/macro-usage>`,
@@ -230,7 +231,7 @@ Clang-Tidy Checks
    :doc:`google-build-explicit-make-pair <google/build-explicit-make-pair>`,
    :doc:`google-build-using-namespace <google/build-using-namespace>`,
    :doc:`google-default-arguments <google/default-arguments>`,
-   :doc:`google-explicit-constructor <google/explicit-constructor>`, "Yes"
+   :doc:`google-explicit-constructor <google/explicit-constructor>`,
    :doc:`google-global-names-in-headers <google/global-names-in-headers>`,
    :doc:`google-objc-avoid-nsobject-new <google/objc-avoid-nsobject-new>`,
    :doc:`google-objc-avoid-throwing-exception <google/objc-avoid-throwing-exception>`,
@@ -265,6 +266,7 @@ Clang-Tidy Checks
    :doc:`misc-const-correctness <misc/const-correctness>`, "Yes"
    :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,
    :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes"
+   :doc:`misc-explicit-constructor <misc/explicit-constructor>`, "Yes"
    :doc:`misc-header-include-cycle <misc/header-include-cycle>`,
    :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes"
    :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,
@@ -606,7 +608,7 @@ Check aliases
    :doc:`hicpp-braces-around-statements <hicpp/braces-around-statements>`, :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
    :doc:`hicpp-deprecated-headers <hicpp/deprecated-headers>`, :doc:`modernize-deprecated-headers <modernize/deprecated-headers>`, "Yes"
    :doc:`hicpp-exception-baseclass <hicpp/exception-baseclass>`, :doc:`bugprone-std-exception-baseclass <bugprone/std-exception-baseclass>`,
-   :doc:`hicpp-explicit-conversions <hicpp/explicit-conversions>`, :doc:`google-explicit-constructor <google/explicit-constructor>`, "Yes"
+   :doc:`hicpp-explicit-conversions <hicpp/explicit-conversions>`, :doc:`misc-explicit-constructor <misc/explicit-constructor>`, "Yes"
    :doc:`hicpp-function-size <hicpp/function-size>`, :doc:`readability-function-size <readability/function-size>`,
    :doc:`hicpp-ignored-remove-result <hicpp/ignored-remove-result>`, :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,
    :doc:`hicpp-invalid-access-moved <hicpp/invalid-access-moved>`, :doc:`bugprone-use-after-move <bugprone/use-after-move>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/explicit-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/explicit-constructor.rst
@@ -1,0 +1,56 @@
+.. title:: clang-tidy - misc-explicit-constructor
+
+misc-explicit-constructor
+===========================
+
+
+Checks that constructors callable with a single argument and conversion
+operators are marked explicit to avoid the risk of unintentional implicit
+conversions.
+
+Consider this example:
+
+.. code-block:: c++
+
+  struct S {
+    int x;
+    operator bool() const { return true; }
+  };
+
+  bool f() {
+    S a{1};
+    S b{2};
+    return a == b;
+  }
+
+The function will return ``true``, since the objects are implicitly converted
+to ``bool`` before comparison, which is unlikely to be the intent.
+
+The check will suggest inserting ``explicit`` before the constructor or
+conversion operator declaration. However, copy and move constructors should not
+be explicit, as well as constructors taking a single ``initializer_list``
+argument.
+
+This code:
+
+.. code-block:: c++
+
+  struct S {
+    S(int a);
+    explicit S(const S&);
+    operator bool() const;
+    ...
+
+will become
+
+.. code-block:: c++
+
+  struct S {
+    explicit S(int a);
+    S(const S&);
+    explicit operator bool() const;
+    ...
+
+
+
+See https://google.github.io/styleguide/cppguide.html#Explicit_Constructors

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/explicit-constructor-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/explicit-constructor-cxx20.cpp
@@ -1,4 +1,7 @@
-// RUN: %check_clang_tidy %s google-explicit-constructor %t -std=c++20-or-later
+// RUN: %check_clang_tidy %s misc-explicit-constructor %t -std=c++20-or-latermisc
+// RUN: %check_clang_tidy %s google-explicit-constructor %t -std=c++20-or-latermisc
+// RUN: %check_clang_tidy %s cppcoreguidelines-explicit-constructor %t -std=c++20-or-latermisc
+// RUN: %check_clang_tidy %s hicpp-explicit-conversions %t -std=c++20-or-latermisc
 
 namespace issue_81121
 {
@@ -20,7 +23,7 @@ struct C {
 
 struct D {
   explicit(ConstFalse) D(int);
-  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: single-argument constructors explicit expression evaluates to 'false' [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: single-argument constructors explicit expression evaluates to 'false' [{{.*}}]
 };
 
 template <typename>
@@ -41,7 +44,7 @@ struct G {
 template <typename>
 struct H {
   explicit(ConstFalse) H(int);
-  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: single-argument constructors explicit expression evaluates to 'false' [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: single-argument constructors explicit expression evaluates to 'false' [{{.*}}]
 };
 
 template <int Val>

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/explicit-constructor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/explicit-constructor.cpp
@@ -1,4 +1,7 @@
+// RUN: %check_clang_tidy %s misc-explicit-constructor %t
 // RUN: %check_clang_tidy %s google-explicit-constructor %t
+// RUN: %check_clang_tidy %s cppcoreguidelines-explicit-constructor %t
+// RUN: %check_clang_tidy %s hicpp-explicit-conversions %t
 
 namespace std {
   typedef decltype(sizeof(int)) size_t;
@@ -43,15 +46,15 @@ struct A {
   operator double() const = delete;
 
   explicit A(const A& a) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: copy constructor should not be declared explicit [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: copy constructor should not be declared explicit [{{.*}}]
   // CHECK-FIXES: A(const A& a) {}
 
   A(int x1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [{{.*}}]
   // CHECK-FIXES: explicit A(int x1);
 
   A(double x2, double y = 3.14) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: constructors that are callable with a single argument must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: constructors that are callable with a single argument must be marked explicit to avoid unintentional implicit conversions [{{.*}}]
   // CHECK-FIXES: explicit A(double x2, double y = 3.14) {}
 
   template <typename... T>
@@ -68,15 +71,15 @@ struct B {
   B(std::initializer_list<unsigned> &&list3) {}
 
   operator bool() const { return true; }
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator bool' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator bool' must be marked explicit to avoid unintentional implicit conversions [{{.*}}]
   // CHECK-FIXES: explicit operator bool() const { return true; }
 
   operator double() const;
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator double' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator double' must be marked explicit to avoid unintentional implicit conversions [{{.*}}]
   // CHECK-FIXES: explicit operator double() const;
 
   explicit B(::std::initializer_list<double> list4) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor should not be declared explicit [google-explicit-constructor]
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor should not be declared explicit [{{.*}}]
   // CHECK-FIXES: B(::std::initializer_list<double> list4) {}
 
   explicit B(const ::std::initializer_list<char> &list5) {}


### PR DESCRIPTION
Fixed #126032 