### PR TITLE
[TableGen] Emit Debug code for dynamic bits(eg: instruction operands) in DecoderEmitter

### DIFF
--- a/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
+++ b/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
@@ -1,0 +1,16 @@
+# REQUIRES: asserts
+# RUN: llvm-mc -triple=aarch64 -mattr=+v8a -disassemble -debug-only=aarch64-disassembler < %s 2>&1 | FileCheck %s
+#
+# Exercises LLVM_DEBUG output from DecoderEmitter for dynamic bits like instruction operand.
+
+# blr x0 — valid; reaches per-operand checks and succeeds.
+# CHECK: OPC_Decode: opcode {{[0-9]+}} using decoder {{[0-9]+}}: PASS, decoding complete
+
+# Malformed `add (imm)` with `shift` field = 2 (only 0 and 1 are legal). The
+# whole-instruction decoder DecodeAddSubImmShift returns Fail, so the generated
+# table emits dbgFailInsn("ADDXri", "DecodeAddSubImmShift").
+# CHECK: OPC_Decode for ADDXri: insn using DecodeAddSubImmShift : FAIL
+# CHECK-NEXT: OPC_Decode: opcode {{[0-9]+}} using decoder {{[0-9]+}}: FAIL, decoding complete
+
+0x0 0x0 0x3f 0xd6
+0xe5 0x98 0x99 0x91

--- a/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
+++ b/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
@@ -1,0 +1,16 @@
+# REQUIRES: asserts
+# RUN: llvm-mc -triple=aarch64 -mattr=+v8a -disassemble -debug-only=aarch64-disassembler < %s 2>&1 | FileCheck %s
+#
+# Exercises LLVM_DEBUG output from DecoderEmitter for dynamic bits like instruction operand.
+
+# blr x0 — valid; reaches per-operand checks and succeeds.
+# CHECK: OPC_Decode: opcode {{[0-9]+}}, using decoder {{[0-9]+}}: PASS, decoding complete
+
+# Malformed `add (imm)` with `shift` field = 2 (only 0 and 1 are legal). The
+# whole-instruction decoder DecodeAddSubImmShift returns Fail, so the generated
+# table emits dbgFailInsn("ADDXri", "DecodeAddSubImmShift").
+# CHECK: OPC_Decode for ADDXri: insn using DecodeAddSubImmShift : FAIL
+# CHECK-NEXT: OPC_Decode: opcode {{[0-9]+}}, using decoder {{[0-9]+}}: FAIL, decoding complete
+
+0x0 0x0 0x3f 0xd6
+0xe5 0x98 0x99 0x91

--- a/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
+++ b/llvm/test/MC/Disassembler/AArch64/aarch64-disassembler-debug.txt
@@ -8,7 +8,7 @@
 
 # Malformed `add (imm)` with `shift` field = 2 (only 0 and 1 are legal). The
 # whole-instruction decoder DecodeAddSubImmShift returns Fail, so the generated
-# table emits dbgFailInsn("ADDXri", "DecodeAddSubImmShift").
+# table emits LLVM_DEBUG(reportInsnDecodeFailure("ADDXri", "DecodeAddSubImmShift")).
 # CHECK: OPC_Decode for ADDXri: insn using DecodeAddSubImmShift : FAIL
 # CHECK-NEXT: OPC_Decode: opcode {{[0-9]+}}, using decoder {{[0-9]+}}: FAIL, decoding complete
 

--- a/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
+++ b/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
@@ -65,17 +65,17 @@ def FOO32 : MyVarInst<MemOp32> {
 
 // CHECK:      case 0:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "field(8,3)", "DecodeRegClassRegisterClass");
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "field(0,3)", "DecodeRegClassRegisterClass");
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 11, 16);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "field(11,16)", "myCustomDecoder");
 // CHECK-NEXT: return S;
 // CHECK-NEXT: case 1:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "field(8,3)", "DecodeRegClassRegisterClass");
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "field(0,3)", "myCustomDecoder");
 // CHECK-NEXT: tmp = 0x0;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 11, 16) << 16;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 27, 16);

--- a/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
+++ b/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
@@ -65,17 +65,17 @@ def FOO32 : MyVarInst<MemOp32> {
 
 // CHECK:      case 0:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {8, 3});
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {0, 3});
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 11, 16);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "myCustomDecoder", {11, 16});
 // CHECK-NEXT: return S;
 // CHECK-NEXT: case 1:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {8, 3});
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "myCustomDecoder", {0, 3});
 // CHECK-NEXT: tmp = 0x0;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 11, 16) << 16;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 27, 16);

--- a/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
+++ b/llvm/test/TableGen/DecoderEmitter/VarLenDecoder.td
@@ -65,17 +65,32 @@ def FOO32 : MyVarInst<MemOp32> {
 
 // CHECK:      case 0:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {8, 3});
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:   LLVM_DEBUG(reportOperandDecodeFailure("opd", "DecodeRegClassRegisterClass", {8, 3}));
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {0, 3});
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:   LLVM_DEBUG(reportOperandDecodeFailure("opd", "DecodeRegClassRegisterClass", {0, 3}));
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 11, 16);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "myCustomDecoder", {11, 16});
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:   LLVM_DEBUG(reportOperandDecodeFailure("opd", "myCustomDecoder", {11, 16}));
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
 // CHECK-NEXT: return S;
 // CHECK-NEXT: case 1:
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 8, 3);
-// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "DecodeRegClassRegisterClass", {8, 3});
+// CHECK-NEXT: if (!Check(S, DecodeRegClassRegisterClass(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:   LLVM_DEBUG(reportOperandDecodeFailure("opd", "DecodeRegClassRegisterClass", {8, 3}));
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
 // CHECK-NEXT: tmp = fieldFromInstruction(insn, 0, 3);
-// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) return dbgFailOpd("opd", "myCustomDecoder", {0, 3});
+// CHECK-NEXT: if (!Check(S, myCustomDecoder(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:   LLVM_DEBUG(reportOperandDecodeFailure("opd", "myCustomDecoder", {0, 3}));
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
 // CHECK-NEXT: tmp = 0x0;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 11, 16) << 16;
 // CHECK-NEXT: tmp |= fieldFromInstruction(insn, 27, 16);

