### PR TITLE
[clang-cl] Add cl compiler build deterministic options for compatibility.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -393,6 +393,17 @@ New Compiler Flags
   a hostname when generates the hashes. Known issues -- does not remap the
   source file pathes within PCH/PCM files.
 
+- New ``-cl`` option ``/experimental:deterministic`` added to match CL's option.
+  This enables warning emission on usage of non-deterministic macros __DATE__,
+  __TIME__ and __TIMESTAMP__ and provides reproducable COFF's timestamp for
+  the output object files.
+
+- New ``-cl`` option ``/d1nodatetime`` added to match CL's option. This option
+  undefines the standard macros __DATE__, __TIME__ and __TIMESTAMP__ to allow
+  reproducable builds. These macros can be redefined from the command line if
+  necessary. ``/d1nodatetime-`` can be used to turn this feature off if
+  necessary to override the common build settings.
+
 Deprecated Compiler Flags
 -------------------------
 
@@ -406,6 +417,10 @@ Modified Compiler Flags
   by ``-unique-internal-linkage-names`` option. Now it uses a path that
   normalized in favor of the target system (same as the preprocessor does
   for the file macros) and allows the reproducable IDs on any build system.
+
+- The ``-cl`` ``/Brepro`` option was modified to match the original CL's option
+  and now defines the standard macros __DATE__, __TIME__ and __TIMESTAMP__ to
+  "1". The previous functionality remains unchanged.
 
 Removed Compiler Flags
 ----------------------

--- a/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/clang/include/clang/Lex/PreprocessorOptions.h
@@ -43,6 +43,18 @@ enum ObjCXXARCStandardLibraryKind {
   ARCXX_libstdcxx
 };
 
+/// How to initialize the date/time macros.
+enum DateTimeInitKind {
+  /// Set to the current date and time.
+  Default = 0,
+
+  /// Set to literal string "1".
+  LiteralOne = 1,
+
+  /// Keep undefined.
+  Undefined = 2
+};
+
 /// Whether to disable the normal validation performed on precompiled
 /// headers and module files when they are loaded.
 enum class DisableValidationForModuleKind {
@@ -208,6 +220,10 @@ public:
   /// The initial value for __COUNTER__; typically is zero but can be set via a
   /// -cc1 flag for testing purposes.
   uint32_t InitialCounterValue = 0;
+
+  /// Specify initialization kind for __DATE__, __TIME__ and __TIMESTAMP__
+  /// macros.
+  DateTimeInitKind InitDateTimeMacros = DateTimeInitKind::Default;
 
 public:
   PreprocessorOptions() : PrecompiledPreambleBytes(0, false) {}

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -8896,6 +8896,11 @@ def fno_modules_check_relocated
       Group<f_Group>,
       HelpText<"Skip checks for relocated modules when loading PCM files">,
       MarshallingInfoNegativeFlag<PreprocessorOpts<"ModulesCheckRelocated">>;
+def init_datetime_macros_EQ : Joined<["-"], "init-datetime-macros=">,
+  HelpText<"Change __DATE__, __TIME__, and __TIMESTAMP__ macros initialization and expansion">,
+  Values<"default,literalone,undefined">,
+  NormalizedValues<["Default", "LiteralOne", "Undefined"]>,
+  MarshallingInfoEnum<PreprocessorOpts<"InitDateTimeMacros">, "Default">;
 
 } // let Visibility = [CC1Option]
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9334,6 +9334,10 @@ def : CLFlag<"Qgather-">, Alias<mno_gather>,
       HelpText<"Disable generation of gather instructions in auto-vectorization(x86 only)">;
 def : CLFlag<"Qscatter-">, Alias<mno_scatter>,
       HelpText<"Disable generation of scatter instructions in auto-vectorization(x86 only)">;
+def _SLASH_experemental_deterministic : CLJoined<"experimental:deterministic">,
+      HelpText<"Emit warnings on usage of non-deterministic macros __DATE__, __TIME__ and __TIMESTAMP__">;
+def _SLASH_d1nodatetime : CLFlag<"d1nodatetime">,
+      HelpText<"Undefine the standard preprocessor macros __DATE__, __TIME__ and __TIMESTAMP__">;
 
 // Non-aliases:
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9338,6 +9338,8 @@ def _SLASH_experemental_deterministic : CLJoined<"experimental:deterministic">,
       HelpText<"Emit warnings on usage of non-deterministic macros __DATE__, __TIME__ and __TIMESTAMP__">;
 def _SLASH_d1nodatetime : CLFlag<"d1nodatetime">,
       HelpText<"Undefine the standard preprocessor macros __DATE__, __TIME__ and __TIMESTAMP__">;
+def _SLASH_d1nodatetime_ : CLFlag<"d1nodatetime-">,
+      HelpText<"Disable undefinition of the standard preprocessor macros __DATE__, __TIME__ and __TIMESTAMP__">;
 
 // Non-aliases:
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9334,7 +9334,7 @@ def : CLFlag<"Qgather-">, Alias<mno_gather>,
       HelpText<"Disable generation of gather instructions in auto-vectorization(x86 only)">;
 def : CLFlag<"Qscatter-">, Alias<mno_scatter>,
       HelpText<"Disable generation of scatter instructions in auto-vectorization(x86 only)">;
