### PR TITLE
[Flang] Coarray allocation, update error for pointer component #193829

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -188,6 +188,8 @@ const Symbol *HasImpureFinal(
 bool MayRequireFinalization(const DerivedTypeSpec &);
 // Does this type have an allocatable direct component?
 bool HasAllocatableDirectComponent(const DerivedTypeSpec &);
+// Does this type have an pointer direct component?
+bool HasPointerDirectComponent(const DerivedTypeSpec &);
 // Does this type have any defined assignment at any level (or any polymorphic
 // allocatable)?
 bool MayHaveDefinedAssignment(const DerivedTypeSpec &);

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -195,6 +195,8 @@ const Symbol *HasImpureFinal(
 bool MayRequireFinalization(const DerivedTypeSpec &);
 // Does this type have an allocatable direct component?
 bool HasAllocatableDirectComponent(const DerivedTypeSpec &);
+// Does this type have a pointer direct component?
+bool HasPointerDirectComponent(const DerivedTypeSpec &);
 // Does this type have any defined assignment at any level (or any polymorphic
 // allocatable)?
 bool MayHaveDefinedAssignment(const DerivedTypeSpec &);

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -123,6 +123,15 @@ hasAllocatableDirectComponent(const Fortran::semantics::Symbol &sym) {
             *derivedTypeSpec);
   return false;
 }
+// Does this variable have a pointer  direct component?
+static bool hasPointerDirectComponent(const Fortran::semantics::Symbol &sym) {
+  if (sym.has<Fortran::semantics::ObjectEntityDetails>())
+    if (const Fortran::semantics::DeclTypeSpec *declTypeSpec = sym.GetType())
+      if (const Fortran::semantics::DerivedTypeSpec *derivedTypeSpec =
+              declTypeSpec->AsDerived())
+        return Fortran::semantics::HasPointerDirectComponent(*derivedTypeSpec);
+  return false;
+}
 //===----------------------------------------------------------------===//
 // Global variables instantiation (not for alias and common)
 //===----------------------------------------------------------------===//
@@ -721,9 +730,10 @@ static void instantiateGlobal(Fortran::lower::AbstractConverter &converter,
   fir::GlobalOp global;
 
   if (Fortran::evaluate::IsCoarray(sym))
-    if (hasFinalization(sym) || hasAllocatableDirectComponent(sym))
-      TODO(loc, "Coarray with an allocatable direct component and/or requiring "
-                "finalization.");
+    if (hasFinalization(sym) || hasAllocatableDirectComponent(sym) ||
+        hasPointerDirectComponent(sym))
+      TODO(loc, "Coarray with a pointer/allocatable direct component and/or "
+                "requiring finalization.");
 
   if (var.isModuleOrSubmoduleVariable()) {
     // A non-intrinsic module global is defined when lowering the module.

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -118,6 +118,15 @@ hasAllocatableDirectComponent(const Fortran::semantics::Symbol &sym) {
             *derivedTypeSpec);
   return false;
 }
+// Does this variable have a pointer  direct component?
+static bool hasPointerDirectComponent(const Fortran::semantics::Symbol &sym) {
+  if (sym.has<Fortran::semantics::ObjectEntityDetails>())
+    if (const Fortran::semantics::DeclTypeSpec *declTypeSpec = sym.GetType())
+      if (const Fortran::semantics::DerivedTypeSpec *derivedTypeSpec =
+              declTypeSpec->AsDerived())
+        return Fortran::semantics::HasPointerDirectComponent(*derivedTypeSpec);
+  return false;
+}
 //===----------------------------------------------------------------===//
 // Global variables instantiation (not for alias and common)
 //===----------------------------------------------------------------===//
@@ -675,9 +684,12 @@ static void instantiateGlobal(Fortran::lower::AbstractConverter &converter,
   fir::GlobalOp global;
 
   if (Fortran::evaluate::IsCoarray(sym)) {
-    if (hasFinalization(sym) || hasAllocatableDirectComponent(sym))
-      TODO(loc, "coarray: coarray with an allocatable direct component and/or "
-                "requiring finalization");
+    if (hasFinalization(sym) || hasAllocatableDirectComponent(sym) ||
+        hasPointerDirectComponent(sym))
+      TODO(
+          loc,
+          "coarray: coarray with a pointer/allocatable direct component and/or "
+          "requiring finalization.");
     const auto *details =
         sym.detailsIf<Fortran::semantics::ObjectEntityDetails>();
     if (details && details->init())

--- a/flang/lib/Optimizer/Dialect/MIF/MIFOps.cpp
+++ b/flang/lib/Optimizer/Dialect/MIF/MIFOps.cpp
@@ -248,9 +248,9 @@ void mif::AllocCoarrayOp::build(mlir::OpBuilder &builder,
 
 llvm::LogicalResult mif::AllocCoarrayOp::verify() {
   if (hasAllocatableOrPointerComponent(getBox().getType()))
-    TODO(getLoc(),
-         "Derived type coarray with at least one ALLOCATABLE or POINTER "
-         "component");
+    return emitOpError(
+        "not implemented: Derived type coarray with at least one ALLOCATABLE"
+        " or POINTER component");
 
   fir::BoxType lcElemType =
       mlir::dyn_cast<fir::BoxType>(getLcobounds().getType());

--- a/flang/lib/Optimizer/Dialect/MIF/MIFOps.cpp
+++ b/flang/lib/Optimizer/Dialect/MIF/MIFOps.cpp
@@ -267,9 +267,9 @@ void mif::AllocCoarrayOp::build(mlir::OpBuilder &builder,
 
 llvm::LogicalResult mif::AllocCoarrayOp::verify() {
   if (hasAllocatableOrPointerComponent(getBox().getType()))
-    TODO(getLoc(),
-         "Derived type coarray with at least one ALLOCATABLE or POINTER "
-         "component");
+    return emitOpError(
+        "not implemented: Derived type coarray with at least one ALLOCATABLE"
+        " or POINTER component");
 
   fir::BoxType lcElemType =
       mlir::dyn_cast<fir::BoxType>(getLcobounds().getType());

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -826,6 +826,11 @@ bool HasAllocatableDirectComponent(const DerivedTypeSpec &derived) {
   return std::any_of(directs.begin(), directs.end(), IsAllocatable);
 }
 
+bool HasPointerDirectComponent(const DerivedTypeSpec &derived) {
+  DirectComponentIterator directs{derived};
+  return std::any_of(directs.begin(), directs.end(), IsPointer);
+}
+
 static bool MayHaveDefinedAssignment(
     const DerivedTypeSpec &derived, std::set<const Scope *> &checked) {
   if (const Scope *scope{derived.GetScope()};

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -841,6 +841,11 @@ bool HasAllocatableDirectComponent(const DerivedTypeSpec &derived) {
   return std::any_of(directs.begin(), directs.end(), IsAllocatable);
 }
 
+bool HasPointerDirectComponent(const DerivedTypeSpec &derived) {
+  DirectComponentIterator directs{derived};
+  return std::any_of(directs.begin(), directs.end(), IsPointer);
+}
+
 static bool MayHaveDefinedAssignment(
     const DerivedTypeSpec &derived, std::set<const Scope *> &checked) {
   if (const Scope *scope{derived.GetScope()};

--- a/flang/test/Lower/MIF/coarray_allocation3.f90
+++ b/flang/test/Lower/MIF/coarray_allocation3.f90
@@ -1,6 +1,6 @@
 ! RUN: not %flang_fc1 -emit-hlfir -fcoarray %s -o - 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: Coarray with an allocatable direct component and/or requiring finalization.
+!CHECK: not yet implemented: Coarray with a pointer/allocatable direct component and/or requiring finalization.
 
 module m_test
     implicit none
@@ -8,6 +8,7 @@ module m_test
     type :: test_type
         integer :: id
         real, allocatable :: arr(:)
+        real, pointer :: ptr
     contains
         final :: finalize_func
     end type test_type

--- a/flang/test/Lower/MIF/coarray_allocation3.f90
+++ b/flang/test/Lower/MIF/coarray_allocation3.f90
@@ -1,6 +1,6 @@
 ! RUN: not %flang_fc1 -emit-hlfir -fcoarray %s -o - 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: coarray: coarray with an allocatable direct component and/or requiring finalization
+!CHECK: not yet implemented: coarray: coarray with a pointer/allocatable direct component and/or requiring finalization.
 
 module m_test
     implicit none
@@ -8,6 +8,7 @@ module m_test
     type :: test_type
         integer :: id
         real, allocatable :: arr(:)
+        real, pointer :: ptr
     contains
         final :: finalize_func
     end type test_type


### PR DESCRIPTION
The TODO message in `verify()` was not completly displayed, so it has been replaced by `emitErrorOp`.
In addition, the test in `ConvertVariable` has been updated by adding pointer direct component case.
Fix #193829