### PR TITLE
[lldb-dap] Mark source deemphasize if path doesn't exist

### DIFF
--- a/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
+++ b/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
@@ -28,7 +28,11 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
                 "line": 4,
                 "moduleId": "01DF54A6-045E-657D-3F8F-FB9CE1118789-14F8BD6D",
                 "name": "bar",
-                "source": {"name": "main.c", "path": "/home/labath/test/main.c"},
+                "source": {
+                    "name": "main.c",
+                    "path": "/home/labath/test/main.c",
+                    "presentationHint": "deemphasize",
+                },
                 "instructionPointerReference": "0x40011C",
             },
             {
@@ -37,7 +41,11 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
                 "line": 10,
                 "moduleId": "01DF54A6-045E-657D-3F8F-FB9CE1118789-14F8BD6D",
                 "name": "foo",
-                "source": {"name": "main.c", "path": "/home/labath/test/main.c"},
+                "source": {
+                    "name": "main.c",
+                    "path": "/home/labath/test/main.c",
+                    "presentationHint": "deemphasize",
+                },
                 "instructionPointerReference": "0x400142",
             },
             {
@@ -46,7 +54,11 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
                 "line": 16,
                 "moduleId": "01DF54A6-045E-657D-3F8F-FB9CE1118789-14F8BD6D",
                 "name": "_start",
-                "source": {"name": "main.c", "path": "/home/labath/test/main.c"},
+                "source": {
+                    "name": "main.c",
+                    "path": "/home/labath/test/main.c",
+                    "presentationHint": "deemphasize",
+                },
                 "instructionPointerReference": "0x40015F",
             },
         ]

--- a/lldb/tools/lldb-dap/ProtocolUtils.cpp
+++ b/lldb/tools/lldb-dap/ProtocolUtils.cpp
@@ -12,6 +12,7 @@
 
 #include "lldb/API/SBDebugger.h"
 #include "lldb/API/SBDeclaration.h"
+#include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBFormat.h"
 #include "lldb/API/SBMutex.h"
 #include "lldb/API/SBStream.h"
@@ -159,8 +160,11 @@ std::optional<protocol::Source> CreateSource(const lldb::SBFileSpec &file) {
     source.name = name;
   char path[PATH_MAX] = "";
   if (file.GetPath(path, sizeof(path)) &&
-      lldb::SBFileSpec::ResolvePath(path, path, PATH_MAX))
+      lldb::SBFileSpec::ResolvePath(path, path, PATH_MAX)) {
     source.path = path;
+    if (!lldb::SBFileSpec(path).Exists())
+      source.presentationHint = Source::eSourcePresentationHintDeemphasize;
+  }
   return source;
 }
 


### PR DESCRIPTION
LLDB-DAP has a problem with sanitizers in GCC. When we stop in sanitizer's code, lldb-dap sends stack frames with path (sanitizer's build dir path) that doesn't exist on machine. It leads to problems in VS Code UI (see issue below).

Fixes #184789 