### PR TITLE
[sancov] Drop inner braces in `createOrDie` initializer

### DIFF
--- a/llvm/tools/sancov/sancov.cpp
+++ b/llvm/tools/sancov/sancov.cpp
@@ -542,7 +542,7 @@ private:
   static std::unique_ptr<SpecialCaseList> createUserIgnorelist() {
     if (ClIgnorelist.empty())
       return std::unique_ptr<SpecialCaseList>();
-    return SpecialCaseList::createOrDie({{ClIgnorelist}},
+    return SpecialCaseList::createOrDie({ClIgnorelist},
                                         *vfs::getRealFileSystem());
   }
   std::unique_ptr<SpecialCaseList> DefaultIgnorelist;


### PR DESCRIPTION
The inner braces in `{{ClIgnorelist}}` ask the compiler to construct `std::string` from `cl::opt<std::string>`, which inherits from `std::string`. One candidate is libc++'s explicit `basic_string` template constructor.

Pre-Clang-20 silently skipped that constructor in this context, so the call compiled. Clang 20's CWG2137 fix now selects it, making `{{ClIgnorelist}}` ill-formed on libc++, e.g., building LLVM on macOS with Xcode 26.

Dropping the inner braces uses `cl::opt`'s implicit conversion to `const std::string&` and compiles cleanly.