### PR TITLE
[WebAssembly] Fix -Wunused-function

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -1579,7 +1579,7 @@ static void splitEndLoopBB(MachineBasicBlock *EndTryTableBB) {
 
 // Print the BB name in the form of bb.NUMBER.ORIGINAL_NAME.
 // e.g., bb.3.catch.start
-static std::string getBBName(const MachineBasicBlock *MBB) {
+[[maybe_unused]] static std::string getBBName(const MachineBasicBlock *MBB) {
   std::string Name = "bb.";
   Name += Twine(MBB->getNumber()).str();
   if (MBB->getBasicBlock()) {


### PR DESCRIPTION
After 4aee20b8caa9b8477aef94d10c37b2f00805de07, getBBName is only used
within an assertion so mark it [[maybe_unused]] so it does not cause a
-Wunused-function warning in non-asserts builds.