### PR TITLE
[scudo] Abort if vector functions fail

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -159,9 +159,9 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
   }
 
   // Attempt to append past the end of the current capacity.
-  Str.append("%d", 12345678);
+  EXPECT_DEATH(Str.append("%d", 12345678), "Vector reallocate failed");
   EXPECT_EQ(MaxSize, Str.capacity());
-  EXPECT_STREQ("B12345", &Str.data()[MaxSize - 6]);
+  EXPECT_STREQ("B", &Str.data()[MaxSize - 6]);
 
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &Limit));
 }

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -33,6 +33,16 @@ TEST(ScudoVectorTest, Stride) {
     EXPECT_EQ(V[I], I);
 }
 
+TEST(ScudoVectorTest, ResizeGrowSuccessful) {
+  scudo::Vector<int, 32U> V;
+  EXPECT_EQ(V.capacity(), 32U);
+  V.resize(100);
+  EXPECT_EQ(V.size(), 100U);
+  EXPECT_GE(V.capacity(), 100U);
+  for (scudo::uptr I = 0; I < 100; I++)
+    EXPECT_EQ(V[I], 0);
+}
+
 TEST(ScudoVectorTest, ResizeReduction) {
   scudo::Vector<int, 64U> V;
   V.push_back(0);
@@ -77,11 +87,34 @@ TEST(ScudoVectorTest, ReallocateFails) {
 
   // Now try to do a push back and verify that the size does not change.
   scudo::uptr Size = V.size();
-  V.push_back('2');
+  EXPECT_DEATH(V.push_back('2'), "Vector reallocate failed");
   EXPECT_EQ(Size, V.size());
   // Verify that the last element in the vector did not change.
   EXPECT_EQ('\0', V.back());
 
+  EXPECT_EQ(0, setrlimit(RLIMIT_AS, &Limit));
+}
+
+TEST(ScudoVectorTest, ResizeFails) {
+  scudo::Vector<char, 256U> V;
+  scudo::uptr capacity = V.capacity();
+
+  rlimit Limit = {};
+  EXPECT_EQ(0, getrlimit(RLIMIT_AS, &Limit));
+
+  rlimit EmptyLimit = {.rlim_cur = 0, .rlim_max = Limit.rlim_max};
+  EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
+
+  scudo::MemMapT MemMap;
+  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test",
+                 MAP_ALLOWNOMEM)) {
+    MemMap.unmap();
+    setrlimit(RLIMIT_AS, &Limit);
+    TEST_SKIP("Limiting address space does not prevent mmap.");
+  }
+
+  V.resize(capacity);
+  EXPECT_DEATH(V.resize(capacity + 1000), "Vector resize failed");
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &Limit));
 }
 #endif

--- a/compiler-rt/lib/scudo/standalone/vector.h
+++ b/compiler-rt/lib/scudo/standalone/vector.h
@@ -35,9 +35,7 @@ public:
     DCHECK_LE(Size, capacity());
     if (Size == capacity()) {
       const uptr NewCapacity = roundUpPowerOfTwo(Size + 1);
-      if (!reallocate(NewCapacity)) {
-        return;
-      }
+      RAW_CHECK_MSG(reallocate(NewCapacity), "Vector reallocate failed");
     }
     memcpy(&Data[Size++], &Element, sizeof(T));
   }
@@ -61,9 +59,7 @@ public:
   }
   void resize(uptr NewSize) {
     if (NewSize > Size) {
-      if (!reserve(NewSize)) {
-        return;
-      }
+      RAW_CHECK_MSG(reserve(NewSize), "Vector resize failed");
       memset(&Data[Size], 0, sizeof(T) * (NewSize - Size));
     }
     Size = NewSize;


### PR DESCRIPTION
Change push_back and resize to abort early with a RAW_CHECK_MSG if they fail to reallocate or reserve space instead of silently returning and leaving the vector in an inconsistent state.