### PR TITLE
[InstSimplify] Fix invalid dereference in simplifyBinaryIntrinsic

### DIFF
--- a/llvm/include/llvm/Analysis/InstructionSimplify.h
+++ b/llvm/include/llvm/Analysis/InstructionSimplify.h
@@ -195,6 +195,7 @@ LLVM_ABI Value *simplifyCastInst(unsigned CastOpc, Value *Op, Type *Ty,
                                  const SimplifyQuery &Q);
 
 /// Given operands for a BinaryIntrinsic, fold the result or return null.
+/// The \p `Call` argument is optional and may be null.
 LLVM_ABI Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
                                         Value *Op0, Value *Op1,
                                         const SimplifyQuery &Q,

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6851,6 +6851,9 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     if (match(Op1, m_Zero()))
       return ConstantInt::getFalse(ReturnType);
 
+    if (!Call)
+      break;
+
     const Function *F = Call->getFunction();
     auto *ScalableTy = dyn_cast<ScalableVectorType>(ReturnType);
     Attribute Attr = F->getFnAttribute(Attribute::VScaleRange);


### PR DESCRIPTION
For the simplifyBinaryIntrinsic interface the `Call` argument passed in may be null, which differs from other interfaces such as simplifyIntrinsic and simplifyUnaryIntrinsic which require `Call` to be non-null. See FoldBinaryIntrinsic in InstSimplifyFolder.h where the `Call` argument has a default value of null.

That means for all uses of `Call` in simplifyBinaryIntrinsic we must first check the pointer is not null to avoid an invalid dereference. This PR fixes the case for the get.active.lane.mask intrinsic.

There isn't currently an easy way to test this fix because the only place I can see where FoldBinaryIntrinsic is called without a null `Call` is VPlanTransforms.cpp and we don't currently invoke the function for get.active.lane.mask intrinsics.