-def _SLASH_experemental_deterministic : CLJoined<"experimental:deterministic">,
+def _SLASH_experimental_deterministic : CLJoined<"experimental:deterministic">,
       HelpText<"Emit warnings on usage of non-deterministic macros __DATE__, __TIME__ and __TIMESTAMP__">;
 def _SLASH_d1nodatetime : CLFlag<"d1nodatetime">,
       HelpText<"Undefine the standard preprocessor macros __DATE__, __TIME__ and __TIMESTAMP__">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9678,6 +9678,10 @@ def : CLFlag<"Qgather-">, Alias<mno_gather>,
       HelpText<"Disable generation of gather instructions in auto-vectorization(x86 only)">;
 def : CLFlag<"Qscatter-">, Alias<mno_scatter>,
       HelpText<"Disable generation of scatter instructions in auto-vectorization(x86 only)">;
+def _SLASH_experemental_deterministic : CLJoined<"experimental:deterministic">,
+      HelpText<"Emit warnings on usage of non-deterministic macros __DATE__, __TIME__ and __TIMESTAMP__">;
+def _SLASH_d1nodatetime : CLFlag<"d1nodatetime">,
+      HelpText<"Undefine the standard preprocessor macros __DATE__, __TIME__ and __TIMESTAMP__">;
 
 // Non-aliases:
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8911,10 +8911,11 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     CmdArgs.push_back("-mno-incremental-linker-compatible");
   }
 
-  if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
-                   options::OPT__SLASH_d1nodatetime_, false)) {
+  bool HasNoDateTime = Args.hasFlag(options::OPT__SLASH_d1nodatetime,
+                                    options::OPT__SLASH_d1nodatetime_, false);
+
+  if (HasNoDateTime)
     CmdArgs.push_back("-init-datetime-macros=undefined");
-  }
 
   // /Brepro is an alias for -mincremental-linker-compatible option.
   if (!Args.hasFlag(options::OPT_mincremental_linker_compatible,
@@ -8924,10 +8925,8 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
                         .isDefaultIncrementalLinkerCompatibleByDefault())) {
     // Redefine the date/time macros only if /d1nodatetime wasn't specified.
     // This options does not allow the user redifinitions for these macros.
-    if (!Args.hasFlag(options::OPT__SLASH_d1nodatetime,
-                      options::OPT__SLASH_d1nodatetime_, false)) {
+    if (!HasNoDateTime)
       CmdArgs.push_back("-init-datetime-macros=literalone");
-    }
   }
 }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8906,7 +8906,6 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
                   options::OPT__SLASH_d1nodatetime, false)) {
    CmdArgs.push_back("-Wno-builtin-macro-redefined");
  }
-
 }
 
 const char *Clang::getBaseInputName(const ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8897,39 +8897,23 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
         Twine("-loader-replaceable-function=") + FuncOverride));
   }
 
-  auto findMacro = [&](const std::string &Macro, bool claim = false) {
-    for (const auto *A : Args.filtered(options::OPT_D, options::OPT_U)) {
-      const std::string v(A->getValue());
-      if (v == Macro || v.find(Macro + '=') != std::string::npos)
-        if (claim)
-          A->claim();
-        return true;
-    }
-    return false;
-  };
-
   if (Args.hasArg(options::OPT__SLASH_experimental_deterministic)) {
     CmdArgs.push_back("-Wdate-time");
 
     if (Args.hasArg(options::OPT_mincremental_linker_compatible)) {
-      D.Diag(diag::err_drv_argument_not_allowed_with) << "/experimental:deterministic"
-                                                      << "/Brepro-";
+      D.Diag(diag::err_drv_argument_not_allowed_with)
+          << "/experimental:deterministic"
+          << "/Brepro-";
     }
-    // CL's sets COFF's OBJ timestamp to a hash of the source file path to get deterministic
-    // result, but we force this timestamp to 0, which also produces deterministic result.
+    // CL's sets COFF's OBJ timestamp to a hash of the source file path to get
+    // deterministic result, but we force this timestamp to 0, which also
+    // produces deterministic result.
     CmdArgs.push_back("-mno-incremental-linker-compatible");
   }
 
   if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
                   options::OPT__SLASH_d1nodatetime_, false)) {
-    // Allow user definitions for these macros from the command line.
-    CmdArgs.push_back("-Wno-builtin-macro-redefined");
-    if (!findMacro("__DATE__"))
-      CmdArgs.push_back("-U__DATE__");
-    if (!findMacro("__TIME__"))
-      CmdArgs.push_back("-U__TIME__");
-    if (!findMacro("__TIMESTAMP__"))
-      CmdArgs.push_back("-U__TIMESTAMP__");
+    CmdArgs.push_back("-init-datetime-macros=undefined");
   }
 
   // /Brepro is an alias for -mincremental-linker-compatible option.
