### PR TITLE
[Github] Disable prune-unused-branches workflow

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -8,8 +8,6 @@ on:
     paths:
      - .github/workflows/prune-branches.yml
      - .github/workflows/prune-unused-branches.py
-  schedule:
-    - cron: '0 8 * * *' # Runs daily at 08:00 UTC.
 
 jobs:
   prune-branches:


### PR DESCRIPTION
It decided to delete 237 branches today which is probably not correct
and at least one of them was tied to an open PR which is definitely not
correct, so disable for now until we can investigate fully.