### PR TITLE
[lldb] Add a @skipIfNoSignals decorator for Windows and Wasm

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -868,6 +868,11 @@ def skipIfWasm(func):
     return skipIfPlatform(["wasip1", "wasi"])(func)
 
 
+def skipIfNoSignals(func):
+    """Decorate the item to skip tests on platforms without signal support."""
+    return skipIfPlatform(["windows", "wasip1", "wasi"])(func)
+
+
 def skipIfWindows(func=None, windows_version=None):
     """Decorate the item to skip tests that should be skipped on Windows."""
 

--- a/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
+++ b/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfNoSignals
 class ExprCommandThatRestartsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/attach/attach_denied/TestAttachDenied.py
+++ b/lldb/test/API/commands/process/attach/attach_denied/TestAttachDenied.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 exe_name = "AttachDenied"  # Must match Makefile
 
 
+@skipIfNoSignals
 class AttachDeniedTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/signal/TestSendSignal.py
+++ b/lldb/test/API/functionalities/signal/TestSendSignal.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfNoSignals
 class SendSignalTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/signal/handle-abrt/TestHandleAbort.py
+++ b/lldb/test/API/functionalities/signal/handle-abrt/TestHandleAbort.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfNoSignals
 class HandleAbortTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/signal/handle-abrt/TestHandleAbort.py
+++ b/lldb/test/API/functionalities/signal/handle-abrt/TestHandleAbort.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 class HandleAbortTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfWindows  # signals do not exist on Windows
     @expectedFailureNetBSD
     def test_inferior_handle_sigabrt(self):
         """Inferior calls abort() and handles the resultant SIGABRT.

--- a/lldb/test/API/functionalities/signal/handle-segv/TestHandleSegv.py
+++ b/lldb/test/API/functionalities/signal/handle-segv/TestHandleSegv.py
@@ -7,8 +7,8 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfNoSignals
 class HandleSegvTestCase(TestBase):
-    @skipIfWindows  # signals do not exist on Windows
     @skipIfDarwin
     @expectedFailureNetBSD
     def test_inferior_handle_sigsegv(self):

--- a/lldb/test/API/functionalities/signal/raise/TestRaise.py
+++ b/lldb/test/API/functionalities/signal/raise/TestRaise.py
@@ -9,7 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfWindows  # signals do not exist on Windows
+@skipIfNoSignals
 class RaiseTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/signals/TestSignalsAPI.py
+++ b/lldb/test/API/python_api/signals/TestSignalsAPI.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.lldbutil import get_stopped_thread, state_type_to_str
 
 
+@skipIfNoSignals
 class SignalsAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/python_api/signals/TestSignalsAPI.py
+++ b/lldb/test/API/python_api/signals/TestSignalsAPI.py
@@ -14,7 +14,6 @@ from lldbsuite.test.lldbutil import get_stopped_thread, state_type_to_str
 class SignalsAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfWindows  # Windows doesn't have signals
     def test_ignore_signal(self):
         """Test Python SBUnixSignals.Suppress/Stop/Notify() API."""
         self.build()

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
 
 
+@skipIfNoSignals
 class TestDAP_exception(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_stopped_description(self):

--- a/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
+++ b/lldb/test/API/tools/lldb-dap/exception/TestDAP_exception.py
@@ -9,7 +9,6 @@ import lldbdap_testcase
 
 @skipIfNoSignals
 class TestDAP_exception(lldbdap_testcase.DAPTestCaseBase):
-    @skipIfWindows
     def test_stopped_description(self):
         """
         Test that exception description is shown correctly in stopped


### PR DESCRIPTION
Add a new @skipIfNoSignals test decorator that skips tests on platforms that lack signal support (Windows & WASI).