--- a/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
+++ b/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
@@ -1,0 +1,54 @@
+// RUN: llvm-tblgen -gen-disassembler -I %p/../../../include %s | FileCheck %s
+
+// Verify the DecoderEmitter emits the dbgFailOpd / dbgFailInsn helpers used
+// by per-operand and whole-instruction decode debug logging.
+
+include "llvm/Target/Target.td"
+
+def R0 : Register<"r0">;
+def RC : RegisterClass<"MyTarget", [i32], 32, (add R0)>;
+
+def MyInstrInfo : InstrInfo;
+
+def MyTarget : Target {
+  let InstructionSet = MyInstrInfo;
+}
+
+def I : Instruction {
+  let OutOperandList = (outs RC:$dst);
+  let InOperandList = (ins);
+  let Size = 4;
+  bits<32> Inst;
+  bits<4> dst;
+  let Inst{3...0} = dst;
+  let Inst{31...4} = 0;
+}
+
+// dbgFailOpd: per-operand check-site helper.
+// CHECK:      DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
+// CHECK-NEXT:                         bool *DecodeComplete = nullptr) {
+// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
+// CHECK-NEXT:                     << Decoder << " : FAIL\n");
+// CHECK-NEXT:   if (DecodeComplete)
+// CHECK-NEXT:     *DecodeComplete = false;
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
+
+// dbgFailInsn: whole-instruction custom-decoder check-site helper.
+// CHECK{LITERAL}: [[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
+// CHECK-NEXT:                                           bool *DecodeComplete = nullptr) {
+// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+// CHECK-NEXT:                     << " : FAIL\n");
+// CHECK-NEXT:   if (DecodeComplete)
+// CHECK-NEXT:     *DecodeComplete = false;
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
+
+// And the per-operand check site inside decodeToMCInst calls dbgFailOpd
+// with the operand name, field description, and decoder-method name as
+// separate string-literal arguments.
+// CHECK-LABEL: static DecodeStatus decodeToMCInst(
+// CHECK:       case 0:
+// CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 4);
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("dst", "field(0,4)", "DecodeRCRegisterClass");
+// CHECK-NEXT:    return S;

--- a/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
+++ b/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
@@ -1,0 +1,73 @@
+// RUN: llvm-tblgen -gen-disassembler -I %p/../../../include %s | FileCheck %s
+
+// Verify the DecoderEmitter emits the dbgFailOpd / dbgFailInsn helpers used
+// by per-operand and whole-instruction decode debug logging.
+
+include "llvm/Target/Target.td"
+
+def R0 : Register<"r0">;
+def RC : RegisterClass<"MyTarget", [i32], 32, (add R0)>;
+
+def MyInstrInfo : InstrInfo;
+
+def MyTarget : Target {
+  let InstructionSet = MyInstrInfo;
+}
+
+def I : Instruction {
+  let OutOperandList = (outs RC:$dst);
+  let InOperandList = (ins);
+  let Size = 4;
+  bits<32> Inst;
+  bits<4> dst;
+  let Inst{3...0} = dst;
+  let Inst{31...4} = 0;
+}
+
+// dbgFailOpd (no-field overload): the description is a single shared literal.
+// CHECK:      DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
+// CHECK-NEXT:                         bool *DecodeComplete = nullptr) {
+// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
+// CHECK-NEXT:                     << Decoder << " : FAIL\n");
+// CHECK-NEXT:   if (DecodeComplete)
+// CHECK-NEXT:     *DecodeComplete = false;
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
+
+// dbgFailOpd (field overload): forms "field(b,w)" from raw (base, width)
+// integers rather than baking a unique string literal into each call site.
+// CHECK:      DecodeStatus dbgFailOpd(const char *Op, const char *Decoder,
+// CHECK-NEXT:                         ArrayRef<uint32_t> Fields,
+// CHECK-NEXT:                         bool *DecodeComplete = nullptr) {
+// CHECK-NEXT:   LLVM_DEBUG({
+// CHECK-NEXT:     dbgs() << "OPC_Decode for " << Op << ": ";
+// CHECK-NEXT:     for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
+// CHECK-NEXT:       if (I)
+// CHECK-NEXT:         dbgs() << " + ";
+// CHECK-NEXT:       dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
+// CHECK-NEXT:     }
+// CHECK-NEXT:     dbgs() << " using " << Decoder << " : FAIL\n";
+// CHECK-NEXT:   });
+// CHECK-NEXT:   if (DecodeComplete)
+// CHECK-NEXT:     *DecodeComplete = false;
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
+
+// dbgFailInsn: whole-instruction custom-decoder check-site helper.
+// CHECK{LITERAL}: [[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
+// CHECK-NEXT:                                           bool *DecodeComplete = nullptr) {
+// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+// CHECK-NEXT:                     << " : FAIL\n");
+// CHECK-NEXT:   if (DecodeComplete)
+// CHECK-NEXT:     *DecodeComplete = false;
+// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK-NEXT: }
+
+// And the per-operand check site inside decodeToMCInst calls dbgFailOpd
+// with the operand name, field description, and decoder-method name as
+// separate string-literal arguments.
+// CHECK-LABEL: static DecodeStatus decodeToMCInst(
+// CHECK:       case 0:
+// CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 4);
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("dst", "DecodeRCRegisterClass", {0, 4});
+// CHECK-NEXT:    return S;

--- a/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
+++ b/llvm/test/TableGen/DecoderEmitter/dbg-fail-helpers.td
@@ -1,6 +1,6 @@
 // RUN: llvm-tblgen -gen-disassembler -I %p/../../../include %s | FileCheck %s
 
-// Verify the DecoderEmitter emits the dbgFailOpd / dbgFailInsn helpers used
+// Verify the DecoderEmitter emits the reportOperandDecodeFailure / reportInsnDecodeFailure helpers used
 // by per-operand and whole-instruction decode debug logging.
 
 include "llvm/Target/Target.td"
