### PR TITLE
[clang][deps] Fix race condition in implicit Clang module builds

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1570,6 +1570,17 @@ compileModuleBehindLockOrRead(CompilerInstance &ImportingInstance,
       return CompileOrReadResult::Compiled;
     }
     if (Owned) {
+      // If another thread finished building the module before we acquired the
+      // lock, but after our initial cache miss, try to read it from the cache
+      // instead of rebuilding.
+      bool OutOfDate = false;
+      bool Missing = false;
+      if (readASTAfterCompileModule(ImportingInstance, ImportLoc, ModuleNameLoc,
+                                    Module, ModuleFileName, &OutOfDate,
+                                    &Missing))
+        return CompileOrReadResult::Read;
+      if (!OutOfDate && !Missing)
+        return CompileOrReadResult::FailedToRead;
       // We're responsible for building the module ourselves.
       if (!compileModuleImpl(ImportingInstance, ImportLoc, ModuleNameLoc,
                              Module, ModuleFileName))


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/194475#issuecomment-4333333223.

The assert was thrown in the following scenario:

Say threads 1 and 2 both try to compile the same module and both concurrently call `findOrCompileModuleAndReadAST()` and both have a cache miss.
Both will then go and call `compileModuleBehindLockOrRead()`.
If thread 1 completes the module compilation, locking and unlocking before thread 2 even tries to lock, thread 2 will also compile the module a second time.

This adds a check after acquiring the lock to prevent such situations.

Since the original bug occurred randomly, this fix was tested by running the failing test ~25 times while deleting the module cache after each run.
(Before the fix, the bug was reproduced within a few runs of the same).