### PR TITLE
[IR] Add Attribute::getValueAsParsedInteger helper

### DIFF
--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -291,9 +291,10 @@ public:
   LLVM_ABI StringRef getValueAsString() const;
 
   /// Return the attribute's value parsed as an integer. This requires the
-  /// attribute to be a string attribute.
+  /// attribute to be a string attribute. Reports a fatal usage error if the
+  /// value cannot be parsed.
   ///
-  /// \returns \p Default if parsing fails.
+  /// \returns \p Default if the attribute is not a string attribute.
   LLVM_ABI uint64_t getValueAsParsedInteger(uint64_t Default = 0) const;
 
   /// Return the attribute's value as a Type. This requires the attribute to be

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -290,6 +290,12 @@ public:
   /// attribute to be a string attribute.
   LLVM_ABI StringRef getValueAsString() const;
 
+  /// Return the attribute's value parsed as an integer. This requires the
+  /// attribute to be a string attribute.
+  ///
+  /// \returns \p Default if parsing fails.
+  LLVM_ABI uint64_t getValueAsParsedInteger(uint64_t Default = 0) const;
+
   /// Return the attribute's value as a Type. This requires the attribute to be
   /// a type attribute.
   LLVM_ABI Type *getValueAsType() const;

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -291,10 +291,8 @@ public:
   LLVM_ABI StringRef getValueAsString() const;
 
   /// Return the attribute's value parsed as an integer. This requires the
-  /// attribute to be a string attribute. Reports a fatal usage error if the
-  /// value cannot be parsed.
-  ///
-  /// \returns \p Default if the attribute is not a string attribute.
+  /// attribute to be a string attribute. Reports a fatal usage error on
+  /// parse failure.
   LLVM_ABI uint64_t getValueAsParsedInteger(uint64_t Default = 0) const;
 
   /// Return the attribute's value as a Type. This requires the attribute to be

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -409,6 +409,14 @@ StringRef Attribute::getValueAsString() const {
   return pImpl->getValueAsString();
 }
 