@@ -24,50 +24,39 @@ def I : Instruction {
   let Inst{31...4} = 0;
 }
 
-// dbgFailOpd (no-field overload): the description is a single shared literal.
-// CHECK:      DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
-// CHECK-NEXT:                         bool *DecodeComplete = nullptr) {
-// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
-// CHECK-NEXT:                     << Decoder << " : FAIL\n");
-// CHECK-NEXT:   if (DecodeComplete)
-// CHECK-NEXT:     *DecodeComplete = false;
-// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK: #ifndef NDEBUG
+
+// CHECK{LITERAL}: [[maybe_unused]] void reportOperandDecodeFailure(const char *Op,
+// CHECK-NEXT:                          const char *Desc,
+// CHECK-NEXT:                          const char *Decoder) {
+// CHECK-NEXT:   dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using " << Decoder
+// CHECK-NEXT:          << " : FAIL\n";
 // CHECK-NEXT: }
 
-// dbgFailOpd (field overload): forms "field(b,w)" from raw (base, width)
-// integers rather than baking a unique string literal into each call site.
-// CHECK:      DecodeStatus dbgFailOpd(const char *Op, const char *Decoder,
-// CHECK-NEXT:                         ArrayRef<uint32_t> Fields,
-// CHECK-NEXT:                         bool *DecodeComplete = nullptr) {
-// CHECK-NEXT:   LLVM_DEBUG({
-// CHECK-NEXT:     dbgs() << "OPC_Decode for " << Op << ": ";
-// CHECK-NEXT:     for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
-// CHECK-NEXT:       if (I)
-// CHECK-NEXT:         dbgs() << " + ";
-// CHECK-NEXT:       dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
-// CHECK-NEXT:     }
-// CHECK-NEXT:     dbgs() << " using " << Decoder << " : FAIL\n";
-// CHECK-NEXT:   });
-// CHECK-NEXT:   if (DecodeComplete)
-// CHECK-NEXT:     *DecodeComplete = false;
-// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK{LITERAL}: [[maybe_unused]] void reportOperandDecodeFailure(const char *Op,
+// CHECK-NEXT:                          const char *Decoder,
+// CHECK-NEXT:                          ArrayRef<uint32_t> Fields) {
+// CHECK-NEXT:   dbgs() << "OPC_Decode for " << Op << ": ";
+// CHECK-NEXT:   for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
+// CHECK-NEXT:     if (I)
+// CHECK-NEXT:       dbgs() << " + ";
+// CHECK-NEXT:     dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
+// CHECK-NEXT:   }
+// CHECK-NEXT:   dbgs() << " using " << Decoder << " : FAIL\n";
 // CHECK-NEXT: }
 
-// dbgFailInsn: whole-instruction custom-decoder check-site helper.
-// CHECK{LITERAL}: [[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
-// CHECK-NEXT:                                           bool *DecodeComplete = nullptr) {
-// CHECK-NEXT:   LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
-// CHECK-NEXT:                     << " : FAIL\n");
-// CHECK-NEXT:   if (DecodeComplete)
-// CHECK-NEXT:     *DecodeComplete = false;
-// CHECK-NEXT:   return MCDisassembler::Fail;
+// CHECK{LITERAL}: [[maybe_unused]] void reportInsnDecodeFailure(const char *Name,
+// CHECK-NEXT:                          const char *Decoder) {
+// CHECK-NEXT:   dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+// CHECK-NEXT:          << " : FAIL\n";
 // CHECK-NEXT: }
+// CHECK-NEXT: #endif // NDEBUG
 
-// And the per-operand check site inside decodeToMCInst calls dbgFailOpd
-// with the operand name, field description, and decoder-method name as
-// separate string-literal arguments.
 // CHECK-LABEL: static DecodeStatus decodeToMCInst(
 // CHECK:       case 0:
 // CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 4);
-// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("dst", "DecodeRCRegisterClass", {0, 4});
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportOperandDecodeFailure("dst", "DecodeRCRegisterClass", {0, 4}));
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }
 // CHECK-NEXT:    return S;

--- a/llvm/test/TableGen/DecoderEmitter/dbg-fail-multifield.td
+++ b/llvm/test/TableGen/DecoderEmitter/dbg-fail-multifield.td
@@ -1,0 +1,42 @@
+// RUN: llvm-tblgen -gen-disassembler -I %p/../../../include %s | FileCheck %s
+
+// Verify the per-operand decode debug path for an operand whose encoding bits
+// are spread across several disjoint islands of the instruction. Each island
+// becomes one (base, width) pair; the call site passes them as raw integers
+// and dbgFailOpd joins them with " + " at runtime, so no unique
+// "field(b,w) + ..." string literal is baked into the table.
+
+include "llvm/Target/Target.td"
+
+def R0 : Register<"r0">;
+def RC : RegisterClass<"MyTarget", [i32], 32, (add R0)>;
+
+def MyInstrInfo : InstrInfo;
+
+def MyTarget : Target {
+  let InstructionSet = MyInstrInfo;
+}
+
+// Operand `op` (6 bits) is split across three disjoint islands in Inst:
+//   op{1:0} -> Inst{1:0}, op{3:2} -> Inst{9:8}, op{5:4} -> Inst{20:19}.
+def I : Instruction {
+  let OutOperandList = (outs RC:$op);
+  let InOperandList = (ins);
+  let Size = 4;
+  bits<32> Inst;
+  bits<6> op;
+  let Inst{1...0}   = op{1...0};
+  let Inst{9...8}   = op{3...2};
+  let Inst{20...19} = op{5...4};
+  let Inst{31} = 0;
+}
+
+// The operand is assembled from the three islands, then the field overload of
+// dbgFailOpd is called with all three (base, width) pairs.
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    tmp = 0x0;
+// CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 0, 2);
+// CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 8, 2) << 2;
+// CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 19, 2) << 4;
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("op", "DecodeRCRegisterClass", {0, 2, 8, 2, 19, 2});
+// CHECK-NEXT:    return S;

