### PR TITLE
[flang][NFC] Converted five tests from old lowering to new lowering (part 54)

### DIFF
--- a/flang/test/Lower/Intrinsics/c_f_pointer.f90
+++ b/flang/test/Lower/Intrinsics/c_f_pointer.f90
@@ -1,16 +1,17 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test intrinsic module procedure c_f_pointer
 
 ! CHECK-LABEL: func.func @_QPtest_scalar(
 ! CHECK-SAME:                            %[[VAL_0:.*]]: !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>> {fir.bindc_name = "cptr"},
 ! CHECK-SAME:                            %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<f32>>> {fir.bindc_name = "fptr"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<i64>
-! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> !fir.ptr<f32>
-! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_5]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
-! CHECK:         fir.store %[[VAL_6]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<f32>>>
+! CHECK:         %[[CPTR:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} {uniq_name = "_QFtest_scalarEcptr"}
+! CHECK:         %[[FPTR:.*]]:2 = hlfir.declare %[[VAL_1]] {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_scalarEfptr"}
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %[[CPTR]]#0, __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<f32>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]] : (!fir.ptr<f32>) -> !fir.box<!fir.ptr<f32>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR]]#0 : !fir.ref<!fir.box<!fir.ptr<f32>>>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -25,22 +26,24 @@ end
 ! CHECK-LABEL: func.func @_QPtest_array(
 ! CHECK-SAME:                           %[[VAL_0:.*]]: !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>> {fir.bindc_name = "cptr"},
 ! CHECK-SAME:                           %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>> {fir.bindc_name = "fptr"}) {
-! CHECK:         %[[VAL_66:.*]] = fir.coordinate_of %[[VAL_0]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_67:.*]] = fir.load %[[VAL_66]] : !fir.ref<i64>
-! CHECK:         %[[VAL_68:.*]] = fir.convert %[[VAL_67]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
-! CHECK:         %[[VAL_69:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_70:.*]] = fir.coordinate_of %[[VAL_53:.*]], %[[VAL_69]] : (!fir.heap<!fir.array<2xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_71:.*]] = fir.load %[[VAL_70]] : !fir.ref<i32>
-! CHECK:         %[[VAL_72:.*]] = fir.convert %[[VAL_71]] : (i32) -> index
-! CHECK:         %[[VAL_73:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_74:.*]] = fir.coordinate_of %[[VAL_53]], %[[VAL_73]] : (!fir.heap<!fir.array<2xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_75:.*]] = fir.load %[[VAL_74]] : !fir.ref<i32>
-! CHECK:         %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (i32) -> index
-! CHECK:         %[[VAL_77:.*]] = fir.shape %[[VAL_72]], %[[VAL_76]] : (index, index) -> !fir.shape<2>
-! CHECK:         %[[VAL_78:.*]] = fir.embox %[[VAL_68]](%[[VAL_77]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-! CHECK:         fir.store %[[VAL_78]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
-! CHECK:         return
-! CHECK:       }
+! CHECK:         %[[CPTR:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} {uniq_name = "_QFtest_arrayEcptr"}
+! CHECK:         %[[FPTR:.*]]:2 = hlfir.declare %[[VAL_1]] {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_arrayEfptr"}
+! CHECK:         %[[ARR:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = ".tmp.arrayctor"} : (!fir.heap<!fir.array<2xi32>>, !fir.shape<1>) -> (!fir.heap<!fir.array<2xi32>>, !fir.heap<!fir.array<2xi32>>)
+! CHECK:         %[[ASSOC:.*]]:3 = hlfir.associate %{{.*}}({{.*}}) {{.*}} : (!hlfir.expr<2xi32>, !fir.shape<1>) -> (!fir.ref<!fir.array<2xi32>>, !fir.ref<!fir.array<2xi32>>, i1)
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %[[CPTR]]#0, __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
+! CHECK:         %[[CONST_0:.*]] = arith.constant 0 : index
+! CHECK:         %[[E0:.*]] = fir.coordinate_of %[[ASSOC]]#0, %[[CONST_0]] : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D1_VAL:.*]] = fir.load %[[E0]] : !fir.ref<i32>
+! CHECK:         %[[D1:.*]] = fir.convert %[[D1_VAL]] : (i32) -> index
+! CHECK:         %[[CONST_1:.*]] = arith.constant 1 : index
+! CHECK:         %[[E1:.*]] = fir.coordinate_of %[[ASSOC]]#0, %[[CONST_1]] : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D2_VAL:.*]] = fir.load %[[E1]] : !fir.ref<i32>
+! CHECK:         %[[D2:.*]] = fir.convert %[[D2_VAL]] : (i32) -> index
+! CHECK:         %[[SHAPE:.*]] = fir.shape %[[D1]], %[[D2]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]](%[[SHAPE]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
 
 subroutine test_array(cptr, fptr)
   use iso_c_binding
@@ -54,11 +57,13 @@ end
 ! CHECK-LABEL: func.func @_QPtest_char(
 ! CHECK-SAME:                          %[[VAL_0:.*]]: !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>> {fir.bindc_name = "cptr"},
 ! CHECK-SAME:                          %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.char<1,10>>>> {fir.bindc_name = "fptr"}) {
-! CHECK:         %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_3]] : !fir.ref<i64>
-! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> !fir.ptr<!fir.char<1,10>>
-! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_5]] : (!fir.ptr<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
-! CHECK:         fir.store %[[VAL_6]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,10>>>>
+! CHECK:         %[[CPTR:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}} {uniq_name = "_QFtest_charEcptr"}
+! CHECK:         %[[FPTR:.*]]:2 = hlfir.declare %[[VAL_1]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_charEfptr"}
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %[[CPTR]]#0, __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<!fir.char<1,10>>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]] : (!fir.ptr<!fir.char<1,10>>) -> !fir.box<!fir.ptr<!fir.char<1,10>>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.char<1,10>>>>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -74,26 +79,27 @@ end
 ! CHECK-SAME:                               %[[VAL_0:.*]]: !fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>> {fir.bindc_name = "cptr"},
 ! CHECK-SAME:                               %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>> {fir.bindc_name = "fptr"},
 ! CHECK-SAME:                               %[[VAL_2:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
-! CHECK:         %[[VAL_7:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : i32
-! CHECK:         %[[VAL_9:.*]] = arith.cmpi sgt, %[[VAL_7]], %[[VAL_8]] : i32
-! CHECK:         %[[VAL_10:.*]] = arith.select %[[VAL_9]], %[[VAL_7]], %[[VAL_8]] : i32
-! CHECK:         %[[VAL_71:.*]] = fir.coordinate_of %[[VAL_0]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_72:.*]] = fir.load %[[VAL_71]] : !fir.ref<i64>
-! CHECK:         %[[VAL_73:.*]] = fir.convert %[[VAL_72]] : (i64) -> !fir.ptr<!fir.array<?x?x!fir.char<1,?>>>
-! CHECK:         %[[VAL_74:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_75:.*]] = fir.coordinate_of %[[VAL_58:.*]], %[[VAL_74]] : (!fir.heap<!fir.array<2xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_76:.*]] = fir.load %[[VAL_75]] : !fir.ref<i32>
-! CHECK:         %[[VAL_77:.*]] = fir.convert %[[VAL_76]] : (i32) -> index
-! CHECK:         %[[VAL_78:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_79:.*]] = fir.coordinate_of %[[VAL_58]], %[[VAL_78]] : (!fir.heap<!fir.array<2xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_80:.*]] = fir.load %[[VAL_79]] : !fir.ref<i32>
-! CHECK:         %[[VAL_81:.*]] = fir.convert %[[VAL_80]] : (i32) -> index
-! CHECK:         %[[VAL_82:.*]] = fir.shape %[[VAL_77]], %[[VAL_81]] : (index, index) -> !fir.shape<2>
-! CHECK:         %[[VAL_83:.*]] = fir.embox %[[VAL_73]](%[[VAL_82]]) typeparams %[[VAL_10]] : (!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, i32) -> !fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>
-! CHECK:         fir.store %[[VAL_83]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>>
-! CHECK:         return
-! CHECK:       }
+! CHECK:         %[[N:.*]]:2 = hlfir.declare %[[VAL_2]] {{.*}} {uniq_name = "_QFtest_chararrayEn"}
+! CHECK:         %[[N_VAL:.*]] = fir.load %[[N]]#0 : !fir.ref<i32>
+! CHECK:         %[[ZERO:.*]] = arith.constant 0 : i32
+! CHECK:         %[[CMP:.*]] = arith.cmpi sgt, %[[N_VAL]], %[[ZERO]] : i32
+! CHECK:         %[[LEN:.*]] = arith.select %[[CMP]], %[[N_VAL]], %[[ZERO]] : i32
+! CHECK:         %[[FPTR:.*]]:2 = hlfir.declare %[[VAL_1]] typeparams %[[LEN]] {{.*}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_chararrayEfptr"}
+! CHECK:         %[[ASSOC:.*]]:3 = hlfir.associate %{{.*}}({{.*}}) {{.*}} : (!hlfir.expr<2xi32>, !fir.shape<1>) -> (!fir.ref<!fir.array<2xi32>>, !fir.ref<!fir.array<2xi32>>, i1)
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %{{.*}}#0, __address
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<!fir.array<?x?x!fir.char<1,?>>>
+! CHECK:         %[[CZERO:.*]] = arith.constant 0 : index
+! CHECK:         %[[E0:.*]] = fir.coordinate_of %[[ASSOC]]#0, %[[CZERO]] : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D1_VAL:.*]] = fir.load %[[E0]] : !fir.ref<i32>
+! CHECK:         %[[D1:.*]] = fir.convert %[[D1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE:.*]] = arith.constant 1 : index
+! CHECK:         %[[E1:.*]] = fir.coordinate_of %[[ASSOC]]#0, %[[CONE]] : (!fir.ref<!fir.array<2xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D2_VAL:.*]] = fir.load %[[E1]] : !fir.ref<i32>
+! CHECK:         %[[D2:.*]] = fir.convert %[[D2_VAL]] : (i32) -> index
+! CHECK:         %[[SHAPE:.*]] = fir.shape %[[D1]], %[[D2]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]](%[[SHAPE]]) typeparams %[[LEN]] : (!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>, !fir.shape<2>, i32) -> !fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x!fir.char<1,?>>>>>
 
 subroutine test_chararray(cptr, fptr, n)
   use iso_c_binding
@@ -110,15 +116,16 @@ subroutine dynamic_shape_size(cptr, fptr, shape)
   type(c_ptr)  :: cptr
   real, pointer :: fptr(:, :)
   integer :: shape(:)
-! CHECK:         %[[VAL_7:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_8:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_7]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_9:.*]] = fir.load %[[VAL_8]] : !fir.ref<i32>
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i32) -> index
-! CHECK:         %[[VAL_11:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_12:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_11]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_13:.*]] = fir.load %[[VAL_12]] : !fir.ref<i32>
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (i32) -> index
-! CHECK:         %[[VAL_15:.*]] = fir.shape %[[VAL_10]], %[[VAL_14]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[SHAPE_DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdynamic_shape_sizeEshape"}
+! CHECK:         %[[CZERO:.*]] = arith.constant 0 : index
+! CHECK:         %[[E0:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CZERO]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D1_VAL:.*]] = fir.load %[[E0]] : !fir.ref<i32>
+! CHECK:         %[[D1:.*]] = fir.convert %[[D1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE:.*]] = arith.constant 1 : index
+! CHECK:         %[[E1:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CONE]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D2_VAL:.*]] = fir.load %[[E1]] : !fir.ref<i32>
+! CHECK:         %[[D2:.*]] = fir.convert %[[D2_VAL]] : (i32) -> index
+! CHECK:         %[[SHAPE_OP:.*]] = fir.shape %[[D1]], %[[D2]] : (index, index) -> !fir.shape<2>
   call c_f_pointer(cptr, fptr, shape)
 end subroutine
 
@@ -129,15 +136,16 @@ subroutine dynamic_shape_size_2(cptr, fptr, shape, n)
   real, pointer :: fptr(:, :)
   integer :: n
   integer :: shape(n)
-! CHECK:         %[[VAL_8:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_8]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_9]] : !fir.ref<i32>
-! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
-! CHECK:         %[[VAL_12:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_2]], %[[VAL_12]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_14:.*]] = fir.load %[[VAL_13]] : !fir.ref<i32>
-! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i32) -> index
-! CHECK:         %[[VAL_16:.*]] = fir.shape %[[VAL_11]], %[[VAL_15]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[SHAPE_DECL:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) {{.*}} {uniq_name = "_QFdynamic_shape_size_2Eshape"}
+! CHECK:         %[[CZERO:.*]] = arith.constant 0 : index
+! CHECK:         %[[E0:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CZERO]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D1_VAL:.*]] = fir.load %[[E0]] : !fir.ref<i32>
+! CHECK:         %[[D1:.*]] = fir.convert %[[D1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE:.*]] = arith.constant 1 : index
+! CHECK:         %[[E1:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CONE]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[D2_VAL:.*]] = fir.load %[[E1]] : !fir.ref<i32>
+! CHECK:         %[[D2:.*]] = fir.convert %[[D2_VAL]] : (i32) -> index
+! CHECK:         %[[SHAPE_OP:.*]] = fir.shape %[[D1]], %[[D2]] : (index, index) -> !fir.shape<2>
   call c_f_pointer(cptr, fptr, shape)
 end subroutine
 
@@ -149,32 +157,37 @@ subroutine dynamic_shape_lower(cptr, fpr, shape, lower)
   integer :: n
   integer :: shape(:)
   integer :: lower(:)
-! CHECK: %[[C_0:.*]] = arith.constant 0 : index
-! CHECK: %[[VAL_2:.*]] = fir.shape %[[C_0]], %[[C_0]] : (index, index) -> !fir.shape<2>
-! CHECK: %[[VAL_3:.*]] = fir.embox %[[VAL_1:.*]](%[[VAL_2]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-! CHECK: fir.store %[[VAL_3]] to %[[VAL_0:.*]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
-! CHECK: %[[VAL_5:.*]] = fir.coordinate_of %[[ARG_0:.*]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK: %[[VAL_6:.*]] = fir.load %[[VAL_5]] : !fir.ref<i64>
-! CHECK: %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
-! CHECK: %[[C_0:.*]]_0 = arith.constant 0 : index
-! CHECK: %[[VAL_8:.*]] = fir.coordinate_of %[[ARG_2:.*]], %[[C_0]]_0 : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK: %[[VAL_9:.*]] = fir.load %[[VAL_8]] : !fir.ref<i32>
-! CHECK: %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i32) -> index
-! CHECK: %[[C_1:.*]] = arith.constant 1 : index
-! CHECK: %[[VAL_11:.*]] = fir.coordinate_of %[[ARG_2:.*]], %[[C_1]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK: %[[VAL_12:.*]] = fir.load %[[VAL_11]] : !fir.ref<i32>
-! CHECK: %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i32) -> index
-! CHECK: %[[C_0:.*]]_1 = arith.constant 0 : index
-! CHECK: %[[VAL_14:.*]] = fir.coordinate_of %[[ARG_3:.*]], %[[C_0]]_1 : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK: %[[VAL_15:.*]] = fir.load %[[VAL_14]] : !fir.ref<i32>
-! CHECK: %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (i32) -> index
-! CHECK: %[[C_1:.*]]_2 = arith.constant 1 : index
-! CHECK: %[[VAL_17:.*]] = fir.coordinate_of %[[ARG_3:.*]], %[[C_1]]_2 : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-! CHECK: %[[VAL_18:.*]] = fir.load %[[VAL_17]] : !fir.ref<i32>
-! CHECK: %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> index
-! CHECK: %[[VAL_20:.*]] = fir.shape_shift %[[VAL_16]], %[[VAL_10]], %[[VAL_19]], %[[VAL_13]] : (index, index, index, index) -> !fir.shapeshift<2>
-! CHECK: %[[VAL_21:.*]] = fir.embox %[[VAL_7]](%[[VAL_20]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-! CHECK: fir.store %[[VAL_21:.*]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK:         %[[FPTR_ALLOCA:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         %[[ZERO_BITS:.*]] = fir.zero_bits !fir.ptr<!fir.array<?x?xf32>>
+! CHECK:         %[[ZERO_INDEX:.*]] = arith.constant 0 : index
+! CHECK:         %[[ZERO_SHAPE:.*]] = fir.shape %[[ZERO_INDEX]], %[[ZERO_INDEX]] : (index, index) -> !fir.shape<2>
+! CHECK:         %[[INIT_BOX:.*]] = fir.embox %[[ZERO_BITS]](%[[ZERO_SHAPE]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         fir.store %[[INIT_BOX]] to %[[FPTR_ALLOCA]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK:         %[[FPTR_DECL:.*]]:2 = hlfir.declare %[[FPTR_ALLOCA]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFdynamic_shape_lowerEfptr"}
+! CHECK:         %[[LOWER_DECL:.*]]:2 = hlfir.declare %{{.*}} {{.*}} {uniq_name = "_QFdynamic_shape_lowerElower"}
+! CHECK:         %[[SHAPE_DECL:.*]]:2 = hlfir.declare %{{.*}} {{.*}} {uniq_name = "_QFdynamic_shape_lowerEshape"}
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %{{.*}}#0, __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
+! CHECK:         %[[CZERO:.*]] = arith.constant 0 : index
+! CHECK:         %[[SE0:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CZERO]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[S1_VAL:.*]] = fir.load %[[SE0]] : !fir.ref<i32>
+! CHECK:         %[[S1:.*]] = fir.convert %[[S1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE:.*]] = arith.constant 1 : index
+! CHECK:         %[[SE1:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CONE]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[S2_VAL:.*]] = fir.load %[[SE1]] : !fir.ref<i32>
+! CHECK:         %[[S2:.*]] = fir.convert %[[S2_VAL]] : (i32) -> index
+! CHECK:         %[[CZERO2:.*]] = arith.constant 0 : index
+! CHECK:         %[[LE0:.*]] = fir.coordinate_of %[[LOWER_DECL]]#1, %[[CZERO2]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[L1_VAL:.*]] = fir.load %[[LE0]] : !fir.ref<i32>
+! CHECK:         %[[L1:.*]] = fir.convert %[[L1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE2:.*]] = arith.constant 1 : index
+! CHECK:         %[[LE1:.*]] = fir.coordinate_of %[[LOWER_DECL]]#1, %[[CONE2]] : (!fir.box<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[L2_VAL:.*]] = fir.load %[[LE1]] : !fir.ref<i32>
+! CHECK:         %[[L2:.*]] = fir.convert %[[L2_VAL]] : (i32) -> index
+! CHECK:         %[[SS:.*]] = fir.shape_shift %[[L1]], %[[S1]], %[[L2]], %[[S2]] : (index, index, index, index) -> !fir.shapeshift<2>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]](%[[SS]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
   call c_f_pointer(cptr, fptr, shape, lower)
 end subroutine dynamic_shape_lower
 
@@ -186,31 +199,31 @@ subroutine dynamic_shape_lower_2(cptr, fpr, shape, lower, n)
   integer :: n
   integer :: shape(n)
   integer :: lower(n)
-!CHECK: %[[C_0:.*]] = arith.constant 0 : index
-!CHECK: %[[VAL_2:.*]] = fir.shape %[[C_0]], %[[C_0]] : (index, index) -> !fir.shape<2>
-!CHECK: %[[VAL_3:.*]] = fir.embox %[[ARG1:.*]](%[[VAL_2]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-!CHECK: fir.store %[[VAL_3]] to %[[VAL_0:.*]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
-!CHECK: %[[VAL_4:.*]] = fir.coordinate_of %[[ARG_0:.*]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-!CHECK: %[[VAL_5:.*]] = fir.load %[[VAL_4]] : !fir.ref<i64>
-!CHECK: %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
-!CHECK: %[[C_0:.*]]_0 = arith.constant 0 : index
-!CHECK: %[[VAL_7:.*]] = fir.coordinate_of %[[ARG_2:.*]], %[[C_0]]_0 : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-!CHECK: %[[VAL_8:.*]] = fir.load %[[VAL_7]] : !fir.ref<i32>
-!CHECK: %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i32) -> index
-!CHECK: %[[C_1:.*]] = arith.constant 1 : index
-!CHECK: %[[VAL_10:.*]] = fir.coordinate_of %[[ARG_2]], %[[C_1]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-!CHECK: %[[VAL_11:.*]] = fir.load %[[VAL_10]] : !fir.ref<i32>
-!CHECK: %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (i32) -> index
-!CHECK: %[[C_0:.*]]_1 = arith.constant 0 : index
-!CHECK: %[[VAL_13:.*]] = fir.coordinate_of %[[ARG_3:.*]], %[[C_0]]_1 : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-!CHECK: %[[VAL_14:.*]] = fir.load %[[VAL_13]] : !fir.ref<i32>
-!CHECK: %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i32) -> index
-!CHECK: %[[C_1:.*]]_2 = arith.constant 1 : index
-!CHECK: %[[VAL_16:.*]] = fir.coordinate_of %[[ARG_3]], %[[C_1]]_2 : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
-!CHECK: %[[VAL_17:.*]] = fir.load %[[VAL_16]] : !fir.ref<i32>
-!CHECK: %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (i32) -> index
-!CHECK: %[[VAL_19:.*]] = fir.shape_shift %[[VAL_15]], %[[VAL_9]], %[[VAL_18]], %[[VAL_12]] : (index, index, index, index) -> !fir.shapeshift<2>
-!CHECK: %[[VAL_20:.*]] = fir.embox %[[VAL_6]](%[[VAL_19]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shapeshift<2>)
-!CHECK: fir.store %[[VAL_20]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK:         %[[FPTR_ALLOCA:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         %[[FPTR_DECL:.*]]:2 = hlfir.declare %[[FPTR_ALLOCA]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFdynamic_shape_lower_2Efptr"}
+! CHECK:         %[[LOWER_DECL:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) {{.*}} {uniq_name = "_QFdynamic_shape_lower_2Elower"}
+! CHECK:         %[[SHAPE_DECL:.*]]:2 = hlfir.declare %{{.*}}({{.*}}) {{.*}} {uniq_name = "_QFdynamic_shape_lower_2Eshape"}
+! CHECK:         %[[ADDR:.*]] = fir.coordinate_of %{{.*}}#0, __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[ADDR_VAL:.*]] = fir.load %[[ADDR]] : !fir.ref<i64>
+! CHECK:         %[[PTR:.*]] = fir.convert %[[ADDR_VAL]] : (i64) -> !fir.ptr<!fir.array<?x?xf32>>
+! CHECK:         %[[CZERO:.*]] = arith.constant 0 : index
+! CHECK:         %[[SE0:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CZERO]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[S1_VAL:.*]] = fir.load %[[SE0]] : !fir.ref<i32>
+! CHECK:         %[[S1:.*]] = fir.convert %[[S1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE:.*]] = arith.constant 1 : index
+! CHECK:         %[[SE1:.*]] = fir.coordinate_of %[[SHAPE_DECL]]#1, %[[CONE]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[S2_VAL:.*]] = fir.load %[[SE1]] : !fir.ref<i32>
+! CHECK:         %[[S2:.*]] = fir.convert %[[S2_VAL]] : (i32) -> index
+! CHECK:         %[[CZERO2:.*]] = arith.constant 0 : index
+! CHECK:         %[[LE0:.*]] = fir.coordinate_of %[[LOWER_DECL]]#1, %[[CZERO2]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[L1_VAL:.*]] = fir.load %[[LE0]] : !fir.ref<i32>
+! CHECK:         %[[L1:.*]] = fir.convert %[[L1_VAL]] : (i32) -> index
+! CHECK:         %[[CONE2:.*]] = arith.constant 1 : index
+! CHECK:         %[[LE1:.*]] = fir.coordinate_of %[[LOWER_DECL]]#1, %[[CONE2]] : (!fir.ref<!fir.array<?xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[L2_VAL:.*]] = fir.load %[[LE1]] : !fir.ref<i32>
+! CHECK:         %[[L2:.*]] = fir.convert %[[L2_VAL]] : (i32) -> index
+! CHECK:         %[[SS:.*]] = fir.shape_shift %[[L1]], %[[S1]], %[[L2]], %[[S2]] : (index, index, index, index) -> !fir.shapeshift<2>
+! CHECK:         %[[BOX:.*]] = fir.embox %[[PTR]](%[[SS]]) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:         fir.store %[[BOX]] to %[[FPTR_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
   call c_f_pointer(cptr, fptr, shape, lower)
 end subroutine dynamic_shape_lower_2

--- a/flang/test/Lower/Intrinsics/c_loc.f90
+++ b/flang/test/Lower/Intrinsics/c_loc.f90
@@ -1,17 +1,22 @@
-! RUN: bbc --use-desc-for-alloc=false --emit-fir -hlfir=false %s -o - | FileCheck %s
-! RUN: %flang_fc1 -mllvm --use-desc-for-alloc=false -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test intrinsic module procedure c_loc
 
 ! CHECK-LABEL: func.func @_QPc_loc_scalar() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_scalarEi) : !fir.ref<i32>
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_scalarEptr"}
-! CHECK:         %[[VAL_2:.*]] = fir.embox %[[VAL_0]] : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_4:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK-DAG:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<i32>) -> i64
-! CHECK-DAG:         %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_3]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_5]] to %[[VAL_7]] : !fir.ref<i64>
+! CHECK:         %[[VAL_I_ADDR:.*]] = fir.address_of(@_QFc_loc_scalarEi) : !fir.ref<i32>
+! CHECK:         %[[VAL_I:.*]]:2 = hlfir.declare %[[VAL_I_ADDR]] {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_scalarEi"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_scalarEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_scalarEptr"}
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_I]]#0 : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<i32>) -> !fir.ref<i32>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<i32>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
+! CHECK:         %[[VAL_TMP_DECL:.*]]:2 = hlfir.declare %[[VAL_TMP]] {uniq_name = ".tmp.intrinsic_result"}
+! CHECK:         %[[VAL_EXPR:.*]] = hlfir.as_expr %[[VAL_TMP_DECL]]#0
+! CHECK:         hlfir.assign %[[VAL_EXPR]] to %[[VAL_PTR]]#0
+! CHECK:         hlfir.destroy %[[VAL_EXPR]]
 ! CHECK:       }
 
 subroutine c_loc_scalar()
@@ -22,14 +27,18 @@ subroutine c_loc_scalar()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_char() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_charEichr) : !fir.ref<!fir.char<1,5>>
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_charEptr"}
-! CHECK:         %[[VAL_2:.*]] = fir.embox %[[VAL_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.box<!fir.char<1,5>>
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_4:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.char<1,5>>) -> !fir.ref<!fir.char<1,5>>
-! CHECK-DAG:         %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,5>>) -> i64
-! CHECK-DAG:         %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_3]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_5]] to %[[VAL_7]] : !fir.ref<i64>
+! CHECK:         %[[VAL_ICHR_ADDR:.*]] = fir.address_of(@_QFc_loc_charEichr) : !fir.ref<!fir.char<1,5>>
+! CHECK:         %[[VAL_ICHR:.*]]:2 = hlfir.declare %[[VAL_ICHR_ADDR]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_charEichr"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_charEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_charEptr"}
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_ICHR]]#0 : (!fir.ref<!fir.char<1,5>>) -> !fir.box<!fir.char<1,5>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<!fir.char<1,5>>) -> !fir.ref<!fir.char<1,5>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.char<1,5>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
+! CHECK:         %[[VAL_TMP_DECL:.*]]:2 = hlfir.declare %[[VAL_TMP]] {uniq_name = ".tmp.intrinsic_result"}
+! CHECK:         hlfir.assign
 ! CHECK:       }
 
 subroutine c_loc_char()
@@ -40,28 +49,22 @@ subroutine c_loc_char()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_substring() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_substringEichr) : !fir.ref<!fir.char<1,5>>
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_substringEptr"}
-! CHECK:         %[[VAL_2:.*]] = arith.constant 2 : i64
-! CHECK:         %[[VAL_3:.*]] = arith.constant 5 : i64
-! CHECK:         %[[VAL_4:.*]] = fir.convert %[[VAL_2]] : (i64) -> index
-! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
-! CHECK:         %[[VAL_6:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_7:.*]] = arith.subi %[[VAL_4]], %[[VAL_6]] : index
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<!fir.array<5x!fir.char<1>>>
-! CHECK:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_8]], %[[VAL_7]] : (!fir.ref<!fir.array<5x!fir.char<1>>>, index) -> !fir.ref<!fir.char<1>>
-! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<!fir.char<1,?>>
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_5]], %[[VAL_4]] : index
-! CHECK:         %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_6]] : index
-! CHECK:         %[[VAL_13:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_14:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_13]] : index
-! CHECK:         %[[VAL_15:.*]] = arith.select %[[VAL_14]], %[[VAL_13]], %[[VAL_12]] : index
-! CHECK:         %[[VAL_16:.*]] = fir.embox %[[VAL_10]] typeparams %[[VAL_15]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.box<!fir.char<1,?>>
-! CHECK:         %[[VAL_17:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_18:.*]] = fir.box_addr %[[VAL_16]] : (!fir.box<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,?>>
-! CHECK-DAG:         %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.char<1,?>>) -> i64
-! CHECK-DAG:         %[[VAL_21:.*]] = fir.coordinate_of %[[VAL_17]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_19]] to %[[VAL_21]] : !fir.ref<i64>
+! CHECK:         %[[VAL_ICHR_ADDR:.*]] = fir.address_of(@_QFc_loc_substringEichr) : !fir.ref<!fir.char<1,5>>
+! CHECK:         %[[VAL_ICHR:.*]]:2 = hlfir.declare %[[VAL_ICHR_ADDR]] typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_substringEichr"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_substringEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_substringEptr"}
+! CHECK:         %[[VAL_C2:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_C5:.*]] = arith.constant 5 : index
+! CHECK:         %[[VAL_C4:.*]] = arith.constant 4 : index
+! CHECK:         %[[VAL_SUBSTR:.*]] = hlfir.designate %[[VAL_ICHR]]#0  substr %[[VAL_C2]], %[[VAL_C5]]  typeparams %[[VAL_C4]] : (!fir.ref<!fir.char<1,5>>, index, index, index) -> !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_SUBSTR]] : (!fir.ref<!fir.char<1,4>>) -> !fir.box<!fir.char<1,4>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<!fir.char<1,4>>) -> !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.char<1,4>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
+! CHECK:         %[[VAL_TMP_DECL:.*]]:2 = hlfir.declare %[[VAL_TMP]] {uniq_name = ".tmp.intrinsic_result"}
+! CHECK:         hlfir.assign
 ! CHECK:       }
 
 subroutine c_loc_substring()
@@ -72,16 +75,20 @@ subroutine c_loc_substring()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_array() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_arrayEa) : !fir.ref<!fir.array<10xi32>>
-! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arrayEptr"}
-! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_4:.*]] = fir.embox %[[VAL_0]](%[[VAL_3]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
-! CHECK:         %[[VAL_5:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_6:.*]] = fir.box_addr %[[VAL_4]] : (!fir.box<!fir.array<10xi32>>) -> !fir.ref<!fir.array<10xi32>>
-! CHECK-DAG:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.array<10xi32>>) -> i64
-! CHECK-DAG:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_5]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_7]] to %[[VAL_9]] : !fir.ref<i64>
+! CHECK:         %[[VAL_A_ADDR:.*]] = fir.address_of(@_QFc_loc_arrayEa) : !fir.ref<!fir.array<10xi32>>
+! CHECK:         %[[VAL_C10:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_A:.*]]:2 = hlfir.declare %[[VAL_A_ADDR]](%{{.*}}) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_arrayEa"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arrayEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_arrayEptr"}
+! CHECK:         %[[VAL_SHAPE2:.*]] = fir.shape %[[VAL_C10]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_A]]#0(%[[VAL_SHAPE2]]) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<!fir.array<10xi32>>) -> !fir.ref<!fir.array<10xi32>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.array<10xi32>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
+! CHECK:         %[[VAL_TMP_DECL:.*]]:2 = hlfir.declare %[[VAL_TMP]] {uniq_name = ".tmp.intrinsic_result"}
+! CHECK:         hlfir.assign
 ! CHECK:       }
 
 subroutine c_loc_array
