### PR TITLE
[CodeGen] Use SmallMapVector for SpillPlacement::Node::Links

### DIFF
--- a/llvm/lib/CodeGen/SpillPlacement.cpp
+++ b/llvm/lib/CodeGen/SpillPlacement.cpp
@@ -81,11 +81,9 @@ struct SpillPlacement::Node {
   /// variable should go in a register through this bundle.
   int Value;
 
-  using LinkVector = SmallVector<std::pair<BlockFrequency, unsigned>, 4>;
-
-  /// Links - (Weight, BundleNo) for all transparent blocks connecting to other
+  /// Links - (BundleNo, Weight) for all transparent blocks connecting to other
   /// bundles. The weights are all positive block frequencies.
-  LinkVector Links;
+  SmallMapVector<unsigned, BlockFrequency, 4> Links;
 
   /// SumLinkWeights - Cached sum of the weights of all links + ThresHold.
   BlockFrequency SumLinkWeights;
@@ -120,13 +118,13 @@ struct SpillPlacement::Node {
     SumLinkWeights += w;
 
     // There can be multiple links to the same bundle, add them up.
-    for (std::pair<BlockFrequency, unsigned> &L : Links)
-      if (L.second == b) {
-        L.first += w;
-        return;
-      }
+    auto It = Links.find(b);
+    if (It != Links.end()) {
+      It->second += w;
+      return;
+    }
     // This must be the first link to b.
-    Links.push_back(std::make_pair(w, b));
+    Links.insert(std::make_pair(b, w));
   }
 
   /// addBias - Bias this node.
@@ -152,11 +150,11 @@ struct SpillPlacement::Node {
     // Compute the weighted sum of inputs.
     BlockFrequency SumN = BiasN;
     BlockFrequency SumP = BiasP;
-    for (std::pair<BlockFrequency, unsigned> &L : Links) {
-      if (nodes[L.second].Value == -1)
-        SumN += L.first;
-      else if (nodes[L.second].Value == 1)
-        SumP += L.first;
+    for (std::pair<unsigned int, llvm::BlockFrequency> &L : Links) {
+      if (nodes[L.first].Value == -1)
+        SumN += L.second;
+      else if (nodes[L.first].Value == 1)
+        SumP += L.second;
     }
 
     // Each weighted sum is going to be less than the total frequency of the
@@ -180,7 +178,7 @@ struct SpillPlacement::Node {
   void getDissentingNeighbors(SparseSet<unsigned> &List,
                               const Node nodes[]) const {
     for (const auto &Elt : Links) {
-      unsigned n = Elt.second;
+      unsigned n = Elt.first;
       // Neighbors that already have the same value are not going to
       // change because of this node changing.
       if (Value != nodes[n].Value)

--- a/llvm/lib/CodeGen/SpillPlacement.cpp
+++ b/llvm/lib/CodeGen/SpillPlacement.cpp
@@ -119,13 +119,9 @@ struct SpillPlacement::Node {
     SumLinkWeights += w;
 
     // There can be multiple links to the same bundle, add them up.
-    auto It = Links.find(b);
-    if (It != Links.end()) {
+    auto [It, Inserted] = Links.try_emplace(b, w);
+    if (!Inserted)
       It->second += w;
-      return;
-    }
-    // This must be the first link to b.
-    Links.insert(std::make_pair(b, w));
   }
 
   /// addBias - Bias this node.

--- a/llvm/lib/CodeGen/SpillPlacement.cpp
+++ b/llvm/lib/CodeGen/SpillPlacement.cpp
@@ -28,6 +28,7 @@
 
 #include "llvm/CodeGen/SpillPlacement.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/CodeGen/EdgeBundles.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineBlockFrequencyInfo.h"

--- a/llvm/lib/CodeGen/SpillPlacement.cpp
+++ b/llvm/lib/CodeGen/SpillPlacement.cpp
@@ -147,11 +147,11 @@ struct SpillPlacement::Node {
     // Compute the weighted sum of inputs.
     BlockFrequency SumN = BiasN;
     BlockFrequency SumP = BiasP;
-    for (std::pair<unsigned int, llvm::BlockFrequency> &L : Links) {
-      if (nodes[L.first].Value == -1)
-        SumN += L.second;
-      else if (nodes[L.first].Value == 1)
-        SumP += L.second;
+    for (auto [BundleNo, Weight] : Links) {
+      if (nodes[BundleNo].Value == -1)
+        SumN += Weight;
+      else if (nodes[BundleNo].Value == 1)
+        SumP += Weight;
     }
 
     // Each weighted sum is going to be less than the total frequency of the

--- a/llvm/lib/CodeGen/SpillPlacement.cpp
+++ b/llvm/lib/CodeGen/SpillPlacement.cpp
@@ -174,12 +174,11 @@ struct SpillPlacement::Node {
 
   void getDissentingNeighbors(SparseSet<unsigned> &List,
                               const Node nodes[]) const {
-    for (const auto &Elt : Links) {
-      unsigned n = Elt.first;
+    for (auto [BundleNo, _] : Links) {
       // Neighbors that already have the same value are not going to
       // change because of this node changing.
-      if (Value != nodes[n].Value)
-        List.insert(n);
+      if (Value != nodes[BundleNo].Value)
+        List.insert(BundleNo);
     }
   }
 };


### PR DESCRIPTION
Previously, `SpillPlacement::Node::Links` was implemented as a `SmallVector` of `(Weight, BundleNo)` pairs.

This patch replaces the `SmallVector` with a `SmallMapVector<unsigned, BlockFrequency, 4>`, which stores `(BundleNo, Weight)` pairs. This allows for more efficient lookups and weight accumulations when multiple links to the same bundle are added.