### PR TITLE
[lldb] Add skipIfWasm decorator and skip unsupported WebAssembly tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -863,6 +863,11 @@ def skipIfLinux(func):
     return skipIfPlatform(["linux"])(func)
 
 
+def skipIfWasm(func):
+    """Decorate the item to skip tests that should be skipped on WebAssembly."""
+    return skipIfPlatform(["wasip1", "wasi"])(func)
+
+
 def skipIfWindows(func=None, windows_version=None):
     """Decorate the item to skip tests that should be skipped on Windows."""
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -15,6 +15,7 @@ import tempfile
 import time
 from lldbsuite.test import configuration
 from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import skipIfWasm
 from lldbsuite.support import seven
 from lldbgdbserverutils import *
 import logging
@@ -55,6 +56,7 @@ class GdbRemoteTestCaseFactory(type):
         return super(GdbRemoteTestCaseFactory, cls).__new__(cls, name, bases, newattrs)
 
 
+@skipIfWasm  # wasm uses runtime's GDB stub, not lldb-server
 class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
     # Default time out in seconds. The timeout is increased tenfold under Asan.
     DEFAULT_TIMEOUT = 20 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def _run_cmd(self, cmd: str) -> str:
         """Run the given lldb command and return its output."""

--- a/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
+++ b/lldb/test/API/commands/expression/anonymous-struct/TestCallUserAnonTypedef.py
@@ -13,6 +13,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestExprLookupAnonStructTypedef(TestBase):
     def test(self):
         """Test typedeffed untagged struct arguments for function call expressions"""

--- a/lldb/test/API/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
+++ b/lldb/test/API/commands/expression/argument_passing_restrictions/TestArgumentPassingRestrictions.py
@@ -15,6 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestArgumentPassingRestrictions(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "7.0"])
     def test_argument_passing_restrictions(self):

