### PR TITLE
[Clang] Fix assertion when __block is used on global variables in C mode

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -601,6 +601,7 @@ Bug Fixes to AST Handling
   parameter list. This also adds asserts to prevent this from happening again.
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
+- Fixed a assertion when __block is used on global variables in C mode. (#GH183974)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -601,7 +601,7 @@ Bug Fixes to AST Handling
   parameter list. This also adds asserts to prevent this from happening again.
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
-- Fixed a assertion when __block is used on global variables in C mode. (#GH183974)
+- Fixed a assertion when ``__block`` is used on global variables in C mode. (#GH183974)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9133,12 +9133,6 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     }
   }
 
-  if (!NewVD->hasLocalStorage() && NewVD->hasAttr<BlocksAttr>()) {
-    Diag(NewVD->getLocation(), diag::err_block_on_nonlocal);
-    NewVD->setInvalidDecl();
-    return;
-  }
-
   if (!NewVD->hasLocalStorage() && T->isSizelessType() &&
       !T.isWebAssemblyReferenceType() && !T->isHLSLSpecificType()) {
     Diag(NewVD->getLocation(), diag::err_sizeless_nonlocal) << T;

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1711,6 +1711,12 @@ void SemaObjC::handleBlocksAttr(Decl *D, const ParsedAttr &AL) {
     return;
   }
 
+  VarDecl *VD = dyn_cast<VarDecl>(D);
+  if (VD && !VD->hasLocalStorage()) {
+    Diag(AL.getLoc(), diag::err_block_on_nonlocal) << AL;
+    return;
+  }
+
   D->addAttr(::new (getASTContext()) BlocksAttr(getASTContext(), AL, type));
 }
 

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1714,6 +1714,7 @@ void SemaObjC::handleBlocksAttr(Decl *D, const ParsedAttr &AL) {
   VarDecl *VD = dyn_cast<VarDecl>(D);
   if (VD && !VD->hasLocalStorage()) {
     Diag(AL.getLoc(), diag::err_block_on_nonlocal) << AL;
+    D->setInvalidDecl();
     return;
   }
 

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1714,7 +1714,6 @@ void SemaObjC::handleBlocksAttr(Decl *D, const ParsedAttr &AL) {
   VarDecl *VD = dyn_cast<VarDecl>(D);
   if (VD && !VD->hasLocalStorage()) {
     Diag(AL.getLoc(), diag::err_block_on_nonlocal) << AL;
-    D->setInvalidDecl();
     return;
   }
 

--- a/clang/test/Sema/block-on-objc-ivars.m
+++ b/clang/test/Sema/block-on-objc-ivars.m
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fblocks -fsyntax-only -verify %s
+
+@interface MyClass {
+    // expected-warning@-1 {{class 'MyClass' defined without specifying a base class}}
+    // expected-note@-2 {{add a super class to fix this problem}}
+    __block int _myIvar;
+}
+@end
+
+@implementation MyClass
+@end

--- a/clang/test/Sema/gh183974.c
+++ b/clang/test/Sema/gh183974.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fblocks -fsyntax-only -verify %s
+
+__block int x; // expected-error {{__block attribute not allowed, only allowed on local variables}}
+
+int x;


### PR DESCRIPTION
This is a reland PR, related to #183988 

I added an extra check in handleBlocksAttr to ensure that illegal Decl values ​​are not passed to downstream functions.
And remove unnecessary check in `CheckCompleteVariableDeclaration`.
Fixes #183974

Also added a extra regression test.