+uint64_t Attribute::getValueAsParsedInteger(uint64_t Default) const {
+  if (!isStringAttribute())
+    return Default;
+  uint64_t Result = Default;
+  getValueAsString().getAsInteger(0, Result);
+  return Result;
+}
+
 Type *Attribute::getValueAsType() const {
   if (!pImpl) return {};
   assert(isTypeAttribute() &&
@@ -2686,9 +2694,8 @@ adjustCallerStackProbeSize(Function &Caller, const Function &Callee) {
   if (CalleeAttr.isValid()) {
     Attribute CallerAttr = Caller.getFnAttribute("stack-probe-size");
     if (CallerAttr.isValid()) {
-      uint64_t CallerStackProbeSize, CalleeStackProbeSize;
-      CallerAttr.getValueAsString().getAsInteger(0, CallerStackProbeSize);
-      CalleeAttr.getValueAsString().getAsInteger(0, CalleeStackProbeSize);
+      uint64_t CallerStackProbeSize = CallerAttr.getValueAsParsedInteger();
+      uint64_t CalleeStackProbeSize = CalleeAttr.getValueAsParsedInteger();
 
       if (CallerStackProbeSize > CalleeStackProbeSize) {
         Caller.addFnAttr(CalleeAttr);
@@ -2714,9 +2721,8 @@ adjustMinLegalVectorWidth(Function &Caller, const Function &Callee) {
   if (CallerAttr.isValid()) {
     Attribute CalleeAttr = Callee.getFnAttribute("min-legal-vector-width");
     if (CalleeAttr.isValid()) {
-      uint64_t CallerVectorWidth, CalleeVectorWidth;
-      CallerAttr.getValueAsString().getAsInteger(0, CallerVectorWidth);
-      CalleeAttr.getValueAsString().getAsInteger(0, CalleeVectorWidth);
+      uint64_t CallerVectorWidth = CallerAttr.getValueAsParsedInteger();
+      uint64_t CalleeVectorWidth = CalleeAttr.getValueAsParsedInteger();
       if (CallerVectorWidth < CalleeVectorWidth)
         Caller.addFnAttr(CalleeAttr);
     } else {
@@ -2812,8 +2818,7 @@ void AttributeFuncs::updateMinLegalVectorWidthAttr(Function &Fn,
                                                    uint64_t Width) {
   Attribute Attr = Fn.getFnAttribute("min-legal-vector-width");
   if (Attr.isValid()) {
-    uint64_t OldWidth;
-    Attr.getValueAsString().getAsInteger(0, OldWidth);
+    uint64_t OldWidth = Attr.getValueAsParsedInteger();
     if (Width > OldWidth)
       Fn.addFnAttr("min-legal-vector-width", llvm::utostr(Width));
   }

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -413,7 +413,9 @@ uint64_t Attribute::getValueAsParsedInteger(uint64_t Default) const {
   if (!isStringAttribute())
     return Default;
   uint64_t Result = Default;
-  getValueAsString().getAsInteger(0, Result);
+  if (getValueAsString().getAsInteger(0, Result))
+    reportFatalUsageError("cannot parse integer attribute " +
+                          getKindAsString());
   return Result;
 }
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -410,8 +410,8 @@ StringRef Attribute::getValueAsString() const {
 }
 
 uint64_t Attribute::getValueAsParsedInteger(uint64_t Default) const {
-  if (!isStringAttribute())
-    return Default;
+  assert(isStringAttribute() &&
+         "Expected the attribute to be a string attribute!");
   uint64_t Result = Default;
   if (getValueAsString().getAsInteger(0, Result))
     reportFatalUsageError("cannot parse integer attribute " +

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -775,13 +775,11 @@ Attribute Function::getRetAttribute(Attribute::AttrKind Kind) const {
 uint64_t Function::getFnAttributeAsParsedInteger(StringRef Name,
                                                  uint64_t Default) const {
   Attribute A = getFnAttribute(Name);
+  if (!A.isStringAttribute())
+    return Default;
   uint64_t Result = Default;
-  if (A.isStringAttribute()) {
-    StringRef Str = A.getValueAsString();
-    if (Str.getAsInteger(0, Result))
-      getContext().emitError("cannot parse integer attribute " + Name);
-  }
-
+  if (A.getValueAsString().getAsInteger(0, Result))
+    getContext().emitError("cannot parse integer attribute " + Name);
   return Result;
 }
 

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -775,11 +775,13 @@ Attribute Function::getRetAttribute(Attribute::AttrKind Kind) const {
 uint64_t Function::getFnAttributeAsParsedInteger(StringRef Name,
                                                  uint64_t Default) const {
   Attribute A = getFnAttribute(Name);
-  if (!A.isStringAttribute())
-    return Default;
   uint64_t Result = Default;
-  if (A.getValueAsString().getAsInteger(0, Result))
-    getContext().emitError("cannot parse integer attribute " + Name);
+  if (A.isStringAttribute()) {
+    StringRef Str = A.getValueAsString();
+    if (Str.getAsInteger(0, Result))
+      getContext().emitError("cannot parse integer attribute " + Name);
+  }
+
   return Result;
 }
 

--- a/llvm/unittests/IR/AttributesTest.cpp
+++ b/llvm/unittests/IR/AttributesTest.cpp
@@ -818,4 +818,16 @@ TEST(Attributes, ListIntersect) {
   ASSERT_TRUE(Res->hasParamAttr(3, Attribute::ByVal));
 }
 
+TEST(Attributes, GetValueAsParsedInteger) {
+  LLVMContext C;
+  Attribute A = Attribute::get(C, "test-attr", "42");
+  EXPECT_EQ(A.getValueAsParsedInteger(), 42u);
+
+  Attribute Hex = Attribute::get(C, "hex-attr", "0xFF");
+  EXPECT_EQ(Hex.getValueAsParsedInteger(), 255u);
+
+  Attribute Zero = Attribute::get(C, "zero-attr", "0");
+  EXPECT_EQ(Zero.getValueAsParsedInteger(), 0u);
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
Add `Attribute::getValueAsParsedInteger(uint64_t Default = 0)` to parse a
string attribute's value as an integer. Asserts that the attribute is a string
attribute; reports a fatal usage error on parse failure.

Use this in the attribute-merging functions (`adjustCallerStackProbeSize`,
`adjustMinLegalVectorWidth`, `updateMinLegalVectorWidthAttr`) to replace
unchecked `getAsInteger` calls.

This complements `Function::getFnAttributeAsParsedInteger()`, which emits a
recoverable diagnostic via LLVMContext. The Attribute-level helper uses
`reportFatalUsageError()` instead, since Attribute does not carry a context
reference.