### PR TITLE
[lldb] Remove the BreakpointSite destructor

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointSite.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointSite.h
@@ -48,7 +48,7 @@ public:
   typedef lldb::break_id_t SiteID;
   typedef lldb::break_id_t ConstituentID;
 
-  ~BreakpointSite() override;
+  ~BreakpointSite() = default;
 
   // This section manages the breakpoint traps
 

--- a/lldb/source/Breakpoint/BreakpointSite.cpp
+++ b/lldb/source/Breakpoint/BreakpointSite.cpp
@@ -30,13 +30,6 @@ BreakpointSite::BreakpointSite(const BreakpointLocationSP &constituent,
   m_constituents.Add(constituent);
 }
 
-BreakpointSite::~BreakpointSite() {
-  BreakpointLocationSP bp_loc_sp;
-  const size_t constituent_count = m_constituents.GetSize();
-  for (size_t i = 0; i < constituent_count; i++)
-    llvm::consumeError(m_constituents.GetByIndex(i)->ClearBreakpointSite());
-}
-
 break_id_t BreakpointSite::GetNextID() {
   static break_id_t g_next_id = 0;
   return ++g_next_id;


### PR DESCRIPTION
This destructor iterates over all constituents (`BreakpointLocation`s), calling `ClearBreakpointSite` on each of them. This is meant to clear the `m_bp_site_sp` member of BreakpointLocation. However, if the BreakpointSite is being destroyed, then surely no BreakpointLocation is pointing to it.

At least one of the following must be true:

1. This destructor doesn't do anything.
2. Someone manually called "free" on the BreakpointSite.
3. Following the shared pointers from the BreakpointSite -> BreakpointLocation -> BreakpointSite does not return to where we started.

It would be really sad if 2 or 3 were true. So let's assume it is only 1 and delete the destructor.