### PR TITLE
[AArch64][GlobalISel] Drop unused value tracking from O0 pre-legalizer combiner (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
@@ -55,8 +55,7 @@ protected:
 
 public:
   AArch64O0PreLegalizerCombinerImpl(
-      MachineFunction &MF, CombinerInfo &CInfo, GISelValueTracking &VT,
-      GISelCSEInfo *CSEInfo,
+      MachineFunction &MF, CombinerInfo &CInfo, GISelCSEInfo *CSEInfo,
       const AArch64O0PreLegalizerCombinerImplRuleConfig &RuleConfig,
       const AArch64Subtarget &STI, const LibcallLoweringInfo &Libcalls);
 
@@ -77,13 +76,12 @@ private:
 #undef GET_GICOMBINER_IMPL
 
 AArch64O0PreLegalizerCombinerImpl::AArch64O0PreLegalizerCombinerImpl(
-    MachineFunction &MF, CombinerInfo &CInfo, GISelValueTracking &VT,
-    GISelCSEInfo *CSEInfo,
+    MachineFunction &MF, CombinerInfo &CInfo, GISelCSEInfo *CSEInfo,
     const AArch64O0PreLegalizerCombinerImplRuleConfig &RuleConfig,
     const AArch64Subtarget &STI, const LibcallLoweringInfo &Libcalls)
-    : Combiner(MF, CInfo, &VT, CSEInfo),
-      Helper(Observer, B, /*IsPreLegalize*/ true, &VT), RuleConfig(RuleConfig),
-      STI(STI), Libcalls(Libcalls),
+    : Combiner(MF, CInfo, /*VT=*/nullptr, CSEInfo),
+      Helper(Observer, B, /*IsPreLegalize*/ true, /*VT=*/nullptr),
+      RuleConfig(RuleConfig), STI(STI), Libcalls(Libcalls),
 #define GET_GICOMBINER_CONSTRUCTOR_INITS
 #include "AArch64GenO0PreLegalizeGICombiner.inc"
 #undef GET_GICOMBINER_CONSTRUCTOR_INITS
@@ -119,8 +117,7 @@ bool AArch64O0PreLegalizerCombinerImpl::tryCombineAll(MachineInstr &MI) const {
 }
 
 bool runCombiner(
-    MachineFunction &MF, GISelValueTracking *VT,
-    const LibcallLoweringInfo &Libcalls,
+    MachineFunction &MF, const LibcallLoweringInfo &Libcalls,
     const AArch64O0PreLegalizerCombinerImplRuleConfig &RuleConfig) {
   const Function &F = MF.getFunction();
   const AArch64Subtarget &ST = MF.getSubtarget<AArch64Subtarget>();
@@ -132,7 +129,7 @@ bool runCombiner(
   // at the cost of possibly missing optimizations. See PR#94291 for details.
   CInfo.MaxIterations = 1;
 
-  AArch64O0PreLegalizerCombinerImpl Impl(MF, CInfo, *VT,
+  AArch64O0PreLegalizerCombinerImpl Impl(MF, CInfo,
                                          /*CSEInfo*/ nullptr, RuleConfig, ST,
                                          Libcalls);
   return Impl.combineMachineInstrs();
@@ -164,8 +161,6 @@ void AArch64O0PreLegalizerCombinerLegacy::getAnalysisUsage(
     AnalysisUsage &AU) const {
   AU.setPreservesCFG();
   getSelectionDAGFallbackAnalysisUsage(AU);
-  AU.addRequired<GISelValueTrackingAnalysisLegacy>();
-  AU.addPreserved<GISelValueTrackingAnalysisLegacy>();
   AU.addRequired<LibcallLoweringInfoWrapper>();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
@@ -182,22 +177,19 @@ bool AArch64O0PreLegalizerCombinerLegacy::runOnMachineFunction(
     return false;
 
   const Function &F = MF.getFunction();
-  GISelValueTracking *VT =
-      &getAnalysis<GISelValueTrackingAnalysisLegacy>().get(MF);
 
   const AArch64Subtarget &ST = MF.getSubtarget<AArch64Subtarget>();
   const LibcallLoweringInfo &Libcalls =
       getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(
           *F.getParent(), ST);
 
-  return runCombiner(MF, VT, Libcalls, RuleConfig);
+  return runCombiner(MF, Libcalls, RuleConfig);
 }
 
 char AArch64O0PreLegalizerCombinerLegacy::ID = 0;
 INITIALIZE_PASS_BEGIN(AArch64O0PreLegalizerCombinerLegacy, DEBUG_TYPE,
                       "Combine AArch64 machine instrs before legalization",
                       false, false)
-INITIALIZE_PASS_DEPENDENCY(GISelValueTrackingAnalysisLegacy)
 INITIALIZE_PASS_DEPENDENCY(GISelCSEAnalysisWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LibcallLoweringInfoWrapper)
 INITIALIZE_PASS_END(AArch64O0PreLegalizerCombinerLegacy, DEBUG_TYPE,
@@ -223,8 +215,6 @@ AArch64O0PreLegalizerCombinerPass::run(MachineFunction &MF,
   if (MF.getProperties().hasFailedISel())
     return PreservedAnalyses::all();
 
-  GISelValueTracking &VT = MFAM.getResult<GISelValueTrackingAnalysis>(MF);
-
   const AArch64Subtarget &ST = MF.getSubtarget<AArch64Subtarget>();
   auto &MAMProxy =
       MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF);
@@ -236,12 +226,11 @@ AArch64O0PreLegalizerCombinerPass::run(MachineFunction &MF,
 
   const LibcallLoweringInfo &Libcalls = LibcallResult->getLibcallLowering(ST);
 
-  if (!runCombiner(MF, &VT, Libcalls, *RuleConfig))
+  if (!runCombiner(MF, Libcalls, *RuleConfig))
     return PreservedAnalyses::all();
 
   PreservedAnalyses PA = getMachineFunctionPassPreservedAnalyses();
   PA.preserveSet<CFGAnalyses>();
-  PA.preserve<GISelValueTrackingAnalysis>();
   return PA;
 }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
@@ -58,7 +58,7 @@
 ; ENABLED-O1-NEXT: Function Alias Analysis Results
 ; ENABLED:       IRTranslator
 ; VERIFY-NEXT:   Verify generated machine code
-; ENABLED-NEXT:  Analysis for ComputingKnownBits
+; ENABLED-O1-NEXT:  Analysis for ComputingKnownBits
 ; ENABLED-O1-NEXT:  MachineDominator Tree Construction
 ; ENABLED-O1-NEXT:  Analysis containing CSE Info
 ; ENABLED-O1-NEXT:  PreLegalizerCombiner

--- a/llvm/test/CodeGen/AArch64/O0-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O0-pipeline.ll
@@ -34,7 +34,6 @@
 ; CHECK-NEXT:       Module Verifier
 ; CHECK-NEXT:       Analysis containing CSE Info
 ; CHECK-NEXT:       IRTranslator
-; CHECK-NEXT:       Analysis for ComputingKnownBits
 ; CHECK-NEXT:       AArch64O0PreLegalizerCombiner
 ; CHECK-NEXT:       Localizer
 ; CHECK-NEXT:       Analysis containing CSE Info

--- a/llvm/test/CodeGen/AArch64/O3-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O3-pipeline.ll
@@ -115,7 +115,6 @@
 ; CHECK-NEXT:       Basic Alias Analysis (stateless AA impl)
 ; CHECK-NEXT:       Function Alias Analysis Results
 ; CHECK-NEXT:       IRTranslator
-; CHECK-NEXT:       Analysis for ComputingKnownBits
 ; CHECK-NEXT:       AArch64O0PreLegalizerCombiner
 ; CHECK-NEXT:       Localizer
 ; CHECK-NEXT:       Analysis containing CSE Info

--- a/llvm/test/Other/print-changed-machine.ll
+++ b/llvm/test/Other/print-changed-machine.ll
@@ -7,8 +7,7 @@
 ; VERBOSE-NEXT:  Function Live Ins: $w0
 ; VERBOSE-EMPTY:
 ; VERBOSE-NEXT:  bb.1.entry:
-; VERBOSE:       *** IR Dump After Analysis for ComputingKnownBits (gisel-known-bits) on foo omitted because no change ***
-; VERBOSE-NEXT:  *** IR Dump After AArch64O0PreLegalizerCombiner (aarch64-O0-prelegalizer-combiner) on foo omitted because no change ***
+; VERBOSE:       *** IR Dump After AArch64O0PreLegalizerCombiner (aarch64-O0-prelegalizer-combiner) on foo omitted because no change ***
 ; VERBOSE:       *** IR Dump After Legalizer (legalizer) on foo ***
 ; VERBOSE-NEXT:  # Machine code for function foo: IsSSA, TracksLiveness, Legalized
 ; VERBOSE-NEXT:  Function Live Ins: $w0


### PR DESCRIPTION
It doesn't improve compile-time, but it isn't necessary and can be removed.