### PR TITLE
[mlir][SPIR-V] Add OpenCL.std ldexp, pown, and rootn ops

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
@@ -505,6 +505,48 @@ def SPIRV_CLFmaOp : SPIRV_CLTernaryArithmeticOp<"fma", 26, SPIRV_Float> {
 
 // -----
 
+def SPIRV_CLLdexpOp : SPIRV_CLOp<"ldexp", 34, [Pure]> {
+  let summary = "Builds y such that y = significand * 2^exponent.";
+
+  let description = [{
+    Builds a floating-point number from x and the corresponding
+    integral exponent of two in n:
+
+    significand * 2^exponent
+
+    The operand x must be a scalar or vector whose component type is
+    floating-point.
+
+    The exp operand must be a scalar or vector with integer component type.
+    The number of components in x and exp must be the same.
+
+    Result Type must be the same type as the type of x. Results are computed
+    per component.
+
+    #### Example:
+
+    ```mlir
+    %y = spirv.CL.ldexp %x : f32, %exp : i32 -> f32
+    %y = spirv.CL.ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$x,
+    SPIRV_ScalarOrVectorOf<SPIRV_Integer>:$exp
+  );
+
+  let results = (outs
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$y
+  );
+
+  let assemblyFormat = [{
+    attr-dict $x `:` type($x) `,` $exp `:` type($exp) `->` type($y)
+  }];
+}
+
+// -----
+
 def SPIRV_CLLogOp : SPIRV_CLUnaryArithmeticOp<"log", 37, SPIRV_Float> {
   let summary = "Compute the natural logarithm of x.";
 
@@ -571,6 +613,45 @@ def SPIRV_CLPowOp : SPIRV_CLBinaryArithmeticOp<"pow", 48, SPIRV_Float> {
 
 // -----
 
+def SPIRV_CLPownOp : SPIRV_CLOp<"pown", 49, [Pure]> {
+  let summary = "Compute x to the power y, where y is an integer.";
+
+  let description = [{
+    Result is x raised to the power y, where y is an integer.
+
+    The operand x must be a scalar or vector whose component type is
+    floating-point.
+
+    The y operand must be a scalar or vector with integer component type.
+    The number of components in x and y must be the same.
+
+    Result Type must be the same type as the type of x. Results are computed
+    per component.
+
+    #### Example:
+
+    ```mlir
+    %2 = spirv.CL.pown %0 : f32, %1 : i32 -> f32
+    %2 = spirv.CL.pown %0 : vector<3xf32>, %1 : vector<3xi32> -> vector<3xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$x,
+    SPIRV_ScalarOrVectorOf<SPIRV_Integer>:$y
+  );
+
+  let results = (outs
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$result
+  );
+
+  let assemblyFormat = [{
+    attr-dict $x `:` type($x) `,` $y `:` type($y) `->` type($result)
+  }];
+}
+
+// -----
+
 def SPIRV_CLRintOp : SPIRV_CLUnaryArithmeticOp<"rint", 53, SPIRV_Float> {
   let summary = [{
     Round x to integral value (using round to nearest even rounding mode) in
@@ -590,6 +671,45 @@ def SPIRV_CLRintOp : SPIRV_CLUnaryArithmeticOp<"rint", 53, SPIRV_Float> {
     %0 = spirv.CL.rint %0 : f32
     %1 = spirv.CL.rint %1 : vector<3xf16>
     ```
+  }];
+}
+
+// -----
+
+def SPIRV_CLRootnOp : SPIRV_CLOp<"rootn", 54, [Pure]> {
+  let summary = "Compute the n-th root of x, where n is an integer.";
+
+  let description = [{
+    Result is the n-th root of x, where n is an integer.
+
+    The operand x must be a scalar or vector whose component type is
+    floating-point.
+
+    The n operand must be a scalar or vector with integer component type.
+    The number of components in x and n must be the same.
+
+    Result Type must be the same type as the type of x. Results are computed
+    per component.
+
+    #### Example:
+
+    ```mlir
+    %2 = spirv.CL.rootn %0 : f32, %1 : i32 -> f32
+    %2 = spirv.CL.rootn %0 : vector<3xf32>, %1 : vector<3xi32> -> vector<3xf32>
+    ```
+  }];
+
+  let arguments = (ins
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$x,
+    SPIRV_ScalarOrVectorOf<SPIRV_Integer>:$n
+  );
+
+  let results = (outs
+    SPIRV_ScalarOrVectorOf<SPIRV_Float>:$result
+  );
+
+  let assemblyFormat = [{
+    attr-dict $x `:` type($x) `,` $n `:` type($n) `->` type($result)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
@@ -526,8 +526,8 @@ def SPIRV_CLLdexpOp : SPIRV_CLOp<"ldexp", 34, [Pure, AllTypesMatch<["x", "y"]>]>
     #### Example:
 
     ```mlir
-    %y = spirv.CL.ldexp %x : f32, %exp : i32 -> f32
-    %y = spirv.CL.ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
+    %y = spirv.CL.ldexp %x, %exp : f32, i32 -> f32
+    %y = spirv.CL.ldexp %x, %exp : vector<3xf32>, vector<3xi32> -> vector<3xf32>
     ```
   }];
 
@@ -541,7 +541,7 @@ def SPIRV_CLLdexpOp : SPIRV_CLOp<"ldexp", 34, [Pure, AllTypesMatch<["x", "y"]>]>
   );
 
   let assemblyFormat = [{
-    attr-dict $x `:` type($x) `,` $exp `:` type($exp) `->` type($y)
+    attr-dict $x `,` $exp `:` type($x) `,` type($exp) `->` type($y)
   }];
 }
 
@@ -631,8 +631,8 @@ def SPIRV_CLPownOp : SPIRV_CLOp<"pown", 49, [Pure, AllTypesMatch<["x", "result"]
     #### Example:
 
     ```mlir
-    %2 = spirv.CL.pown %0 : f32, %1 : i32 -> f32
-    %2 = spirv.CL.pown %0 : vector<3xf32>, %1 : vector<3xi32> -> vector<3xf32>
+    %2 = spirv.CL.pown %0, %1 : f32, i32 -> f32
+    %2 = spirv.CL.pown %0, %1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
     ```
   }];
 
@@ -646,7 +646,7 @@ def SPIRV_CLPownOp : SPIRV_CLOp<"pown", 49, [Pure, AllTypesMatch<["x", "result"]
   );
 
   let assemblyFormat = [{
-    attr-dict $x `:` type($x) `,` $y `:` type($y) `->` type($result)
+    attr-dict $x `,` $y `:` type($x) `,` type($y) `->` type($result)
   }];
 }
 
@@ -694,8 +694,8 @@ def SPIRV_CLRootnOp : SPIRV_CLOp<"rootn", 54, [Pure, AllTypesMatch<["x", "result
     #### Example:
 
     ```mlir
-    %2 = spirv.CL.rootn %0 : f32, %1 : i32 -> f32
-    %2 = spirv.CL.rootn %0 : vector<3xf32>, %1 : vector<3xi32> -> vector<3xf32>
+    %2 = spirv.CL.rootn %0, %1 : f32, i32 -> f32
+    %2 = spirv.CL.rootn %0, %1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
     ```
   }];
 
@@ -709,7 +709,7 @@ def SPIRV_CLRootnOp : SPIRV_CLOp<"rootn", 54, [Pure, AllTypesMatch<["x", "result
   );
 
   let assemblyFormat = [{
-    attr-dict $x `:` type($x) `,` $n `:` type($n) `->` type($result)
+    attr-dict $x `,` $n `:` type($x) `,` type($n) `->` type($result)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
@@ -505,12 +505,12 @@ def SPIRV_CLFmaOp : SPIRV_CLTernaryArithmeticOp<"fma", 26, SPIRV_Float> {
 
 // -----
 
-def SPIRV_CLLdexpOp : SPIRV_CLOp<"ldexp", 34, [Pure]> {
+def SPIRV_CLLdexpOp : SPIRV_CLOp<"ldexp", 34, [Pure, AllTypesMatch<["x", "y"]>]> {
   let summary = "Builds y such that y = significand * 2^exponent.";
 
   let description = [{
     Builds a floating-point number from x and the corresponding
-    integral exponent of two in n:
+    integral exponent of two in exp:
 
     significand * 2^exponent
 
@@ -613,7 +613,7 @@ def SPIRV_CLPowOp : SPIRV_CLBinaryArithmeticOp<"pow", 48, SPIRV_Float> {
 
 // -----
 
-def SPIRV_CLPownOp : SPIRV_CLOp<"pown", 49, [Pure]> {
+def SPIRV_CLPownOp : SPIRV_CLOp<"pown", 49, [Pure, AllTypesMatch<["x", "result"]>]> {
   let summary = "Compute x to the power y, where y is an integer.";
 
   let description = [{
@@ -676,7 +676,7 @@ def SPIRV_CLRintOp : SPIRV_CLUnaryArithmeticOp<"rint", 53, SPIRV_Float> {
 
 // -----
 
-def SPIRV_CLRootnOp : SPIRV_CLOp<"rootn", 54, [Pure]> {
+def SPIRV_CLRootnOp : SPIRV_CLOp<"rootn", 54, [Pure, AllTypesMatch<["x", "result"]>]> {
   let summary = "Compute the n-th root of x, where n is an integer.";
 
   let description = [{

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -2049,12 +2049,10 @@ LogicalResult spirv::GLFrexpStructOp::verify() {
 // spirv.GL.Ldexp
 //===----------------------------------------------------------------------===//
 
-LogicalResult spirv::GLLdexpOp::verify() {
-  Type significandType = getX().getType();
-  Type exponentType = getExp().getType();
-
-  if (isa<FloatType>(significandType) != isa<IntegerType>(exponentType))
-    return emitOpError("operands must both be scalars or vectors");
+static LogicalResult verifyFloatIntegerBuiltin(Operation *op, Type floatType,
+                                               Type integerType) {
+  if (isa<FloatType>(floatType) != isa<IntegerType>(integerType))
+    return op->emitOpError("operands must both be scalars or vectors");
 
   auto getNumElements = [](Type type) -> unsigned {
     if (auto vectorType = dyn_cast<VectorType>(type))
@@ -2062,10 +2060,42 @@ LogicalResult spirv::GLLdexpOp::verify() {
     return 1;
   };
 
-  if (getNumElements(significandType) != getNumElements(exponentType))
-    return emitOpError("operands must have the same number of elements");
+  if (getNumElements(floatType) != getNumElements(integerType))
+    return op->emitOpError("operands must have the same number of elements");
 
   return success();
+}
+
+LogicalResult spirv::GLLdexpOp::verify() {
+  return verifyFloatIntegerBuiltin(getOperation(), getX().getType(),
+                                   getExp().getType());
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.ldexp
+//===----------------------------------------------------------------------===//
+
+LogicalResult spirv::CLLdexpOp::verify() {
+  return verifyFloatIntegerBuiltin(getOperation(), getX().getType(),
+                                   getExp().getType());
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.pown
+//===----------------------------------------------------------------------===//
+
+LogicalResult spirv::CLPownOp::verify() {
+  return verifyFloatIntegerBuiltin(getOperation(), getX().getType(),
+                                   getY().getType());
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.rootn
+//===----------------------------------------------------------------------===//
+
+LogicalResult spirv::CLRootnOp::verify() {
+  return verifyFloatIntegerBuiltin(getOperation(), getX().getType(),
+                                   getN().getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
@@ -440,3 +440,118 @@ func.func @atan2(%arg0 : vector<4xf16>, %arg1 : vector<4xf16>) -> () {
   return
 }
 
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.ldexp
+//===----------------------------------------------------------------------===//
+
+func.func @ldexp(%arg0 : f32, %arg1 : i32) -> () {
+  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : f32, {{%.*}} : i32 -> f32
+  %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : i32 -> f32
+  return
+}
+
+// -----
+
+func.func @ldexp_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
+  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  return
+}
+
+// -----
+
+func.func @ldexp_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must both be scalars or vectors}}
+  %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  return
+}
+
+// -----
+
+func.func @ldexp_wrong_type_vec_1(%arg0 : vector<3xf32>, %arg1 : i32) -> () {
+  // expected-error @+1 {{operands must both be scalars or vectors}}
+  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : i32 -> vector<3xf32>
+  return
+}
+
+// -----
+
+func.func @ldexp_wrong_type_vec_2(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must have the same number of elements}}
+  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.pown
+//===----------------------------------------------------------------------===//
+
+func.func @pown(%arg0 : f32, %arg1 : i32) -> () {
+  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : f32, {{%.*}} : i32 -> f32
+  %0 = spirv.CL.pown %arg0 : f32, %arg1 : i32 -> f32
+  return
+}
+
+// -----
+
+func.func @pown_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
+  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  return
+}
+
+// -----
+
+func.func @pown_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must both be scalars or vectors}}
+  %0 = spirv.CL.pown %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  return
+}
+
+// -----
+
+func.func @pown_wrong_type_vec(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must have the same number of elements}}
+  %0 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.CL.rootn
+//===----------------------------------------------------------------------===//
+
+func.func @rootn(%arg0 : f32, %arg1 : i32) -> () {
+  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : f32, {{%.*}} : i32 -> f32
+  %0 = spirv.CL.rootn %arg0 : f32, %arg1 : i32 -> f32
+  return
+}
+
+// -----
+
+func.func @rootn_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
+  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  return
+}
+
+// -----
+
+func.func @rootn_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must both be scalars or vectors}}
+  %0 = spirv.CL.rootn %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  return
+}
+
+// -----
+
+func.func @rootn_wrong_type_vec(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
+  // expected-error @+1 {{operands must have the same number of elements}}
+  %0 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  return
+}

--- a/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
@@ -447,16 +447,16 @@ func.func @atan2(%arg0 : vector<4xf16>, %arg1 : vector<4xf16>) -> () {
 //===----------------------------------------------------------------------===//
 
 func.func @ldexp(%arg0 : f32, %arg1 : i32) -> () {
-  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : f32, {{%.*}} : i32 -> f32
-  %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : i32 -> f32
+  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}}, {{%.*}} : f32, i32 -> f32
+  %0 = spirv.CL.ldexp %arg0, %arg1 : f32, i32 -> f32
   return
 }
 
 // -----
 
 func.func @ldexp_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
-  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.ldexp %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
   return
 }
 
@@ -464,7 +464,7 @@ func.func @ldexp_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
 
 func.func @ldexp_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must both be scalars or vectors}}
-  %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  %0 = spirv.CL.ldexp %arg0, %arg1 : f32, vector<2xi32> -> f32
   return
 }
 
@@ -472,7 +472,7 @@ func.func @ldexp_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
 
 func.func @ldexp_wrong_type_vec_1(%arg0 : vector<3xf32>, %arg1 : i32) -> () {
   // expected-error @+1 {{operands must both be scalars or vectors}}
-  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : i32 -> vector<3xf32>
+  %0 = spirv.CL.ldexp %arg0, %arg1 : vector<3xf32>, i32 -> vector<3xf32>
   return
 }
 
@@ -480,7 +480,7 @@ func.func @ldexp_wrong_type_vec_1(%arg0 : vector<3xf32>, %arg1 : i32) -> () {
 
 func.func @ldexp_wrong_type_vec_2(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must have the same number of elements}}
-  %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  %0 = spirv.CL.ldexp %arg0, %arg1 : vector<3xf32>, vector<2xi32> -> vector<3xf32>
   return
 }
 
@@ -491,16 +491,16 @@ func.func @ldexp_wrong_type_vec_2(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) 
 //===----------------------------------------------------------------------===//
 
 func.func @pown(%arg0 : f32, %arg1 : i32) -> () {
-  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : f32, {{%.*}} : i32 -> f32
-  %0 = spirv.CL.pown %arg0 : f32, %arg1 : i32 -> f32
+  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}}, {{%.*}} : f32, i32 -> f32
+  %0 = spirv.CL.pown %arg0, %arg1 : f32, i32 -> f32
   return
 }
 
 // -----
 
 func.func @pown_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
-  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-  %0 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  // CHECK: {{%.*}} = spirv.CL.pown {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.pown %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
   return
 }
 
@@ -508,7 +508,7 @@ func.func @pown_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
 
 func.func @pown_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must both be scalars or vectors}}
-  %0 = spirv.CL.pown %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  %0 = spirv.CL.pown %arg0, %arg1 : f32, vector<2xi32> -> f32
   return
 }
 
@@ -516,7 +516,7 @@ func.func @pown_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
 
 func.func @pown_wrong_type_vec(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must have the same number of elements}}
-  %0 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  %0 = spirv.CL.pown %arg0, %arg1 : vector<3xf32>, vector<2xi32> -> vector<3xf32>
   return
 }
 
@@ -527,16 +527,16 @@ func.func @pown_wrong_type_vec(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> 
 //===----------------------------------------------------------------------===//
 
 func.func @rootn(%arg0 : f32, %arg1 : i32) -> () {
-  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : f32, {{%.*}} : i32 -> f32
-  %0 = spirv.CL.rootn %arg0 : f32, %arg1 : i32 -> f32
+  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}}, {{%.*}} : f32, i32 -> f32
+  %0 = spirv.CL.rootn %arg0, %arg1 : f32, i32 -> f32
   return
 }
 
 // -----
 
 func.func @rootn_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
-  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-  %0 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+  // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+  %0 = spirv.CL.rootn %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
   return
 }
 
@@ -544,7 +544,7 @@ func.func @rootn_vec(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) -> () {
 
 func.func @rootn_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must both be scalars or vectors}}
-  %0 = spirv.CL.rootn %arg0 : f32, %arg1 : vector<2xi32> -> f32
+  %0 = spirv.CL.rootn %arg0, %arg1 : f32, vector<2xi32> -> f32
   return
 }
 
@@ -552,6 +552,6 @@ func.func @rootn_wrong_type_scalar(%arg0 : f32, %arg1 : vector<2xi32>) -> () {
 
 func.func @rootn_wrong_type_vec(%arg0 : vector<3xf32>, %arg1 : vector<2xi32>) -> () {
   // expected-error @+1 {{operands must have the same number of elements}}
-  %0 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<2xi32> -> vector<3xf32>
+  %0 = spirv.CL.rootn %arg0, %arg1 : vector<3xf32>, vector<2xi32> -> vector<3xf32>
   return
 }

--- a/mlir/test/Target/SPIRV/ocl-ops.mlir
+++ b/mlir/test/Target/SPIRV/ocl-ops.mlir
@@ -50,6 +50,26 @@ spirv.module Physical64 OpenCL requires #spirv.vce<v1.0, [Kernel, Addresses, Vec
     spirv.Return
   }
 
+  spirv.func @float_int_insts(%arg0 : f32, %arg1 : i32) "None" {
+    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : f32, {{%.*}} : i32 -> f32
+    %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : i32 -> f32
+    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : f32, {{%.*}} : i32 -> f32
+    %1 = spirv.CL.pown %arg0 : f32, %arg1 : i32 -> f32
+    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : f32, {{%.*}} : i32 -> f32
+    %2 = spirv.CL.rootn %arg0 : f32, %arg1 : i32 -> f32
+    spirv.Return
+  }
+
+  spirv.func @float_int_vec_insts(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) "None" {
+    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+    %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+    %1 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
+    %2 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+    spirv.Return
+  }
+
   spirv.func @maxmin(%arg0 : f32, %arg1 : f32, %arg2 : i32, %arg3 : i32) "None" {
     // CHECK: {{%.*}} = spirv.CL.fmax {{%.*}}, {{%.*}} : f32
     %1 = spirv.CL.fmax %arg0, %arg1 : f32

--- a/mlir/test/Target/SPIRV/ocl-ops.mlir
+++ b/mlir/test/Target/SPIRV/ocl-ops.mlir
@@ -51,22 +51,22 @@ spirv.module Physical64 OpenCL requires #spirv.vce<v1.0, [Kernel, Addresses, Vec
   }
 
   spirv.func @float_int_insts(%arg0 : f32, %arg1 : i32) "None" {
-    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : f32, {{%.*}} : i32 -> f32
-    %0 = spirv.CL.ldexp %arg0 : f32, %arg1 : i32 -> f32
-    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : f32, {{%.*}} : i32 -> f32
-    %1 = spirv.CL.pown %arg0 : f32, %arg1 : i32 -> f32
-    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : f32, {{%.*}} : i32 -> f32
-    %2 = spirv.CL.rootn %arg0 : f32, %arg1 : i32 -> f32
+    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}}, {{%.*}} : f32, i32 -> f32
+    %0 = spirv.CL.ldexp %arg0, %arg1 : f32, i32 -> f32
+    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}}, {{%.*}} : f32, i32 -> f32
+    %1 = spirv.CL.pown %arg0, %arg1 : f32, i32 -> f32
+    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}}, {{%.*}} : f32, i32 -> f32
+    %2 = spirv.CL.rootn %arg0, %arg1 : f32, i32 -> f32
     spirv.Return
   }
 
   spirv.func @float_int_vec_insts(%arg0 : vector<3xf32>, %arg1 : vector<3xi32>) "None" {
-    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-    %0 = spirv.CL.ldexp %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
-    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-    %1 = spirv.CL.pown %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
-    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}} : vector<3xf32>, {{%.*}} : vector<3xi32> -> vector<3xf32>
-    %2 = spirv.CL.rootn %arg0 : vector<3xf32>, %arg1 : vector<3xi32> -> vector<3xf32>
+    // CHECK: {{%.*}} = spirv.CL.ldexp {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+    %0 = spirv.CL.ldexp %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+    // CHECK: {{%.*}} = spirv.CL.pown {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+    %1 = spirv.CL.pown %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+    // CHECK: {{%.*}} = spirv.CL.rootn {{%.*}}, {{%.*}} : vector<3xf32>, vector<3xi32> -> vector<3xf32>
+    %2 = spirv.CL.rootn %arg0, %arg1 : vector<3xf32>, vector<3xi32> -> vector<3xf32>
     spirv.Return
   }
 


### PR DESCRIPTION
Add operations that follow `float op(float, int)` pattern, mirroring the existing `spirv.GL.Ldexp` op