### PR TITLE
Revert "[CodeGen] Temporary disable the unreachable"

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2287,12 +2287,8 @@ public:
                                   MachineBasicBlock::iterator Iter,
                                   DebugLoc &DL,
                                   bool AllowSideEffects = true) const {
-#if 0
-    // FIXME: This should exist once all platforms that use stack protectors
-    // implements it.
     llvm_unreachable(
         "Target didn't implement TargetInstrInfo::buildClearRegister!");
-#endif
   }
 
   /// Return true if the function can safely be outlined from.


### PR DESCRIPTION
This reverts commit 7dc644fc463a8f42f54d63a99c3a4579df2c3859.

This code path is only used in implementations of
`emitZeroCallUsedRegs()`, it is not required for all platforms that use stack protectors.