### PR TITLE
[flang][cuda][openacc] Fix OpenACC use_device host association symbol copies

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1637,7 +1637,7 @@ Symbol *AccVisitor::CopyUseDeviceSymbol(const Symbol &symbol) {
         hostAssoc && copy->owner().kind() == Scope::Kind::OpenACCConstruct) {
       Scope &hostScope{currScope().parent()};
       if (!FindInScope(hostScope, ultimate.name())) {
-        hostScope.CopySymbol(ultimate);
+        hostScope.CopySymbol(*copy);
       }
     }
     if (const auto *object{ultimate.detailsIf<ObjectEntityDetails>()}) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1637,15 +1637,7 @@ Symbol *AccVisitor::CopyUseDeviceSymbol(const Symbol &symbol) {
         hostAssoc && copy->owner().kind() == Scope::Kind::OpenACCConstruct) {
       Scope &hostScope{currScope().parent()};
       if (!FindInScope(hostScope, ultimate.name())) {
-        auto pair{hostScope.try_emplace(
-            ultimate.name(), HostAssocDetails{hostAssoc->symbol()})};
-        Symbol &hostCopy{*pair.first->second};
-        hostCopy.attrs() = hostAssoc->symbol().attrs();
-        hostCopy.implicitAttrs() =
-            hostCopy.attrs() & Attrs{Attr::ASYNCHRONOUS, Attr::VOLATILE};
-        hostCopy.implicitAttrs() |=
-            hostAssoc->symbol().implicitAttrs() & Attrs{Attr::SAVE};
-        hostCopy.flags() = hostAssoc->symbol().flags();
+        hostScope.CopySymbol(ultimate);
       }
     }
     if (const auto *object{ultimate.detailsIf<ObjectEntityDetails>()}) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1478,6 +1478,7 @@ public:
       llvm::ArrayRef<SourceName> componentPath, parser::Designator &designator);
 
 private:
+  Symbol *CopyUseDeviceSymbol(const Symbol &symbol);
   SemanticsContext &context_;
 };
 
@@ -1615,18 +1616,47 @@ void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
   // New symbols are created for those appearing in the use_device clause.
   // These new symbols get the CUDA device attribute.
   if (name && name->symbol) {
-    Symbol *copy{currScope().CopySymbol(name->symbol->GetUltimate())};
+    Symbol *copy{CopyUseDeviceSymbol(*name->symbol)};
     if (copy) {
-      if (auto *object{copy->GetUltimate().detailsIf<ObjectEntityDetails>()}) {
+      if (auto *object{copy->detailsIf<ObjectEntityDetails>()}) {
         object->set_cudaDataAttr(common::CUDADataAttr::Device);
       }
-    } else {
-      copy = FindInScope(currScope(), name->symbol->GetUltimate().name());
-    }
-    if (copy) {
       name->symbol = copy;
     }
   }
+}
+
+Symbol *AccVisitor::CopyUseDeviceSymbol(const Symbol &symbol) {
+  const Symbol &ultimate{symbol.GetUltimate()};
+  Symbol *copy{currScope().CopySymbol(ultimate)};
+  if (!copy) {
+    copy = FindInScope(currScope(), ultimate.name());
+  }
+  if (copy && copy->has<HostAssocDetails>()) {
+    if (const auto *hostAssoc{copy->detailsIf<HostAssocDetails>()};
+        hostAssoc && copy->owner().kind() == Scope::Kind::OpenACCConstruct) {
+      Scope &hostScope{currScope().parent()};
+      if (!FindInScope(hostScope, ultimate.name())) {
+        auto pair{hostScope.try_emplace(
+            ultimate.name(), HostAssocDetails{hostAssoc->symbol()})};
+        Symbol &hostCopy{*pair.first->second};
+        hostCopy.attrs() = hostAssoc->symbol().attrs();
+        hostCopy.implicitAttrs() =
+            hostCopy.attrs() & Attrs{Attr::ASYNCHRONOUS, Attr::VOLATILE};
+        hostCopy.implicitAttrs() |=
+            hostAssoc->symbol().implicitAttrs() & Attrs{Attr::SAVE};
+        hostCopy.flags() = hostAssoc->symbol().flags();
+      }
+    }
+    if (const auto *object{ultimate.detailsIf<ObjectEntityDetails>()}) {
+      currScope().erase(copy->name());
+      auto pair{currScope().try_emplace(
+          ultimate.name(), ultimate.attrs(), ObjectEntityDetails{*object})};
+      copy = &*pair.first->second;
+      copy->flags() = ultimate.flags();
+    }
+  }
+  return copy;
 }
 
 void AccVisitor::CopySymbolWithDeviceStructurePath(const parser::Name *baseName,
@@ -1634,11 +1664,7 @@ void AccVisitor::CopySymbolWithDeviceStructurePath(const parser::Name *baseName,
   if (!baseName || !baseName->symbol || componentPath.empty()) {
     return;
   }
-  const Symbol &orig{*baseName->symbol};
-  Symbol *copy{currScope().CopySymbol(orig)};
-  if (!copy) {
-    copy = FindInScope(currScope(), baseName->symbol->name());
-  }
+  Symbol *copy{CopyUseDeviceSymbol(*baseName->symbol)};
   if (!copy) {
     return;
   }

--- a/flang/test/Lower/OpenACC/acc-host-data-cuda-host-assoc.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data-cuda-host-assoc.f90
@@ -1,0 +1,24 @@
+! RUN: bbc -fopenacc -fcuda -emit-hlfir %s -o - | FileCheck %s
+
+interface something 
+  subroutine proc_device(x) 
+    real(4), device :: x(100) 
+  end subroutine 
+  subroutine proc_host(x) 
+    real(4) :: x(100) 
+  end subroutine 
+end interface 
+
+real(4) :: a(100)  
+!$acc declare copy(a)  
+
+call test_simple() 
+contains  
+  subroutine test_simple  
+    !$acc host_data use_device(a)  
+    call something(a)  
+    !$acc end host_data  
+  end subroutine  
+end 
+
+! CHECK: fir.call @_QPproc_device


### PR DESCRIPTION
When a use_device object comes from host association, the OpenACC construct scope may already contain a HostAssocDetails symbol. Reusing that symbol prevents semantics from applying the CUDA DEVICE attribute, because the copied symbol is not an object entity. The fix materializes the expected host-associated symbol in the containing scope, then replaces the OpenACC-scope symbol with an ObjectEntityDetails copy that can carry the device attribute.

This allows generic resolution and lowering to see the device version inside the host_data construct while preserving the host-associated binding needed by lowering.