### PR TITLE
[mlir][Presburger] Fix inlining failure for dynamicAPIntFromInt64 in debug builds

### DIFF
--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -521,7 +521,9 @@ void DivisionRepr::dump() const { print(llvm::errs()); }
 SmallVector<DynamicAPInt, 8>
 presburger::getDynamicAPIntVec(ArrayRef<int64_t> range) {
   SmallVector<DynamicAPInt, 8> result(range.size());
-  llvm::transform(range, result.begin(), dynamicAPIntFromInt64);
+  // llvm::transform(range, result.begin(), dynamicAPIntFromInt64);
+  llvm::transform(range, result.begin(),
+                  [](int64_t x) { return dynamicAPIntFromInt64(x); });
   return result;
 }
 

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -521,7 +521,8 @@ void DivisionRepr::dump() const { print(llvm::errs()); }
 SmallVector<DynamicAPInt, 8>
 presburger::getDynamicAPIntVec(ArrayRef<int64_t> range) {
   SmallVector<DynamicAPInt, 8> result(range.size());
-  // llvm::transform(range, result.begin(), dynamicAPIntFromInt64);
+  // Wrapping dynamicAPIntFromInt64 in a lambda, turning the indirect call into
+  // a direct call that the compiler can inline at the call site.
   llvm::transform(range, result.begin(),
                   [](int64_t x) { return dynamicAPIntFromInt64(x); });
   return result;

--- a/mlir/unittests/Analysis/Presburger/Utils.h
+++ b/mlir/unittests/Analysis/Presburger/Utils.h
@@ -153,6 +153,8 @@ inline void expectComputedVolumeIsValidOverapprox(
 inline void expectComputedVolumeIsValidOverapprox(
     const std::optional<DynamicAPInt> &computedVolume,
     std::optional<int64_t> trueVolume, std::optional<int64_t> resultBound) {
+  // Wrapping dynamicAPIntFromInt64 in a lambda, turning the indirect call into
+  // a direct call that the compiler can inline at the call site.
   auto getDynamicAPInt = [](int64_t x) { return dynamicAPIntFromInt64(x); };
   expectComputedVolumeIsValidOverapprox(
       computedVolume, llvm::transformOptional(trueVolume, getDynamicAPInt),

--- a/mlir/unittests/Analysis/Presburger/Utils.h
+++ b/mlir/unittests/Analysis/Presburger/Utils.h
@@ -153,10 +153,10 @@ inline void expectComputedVolumeIsValidOverapprox(
 inline void expectComputedVolumeIsValidOverapprox(
     const std::optional<DynamicAPInt> &computedVolume,
     std::optional<int64_t> trueVolume, std::optional<int64_t> resultBound) {
+  auto getDynamicAPInt = [](int64_t x) { return dynamicAPIntFromInt64(x); };
   expectComputedVolumeIsValidOverapprox(
-      computedVolume,
-      llvm::transformOptional(trueVolume, dynamicAPIntFromInt64),
-      llvm::transformOptional(resultBound, dynamicAPIntFromInt64));
+      computedVolume, llvm::transformOptional(trueVolume, getDynamicAPInt),
+      llvm::transformOptional(resultBound, getDynamicAPInt));
 }
 
 } // namespace presburger


### PR DESCRIPTION
When `dynamicAPIntFromInt64` is passed as a function pointer to `llvm::transform`, it becomes an indirect call. This causes the compiler to fail to inline the function despite the `LLVM_ATTRIBUTE_ALWAYS_INLINE` annotation, resulting in a compilation error in debug builds: 
```
error: inlining failed in call to 'always_inline' 'llvm::DynamicAPInt llvm::dynamicAPIntFromInt64(int64_t)': indirect function call with a yet undetermined callee
  250 | LLVM_ATTRIBUTE_ALWAYS_INLINE DynamicAPInt dynamicAPIntFromInt64(int64_t X) {
```

Fix this by wrapping `dynamicAPIntFromInt64` in a lambda, turning the indirect call into a direct call that the compiler can inline at the call site.