--- a/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprCommandCallFunctionTestCase(TestBase):
     @expectedFailureAll(
         compiler="icc", bugnumber="llvm.org/pr14437, fails with ICC 13.1"

--- a/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
@@ -3,10 +3,12 @@ Test calling a function, stopping in the call, continue and gather the result on
 """
 
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprCommandCallStopContinueTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/call-function/TestCallUserDefinedFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallUserDefinedFunction.py
@@ -13,6 +13,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprCommandCallUserDefinedFunction(TestBase):
     def test(self):
         """Test return values of user defined function calls."""

--- a/lldb/test/API/commands/expression/class_template_specialization_empty_pack/TestClassTemplateSpecializationParametersHandling.py
+++ b/lldb/test/API/commands/expression/class_template_specialization_empty_pack/TestClassTemplateSpecializationParametersHandling.py
@@ -11,6 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestClassTemplateSpecializationParametersHandling(TestBase):
     def test_class_template_specialization(self):
         self.build()

--- a/lldb/test/API/commands/expression/context-object/TestContextObject.py
+++ b/lldb/test/API/commands/expression/context-object/TestContextObject.py
@@ -4,9 +4,11 @@ Tests expression evaluation in context of an object.
 
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class ContextObjectTestCase(TestBase):
     def test_context_object(self):
         """Tests expression evaluation in context of an object."""

--- a/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
+++ b/lldb/test/API/commands/expression/expr_inside_lambda/TestExprInsideLambdas.py
@@ -6,9 +6,11 @@
 
 
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class ExprInsideLambdaTestCase(TestBase):
     def expectExprError(self, expr: str, expected: str):
         frame = self.thread.GetFrameAtIndex(0)

--- a/lldb/test/API/commands/expression/formatters/TestFormatters.py
+++ b/lldb/test/API/commands/expression/formatters/TestFormatters.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprFormattersTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
+++ b/lldb/test/API/commands/expression/inline-namespace/TestInlineNamespace.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestInlineNamespace(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/namespace-alias/TestInlineNamespaceAlias.py
+++ b/lldb/test/API/commands/expression/namespace-alias/TestInlineNamespaceAlias.py
@@ -11,6 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestInlineNamespace(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "16.0"])
     def test(self):

--- a/lldb/test/API/commands/expression/persistent_types/TestNestedPersistentTypes.py
+++ b/lldb/test/API/commands/expression/persistent_types/TestNestedPersistentTypes.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class NestedPersistentTypesTestCase(TestBase):
     def test_persistent_types(self):
         """Test that nested persistent types work."""

--- a/lldb/test/API/commands/expression/persistent_types/TestPersistentTypes.py
+++ b/lldb/test/API/commands/expression/persistent_types/TestPersistentTypes.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class PersistenttypesTestCase(TestBase):
     def test_persistent_types(self):
         """Test that lldb persistent types works correctly."""

--- a/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
+++ b/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprBug35310(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/radar_9531204/TestPrintfAfterUp.py
+++ b/lldb/test/API/commands/expression/radar_9531204/TestPrintfAfterUp.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class Radar9531204TestCase(TestBase):
     # rdar://problem/9531204
     def test_expr_commands(self):

--- a/lldb/test/API/commands/expression/radar_9673664/TestExprHelpExamples.py
+++ b/lldb/test/API/commands/expression/radar_9673664/TestExprHelpExamples.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class Radar9673644TestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
+++ b/lldb/test/API/commands/expression/result_numbering/TestResultNumbering.py
@@ -6,9 +6,11 @@ influence the result variable numbering.
 
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestExpressionResultNumbering(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/expression/test/TestExprs.py
+++ b/lldb/test/API/commands/expression/test/TestExprs.py
@@ -19,6 +19,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class BasicExprCommandsTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
+++ b/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprCommandWithTimeoutsTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
+++ b/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class UnwindFromExpressionTest(TestBase):
     main_spec = lldb.SBFileSpec("main.cpp", False)
 

--- a/lldb/test/API/commands/expression/xvalue/TestXValuePrinting.py
+++ b/lldb/test/API/commands/expression/xvalue/TestXValuePrinting.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class ExprXValuePrintingTestCase(TestBase):
     def test(self):
         """Printing an xvalue should work."""

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -5,9 +5,11 @@ Test stop hook functionality
 
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestStopHooks(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
+++ b/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def getFormatted(self, format, expr):
         """

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CppDataFormatterTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class DataFormatterSynthValueTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/strings/TestCStrings.py
+++ b/lldb/test/API/lang/c/strings/TestCStrings.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CStringsTestCase(TestBase):
     def test_with_run_command(self):
         """Tests that C strings work as expected in expressions"""

--- a/lldb/test/API/lang/cpp/auto/TestCPPAuto.py
+++ b/lldb/test/API/lang/cpp/auto/TestCPPAuto.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CPPAutoTestCase(TestBase):
     def test_with_run_command(self):
         """Test that auto types work in the expression parser"""

--- a/lldb/test/API/lang/cpp/call-function/TestCallCPPFunction.py
+++ b/lldb/test/API/lang/cpp/call-function/TestCallCPPFunction.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CallCPPFunctionTestCase(TestBase):
     def setUp(self):
         TestBase.setUp(self)

--- a/lldb/test/API/lang/cpp/chained-calls/TestCppChainedCalls.py
+++ b/lldb/test/API/lang/cpp/chained-calls/TestCppChainedCalls.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCppChainedCalls(TestBase):
     def test_with_run_command(self):
         self.build()

--- a/lldb/test/API/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     # int128 is not available on 32-bit ARM.
     @skipIf(archs=["arm$"])

--- a/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
+++ b/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     @expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc")
     def test_constructors(self):

--- a/lldb/test/API/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
+++ b/lldb/test/API/lang/cpp/covariant-return-types/TestCovariantReturnTypes.py
@@ -1,8 +1,10 @@
 import lldb
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/cv_qualified_objects/TestExprOnCVQualifiedObjects.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/cv_qualified_objects/TestExprOnCVQualifiedObjects.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/function-call-from-object-file/TestFunctionCallFromObjectFile.py
+++ b/lldb/test/API/lang/cpp/function-call-from-object-file/TestFunctionCallFromObjectFile.py
@@ -15,6 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestFunctionCallFromObjectFile(TestBase):
     def test_lib1(self):
         self.build()

--- a/lldb/test/API/lang/cpp/function-qualifiers/TestCppFunctionQualifiers.py
+++ b/lldb/test/API/lang/cpp/function-qualifiers/TestCppFunctionQualifiers.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestFunctionQualifiers(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
+++ b/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
@@ -10,6 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestFunctionRefQualifiers(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/multiple-inheritance/TestCppMultipleInheritance.py
+++ b/lldb/test/API/lang/cpp/multiple-inheritance/TestCppMultipleInheritance.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/namespace/TestNamespace.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespace.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class NamespaceBreakpointTestCase(TestBase):
     @expectedFailureAll(bugnumber="llvm.org/pr28548", compiler="gcc")
     @expectedFailureAll(oslist=["windows"])

--- a/lldb/test/API/lang/cpp/overloaded-functions/TestOverloadedFunctions.py
+++ b/lldb/test/API/lang/cpp/overloaded-functions/TestOverloadedFunctions.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class OverloadedFunctionsTestCase(TestBase):
     def test_with_run_command(self):
         """Test that functions with the same name are resolved correctly"""

--- a/lldb/test/API/lang/cpp/rvalue-references/TestRvalueReferences.py
+++ b/lldb/test/API/lang/cpp/rvalue-references/TestRvalueReferences.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class RvalueReferencesTestCase(TestBase):
     # rdar://problem/11479676
     @expectedFailureAll(

--- a/lldb/test/API/lang/cpp/scope/TestCppScope.py
+++ b/lldb/test/API/lang/cpp/scope/TestCppScope.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
     def test(self):

--- a/lldb/test/API/lang/cpp/static_methods/TestCPPStaticMethods.py
+++ b/lldb/test/API/lang/cpp/static_methods/TestCPPStaticMethods.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CPPStaticMethodsTestCase(TestBase):
     def test_with_run_command(self):
         """Test that static methods are properly distinguished from regular methods"""

--- a/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
+++ b/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
@@ -14,6 +14,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/lang/cpp/typedef/TestCppTypedef.py
+++ b/lldb/test/API/lang/cpp/typedef/TestCppTypedef.py
@@ -5,9 +5,10 @@ Test typedef types.
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import decorators
+from lldbsuite.test.decorators import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestCppTypedef(TestBase):
     def test_typedef(self):
         """

--- a/lldb/test/API/lang/cpp/unicode-literals/TestUnicodeLiterals.py
+++ b/lldb/test/API/lang/cpp/unicode-literals/TestUnicodeLiterals.py
@@ -23,6 +23,7 @@ from lldbsuite.test import lldbutil
 # }
 
 
+@skipIfWasm  # no expression evaluation
 class UnicodeLiteralsTestCase(TestBase):
     def test_expr1(self):
         """Test that the expression parser returns proper Unicode strings."""

--- a/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
+++ b/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CppUnionStaticMembersTestCase(TestBase):
     def test_print_union(self):
         """Tests that frame variable and expr work

--- a/lldb/test/API/lang/cpp/virtual-functions/TestCppVirtualFunctions.py
+++ b/lldb/test/API/lang/cpp/virtual-functions/TestCppVirtualFunctions.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def common_setup(self):
         self.build()


### PR DESCRIPTION
Add a new `skipIfWasm` test decorator that skips tests on the "wasip1" and "wasi" platforms, and apply it to the test classes that rely on expression evaluation or lldb-server, neither of which is available when debugging WebAssembly targets.