### PR TITLE
[flang][FIR][Mem2Reg] Do not emit potentially wrong debug info

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -5646,8 +5646,13 @@ void fir::DeclareOp::visitReplacedValues(
     llvm::ArrayRef<std::pair<mlir::Operation *, mlir::Value>> definitions,
     mlir::OpBuilder &builder) {
   for (auto [op, value] : definitions) {
+    // Do not emit DeclareValue when we have a dummy scope as this can
+    // potentially result in us generating it where the DummyScope does not
+    // dominate it. This can happen after inlining.
+    if (getDummyScope())
+      continue;
     builder.setInsertionPointAfter(op);
-    fir::DeclareValueOp::create(builder, getLoc(), value, getDummyScope(),
+    fir::DeclareValueOp::create(builder, getLoc(), value, nullptr,
                                 getUniqNameAttr(), getFortranAttrsAttr(),
                                 getDataAttrAttr(), getDummyArgNoAttr());
   }

--- a/flang/test/Fir/mem2reg.mlir
+++ b/flang/test/Fir/mem2reg.mlir
@@ -215,3 +215,21 @@ func.func @loop_conditional_update(%arg0: i32, %cdt: i1) -> i32 {
   %result = fir.load %declare : !fir.ref<i32>
   return %result : i32
 }
+
+// -----
+
+// Make sure we do not generate fir.declare_value for a replaced value
+// fir.declare with dummy_scope. This can result in the declare_value being
+// inserted before the dummy_scope it uses as would be the case here.
+
+// CHECK-LABEL: func.func @dummy_scope(
+// CHECK-NOT: fir.declare_value
+func.func @dummy_scope(%arg : i32) {
+  %alloca = fir.alloca i32 {adapt.valuebyref}
+  fir.store %arg to %alloca : !fir.ref<i32>
+  %scope = fir.dummy_scope : !fir.dscope
+  %declare = fir.declare %alloca dummy_scope %scope arg 1 {fortran_attrs = #fir.var_attrs<intent_in>, uniq_name = "foo"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+  %result = fir.load %declare : !fir.ref<i32>
+  fir.call @use(%result) : (i32) -> ()
+  return
+}


### PR DESCRIPTION
When mem2reg replaces values, it can potentially replace a value that is stored before a fir.declare comes in scope, when the fir.declare was inlined from another routine. When we emit a declare_value op for such a variable, it can potentially break dominance with regards to the fir.dummy_scope op.

Do not emit fir.declare_value op in such cases to prevent compiler crashes.