### PR TITLE
[libcxx][lit] Fixing libcxx test failures on Windows

### DIFF
--- a/libcxx/test/selftest/dsl/dsl.sh.py
+++ b/libcxx/test/selftest/dsl/dsl.sh.py
@@ -160,7 +160,9 @@ class TestProgramOutput(SetupConfigs):
         #include <cstdio>
         int main(int, char**) { std::printf("FOOBAR\\n"); return 0; }
         """
-        self.assertEqual(dsl.programOutput(self.config, source), "FOOBAR\n")
+        self.assertEqual(
+            dsl.programOutput(self.config, source), "FOOBAR%s" % os.linesep
+        )
 
     def test_valid_program_returns_no_output(self):
         source = """
@@ -224,14 +226,14 @@ class TestProgramOutput(SetupConfigs):
             compileFlags + " -DMACRO=1",
         )
         output1 = dsl.programOutput(self.config, source)
-        self.assertEqual(output1, "MACRO=1\n")
+        self.assertEqual(output1, "MACRO=1%s" % os.linesep)
 
         self.config.substitutions[compileFlagsIndex] = (
             "%{compile_flags}",
             compileFlags + " -DMACRO=2",
         )
         output2 = dsl.programOutput(self.config, source)
-        self.assertEqual(output2, "MACRO=2\n")
+        self.assertEqual(output2, "MACRO=2%s" % os.linesep)
 
     def test_program_stderr_is_not_conflated_with_stdout(self):
         # Run a program that produces stdout output and stderr output too, making

--- a/libcxx/utils/libcxx/test/features/localization.py
+++ b/libcxx/utils/libcxx/test/features/localization.py
@@ -144,5 +144,5 @@ def _getLocaleFlagsAction(cfg, locale, alts, members):
             f"%{{LOCALE_CONV_{valid_define_name}_{member.upper()}}}",
             lambda cfg, value=value: f"'L\"{value}\"'",
         )
-        for member, value in zip(members, localeconv_info.split("\n"))
+        for member, value in zip(members, localeconv_info.splitlines())
     ]


### PR DESCRIPTION
PR#194368 changed how line breaks are handles on Windows and it broke several libcxx tests on Windows, including libcxx/test/std/localization/locale.categories/facet.numpunct/ locale.numpunct.byname/thousands_sep.pass.cpp
This patch addresses this issue.