### PR TITLE
[ProfileData] Require OpenCSD >= 1.5.4 in CMake

### DIFF
--- a/llvm/docs/CommandGuide/llvm-profgen.rst
+++ b/llvm/docs/CommandGuide/llvm-profgen.rst
@@ -27,7 +27,10 @@ At least one of the following commands are required:
 .. option:: --etm=<string>
 
   Path of the ETM trace file created by ARM CoreSight trace tools.
-  Requires the OpenCSD library to be enabled during the build.
+  Requires the OpenCSD library (version 1.5.4 or newer) to be enabled
+  during the build via ``-DLLVM_ENABLE_OPENCSD=ON`` (the default ``AUTO``
+  setting auto-detects a suitable OpenCSD installation, and silently
+  disables ETM support if none is found).
 
 .. option:: --perfdata=<perfdata>, --pd
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -245,7 +245,8 @@ Changes to the Debug Info
 Changes to the LLVM tools
 -------------------------
 
-* `llvm-profgen` now supports ETM trace decoding using the OpenCSD library for Cortex-M targets.
+* `llvm-profgen` now supports ETM trace decoding using the OpenCSD library
+  (version 1.5.4 or newer) for Cortex-M targets.
 
 * `llvm-objcopy` no longer corrupts the symbol table when `--update-section` is called for ELF files.
 * `FileCheck` option `-check-prefix` now accepts a comma-separated list of

--- a/llvm/lib/ProfileData/CMakeLists.txt
+++ b/llvm/lib/ProfileData/CMakeLists.txt
@@ -42,15 +42,49 @@ add_llvm_component_library(LLVMProfileData
 
 set(LLVM_ENABLE_OPENCSD "AUTO" CACHE STRING "Enable OpenCSD support in LLVMProfileData")
 
+# Minimum OpenCSD release that exposes every symbol referenced by
+# ETMTraceDecoder.cpp. OCSD_OPFLG_CHK_RANGE_CONTINUE was introduced in
+# OpenCSD 1.5.4; older releases (e.g. the 1.2.0 shipped by Debian/Ubuntu)
+# build the OpenCSD library but cannot satisfy our use of the C API.
+set(LLVM_OPENCSD_MIN_VERSION "1.5.4")
+
 if(NOT LLVM_ENABLE_OPENCSD STREQUAL "OFF")
   find_library(OPENCSD_LIB NAMES opencsd_c_api opencsd)
   find_path(OPENCSD_INCLUDE NAMES opencsd/ocsd_if_types.h)
 
+  set(OPENCSD_VERSION "")
+  set(OPENCSD_VERSION_OK OFF)
   if(OPENCSD_LIB AND OPENCSD_INCLUDE)
+    # The header exposes an OCSD_VER_STRING macro of the form "M.m.p"
+    # which we extract for a robust version comparison.
+    file(READ "${OPENCSD_INCLUDE}/opencsd/ocsd_if_version.h" _opencsd_ver_h)
+    string(REGEX MATCH "OCSD_VER_STRING[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+)\""
+                 _ver_match "${_opencsd_ver_h}")
+    set(OPENCSD_VERSION "${CMAKE_MATCH_1}")
+    if(OPENCSD_VERSION AND
+       NOT OPENCSD_VERSION VERSION_LESS LLVM_OPENCSD_MIN_VERSION)
+      set(OPENCSD_VERSION_OK ON)
+    endif()
+  endif()
+
+  if(OPENCSD_LIB AND OPENCSD_INCLUDE AND OPENCSD_VERSION_OK)
     target_compile_definitions(LLVMProfileData PRIVATE HAVE_OPENCSD)
     target_include_directories(LLVMProfileData PRIVATE ${OPENCSD_INCLUDE})
     target_link_libraries(LLVMProfileData PRIVATE ${OPENCSD_LIB})
-    message(STATUS "LLVMProfileData: OpenCSD support enabled.")
+    message(STATUS "LLVMProfileData: OpenCSD support enabled "
+                   "(found ${OPENCSD_VERSION}).")
+  elseif(OPENCSD_LIB AND OPENCSD_INCLUDE)
+    if(LLVM_ENABLE_OPENCSD STREQUAL "ON")
+      message(FATAL_ERROR
+        "OpenCSD found at ${OPENCSD_LIB} but its version "
+        "(${OPENCSD_VERSION}) is older than the required "
+        "${LLVM_OPENCSD_MIN_VERSION}. Install a newer OpenCSD or "
+        "configure with -DLLVM_ENABLE_OPENCSD=OFF.")
+    else()
+      message(STATUS
+        "LLVMProfileData: OpenCSD ${OPENCSD_VERSION} is older than "
+        "${LLVM_OPENCSD_MIN_VERSION}; ETM decoding support disabled.")
+    endif()
   else()
     if(LLVM_ENABLE_OPENCSD STREQUAL "ON")
       message(FATAL_ERROR "OpenCSD enabled but library or headers not found.")


### PR DESCRIPTION
Since 0eaa1f5884bf relanded ETM trace decoding, ETMTraceDecoder.cpp unconditionally references OCSD_OPFLG_CHK_RANGE_CONTINUE, which was introduced in OpenCSD 1.5.4. The CMake glue only checked that the OpenCSD library and headers were present, so on systems shipping an older OpenCSD (e.g. Debian/Ubuntu 1.2.0) configure succeeds with HAVE_OPENCSD defined and the build then fails with:

  error: use of undeclared identifier 'OCSD_OPFLG_CHK_RANGE_CONTINUE'

Read OCSD_VER_STRING from the discovered ocsd_if_version.h and gate HAVE_OPENCSD on it being at least the new LLVM_OPENCSD_MIN_VERSION ("1.5.4"). With LLVM_ENABLE_OPENCSD=AUTO an outdated install is treated like a missing one (STATUS message, ETM disabled). With LLVM_ENABLE_OPENCSD=ON it is a FATAL_ERROR that names the path, the found version and the required version. Update the llvm-profgen docs and the release note to reflect the requirement.