--- a/llvm/test/TableGen/DecoderEmitter/dbg-fail-multifield.td
+++ b/llvm/test/TableGen/DecoderEmitter/dbg-fail-multifield.td
@@ -3,7 +3,7 @@
 // Verify the per-operand decode debug path for an operand whose encoding bits
 // are spread across several disjoint islands of the instruction. Each island
 // becomes one (base, width) pair; the call site passes them as raw integers
-// and dbgFailOpd joins them with " + " at runtime, so no unique
+// and reportOperandDecodeFailure joins them with " + " at runtime, so no unique
 // "field(b,w) + ..." string literal is baked into the table.
 
 include "llvm/Target/Target.td"
@@ -32,11 +32,14 @@ def I : Instruction {
 }
 
 // The operand is assembled from the three islands, then the field overload of
-// dbgFailOpd is called with all three (base, width) pairs.
+// reportOperandDecodeFailure is called with all three (base, width) pairs.
 // CHECK-LABEL: case 0:
 // CHECK-NEXT:    tmp = 0x0;
 // CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 0, 2);
 // CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 8, 2) << 2;
 // CHECK-NEXT:    tmp |= fieldFromInstruction(insn, 19, 2) << 4;
-// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) return dbgFailOpd("op", "DecodeRCRegisterClass", {0, 2, 8, 2, 19, 2});
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportOperandDecodeFailure("op", "DecodeRCRegisterClass", {0, 2, 8, 2, 19, 2}));
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }
 // CHECK-NEXT:    return S;

--- a/llvm/test/TableGen/DecoderEmitter/operand-decoder.td
+++ b/llvm/test/TableGen/DecoderEmitter/operand-decoder.td
@@ -12,8 +12,7 @@ def MyTarget : Target {
 }
 
 // CHECK-LABEL: case 0:
-// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, Decoder)))
-// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, Decoder))) return dbgFailOpd("op0", "bits<0>", "DecodeRCRegisterClass");
 // CHECK-NEXT:    tmp = fieldFromInstruction(insn, 2, 4);
 // CHECK-NEXT:    MI.addOperand(MCOperand::createImm(tmp));
 // CHECK-NEXT:    tmp = 0x0;

--- a/llvm/test/TableGen/DecoderEmitter/operand-decoder.td
+++ b/llvm/test/TableGen/DecoderEmitter/operand-decoder.td
@@ -12,7 +12,10 @@ def MyTarget : Target {
 }
 
 // CHECK-LABEL: case 0:
-// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, Decoder))) return dbgFailOpd("op0", "bits<0>", "DecodeRCRegisterClass");
+// CHECK-NEXT:    if (!Check(S, DecodeRCRegisterClass(MI, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportOperandDecodeFailure("op0", "bits<0>", "DecodeRCRegisterClass"));
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }
 // CHECK-NEXT:    tmp = fieldFromInstruction(insn, 2, 4);
 // CHECK-NEXT:    MI.addOperand(MCOperand::createImm(tmp));
 // CHECK-NEXT:    tmp = 0x0;

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission.td
@@ -43,4 +43,5 @@ def InstB : TestInstruction {
 // CHECK-NEXT:                                 // 14: }
 // CHECK-NEXT: };
 
-// CHECK: if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission.td
@@ -44,4 +44,8 @@ def InstB : TestInstruction {
 // CHECK-NEXT: };
 
 // CHECK-LABEL: case 0:
-// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportInsnDecodeFailure("InstB", "DecodeInstB"));
+// CHECK-NEXT:      DecodeComplete = false;
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission2.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission2.td
@@ -42,5 +42,7 @@ def InstB : TestInstruction {
 // CHECK-NEXT:                                 // 22: }
 // CHECK-NEXT: };
 
-// CHECK: if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
-// CHECK: if (!Check(S, DecodeInstA(MI, insn, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);
+// CHECK-LABEL: case 1:
+// CHECK-NEXT:    if (!Check(S, DecodeInstA(MI, insn, Address, Decoder))) return dbgFailInsn("InstA", "DecodeInstA", &DecodeComplete);

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission2.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission2.td
@@ -43,6 +43,14 @@ def InstB : TestInstruction {
 // CHECK-NEXT: };
 
 // CHECK-LABEL: case 0:
-// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportInsnDecodeFailure("InstB", "DecodeInstB"));
+// CHECK-NEXT:      DecodeComplete = false;
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }
 // CHECK-LABEL: case 1:
-// CHECK-NEXT:    if (!Check(S, DecodeInstA(MI, insn, Address, Decoder))) return dbgFailInsn("InstA", "DecodeInstA", &DecodeComplete);
+// CHECK-NEXT:    if (!Check(S, DecodeInstA(MI, insn, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportInsnDecodeFailure("InstA", "DecodeInstA"));
+// CHECK-NEXT:      DecodeComplete = false;
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
@@ -44,4 +44,6 @@ def InstB : TestInstruction {
 // CHECK-NEXT:                                 // 14: }
 // CHECK-NEXT: };
 
-// CHECK: if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 2);
+// CHECK-NEXT:    if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) return dbgFailOpd("op", "field(0,2)", "DecodeInstBOp", &DecodeComplete);

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
@@ -44,4 +44,6 @@ def InstB : TestInstruction {
 // CHECK-NEXT:                                 // 14: }
 // CHECK-NEXT: };
 
-// CHECK: if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 2);
+// CHECK-NEXT:    if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) return dbgFailOpd("op", "DecodeInstBOp", {0, 2}, &DecodeComplete);

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission3.td
@@ -46,4 +46,8 @@ def InstB : TestInstruction {
 
 // CHECK-LABEL: case 0:
 // CHECK-NEXT:    tmp = fieldFromInstruction(insn, 0, 2);
-// CHECK-NEXT:    if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) return dbgFailOpd("op", "DecodeInstBOp", {0, 2}, &DecodeComplete);
+// CHECK-NEXT:    if (!Check(S, DecodeInstBOp(MI, tmp, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportOperandDecodeFailure("op", "DecodeInstBOp", {0, 2}));
+// CHECK-NEXT:      DecodeComplete = false;
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission4.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission4.td
@@ -42,4 +42,5 @@ def InstB : TestInstruction {
 // CHECK-NEXT:                                  // 16: }
 // CHECK-NEXT: };
 
-// CHECK: if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) { DecodeComplete = false; return MCDisassembler::Fail; }
+// CHECK-LABEL: case 0:
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);

--- a/llvm/test/TableGen/DecoderEmitter/trydecode-emission4.td
+++ b/llvm/test/TableGen/DecoderEmitter/trydecode-emission4.td
@@ -43,4 +43,8 @@ def InstB : TestInstruction {
 // CHECK-NEXT: };
 
 // CHECK-LABEL: case 0:
-// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) return dbgFailInsn("InstB", "DecodeInstB", &DecodeComplete);
+// CHECK-NEXT:    if (!Check(S, DecodeInstB(MI, insn, Address, Decoder))) {
+// CHECK-NEXT:      LLVM_DEBUG(reportInsnDecodeFailure("InstB", "DecodeInstB"));
+// CHECK-NEXT:      DecodeComplete = false;
+// CHECK-NEXT:      return MCDisassembler::Fail;
+// CHECK-NEXT:    }

--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -143,8 +143,7 @@ include "Common/RegClassByHwModeCommon.td"
 // ASMMATCHER: /* my_mov */, MyTarget::MY_MOV, Convert__RegByHwMode_YRegs_EvenIfRequired1_0__RegByHwMode_XRegs_EvenIfRequired1_1, AMFBS_None, { MCK_RegByHwMode_YRegs_EvenIfRequired, MCK_RegByHwMode_XRegs_EvenIfRequired }, },
 
 
-
-// DISASM{LITERAL}: [[maybe_unused]]
+// DISASM:      {{^\[\[maybe_unused\]\]$}}
 // DISASM-NEXT: static DecodeStatus DecodeMyPtrRCRegClassByHwMode(MCInst &Inst, unsigned Imm, uint64_t Addr, const MCDisassembler *Decoder) {
 // DISASM-NEXT:   switch (Decoder->getSubtargetInfo().getHwMode(MCSubtargetInfo::HwMode_RegInfo)) {
 // DISASM-NEXT:   case 0: // DefaultMode
@@ -156,7 +155,7 @@ include "Common/RegClassByHwModeCommon.td"
 // DISASM-NEXT:   }
 // DISASM-NEXT: }
 
-// DISASM{LITERAL}: [[maybe_unused]]
+// DISASM:      {{^\[\[maybe_unused\]\]$}}
 // DISASM-NEXT: static DecodeStatus DecodeXRegs_EvenIfRequiredRegClassByHwMode(MCInst &Inst, unsigned Imm, uint64_t Addr, const MCDisassembler *Decoder) {
 // DISASM-NEXT:  switch (Decoder->getSubtargetInfo().getHwMode(MCSubtargetInfo::HwMode_RegInfo)) {
 // DISASM-NEXT:  case 0: // DefaultMode
@@ -170,7 +169,7 @@ include "Common/RegClassByHwModeCommon.td"
 // DISASM-NEXT:  }
 // DISASM-NEXT:}
 // DISASM-EMPTY:
-// DISASM{LITERAL}: [[maybe_unused]]
+// DISASM:      {{^\[\[maybe_unused\]\]$}}
 // DISASM-NEXT: static DecodeStatus DecodeYRegs_EvenIfRequiredRegClassByHwMode(MCInst &Inst, unsigned Imm, uint64_t Addr, const MCDisassembler *Decoder) {
 // DISASM-NEXT:  switch (Decoder->getSubtargetInfo().getHwMode(MCSubtargetInfo::HwMode_RegInfo)) {
 // DISASM-NEXT:  case 0: // DefaultMode
@@ -185,19 +184,19 @@ include "Common/RegClassByHwModeCommon.td"
 // DISASM: static DecodeStatus decodeToMCInst(
 // DISASM:   switch (Idx) {
 // DISASM: case 0:
-// DISASM: if (!Check(S, DecodeYRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
-// DISASM: if (!Check(S, DecodeXRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// DISASM: Check(S, DecodeYRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))
+// DISASM: Check(S, DecodeXRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))
 
 // DISASM: case 1:
-// DISASM: if (!Check(S, DecodeXRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// DISASM: Check(S, DecodeXRegs_EvenIfRequiredRegClassByHwMode(MI, tmp, Address, Decoder))
 
 // DISASM: case 2:
-// DISASM: if (!Check(S, DecodeXRegs_EvenRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// DISASM: Check(S, DecodeXRegs_EvenRegisterClass(MI, tmp, Address, Decoder))
 // DISASM: case 3:
-// DISASM: if (!Check(S, DecodeXRegsRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// DISASM: Check(S, DecodeXRegsRegisterClass(MI, tmp, Address, Decoder))
 
 // DISASM: case 4:
-// DISASM: if (!Check(S, YEvenIfRequiredCustomDecoder(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
+// DISASM: Check(S, YEvenIfRequiredCustomDecoder(MI, tmp, Address, Decoder))
 
 
 // ISEL-SDAG: MatcherTable

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -683,6 +683,61 @@ static std::vector<EncodingIsland> getIslands(const KnownBits &EncodingBits,
   return Islands;
 }
 
+static std::string getOperandFieldDescForDebug(const OperandInfo &OpInfo) {
+  if (OpInfo.Fields.empty() && !OpInfo.InitValue)
+    return "bits<0>";
+  if (OpInfo.Fields.empty())
+    return "imm";
+  std::string S;
+  raw_string_ostream OS(S);
+  ListSeparator LS(" + ");
+  for (const auto &EF : OpInfo.Fields)
+    OS << LS << formatv("field({},{})", EF.Base, EF.Width);
+  return S;
+}
+
+/// Emit `if (!Check(...)) return <Helper>(<Args>[, &DecodeComplete]);`. The
+/// connector strings (": ", " using ", " : FAIL") live once inside the helper
+/// rather than being baked into every per-site string literal, so each call
+/// site only carries the unique parts (op name, field desc, decoder name) as
+/// separate string arguments — letting the linker dedup them.
+static void emitCheckWithDbgMsg(raw_ostream &OS, indent Indent,
+                                const Twine &CheckCall, StringRef Helper,
+                                const Twine &Args,
+                                bool SetDecodeCompleteOnFail) {
+  OS << Indent << "if (!Check(S, " << CheckCall << ")) return " << Helper << "("
+     << Args;
+  if (SetDecodeCompleteOnFail)
+    OS << ", &DecodeComplete";
+  OS << ");\n";
+}
+
+/// Operand-level decoder (emitBinaryParser).
+static void emitDecoderCheckWithOpcDebug(raw_ostream &OS, indent Indent,
+                                         const OperandInfo &OpInfo,
+                                         const Twine &CheckCall) {
+  StringRef OpName = OpInfo.Name.empty() ? "opd" : OpInfo.Name;
+  std::string FieldDesc = getOperandFieldDescForDebug(OpInfo);
+  StringRef DecoderName = OpInfo.Decoder;
+
+  emitCheckWithDbgMsg(
+      OS, Indent, CheckCall, "dbgFailOpd",
+      formatv("\"{}\", \"{}\", \"{}\"", OpName, FieldDesc, DecoderName),
+      !OpInfo.HasCompleteDecoder);
+}
+
+/// Whole-instruction \p DecoderMethod. Used when the encoding
+/// has a custom \p DecoderMethod (whole-instruction decoder).
+static void emitDecoderMethodOpcDebug(raw_ostream &OS, indent Indent,
+                                      const InstructionEncoding &Encoding,
+                                      StringRef DecoderMethod) {
+  StringRef EncName = Encoding.getName();
+  emitCheckWithDbgMsg(
+      OS, Indent, formatv("{}(MI, insn, Address, Decoder)", DecoderMethod),
+      "dbgFailInsn", formatv("\"{}\", \"{}\"", EncName, DecoderMethod),
+      !Encoding.hasCompleteDecoder());
+}
+
 static void emitBinaryParser(raw_ostream &OS, indent Indent,
                              const InstructionEncoding &Encoding,
                              const OperandInfo &OpInfo) {
@@ -702,8 +757,8 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
     // The operand has no encoding, so the corresponding argument is omitted.
     // This avoids confusion and allows the function to be overloaded if the
     // operand does have an encoding in other instructions.
-    OS << Indent << "if (!Check(S, " << OpInfo.Decoder << "(MI, Decoder)))\n"
-       << Indent << "  return MCDisassembler::Fail;\n";
+    emitDecoderCheckWithOpcDebug(OS, Indent, OpInfo,
+                                 formatv("{}(MI, Decoder)", OpInfo.Decoder));
     return;
   }
 
@@ -738,10 +793,8 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
 
   StringRef Decoder = OpInfo.Decoder;
   if (!Decoder.empty()) {
-    OS << Indent << "if (!Check(S, " << Decoder
-       << "(MI, tmp, Address, Decoder))) { "
-       << (OpInfo.HasCompleteDecoder ? "" : "DecodeComplete = false; ")
-       << "return MCDisassembler::Fail; }\n";
+    emitDecoderCheckWithOpcDebug(
+        OS, Indent, OpInfo, formatv("{}(MI, tmp, Address, Decoder)", Decoder));
   } else {
     OS << Indent << "MI.addOperand(MCOperand::createImm(tmp));\n";
   }
@@ -755,10 +808,7 @@ static std::string getDecoderString(const InstructionEncoding &Encoding) {
   // If a custom instruction decoder was specified, use that.
   StringRef DecoderMethod = Encoding.getDecoderMethod();
   if (!DecoderMethod.empty()) {
-    OS << Indent << "if (!Check(S, " << DecoderMethod
-       << "(MI, insn, Address, Decoder))) { "
-       << (Encoding.hasCompleteDecoder() ? "" : "DecodeComplete = false; ")
-       << "return MCDisassembler::Fail; }\n";
+    emitDecoderMethodOpcDebug(OS, Indent, Encoding, DecoderMethod);
   } else {
     for (const OperandInfo &Op : Encoding.getOperands())
       emitBinaryParser(OS, Indent, Encoding, Op);
@@ -1184,8 +1234,8 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
       S = decodeToMCInst(DecodeIdx, S, insn, MI, Address, DisAsm,
                          DecodeComplete);
       LLVM_DEBUG(dbgs() << Loc << ": OPC_Decode: opcode " << Opc
-                        << ", using decoder " << DecodeIdx << ": "
-                        << (S ? "PASS, " : "FAIL, "));
+                        << " using decoder " << DecodeIdx
+                        << ": " << (S ? "PASS, " : "FAIL, "));
 
       if (DecodeComplete) {
         LLVM_DEBUG(dbgs() << "decoding complete\n");
@@ -1516,6 +1566,24 @@ namespace {
 // Individual targets are expected to provide specializations for these based
 // on their usage.
 template <typename T> constexpr uint32_t InsnBitWidth = 0;
+
+DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
+                        bool *DecodeComplete = nullptr) {
+  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
+                    << Decoder << " : FAIL\n");
+  if (DecodeComplete)
+    *DecodeComplete = false;
+  return MCDisassembler::Fail;
+}
+
+[[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
+                                          bool *DecodeComplete = nullptr) {
+  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+                    << " : FAIL\n");
+  if (DecodeComplete)
+    *DecodeComplete = false;
+  return MCDisassembler::Fail;
+}
 
 )";
 

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -683,6 +683,54 @@ static std::vector<EncodingIsland> getIslands(const KnownBits &EncodingBits,
   return Islands;
 }
 
+/// Emit `if (!Check(...)) return <Helper>(<Args>[, &DecodeComplete]);`.
+static void emitCheckWithDbgMsg(raw_ostream &OS, indent Indent,
+                                const Twine &CheckCall, StringRef Helper,
+                                const Twine &Args,
+                                bool SetDecodeCompleteOnFail) {
+  OS << Indent << "if (!Check(S, " << CheckCall << ")) return " << Helper << "("
+     << Args;
+  if (SetDecodeCompleteOnFail)
+    OS << ", &DecodeComplete";
+  OS << ");\n";
+}
+
+/// Operand-level decoder (emitBinaryParser).
+static void emitDecoderCheckWithOpcDebug(raw_ostream &OS, indent Indent,
+                                         const OperandInfo &OpInfo,
+                                         const Twine &CheckCall) {
+  StringRef OpName = OpInfo.Name.empty() ? "opd" : OpInfo.Name;
+  StringRef DecoderName = OpInfo.Decoder;
+
+  std::string Args;
+  raw_string_ostream AS(Args);
+  if (OpInfo.Fields.empty()) {
+    const char *Desc = OpInfo.InitValue ? "imm" : "bits<0>";
+    AS << '"' << OpName << "\", \"" << Desc << "\", \"" << DecoderName << '"';
+  } else {
+    AS << '"' << OpName << "\", \"" << DecoderName << "\", {";
+    ListSeparator LS;
+    for (const EncodingField &EF : OpInfo.Fields)
+      AS << LS << EF.Base << ", " << EF.Width;
+    AS << '}';
+  }
+
+  emitCheckWithDbgMsg(OS, Indent, CheckCall, "dbgFailOpd", Args,
+                      !OpInfo.HasCompleteDecoder);
+}
+
+/// Whole-instruction \p DecoderMethod. Used when the encoding
+/// has a custom \p DecoderMethod (whole-instruction decoder).
+static void emitDecoderMethodOpcDebug(raw_ostream &OS, indent Indent,
+                                      const InstructionEncoding &Encoding,
+                                      StringRef DecoderMethod) {
+  StringRef EncName = Encoding.getName();
+  emitCheckWithDbgMsg(
+      OS, Indent, formatv("{}(MI, insn, Address, Decoder)", DecoderMethod),
+      "dbgFailInsn", formatv("\"{}\", \"{}\"", EncName, DecoderMethod),
+      !Encoding.hasCompleteDecoder());
+}
+
 static void emitBinaryParser(raw_ostream &OS, indent Indent,
                              const InstructionEncoding &Encoding,
                              const OperandInfo &OpInfo) {
@@ -702,8 +750,8 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
     // The operand has no encoding, so the corresponding argument is omitted.
     // This avoids confusion and allows the function to be overloaded if the
     // operand does have an encoding in other instructions.
-    OS << Indent << "if (!Check(S, " << OpInfo.Decoder << "(MI, Decoder)))\n"
-       << Indent << "  return MCDisassembler::Fail;\n";
+    emitDecoderCheckWithOpcDebug(OS, Indent, OpInfo,
+                                 formatv("{}(MI, Decoder)", OpInfo.Decoder));
     return;
   }
 
@@ -738,10 +786,8 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
 
   StringRef Decoder = OpInfo.Decoder;
   if (!Decoder.empty()) {
-    OS << Indent << "if (!Check(S, " << Decoder
-       << "(MI, tmp, Address, Decoder))) { "
-       << (OpInfo.HasCompleteDecoder ? "" : "DecodeComplete = false; ")
-       << "return MCDisassembler::Fail; }\n";
+    emitDecoderCheckWithOpcDebug(
+        OS, Indent, OpInfo, formatv("{}(MI, tmp, Address, Decoder)", Decoder));
   } else {
     OS << Indent << "MI.addOperand(MCOperand::createImm(tmp));\n";
   }
@@ -755,10 +801,7 @@ static std::string getDecoderString(const InstructionEncoding &Encoding) {
   // If a custom instruction decoder was specified, use that.
   StringRef DecoderMethod = Encoding.getDecoderMethod();
   if (!DecoderMethod.empty()) {
-    OS << Indent << "if (!Check(S, " << DecoderMethod
-       << "(MI, insn, Address, Decoder))) { "
-       << (Encoding.hasCompleteDecoder() ? "" : "DecodeComplete = false; ")
-       << "return MCDisassembler::Fail; }\n";
+    emitDecoderMethodOpcDebug(OS, Indent, Encoding, DecoderMethod);
   } else {
     for (const OperandInfo &Op : Encoding.getOperands())
       emitBinaryParser(OS, Indent, Encoding, Op);
@@ -1516,6 +1559,44 @@ namespace {
 // Individual targets are expected to provide specializations for these based
 // on their usage.
 template <typename T> constexpr uint32_t InsnBitWidth = 0;
+
+// Operand with no encoding fields: `Desc` is either "imm" (a constant
+// immediate) or "bits<0>" (no encoding at all).
+DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
+                        bool *DecodeComplete = nullptr) {
+  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
+                    << Decoder << " : FAIL\n");
+  if (DecodeComplete)
+    *DecodeComplete = false;
+  return MCDisassembler::Fail;
+}
+
+// Operand with encoding fields, passed as (base, width) integer pairs.
+DecodeStatus dbgFailOpd(const char *Op, const char *Decoder,
+                        ArrayRef<uint32_t> Fields,
+                        bool *DecodeComplete = nullptr) {
+  LLVM_DEBUG({
+    dbgs() << "OPC_Decode for " << Op << ": ";
+    for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
+      if (I)
+        dbgs() << " + ";
+      dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
+    }
+    dbgs() << " using " << Decoder << " : FAIL\n";
+  });
+  if (DecodeComplete)
+    *DecodeComplete = false;
+  return MCDisassembler::Fail;
+}
+
+[[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
+                                          bool *DecodeComplete = nullptr) {
+  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+                    << " : FAIL\n");
+  if (DecodeComplete)
+    *DecodeComplete = false;
+  return MCDisassembler::Fail;
+}
 
 )";
 

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -683,16 +683,22 @@ static std::vector<EncodingIsland> getIslands(const KnownBits &EncodingBits,
   return Islands;
 }
 
-/// Emit `if (!Check(...)) return <Helper>(<Args>[, &DecodeComplete]);`.
+/// Emit:
+///   if (!Check(...)) {
+///     LLVM_DEBUG(<Helper>(<Args>));
+///     [DecodeComplete = false;]
+///     return MCDisassembler::Fail;
+///   }
 static void emitCheckWithDbgMsg(raw_ostream &OS, indent Indent,
                                 const Twine &CheckCall, StringRef Helper,
                                 const Twine &Args,
                                 bool SetDecodeCompleteOnFail) {
-  OS << Indent << "if (!Check(S, " << CheckCall << ")) return " << Helper << "("
-     << Args;
+  OS << Indent << "if (!Check(S, " << CheckCall << ")) {\n";
+  OS << Indent << "  LLVM_DEBUG(" << Helper << "(" << Args << "));\n";
   if (SetDecodeCompleteOnFail)
-    OS << ", &DecodeComplete";
-  OS << ");\n";
+    OS << Indent << "  DecodeComplete = false;\n";
+  OS << Indent << "  return MCDisassembler::Fail;\n";
+  OS << Indent << "}\n";
 }
 
 /// Operand-level decoder (emitBinaryParser).
@@ -715,7 +721,7 @@ static void emitDecoderCheckWithOpcDebug(raw_ostream &OS, indent Indent,
     AS << '}';
   }
 
-  emitCheckWithDbgMsg(OS, Indent, CheckCall, "dbgFailOpd", Args,
+  emitCheckWithDbgMsg(OS, Indent, CheckCall, "reportOperandDecodeFailure", Args,
                       !OpInfo.HasCompleteDecoder);
 }
 
@@ -725,10 +731,11 @@ static void emitDecoderMethodOpcDebug(raw_ostream &OS, indent Indent,
                                       const InstructionEncoding &Encoding,
                                       StringRef DecoderMethod) {
   StringRef EncName = Encoding.getName();
-  emitCheckWithDbgMsg(
-      OS, Indent, formatv("{}(MI, insn, Address, Decoder)", DecoderMethod),
-      "dbgFailInsn", formatv("\"{}\", \"{}\"", EncName, DecoderMethod),
-      !Encoding.hasCompleteDecoder());
+  emitCheckWithDbgMsg(OS, Indent,
+                      formatv("{}(MI, insn, Address, Decoder)", DecoderMethod),
+                      "reportInsnDecodeFailure",
+                      formatv("\"{}\", \"{}\"", EncName, DecoderMethod),
+                      !Encoding.hasCompleteDecoder());
 }
 
 static void emitBinaryParser(raw_ostream &OS, indent Indent,
@@ -1560,43 +1567,35 @@ namespace {
 // on their usage.
 template <typename T> constexpr uint32_t InsnBitWidth = 0;
 
+#ifndef NDEBUG
 // Operand with no encoding fields: `Desc` is either "imm" (a constant
 // immediate) or "bits<0>" (no encoding at all).
-DecodeStatus dbgFailOpd(const char *Op, const char *Desc, const char *Decoder,
-                        bool *DecodeComplete = nullptr) {
-  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using "
-                    << Decoder << " : FAIL\n");
-  if (DecodeComplete)
-    *DecodeComplete = false;
-  return MCDisassembler::Fail;
+[[maybe_unused]] void reportOperandDecodeFailure(const char *Op,
+                                                 const char *Desc,
+                                                 const char *Decoder) {
+  dbgs() << "OPC_Decode for " << Op << ": " << Desc << " using " << Decoder
+         << " : FAIL\n";
 }
 
 // Operand with encoding fields, passed as (base, width) integer pairs.
-DecodeStatus dbgFailOpd(const char *Op, const char *Decoder,
-                        ArrayRef<uint32_t> Fields,
-                        bool *DecodeComplete = nullptr) {
-  LLVM_DEBUG({
-    dbgs() << "OPC_Decode for " << Op << ": ";
-    for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
-      if (I)
-        dbgs() << " + ";
-      dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
-    }
-    dbgs() << " using " << Decoder << " : FAIL\n";
-  });
-  if (DecodeComplete)
-    *DecodeComplete = false;
-  return MCDisassembler::Fail;
+[[maybe_unused]] void reportOperandDecodeFailure(const char *Op,
+                                                 const char *Decoder,
+                                                 ArrayRef<uint32_t> Fields) {
+  dbgs() << "OPC_Decode for " << Op << ": ";
+  for (unsigned I = 0, E = Fields.size(); I != E; I += 2) {
+    if (I)
+      dbgs() << " + ";
+    dbgs() << "field(" << Fields[I] << ',' << Fields[I + 1] << ')';
+  }
+  dbgs() << " using " << Decoder << " : FAIL\n";
 }
 
-[[maybe_unused]] DecodeStatus dbgFailInsn(const char *Name, const char *Decoder,
-                                          bool *DecodeComplete = nullptr) {
-  LLVM_DEBUG(dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
-                    << " : FAIL\n");
-  if (DecodeComplete)
-    *DecodeComplete = false;
-  return MCDisassembler::Fail;
+[[maybe_unused]] void reportInsnDecodeFailure(const char *Name,
+                                              const char *Decoder) {
+  dbgs() << "OPC_Decode for " << Name << ": insn using " << Decoder
+         << " : FAIL\n";
 }
+#endif // NDEBUG
 
 )";
 


### PR DESCRIPTION
Generated disassembler code now logs PASS/FAIL for each operand decode and for custom whole-instruction decoder methods. 1. On TOT, we don't have any debug dumps for dynamic bits like operands, like which fields were extracted or what decoder function was used.
2. Adding debug log for the same would help understand which the decoder failed for which operand.

Code assisted by cursor.

In colab with Vivek EP(NVIDIA), Sunil Pratap Singh (NVIDIA)