### PR TITLE
[clang] fix crash with c-style casts involving dependent member-pointer types

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -7198,18 +7198,17 @@ bool ASTContext::UnwrapSimilarTypes(QualType &T1, QualType &T2,
     return true;
   }
 
-  if (const auto *T1MPType = T1->getAs<MemberPointerType>(),
-      *T2MPType = T2->getAs<MemberPointerType>();
+  if (const auto *T1MPType = T1->getAsCanonical<MemberPointerType>(),
+      *T2MPType = T2->getAsCanonical<MemberPointerType>();
       T1MPType && T2MPType) {
-    if (auto *RD1 = T1MPType->getMostRecentCXXRecordDecl(),
-        *RD2 = T2MPType->getMostRecentCXXRecordDecl();
-        RD1 != RD2 && RD1->getCanonicalDecl() != RD2->getCanonicalDecl())
+    // Compare the qualifiers of the canonical type, as the non-canonical type
+    // may have qualifiers pointing to a base or derived class.
+    if (T1MPType->getQualifier() != T2MPType->getQualifier())
       return false;
-    if (T1MPType->getQualifier().getCanonical() !=
-        T2MPType->getQualifier().getCanonical())
-      return false;
-    T1 = T1MPType->getPointeeType();
-    T2 = T2MPType->getPointeeType();
+    // Get the pointee types of the non-canonical type, in order to preserve
+    // their sugar.
+    T1 = T1->getAs<MemberPointerType>()->getPointeeType();
+    T2 = T2->getAs<MemberPointerType>()->getPointeeType();
     return true;
   }
 

--- a/clang/test/SemaCXX/member-pointer.cpp
+++ b/clang/test/SemaCXX/member-pointer.cpp
@@ -430,3 +430,16 @@ namespace deduction_qualifiers {
     h(b, &CA::v);
   }
 } // namespace deduction_qualifiers
+
+namespace GH194524 {
+  struct Base {
+    typedef void (Base::*Func)(void);
+  };
+
+  template <class T> struct Sub {
+    typedef void (T::*TFunc)(void);
+    Sub(TFunc tfunc) {
+      (Base::Func&)tfunc;
+    }
+  };
+} // namespace GH194524


### PR DESCRIPTION
A dependent member-pointer type doesn't necessarily have a class declaration.

This simplifies the check performed in a helper for diagnosing a cast which removes qualifiers, so it doesn't rely on this assumption.

This fixes a regression introduced in https://github.com/llvm/llvm-project/pull/132401, which landed in the last release, and this will be back ported, so no release notes.

Fixes #194524