### PR TITLE
[clang][NFC] Mark CWG2807 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -6,6 +6,16 @@
 // RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,cxx11-23,since-cxx20,since-cxx23 %s
 // RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,since-cxx20,since-cxx23,since-cxx26 %s
 
+namespace cwg2807 { // cwg2807: 11
+
+#if __cplusplus >= 202002L
+struct s {
+  consteval ~s() {}
+  // since-cxx20-error@-1 {{destructor cannot be declared consteval}}
+};
+#endif
+
+} // namespace cwg2807
 
 int main() {} // required for cwg2811
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19458,7 +19458,7 @@
     <td>[<a href="https://wg21.link/class.dtor">class.dtor</a>]</td>
     <td>CD7</td>
     <td>Destructors declared <TT>consteval</TT></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 11</td>
   </tr>
   <tr class="open" id="2808">
     <td><a href="https://cplusplus.github.io/CWG/issues/2808.html">2808</a></td>


### PR DESCRIPTION
[CWG2807](https://wg21.link/cwg2807): One part of the standard correctly said destructors can't be `consteval`, but another incorrectly said they can be.

Clang diagnosed this in 9.0, for some reason started accepting it in 10.0, then went back to diagnosing in 11.0: https://godbolt.org/z/6sWTYT38M. I've marked it as implemented since 11.0.

The issue that prompted the DR: #65665