### PR TITLE
[bazel] Prevent bazel from scanning .git metadata

### DIFF
--- a/utils/bazel/llvm-project-overlay/.bazelignore
+++ b/utils/bazel/llvm-project-overlay/.bazelignore
@@ -1,3 +1,5 @@
+# Prevent bazel from scanning git metadata
+.git
 # Ignore the utils/bazel directory when this is overlayed onto the repo root.
 utils/bazel
 # Ignore third-party projects. These should be configured separately and some


### PR DESCRIPTION
This prevents race condition when git triggers its GC during a bazel build. Bazel build fails as follows in that case:

```
Loading: 0 packages loaded

ERROR: Failed to list directory contents, for .git/objects/05, skipping: /var/lib/buildkite-agent/llvm-project-bazelbot/.git/objects/05 (No such file or directory)
ERROR: Target parsing failed due to unexpected exception: /var/lib/buildkite-agent/llvm-project-bazelbot/.git/objects/05 (No such file or directory)
Loading: 0 packages loaded 
```