### PR TITLE
[Flang][Semantics] Fix crash on invalid function result declaration

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -497,7 +497,7 @@ public:
     Symbol *resultSymbol{nullptr};
     bool inFunctionStmt{false}; // true between Pre/Post of FunctionStmt
     // re-entrancy guard for CompleteFunctionResultType
-    bool completingType{false}; 
+    bool completingType{false};
     // Functions with previous implicitly-typed references get those types
     // checked against their later definitions.
     const DeclTypeSpec *previousImplicitType{nullptr};

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -496,8 +496,8 @@ public:
     // Result symbol
     Symbol *resultSymbol{nullptr};
     bool inFunctionStmt{false}; // true between Pre/Post of FunctionStmt
-    bool completingType{
-        false}; // re-entrancy guard for CompleteFunctionResultType
+    // re-entrancy guard for CompleteFunctionResultType
+    bool completingType{false}; 
     // Functions with previous implicitly-typed references get those types
     // checked against their later definitions.
     const DeclTypeSpec *previousImplicitType{nullptr};

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -496,6 +496,7 @@ public:
     // Result symbol
     Symbol *resultSymbol{nullptr};
     bool inFunctionStmt{false}; // true between Pre/Post of FunctionStmt
+    bool completingType{false}; // re-entrancy guard for CompleteFunctionResultType
     // Functions with previous implicitly-typed references get those types
     // checked against their later definitions.
     const DeclTypeSpec *previousImplicitType{nullptr};
@@ -2874,6 +2875,7 @@ void FuncResultStack::CompleteFunctionResultType() {
   if (info && &info->scope == &scopeHandler_.currScope() &&
       info->resultSymbol) {
     if (info->parsedType) {
+      auto completingTypeScope{common::ScopedSet(info->completingType, true)};
       scopeHandler_.messageHandler().set_currStmtSource(info->source);
       if (const auto *type{
               scopeHandler_.ProcessTypeSpec(*info->parsedType, true)}) {
@@ -2908,7 +2910,15 @@ void FuncResultStack::CompleteFunctionResultType() {
 void FuncResultStack::CompleteTypeIfFunctionResult(Symbol &symbol) {
   if (FuncInfo * info{Top()}) {
     if (info->resultSymbol == &symbol) {
-      CompleteFunctionResultType();
+      if (info->completingType) {
+        if (!scopeHandler_.context().HasError(symbol)) {
+          scopeHandler_.SayAlreadyDeclared(symbol.name(),
+              info->resultName ? info->resultName->source : symbol.name());
+          scopeHandler_.context().SetError(symbol);
+        }
+      } else {
+        CompleteFunctionResultType();
+      }
     }
   }
 }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -496,7 +496,8 @@ public:
     // Result symbol
     Symbol *resultSymbol{nullptr};
     bool inFunctionStmt{false}; // true between Pre/Post of FunctionStmt
-    bool completingType{false}; // re-entrancy guard for CompleteFunctionResultType
+    bool completingType{
+        false}; // re-entrancy guard for CompleteFunctionResultType
     // Functions with previous implicitly-typed references get those types
     // checked against their later definitions.
     const DeclTypeSpec *previousImplicitType{nullptr};

--- a/flang/test/Semantics/resolve128.f90
+++ b/flang/test/Semantics/resolve128.f90
@@ -21,6 +21,6 @@ integer(f3) function f3()
 end function
 
 !ERROR: 'f4' is already declared in this scoping unit
-character*(f4) function bb() result(f4) ! ERROR
+character*(f4) function bb() result(f4)
 f4 = "a"
 end

--- a/flang/test/Semantics/resolve128.f90
+++ b/flang/test/Semantics/resolve128.f90
@@ -1,25 +1,26 @@
-!RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+!RUN: %python %S/test_errors.py %s %flang_fc1
 !Test that a self-referencing character length specification in a function
 !prefix does not cause infinite recursion (crash) in the compiler.
 
-!CHECK: error: 'f1' is already declared in this scoping unit 
+!ERROR: 'f1' is already declared in this scoping unit
 character(f1) function f1()
   implicit integer(f)
   f = 2
 end function
 
-!CHECK: error: Use of 'f2' as a procedure conflicts with its declaration
+!ERROR: 'f2' is not a callable procedure
+!ERROR: Use of 'f2' as a procedure conflicts with its declaration
 character(f2(1)) function f2()
   implicit integer(f)
   f = 2
 end function
 
-!CHECK: error: 'f3' is already declared in this scoping unit
+!ERROR: 'f3' is already declared in this scoping unit
 integer(f3) function f3()
   f3 = 2
 end function
 
-!CHECK: error: 'f4' is already declared in this scoping unit
+!ERROR: 'f4' is already declared in this scoping unit
 character*(f4) function bb() result(f4) ! ERROR
 f4 = "a"
 end

--- a/flang/test/Semantics/resolve128.f90
+++ b/flang/test/Semantics/resolve128.f90
@@ -1,0 +1,25 @@
+!RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+!Test that a self-referencing character length specification in a function
+!prefix does not cause infinite recursion (crash) in the compiler.
+
+!CHECK: error: 'f1' is already declared in this scoping unit 
+character(f1) function f1()
+  implicit integer(f)
+  f = 2
+end function
+
+!CHECK: error: Use of 'f2' as a procedure conflicts with its declaration
+character(f2(1)) function f2()
+  implicit integer(f)
+  f = 2
+end function
+
+!CHECK: error: 'f3' is already declared in this scoping unit
+integer(f3) function f3()
+  f3 = 2
+end function
+
+!CHECK: error: 'f4' is already declared in this scoping unit
+character*(f4) function bb() result(f4) ! ERROR
+f4 = "a"
+end


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/194596.

When the function result symbol is encountered while the compiler is already completing the function result type, flang could recursively re-enter _CompleteFunctionResultType()_ and crash on invalid code.
Example:
```
character*(a) function bb() result(a) ! ERROR
implicit integer(a)
A = "a"
end
```
Instead of crashing on conflicting declarations, flang now reports an “already declared” error and stops further recursion.