### PR TITLE
[SLP] Handle strides that are the results of multiplication by constant

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -3749,13 +3749,32 @@ const SCEV *ScalarEvolution::getUDivExactExpr(SCEVUse LHS, SCEVUse RHS) {
   if (!Mul || !Mul->hasNoUnsignedWrap())
     return getUDivExpr(LHS, RHS);
 
+  const SCEVMulExpr *RHSMul = dyn_cast<SCEVMulExpr>(RHS);
+  if (RHSMul && RHSMul->hasNoUnsignedWrap()) {
+    const SCEV *CurrSCEV = Mul;
+    SmallVector<SCEVUse, 2> Operands;
+    for (SCEVUse Op : RHSMul->operands()) {
+      const SCEV *NewSCEV = getUDivExactExpr(CurrSCEV, Op);
+      if (isa<SCEVUDivExpr>(NewSCEV)) {
+        Operands.push_back(Op);
+        continue;
+      }
+      CurrSCEV = NewSCEV;
+    }
+    if (Operands.size())
+      return getUDivExpr(CurrSCEV,
+                         getMulExpr(Operands, RHSMul->getNoWrapFlags()));
+    else
+      return CurrSCEV;
+  }
+
   if (const SCEVConstant *RHSCst = dyn_cast<SCEVConstant>(RHS)) {
     // If the mulexpr multiplies by a constant, then that constant must be the
     // first element of the mulexpr.
     if (const auto *LHSCst = dyn_cast<SCEVConstant>(Mul->getOperand(0))) {
       if (LHSCst == RHSCst) {
         SmallVector<SCEVUse, 2> Operands(drop_begin(Mul->operands()));
-        return getMulExpr(Operands);
+        return getMulExpr(Operands, Mul->getNoWrapFlags());
       }
 
       // We can't just assume that LHSCst divides RHSCst cleanly, it could be
@@ -3770,7 +3789,7 @@ const SCEV *ScalarEvolution::getUDivExactExpr(SCEVUse LHS, SCEVUse RHS) {
         SmallVector<SCEVUse, 2> Operands;
         Operands.push_back(LHSCst);
         append_range(Operands, Mul->operands().drop_front());
-        LHS = getMulExpr(Operands);
+        LHS = getMulExpr(Operands, Mul->getNoWrapFlags());
         RHS = RHSCst;
         Mul = dyn_cast<SCEVMulExpr>(LHS);
         if (!Mul)

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6862,15 +6862,24 @@ static const SCEV *calculateRtStride(ArrayRef<Value *> PointerOps, Type *ElemTy,
   int Size = DL.getTypeStoreSize(ElemTy);
   auto TryGetStride = [&](const SCEV *Dist,
                           const SCEV *Multiplier) -> const SCEV * {
-    if (const auto *M = dyn_cast<SCEVMulExpr>(Dist)) {
-      if (M->getOperand(0) == Multiplier)
-        return M->getOperand(1);
-      if (M->getOperand(1) == Multiplier)
-        return M->getOperand(0);
-      return nullptr;
-    }
     if (Multiplier == Dist)
       return SE.getConstant(Dist->getType(), 1);
+    if (const auto *M = dyn_cast<SCEVMulExpr>(Dist)) {
+      // Want to simplify the distant/multiplier, but can only be done
+      // if NUW is assumed
+      SCEV::NoWrapFlags Flags =
+          ScalarEvolution::setFlags(M->getNoWrapFlags(), SCEV::FlagNUW);
+      SmallVector<SCEVUseT<const SCEV *>> Ops(M->operands());
+      Dist = SE.getMulExpr(Ops, Flags);
+    }
+    if (const auto *M = dyn_cast<SCEVMulExpr>(Multiplier)) {
+      // Want to simplify the distant/multiplier, but can only be done
+      // if NUW is assumed
+      SCEV::NoWrapFlags Flags =
+          ScalarEvolution::setFlags(M->getNoWrapFlags(), SCEV::FlagNUW);
+      SmallVector<SCEVUseT<const SCEV *>> Ops(M->operands());
+      Multiplier = SE.getMulExpr(Ops, Flags);
+    }
     return SE.getUDivExactExpr(Dist, Multiplier);
   };
   // Stride_in_elements = Dist / element_size * (num_elems - 1).

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
@@ -810,14 +810,11 @@ define void @rt_stride_mul_scev(ptr %pl, i64 %base_stride, ptr %ps) {
 ; CHECK-LABEL: define void @rt_stride_mul_scev(
 ; CHECK-SAME: ptr [[PL:%.*]], i64 [[BASE_STRIDE:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[STRIDE:%.*]] = mul i64 [[BASE_STRIDE]], 2
+; CHECK-NEXT:    [[STRIDE0:%.*]] = mul nsw i64 [[STRIDE]], 0
+; CHECK-NEXT:    [[GEP_L0:%.*]] = getelementptr inbounds i8, ptr [[PL]], i64 [[STRIDE0]]
 ; CHECK-NEXT:    [[GEP_S0:%.*]] = getelementptr inbounds i8, ptr [[PS]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <8 x i64> poison, i64 [[STRIDE]], i32 0
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x i64> [[TMP1]], <8 x i64> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP3:%.*]] = mul nsw <8 x i64> [[TMP2]], <i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7>
-; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x ptr> poison, ptr [[PL]], i32 0
-; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <8 x ptr> [[TMP4]], <8 x ptr> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr i8, <8 x ptr> [[TMP5]], <8 x i64> [[TMP3]]
-; CHECK-NEXT:    [[TMP7:%.*]] = call <8 x i8> @llvm.masked.gather.v8i8.v8p0(<8 x ptr> align 1 [[TMP6]], <8 x i1> splat (i1 true), <8 x i8> poison)
+; CHECK-NEXT:    [[TMP1:%.*]] = mul i64 [[STRIDE]], 1
+; CHECK-NEXT:    [[TMP7:%.*]] = call <8 x i8> @llvm.experimental.vp.strided.load.v8i8.p0.i64(ptr align 1 [[GEP_L0]], i64 [[TMP1]], <8 x i1> splat (i1 true), i32 8)
 ; CHECK-NEXT:    store <8 x i8> [[TMP7]], ptr [[GEP_S0]], align 1
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
@@ -805,3 +805,67 @@ define void @rt_stride_widen_no_reordering(ptr %pl, i64 %stride, ptr %ps) {
 
   ret void
 }
+
+define void @rt_stride_mul_scev(ptr %pl, i64 %base_stride, ptr %ps) {
+; CHECK-LABEL: define void @rt_stride_mul_scev(
+; CHECK-SAME: ptr [[PL:%.*]], i64 [[BASE_STRIDE:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[STRIDE:%.*]] = mul i64 [[BASE_STRIDE]], 2
+; CHECK-NEXT:    [[GEP_S0:%.*]] = getelementptr inbounds i8, ptr [[PS]], i64 0
+; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <8 x i64> poison, i64 [[STRIDE]], i32 0
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x i64> [[TMP1]], <8 x i64> poison, <8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP3:%.*]] = mul nsw <8 x i64> [[TMP2]], <i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7>
+; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x ptr> poison, ptr [[PL]], i32 0
+; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <8 x ptr> [[TMP4]], <8 x ptr> poison, <8 x i32> zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr i8, <8 x ptr> [[TMP5]], <8 x i64> [[TMP3]]
+; CHECK-NEXT:    [[TMP7:%.*]] = call <8 x i8> @llvm.masked.gather.v8i8.v8p0(<8 x ptr> align 1 [[TMP6]], <8 x i1> splat (i1 true), <8 x i8> poison)
+; CHECK-NEXT:    store <8 x i8> [[TMP7]], ptr [[GEP_S0]], align 1
+; CHECK-NEXT:    ret void
+;
+  %stride = mul i64 %base_stride,2
+  %stride0  = mul nsw i64 %stride, 0
+  %stride1  = mul nsw i64 %stride, 1
+  %stride2  = mul nsw i64 %stride, 2
+  %stride3  = mul nsw i64 %stride, 3
+  %stride4  = mul nsw i64 %stride, 4
+  %stride5  = mul nsw i64 %stride, 5
+  %stride6  = mul nsw i64 %stride, 6
+  %stride7  = mul nsw i64 %stride, 7
+
+  %gep_l0 = getelementptr inbounds i8, ptr %pl, i64 %stride0
+  %gep_l1 = getelementptr inbounds i8, ptr %pl, i64 %stride1
+  %gep_l2 = getelementptr inbounds i8, ptr %pl, i64 %stride2
+  %gep_l3 = getelementptr inbounds i8, ptr %pl, i64 %stride3
+  %gep_l4 = getelementptr inbounds i8, ptr %pl, i64 %stride4
+  %gep_l5 = getelementptr inbounds i8, ptr %pl, i64 %stride5
+  %gep_l6 = getelementptr inbounds i8, ptr %pl, i64 %stride6
+  %gep_l7 = getelementptr inbounds i8, ptr %pl, i64 %stride7
+
+  %load0  = load i8, ptr %gep_l0 , align 1
+  %load1  = load i8, ptr %gep_l1 , align 1
+  %load2  = load i8, ptr %gep_l2 , align 1
+  %load3  = load i8, ptr %gep_l3 , align 1
+  %load4  = load i8, ptr %gep_l4 , align 1
+  %load5  = load i8, ptr %gep_l5 , align 1
+  %load6  = load i8, ptr %gep_l6 , align 1
+  %load7  = load i8, ptr %gep_l7 , align 1
+
+  %gep_s0 = getelementptr inbounds i8, ptr %ps, i64 0
+  %gep_s1 = getelementptr inbounds i8, ptr %ps, i64 1
+  %gep_s2 = getelementptr inbounds i8, ptr %ps, i64 2
+  %gep_s3 = getelementptr inbounds i8, ptr %ps, i64 3
+  %gep_s4 = getelementptr inbounds i8, ptr %ps, i64 4
+  %gep_s5 = getelementptr inbounds i8, ptr %ps, i64 5
+  %gep_s6 = getelementptr inbounds i8, ptr %ps, i64 6
+  %gep_s7 = getelementptr inbounds i8, ptr %ps, i64 7
+
+  store i8 %load0, ptr %gep_s0, align 1
+  store i8 %load1, ptr %gep_s1, align 1
+  store i8 %load2, ptr %gep_s2, align 1
+  store i8 %load3, ptr %gep_s3, align 1
+  store i8 %load4, ptr %gep_s4, align 1
+  store i8 %load5, ptr %gep_s5, align 1
+  store i8 %load6, ptr %gep_s6, align 1
+  store i8 %load7, ptr %gep_s7, align 1
+
+  ret void
+}


### PR DESCRIPTION
I'm not entirely sure if this is the best way to approach this issue. Will need to add more tests but want to make sure the approach is correct first.

This addresses cases where the stride for a series of strided loads/stores is the result of a multiplication by a constant, for instance,  `%stride = mul i64 %X, 2`. In such cases, the current `TryGetStride` macro fails to properly factor the SCEV when we try to divide `Dist` by `Sz`.
```
   auto TryGetStride = [&](const SCEV *Dist,
                           const SCEV *Multiplier) -> const SCEV * {
   if (const auto *M = dyn_cast<SCEVMulExpr>(Dist)) {
      if (M->getOperand(0) == Multiplier)
        return M->getOperand(1);
      if (M->getOperand(1) == Multiplier)
        return M->getOperand(0);
      return nullptr;
    }
     if (Multiplier == Dist)
       return SE.getConstant(Dist->getType(), 1);
     return SE.getUDivExactExpr(Dist, Multiplier);
   };
```
In such a case where `Stride = mul i64 %X, 2` and `VF=4`, we will have a `Dist` of  `%x * 8` and a Sz of `4`. The current TryGetStride will fall back in this case to `SE.getUDivExactExpr(Dist, Multiplier)`, which will only successfully factor `Stride` if `NUW` is set. Even that factorization is successful and we find stride of `%x * 2`, the following call to `TryGetStride(Diff, Stride)` with a Diff of `%x * 4` and Stride of `%x * 2` won't successfully return `2` because `SE.getUDivExactExpr` cannot currently handle the division of two multiplies.

To resolve these issues, the following changes were made:
- Update `SE.getUDivExactExpr` to handle the factoring the division of two multiplications
- Update -`TryGetStride` to always call `SE.getUDivExactExpr`, setting any multiplications to `NUW`. I'm not entirely sure if this is safe to do, but it matches the current behavior (we implicitly assume `NUW` when we match the operands in the current `TryGetStride`)