### PR TITLE
[CIR][NFC] Add missing checks in emitForMemory

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1764,6 +1764,16 @@ mlir::Attribute ConstantEmitter::emitForMemory(CIRGenModule &cgm,
     cgm.errorNYI("emitForMemory: tail padding in atomic initializer");
   }
 
+  // In HLSL bool vectors are stored in memory as a vector of i32
+  if (destType->isExtVectorBoolType() &&
+      !destType->isPackedVectorBoolType(cgm.getASTContext())) {
+    cgm.errorNYI("emitForMemory: zero-extend HLSL bool vectors");
+  }
+
+  if (destType->isBitIntType()) {
+    cgm.errorNYI("emitForMemory: _BitInt type");
+  }
+
   return c;
 }
 


### PR DESCRIPTION
As mentioned at https://github.com/llvm/llvm-project/pull/194239#discussion_r3149409711 :

> Not related to your PR, but it looks like we're missing checks here for bool vectors and BitInt destination types.

This patch adds the missing checks for bool vectors and BitInt types in the `ConstantEmitter::emitForMemory` function.