### PR TITLE
[dyndbg] Create .debug_llvm_dyndbg section without any section flags

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -492,6 +492,12 @@ static SectionKind getELFKindForNamedSection(StringRef Name, SectionKind K) {
       Name.starts_with(".llvm.linkonce.tb."))
     return SectionKind::getThreadBSS();
 
+  // TODO: We could avoid a magic name by adding metadata similar to MD_exclude
+  // to the embedded object global, to choose SectionKind::Metadata earlier
+  // without checking the section name (in getKindForGlobal for example).
+  if (Name == ".debug_llvm_dyndbg")
+    return SectionKind::getMetadata();
+
   return K;
 }
 

--- a/llvm/test/CodeGen/X86/metadata-section-type.ll
+++ b/llvm/test/CodeGen/X86/metadata-section-type.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=x86_64-unknown-linux %s -o - | FileCheck %s
+
+; Check that the section '.debug_llvm_dyndbg' is created without flags.
+; FIXME: A more flexible approach would be to add metadata (like !exclude) to
+; signal this, rather than checking for a specific section name.
+
+@llvm.embedded.object = private constant [1 x i8] c"\00", section ".debug_llvm_dyndbg", align 1
+@llvm.compiler.used = appending global [1 x ptr] [ptr @llvm.embedded.object], section "llvm.metadata"
+
+; CHECK: .section .debug_llvm_dyndbg,"",@progbits
+; CHECK-NEXT: .Lllvm.embedded.object:
+; CHECK-NEXT: .zero  1
+; CHECK-NEXT: .size .Lllvm.embedded.object, 1


### PR DESCRIPTION
This patch is to support dynamic debugging, RFC:
https://discourse.llvm.org/t/90113

A .debug_llvm_dyndbg section is created using an embedded object global (in a coming patch).

We don't want any section flags applied to .debug_llvm_dyndbg. Without this patch LLVM applies SHF_EXCLUDE because of the !exclude metadata, and if we omit !exclude LLVM applies SHF_ALLOC.

As the comments in this patch point out, it would be more flexible to add metadata (like !exclude) to control this.