@@ -8940,14 +8924,7 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     // This options does not allow the user redifinitions for these macros.
     if (!Args.hasFlag(options::OPT__SLASH_d1nodatetime,
                       options::OPT__SLASH_d1nodatetime_, false)) {
-      findMacro("__DATE__", true);
-      findMacro("__TIME__", true);
-      findMacro("__TIMESTAMP__", true);
-
-      CmdArgs.push_back("-Wno-builtin-macro-redefined");
-      CmdArgs.push_back("-D__DATE__=\"1\"");
-      CmdArgs.push_back("-D__TIME__=\"1\"");
-      CmdArgs.push_back("-D__TIMESTAMP__=\"1\"");
+      CmdArgs.push_back("-init-datetime-macros=literalone");
     }
   }
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8897,15 +8897,59 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
         Twine("-loader-replaceable-function=") + FuncOverride));
   }
 
- if (Args.hasFlag(options::OPT__SLASH_experemental_deterministic,
-                  options::OPT__SLASH_experemental_deterministic, false)) {
-   CmdArgs.push_back("-Wdate-time");
- }
+  auto findMacro = [&](const std::string &Macro, bool claim = false) {
+    for (const auto *A : Args.filtered(options::OPT_D, options::OPT_U)) {
+      const std::string v(A->getValue());
+      if (v == Macro || v.find(Macro + '=') != std::string::npos)
+        if (claim)
+          A->claim();
+        return true;
+    }
+    return false;
+  };
 
- if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
-                  options::OPT__SLASH_d1nodatetime, false)) {
-   CmdArgs.push_back("-Wno-builtin-macro-redefined");
- }
+  if (Args.hasArg(options::OPT__SLASH_experemental_deterministic)) {
+    CmdArgs.push_back("-Wdate-time");
+
+    if (Args.hasArg(options::OPT_mincremental_linker_compatible)) {
+      D.Diag(diag::err_drv_argument_not_allowed_with) << "/experemental:determenistic"
+                                                      << "/Brepro-";
+    }
+    // CL's sets COFF's OBJ timestamp to a hash of the source file path to get deterministic
+    // result, but we force this timestamp to 0, which also produces determinitic result.
+    CmdArgs.push_back("-mno-incremental-linker-compatible");
+  }
+
+  if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
+                  options::OPT__SLASH_d1nodatetime_, false)) {
+    // Allow user definitions for these macros from the command line.
+    CmdArgs.push_back("-Wno-builtin-macro-redefined");
+    if (!findMacro("__DATE__"))
+      CmdArgs.push_back("-U__DATE__");
+    if (!findMacro("__TIME__"))
+      CmdArgs.push_back("-U__TIME__");
+    if (!findMacro("__TIMESTAMP__"))
+      CmdArgs.push_back("-U__TIMESTAMP__");
+  }
+
+  // /Brepro is an alias for -mincremental-linker-compatible option.
+  if (!Args.hasFlag(options::OPT_mincremental_linker_compatible,
+                    options::OPT_mno_incremental_linker_compatible,
+                    getToolChain().getTriple().isDefaultIncrementalLinkerCompatibleByDefault())) {
+    // Redefine the date/time macros only if /d1nodatetime wasn't specified.
+    // This options does not allow the user redifinitions for these macros.
+    if (!Args.hasFlag(options::OPT__SLASH_d1nodatetime,
+                      options::OPT__SLASH_d1nodatetime_, false)) {
+      findMacro("__DATE__", true);
+      findMacro("__TIME__", true);
+      findMacro("__TIMESTAMP__", true);
+
+      CmdArgs.push_back("-Wno-builtin-macro-redefined");
+      CmdArgs.push_back("-D__DATE__=\"1\"");
+      CmdArgs.push_back("-D__TIME__=\"1\"");
+      CmdArgs.push_back("-D__TIMESTAMP__=\"1\"");
+    }
+  }
 }
 
 const char *Clang::getBaseInputName(const ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8896,6 +8896,17 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     CmdArgs.push_back(Args.MakeArgString(
         Twine("-loader-replaceable-function=") + FuncOverride));
   }
+
+ if (Args.hasFlag(options::OPT__SLASH_experemental_deterministic,
+                  options::OPT__SLASH_experemental_deterministic, false)) {
+   CmdArgs.push_back("-Wdate-time");
+ }
+
+ if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
+                  options::OPT__SLASH_d1nodatetime, false)) {
+   CmdArgs.push_back("-Wno-builtin-macro-redefined");
+ }
+
 }
 
 const char *Clang::getBaseInputName(const ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8912,14 +8912,16 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
   }
 
   if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
