### PR TITLE
[clang][Fuchsia] Add test for Fuchsia-specific predefines

### DIFF
--- a/clang/test/Preprocessor/init-fuchsia.c
+++ b/clang/test/Preprocessor/init-fuchsia.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -E -dM -triple=aarch64-unknown-fuchsia < /dev/null \
+// RUN:   | FileCheck -match-full-lines -check-prefixes=FUCHSIA %s
+// RUN: %clang_cc1 -E -dM -triple=arm-unknown-fuchsia < /dev/null \
+// RUN:   | FileCheck -match-full-lines -check-prefixes=FUCHSIA %s
+// RUN: %clang_cc1 -E -dM -triple=riscv64-unknown-fuchsia < /dev/null \
+// RUN:   | FileCheck -match-full-lines -check-prefixes=FUCHSIA %s
+// RUN: %clang_cc1 -E -dM -triple=x86_64-unknown-fuchsia < /dev/null \
+// RUN:   | FileCheck -match-full-lines -check-prefixes=FUCHSIA %s
+
+// FUCHSIA-DAG: #define __Fuchsia__ 1
+// FUCHSIA-DAG: #define __Fuchsia_API_level__ {{[0-9]+}}


### PR DESCRIPTION
One of these is tested indirectly via the driver test for
plumbing the `-ffuchsia-api-level=...` switch.  But there is no
proper cc1 test for the predefines being defined per se.
