### PR TITLE
[libc][sched] Fix CPU_SET and CPU_ISSET macros

### DIFF
--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -30,8 +30,8 @@
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)
 #define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
 #define CPU_SET_S(cpu, setsize, set) __sched_setcpuset(cpu, setsize, set)
-#define CPU_SET(cpu, setsize, set) CPU_SET_S(cpu, sizeof(cpt_set_t), set)
+#define CPU_SET(cpu, set) CPU_SET_S(cpu, sizeof(cpu_set_t), set)
 #define CPU_ISSET_S(cpu, setsize, set) __sched_getcpuisset(cpu, setsize, set)
-#define CPU_ISSET(cpu, setsize, set) CPU_ISSET_S(cpu, sizeof(cpt_set_t), set)
+#define CPU_ISSET(cpu, set) CPU_ISSET_S(cpu, sizeof(cpu_set_t), set)
 
 #endif // LLVM_LIBC_MACROS_LINUX_SCHED_MACROS_H

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -25,6 +25,29 @@ functions:
     arguments:
       - type: size_t
       - type: const cpu_set_t *
+  - name: __sched_getcpuisset
+    standards:
+      - llvm_libc_ext
+    return_type: int
+    arguments:
+      - type: int
+      - type: size_t
+      - type: const cpu_set_t *
+  - name: __sched_setcpuset
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: int
+      - type: size_t
+      - type: cpu_set_t *
+  - name: __sched_setcpuzero
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: size_t
+      - type: cpu_set_t *
   - name: getcpu
     standards:
       - Linux

--- a/libc/src/sched/linux/sched_getcpuisset.cpp
+++ b/libc/src/sched/linux/sched_getcpuisset.cpp
@@ -19,7 +19,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, __sched_getcpuisset,
-                   (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
+                   (int cpu, const size_t cpuset_size, const cpu_set_t *set)) {
   LIBC_CRASH_ON_NULLPTR(set);
 
   if (static_cast<size_t>(cpu) / 8 < cpuset_size) {

--- a/libc/src/sched/sched_getcpuisset.h
+++ b/libc/src/sched/sched_getcpuisset.h
@@ -17,7 +17,8 @@
 namespace LIBC_NAMESPACE_DECL {
 
 // for internal use in the CPU_ISSET macro
-int __sched_getcpuisset(int cpu, const size_t cpuset_size, cpu_set_t *set);
+int __sched_getcpuisset(int cpu, const size_t cpuset_size,
+                        const cpu_set_t *set);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -88,6 +88,17 @@ add_libc_test(
 )
 
 add_libc_test(
+  sched_test
+  UNIT_TEST_ONLY
+  SUITE
+    libc_include_tests
+  SRCS
+    sched_test.cpp
+  DEPENDS
+    libc.include.sched
+)
+
+add_libc_test(
   issubnormal_test
   SUITE
     libc_include_tests

--- a/libc/test/include/sched_test.cpp
+++ b/libc/test/include/sched_test.cpp
@@ -1,0 +1,26 @@
+//===-- Unittests for sched -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sched.h>
+
+template <typename T, typename U> struct SameType {
+  static constexpr bool value = false;
+};
+
+template <typename T> struct SameType<T, T> {
+  static constexpr bool value = true;
+};
+
+// Use unevaluated contexts to verify the public macro declarations without
+// requiring this include test to link the helper entrypoints.
+static_assert(SameType<decltype(CPU_ZERO((cpu_set_t *)0)), void>::value, "");
+static_assert(SameType<decltype(CPU_COUNT((cpu_set_t *)0)), int>::value, "");
+static_assert(SameType<decltype(CPU_SET(0, (cpu_set_t *)0)), void>::value, "");
+static_assert(SameType<decltype(CPU_ISSET(0, (cpu_set_t *)0)), int>::value, "");
+
+extern "C" int main() { return 0; }

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -109,6 +109,9 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
     libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sched/cpu_count_test.cpp
+++ b/libc/test/src/sched/cpu_count_test.cpp
@@ -9,6 +9,9 @@
 #include "src/__support/OSUtil/syscall.h"
 #include "src/sched/sched_getaffinity.h"
 #include "src/sched/sched_getcpucount.h"
+#include "src/sched/sched_getcpuisset.h"
+#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_setcpuzero.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
@@ -31,4 +34,16 @@ TEST_F(LlvmLibcSchedCpuCountTest, SmokeTest) {
   int num_cpus = LIBC_NAMESPACE::CPU_COUNT(&mask);
   ASSERT_GT(num_cpus, 0);
   ASSERT_LE(num_cpus, int(sizeof(cpu_set_t) * sizeof(unsigned long)));
+}
+
+TEST_F(LlvmLibcSchedCpuCountTest, CpuSetMacros) {
+  cpu_set_t mask;
+
+  LIBC_NAMESPACE::CPU_ZERO(&mask);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_COUNT(&mask), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET(1, &mask), 0);
+
+  LIBC_NAMESPACE::CPU_SET(1, &mask);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET(1, &mask), 1);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_COUNT(&mask), 1);
 }


### PR DESCRIPTION
Fix the public CPU_SET and CPU_ISSET macros to match the expected two-argument forms and to use cpu_set_t instead of the misspelled cpt_set_t.

Also declare the helper functions used by the CPU set macros in the generated sched.h header, and add regression coverage for the CPU set macro family.