### PR TITLE
[offload] Enable Intel GPU tests and mark CUDA tests unsupported

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -184,6 +184,10 @@ elif config.libomptarget_current_target.startswith('amdgcn'):
     if ((config.amdgpu_test_arch.startswith("gfx942") and
          evaluate_bool_env(config.environment['IS_APU']))):
        supports_apu = True
+elif config.libomptarget_current_target.startswith('spirv64-intel'):
+    # Assume Intel GPUs don't support USM and large allocations for now.
+    supports_unified_shared_memory = False
+    supports_large_allocation_memory_pool = False
 if supports_unified_shared_memory:
    config.available_features.add('unified_shared_memory')
 if supports_apu:

--- a/offload/test/mapping/data_member_ref.cpp
+++ b/offload/test/mapping/data_member_ref.cpp
@@ -1,8 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
-
 #include <stdio.h>
 
 struct View {

--- a/offload/test/offloading/CUDA/basic_launch.cu
+++ b/offload/test/offloading/CUDA/basic_launch.cu
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
+++ b/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/basic_launch_multi_arg.cu
+++ b/offload/test/offloading/CUDA/basic_launch_multi_arg.cu
@@ -6,7 +6,7 @@
 // clang-format on
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/launch_tu.cu
+++ b/offload/test/offloading/CUDA/launch_tu.cu
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/bug50022.cpp
+++ b/offload/test/offloading/bug50022.cpp
@@ -1,7 +1,5 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 // RUN: %libomptarget-compileoptxx-and-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/info.c
+++ b/offload/test/offloading/info.c
@@ -7,8 +7,6 @@
 
 // FIXME: Fails due to optimized debugging in 'ptxas'.
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/strided_update/strided_update_count_expression.c
+++ b/offload/test/offloading/strided_update/strided_update_count_expression.c
@@ -2,8 +2,6 @@
 // supported when elements are updated in a non-contiguous manner with variable
 // count expression. Tests #pragma omp target update from/to(data[0:len/2:2])
 // where the count (len/2) is a variable expression, not a constant.
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 // RUN: %libomptarget-compile-run-and-check-generic
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/strided_update/strided_update_partial_to.c
+++ b/offload/test/offloading/strided_update/strided_update_partial_to.c
@@ -3,8 +3,6 @@
 // across the array
 
 // RUN: %libomptarget-compile-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/strided_update/strided_update_ptr_count_expression.c
+++ b/offload/test/offloading/strided_update/strided_update_ptr_count_expression.c
@@ -2,9 +2,6 @@
 // Tests non-contiguous array sections with expression-based count on
 // heap-allocated pointer arrays with both FROM and TO directives.
 
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
-
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/strided_update/strided_update_to.c
+++ b/offload/test/offloading/strided_update/strided_update_to.c
@@ -4,8 +4,6 @@
 // other element (stride 2) from the host to the device
 
 // RUN: %libomptarget-compile-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/strided_update/strided_update_to_pointer.c
+++ b/offload/test/offloading/strided_update/strided_update_to_pointer.c
@@ -2,8 +2,6 @@
 // This test checks that "update to" clause in OpenMP supports strided sections.
 // #pragma omp target update to(result[0:8:2]) updates every other element
 // (stride 2)
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_critical_region.cpp
+++ b/offload/test/offloading/target_critical_region.cpp
@@ -4,7 +4,6 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_depend_nowait.cpp
+++ b/offload/test/offloading/target_depend_nowait.cpp
@@ -1,6 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_nowait_target.cpp
+++ b/offload/test/offloading/target_nowait_target.cpp
@@ -1,7 +1,5 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 // RUN: %libomptarget-compileoptxx-and-run-generic
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <cassert>
 

--- a/offload/test/unified_shared_memory/close_member.c
+++ b/offload/test/unified_shared_memory/close_member.c
@@ -2,8 +2,6 @@
 
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
-// https://github.com/llvm/llvm-project/issues/182119
-// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
- Remove UNSUPPORTED: intelgpu from 12 passing tests:
  * mapping/data_member_ref.cpp
  * offloading/bug50022.cpp, info.c
  * offloading/target_critical_region.cpp, target_depend_nowait.cpp, target_nowait_target.cpp
  * offloading/strided_update/* (6 tests)
  * unified_shared_memory/close_member.c

- Change CUDA tests from XFAIL to UNSUPPORTED for Intel GPU:
  * offloading/CUDA/basic_launch.cu
  * offloading/CUDA/basic_launch_blocks_and_threads.cu
  * offloading/CUDA/basic_launch_multi_arg.cu
  * offloading/CUDA/launch_tu.cu

- Add Intel GPU configuration section to lit.cfg to disable USM tests by default