-                  options::OPT__SLASH_d1nodatetime_, false)) {
+                   options::OPT__SLASH_d1nodatetime_, false)) {
     CmdArgs.push_back("-init-datetime-macros=undefined");
   }
 
   // /Brepro is an alias for -mincremental-linker-compatible option.
   if (!Args.hasFlag(options::OPT_mincremental_linker_compatible,
                     options::OPT_mno_incremental_linker_compatible,
-                    getToolChain().getTriple().isDefaultIncrementalLinkerCompatibleByDefault())) {
+                    getToolChain()
+                        .getTriple()
+                        .isDefaultIncrementalLinkerCompatibleByDefault())) {
     // Redefine the date/time macros only if /d1nodatetime wasn't specified.
     // This options does not allow the user redifinitions for these macros.
     if (!Args.hasFlag(options::OPT__SLASH_d1nodatetime,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8908,15 +8908,15 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     return false;
   };
 
-  if (Args.hasArg(options::OPT__SLASH_experemental_deterministic)) {
+  if (Args.hasArg(options::OPT__SLASH_experimental_deterministic)) {
     CmdArgs.push_back("-Wdate-time");
 
     if (Args.hasArg(options::OPT_mincremental_linker_compatible)) {
-      D.Diag(diag::err_drv_argument_not_allowed_with) << "/experemental:determenistic"
+      D.Diag(diag::err_drv_argument_not_allowed_with) << "/experimental:deterministic"
                                                       << "/Brepro-";
     }
     // CL's sets COFF's OBJ timestamp to a hash of the source file path to get deterministic
-    // result, but we force this timestamp to 0, which also produces determinitic result.
+    // result, but we force this timestamp to 0, which also produces deterministic result.
     CmdArgs.push_back("-mno-incremental-linker-compatible");
   }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8924,7 +8924,7 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
                         .getTriple()
                         .isDefaultIncrementalLinkerCompatibleByDefault())) {
     // Redefine the date/time macros only if /d1nodatetime wasn't specified.
-    // This options does not allow the user redifinitions for these macros.
+    // This option does not allow the user redefinitions for these macros.
     if (!HasNoDateTime)
       CmdArgs.push_back("-init-datetime-macros=literalone");
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8783,6 +8783,17 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
     CmdArgs.push_back(Args.MakeArgString(
         Twine("-loader-replaceable-function=") + FuncOverride));
   }
+
+ if (Args.hasFlag(options::OPT__SLASH_experemental_deterministic,
+                  options::OPT__SLASH_experemental_deterministic, false)) {
+   CmdArgs.push_back("-Wdate-time");
+ }
+
+ if (Args.hasFlag(options::OPT__SLASH_d1nodatetime,
+                  options::OPT__SLASH_d1nodatetime, false)) {
+   CmdArgs.push_back("-Wno-builtin-macro-redefined");
+ }
+
 }
 
 const char *Clang::getBaseInputName(const ArgList &Args,

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -324,8 +324,15 @@ void Preprocessor::dumpMacroInfo(const IdentifierInfo *II) {
 void Preprocessor::RegisterBuiltinMacros() {
   Ident__LINE__ = RegisterBuiltinMacro("__LINE__");
   Ident__FILE__ = RegisterBuiltinMacro("__FILE__");
-  Ident__DATE__ = RegisterBuiltinMacro("__DATE__");
-  Ident__TIME__ = RegisterBuiltinMacro("__TIME__");
+  // Keep __DATE__, __TIME__ and __TIMESTAMP__ undefined if it was requested.
+  // Those macros still be able defined from the command line.
+  if (getPreprocessorOpts().InitDateTimeMacros != DateTimeInitKind::Undefined) {
+    Ident__DATE__ = RegisterBuiltinMacro("__DATE__");
+    Ident__TIME__ = RegisterBuiltinMacro("__TIME__");
+  } else {
+    Ident__DATE__ = nullptr;
+    Ident__TIME__ = nullptr;
+  }
   Ident__COUNTER__ = RegisterBuiltinMacro("__COUNTER__");
   Ident_Pragma = RegisterBuiltinMacro("_Pragma");
   Ident__FLT_EVAL_METHOD__ = RegisterBuiltinMacro("__FLT_EVAL_METHOD__");
@@ -339,7 +346,10 @@ void Preprocessor::RegisterBuiltinMacros() {
   // GCC Extensions.
   Ident__BASE_FILE__ = RegisterBuiltinMacro("__BASE_FILE__");
   Ident__INCLUDE_LEVEL__ = RegisterBuiltinMacro("__INCLUDE_LEVEL__");
-  Ident__TIMESTAMP__ = RegisterBuiltinMacro("__TIMESTAMP__");
+  if (getPreprocessorOpts().InitDateTimeMacros != DateTimeInitKind::Undefined)
+    Ident__TIMESTAMP__ = RegisterBuiltinMacro("__TIMESTAMP__");
+  else
+    Ident__TIMESTAMP__ = nullptr;
 
   // Microsoft Extensions.
   if (getLangOpts().MicrosoftExt) {
@@ -1040,8 +1050,32 @@ void Preprocessor::removeCachedMacroExpandedTokensOfLastLexer() {
 /// ComputeDATE_TIME - Compute the current time, enter it into the specified
 /// scratch buffer, then return DATELoc/TIMELoc locations with the position of
 /// the identifier tokens inserted.
-static void ComputeDATE_TIME(SourceLocation &DATELoc, SourceLocation &TIMELoc,
+static void ComputeDATE_TIME(SourceLocation &DATELoc, size_t &DATETokLen,
+                             SourceLocation &TIMELoc, size_t &TIMETokLen,
                              Preprocessor &PP) {
+
+  if (PP.getPreprocessorOpts().InitDateTimeMacros ==
+      DateTimeInitKind::LiteralOne) {
+    if (!DATELoc.isValid()) {
+      Token TmpTok;
+      TmpTok.startToken();
+      PP.CreateString("\"1\"", TmpTok);
+      DATELoc = TmpTok.getLocation();
+    }
+    // Always set up and return a token length for both - DATE and TIME.
+    DATETokLen = strlen("\"1\"");
+
+    if (!TIMELoc.isValid()) {
+      Token TmpTok;
+      TmpTok.startToken();
+      PP.CreateString("\"1\"", TmpTok);
+      TIMELoc = TmpTok.getLocation();
+    }
+    TIMETokLen = strlen("\"1\"");
+
+    return;
+  }
+
   time_t TT;
   std::tm *TM;
   if (PP.getPreprocessorOpts().SourceDateEpoch) {
@@ -1056,7 +1090,7 @@ static void ComputeDATE_TIME(SourceLocation &DATELoc, SourceLocation &TIMELoc,
     "Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"
   };
 
-  {
+  if (!DATELoc.isValid()) {
     SmallString<32> TmpBuffer;
     llvm::raw_svector_ostream TmpStream(TmpBuffer);
     if (TM)
@@ -1069,8 +1103,9 @@ static void ComputeDATE_TIME(SourceLocation &DATELoc, SourceLocation &TIMELoc,
     PP.CreateString(TmpStream.str(), TmpTok);
     DATELoc = TmpTok.getLocation();
   }
+  DATETokLen = strlen("\"Mmm dd yyyy\"");
 
-  {
+  if (!TIMELoc.isValid()) {
     SmallString<32> TmpBuffer;
     llvm::raw_svector_ostream TmpStream(TmpBuffer);
     if (TM)
@@ -1083,6 +1118,7 @@ static void ComputeDATE_TIME(SourceLocation &DATELoc, SourceLocation &TIMELoc,
     PP.CreateString(TmpStream.str(), TmpTok);
     TIMELoc = TmpTok.getLocation();
   }
+  TIMETokLen = strlen("\"hh:mm:ss\"");
 }
 
 /// HasFeature - Return true if we recognize and implement the feature
@@ -1659,20 +1695,22 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     Tok.setKind(tok::string_literal);
   } else if (II == Ident__DATE__) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
-    if (!DATELoc.isValid())
-      ComputeDATE_TIME(DATELoc, TIMELoc, *this);
+
+    size_t TIMETokLen = 0, DATETokLen = 0;
+    ComputeDATE_TIME(DATELoc, DATETokLen, TIMELoc, TIMETokLen, *this);
     Tok.setKind(tok::string_literal);
-    Tok.setLength(strlen("\"Mmm dd yyyy\""));
+    Tok.setLength(DATETokLen);
     Tok.setLocation(SourceMgr.createExpansionLoc(DATELoc, Tok.getLocation(),
                                                  Tok.getLocation(),
                                                  Tok.getLength()));
     return;
   } else if (II == Ident__TIME__) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
-    if (!TIMELoc.isValid())
-      ComputeDATE_TIME(DATELoc, TIMELoc, *this);
+
+    size_t TIMETokLen = 0, DATETokLen = 0;
+    ComputeDATE_TIME(DATELoc, DATETokLen, TIMELoc, TIMETokLen, *this);
     Tok.setKind(tok::string_literal);
-    Tok.setLength(strlen("\"hh:mm:ss\""));
+    Tok.setLength(TIMETokLen);
     Tok.setLocation(SourceMgr.createExpansionLoc(TIMELoc, Tok.getLocation(),
                                                  Tok.getLocation(),
                                                  Tok.getLength()));
@@ -1696,28 +1734,32 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     Diag(Tok.getLocation(), diag::warn_pp_date_time);
     // MSVC, ICC, GCC, VisualAge C++ extension.  The generated string should be
     // of the form "Ddd Mmm dd hh::mm::ss yyyy", which is returned by asctime.
-    std::string Result;
+    std::string Result = "1"; // DateTimeInitKind::LiteralOne by default.
     std::stringstream TmpStream;
-    TmpStream.imbue(std::locale("C"));
-    if (getPreprocessorOpts().SourceDateEpoch) {
-      time_t TT = *getPreprocessorOpts().SourceDateEpoch;
-      std::tm *TM = std::gmtime(&TT);
-      TmpStream << std::put_time(TM, "%a %b %e %T %Y");
-    } else {
-      // Get the file that we are lexing out of.  If we're currently lexing from
-      // a macro, dig into the include stack.
-      const FileEntry *CurFile = nullptr;
-      if (PreprocessorLexer *TheLexer = getCurrentFileLexer())
-        CurFile = SourceMgr.getFileEntryForID(TheLexer->getFileID());
-      if (CurFile) {
-        time_t TT = CurFile->getModificationTime();
-        struct tm *TM = localtime(&TT);
+
+    // Requested regular __TIMESTAMP__ initialization.
+    if (getPreprocessorOpts().InitDateTimeMacros == DateTimeInitKind::Default) {
+      TmpStream.imbue(std::locale("C"));
+      if (getPreprocessorOpts().SourceDateEpoch) {
+        time_t TT = *getPreprocessorOpts().SourceDateEpoch;
+        std::tm *TM = std::gmtime(&TT);
         TmpStream << std::put_time(TM, "%a %b %e %T %Y");
+      } else {
+        // Get the file that we are lexing out of.  If we're currently lexing
+        // from a macro, dig into the include stack.
+        const FileEntry *CurFile = nullptr;
+        if (PreprocessorLexer *TheLexer = getCurrentFileLexer())
+          CurFile = SourceMgr.getFileEntryForID(TheLexer->getFileID());
+        if (CurFile) {
+          time_t TT = CurFile->getModificationTime();
+          struct tm *TM = localtime(&TT);
+          TmpStream << std::put_time(TM, "%a %b %e %T %Y");
+        }
       }
+      Result = TmpStream.str();
+      if (Result.empty())
+        Result = "??? ??? ?? ??:??:?? ????";
     }
-    Result = TmpStream.str();
-    if (Result.empty())
-      Result = "??? ??? ?? ??:??:?? ????";
     OS << '"' << Result << '"';
     Tok.setKind(tok::string_literal);
   } else if (II == Ident__FLT_EVAL_METHOD__) {

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -1,6 +1,3 @@
-// We have to run the compilation step to see the output, so we must be able to
-// target Windows.
-
 // RUN: %clang_cl -fno-integrated-cc1 -E /experimental:deterministic /d1nodatetime %s
 // RUN: %clang_cl -fno-integrated-cc1 -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
 

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -1,0 +1,36 @@
+// We have to run the compilation step to see the output, so we must be able to
+// target Windows.
+
+// REQUIRES: system-windows
+
+// RUN: %clang_cl -fno-integrated-cc1 -E /experimental:deterministic /d1nodatetime %s
+// RUN: %clang_cl -fno-integrated-cc1 -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
+
+// RUN: %clang_cl -E /experimental:deterministic /d1nodatetime %s
+// RUN: %clang_cl -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
+
+// not %clang_cc1 -Werror=date-time -Wno-builtin-macro-redefined %s -DIS_SYSHEADER -E 2>&1 | grep 'error: expansion' | count 3
+
+// RUN: %clang_cl -E -### /experimental:deterministic %s 2>&1 | FileCheck %s --check-prefix=WDATETIME
+// WDATETIME: -Wdate-time
+// RUN: %clang_cl -E -### /d1nodatetime %s 2>&1 | FileCheck %s --check-prefix=MACROREDEF
+// MACROREDEF: -Wno-builtin-macro-redefined
+
+#ifdef IS_HEADER
+
+#ifdef IS_SYSHEADER
+#pragma clang system_header
+#endif
+
+__TIME__ // expected-warning {{expansion of date or time macro is not reproducible}}
+__DATE__  // expected-warning {{expansion of date or time macro is not reproducible}}
+__TIMESTAMP__ // expected-warning {{expansion of date or time macro is not reproducible}}
+
+#define __TIME__
+__TIME__
+
+#else
+
+#define IS_HEADER
+#include __FILE__
+#endif 

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -29,4 +29,4 @@ __TIME__
 
 #define IS_HEADER
 #include __FILE__
-#endif 
+#endif

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -1,15 +1,15 @@
-// RUN: %clang_cl -fno-integrated-cc1 -E /experimental:deterministic /d1nodatetime %s
-// RUN: %clang_cl -fno-integrated-cc1 -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
+// RUN: %clang_cl -fno-integrated-cc1 -E /experimental:deterministic /d1nodatetime -- %s
+// RUN: %clang_cl -fno-integrated-cc1 -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime -- %s
 
-// RUN: %clang_cl -E /experimental:deterministic /d1nodatetime %s
-// RUN: %clang_cl -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
+// RUN: %clang_cl -E /experimental:deterministic /d1nodatetime -- %s
+// RUN: %clang_cl -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime -- %s
 
 // not %clang_cc1 -Werror=date-time -Wno-builtin-macro-redefined %s -DIS_SYSHEADER -E 2>&1 | grep 'error: expansion' | count 3
 
-// RUN: %clang_cl -E -### /experimental:deterministic %s 2>&1 | FileCheck %s --check-prefix=WDATETIME
+// RUN: %clang_cl -E -### /experimental:deterministic -- %s 2>&1 | FileCheck %s --check-prefix=WDATETIME
 // WDATETIME: -Wdate-time
 // WDATETIME: -mno-incremental-linker-compatible
-// RUN: %clang_cl -E -### /d1nodatetime %s 2>&1 | FileCheck %s --check-prefix=MACROREDEF
+// RUN: %clang_cl -E -### /d1nodatetime -- %s 2>&1 | FileCheck %s --check-prefix=MACROREDEF
 // MACROREDEF: -init-datetime-macros=undefined
 
 #ifdef IS_HEADER

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -1,8 +1,6 @@
 // We have to run the compilation step to see the output, so we must be able to
 // target Windows.
 
-// REQUIRES: system-windows
-
 // RUN: %clang_cl -fno-integrated-cc1 -E /experimental:deterministic /d1nodatetime %s
 // RUN: %clang_cl -fno-integrated-cc1 -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime %s
 
@@ -13,8 +11,9 @@
 
 // RUN: %clang_cl -E -### /experimental:deterministic %s 2>&1 | FileCheck %s --check-prefix=WDATETIME
 // WDATETIME: -Wdate-time
+// WDATETIME: -mno-incremental-linker-compatible
 // RUN: %clang_cl -E -### /d1nodatetime %s 2>&1 | FileCheck %s --check-prefix=MACROREDEF
-// MACROREDEF: -Wno-builtin-macro-redefined
+// MACROREDEF: -init-datetime-macros=undefined
 
 #ifdef IS_HEADER
 

--- a/clang/test/Driver/cl-deterministic.c
+++ b/clang/test/Driver/cl-deterministic.c
@@ -4,7 +4,7 @@
 // RUN: %clang_cl -E /experimental:deterministic /d1nodatetime -- %s
 // RUN: %clang_cl -E /D IS_SYSHEADER=1 /experimental:deterministic /d1nodatetime -- %s
 
-// not %clang_cc1 -Werror=date-time -Wno-builtin-macro-redefined %s -DIS_SYSHEADER -E 2>&1 | grep 'error: expansion' | count 3
+// expected-no-diagnostics
 
 // RUN: %clang_cl -E -### /experimental:deterministic -- %s 2>&1 | FileCheck %s --check-prefix=WDATETIME
 // WDATETIME: -Wdate-time
@@ -18,9 +18,9 @@
 #pragma clang system_header
 #endif
 
-__TIME__ // expected-warning {{expansion of date or time macro is not reproducible}}
-__DATE__  // expected-warning {{expansion of date or time macro is not reproducible}}
-__TIMESTAMP__ // expected-warning {{expansion of date or time macro is not reproducible}}
+__TIME__
+__DATE__
+__TIMESTAMP__
 
 #define __TIME__
 __TIME__

--- a/clang/test/Preprocessor/init-datetime-macros-nowarns.c
+++ b/clang/test/Preprocessor/init-datetime-macros-nowarns.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=undefined -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" -verify %s
+// expected-no-diagnostics
+
+date: __DATE__
+time: __TIME__
+timestamp: __TIMESTAMP__

--- a/clang/test/Preprocessor/init-datetime-macros-warns.c
+++ b/clang/test/Preprocessor/init-datetime-macros-warns.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=literalone -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" -verify %s
+// expected-warning@2{{redefining builtin macro}}
+// expected-warning@3{{redefining builtin macro}}
+// expected-warning@4{{redefining builtin macro}}
+
+date: __DATE__
+time: __TIME__
+timestamp: __TIMESTAMP__

--- a/clang/test/Preprocessor/init-datetime-macros.c
+++ b/clang/test/Preprocessor/init-datetime-macros.c
@@ -27,9 +27,9 @@
 //  /d1nodatetime - undefines __DATE__, __TIME__ and __TIMESTAMP__
 //  /Brepro - sets __DATE__, __TIME__ and __TIMESTAMP__ to "1"
 
-// RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /c %s
+// RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /c -- %s
 
-// RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE /c %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
+// RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE /c -- %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
 
 #if defined(DATETIME_LITERALONE) || defined(DATETIME_DEFAULT) || defined(DATETIME_CUSTOM)
 date: __DATE__

--- a/clang/test/Preprocessor/init-datetime-macros.c
+++ b/clang/test/Preprocessor/init-datetime-macros.c
@@ -15,6 +15,7 @@
 // CHECK-INIT-DATETIME-LITERALONE-NOT: time: 
 // CHECK-INIT-DATETIME-LITERALONE-NOT: timestamp: 
 
+// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=literalone -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
 // RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=undefined -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
 // CHECK-INIT-DATETIME-CUSTOM: date: "d3"
 // CHECK-INIT-DATETIME-CUSTOM: time: "t4"

--- a/clang/test/Preprocessor/init-datetime-macros.c
+++ b/clang/test/Preprocessor/init-datetime-macros.c
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -E -DDATETIME_DEFAULT -init-datetime-macros=default %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-DEFAULT
+// RUN: %clang_cc1 -E -DDATETIME_DEFAULT %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-DEFAULT
+// CHECK-INIT-DATETIME-DEFAULT: date: "{{(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)}} {{.*}}"
+// CHECK-INIT-DATETIME-DEFAULT: time: "{{[0-9][0-9]:[0-9][0-9]:[0-9][0-9]}}"
+// CHECK-INIT-DATETIME-DEFAULT: timestamp: "{{.*}} {{[0-9][0-9]:[0-9][0-9]:[0-9][0-9]}} {{.*}}"
+// CHECK-INIT-DATETIME-DEFAULT-NOT: date: 
+// CHECK-INIT-DATETIME-DEFAULT-NOT: time: 
+// CHECK-INIT-DATETIME-DEFAULT-NOT: timestamp: 
+
+// RUN: %clang_cc1 -E -DDATETIME_LITERALONE -init-datetime-macros=literalone %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
+// CHECK-INIT-DATETIME-LITERALONE: date: "1"
+// CHECK-INIT-DATETIME-LITERALONE: time: "1"
+// CHECK-INIT-DATETIME-LITERALONE: timestamp: "1"
+// CHECK-INIT-DATETIME-LITERALONE-NOT: date: 
+// CHECK-INIT-DATETIME-LITERALONE-NOT: time: 
+// CHECK-INIT-DATETIME-LITERALONE-NOT: timestamp: 
+
+// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=undefined -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
+// CHECK-INIT-DATETIME-CUSTOM: date: "d3"
+// CHECK-INIT-DATETIME-CUSTOM: time: "t4"
+// CHECK-INIT-DATETIME-CUSTOM: timestamp: "ts5"
+
+// RUN: %clang_cc1 -DDATETIME_UNDEFINED -verify -Wall -init-datetime-macros=undefined %s
+
+// clang-cl deterministic options checks:
+//  /d1nodatetime - undefines __DATE__, __TIME__ and __TIMESTAMP__
+//  /Brepro - sets __DATE__, __TIME__ and __TIMESTAMP__ to "1"
+
+// RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /c %s
+
+// RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE /c %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
+
+#if defined(DATETIME_LITERALONE) || defined(DATETIME_DEFAULT) || defined(DATETIME_CUSTOM)
+date: __DATE__
+time: __TIME__
+timestamp: __TIMESTAMP__
+#endif
+
+// Check we didn't break literal processing inside of PP macro expansion.
+#if defined(DATETIME_DEFAULT)
+#define CUST_DATE __DATE__
+#define CUST_TIME __TIME__
+#define CUST_TIMESTAMP __TIMESTAMP__
+const char *s0 = "CD: "  CUST_DATE " CT: " CUST_TIME " CTS: " CUST_TIMESTAMP
+// CHECK-INIT-DATETIME-DEFAULT: const char *s0 = "CD: " "{{(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)}} {{.*}}" " CT: " "{{[0-9][0-9]:[0-9][0-9]:[0-9][0-9]}}" " CTS: " "{{.*}} {{[0-9][0-9]:[0-9][0-9]:[0-9][0-9]}} {{.*}}" 
+#endif
+
+#if defined(DATETIME_LITERALONE)
+#define CUST_DATE __DATE__
+#define CUST_TIME __TIME__
+#define CUST_TIMESTAMP __TIMESTAMP__
+const char *s0 = "CD: "  CUST_DATE " CT: " CUST_TIME " CTS: " CUST_TIMESTAMP
+// CHECK-INIT-DATETIME-LITERALONE: const char *s0 = "CD: " "1" " CT: " "1" " CTS: " "1" 
+#endif
+
+#ifdef DATETIME_UNDEFINED
+const char *s1 = __DATE__; // expected-error{{use of undeclared identifier '__DATE__'}} 
+const char *s2 = __TIME__; // expected-error{{use of undeclared identifier '__TIME__'}} 
+const char *s3 = __TIMESTAMP__; // expected-error{{use of undeclared identifier '__TIMESTAMP__'}}
+#endif

--- a/clang/test/Preprocessor/init-datetime-macros.c
+++ b/clang/test/Preprocessor/init-datetime-macros.c
@@ -15,7 +15,7 @@
 // CHECK-INIT-DATETIME-LITERALONE-NOT: time: 
 // CHECK-INIT-DATETIME-LITERALONE-NOT: timestamp: 
 
-// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=literalone -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
+// RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=literalone -Wno-builtin-macro-redefined -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
 // RUN: %clang_cc1 -E -DDATETIME_CUSTOM -init-datetime-macros=undefined -D__DATE__="\"d3\"" -D__TIME__="\"t4\"" -D__TIMESTAMP__="\"ts5\"" %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-CUSTOM
 // CHECK-INIT-DATETIME-CUSTOM: date: "d3"
 // CHECK-INIT-DATETIME-CUSTOM: time: "t4"
@@ -29,7 +29,7 @@
 
 // RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /c -- %s
 
-// RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE /c -- %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
+// RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE -- %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
 
 #if defined(DATETIME_LITERALONE) || defined(DATETIME_DEFAULT) || defined(DATETIME_CUSTOM)
 date: __DATE__


### PR DESCRIPTION
Added the following options to clang-cl:

* `/experimental:deterministic`

The original CL's option enables emitting of warnings on usage of non-deterministic macros `__DATE__`, `__TIME__` and `__TIMESTAMP__` and provides few additional operations to help produce a deterministic output:
  - sets .obj COFF header timestamp (offset 4) to a hash based on a path to the source file.
  - removes a host name from the hash gen for the anon namespace and lambdas.
  - zeroed PE timestamps, when passed to the linker.
  - sets PDB Guid field to `{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}`.
  - sets PDB Signature field to `1`.

Currently `clang-cl` does not use a hostname to generate the symbols hash, also it does not produce PDB files, because of it the option only implements the warning emission on the date/time macros (`-Wdate-time option`) and sets COFF's timestamp to 0 (by using overlapped `/Brepro` / `-mno-incremental_linker_compatible` options).

* `/Brepro`

The original CL's option does the following:
 - defines `__DATE__`, `__TIME__`, and `__TIMESTAMP__` to the literal string `"1"`.
 - sets PE timestamps to 0, but does not affect .obj COFF's header timestamp (still current timestamp).
 - sets PCH unique IDs to content hash instead.

Currently `clang-cl` sets to 0 .obj and .exe timestamps by `/Brepro` option. These changes keep it unmodified for compatibility and add the extra macros definitions. `clang-cl` provides its own PCH format and requires the different operations to make it reproducable.

* `/d1nodatetime`

Undefine the standard preprocessor macros `__DATE__`, `__TIME__` and `__TIMESTAMP__`. This option allows redefinitions for these macros from the command line.
