### PR TITLE
[VPlan] Recognise single-scalar VPInstructions in isUniformAcrossVFsAndUFs

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -429,7 +429,8 @@ bool vputils::isUniformAcrossVFsAndUFs(VPValue *V) {
                all_of(R->operands(), isUniformAcrossVFsAndUFs);
       })
       .Case([](const VPInstruction *VPI) {
-        return preservesUniformity(VPI->getOpcode()) &&
+        return (VPI->isSingleScalar() || VPI->isVectorToScalar() ||
+                preservesUniformity(VPI->getOpcode())) &&
                all_of(VPI->operands(), isUniformAcrossVFsAndUFs);
       })
       .Case([](const VPWidenCastRecipe *R) {

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1797,8 +1797,8 @@ TEST_F(VPUtilsTest, IsUniformAcrossVFsAndUFsForSingleScalarOpcodes) {
       new VPInstruction(VPInstruction::VScale, {}));
   EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(VScale.get()));
 
-  std::unique_ptr<VPInstruction> EVL(new VPInstruction(
-      VPInstruction::ExplicitVectorLength, {&Plan.getVF()}));
+  std::unique_ptr<VPInstruction> EVL(
+      new VPInstruction(VPInstruction::ExplicitVectorLength, {&Plan.getVF()}));
   EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(EVL.get()));
 }
 

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -10,6 +10,7 @@
 #include "../lib/Transforms/Vectorize/VPlan.h"
 #include "../lib/Transforms/Vectorize/VPlanCFG.h"
 #include "../lib/Transforms/Vectorize/VPlanHelpers.h"
+#include "../lib/Transforms/Vectorize/VPlanUtils.h"
 #include "VPlanTestBase.h"
 #include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -1785,6 +1786,20 @@ TEST_F(VPInstructionTest, VPSymbolicValueMaterialization) {
 
   // Now VF should be materialized.
   EXPECT_TRUE(Plan.getVF().isMaterialized());
+}
+
+using VPUtilsTest = VPlanTestBase;
+
+TEST_F(VPUtilsTest, IsUniformAcrossVFsAndUFsForSingleScalarOpcodes) {
+  VPlan &Plan = getPlan();
+
+  std::unique_ptr<VPInstruction> VScale(
+      new VPInstruction(VPInstruction::VScale, {}));
+  EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(VScale.get()));
+
+  std::unique_ptr<VPInstruction> EVL(new VPInstruction(
+      VPInstruction::ExplicitVectorLength, {&Plan.getVF()}));
+  EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(EVL.get()));
 }
 
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1793,13 +1793,20 @@ using VPUtilsTest = VPlanTestBase;
 TEST_F(VPUtilsTest, IsUniformAcrossVFsAndUFsForSingleScalarOpcodes) {
   VPlan &Plan = getPlan();
 
+  // isSingleScalar opcode without operands.
   std::unique_ptr<VPInstruction> VScale(
       new VPInstruction(VPInstruction::VScale, {}));
   EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(VScale.get()));
 
+  // isSingleScalar opcode with a uniform operand.
   std::unique_ptr<VPInstruction> EVL(
       new VPInstruction(VPInstruction::ExplicitVectorLength, {&Plan.getVF()}));
   EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(EVL.get()));
+
+  // isVectorToScalar opcode with a uniform operand.
+  std::unique_ptr<VPInstruction> FirstActiveLane(
+      new VPInstruction(VPInstruction::FirstActiveLane, {&Plan.getVF()}));
+  EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(FirstActiveLane.get()));
 }
 
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1807,6 +1807,23 @@ TEST_F(VPUtilsTest, IsUniformAcrossVFsAndUFsForSingleScalarOpcodes) {
   std::unique_ptr<VPInstruction> FirstActiveLane(
       new VPInstruction(VPInstruction::FirstActiveLane, {&Plan.getVF()}));
   EXPECT_TRUE(vputils::isUniformAcrossVFsAndUFs(FirstActiveLane.get()));
+
+  // StepVector produces a distinct value per lane and is non-uniform; use it
+  // as the non-single-scalar operand in the negative cases below.
+  std::unique_ptr<VPInstruction> StepVector(
+      new VPInstruction(VPInstruction::StepVector, {}));
+  EXPECT_FALSE(vputils::isUniformAcrossVFsAndUFs(StepVector.get()));
+
+  // isSingleScalar opcode with a non-single-scalar operand.
+  std::unique_ptr<VPInstruction> EVLNonUniform(new VPInstruction(
+      VPInstruction::ExplicitVectorLength, {StepVector.get()}));
+  EXPECT_FALSE(vputils::isUniformAcrossVFsAndUFs(EVLNonUniform.get()));
+
+  // isVectorToScalar opcode with a non-single-scalar operand.
+  std::unique_ptr<VPInstruction> FirstActiveLaneNonUniform(
+      new VPInstruction(VPInstruction::FirstActiveLane, {StepVector.get()}));
+  EXPECT_FALSE(
+      vputils::isUniformAcrossVFsAndUFs(FirstActiveLaneNonUniform.get()));
 }
 
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG)


### PR DESCRIPTION
 The VPInstruction case of vputils::isUniformAcrossVFsAndUFs only consults preservesUniformity(opcode), missing single-scalar opcodes like VScale, ExplicitVectorLength, and ResumeForEpilogue. Mirror the structure of vputils::isSingleScalar's VPInstruction case: also accept VPI->isSingleScalar() and VPI->isVectorToScalar(), gated by
the existing all_of(operands, isUniformAcrossVFsAndUFs) recursion.