### PR TITLE
[flang][NFC] Converted five tests from old lowering to new lowering (part 53)

### DIFF
--- a/flang/test/Lower/Intrinsics/count.f90
+++ b/flang/test/Lower/Intrinsics/count.f90
@@ -1,45 +1,40 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
-! CHECK-LABEL: count_test1
+! CHECK-LABEL: func.func @_QPcount_test1(
 ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
 subroutine count_test1(rslt, mask)
-    integer :: rslt
-    logical :: mask(:)
-  ! CHECK-DAG:  %[[c1:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[a2:.*]] = fir.convert %[[arg1]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
-  ! CHECK:  %[[a4:.*]] = fir.convert %[[c1]] : (index) -> i32
-    rslt = count(mask)
-  ! CHECK:  %[[a5:.*]] = fir.call @_FortranACount(%[[a2]], %{{.*}}, %{{.*}}, %[[a4]]) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64
-  end subroutine
+  integer :: rslt
+  logical :: mask(:)
+  ! CHECK: %[[mask_decl:.*]]:2 = hlfir.declare %[[arg1]] {{.*}}
+  ! CHECK: %[[rslt_decl:.*]]:2 = hlfir.declare %[[arg0]] {{.*}}
+  ! CHECK: %[[res:.*]] = hlfir.count %[[mask_decl]]#0 : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> i32
+  ! CHECK: hlfir.assign %[[res]] to %[[rslt_decl]]#0 : i32, !fir.ref<i32>
+  rslt = count(mask)
+end subroutine
 
-  ! CHECK-LABEL: test_count2
-  ! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>{{.*}})
-  subroutine test_count2(rslt, mask)
-    integer :: rslt(:)
-    logical :: mask(:,:)
-  ! CHECK-DAG:  %[[c1_i32:.*]] = arith.constant 1 : i32
-  ! CHECK-DAG:  %[[c4:.*]] = arith.constant 4 : index
-  ! CHECK-DAG:  %[[a0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-  ! CHECK:  %[[a5:.*]] = fir.convert %[[a0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK:  %[[a6:.*]] = fir.convert %[[arg1]] : (!fir.box<!fir.array<?x?x!fir.logical<4>>>) -> !fir.box<none>
-  ! CHECK:  %[[a7:.*]] = fir.convert %[[c4]] : (index) -> i32
-    rslt = count(mask, dim=1)
-  ! CHECK:  fir.call @_FortranACountDim(%[[a5]], %[[a6]], %[[c1_i32]], %[[a7]], %{{.*}}, %{{.*}}) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, i32, !fir.ref<i8>, i32) -> ()
-  ! CHECK:  %[[a10:.*]] = fir.load %[[a0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK:  %[[a12:.*]] = fir.box_addr %[[a10]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-  ! CHECK:  fir.freemem %[[a12]]
-  end subroutine
+! CHECK-LABEL: func.func @_QPtest_count2(
+! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xi32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?x!fir.logical<4>>>{{.*}})
+subroutine test_count2(rslt, mask)
+  integer :: rslt(:)
+  logical :: mask(:,:)
+  ! CHECK: %[[mask_decl:.*]]:2 = hlfir.declare %[[arg1]] {{.*}}
+  ! CHECK: %[[rslt_decl:.*]]:2 = hlfir.declare %[[arg0]] {{.*}}
+  ! CHECK: %[[c1_i32:.*]] = arith.constant 1 : i32
+  ! CHECK: %[[res:.*]] = hlfir.count %[[mask_decl]]#0 dim %[[c1_i32]] : (!fir.box<!fir.array<?x?x!fir.logical<4>>>, i32) -> !hlfir.expr<?xi32>
+  ! CHECK: hlfir.assign %[[res]] to %[[rslt_decl]]#0 : !hlfir.expr<?xi32>, !fir.box<!fir.array<?xi32>>
+  ! CHECK: hlfir.destroy %[[res]] : !hlfir.expr<?xi32>
+  rslt = count(mask, dim=1)
+end subroutine
 
-  ! CHECK-LABEL: test_count3
-  ! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
-  subroutine test_count3(rslt, mask)
-    integer :: rslt
-    logical :: mask(:)
-  ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[a1:.*]] = fir.convert %[[arg1]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
-  ! CHECK:  %[[a3:.*]] = fir.convert %[[c0]] : (index) -> i32
-    call bar(count(mask, kind=2))
-  ! CHECK:  %[[a4:.*]] = fir.call @_FortranACount(%[[a1]], %{{.*}}, %{{.*}}, %[[a3]]) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64
-  ! CHECK:  %{{.*}} = fir.convert %[[a4]] : (i64) -> i16
-  end subroutine
-
+! CHECK-LABEL: func.func @_QPtest_count3(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x!fir.logical<4>>>{{.*}})
+subroutine test_count3(rslt, mask)
+  integer :: rslt
+  logical :: mask(:)
+  ! CHECK: %[[mask_decl:.*]]:2 = hlfir.declare %[[arg1]] {{.*}}
+  ! CHECK: %[[res:.*]] = hlfir.count %[[mask_decl]]#0 : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> i16
+  ! CHECK: %[[assoc:.*]]:3 = hlfir.associate %[[res]] {{.*}}: (i16) -> (!fir.ref<i16>, !fir.ref<i16>, i1)
+  ! CHECK: fir.call @_QPbar(%[[assoc]]#0) {{.*}}: (!fir.ref<i16>) -> ()
+  ! CHECK: hlfir.end_associate %[[assoc]]#1, %[[assoc]]#2 : !fir.ref<i16>, i1
+  call bar(count(mask, kind=2))
+end subroutine

--- a/flang/test/Lower/allocatable-callee.f90
+++ b/flang/test/Lower/allocatable-callee.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test allocatable dummy argument on callee side
 
@@ -8,7 +8,8 @@ subroutine test_scalar(x)
   real, allocatable :: x
 
   print *, x
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[x]]#0 : !fir.ref<!fir.box<!fir.heap<f32>>>
   ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
   ! CHECK: %[[val:.*]] = fir.load %[[addr]] : !fir.heap<f32>
 end subroutine
@@ -19,10 +20,10 @@ subroutine test_array(x)
   integer, allocatable :: x(:,:)
 
   print *, x(1,2)
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
-  ! CHECK-DAG: fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>) -> !fir.heap<!fir.array<?x?xi32>>
-  ! CHECK-DAG: fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>, index) -> (index, index, index)
-  ! CHECK-DAG: fir.box_dims %[[box]], %c1{{.*}} : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>, index) -> (index, index, index)
+  ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[x]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xi32>>>>
+  ! CHECK: %[[elem:.*]] = hlfir.designate %[[box]] (%{{.*}}, %{{.*}})  : (!fir.box<!fir.heap<!fir.array<?x?xi32>>>, index, index) -> !fir.ref<i32>
+  ! CHECK: fir.load %[[elem]] : !fir.ref<i32>
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_deferred(
@@ -31,9 +32,11 @@ subroutine test_char_scalar_deferred(c)
   character(:), allocatable :: c
   external foo1
   call foo1(c)
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
   ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
-  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+  ! CHECK-DAG: %[[box1:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box1]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
@@ -44,9 +47,11 @@ subroutine test_char_scalar_explicit_cst(c)
   character(10), allocatable :: c
   external foo1
   call foo1(c)
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
-  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %c10{{.*}} : (!fir.heap<!fir.char<1,10>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+  ! CHECK: %[[cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[cast]], %c10{{.*}} : (!fir.ref<!fir.char<1,10>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 
@@ -57,17 +62,18 @@ subroutine test_char_scalar_explicit_dynamic(c, n)
   character(n), allocatable :: c
   external foo1
   ! Check that the length expr was evaluated before the execution parts.
-  ! CHECK: %[[raw_len:.*]] = fir.load %arg1 : !fir.ref<i32>
-  ! CHECK:  %[[c0_i32:.*]] = arith.constant 0 : i32
-  ! CHECK:  %[[cmp:.*]] = arith.cmpi sgt, %[[raw_len]], %[[c0_i32]] : i32
-  ! CHECK:  %[[len:.*]] = arith.select %[[cmp]], %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[n:.*]]:2 = hlfir.declare %[[arg1]]
+  ! CHECK: %[[raw_len:.*]] = fir.load %[[n]]#0 : !fir.ref<i32>
+  ! CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+  ! CHECK: %[[cmp:.*]] = arith.cmpi sgt, %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[len:.*]] = arith.select %[[cmp]], %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]] typeparams %[[len]]{{.*}}allocatable
   n = n + 1
-  ! CHECK: fir.store {{.*}} to %arg1 : !fir.ref<i32>
+  ! CHECK: hlfir.assign %{{.*}} to %[[n]]#0 : i32, !fir.ref<i32>
   call foo1(c)
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
-  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
-  ! CHECK-DAG: %[[len_cast:.*]] = fir.convert %[[len]] : (i32) -> index
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len_cast]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+  ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 
@@ -77,12 +83,10 @@ subroutine test_char_array_deferred(c)
   character(:), allocatable :: c(:)
   external foo1
   call foo1(c(10))
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
-  ! CHECK-DAG: fir.box_dims %[[box]], %c0{{.*}} : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>, index) -> (index, index, index)
-  ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
-  ! [...] address computation
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %[[len]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK: %[[len:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
+  ! CHECK: %[[boxchar:.*]] = hlfir.designate %[[box]] (%{{.*}})  typeparams %[[len]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>, index, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 
@@ -92,10 +96,10 @@ subroutine test_char_array_explicit_cst(c)
   character(10), allocatable :: c(:)
   external foo1
   call foo1(c(3))
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
-  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,10>>>
-  ! [...] address computation
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %c10{{.*}} : (!fir.ref<!fir.char<1,10>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK: %[[elem:.*]] = hlfir.designate %[[box]] (%{{.*}})  typeparams %c10{{.*}} : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>, index, index) -> !fir.ref<!fir.char<1,10>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[elem]], %c10{{.*}} : (!fir.ref<!fir.char<1,10>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 
@@ -106,19 +110,17 @@ subroutine test_char_array_explicit_dynamic(c, n)
   character(n), allocatable :: c(:)
   external foo1
   ! Check that the length expr was evaluated before the execution parts.
-  ! CHECK: %[[raw_len:.*]] = fir.load %arg1 : !fir.ref<i32>
-  ! CHECK:  %[[c0_i32:.*]] = arith.constant 0 : i32
-  ! CHECK:  %[[cmp:.*]] = arith.cmpi sgt, %[[raw_len]], %[[c0_i32]] : i32
-  ! CHECK:  %[[len:.*]] = arith.select %[[cmp]], %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[n:.*]]:2 = hlfir.declare %[[arg1]]
+  ! CHECK: %[[raw_len:.*]] = fir.load %[[n]]#0 : !fir.ref<i32>
+  ! CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
+  ! CHECK: %[[cmp:.*]] = arith.cmpi sgt, %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[len:.*]] = arith.select %[[cmp]], %[[raw_len]], %[[c0_i32]] : i32
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]] typeparams %[[len]]{{.*}}allocatable
   n = n + 1
-  ! CHECK: fir.store {{.*}} to %arg1 : !fir.ref<i32>
+  ! CHECK: hlfir.assign %{{.*}} to %[[n]]#0 : i32, !fir.ref<i32>
   call foo1(c(1))
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-  ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
-  ! [...] address computation
-  ! CHECK: fir.coordinate_of
-  ! CHECK-DAG: %[[len_cast:.*]] = fir.convert %[[len]] : (i32) -> index
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %{{.*}}, %[[len_cast]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+  ! CHECK: %[[boxchar:.*]] = hlfir.designate %[[box]] (%{{.*}})  typeparams %[[len]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>, index, i32) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPfoo1(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 
@@ -131,9 +133,11 @@ subroutine test_char_scalar_deferred_k2(c)
   character(kind=2, len=:), allocatable :: c
   external foo2
   call foo2(c)
-  ! CHECK: %[[box:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>
+  ! CHECK: %[[c:.*]]:2 = hlfir.declare %[[arg0]]{{.*}}allocatable
+  ! CHECK: %[[box:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>
   ! CHECK-DAG: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.char<2,?>>>) -> !fir.heap<!fir.char<2,?>>
-  ! CHECK-DAG: %[[size:.*]] = fir.box_elesize %[[box]] : (!fir.box<!fir.heap<!fir.char<2,?>>>) -> index
+  ! CHECK-DAG: %[[box1:.*]] = fir.load %[[c]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.char<2,?>>>>
+  ! CHECK-DAG: %[[size:.*]] = fir.box_elesize %[[box1]] : (!fir.box<!fir.heap<!fir.char<2,?>>>) -> index
   ! CHECK-DAG: %[[len:.*]] = arith.divsi %[[size]], %c2{{.*}} : index
   ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[addr]], %[[len]] : (!fir.heap<!fir.char<2,?>>, index) -> !fir.boxchar<2>
   ! CHECK: fir.call @_QPfoo2(%[[boxchar]]) {{.*}}: (!fir.boxchar<2>) -> ()
@@ -149,10 +153,11 @@ subroutine test_char_assumed(a)
   character(len=*), allocatable :: a
   ! CHECK: %[[argLoad:.*]] = fir.load %[[arg0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
   ! CHECK: %[[argLen:.*]] = fir.box_elesize %[[argLoad]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+  ! CHECK: hlfir.declare %[[arg0]] typeparams %[[argLen]]{{.*}}allocatable
 
   n = len(a)
   ! CHECK: %[[argLenCast:.*]] = fir.convert %[[argLen]] : (index) -> i32
-  ! CHECK: fir.store %[[argLenCast]] to %{{.*}} : !fir.ref<i32>
+  ! CHECK: hlfir.assign %[[argLenCast]] to %{{.*}} : i32, !fir.ref<i32>
 end subroutine
 
 ! CHECK-LABEL: _QPtest_char_assumed_optional(
@@ -168,10 +173,11 @@ subroutine test_char_assumed_optional(a)
   ! CHECK: } else {
   ! CHECK:   %[[undef:.*]] = fir.undefined index
   ! CHECK:   fir.result %[[undef]] : index
+  ! CHECK: %[[a:.*]]:2 = hlfir.declare %[[arg0]] typeparams %[[argLen]]{{.*}}allocatable, optional
 
   if (present(a)) then
     n = len(a)
     ! CHECK:   %[[argLenCast:.*]] = fir.convert %[[argLen]] : (index) -> i32
-    ! CHECK:   fir.store %[[argLenCast]] to %{{.*}} : !fir.ref<i32>
+    ! CHECK:   hlfir.assign %[[argLenCast]] to %{{.*}} : i32, !fir.ref<i32>
   endif
 end subroutine

--- a/flang/test/Lower/allocatable-caller.f90
+++ b/flang/test/Lower/allocatable-caller.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test passing allocatables on caller side
 
@@ -10,9 +10,10 @@ subroutine test_scalar_call()
   end subroutine
   end interface
   real, allocatable :: x
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {{{.*}}uniq_name = "_QFtest_scalar_callEx"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {{{.*}}uniq_name = "_QFtest_scalar_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]]{{.*}}allocatable
   call test_scalar(x)
-  ! CHECK: fir.call @_QPtest_scalar(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<f32>>>) -> ()
+  ! CHECK: fir.call @_QPtest_scalar(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<f32>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_array_call(
@@ -23,9 +24,10 @@ subroutine test_array_call()
   end subroutine
   end interface
   integer, allocatable :: x(:)
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {{{.*}}uniq_name = "_QFtest_array_callEx"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {{{.*}}uniq_name = "_QFtest_array_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]]{{.*}}allocatable
   call test_array(x)
-  ! CHECK: fir.call @_QPtest_array(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> ()
+  ! CHECK: fir.call @_QPtest_array(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_deferred_call(
@@ -36,9 +38,10 @@ subroutine test_char_scalar_deferred_call()
   end subroutine
   end interface
   character(:), allocatable :: x
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_deferred_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]]{{.*}}allocatable
   call test_char_scalar_deferred(x)
-  ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
+  ! CHECK: fir.call @_QPtest_char_scalar_deferred(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_scalar_explicit_call(
@@ -51,12 +54,14 @@ subroutine test_char_scalar_explicit_call(n)
   end interface
   character(10), allocatable :: x
   character(n), allocatable :: x2
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx2"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_char_scalar_explicit_callEx"}
+  ! CHECK: %[[alloca2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {{{.*}}uniq_name = "_QFtest_char_scalar_explicit_callEx2"}
+  ! CHECK: %[[box2:.*]]:2 = hlfir.declare %[[alloca2]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_char_scalar_explicit_callEx2"}
   call test_char_scalar_explicit(x)
-  ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
+  ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
   call test_char_scalar_explicit(x2)
-  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
   ! CHECK: fir.call @_QPtest_char_scalar_explicit(%[[box2cast]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> ()
 end subroutine
 
@@ -68,9 +73,10 @@ subroutine test_char_array_deferred_call()
   end subroutine
   end interface
   character(:), allocatable :: x(:)
-  ! CHECK: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_deferred_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]]{{.*}}allocatable
   call test_char_array_deferred(x)
-  ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
+  ! CHECK: fir.call @_QPtest_char_array_deferred(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> ()
 end subroutine
 
 ! CHECK-LABEL: func @_QPtest_char_array_explicit_call(
@@ -83,11 +89,13 @@ subroutine test_char_array_explicit_call(n)
   end interface
   character(10), allocatable :: x(:)
   character(n), allocatable :: x2(:)
-  ! CHECK-DAG: %[[box:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx"}
-  ! CHECK-DAG: %[[box2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx2"}
+  ! CHECK: %[[alloca:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx"}
+  ! CHECK: %[[box:.*]]:2 = hlfir.declare %[[alloca]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_char_array_explicit_callEx"}
+  ! CHECK: %[[alloca2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {{{.*}}uniq_name = "_QFtest_char_array_explicit_callEx2"}
+  ! CHECK: %[[box2:.*]]:2 = hlfir.declare %[[alloca2]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_char_array_explicit_callEx2"}
   call test_char_array_explicit(x)
-  ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
+  ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
   call test_char_array_explicit(x2)
-  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
+  ! CHECK: %[[box2cast:.*]] = fir.convert %[[box2]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>
   ! CHECK: fir.call @_QPtest_char_array_explicit(%[[box2cast]]) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> ()
 end subroutine

--- a/flang/test/Lower/assignment.f90
+++ b/flang/test/Lower/assignment.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 %s -o "-" -emit-fir -cpp -flang-deprecated-no-hlfir | FileCheck %s --check-prefixes=CHECK,%if flang-supports-f128-math %{F128%} %else %{F64%}%if target=x86_64-unknown-linux{{.*}} %{,CHECK-X86-64%}
+! RUN: %flang_fc1 %s -o "-" -emit-hlfir -cpp | FileCheck %s --check-prefixes=CHECK,%if flang-supports-f128-math %{F128%} %else %{F64%}%if target=x86_64-unknown-linux{{.*}} %{,CHECK-X86-64%}
 
 subroutine sub1(a)
   integer :: a
@@ -7,8 +7,9 @@ end
 
 ! CHECK-LABEL: func @_QPsub1(
 ! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32>
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[C1:.*]] = arith.constant 1 : i32
-! CHECK:         fir.store %[[C1]] to %[[ARG0]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[C1]] to %[[A]]#0 : i32, !fir.ref<i32>
 
 subroutine sub2(a, b)
   integer(4) :: a
@@ -17,11 +18,13 @@ subroutine sub2(a, b)
 end
 
 ! CHECK-LABEL: func @_QPsub2(
-! CHECK:         %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}
-! CHECK:         %[[B:.*]]: !fir.ref<i64> {fir.bindc_name = "b"}
-! CHECK:         %[[B_VAL:.*]] = fir.load %arg1 : !fir.ref<i64>
+! CHECK:         %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}
+! CHECK:         %[[ARG1:.*]]: !fir.ref<i64> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<i64>
 ! CHECK:         %[[B_CONV:.*]] = fir.convert %[[B_VAL]] : (i64) -> i32
-! CHECK:         fir.store %[[B_CONV]] to %[[A]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[B_CONV]] to %[[A]]#0 : i32, !fir.ref<i32>
 
 integer function negi(a)
   integer :: a
@@ -29,13 +32,15 @@ integer function negi(a)
 end
 
 ! CHECK-LABEL: func @_QPnegi(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) -> i32 {
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) -> i32 {
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca i32 {bindc_name = "negi", uniq_name = "_QFnegiEnegi"}
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<i32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
 ! CHECK:         %[[C0:.*]] = arith.constant 0 : i32
 ! CHECK:         %[[NEG:.*]] = arith.subi %[[C0]], %[[A_VAL]] : i32
-! CHECK:         fir.store %[[NEG]] to %[[FCTRES]] : !fir.ref<i32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[NEG]] to %[[FCTRES_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<i32>
 ! CHECK:         return %[[RET]] : i32
 
 real function negr(a)
@@ -44,12 +49,14 @@ real function negr(a)
 end
 
 ! CHECK-LABEL: func @_QPnegr(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"}) -> f32 {
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"}) -> f32 {
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca f32 {bindc_name = "negr", uniq_name = "_QFnegrEnegr"}
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<f32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<f32>
 ! CHECK:         %[[NEG:.*]] = arith.negf %[[A_VAL]] {{.*}}: f32
-! CHECK:         fir.store %[[NEG]] to %[[FCTRES]] : !fir.ref<f32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[NEG]] to %[[FCTRES_DECL]]#0 : f32, !fir.ref<f32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<f32>
 ! CHECK:         return %[[RET]] : f32
 
 complex function negc(a)
@@ -58,11 +65,13 @@ complex function negc(a)
 end
 
 ! CHECK-LABEL: func @_QPnegc(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"}) -> complex<f32> {
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"}) -> complex<f32> {
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca complex<f32> {bindc_name = "negc", uniq_name = "_QFnegcEnegc"}
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<complex<f32>>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         %[[NEG:.*]] = fir.negc %[[A_VAL]] : complex<f32>
-! CHECK:         fir.store %[[NEG]] to %[[FCTRES]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[NEG]] to %[[FCTRES_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
 
 integer function addi(a, b)
   integer :: a, b
@@ -70,14 +79,17 @@ integer function addi(a, b)
 end
 
 ! CHECK-LABEL: func @_QPaddi(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca i32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<i32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<i32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<i32>
 ! CHECK:         %[[ADD:.*]] = arith.addi %[[A_VAL]], %[[B_VAL]] : i32
-! CHECK:         fir.store %[[ADD]] to %[[FCTRES]] : !fir.ref<i32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[ADD]] to %[[FCTRES_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<i32>
 ! CHECK:         return %[[RET]] : i32
 
 integer function subi(a, b)
@@ -86,14 +98,17 @@ integer function subi(a, b)
 end
 
 ! CHECK-LABEL: func @_QPsubi(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca i32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<i32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<i32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<i32>
 ! CHECK:         %[[SUB:.*]] = arith.subi %[[A_VAL]], %[[B_VAL]] : i32
-! CHECK:         fir.store %[[SUB]] to %[[FCTRES]] : !fir.ref<i32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[SUB]] to %[[FCTRES_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<i32>
 ! CHECK:         return %[[RET]] : i32
 
 integer function muli(a, b)
@@ -102,14 +117,17 @@ integer function muli(a, b)
 end
 
 ! CHECK-LABEL: func @_QPmuli(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca i32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<i32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<i32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<i32>
 ! CHECK:         %[[MUL:.*]] = arith.muli %[[A_VAL]], %[[B_VAL]] : i32
-! CHECK:         fir.store %[[MUL]] to %[[FCTRES]] : !fir.ref<i32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[MUL]] to %[[FCTRES_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<i32>
 ! CHECK:         return %[[RET]] : i32
 
 integer function divi(a, b)
@@ -118,14 +136,17 @@ integer function divi(a, b)
 end
 
 ! CHECK-LABEL: func @_QPdivi(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca i32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<i32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<i32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<i32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<i32>
 ! CHECK:         %[[DIV:.*]] = arith.divsi %[[A_VAL]], %[[B_VAL]] : i32
-! CHECK:         fir.store %[[DIV]] to %[[FCTRES]] : !fir.ref<i32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<i32>
+! CHECK:         hlfir.assign %[[DIV]] to %[[FCTRES_DECL]]#0 : i32, !fir.ref<i32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<i32>
 ! CHECK:         return %[[RET]] : i32
 
 real function addf(a, b)
@@ -134,14 +155,17 @@ real function addf(a, b)
 end
 
 ! CHECK-LABEL: func @_QPaddf(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca f32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<f32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<f32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<f32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<f32>
 ! CHECK:         %[[ADD:.*]] = arith.addf %[[A_VAL]], %[[B_VAL]] {{.*}}: f32
-! CHECK:         fir.store %[[ADD]] to %[[FCTRES]] : !fir.ref<f32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[ADD]] to %[[FCTRES_DECL]]#0 : f32, !fir.ref<f32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<f32>
 ! CHECK:         return %[[RET]] : f32
 
 real function subf(a, b)
@@ -150,14 +174,17 @@ real function subf(a, b)
 end
 
 ! CHECK-LABEL: func @_QPsubf(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca f32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<f32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<f32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<f32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<f32>
 ! CHECK:         %[[SUB:.*]] = arith.subf %[[A_VAL]], %[[B_VAL]] {{.*}}: f32
-! CHECK:         fir.store %[[SUB]] to %[[FCTRES]] : !fir.ref<f32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[SUB]] to %[[FCTRES_DECL]]#0 : f32, !fir.ref<f32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<f32>
 ! CHECK:         return %[[RET]] : f32
 
 real function mulf(a, b)
@@ -166,14 +193,17 @@ real function mulf(a, b)
 end
 
 ! CHECK-LABEL: func @_QPmulf(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca f32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<f32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<f32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<f32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<f32>
 ! CHECK:         %[[MUL:.*]] = arith.mulf %[[A_VAL]], %[[B_VAL]] {{.*}}: f32
-! CHECK:         fir.store %[[MUL]] to %[[FCTRES]] : !fir.ref<f32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[MUL]] to %[[FCTRES_DECL]]#0 : f32, !fir.ref<f32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<f32>
 ! CHECK:         return %[[RET]] : f32
 
 real function divf(a, b)
@@ -182,14 +212,17 @@ real function divf(a, b)
 end
 
 ! CHECK-LABEL: func @_QPdivf(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca f32
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<f32>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<f32>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<f32>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<f32>
 ! CHECK:         %[[DIV:.*]] = arith.divf %[[A_VAL]], %[[B_VAL]] {{.*}}: f32
-! CHECK:         fir.store %[[DIV]] to %[[FCTRES]] : !fir.ref<f32>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[DIV]] to %[[FCTRES_DECL]]#0 : f32, !fir.ref<f32>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<f32>
 ! CHECK:         return %[[RET]] : f32
 
 complex function addc(a, b)
@@ -198,14 +231,17 @@ complex function addc(a, b)
 end
 
 ! CHECK-LABEL: func @_QPaddc(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca complex<f32>
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<complex<f32>>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<complex<f32>>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<complex<f32>>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         %[[ADD:.*]] = fir.addc %[[A_VAL]], %[[B_VAL]] {fastmath = #arith.fastmath<contract>} : complex<f32>
-! CHECK:         fir.store %[[ADD]] to %[[FCTRES]] : !fir.ref<complex<f32>>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[ADD]] to %[[FCTRES_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         return %[[RET]] : complex<f32>
 
 complex function subc(a, b)
@@ -214,14 +250,17 @@ complex function subc(a, b)
 end
 
 ! CHECK-LABEL: func @_QPsubc(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca complex<f32>
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<complex<f32>>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<complex<f32>>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<complex<f32>>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         %[[SUB:.*]] = fir.subc %[[A_VAL]], %[[B_VAL]] {fastmath = #arith.fastmath<contract>} : complex<f32>
-! CHECK:         fir.store %[[SUB]] to %[[FCTRES]] : !fir.ref<complex<f32>>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[SUB]] to %[[FCTRES_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         return %[[RET]] : complex<f32>
 
 complex function mulc(a, b)
@@ -230,14 +269,17 @@ complex function mulc(a, b)
 end
 
 ! CHECK-LABEL: func @_QPmulc(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca complex<f32>
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<complex<f32>>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<complex<f32>>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<complex<f32>>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         %[[MUL:.*]] = fir.mulc %[[A_VAL]], %[[B_VAL]] {fastmath = #arith.fastmath<contract>} : complex<f32>
-! CHECK:         fir.store %[[MUL]] to %[[FCTRES]] : !fir.ref<complex<f32>>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[MUL]] to %[[FCTRES_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         return %[[RET]] : complex<f32>
 
 complex function divc(a, b)
@@ -246,18 +288,21 @@ complex function divc(a, b)
 end
 
 ! CHECK-LABEL: func @_QPdivc(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
-! CHECK-SAME:    %[[B:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"},
+! CHECK-SAME:    %[[ARG1:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "b"}
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]
+! CHECK:         %[[B:.*]]:2 = hlfir.declare %[[ARG1]]
 ! CHECK:         %[[FCTRES:.*]] = fir.alloca complex<f32>
-! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]] : !fir.ref<complex<f32>>
-! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]] : !fir.ref<complex<f32>>
+! CHECK:         %[[FCTRES_DECL:.*]]:2 = hlfir.declare %[[FCTRES]]
+! CHECK:         %[[A_VAL:.*]] = fir.load %[[A]]#0 : !fir.ref<complex<f32>>
+! CHECK:         %[[B_VAL:.*]] = fir.load %[[B]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         %[[A_REAL:.*]] = fir.extract_value %[[A_VAL]], [0 : index] : (complex<f32>) -> f32
 ! CHECK:         %[[A_IMAG:.*]] = fir.extract_value %[[A_VAL]], [1 : index] : (complex<f32>) -> f32
 ! CHECK:         %[[B_REAL:.*]] = fir.extract_value %[[B_VAL]], [0 : index] : (complex<f32>) -> f32
 ! CHECK:         %[[B_IMAG:.*]] = fir.extract_value %[[B_VAL]], [1 : index] : (complex<f32>) -> f32
 ! CHECK:         %[[DIV:.*]] = fir.call @__divsc3(%[[A_REAL]], %[[A_IMAG]], %[[B_REAL]], %[[B_IMAG]]) fastmath<contract> : (f32, f32, f32, f32) -> complex<f32>
-! CHECK:         fir.store %[[DIV]] to %[[FCTRES]] : !fir.ref<complex<f32>>
-! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[DIV]] to %[[FCTRES_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
+! CHECK:         %[[RET:.*]] = fir.load %[[FCTRES_DECL]]#0 : !fir.ref<complex<f32>>
 ! CHECK:         return %[[RET]] : complex<f32>
 
 subroutine real_constant()
@@ -279,23 +324,29 @@ subroutine real_constant()
 end
 
 ! CHECK: %[[A:.*]] = fir.alloca f16
+! CHECK: %[[A_DECL:.*]]:2 = hlfir.declare %[[A]]
 ! CHECK: %[[B:.*]] = fir.alloca f32
+! CHECK: %[[B_DECL:.*]]:2 = hlfir.declare %[[B]]
 ! CHECK: %[[C:.*]] = fir.alloca f64
+! CHECK: %[[C_DECL:.*]]:2 = hlfir.declare %[[C]]
 ! CHECK-X86-64: %[[D:.*]] = fir.alloca f80
+! CHECK-X86-64: %[[D_DECL:.*]]:2 = hlfir.declare %[[D]]
 ! F128: %[[E:.*]] = fir.alloca f128
 ! F64: %[[E:.*]] = fir.alloca f64
+! F128: %[[E_DECL:.*]]:2 = hlfir.declare %[[E]]
+! F64: %[[E_DECL:.*]]:2 = hlfir.declare %[[E]]
 ! CHECK: %[[C2:.*]] = arith.constant 2.000000e+00 : f16
-! CHECK: fir.store %[[C2]] to %[[A]] : !fir.ref<f16>
+! CHECK: hlfir.assign %[[C2]] to %[[A_DECL]]#0 : f16, !fir.ref<f16>
 ! CHECK: %[[C4:.*]] = arith.constant 4.000000e+00 : f32
-! CHECK: fir.store %[[C4]] to %[[B]] : !fir.ref<f32>
+! CHECK: hlfir.assign %[[C4]] to %[[B_DECL]]#0 : f32, !fir.ref<f32>
 ! CHECK: %[[C8:.*]] = arith.constant 8.000000e+00 : f64
-! CHECK: fir.store %[[C8]] to %[[C]] : !fir.ref<f64>
+! CHECK: hlfir.assign %[[C8]] to %[[C_DECL]]#0 : f64, !fir.ref<f64>
 ! CHECK-X86-64: %[[C10:.*]] = arith.constant 1.000000e+01 : f80
-! CHECK-X86-64: fir.store %[[C10]] to %[[D]] : !fir.ref<f80>
+! CHECK-X86-64: hlfir.assign %[[C10]] to %[[D_DECL]]#0 : f80, !fir.ref<f80>
 ! F128: %[[C16:.*]] = arith.constant 1.600000e+01 : f128
 ! F64: %[[C16:.*]] = arith.constant 1.600000e+01 : f64
-! F128: fir.store %[[C16]] to %[[E]] : !fir.ref<f128>
-! F64: fir.store %[[C16]] to %[[E]] : !fir.ref<f64>
+! F128: hlfir.assign %[[C16]] to %[[E_DECL]]#0 : f128, !fir.ref<f128>
+! F64: hlfir.assign %[[C16]] to %[[E_DECL]]#0 : f64, !fir.ref<f64>
 
 subroutine complex_constant()
   complex(4) :: a
@@ -304,12 +355,13 @@ end
 
 ! CHECK-LABEL: func @_QPcomplex_constant()
 ! CHECK:         %[[A:.*]] = fir.alloca complex<f32> {bindc_name = "a", uniq_name = "_QFcomplex_constantEa"}
+! CHECK:         %[[A_DECL:.*]]:2 = hlfir.declare %[[A]]
 ! CHECK:         %[[C0:.*]] = arith.constant 0.000000e+00 : f32
 ! CHECK:         %[[C1:.*]] = arith.constant 1.000000e+00 : f32
 ! CHECK:         %[[UNDEF:.*]] = fir.undefined complex<f32>
 ! CHECK:         %[[INS0:.*]] = fir.insert_value %[[UNDEF]], %[[C0]], [0 : index] : (complex<f32>, f32) -> complex<f32>
 ! CHECK:         %[[INS1:.*]] = fir.insert_value %[[INS0]], %[[C1]], [1 : index] : (complex<f32>, f32) -> complex<f32>
-! CHECK:         fir.store %[[INS1]] to %[[A]] : !fir.ref<complex<f32>>
+! CHECK:         hlfir.assign %[[INS1]] to %[[A_DECL]]#0 : complex<f32>, !fir.ref<complex<f32>>
 
 subroutine sub1_arr(a)
   integer :: a(10)
@@ -317,13 +369,12 @@ subroutine sub1_arr(a)
 end
 
 ! CHECK-LABEL: func @_QPsub1_arr(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<!fir.array<10xi32>> {fir.bindc_name = "a"})
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<!fir.array<10xi32>> {fir.bindc_name = "a"})
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]({{.*}}) {{.*}} {uniq_name = "_QFsub1_arrEa"}
 ! CHECK-DAG:     %[[C10:.*]] = arith.constant 10 : i32
-! CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : i64
-! CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : i64
-! CHECK:         %[[ZERO_BASED_INDEX:.*]] = arith.subi %[[C2]], %[[C1]] : i64
-! CHECK:         %[[COORD:.*]] = fir.coordinate_of %[[A]], %[[ZERO_BASED_INDEX]] : (!fir.ref<!fir.array<10xi32>>, i64) -> !fir.ref<i32>
-! CHECK:         fir.store %[[C10]] to %[[COORD]] : !fir.ref<i32>
+! CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
+! CHECK:         %[[ELEM:.*]] = hlfir.designate %[[A]]#0 (%[[C2]])  : (!fir.ref<!fir.array<10xi32>>, index) -> !fir.ref<i32>
+! CHECK:         hlfir.assign %[[C10]] to %[[ELEM]] : i32, !fir.ref<i32>
 ! CHECK:         return
 
 subroutine sub2_arr(a)
@@ -332,17 +383,8 @@ subroutine sub2_arr(a)
 end
 
 ! CHECK-LABEL: func @_QPsub2_arr(
-! CHECK-SAME:    %[[A:.*]]: !fir.ref<!fir.array<10xi32>> {fir.bindc_name = "a"})
-! CHECK-DAG:     %[[C10_0:.*]] = arith.constant 10 : index
-! CHECK:         %[[SHAPE:.*]] = fir.shape %[[C10_0]] : (index) -> !fir.shape<1>
-! CHECK:         %[[LOAD:.*]] = fir.array_load %[[A]](%[[SHAPE]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.array<10xi32>
-! CHECK-DAG:     %[[C10_1:.*]] = arith.constant 10 : i32
-! CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
-! CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
-! CHECK-DAG:     %[[UB:.*]] = arith.subi %[[C10_0]], %c1 : index
-! CHECK:         %[[DO_RES:.*]] = fir.do_loop %[[ARG1:.*]] = %[[C0]] to %[[UB]] step %[[C1]] unordered iter_args(%[[ARG2:.*]] = %[[LOAD]]) -> (!fir.array<10xi32>) {
-! CHECK:           %[[RES:.*]] = fir.array_update %[[ARG2]], %[[C10_1]], %[[ARG1]] : (!fir.array<10xi32>, i32, index) -> !fir.array<10xi32>
-! CHECK:           fir.result %[[RES]] : !fir.array<10xi32>
-! CHECK:         }
-! CHECK:         fir.array_merge_store %[[LOAD]], %[[DO_RES]] to %[[A]] : !fir.array<10xi32>, !fir.array<10xi32>, !fir.ref<!fir.array<10xi32>>
+! CHECK-SAME:    %[[ARG0:.*]]: !fir.ref<!fir.array<10xi32>> {fir.bindc_name = "a"})
+! CHECK:         %[[A:.*]]:2 = hlfir.declare %[[ARG0]]({{.*}}) {{.*}} {uniq_name = "_QFsub2_arrEa"}
+! CHECK:         %[[C10:.*]] = arith.constant 10 : i32
+! CHECK:         hlfir.assign %[[C10]] to %[[A]]#0 : i32, !fir.ref<!fir.array<10xi32>>
 ! CHECK:         return

--- a/flang/test/Lower/assumed-shape-caller.f90
+++ b/flang/test/Lower/assumed-shape-caller.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test passing arrays to assumed shape dummy arguments
 
@@ -16,10 +16,11 @@ subroutine foo()
   ! CHECK-DAG: %[[c55:.*]] = arith.constant 55 : index
   ! CHECK-DAG: %[[c12:.*]] = arith.constant 12 : index
   ! CHECK-DAG: %[[addr:.*]] = fir.alloca !fir.array<42x55x12xf32> {{{.*}}uniq_name = "_QFfooEx"}
+  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
+  ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[addr]](%[[shape]]) {uniq_name = "_QFfooEx"}
 
   call bar(x)
-  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
-  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) : (!fir.ref<!fir.array<42x55x12xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<42x55x12xf32>>
+  ! CHECK: %[[embox:.*]] = fir.embox %[[x]]#0(%[[shape]]) : (!fir.ref<!fir.array<42x55x12xf32>>, !fir.shape<3>) -> !fir.box<!fir.array<42x55x12xf32>>
   ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<42x55x12xf32>>) -> !fir.box<!fir.array<?x?x?xf32>>
   ! CHECK: fir.call @_QPbar(%[[castedBox]]) {{.*}}: (!fir.box<!fir.array<?x?x?xf32>>) -> ()
 end subroutine
@@ -34,16 +35,16 @@ subroutine foo_char(x)
     end subroutine
   end interface
   character(*) :: x(42, 55, 12)
-  ! CHECK-DAG: %[[x:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[x]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>
+  ! CHECK-DAG: %[[unb:.*]]:2 = fir.unboxchar %arg0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
+  ! CHECK-DAG: %[[addr:.*]] = fir.convert %[[unb]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>
   ! CHECK-DAG: %[[c42:.*]] = arith.constant 42 : index
   ! CHECK-DAG: %[[c55:.*]] = arith.constant 55 : index
   ! CHECK-DAG: %[[c12:.*]] = arith.constant 12 : index
+  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
+  ! CHECK: %[[x:.*]]:2 = hlfir.declare %[[addr]](%[[shape]]) typeparams %[[unb]]#1{{.*}} {uniq_name = "_QFfoo_charEx"}{{.*}} -> (!fir.box<!fir.array<42x55x12x!fir.char<1,?>>>, !fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>)
 
   call bar_char(x)
-  ! CHECK: %[[shape:.*]] = fir.shape %[[c42]], %[[c55]], %[[c12]] : (index, index, index) -> !fir.shape<3>
-  ! CHECK: %[[embox:.*]] = fir.embox %[[addr]](%[[shape]]) typeparams %[[x]]#1 : (!fir.ref<!fir.array<42x55x12x!fir.char<1,?>>>, !fir.shape<3>, index) -> !fir.box<!fir.array<42x55x12x!fir.char<1,?>>>
-  ! CHECK: %[[castedBox:.*]] = fir.convert %[[embox]] : (!fir.box<!fir.array<42x55x12x!fir.char<1,?>>>) -> !fir.box<!fir.array<?x?x?x!fir.char<1,?>>>
+  ! CHECK: %[[castedBox:.*]] = fir.convert %[[x]]#0 : (!fir.box<!fir.array<42x55x12x!fir.char<1,?>>>) -> !fir.box<!fir.array<?x?x?x!fir.char<1,?>>>
   ! CHECK: fir.call @_QPbar_char(%[[castedBox]]) {{.*}}: (!fir.box<!fir.array<?x?x?x!fir.char<1,?>>>) -> ()
 end subroutine
 
@@ -61,34 +62,31 @@ subroutine test_vector_subcripted_section_to_box(v, x)
   integer :: v(:)
   real :: x(:)
   call takes_box(x(v))
-! CHECK:  %[[VAL_2:.*]] = arith.constant 1 : index
-! CHECK:  %[[VAL_3:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_4:.*]]:3 = fir.box_dims %[[VAL_1]], %[[VAL_3]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
-! CHECK:  %[[VAL_5:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_6:.*]]:3 = fir.box_dims %[[VAL_0]], %[[VAL_5]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
-! CHECK:  %[[VAL_7:.*]] = fir.array_load %[[VAL_0]] : (!fir.box<!fir.array<?xi32>>) -> !fir.array<?xi32>
-! CHECK:  %[[VAL_8:.*]] = arith.cmpi sgt, %[[VAL_6]]#1, %[[VAL_4]]#1 : index
-! CHECK:  %[[VAL_9:.*]] = arith.select %[[VAL_8]], %[[VAL_4]]#1, %[[VAL_6]]#1 : index
-! CHECK:  %[[VAL_10:.*]] = fir.array_load %[[VAL_1]] : (!fir.box<!fir.array<?xf32>>) -> !fir.array<?xf32>
-! CHECK:  %[[VAL_11:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_9]] {uniq_name = ".array.expr"}
-! CHECK:  %[[VAL_12:.*]] = fir.shape %[[VAL_9]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_13:.*]] = fir.array_load %[[VAL_11]](%[[VAL_12]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.array<?xf32>
-! CHECK:  %[[VAL_14:.*]] = arith.constant 1 : index
-! CHECK:  %[[VAL_15:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_16:.*]] = arith.subi %[[VAL_9]], %[[VAL_14]] : index
-! CHECK:  %[[VAL_17:.*]] = fir.do_loop %[[VAL_18:.*]] = %[[VAL_15]] to %[[VAL_16]] step %[[VAL_14]] unordered iter_args(%[[VAL_19:.*]] = %[[VAL_13]]) -> (!fir.array<?xf32>) {
-! CHECK:    %[[VAL_20:.*]] = fir.array_fetch %[[VAL_7]], %[[VAL_18]] : (!fir.array<?xi32>, index) -> i32
-! CHECK:    %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i32) -> index
-! CHECK:    %[[VAL_22:.*]] = arith.subi %[[VAL_21]], %[[VAL_2]] : index
-! CHECK:    %[[VAL_23:.*]] = fir.array_fetch %[[VAL_10]], %[[VAL_22]] : (!fir.array<?xf32>, index) -> f32
-! CHECK:    %[[VAL_24:.*]] = fir.array_update %[[VAL_19]], %[[VAL_23]], %[[VAL_18]] : (!fir.array<?xf32>, f32, index) -> !fir.array<?xf32>
-! CHECK:    fir.result %[[VAL_24]] : !fir.array<?xf32>
+! CHECK:  %[[V:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} {uniq_name = "_QFtest_vector_subcripted_section_to_boxEv"}
+! CHECK:  %[[X:.*]]:2 = hlfir.declare %[[VAL_1]] {{.*}} {uniq_name = "_QFtest_vector_subcripted_section_to_boxEx"}
+! CHECK:  %[[c0:.*]] = arith.constant 0 : index
+! CHECK:  %[[VDIMS:.*]]:3 = fir.box_dims %[[V]]#0, %[[c0]] : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+! CHECK:  %[[SHAPE_V:.*]] = fir.shape %[[VDIMS]]#1 : (index) -> !fir.shape<1>
+! CHECK:  %[[VEXPR:.*]] = hlfir.elemental %[[SHAPE_V]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi64> {
+! CHECK:  ^bb0(%[[I:.*]]: index):
+! CHECK:    %[[VELEM:.*]] = hlfir.designate %[[V]]#0 (%[[I]])  : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:    %[[VVAL:.*]] = fir.load %[[VELEM]] : !fir.ref<i32>
+! CHECK:    %[[VVAL64:.*]] = fir.convert %[[VVAL]] : (i32) -> i64
+! CHECK:    hlfir.yield_element %[[VVAL64]] : i64
 ! CHECK:  }
-! CHECK:  fir.array_merge_store %[[VAL_13]], %[[VAL_25:.*]] to %[[VAL_11]] : !fir.array<?xf32>, !fir.array<?xf32>, !fir.heap<!fir.array<?xf32>>
-! CHECK:  %[[VAL_26:.*]] = fir.shape %[[VAL_9]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_27:.*]] = fir.embox %[[VAL_11]](%[[VAL_26]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xf32>>
-! CHECK:  fir.call @_QPtakes_box(%[[VAL_27]]) {{.*}}: (!fir.box<!fir.array<?xf32>>) -> ()
-! CHECK:  fir.freemem %[[VAL_11]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:  %[[SHAPE_X:.*]] = fir.shape %[[VDIMS]]#1 : (index) -> !fir.shape<1>
+! CHECK:  %[[XEXPR:.*]] = hlfir.elemental %[[SHAPE_X]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xf32> {
+! CHECK:  ^bb0(%[[I2:.*]]: index):
+! CHECK:    %[[IDX:.*]] = hlfir.apply %[[VEXPR]], %[[I2]] : (!hlfir.expr<?xi64>, index) -> i64
+! CHECK:    %[[XELEM:.*]] = hlfir.designate %[[X]]#0 (%[[IDX]])  : (!fir.box<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+! CHECK:    %[[XVAL:.*]] = fir.load %[[XELEM]] : !fir.ref<f32>
+! CHECK:    hlfir.yield_element %[[XVAL]] : f32
+! CHECK:  }
+! CHECK:  %[[ASSOC:.*]]:3 = hlfir.associate %[[XEXPR]](%[[SHAPE_X]]) {{.*}}: (!hlfir.expr<?xf32>, !fir.shape<1>) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>, i1)
+! CHECK:  fir.call @_QPtakes_box(%[[ASSOC]]#0) {{.*}}: (!fir.box<!fir.array<?xf32>>) -> ()
+! CHECK:  hlfir.end_associate %[[ASSOC]]#1, %[[ASSOC]]#2 : !fir.ref<!fir.array<?xf32>>, i1
+! CHECK:  hlfir.destroy %[[XEXPR]] : !hlfir.expr<?xf32>
+! CHECK:  hlfir.destroy %[[VEXPR]] : !hlfir.expr<?xi64>
 end subroutine
 
 ! Test external function declarations


### PR DESCRIPTION
Convert five tests to use new HLFIR lowering instead of legacy FIR lowering:
Lower/allocatable-callee.f90, Lower/allocatable-caller.f90, Lower/assignment.f90, Lower/assumed-shape-caller.f90, Lower/Intrinsics/count.f90
