### PR TITLE
workflows: Add require-release-manager composite action

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -78,9 +78,6 @@ jobs:
 
   release-binaries-all:
     name: Build Release Binaries
-    environment:
-      deployment: false
-      name: ${{ case( github.event_name == 'pull_request', null, 'release') }}
     needs:
       - setup-variables
     permissions:

--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -78,6 +78,9 @@ jobs:
 
   release-binaries-all:
     name: Build Release Binaries
+    environment:
+      deployment: false
+      name: ${{ case( github.event_name == 'pull_request', null, 'release') }}
     needs:
       - setup-variables
     permissions:
@@ -102,7 +105,8 @@ jobs:
       upload: ${{ needs.setup-variables.outputs.upload == 'true'}}
       runs-on: "${{ matrix.runs-on }}"
     secrets:
-      # This will be empty for pull_request events, but that's fine, because
-      # the release-binaries workflow does not use this secret for the
+      # These will be empty for pull_request events, but that's fine, because
+      # the release-binaries workflow does not use these secrets for the
       # pull_request event.
-      RELEASE_TASKS_USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
+      LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+      LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -50,7 +50,9 @@ permissions:
 jobs:
   prepare:
     name: Prepare to build binaries
-    environment: release
+    environment:
+      deployment: false
+      environment: ${{ case( github.event_name == 'pull_request', null, 'release') }}
     runs-on: ${{ inputs.runs-on }}
     if: github.repository_owner == 'llvm'
     outputs:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -40,10 +40,10 @@ on:
         type: string
     secrets:
       LLVM_TOKEN_GENERATOR_CLIENT_ID:
-        description: "Secret used to generate access tokens."
+        description: "Client ID for our GitHub App we use for generating access tokens."
         required: true
       LLVM_TOKEN_GENERATOR_PRIVATE_KEY:
-        description: "Secret used to generate access tokens."
+        description: "Private key for our GitHub App we use for generating access tokens."
         required: true
 
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,9 +39,12 @@ on:
         required: true
         type: string
     secrets:
-      RELEASE_TASKS_USER_TOKEN:
-        description: "Secret used to check user permissions."
-        required: false
+      LLVM_TOKEN_GENERATOR_CLIENT_ID:
+        description: "Secret used to generate access tokens."
+        required: true
+      LLVM_TOKEN_GENERATOR_PRIVATE_KEY:
+        description: "Secret used to generate access tokens."
+        required: true
 
 
 permissions:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -52,7 +52,7 @@ jobs:
     name: Prepare to build binaries
     environment:
       deployment: false
-      environment: ${{ case( github.event_name == 'pull_request', null, 'release') }}
+      name: ${{ case( github.event_name == 'pull_request', null, 'release') }}
     runs-on: ${{ inputs.runs-on }}
     if: github.repository_owner == 'llvm'
     outputs:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -50,6 +50,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare to build binaries
+    environment: release
     runs-on: ${{ inputs.runs-on }}
     if: github.repository_owner == 'llvm'
     outputs:
@@ -65,12 +66,6 @@ jobs:
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
 
     steps:
-    # It's good practice to use setup-python, but this is also required on macos-14
-    # due to https://github.com/actions/runner-images/issues/10385
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: '3.14'
-
     - name: Install Windows ARM64 dependencies
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       run: |
@@ -83,19 +78,12 @@ jobs:
       with:
           persist-credentials: false
 
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        pip install --require-hashes -r ./llvm/utils/git/requirements.txt
-
     - name: Check Permissions
       if: github.event_name != 'pull_request'
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        USER_TOKEN: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}
-      shell: bash
-      run: |
-        ./llvm/utils/release/./github-upload-release.py --token "$GITHUB_TOKEN" --user "$GITHUB_ACTOR" --user-token "$USER_TOKEN" check-permissions
+      uses: ./.github/workflows/require-release-manager
+      with:
+        LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+        LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
     # The name of the Windows binaries uses the version from source, so we need
     # to fetch it here.

--- a/.github/workflows/require-release-manager/action.yml
+++ b/.github/workflows/require-release-manager/action.yml
@@ -5,11 +5,11 @@ description: >-
 inputs:
   LLVM_TOKEN_GENERATOR_CLIENT_ID:
     description: >-
-      Client ID for generating access tokens.
+      Client ID for our GitHub App we use for generating access tokens.
     required: true
   LLVM_TOKEN_GENERATOR_PRIVATE_KEY:
     description: >-
-      Private key for generating access tokens
+      Private key for our GitHub App we use for generating access tokens.
     required: true
 
 runs:

--- a/.github/workflows/require-release-manager/action.yml
+++ b/.github/workflows/require-release-manager/action.yml
@@ -1,0 +1,35 @@
+name: Require Release Manager
+description: >-
+  This checks to make sure the person that initiated the workflow is a
+  release manager.
+inputs:
+  LLVM_TOKEN_GENERATOR_CLIENT_ID:
+    description: >-
+      Client ID for generating access tokens.
+    required: true
+  LLVM_TOKEN_GENERATOR_PRIVATE_KEY:
+    description: >-
+      Private key for generating access tokens
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: app-token
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+      with:
+        app-id: ${{ inputs.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
+        private-key: ${{ inputs.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        permission-members: read
+
+    - name: Check Permissions
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        github-token: ${{ steps.app-token.outputs.token }}
+        script: |
+          await github.rest.teams.getMembershipForUserInOrg({
+             org: context.repo.owner,
+             team_slug: "llvm-release-managers"
+             username: context.actor
+          });


### PR DESCRIPTION
This action checks that the workflow was started by someone in the llvm-release-managers team.  This is meant to replace the existing checks which use a python script and will help to consolidate the access token generation into a single place.

Also start using it in the release-binaries workflow.