### PR TITLE
[clang][NFC] Mark CWG2810 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -7,6 +7,16 @@
 // RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,since-cxx20,since-cxx23,since-cxx26 %s
 
 
+namespace cwg2810 { // cwg2810: yes
+
+template <typename>
+void f() {
+  int i = 1.5;
+  // expected-warning@-1 {{implicit conversion from 'double' to 'int' changes value from 1.5 to 1}}
+}
+
+} // namespace cwg2810
+
 int main() {} // required for cwg2811
 
 namespace cwg2811 { // cwg2811: 3.5

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -7,7 +7,7 @@
 // RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,since-cxx20,since-cxx23,since-cxx26 %s
 
 
-namespace cwg2810 { // cwg2810: yes
+namespace cwg2810 { // cwg2810: 2.7
 
 template <typename>
 void f() {

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -11,8 +11,8 @@ namespace cwg2810 { // cwg2810: yes
 
 template <typename>
 void f() {
-  int i = 1.5;
-  // expected-warning@-1 {{implicit conversion from 'double' to 'int' changes value from 1.5 to 1}}
+  0xC0FFEE;
+  // expected-warning@-1 {{expression result unused}}
 }
 
 } // namespace cwg2810

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19479,7 +19479,7 @@
     <td>[<a href="https://wg21.link/temp.res.general">temp.res.general</a>]</td>
     <td>CD7</td>
     <td>Requiring the absence of diagnostics for templates</td>
-    <td class="full" align="center">Yes</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="2811">
     <td><a href="https://cplusplus.github.io/CWG/issues/2811.html">2811</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19479,7 +19479,7 @@
     <td>[<a href="https://wg21.link/temp.res.general">temp.res.general</a>]</td>
     <td>CD7</td>
     <td>Requiring the absence of diagnostics for templates</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Yes</td>
   </tr>
   <tr id="2811">
     <td><a href="https://cplusplus.github.io/CWG/issues/2811.html">2811</a></td>


### PR DESCRIPTION
[CWG2810](https://cplusplus.github.io/CWG/issues/2810.html) just removes some wording that could be misinterpreted as saying "a compiler must not emit any warnings in uninstantiated templates". Clang has never misinterpreted it that way, so we don't need to do anything here.