### PR TITLE
[NFC][LoopUtils] Add Loop::addStringLoopAttribute and Loop::addIntLoopAttribute

### DIFF
--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -368,6 +368,26 @@ public:
   /// Add llvm.loop.mustprogress to this loop's loop id metadata.
   void setLoopMustProgress();
 
+  /// Add a string-only metadata attribute to this loop's loop-ID node.
+  ///
+  /// Creates an MDNode containing just \p Name (no value operand) and appends
+  /// it to the loop metadata via makePostTransformationMetadata. Any existing
+  /// attributes whose key starts with one of \p RemovePrefixes are stripped
+  /// first.
+  LLVM_ABI void
+  addStringLoopAttribute(StringRef Name,
+                         ArrayRef<StringRef> RemovePrefixes = {}) const;
+
+  /// Add an integer metadata attribute to this loop's loop-ID node.
+  ///
+  /// Creates an MDNode of the form { Name, ConstantInt(Value) } and appends
+  /// it to the loop metadata via makePostTransformationMetadata. Any existing
+  /// attributes whose key starts with one of \p RemovePrefixes are stripped
+  /// first.
+  LLVM_ABI void
+  addIntLoopAttribute(StringRef Name, unsigned Value,
+                      ArrayRef<StringRef> RemovePrefixes = {}) const;
+
   void dump() const;
   void dumpVerbose() const;
 

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -557,29 +557,35 @@ void Loop::setLoopID(MDNode *LoopID) const {
 }
 
 void Loop::setLoopAlreadyUnrolled() {
-  LLVMContext &Context = getHeader()->getContext();
-
-  MDNode *DisableUnrollMD =
-      MDNode::get(Context, MDString::get(Context, "llvm.loop.unroll.disable"));
-  MDNode *LoopID = getLoopID();
-  MDNode *NewLoopID = makePostTransformationMetadata(
-      Context, LoopID, {"llvm.loop.unroll."}, {DisableUnrollMD});
-  setLoopID(NewLoopID);
+  addStringLoopAttribute("llvm.loop.unroll.disable", {"llvm.loop.unroll."});
 }
 
 void Loop::setLoopMustProgress() {
-  LLVMContext &Context = getHeader()->getContext();
-
-  MDNode *MustProgress = findOptionMDForLoop(this, "llvm.loop.mustprogress");
-
-  if (MustProgress)
+  if (findOptionMDForLoop(this, "llvm.loop.mustprogress"))
     return;
+  addStringLoopAttribute("llvm.loop.mustprogress");
+}
 
-  MDNode *MustProgressMD =
-      MDNode::get(Context, MDString::get(Context, "llvm.loop.mustprogress"));
+void Loop::addStringLoopAttribute(StringRef Name,
+                                  ArrayRef<StringRef> RemovePrefixes) const {
+  LLVMContext &Context = getHeader()->getContext();
+  MDNode *AttrMD = MDNode::get(Context, MDString::get(Context, Name));
   MDNode *LoopID = getLoopID();
   MDNode *NewLoopID =
-      makePostTransformationMetadata(Context, LoopID, {}, {MustProgressMD});
+      makePostTransformationMetadata(Context, LoopID, RemovePrefixes, {AttrMD});
+  setLoopID(NewLoopID);
+}
+
+void Loop::addIntLoopAttribute(StringRef Name, unsigned Value,
+                               ArrayRef<StringRef> RemovePrefixes) const {
+  LLVMContext &Context = getHeader()->getContext();
+  MDNode *AttrMD = MDNode::get(
+      Context,
+      {MDString::get(Context, Name),
+       ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, Value)))});
+  MDNode *LoopID = getLoopID();
+  MDNode *NewLoopID =
+      makePostTransformationMetadata(Context, LoopID, RemovePrefixes, {AttrMD});
   setLoopID(NewLoopID);
 }
 

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -2205,24 +2205,12 @@ void postUnswitch(Loop &L, LPMUpdater &U, StringRef LoopName,
     if (PartiallyInvariant) {
       // Mark the new loop as partially unswitched, to avoid unswitching on
       // the same condition again.
-      auto &Context = L.getHeader()->getContext();
-      MDNode *DisableUnswitchMD = MDNode::get(
-          Context,
-          MDString::get(Context, "llvm.loop.unswitch.partial.disable"));
-      MDNode *NewLoopID = makePostTransformationMetadata(
-          Context, L.getLoopID(), {"llvm.loop.unswitch.partial"},
-          {DisableUnswitchMD});
-      L.setLoopID(NewLoopID);
+      L.addStringLoopAttribute("llvm.loop.unswitch.partial.disable",
+                               {"llvm.loop.unswitch.partial"});
     } else if (InjectedCondition) {
       // Do the same for injection of invariant conditions.
-      auto &Context = L.getHeader()->getContext();
-      MDNode *DisableUnswitchMD = MDNode::get(
-          Context,
-          MDString::get(Context, "llvm.loop.unswitch.injection.disable"));
-      MDNode *NewLoopID = makePostTransformationMetadata(
-          Context, L.getLoopID(), {"llvm.loop.unswitch.injection"},
-          {DisableUnswitchMD});
-      L.setLoopID(NewLoopID);
+      L.addStringLoopAttribute("llvm.loop.unswitch.injection.disable",
+                               {"llvm.loop.unswitch.injection"});
     } else
       U.revisitCurrentLoop();
   } else

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -166,19 +166,9 @@ LoopVectorizeHints::LoopVectorizeHints(const Loop *L,
 }
 
 void LoopVectorizeHints::setAlreadyVectorized() {
-  LLVMContext &Context = TheLoop->getHeader()->getContext();
-
-  MDNode *IsVectorizedMD = MDNode::get(
-      Context,
-      {MDString::get(Context, "llvm.loop.isvectorized"),
-       ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 1)))});
-  MDNode *LoopID = TheLoop->getLoopID();
-  MDNode *NewLoopID =
-      makePostTransformationMetadata(Context, LoopID,
-                                     {Twine(Prefix(), "vectorize.").str(),
-                                      Twine(Prefix(), "interleave.").str()},
-                                     {IsVectorizedMD});
-  TheLoop->setLoopID(NewLoopID);
+  TheLoop->addIntLoopAttribute("llvm.loop.isvectorized", 1,
+                               {Twine(Prefix(), "vectorize.").str(),
+                                Twine(Prefix(), "interleave.").str()});
 
   // Update internal cache.
   IsVectorized.Value = 1;


### PR DESCRIPTION
Consolidate repeated `makePostTransformationMetadata` boilerplate into two new `Loop` methods:
- `addStringLoopAttribute`: adds a string-only metadata attribute
- `addIntLoopAttribute`: adds a `{Name, ConstantInt(Value)}` metadata attribute

Both accept optional `RemovePrefixes` to strip existing attributes first.

Refactored call sites:
- `Loop::setLoopAlreadyUnrolled` (LoopInfo.cpp)
- `Loop::setLoopMustProgress` (LoopInfo.cpp)
- `postUnswitch` partial/injection (SimpleLoopUnswitch.cpp)
- `LoopVectorizeHints::setAlreadyVectorized` (LoopVectorizationLegality.cpp)

This consolidation was requested by reviewers of #190258.

This patch was generated with assistance of GitHub Copilot/Claude Opus and reviewed by a human.