### PR TITLE
[lldb] Pass `settings set` as a raw command

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -823,7 +823,7 @@ class Base(unittest.TestCase):
 
         # Set any user-overridden settings.
         for setting, value in configuration.settings:
-            commands.append("setting set %s %s" % (setting, value))
+            commands.append("setting set -- %s %s" % (setting, value))
 
         # Make sure that a sanitizer LLDB's environment doesn't get passed on.
         if (


### PR DESCRIPTION
To prevent settings start with a dash to be interpreter as a command option, always pass them as raw values. An example of this is passing `platform.plugin.wasm.runtime-args` with the dotest.py `--settings` flag.