### PR TITLE
[clang] instantiate base classes even if they are instantiation-dependent-only

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -588,6 +588,8 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash related to missing source locations (#GH186655)
 - Fixed a crash when casting a parenthesized unresolved template-id or array section. (#GH183505)
 - Fixed a crash when initializing a ``constexpr`` pointer with a floating-point literal in C23. (#GH180313)
+- Fixed a lack of diagnostic for substitution failures in base classes when using `std::void_t`-like types.
+- Fixed a crash when emitting debug info for base classes with instantiation-dependent-only types (#GH193932)
 - Fixed an assertion when diagnosing address-space qualified ``new``/``delete`` in language-defined address spaces such as OpenCL ``__local``. (#GH178319)
 - Fixed an assertion failure in ObjC++ ARC when binding a rvalue reference to reference with different lifetimes (#GH178524)
 - Fixed a crash when subscripting a vector type with large unsigned integer values. (#GH180563)

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3411,7 +3411,7 @@ Sema::SubstBaseSpecifiers(CXXRecordDecl *Instantiation,
   bool Invalid = false;
   SmallVector<CXXBaseSpecifier*, 4> InstantiatedBases;
   for (const auto &Base : Pattern->bases()) {
-    if (!Base.getType()->isDependentType()) {
+    if (!Base.getType()->isInstantiationDependentType()) {
       if (const CXXRecordDecl *RD = Base.getType()->getAsCXXRecordDecl()) {
         if (RD->isInvalidDecl())
           Instantiation->setInvalidDecl();

--- a/clang/test/DebugInfo/CXX/GH193932.cpp
+++ b/clang/test/DebugInfo/CXX/GH193932.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple x86_64-unk-unk -o - -emit-llvm -debug-info-kind=standalone -gtemplate-alias %s | FileCheck %s
+
+namespace test1 {
+  struct A {};
+  template <class> using B = A;
+  template <class T> struct C : B<T> {};
+  C<int> t1;
+
+  // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "C<int>", {{.+}}, elements: ![[test1_bases:[0-9]+]], {{.+}}, identifier: "_ZTSN5test11CIiEE"
+  // CHECK-NEXT: ![[test1_bases]] = !{![[test1_inheritance:[0-9]+]]}
+  // CHECK-NEXT: ![[test1_inheritance]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[#]], baseType: ![[test1_alias:[0-9]+]],
+  // CHECK-NEXT: ![[test1_alias]] = !DIDerivedType(tag: DW_TAG_template_alias, name: "B<int>", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[test1_basetype:[0-9]+]],
+  // CHECK-NEXT: ![[test1_basetype]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", {{.+}} identifier: "_ZTSN5test11AE"
+} // namespace test1

--- a/clang/test/SemaTemplate/instantiation-dependence.cpp
+++ b/clang/test/SemaTemplate/instantiation-dependence.cpp
@@ -83,6 +83,14 @@ namespace TypeQualifier {
   int k = f<int>(); // expected-error {{no matching}}
 }
 
+namespace BaseClass1 {
+  struct A {};
+  template <class> using B = A;
+  template <class T> struct C : B<T*> {};
+  // expected-error@-1 {{'type name' declared as a pointer to a reference of type 'int &'}}
+  template struct C<int&>; // expected-note {{requested here}}
+} // namespace BaseClass1
+
 namespace MemberOfInstantiationDependentBase {
   template<typename T> struct A { template<int> void f(int); };
   template<typename T> struct B { using X = A<T>; };


### PR DESCRIPTION
This makes sure base classes are fully instantiated, even if only instantiation-dependent.

This fixes a lack of diagnostics for substitution failures in such cases, and also avoids leaking these instantiation-dependent types to CodeGen.

Fixes #193932