@@ -92,16 +99,18 @@ subroutine c_loc_array
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_chararray() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_chararrayEichr) : !fir.ref<!fir.array<2x!fir.char<1,5>>>
-! CHECK:         %[[VAL_1:.*]] = arith.constant 2 : index
-! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_chararrayEptr"}
-! CHECK:         %[[VAL_3:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_4:.*]] = fir.embox %[[VAL_0]](%[[VAL_3]]) : (!fir.ref<!fir.array<2x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<2x!fir.char<1,5>>>
-! CHECK:         %[[VAL_5:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_6:.*]] = fir.box_addr %[[VAL_4]] : (!fir.box<!fir.array<2x!fir.char<1,5>>>) -> !fir.ref<!fir.array<2x!fir.char<1,5>>>
-! CHECK-DAG:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.array<2x!fir.char<1,5>>>) -> i64
-! CHECK-DAG:         %[[VAL_9:.*]] = fir.coordinate_of %[[VAL_5]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_7]] to %[[VAL_9]] : !fir.ref<i64>
+! CHECK:         %[[VAL_ICHR_ADDR:.*]] = fir.address_of(@_QFc_loc_chararrayEichr) : !fir.ref<!fir.array<2x!fir.char<1,5>>>
+! CHECK:         %[[VAL_C2:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_ICHR:.*]]:2 = hlfir.declare %[[VAL_ICHR_ADDR]](%{{.*}}) typeparams %{{.*}} {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_chararrayEichr"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_chararrayEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_chararrayEptr"}
+! CHECK:         %[[VAL_SHAPE2:.*]] = fir.shape %[[VAL_C2]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_ICHR]]#0(%[[VAL_SHAPE2]]) : (!fir.ref<!fir.array<2x!fir.char<1,5>>>, !fir.shape<1>) -> !fir.box<!fir.array<2x!fir.char<1,5>>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<!fir.array<2x!fir.char<1,5>>>) -> !fir.ref<!fir.array<2x!fir.char<1,5>>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.array<2x!fir.char<1,5>>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_chararray()
@@ -112,18 +121,20 @@ subroutine c_loc_chararray()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_arrayelement() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_arrayelementEa) : !fir.ref<!fir.array<10xi32>>
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arrayelementEptr"}
-! CHECK:         %[[VAL_2:.*]] = arith.constant 2 : i64
-! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i64
-! CHECK:         %[[VAL_5:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_4]] : (!fir.ref<!fir.array<10xi32>>, i64) -> !fir.ref<i32>
-! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_5]] : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK:         %[[VAL_7:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_8:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK-DAG:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<i32>) -> i64
-! CHECK-DAG:         %[[VAL_11:.*]] = fir.coordinate_of %[[VAL_7]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_9]] to %[[VAL_11]] : !fir.ref<i64>
+! CHECK:         %[[VAL_A_ADDR:.*]] = fir.address_of(@_QFc_loc_arrayelementEa) : !fir.ref<!fir.array<10xi32>>
+! CHECK:         %[[VAL_C10:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_SHAPE:.*]] = fir.shape %[[VAL_C10]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_A:.*]]:2 = hlfir.declare %[[VAL_A_ADDR]](%[[VAL_SHAPE]]) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_arrayelementEa"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arrayelementEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_arrayelementEptr"}
+! CHECK:         %[[VAL_C2:.*]] = arith.constant 2 : index
+! CHECK:         %[[VAL_ELEM:.*]] = hlfir.designate %[[VAL_A]]#0 (%[[VAL_C2]])  : (!fir.ref<!fir.array<10xi32>>, index) -> !fir.ref<i32>
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_ELEM]] : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<i32>) -> !fir.ref<i32>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<i32>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_arrayelement()
@@ -134,26 +145,23 @@ subroutine c_loc_arrayelement()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_arraysection() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_arraysectionEa) : !fir.ref<!fir.array<10xi32>>
-! CHECK:         %[[VAL_1:.*]] = arith.constant 10 : index
-! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QFc_loc_arraysectionEind) : !fir.ref<i32>
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arraysectionEptr"}
-! CHECK:         %[[VAL_4:.*]] = arith.constant 1 : index
-! CHECK:         %[[VAL_5:.*]] = fir.load %[[VAL_2]] : !fir.ref<i32>
-! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_5]] : (i32) -> i64
-! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_6]] : (i64) -> index
-! CHECK:         %[[VAL_8:.*]] = arith.constant 1 : i64
-! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
-! CHECK:         %[[VAL_10:.*]] = arith.addi %[[VAL_4]], %[[VAL_1]] : index
-! CHECK:         %[[VAL_11:.*]] = arith.subi %[[VAL_10]], %[[VAL_4]] : index
-! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_13:.*]] = fir.slice %[[VAL_7]], %[[VAL_11]], %[[VAL_9]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         %[[VAL_14:.*]] = fir.embox %[[VAL_0]](%[[VAL_12]]) {{\[}}%[[VAL_13]]] : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xi32>>
-! CHECK:         %[[VAL_15:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_16:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
-! CHECK-DAG:         %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.array<?xi32>>) -> i64
-! CHECK-DAG:         %[[VAL_19:.*]] = fir.coordinate_of %[[VAL_15]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_17]] to %[[VAL_19]] : !fir.ref<i64>
+! CHECK:         %[[VAL_A_ADDR:.*]] = fir.address_of(@_QFc_loc_arraysectionEa) : !fir.ref<!fir.array<10xi32>>
+! CHECK:         %[[VAL_C10:.*]] = arith.constant 10 : index
+! CHECK:         %[[VAL_SHAPE_A:.*]] = fir.shape %[[VAL_C10]] : (index) -> !fir.shape<1>
+! CHECK:         %[[VAL_A:.*]]:2 = hlfir.declare %[[VAL_A_ADDR]](%[[VAL_SHAPE_A]]) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_arraysectionEa"}
+! CHECK:         %[[VAL_IND_ADDR:.*]] = fir.address_of(@_QFc_loc_arraysectionEind) : !fir.ref<i32>
+! CHECK:         %[[VAL_IND:.*]]:2 = hlfir.declare %[[VAL_IND_ADDR]] {uniq_name = "_QFc_loc_arraysectionEind"}
+! CHECK:         %[[VAL_PTR_ALLOC:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_arraysectionEptr"}
+! CHECK:         %[[VAL_PTR:.*]]:2 = hlfir.declare %[[VAL_PTR_ALLOC]] {uniq_name = "_QFc_loc_arraysectionEptr"}
+! CHECK:         %[[VAL_IND_VAL:.*]] = fir.load %[[VAL_IND]]#0 : !fir.ref<i32>
+! CHECK:         %[[VAL_IND_64:.*]] = fir.convert %[[VAL_IND_VAL]] : (i32) -> i64
+! CHECK:         %[[VAL_IND_IDX:.*]] = fir.convert %[[VAL_IND_64]] : (i64) -> index
+! CHECK:         %[[VAL_SECTION:.*]] = hlfir.designate %[[VAL_A]]#0 (%[[VAL_IND_IDX]]:%[[VAL_C10]]:%{{.*}})  shape %{{.*}} : (!fir.ref<!fir.array<10xi32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<?xi32>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_SECTION]] : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.array<?xi32>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_arraysection()
@@ -165,38 +173,16 @@ subroutine c_loc_arraysection()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_non_save_pointer_scalar() {
-! CHECK:         %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<i32>> {bindc_name = "i", uniq_name = "_QFc_loc_non_save_pointer_scalarEi"}
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.ptr<i32> {uniq_name = "_QFc_loc_non_save_pointer_scalarEi.addr"}
-! CHECK:         %[[VAL_2:.*]] = fir.zero_bits !fir.ptr<i32>
-! CHECK:         fir.store %[[VAL_2]] to %[[VAL_1]] : !fir.ref<!fir.ptr<i32>>
-! CHECK:         %[[VAL_3:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}> {bindc_name = "ptr", uniq_name = "_QFc_loc_non_save_pointer_scalarEptr"}
-! CHECK:         %[[VAL_false:.*]] = arith.constant false
-! CHECK:         %[[VAL_4:.*]] = fir.absent !fir.box<none>
-! CHECK:         %[[VAL_5:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
-! CHECK:         %[[C_LN:.*]] = arith.constant {{.*}} : i32
-! CHECK:         %[[VAL_6:.*]] = fir.zero_bits !fir.ptr<i32>
-! CHECK:         %[[VAL_7:.*]] = fir.embox %[[VAL_6:.*]] : (!fir.ptr<i32>) -> !fir.box<!fir.ptr<i32>>
-! CHECK:         fir.store %[[VAL_7:.*]] to %[[VAL_0:.*]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
-! CHECK:         %[[VAL_8:.*]] = fir.convert %[[VAL_0:.*]] : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
-! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_5:.*]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_10:.*]] = fir.call @_FortranAPointerAllocate(%[[VAL_8:.*]], %[[VAL_false:.*]], %[[VAL_4:.*]], %[[VAL_9:.*]], %[[C_LN:.*]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32, {{.*}}) -> i32
-! CHECK:         %[[VAL_11:.*]] = fir.load %[[VAL_0:.*]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
-! CHECK:         %[[VAL_12:.*]] = fir.box_addr %[[VAL_11:.*]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
-! CHECK:         fir.store %[[VAL_12:.*]] to %[[VAL_1:.*]] : !fir.ref<!fir.ptr<i32>>
-! CHECK:         %[[C_10:.*]] = arith.constant 10 : i32
-! CHECK:         %[[VAL_13:.*]] = fir.load %[[VAL_1:.*]] : !fir.ref<!fir.ptr<i32>>
-! CHECK:         fir.store %[[C_10]] to %[[VAL_13:.*]] : !fir.ptr<i32>
-! CHECK:         %[[VAL_14:.*]] = fir.load %[[VAL_1:.*]] : !fir.ref<!fir.ptr<i32>>
-! CHECK:         %[[VAL_15:.*]] = fir.embox %[[VAL_14:.*]] : (!fir.ptr<i32>) -> !fir.box<i32>
-! CHECK:         %[[VAL_16:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK:         %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_16:.*]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_19:.*]] = fir.box_addr %[[VAL_15:.*]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_19:.*]] : (!fir.ref<i32>) -> i64
-! CHECK:         fir.store %[[VAL_20:.*]] to %[[VAL_18:.*]] : !fir.ref<i64>
-! CHECK:         %[[VAL_22:.*]] = fir.coordinate_of %[[VAL_16:.*]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_24:.*]] = fir.coordinate_of %[[VAL_3:.*]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         %[[VAL_25:.*]] = fir.load %[[VAL_22:.*]] : !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_25:.*]] to %[[VAL_24:.*]] : !fir.ref<i64>
+! CHECK:         %[[VAL_I_ALLOC:.*]] = fir.alloca !fir.box<!fir.ptr<i32>> {bindc_name = "i", uniq_name = "_QFc_loc_non_save_pointer_scalarEi"}
+! CHECK:         %[[VAL_I:.*]]:2 = hlfir.declare %[[VAL_I_ALLOC]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFc_loc_non_save_pointer_scalarEi"}
+! CHECK:         fir.call @_FortranAPointerAllocate
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ptr<i32>
+! CHECK:         %[[VAL_I_LD:.*]] = fir.load %[[VAL_I]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_I_LD]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ptr<i32>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -210,15 +196,16 @@ subroutine c_loc_non_save_pointer_scalar()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_save_pointer_scalar() {
-! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QFc_loc_save_pointer_scalarEi) : !fir.ref<!fir.box<!fir.ptr<i32>>>
-! CHECK:         %[[VAL_7:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<i32>>>
-! CHECK:         %[[VAL_8:.*]] = fir.box_addr %[[VAL_7]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
-! CHECK:         %[[VAL_9:.*]] = fir.embox %[[VAL_8:.*]] : (!fir.ptr<i32>) -> !fir.box<i32>
-! CHECK:         %[[VAL_10:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_11:.*]] = fir.box_addr %[[VAL_9]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK-DAG:         %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<i32>) -> i64
-! CHECK-DAG:         %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_10]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_12]] to %[[VAL_14]] : !fir.ref<i64>
+! CHECK:         %[[VAL_I_ADDR:.*]] = fir.address_of(@_QFc_loc_save_pointer_scalarEi) : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK:         %[[VAL_I:.*]]:2 = hlfir.declare %[[VAL_I_ADDR]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFc_loc_save_pointer_scalarEi"}
+! CHECK:         fir.call @_FortranAPointerAllocate
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ptr<i32>
+! CHECK:         %[[VAL_I_LD:.*]] = fir.load %[[VAL_I]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_I_LD]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ptr<i32>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_save_pointer_scalar()
@@ -231,13 +218,14 @@ subroutine c_loc_save_pointer_scalar()
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_derived_type() {
-! CHECK:         %[[VAL_1:.*]] = fir.alloca !fir.type<_QFc_loc_derived_typeTt{i:i32}> {bindc_name = "tt", fir.target, uniq_name = "_QFc_loc_derived_typeEtt"}
-! CHECK:         %[[VAL_8:.*]] = fir.embox %[[VAL_1]] : (!fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> !fir.box<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>
-! CHECK:         %[[VAL_9:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_10:.*]] = fir.box_addr %[[VAL_8:.*]] : (!fir.box<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> !fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>
-! CHECK-DAG:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> i64
-! CHECK-DAG:         %[[VAL_13:.*]] = fir.coordinate_of %[[VAL_9]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_11]] to %[[VAL_13]] : !fir.ref<i64>
+! CHECK:         %[[VAL_TT_ALLOC:.*]] = fir.alloca !fir.type<_QFc_loc_derived_typeTt{i:i32}> {bindc_name = "tt", fir.target, uniq_name = "_QFc_loc_derived_typeEtt"}
+! CHECK:         %[[VAL_TT:.*]]:2 = hlfir.declare %[[VAL_TT_ALLOC]] {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFc_loc_derived_typeEtt"}
+! CHECK:         %[[VAL_BOX:.*]] = fir.embox %[[VAL_TT]]#0 : (!fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> !fir.box<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_BOX]] : (!fir.box<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> !fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ref<!fir.type<_QFc_loc_derived_typeTt{i:i32}>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_derived_type
@@ -251,13 +239,16 @@ subroutine c_loc_derived_type
 end
 
 ! CHECK-LABEL: func.func @_QPc_loc_pointer_array() {
-! CHECK:         %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xi32>>> {bindc_name = "a", uniq_name = "_QFc_loc_pointer_arrayEa"}
-! CHECK:         %[[VAL_30:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_31:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
-! CHECK-DAG:         %[[VAL_32:.*]] = fir.box_addr %[[VAL_30:.*]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
-! CHECK-DAG:         %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
-! CHECK-DAG:         %[[VAL_35:.*]] = fir.coordinate_of %[[VAL_31]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
-! CHECK:         fir.store %[[VAL_33]] to %[[VAL_35]] : !fir.ref<i64>
+! CHECK:         %[[VAL_A_ALLOC:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xi32>>> {bindc_name = "a", uniq_name = "_QFc_loc_pointer_arrayEa"}
+! CHECK:         %[[VAL_A:.*]]:2 = hlfir.declare %[[VAL_A_ALLOC]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFc_loc_pointer_arrayEa"}
+! CHECK:         fir.call @_FortranAPointerAllocate
+! CHECK:         hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.box<!fir.ptr<!fir.array<?xi32>>>
+! CHECK:         %[[VAL_A_LD:.*]] = fir.load %[[VAL_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:         %[[VAL_TMP:.*]] = fir.alloca !fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>
+! CHECK:         %[[VAL_ADDR_FIELD:.*]] = fir.coordinate_of %[[VAL_TMP]], __address : (!fir.ref<!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>>) -> !fir.ref<i64>
+! CHECK:         %[[VAL_BADDR:.*]] = fir.box_addr %[[VAL_A_LD]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
+! CHECK:         %[[VAL_INT:.*]] = fir.convert %[[VAL_BADDR]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
+! CHECK:         fir.store %[[VAL_INT]] to %[[VAL_ADDR_FIELD]] : !fir.ref<i64>
 ! CHECK:       }
 
 subroutine c_loc_pointer_array

--- a/flang/test/Lower/cray-pointer.f90
+++ b/flang/test/Lower/cray-pointer.f90
@@ -1,5 +1,4 @@
-! RUN: bbc %s -emit-fir -hlfir=false -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test Cray Pointers
 
@@ -13,34 +12,49 @@ subroutine cray_scalar()
   pointer(ptr, pte)
   ptr = loc(data)
 
-! CHECK: %[[data:.*]] = fir.address_of(@_QFcray_scalarEdata) {{.*}}
-! CHECK: %[[i:.*]] = fir.alloca i32 {{.*}}
-! CHECK: %[[j:.*]] = fir.address_of(@_QFcray_scalarEj) {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[databox:.*]] = fir.embox %[[data]] : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<i32>>
+! CHECK: %[[data_addr:.*]] = fir.address_of(@_QFcray_scalarEdata) {{.*}}
+! CHECK: %[[data:.*]]:2 = hlfir.declare %[[data_addr]]
+! CHECK: %[[i_alloc:.*]] = fir.alloca i32 {{.*}}
+! CHECK: %[[i:.*]]:2 = hlfir.declare %[[i_alloc]]
+! CHECK: %[[j_addr:.*]] = fir.address_of(@_QFcray_scalarEj) {{.*}}
+! CHECK: %[[j:.*]]:2 = hlfir.declare %[[j_addr]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_scalarEptr"}
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_scalarEpte"}
+! CHECK: %[[zero:.*]] = fir.zero_bits !fir.ptr<i32>
+! CHECK: %[[zerobox:.*]] = fir.embox %[[zero]] : (!fir.ptr<i32>) -> !fir.box<!fir.ptr<i32>>
+! CHECK: fir.store %[[zerobox]] to %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[databox:.*]] = fir.embox %[[data]]#0 : (!fir.ref<i32>) -> !fir.box<i32>
 ! CHECK: %[[dataaddr:.*]] = fir.box_addr %[[databox]] : (!fir.box<i32>) -> !fir.ref<i32>
 ! CHECK: %[[dataaddrval:.*]] = fir.convert %[[dataaddr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[dataaddrval]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: hlfir.assign %[[dataaddrval]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 
   i = pte
   print *, i
 
-! CHECK: %[[ptrbox:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr:.*]] = fir.box_addr %[[ptrbox]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval:.*]] = fir.convert %[[ptraddr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld:.*]] = fir.load %[[ptraddrval]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrldd:.*]] = fir.load %[[ptrld]] : !fir.ptr<i32>
-! CHECK: fir.store %[[ptrldd]] to %[[i]] : !fir.ref<i32>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr:.*]] = fir.box_addr %[[pteload]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: %[[ptevalue:.*]] = fir.load %[[pteaddr]] : !fir.ptr<i32>
+! CHECK: hlfir.assign %[[ptevalue]] to %[[i]]#0 : i32, !fir.ref<i32>
 
   pte = j
   print *, data, pte
 
-! CHECK: %[[jld:.*]] = fir.load %[[j]] : !fir.ref<i32>
-! CHECK: %[[ptrbox1:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr1:.*]] = fir.box_addr %[[ptrbox1]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval1:.*]] = fir.convert %[[ptraddr1]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld1:.*]] = fir.load %[[ptraddrval1]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: fir.store %[[jld]] to %[[ptrld1]] : !fir.ptr<i32>
+! CHECK: %[[jld:.*]] = fir.load %[[j]]#0 : !fir.ref<i32>
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr2:.*]] = fir.box_addr %[[pteload2]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: hlfir.assign %[[jld]] to %[[pteaddr2]] : i32, !fir.ptr<i32>
 
 end
 
@@ -57,37 +71,47 @@ subroutine cray_derivedType()
   xdt = dt(-1, -3)
   ptr = loc(xdt)
 
-! CHECK: %[[dt:.*]] = fir.alloca !fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>
-! CHECK: %[[k:.*]] = fir.alloca i32 {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[xdt:.*]] = fir.alloca !fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}> {{.*}}
-! CHECK: %[[xdtbox:.*]] = fir.embox %[[xdt]] : (!fir.ref<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>) -> !fir.box<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<i32>>
+! CHECK: %[[k_alloc:.*]] = fir.alloca i32 {{.*}}
+! CHECK: %[[k:.*]]:2 = hlfir.declare %[[k_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_derivedtypeEptr"}
+! CHECK: %[[xdt_alloc:.*]] = fir.alloca !fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}> {{.*}}
+! CHECK: %[[xdt:.*]]:2 = hlfir.declare %[[xdt_alloc]]
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_derivedtypeEpte"}
+! CHECK: %[[xdtbox:.*]] = fir.embox %[[xdt]]#0 : (!fir.ref<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>) -> !fir.box<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>
 ! CHECK: %[[xdtaddr:.*]] = fir.box_addr %[[xdtbox]] : (!fir.box<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>) -> !fir.ref<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>
 ! CHECK: %[[xdtaddrval:.*]] = fir.convert %[[xdtaddr]] : (!fir.ref<!fir.type<_QFcray_derivedtypeTdt{i:i32,j:i32}>>) -> i64
-! CHECK: fir.store %[[xdtaddrval]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: hlfir.assign %[[xdtaddrval]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 
   k = pte
   print *, k
 
-! CHECK: %[[ptrbox:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr:.*]] = fir.box_addr %[[ptrbox]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval:.*]] = fir.convert %[[ptraddr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld:.*]] = fir.load %[[ptraddrval]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrldd:.*]] = fir.load %[[ptrld]] : !fir.ptr<i32>
-! CHECK: fir.store %[[ptrldd]] to %[[k]] : !fir.ref<i32>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr:.*]] = fir.box_addr %[[pteload]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: %[[ptevalue:.*]] = fir.load %[[pteaddr]] : !fir.ptr<i32>
+! CHECK: hlfir.assign %[[ptevalue]] to %[[k]]#0 : i32, !fir.ref<i32>
 
   pte = k + 2
   print *, xdt, pte
 
-! CHECK: %[[kld:.*]] = fir.load %[[k]] : !fir.ref<i32>
-! CHECK: %[[kld1:.*]] = fir.load %[[k]] : !fir.ref<i32>
+! CHECK: fir.call @_FortranAioEndIoStatement
+! CHECK: %[[kld:.*]] = fir.load %[[k]]#0 : !fir.ref<i32>
 ! CHECK: %[[const:.*]] = arith.constant 2 : i32
-! CHECK: %[[add:.*]] = arith.addi %[[kld1]], %[[const]] : i32
-! CHECK: %[[ptrbox1:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr1:.*]] = fir.box_addr %[[ptrbox1]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval1:.*]] = fir.convert %[[ptraddr1]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld1:.*]] = fir.load %[[ptraddrval1]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: fir.store %[[add]] to %[[ptrld1]] : !fir.ptr<i32>
+! CHECK: %[[add:.*]] = arith.addi %[[kld]], %[[const]] : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr2:.*]] = fir.box_addr %[[pteload2]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: hlfir.assign %[[add]] to %[[pteaddr2]] : i32, !fir.ptr<i32>
 
 end
 
@@ -104,40 +128,54 @@ subroutine cray_ptrArth()
   xdt = dt(5, 11, 2)
   ptr = loc(xdt)
 
-! CHECK: %[[dt:.*]] = fir.alloca !fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>
-! CHECK: %[[i:.*]] = fir.alloca i32 {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[xdt:.*]] = fir.alloca !fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}> {{.*}}
-! CHECK: %[[xdtbox:.*]] = fir.embox %[[xdt]] : (!fir.ref<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>) -> !fir.box<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<i32>>
+! CHECK: %[[i_alloc:.*]] = fir.alloca i32 {{.*}}
+! CHECK: %[[i:.*]]:2 = hlfir.declare %[[i_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_ptrarthEptr"}
+! CHECK: %[[xdt_alloc:.*]] = fir.alloca !fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}> {{.*}}
+! CHECK: %[[xdt:.*]]:2 = hlfir.declare %[[xdt_alloc]]
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_ptrarthEpte"}
+! CHECK: %[[xdtbox:.*]] = fir.embox %[[xdt]]#0 : (!fir.ref<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>) -> !fir.box<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>
 ! CHECK: %[[xdtaddr:.*]] = fir.box_addr %[[xdtbox]] : (!fir.box<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>) -> !fir.ref<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>
 ! CHECK: %[[xdtaddrval:.*]] = fir.convert %[[xdtaddr]] : (!fir.ref<!fir.type<_QFcray_ptrarthTdt{x:i32,y:i32,z:i32}>>) -> i64
-! CHECK: fir.store %[[xdtaddrval]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: hlfir.assign %[[xdtaddrval]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 
   ptr = ptr + 4
   i = pte
   print *, i
 
-! CHECK: %[[ptrbox:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr:.*]] = fir.box_addr %[[ptrbox]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval:.*]] = fir.convert %[[ptraddr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld:.*]] = fir.load %[[ptraddrval]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrldd:.*]] = fir.load %[[ptrld]] : !fir.ptr<i32>
-! CHECK: fir.store %[[ptrldd]] to %[[i]] : !fir.ref<i32>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptr]]#0 : !fir.ref<i64>
+! CHECK: %[[const:.*]] = arith.constant 4 : i64
+! CHECK: %[[add:.*]] = arith.addi %[[ptrld]], %[[const]] : i64
+! CHECK: hlfir.assign %[[add]] to %[[ptr]]#0 : i64, !fir.ref<i64>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr:.*]] = fir.box_addr %[[pteload]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: %[[ptevalue:.*]] = fir.load %[[pteaddr]] : !fir.ptr<i32>
+! CHECK: hlfir.assign %[[ptevalue]] to %[[i]]#0 : i32, !fir.ref<i32>
 
   ptr = ptr + 4
   pte = -7
   print *, xdt
 
-! CHECK: %[[ld:.*]] = fir.load %[[ptr]] : !fir.ref<i64>
-! CHECK: %[[const:.*]] = arith.constant 4 : i64
-! CHECK: %[[add:.*]] = arith.addi %[[ld]], %[[const]] : i64
-! CHECK: fir.store %[[add]] to %[[ptr]] : !fir.ref<i64>
-! CHECK: %[[const1:.*]] = arith.constant -7 : i32
-! CHECK: %[[ptrbox1:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[ptraddr1:.*]] = fir.box_addr %[[ptrbox1]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptraddrval1:.*]] = fir.convert %[[ptraddr1]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptrld1:.*]] = fir.load %[[ptraddrval1]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: fir.store %[[const1]] to %[[ptrld1]] : !fir.ptr<i32>
+! CHECK: %[[ptrld3:.*]] = fir.load %[[ptr]]#0 : !fir.ref<i64>
+! CHECK: %[[const2:.*]] = arith.constant 4 : i64
+! CHECK: %[[add2:.*]] = arith.addi %[[ptrld3]], %[[const2]] : i64
+! CHECK: hlfir.assign %[[add2]] to %[[ptr]]#0 : i64, !fir.ref<i64>
+! CHECK: %[[neg7:.*]] = arith.constant -7 : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld4:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld4]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr2:.*]] = fir.box_addr %[[pteload2]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: hlfir.assign %[[neg7]] to %[[pteaddr2]] : i32, !fir.ptr<i32>
 
 end
 
@@ -150,45 +188,48 @@ subroutine cray_arrayElement()
   data = [ 1, 2, 3, 4, 5 ]
   ptr = loc(data(2))
 
-! CHECK: %[[data:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
-! CHECK: %[[k:.*]] = fir.alloca i32 {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[c2:.*]] = arith.constant 2 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[data]], %[[sub]] : (!fir.ref<!fir.array<5xi32>>, i64) -> !fir.ref<i32>
-! CHECK: %[[box:.*]] = fir.embox %[[cor]] : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xi32>>>
+! CHECK: %[[data_alloc:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
+! CHECK: %[[data:.*]]:2 = hlfir.declare %[[data_alloc]]
+! CHECK: %[[k_alloc:.*]] = fir.alloca i32 {{.*}}
+! CHECK: %[[k:.*]]:2 = hlfir.declare %[[k_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_arrayelementEptr"}
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_arrayelementEpte"}
+! CHECK: %[[c2:.*]] = arith.constant 2 : index
+! CHECK: %[[elem:.*]] = hlfir.designate %[[data]]#0 (%[[c2]])  : (!fir.ref<!fir.array<5xi32>>, index) -> !fir.ref<i32>
+! CHECK: %[[box:.*]] = fir.embox %[[elem]] : (!fir.ref<i32>) -> !fir.box<i32>
 ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<i32>) -> !fir.ref<i32>
 ! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[val]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: hlfir.assign %[[val]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 
   k = pte(3)
   print *, k
 
-! CHECK: %[[c3:.*]] = arith.constant 3 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub:.*]] = arith.subi %[[c3]], %[[c1]] : i64
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld1:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[ld1]], %[[sub]] : (!fir.ptr<!fir.array<3xi32>>, i64) -> !fir.ref<i32>
-! CHECK: %[[ld2:.*]] = fir.load %[[cor]] : !fir.ref<i32>
-! CHECK: fir.store %[[ld2]] to %[[k]] : !fir.ref<i32>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: %[[c3:.*]] = arith.constant 3 : index
+! CHECK: %[[ptedes:.*]] = hlfir.designate %[[pteload]] (%[[c3]])  : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK: %[[ptevalue:.*]] = fir.load %[[ptedes]] : !fir.ref<i32>
+! CHECK: hlfir.assign %[[ptevalue]] to %[[k]]#0 : i32, !fir.ref<i32>
 
   pte(2) = -2
   print *, data
 
-! CHECK: %[[c2n:.*]] = arith.constant -2 : i32
-! CHECK: %[[c2:.*]] = arith.constant 2 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld1:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[ld1]], %[[sub]] : (!fir.ptr<!fir.array<3xi32>>, i64) -> !fir.ref<i32>
-! CHECK: fir.store %[[c2n]] to %[[cor]] : !fir.ref<i32>
+! CHECK: %[[neg2:.*]] = arith.constant -2 : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: %[[c2b:.*]] = arith.constant 2 : index
+! CHECK: %[[ptedes2:.*]] = hlfir.designate %[[pteload2]] (%[[c2b]])  : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK: hlfir.assign %[[neg2]] to %[[ptedes2]] : i32, !fir.ref<i32>
 
 end
 
@@ -201,54 +242,49 @@ subroutine cray_2darrayElement()
   data = reshape([1,2,3,4,5,6,7,8], [2,4])
   ptr = loc(data(2,2))
 
-! CHECK: %[[data:.*]] = fir.alloca !fir.array<2x4xi32> {{.*}}
-! CHECK: %[[k:.*]] = fir.alloca i32 {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[c2:.*]] = arith.constant 2 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub1:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[c22:.*]] = arith.constant 2 : i64
-! CHECK: %[[c12:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub2:.*]] = arith.subi %[[c22]], %[[c12]] : i64
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[data]], %[[sub1]], %[[sub2]] : (!fir.ref<!fir.array<2x4xi32>>, i64, i64) -> !fir.ref<i32>
-! CHECK: %[[box:.*]] = fir.embox %[[cor]] : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?xi32>>>
+! CHECK: %[[data_alloc:.*]] = fir.alloca !fir.array<2x4xi32> {{.*}}
+! CHECK: %[[data:.*]]:2 = hlfir.declare %[[data_alloc]]
+! CHECK: %[[k_alloc:.*]] = fir.alloca i32 {{.*}}
+! CHECK: %[[k:.*]]:2 = hlfir.declare %[[k_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_2darrayelementEptr"}
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_2darrayelementEpte"}
+! CHECK: %[[elem:.*]] = hlfir.designate %[[data]]#0 (%{{.*}}, %{{.*}})  : (!fir.ref<!fir.array<2x4xi32>>, index, index) -> !fir.ref<i32>
+! CHECK: %[[box:.*]] = fir.embox %[[elem]] : (!fir.ref<i32>) -> !fir.box<i32>
 ! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<i32>) -> !fir.ref<i32>
 ! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[val]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: hlfir.assign %[[val]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 
   k = pte(1,1)
   print *, k
 
-! CHECK: %[[c2:.*]] = arith.constant 1 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub1:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[c22:.*]] = arith.constant 1 : i64
-! CHECK: %[[c12:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub2:.*]] = arith.subi %[[c22]], %[[c12]] : i64
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<2x3xi32>>>
-! CHECK: %[[ld1:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<2x3xi32>>>
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[ld1]], %[[sub1]], %[[sub2]] : (!fir.ptr<!fir.array<2x3xi32>>, i64, i64) -> !fir.ref<i32>
-! CHECK: %[[ld2:.*]] = fir.load %[[cor]] : !fir.ref<i32>
-! CHECK: fir.store %[[ld2]] to %[[k]] : !fir.ref<i32>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xi32>>>>
+! CHECK: %[[c1:.*]] = arith.constant 1 : index
+! CHECK: %[[c1b:.*]] = arith.constant 1 : index
+! CHECK: %[[ptedes:.*]] = hlfir.designate %[[pteload]] (%[[c1]], %[[c1b]])  : (!fir.box<!fir.ptr<!fir.array<?x?xi32>>>, index, index) -> !fir.ref<i32>
+! CHECK: %[[ptevalue:.*]] = fir.load %[[ptedes]] : !fir.ref<i32>
+! CHECK: hlfir.assign %[[ptevalue]] to %[[k]]#0 : i32, !fir.ref<i32>
 
   pte(1,2) = -2
   print *, data
 
-! CHECK: %[[c2n:.*]] = arith.constant -2 : i32
-! CHECK: %[[c2:.*]] = arith.constant 1 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub1:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[c22:.*]] = arith.constant 2 : i64
-! CHECK: %[[c12:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub2:.*]] = arith.subi %[[c22]], %[[c12]] : i64
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<2x3xi32>>>
-! CHECK: %[[ld1:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<2x3xi32>>>
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[ld1]], %[[sub1]], %[[sub2]] : (!fir.ptr<!fir.array<2x3xi32>>, i64, i64) -> !fir.ref<i32>
-! CHECK: fir.store %[[c2n]] to %[[cor]] : !fir.ref<i32>
+! CHECK: %[[neg2:.*]] = arith.constant -2 : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xi32>>>>
+! CHECK: %[[c1c:.*]] = arith.constant 1 : index
+! CHECK: %[[c2c:.*]] = arith.constant 2 : index
+! CHECK: %[[ptedes2:.*]] = hlfir.designate %[[pteload2]] (%[[c1c]], %[[c2c]])  : (!fir.box<!fir.ptr<!fir.array<?x?xi32>>>, index, index) -> !fir.ref<i32>
+! CHECK: hlfir.assign %[[neg2]] to %[[ptedes2]] : i32, !fir.ref<i32>
 
 end
 
@@ -261,57 +297,37 @@ subroutine cray_array()
   data = [ 1, 2, 3, 4, 5 ]
   ptr = loc(data(2))
 
-! CHECK: %[[data:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
-! CHECK: %[[c3:.*]] = arith.constant 3 : index
-! CHECK: %[[k:.*]] = fir.alloca !fir.array<3xi32> {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[c31:.*]] = arith.constant 3 : index
-! CHECK: %[[c2:.*]] = arith.constant 2 : i64
-! CHECK: %[[c1:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub:.*]] = arith.subi %[[c2]], %[[c1]] : i64
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[data]], %[[sub]] : (!fir.ref<!fir.array<5xi32>>, i64) -> !fir.ref<i32>
-! CHECK: %[[box:.*]] = fir.embox %[[cor]] : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[val]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xi32>>>
+! CHECK: %[[data_alloc:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
+! CHECK: %[[data:.*]]:2 = hlfir.declare %[[data_alloc]]
+! CHECK: %[[k_alloc:.*]] = fir.alloca !fir.array<3xi32> {{.*}}
+! CHECK: %[[k:.*]]:2 = hlfir.declare %[[k_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_arrayEptr"}
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_arrayEpte"}
 
   k = pte
   print *, k
 
-! CHECK: %[[shape1:.*]] = fir.shape %[[c3]] : (index) -> !fir.shape<1>
-! CHECK: %[[arrayld1:.*]] = fir.array_load %[[k]](%[[shape1]]) : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>) -> !fir.array<3xi32>
-! CHECK: %[[shape:.*]] = fir.shape %[[c31]] : (index) -> !fir.shape<1>
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld:.*]] =  fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[arrayld:.*]] = fir.array_load %[[ld]](%[[shape]]) : (!fir.ptr<!fir.array<3xi32>>, !fir.shape<1>) -> !fir.array<3xi32>
-! CHECK: %[[c1:.*]] = arith.constant 1 : index
-! CHECK: %[[c0:.*]] = arith.constant 0 : index
-! CHECK: %[[sub:.*]] = arith.subi %[[c3]], %[[c1]] : index
-! CHECK: %[[doloop:.*]] = fir.do_loop %arg0 = %[[c0]] to %[[sub]] step %[[c1]] unordered iter_args(%arg1 = %[[arrayld1]]) -> (!fir.array<3xi32>) {
-! CHECK: %[[arrayfetch:.*]] = fir.array_fetch %[[arrayld]], %arg0 : (!fir.array<3xi32>, index) -> i32
-! CHECK: %[[arrayupdate:.*]] = fir.array_update %arg1, %[[arrayfetch]], %arg0 : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
-! CHECK: fir.result %[[arrayupdate]] : !fir.array<3xi32>
-! CHECK: fir.array_merge_store %[[arrayld1]], %[[doloop]] to %[[k]] : !fir.array<3xi32>, !fir.array<3xi32>, !fir.ref<!fir.array<3xi32>>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: hlfir.assign %[[pteload]] to %[[k]]#0 : !fir.box<!fir.ptr<!fir.array<?xi32>>>, !fir.ref<!fir.array<3xi32>>
 
   pte = -2
   print *, data
 
-! CHECK: %[[shape:.*]] = fir.shape %[[c31]] : (index) -> !fir.shape<1>
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[arrayld:.*]] = fir.array_load %[[ld]](%[[shape]]) : (!fir.ptr<!fir.array<3xi32>>, !fir.shape<1>) -> !fir.array<3xi32>
-! CHECK: %[[c2n:.*]] = arith.constant -2 : i32
-! CHECK: %[[c1:.*]] = arith.constant 1 : index
-! CHECK: %[[c0:.*]] = arith.constant 0 : index
-! CHECK: %[[sub1:.*]] = arith.subi %[[c31]], %[[c1]] : index
-! CHECK: %[[doloop:.*]] = fir.do_loop %arg0 = %[[c0]] to %[[sub1]] step %[[c1]] unordered iter_args(%arg1 = %[[arrayld]]) -> (!fir.array<3xi32>) {
-! CHECK: %[[arrayupdate:.*]] = fir.array_update %arg1, %[[c2n]], %arg0 : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
-! CHECK: fir.result %[[arrayupdate]] : !fir.array<3xi32>
-! CHECK: fir.array_merge_store %[[arrayld]], %[[doloop]] to %[[ld]] : !fir.array<3xi32>, !fir.array<3xi32>, !fir.ptr<!fir.array<3xi32>>
+! CHECK: %[[neg2:.*]] = arith.constant -2 : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: hlfir.assign %[[neg2]] to %[[pteload2]] : i32, !fir.box<!fir.ptr<!fir.array<?xi32>>>
 end
 
 ! Test Array Section  case
@@ -323,78 +339,39 @@ subroutine cray_arraySection()
   data = [ 1, 2, 3, 4, 5 ]
   ptr = loc(data(2))
 
-! CHECK: %[[c5:.*]] = arith.constant 5 : index
-! CHECK: %[[data:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
-! CHECK: %[[c2:.*]] = arith.constant 2 : index
-! CHECK: %[[k:.*]] = fir.alloca !fir.array<2xi32> {{.*}}
-! CHECK: %[[ptr:.*]] = fir.alloca i64 {{.*}}
-! CHECK: %[[c3:.*]] = arith.constant 3 : index
-! CHECK: %[[c1:.*]] = arith.constant 2 : i64
-! CHECK: %[[c0:.*]] = arith.constant 1 : i64
-! CHECK: %[[sub:.*]] = arith.subi %[[c1]], %[[c0]] : i64
-! CHECK: %[[cor:.*]] = fir.coordinate_of %[[data]], %[[sub]] : (!fir.ref<!fir.array<5xi32>>, i64) -> !fir.ref<i32>
-! CHECK: %[[box:.*]] = fir.embox %[[cor]] : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[val]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: %[[pte_alloc:.*]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?xi32>>>
+! CHECK: %[[data_alloc:.*]] = fir.alloca !fir.array<5xi32> {{.*}}
+! CHECK: %[[data:.*]]:2 = hlfir.declare %[[data_alloc]]
+! CHECK: %[[k_alloc:.*]] = fir.alloca !fir.array<2xi32> {{.*}}
+! CHECK: %[[k:.*]]:2 = hlfir.declare %[[k_alloc]]
+! CHECK: %[[ptr_alloc:.*]] = fir.alloca i64 {{.*}}
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_alloc]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QFcray_arraysectionEptr"}
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %[[pte_alloc]] {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QFcray_arraysectionEpte"}
 
   k = pte(2:3)
   print *, k
 
-! CHECK: %[[shape1:.*]] = fir.shape %[[c2]] : (index) -> !fir.shape<1>
-! CHECK: %[[arrayld1:.*]] = fir.array_load %[[k]](%[[shape1]]) : (!fir.ref<!fir.array<2xi32>>, !fir.shape<1>) -> !fir.array<2xi32>
-! CHECK: %[[c2i64:.*]] = arith.constant 2 : i64
-! CHECK: %[[conv:.*]] = fir.convert %[[c2i64]] : (i64) -> index
-! CHECK: %[[c1i64:.*]] = arith.constant 1 : i64
-! CHECK: %[[conv1:.*]] = fir.convert %[[c1i64]] : (i64) -> index
-! CHECK: %[[c3i64:.*]] = arith.constant 3 : i64
-! CHECK: %[[conv2:.*]] = fir.convert %[[c3i64]] : (i64) -> index
-! CHECK: %[[shape:.*]] = fir.shape %[[c3]] : (index) -> !fir.shape<1>
-! CHECK: %[[slice:.*]] = fir.slice %[[conv]], %[[conv2]], %[[conv1]] : (index, index, index) -> !fir.slice<1>
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld:.*]] =  fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[arrayld:.*]] = fir.array_load %[[ld]](%[[shape]]) [%[[slice]]] : (!fir.ptr<!fir.array<3xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<3xi32>
-! CHECK: %[[c1_3:.*]] = arith.constant 1 : index
-! CHECK: %[[c0_4:.*]] = arith.constant 0 : index
-! CHECK: %[[sub:.*]] = arith.subi %[[c2]], %[[c1_3]] : index
-! CHECK: %[[doloop:.*]] = fir.do_loop %arg0 = %[[c0_4]] to %[[sub]] step %[[c1_3]] unordered iter_args(%arg1 = %[[arrayld1]]) -> (!fir.array<2xi32>) {
-! CHECK: %[[arrayfetch:.*]] = fir.array_fetch %[[arrayld]], %arg0 : (!fir.array<3xi32>, index) -> i32
-! CHECK: %[[arrayupdate:.*]] = fir.array_update %arg1, %[[arrayfetch]], %arg0 : (!fir.array<2xi32>, i32, index) -> !fir.array<2xi32>
-! CHECK: fir.result %[[arrayupdate]] : !fir.array<2xi32>
-! CHECK: fir.array_merge_store %[[arrayld1]], %[[doloop]] to %[[k]] : !fir.array<2xi32>, !fir.array<2xi32>, !fir.ref<!fir.array<2xi32>>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: %[[ptedes:.*]] = hlfir.designate %[[pteload]] (%{{.*}}:%{{.*}}:%{{.*}})  shape %{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index, index, index, !fir.shape<1>) -> !fir.ref<!fir.array<2xi32>>
+! CHECK: hlfir.assign %[[ptedes]] to %[[k]]#0 : !fir.ref<!fir.array<2xi32>>, !fir.ref<!fir.array<2xi32>>
 
   pte(1:2) = -2
   print *, data
 
-! CHECK: %[[c1_5:.*]] = arith.constant 1 : i64
-! CHECK: %[[conv:.*]] = fir.convert %[[c1_5]] : (i64) -> index
-! CHECK: %[[c1_6:.*]] = arith.constant 1 : i64
-! CHECK: %[[conv1:.*]] = fir.convert %[[c1_6]] : (i64) -> index
-! CHECK: %[[c2_7:.*]] = arith.constant 2 : i64
-! CHECK: %[[conv2:.*]] = fir.convert %[[c2_7]] : (i64) -> index
-! CHECK: %[[c0_8:.*]] = arith.constant 0 : index
-! CHECK: %[[sub:.*]] = arith.subi %[[conv2]], %[[conv]] : index
-! CHECK: %[[add:.*]]  = arith.addi %[[sub]], %[[conv1]] : index
-! CHECK: %[[div:.*]] = arith.divsi %[[add]], %[[conv1]] : index
-! CHECK: %[[cmp:.*]] = arith.cmpi sgt, %[[div]], %[[c0_8]] : index
-! CHECK: %[[sel:.*]] = arith.select %[[cmp]], %[[div]], %[[c0_8]] : index
-! CHECK: %[[shape:.*]] = fir.shape %[[c3]] : (index) -> !fir.shape<1>
-! CHECK: %[[slice:.*]] = fir.slice %[[conv]], %[[conv2]], %[[conv1]] : (index, index, index) -> !fir.slice<1>
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<!fir.ref<i64>>
-! CHECK: %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.ref<i64>>) -> !fir.ref<i64>
-! CHECK: %[[val:.*]] = fir.convert %[[addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[ld:.*]] = fir.load %[[val]] : !fir.ref<!fir.ptr<!fir.array<3xi32>>>
-! CHECK: %[[arrayld:.*]] = fir.array_load %[[ld]](%[[shape]]) [%[[slice]]] : (!fir.ptr<!fir.array<3xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<3xi32>
-! CHECK: %[[c2n:.*]] = arith.constant -2 : i32
-! CHECK: %[[c1_9:.*]] = arith.constant 1 : index
-! CHECK: %[[c0_8:.*]] = arith.constant 0 : index
-! CHECK: %[[sub1:.*]] = arith.subi %[[sel]], %[[c1_9]] : index
-! CHECK: %[[doloop:.*]] = fir.do_loop %arg0 = %[[c0_8]] to %[[sub1]] step %[[c1_9]] unordered iter_args(%arg1 = %[[arrayld]]) -> (!fir.array<3xi32>) {
-! CHECK: %[[arrayupdate:.*]] = fir.array_update %arg1, %[[c2n]], %arg0 : (!fir.array<3xi32>, i32, index) -> !fir.array<3xi32>
-! CHECK: fir.result %[[arrayupdate]] : !fir.array<3xi32>
-! CHECK: fir.array_merge_store %[[arrayld]], %[[doloop]] to %[[ld]][%[[slice]]] : !fir.array<3xi32>, !fir.array<3xi32>, !fir.ptr<!fir.array<3xi32>>, !fir.slice<1>
+! CHECK: %[[neg2:.*]] = arith.constant -2 : i32
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK: %[[ptedes2:.*]] = hlfir.designate %[[pteload2]] (%{{.*}}:%{{.*}}:%{{.*}})  shape %{{.*}} : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index, index, index, !fir.shape<1>) -> !fir.ref<!fir.array<2xi32>>
+! CHECK: hlfir.assign %[[neg2]] to %[[ptedes2]] : i32, !fir.ref<!fir.array<2xi32>>
 end
 
 ! Test Cray pointer declared in a module
@@ -409,12 +386,14 @@ subroutine test_ptr()
   implicit none
   integer :: x
   ptr = loc(x)
-! CHECK: %[[ptr:.*]] = fir.address_of(@_QMmod_cray_ptrEptr) : !fir.ref<i64>
-! CHECK: %[[x:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_ptrEx"}
-! CHECK: %[[box:.*]] = fir.embox %[[x]] : (!fir.ref<i32>) -> !fir.box<i32>
-! CHECK: %[[boxAddr:.*]] = fir.box_addr %[[box]] : (!fir.box<i32>) -> !fir.ref<i32>
-! CHECK: %[[addr_x:.*]] = fir.convert %[[boxAddr]] : (!fir.ref<i32>) -> i64
-! CHECK: fir.store %[[addr_x]] to %[[ptr]] : !fir.ref<i64>
+! CHECK: %[[ptr_addr:.*]] = fir.address_of(@_QMmod_cray_ptrEptr) : !fir.ref<i64>
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_addr]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QMmod_cray_ptrEptr"}
+! CHECK: %[[x_alloc:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_ptrEx"}
+! CHECK: %[[x:.*]]:2 = hlfir.declare %[[x_alloc]]
+! CHECK: %[[xbox:.*]] = fir.embox %[[x]]#0 : (!fir.ref<i32>) -> !fir.box<i32>
+! CHECK: %[[xboxAddr:.*]] = fir.box_addr %[[xbox]] : (!fir.box<i32>) -> !fir.ref<i32>
+! CHECK: %[[addr_x:.*]] = fir.convert %[[xboxAddr]] : (!fir.ref<i32>) -> i64
+! CHECK: hlfir.assign %[[addr_x]] to %[[ptr]]#0 : i64, !fir.ref<i64>
 end
 
 subroutine test_pte()
@@ -422,21 +401,30 @@ subroutine test_pte()
   implicit none
   integer :: x
   pte = x
-! CHECK: %[[ptr:.*]] = fir.address_of(@_QMmod_cray_ptrEptr) : !fir.ref<i64>
-! CHECK: %[[x:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_pteEx"}
-! CHECK: %[[xval:.*]] = fir.load %[[x]] : !fir.ref<i32>
-! CHECK: %[[box:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[boxAddr:.*]] = fir.box_addr %[[box]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[ptr2:.*]] = fir.convert %[[boxAddr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptr2val:.*]] = fir.load %[[ptr2]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: fir.store %[[xval]] to %[[ptr2val]] : !fir.ptr<i32>
+! CHECK-LABEL: func.func @_QPtest_pte()
+! CHECK: %[[ptr_addr:.*]] = fir.address_of(@_QMmod_cray_ptrEptr) : !fir.ref<i64>
+! CHECK: %[[ptr:.*]]:2 = hlfir.declare %[[ptr_addr]] {fortran_attrs = #fir.var_attrs<cray_pointer>, uniq_name = "_QMmod_cray_ptrEptr"}
+! CHECK: %[[x_alloc:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_pteEx"}
+! CHECK: %[[x:.*]]:2 = hlfir.declare %[[x_alloc]]
+! CHECK: %[[pte:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = #fir.var_attrs<pointer, cray_pointee>, uniq_name = "_QMmod_cray_ptrEpte"}
+! CHECK: %[[xval:.*]] = fir.load %[[x]]#0 : !fir.ref<i32>
+! CHECK: %[[ptrcvt:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld:.*]] = fir.load %[[ptrcvt]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr:.*]] = fir.convert %[[ptrld]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt]], %[[rawptr]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr:.*]] = fir.box_addr %[[pteload]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: hlfir.assign %[[xval]] to %[[pteaddr]] : i32, !fir.ptr<i32>
 
   x = pte
-! CHECK: %[[box2:.*]] = fir.embox %[[ptr]] : (!fir.ref<i64>) -> !fir.box<i64>
-! CHECK: %[[box2Addr:.*]] = fir.box_addr %[[box2]] : (!fir.box<i64>) -> !fir.ref<i64>
-! CHECK: %[[refptr:.*]] = fir.convert %[[box2Addr]] : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[ptr4:.*]] = fir.load %[[refptr]] : !fir.ref<!fir.ptr<i32>>
-! CHECK: %[[val:.*]] = fir.load %[[ptr4]] : !fir.ptr<i32>
-! CHECK: fir.store %[[val]] to %[[x]] : !fir.ref<i32>
+! CHECK: %[[ptrcvt2:.*]] = fir.convert %[[ptr]]#0 : (!fir.ref<i64>) -> !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptrld2:.*]] = fir.load %[[ptrcvt2]] : !fir.ref<!fir.ptr<i64>>
+! CHECK: %[[ptebox_cvt2:.*]] = fir.convert %[[pte]]#0 : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK: %[[rawptr2:.*]] = fir.convert %[[ptrld2]] : (!fir.ptr<i64>) -> !fir.llvm_ptr<i8>
+! CHECK: fir.call @_FortranAPointerAssociateScalar(%[[ptebox_cvt2]], %[[rawptr2]]) {{.*}}: (!fir.ref<!fir.box<none>>, !fir.llvm_ptr<i8>) -> ()
+! CHECK: %[[pteload2:.*]] = fir.load %[[pte]]#0 : !fir.ref<!fir.box<!fir.ptr<i32>>>
+! CHECK: %[[pteaddr2:.*]] = fir.box_addr %[[pteload2]] : (!fir.box<!fir.ptr<i32>>) -> !fir.ptr<i32>
+! CHECK: %[[val:.*]] = fir.load %[[pteaddr2]] : !fir.ptr<i32>
+! CHECK: hlfir.assign %[[val]] to %[[x]]#0 : i32, !fir.ref<i32>
 end
-

--- a/flang/test/Lower/default-initialization-globals.f90
+++ b/flang/test/Lower/default-initialization-globals.f90
@@ -1,5 +1,5 @@
 ! Test default initialization of global variables (static init)
-! RUN: bbc -hlfir=false %s -o - | FileCheck %s --check-prefixes=%if target={{.*-aix.*|sparc.*}} %{"CHECK","CHECK-BE"%} \
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=%if target={{.*-aix.*|sparc.*}} %{"CHECK","CHECK-BE"%} \
 ! RUN:                                         %else %{"CHECK","CHECK-LE"%}
 
 module tinit
@@ -65,16 +65,16 @@ module tinit
   ! Test scalar with default init
   type(t0) :: at0
 ! CHECK-LABEL: fir.global @_QMtinitEat0 : !fir.type<_QMtinitTt0{k:i32}> {
-  ! CHECK: %[[VAL_0:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_1:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_0:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_2:.*]] = fir.insert_value %[[VAL_1]], %[[VAL_0]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: fir.has_value %[[VAL_2]] : !fir.type<_QMtinitTt0{k:i32}>
 
   ! Test array with default init
   type(t0) :: bt0(100)
 ! CHECK-LABEL: @_QMtinitEbt0 : !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>> {
-  ! CHECK: %[[VAL_3:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_4:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_3:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_3]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: %[[VAL_6:.*]] = fir.undefined !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>
   ! CHECK: %[[VAL_7:.*]] = fir.insert_on_range %[[VAL_6]], %[[VAL_5]] from (0) to (99) : (!fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>>
@@ -83,62 +83,69 @@ module tinit
   ! Test default init overridden by explicit init
   type(t0) :: ct0 = t0(42)
 ! CHECK-LABEL: fir.global @_QMtinitEct0 : !fir.type<_QMtinitTt0{k:i32}> {
-  ! CHECK: %[[VAL_8:.*]] = arith.constant 42 : i32
   ! CHECK: %[[VAL_9:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_8:.*]] = arith.constant 42 : i32
   ! CHECK: %[[VAL_10:.*]] = fir.insert_value %[[VAL_9]], %[[VAL_8]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: fir.has_value %[[VAL_10]] : !fir.type<_QMtinitTt0{k:i32}>
 
   ! Test a non trivial derived type mixing all sorts of default initialization
   type(t1) :: dt1
 ! CHECK-LABEL: @_QMtinitEdt1 : !fir.type<_QMtinitTt1{{.*}}> {
-  ! CHECK-DAG: %[[VAL_11:.*]] = arith.constant 42 : i32
-  ! CHECK-DAG: %[[VAL_12:.*]] = arith.constant 100 : index
-  ! CHECK-DAG: %[[VAL_13:.*]] = arith.constant 0 : index
-  ! CHECK-DAG: %[[VAL_14:.*]] = arith.constant 33 : i32
-  ! CHECK-DAG: %[[VAL_15:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_16:.*]] = fir.undefined !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_11:.*]] = arith.constant 42 : i32
   ! CHECK: %[[VAL_17:.*]] = fir.insert_value %[[VAL_16]], %[[VAL_11]], ["i", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, i32) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_18:.*]] = fir.zero_bits i32
   ! CHECK: %[[VAL_19:.*]] = fir.insert_value %[[VAL_17]], %[[VAL_18]], ["j", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, i32) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_20:.*]] = fir.address_of(@_QMtinitEziel) : !fir.ref<!fir.array<100xf32>>
+  ! CHECK: %[[VAL_12:.*]] = arith.constant 100 : index
   ! CHECK: %[[VAL_21:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
-  ! CHECK: %[[VAL_22:.*]] = fir.embox %[[VAL_20]](%[[VAL_21]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<100xf32>>
+  ! CHECK: %[[VAL_ZIEL_DECL:.*]]:2 = hlfir.declare %[[VAL_20]](%[[VAL_21]])
+  ! CHECK: %[[VAL_22:.*]] = fir.embox %[[VAL_ZIEL_DECL]]#0(%{{.*}}) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<100xf32>>
   ! CHECK: %[[VAL_22_B:.*]] = fir.rebox %[[VAL_22]] : (!fir.box<!fir.array<100xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
   ! CHECK: %[[VAL_23:.*]] = fir.insert_value %[[VAL_19]], %[[VAL_22_B]], ["x", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_24:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[VAL_13:.*]] = arith.constant 0 : index
   ! CHECK: %[[VAL_25:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_26:.*]] = fir.embox %[[VAL_24]](%[[VAL_25]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
   ! CHECK: %[[VAL_27:.*]] = fir.insert_value %[[VAL_23]], %[[VAL_26]], ["y", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
-  ! CHECK: %[[VAL_28:.*]] = fir.insert_value %[[VAL_27]], %[[VAL_26]], ["z", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_28:.*]] = fir.insert_value %[[VAL_27]], %{{.*}}, ["z", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_29:.*]] = fir.string_lit "hello     "(10) : !fir.char<1,10>
   ! CHECK: %[[VAL_30:.*]] = fir.insert_value %[[VAL_28]], %[[VAL_29]], ["c1", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.char<1,10>) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_31:.*]] = fir.zero_bits !fir.char<1,10>
   ! CHECK: %[[VAL_32:.*]] = fir.insert_value %[[VAL_30]], %[[VAL_31]], ["c2", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.char<1,10>) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_33:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_15:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_34:.*]] = fir.insert_value %[[VAL_33]], %[[VAL_15]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: %[[VAL_35:.*]] = fir.insert_value %[[VAL_32]], %[[VAL_34]], ["somet0", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
   ! CHECK: %[[VAL_36:.*]] = fir.zero_bits !fir.type<_QMtinitTtno_init{k:i32}>
   ! CHECK: %[[VAL_37:.*]] = fir.insert_value %[[VAL_35]], %[[VAL_36]], ["sometno_init", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTtno_init{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
-  ! CHECK: %[[VAL_38:.*]] = fir.insert_value %[[VAL_33]], %[[VAL_14]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
-  ! CHECK: %[[VAL_39:.*]] = fir.insert_value %[[VAL_37]], %[[VAL_38]], ["somet0_2", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
-  ! CHECK: %[[VAL_40:.*]] = fir.insert_value %[[VAL_39]], %[[VAL_34]], ["somet0_array", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
-  ! CHECK: fir.has_value %[[VAL_40]] : !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_38:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_14:.*]] = arith.constant 33 : i32
+  ! CHECK: %[[VAL_39:.*]] = fir.insert_value %[[VAL_38]], %[[VAL_14]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_40:.*]] = fir.insert_value %[[VAL_37]], %[[VAL_39]], ["somet0_2", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: %[[VAL_41:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %{{.*}} = arith.constant 66 : i32
+  ! CHECK: %[[VAL_43:.*]] = fir.insert_value %[[VAL_41]], %{{.*}}, ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_44:.*]] = fir.insert_value %[[VAL_40]], %[[VAL_43]], ["somet0_array", !fir.type<_QMtinitTt1{{.*}}>] : (!fir.type<_QMtinitTt1{{.*}}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTt1{{.*}}>
+  ! CHECK: fir.has_value %[[VAL_44]] : !fir.type<_QMtinitTt1{{.*}}>
 
   ! Test a type extending other type with a default init
   type(textendst0) :: etextendst0
-! CHECK-LABEL: @_QMtinitEetextendst0 : !fir.type<_QMtinitTtextendst0{k:i32,l:i32}> {
-  ! CHECK: %[[VAL_42:.*]] = arith.constant 66 : i32
-  ! CHECK: %[[VAL_43:.*]] = fir.undefined !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
-  ! CHECK: %[[VAL_44:.*]] = fir.insert_value %[[VAL_43]], %[[VAL_42]], ["k", !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>] : (!fir.type<_QMtinitTtextendst0{k:i32,l:i32}>, i32) -> !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
-  ! CHECK: %[[VAL_45:.*]] = fir.zero_bits i32
-  ! CHECK: %[[VAL_46:.*]] = fir.insert_value %[[VAL_44]], %[[VAL_45]], ["l", !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>] : (!fir.type<_QMtinitTtextendst0{k:i32,l:i32}>, i32) -> !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
-  ! CHECK: fir.has_value %[[VAL_46]] : !fir.type<_QMtinitTtextendst0{k:i32,l:i32}>
+! CHECK-LABEL: @_QMtinitEetextendst0 : !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}> {
+  ! CHECK: %[[VAL_EXT:.*]] = fir.undefined !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>
+  ! CHECK: %[[VAL_PARENT:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_C66:.*]] = arith.constant 66 : i32
+  ! CHECK: %[[VAL_PARENT_INIT:.*]] = fir.insert_value %[[VAL_PARENT]], %[[VAL_C66]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_T0:.*]] = fir.insert_value %[[VAL_EXT]], %[[VAL_PARENT_INIT]], ["t0", !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>] : (!fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>, !fir.type<_QMtinitTt0{k:i32}>) -> !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>
+  ! CHECK: %[[VAL_ZERO_L:.*]] = fir.zero_bits i32
+  ! CHECK: %[[VAL_FINAL:.*]] = fir.insert_value %[[VAL_T0]], %[[VAL_ZERO_L]], ["l", !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>] : (!fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>, i32) -> !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>
+  ! CHECK: fir.has_value %[[VAL_FINAL]] : !fir.type<_QMtinitTtextendst0{t0:!fir.type<_QMtinitTt0{k:i32}>,l:i32}>
 
   type(tv) :: withmold = tv(null(mv))
   ! CHECK-LABEL: fir.global @_QMtinitEwithmold
-  ! CHECK: %[[C0:.*]] = arith.constant 0 : index
   ! CHECK: %[[UNDEF:.*]] = fir.undefined !fir.type<_QMtinitTtv{v:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
   ! CHECK: %[[ZERO:.*]] = fir.zero_bits !fir.ptr<!fir.array<?xf32>>
+  ! CHECK: %[[C0:.*]] = arith.constant 0 : index
   ! CHECK: %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
   ! CHECK: %[[ZEROBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.ptr<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
   ! CHECK: %[[RET:.*]] = fir.insert_value %[[UNDEF]], %[[ZEROBOX]], ["v", !fir.type<_QMtinitTtv{v:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>] : (!fir.type<_QMtinitTtv{v:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>, !fir.box<!fir.ptr<!fir.array<?xf32>>>) -> !fir.type<_QMtinitTtv{v:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>
@@ -152,8 +159,8 @@ subroutine saved()
   use tinit
   type(t0), save :: savedt0
 ! CHECK-LABEL: fir.global internal @_QFsavedEsavedt0 : !fir.type<_QMtinitTt0{k:i32}> {
-  ! CHECK: %[[VAL_47:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_48:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
+  ! CHECK: %[[VAL_47:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_49:.*]] = fir.insert_value %[[VAL_48]], %[[VAL_47]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: fir.has_value %[[VAL_49]] : !fir.type<_QMtinitTt0{k:i32}>
 end subroutine
@@ -165,10 +172,10 @@ subroutine eqv()
   integer :: i(2)
   equivalence (somet, i)
 ! CHECK-LABEL: fir.global internal @_QFeqvEi : !fir.array<2xi32> {
-  ! CHECK-DAG: %[[VAL_50:.*]] = arith.constant 2 : i32
-  ! CHECK-DAG: %[[VAL_51:.*]] = arith.constant 3 : i32
   ! CHECK: %[[VAL_52:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_50:.*]] = arith.constant 2 : i32
   ! CHECK: %[[VAL_53:.*]] = fir.insert_value %[[VAL_52]], %[[VAL_50]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_51:.*]] = arith.constant 3 : i32
   ! CHECK: %[[VAL_54:.*]] = fir.insert_value %[[VAL_53]], %[[VAL_51]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
   ! CHECK: fir.has_value %[[VAL_54]] : !fir.array<2xi32>
 end subroutine
@@ -179,10 +186,10 @@ subroutine eqv_explicit_init()
   integer :: i(2) = [4, 5]
   equivalence (somet, i)
 ! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi : !fir.array<2xi32> {
-  ! CHECK-DAG: %[[VAL_57:.*]] = arith.constant 4 : i32
-  ! CHECK-DAG: %[[VAL_58:.*]] = arith.constant 5 : i32
   ! CHECK: %[[VAL_59:.*]] = fir.undefined !fir.array<2xi32>
+  ! CHECK: %[[VAL_57:.*]] = arith.constant 4 : i32
   ! CHECK: %[[VAL_60:.*]] = fir.insert_value %[[VAL_59]], %[[VAL_57]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
+  ! CHECK: %[[VAL_58:.*]] = arith.constant 5 : i32
   ! CHECK: %[[VAL_61:.*]] = fir.insert_value %[[VAL_60]], %[[VAL_58]], [1 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
   ! CHECK: fir.has_value %[[VAL_61]] : !fir.array<2xi32>
 end subroutine
@@ -192,9 +199,9 @@ subroutine eqv_same_default_init()
   type(tseq), save :: somet1(2), somet2
   equivalence (somet1(1), somet2)
 ! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 : !fir.array<2xi64> {
+  ! CHECK: %[[VAL_63:.*]] = fir.undefined !fir.array<2xi64>
   ! CHECK-LE: %[[VAL_62:.*]] = arith.constant 12884901890 : i64
   ! CHECK-BE: %[[VAL_62:.*]] = arith.constant 8589934595 : i64
-  ! CHECK: %[[VAL_63:.*]] = fir.undefined !fir.array<2xi64>
   ! CHECK: %[[VAL_64:.*]] = fir.insert_on_range %[[VAL_63]], %[[VAL_62]] from (0) to (1) : (!fir.array<2xi64>, i64) -> !fir.array<2xi64>
   ! CHECK: fir.has_value %[[VAL_64]] : !fir.array<2xi64>
 end subroutine
@@ -213,16 +220,16 @@ subroutine eqv_full_overlaps_with_explicit_init()
   equivalence (somet, link(2))
   equivalence (j, link(3))
 ! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi : !fir.array<4xi32> {
-  ! CHECK-DAG: %[[VAL_73:.*]] = arith.constant 5 : i32
-  ! CHECK-DAG: %[[VAL_74:.*]] = arith.constant 6 : i32
-  ! CHECK-DAG: %[[VAL_75:.*]] = arith.constant 7 : i32
-  ! CHECK-DAG: %[[VAL_76:.*]] = arith.constant 8 : i32
-  ! CHECK-DAG: %[[VAL_77:.*]] = fir.undefined !fir.array<4xi32>
-  ! CHECK-DAG: %[[VAL_78:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_73]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
-  ! CHECK-DAG: %[[VAL_79:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_74]], [1 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
-  ! CHECK-DAG: %[[VAL_80:.*]] = fir.insert_value %[[VAL_79]], %[[VAL_75]], [2 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
-  ! CHECK-DAG: %[[VAL_81:.*]] = fir.insert_value %[[VAL_80]], %[[VAL_76]], [3 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
-  ! CHECK-DAG: fir.has_value %[[VAL_81]] : !fir.array<4xi32>
+  ! CHECK: %[[VAL_77:.*]] = fir.undefined !fir.array<4xi32>
+  ! CHECK: %[[VAL_73:.*]] = arith.constant 5 : i32
+  ! CHECK: %[[VAL_78:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_73]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK: %[[VAL_74:.*]] = arith.constant 6 : i32
+  ! CHECK: %[[VAL_79:.*]] = fir.insert_value %[[VAL_78]], %[[VAL_74]], [1 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK: %[[VAL_75:.*]] = arith.constant 7 : i32
+  ! CHECK: %[[VAL_80:.*]] = fir.insert_value %[[VAL_79]], %[[VAL_75]], [2 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK: %[[VAL_76:.*]] = arith.constant 8 : i32
+  ! CHECK: %[[VAL_81:.*]] = fir.insert_value %[[VAL_80]], %[[VAL_76]], [3 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+  ! CHECK: fir.has_value %[[VAL_81]] : !fir.array<4xi32>
 end subroutine
 
 subroutine eqv_partial_overlaps_with_explicit_init()
@@ -242,14 +249,14 @@ subroutine eqv_partial_overlaps_with_explicit_init()
   equivalence (somet, link(2))
   equivalence (j, link(4))
 ! CHECK-LABEL: fir.global internal @_QFeqv_partial_overlaps_with_explicit_initEi : !fir.array<4xi32>
-   ! CHECK-DAG: %[[VAL_82:.*]] = arith.constant 5 : i32
-   ! CHECK-DAG: %[[VAL_83:.*]] = arith.constant 6 : i32
-   ! CHECK-DAG: %[[VAL_84:.*]] = arith.constant 3 : i32
-   ! CHECK-DAG: %[[VAL_85:.*]] = arith.constant 7 : i32
    ! CHECK: %[[VAL_86:.*]] = fir.undefined !fir.array<4xi32>
+   ! CHECK: %[[VAL_82:.*]] = arith.constant 5 : i32
    ! CHECK: %[[VAL_87:.*]] = fir.insert_value %[[VAL_86]], %[[VAL_82]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_83:.*]] = arith.constant 6 : i32
    ! CHECK: %[[VAL_88:.*]] = fir.insert_value %[[VAL_87]], %[[VAL_83]], [1 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_84:.*]] = arith.constant 3 : i32
    ! CHECK: %[[VAL_89:.*]] = fir.insert_value %[[VAL_88]], %[[VAL_84]], [2 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
+   ! CHECK: %[[VAL_85:.*]] = arith.constant 7 : i32
    ! CHECK: %[[VAL_90:.*]] = fir.insert_value %[[VAL_89]], %[[VAL_85]], [3 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
    ! CHECK: fir.has_value %[[VAL_90]] : !fir.array<4xi32>
 end subroutine

--- a/flang/test/Lower/loops.f90
+++ b/flang/test/Lower/loops.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false --enable-delayed-privatization=false -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -mllvm --enable-delayed-privatization=false -o - %s | FileCheck %s
 
 ! CHECK-LABEL: loop_test
 subroutine loop_test
@@ -18,7 +18,7 @@ subroutine loop_test
 
   ! CHECK: fir.do_concurrent.loop (%{{.*}}, %{{.*}}, %{{.*}}) = {{.*}}
   do concurrent (i=1:5, j=1:5, k=1:5) ! shared(a)
-    ! CHECK: fir.coordinate_of
+    ! CHECK: hlfir.designate
     a(i,j,k) = 0
   enddo
   ! CHECK: fir.call @_FortranAioBeginExternalListOutput
@@ -27,7 +27,7 @@ subroutine loop_test
   ! CHECK: fir.do_concurrent.loop (%{{.*}}, %{{.*}}, %{{.*}}) = {{.*}}
   ! CHECK: fir.if
   do concurrent (integer(1)::i=1:5, j=1:5, k=1:5, i.ne.j .and. k.ne.3) shared(a)
-    ! CHECK-COUNT-2: fir.coordinate_of
+    ! CHECK-COUNT-2: hlfir.designate
     a(i,j,k) = a(i,j,k) + 1
   enddo
 
@@ -36,7 +36,7 @@ subroutine loop_test
   do i=1,5
     do j=1,5
       do k=1,5
-        ! CHECK: fir.coordinate_of
+        ! CHECK: hlfir.designate
         asum = asum + a(i,j,k)
       enddo
     enddo
@@ -97,10 +97,7 @@ subroutine lis(n)
   integer, pointer   :: p(:,:,:) ! local_init locality
 
   p => a
-  ! CHECK:     fir.do_loop %arg1 = %c0{{.*}} to %{{.*}} step %c1{{.*}} unordered iter_args(%arg2 = %{{.*}}) -> (!fir.array<?x?xi32>) {
-  ! CHECK:       fir.do_loop %arg3 = %c0{{.*}} to %{{.*}} step %c1{{.*}} unordered iter_args(%arg4 = %arg2) -> (!fir.array<?x?xi32>) {
-  ! CHECK:       }
-  ! CHECK:     }
+  ! CHECK:     hlfir.assign %c0{{.*}} to %{{.*}} : i32, !fir.box<!fir.array<?x?xi32>>
   r = 0
 
   ! CHECK:     fir.do_concurrent {
@@ -116,19 +113,19 @@ subroutine lis(n)
 
   ! CHECK:       fir.do_concurrent.loop (%{{.*}}, %{{.*}}) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
   ! CHECK:         fir.if %{{.*}} {
-  ! CHECK:           %[[V_95:[0-9]+]] = fir.alloca !fir.array<?x?xi32>, %{{.*}}, %{{.*}} {bindc_name = "t", pinned, uniq_name = "_QFlisEt"}
-  ! CHECK:           %[[V_96:[0-9]+]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?x?xi32>>> {bindc_name = "p", pinned, uniq_name = "_QFlisEp"}
-  ! CHECK:           fir.store %{{.*}} to %[[V_96]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x?xi32>>>>
+  ! CHECK:           %[[V_T_ALLOC:[0-9]+]] = fir.alloca !fir.array<?x?xi32>, %{{.*}}, %{{.*}} {bindc_name = "t", pinned, uniq_name = "_QFlisEt"}
+  ! CHECK:           %[[V_T_DECL:.*]]:2 = hlfir.declare %[[V_T_ALLOC]]({{.*}}) {uniq_name = "_QFlisEt"}
+  ! CHECK:           %[[V_P_ALLOC:[0-9]+]] = fir.alloca !fir.box<!fir.ptr<!fir.array<?x?x?xi32>>> {bindc_name = "p", pinned, uniq_name = "_QFlisEp"}
+  ! CHECK:           fir.store %{{.*}} to %[[V_P_ALLOC]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x?xi32>>>>
+  ! CHECK:           %[[V_P_DECL:.*]]:2 = hlfir.declare %[[V_P_ALLOC]]
   ! CHECK:           fir.do_loop %arg3 = %{{.*}} to %{{.*}} step %c1{{.*}} iter_args(%arg4 = %{{.*}}) -> (i32) {
   ! CHECK:             fir.do_concurrent {
   ! CHECK:               fir.alloca i32 {bindc_name = "m"}
   ! CHECK:               fir.do_concurrent.loop (%{{.*}}) = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) {
-  ! CHECK:                 fir.load %[[V_96]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x?xi32>>>>
-  ! CHECK:                 fir.convert %[[V_95]] : (!fir.ref<!fir.array<?x?xi32>>) -> !fir.ref<!fir.array<?xi32>>
+  ! CHECK:                 fir.load %[[V_P_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?x?xi32>>>>
   ! CHECK:               }
   ! CHECK:             }
   ! CHECK:           }
-  ! CHECK:           fir.convert %[[V_95]] : (!fir.ref<!fir.array<?x?xi32>>) -> !fir.ref<!fir.array<?xi32>>
   ! CHECK:         }
   ! CHECK:       }
   ! CHECK:     }


### PR DESCRIPTION
Convert five tests to use new HLFIR lowering instead of legacy FIR lowering:
Lower/Intrinsics/c_f_pointer.f90, Lower/Intrinsics/c_loc.f90, Lower/default-initialization-globals.f90, Lower/cray-pointer.f90, Lower/loops.f90