### PR TITLE
[orc-rt] Remove explicit addSimpleNativeMemoryMap call. NFCI.

### DIFF
--- a/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
@@ -113,7 +113,6 @@ read_value_sps_allocaction(const char *ArgData, size_t ArgSize) {
 class SimpleNativeMemoryMapSPSCITest : public ::testing::Test {
 protected:
   void SetUp() override {
-    cantFail(sps_ci::addSimpleNativeMemoryMap(CI));
     S = std::make_unique<Session>(mockExecutorProcessInfo(),
                                   std::make_unique<NoDispatcher>(), noErrors);
     SNMM = cantFail(SimpleNativeMemoryMap::Create(*S, CI));


### PR DESCRIPTION
The SimpleNativeMemoryMap::Create call two lines below will add this interface anyway, so the explicit call is redundant.