### PR TITLE
[analyzer][NFC] Merge `BlockInvocationContext` class into `StackFrameContext`

### DIFF
--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -183,6 +183,7 @@ public:
 
   /// \copydoc LocationContextManager::getStackFrame()
   const StackFrameContext *getStackFrame(LocationContext const *ParentLC,
+                                         const ento::BlockDataRegion *BlockInvocationData,
                                          const Expr *E, const CFGBlock *Blk,
                                          unsigned BlockCount, unsigned Index);
 
@@ -403,16 +404,19 @@ public:
 
   /// Obtain a context of the call stack using its parent context.
   ///
-  /// \param ADC        The AnalysisDeclContext.
-  /// \param ParentLC   The parent context of this newly created context.
-  /// \param E          The call expression.
-  /// \param Block      The basic block.
-  /// \param BlockCount The current count of entering into \p Block.
-  /// \param StmtIdx    The index of the call expression \p E among the
-  ///                   statements of the CFGBlock \p Block.
+  /// \param ADC                 The AnalysisDeclContext.
+  /// \param ParentLC            The parent context of this newly created context.
+  /// \param BlockInvocationData Extra data in case this StackFrameContext is
+  ///                            created for a BlockInvocation.
+  /// \param E                   The call expression.
+  /// \param Block               The basic block.
+  /// \param BlockCount          The current count of entering into \p Block.
+  /// \param StmtIdx             The index of the call expression \p E among the
+  ///                            statements of the CFGBlock \p Block.
   /// \returns The stack frame context corresponding to the call.
   const StackFrameContext *getStackFrame(AnalysisDeclContext *ADC,
                                          const LocationContext *ParentLC,
+                                         const ento::BlockDataRegion *BlockInvocationData,
                                          const Expr *E, const CFGBlock *Block,
                                          unsigned BlockCount, unsigned StmtIdx);
 
@@ -477,7 +481,7 @@ public:
   ///
   /// \returns The top level stack frame for \p D.
   const StackFrameContext *getStackFrame(const Decl *D) {
-    return LocCtxMgr.getStackFrame(getContext(D), nullptr, nullptr, nullptr, 0,
+    return LocCtxMgr.getStackFrame(getContext(D), nullptr, nullptr, nullptr, nullptr, 0,
                                    0);
   }
 

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -330,6 +330,8 @@ class StackFrameContext : public LocationContext {
 public:
   ~StackFrameContext() override = default;
 
+  const ento::BlockDataRegion* getBlockInvocationData() const { return BlockInvocationData; }
+
   const Expr *getCallSite() const { return CallSite; }
 
   const CFGBlock *getCallSiteBlock() const { return Block; }

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -207,10 +207,6 @@ private:
   LocationContextManager &getLocationContextManager();
 };
 
-/// It wraps the AnalysisDeclContext to represent both the call stack with
-/// the help of StackFrameContext and inside the function calls the
-/// BlockInvocationContext. It is needed for context sensitive analysis to
-/// model entering, leaving or inlining function calls.
 class LocationContext : public llvm::FoldingSetNode {
 public:
   enum ContextKind { StackFrame };

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -36,7 +36,6 @@ namespace clang {
 class AnalysisDeclContextManager;
 class ASTContext;
 class BlockDecl;
-class BlockInvocationContext;
 class CFGReverseBlockReachabilityAnalysis;
 class ImplicitParamDecl;
 class LocationContext;
@@ -182,15 +181,10 @@ public:
   const ImplicitParamDecl *getSelfDecl() const;
 
   /// \copydoc LocationContextManager::getStackFrame()
-  const StackFrameContext *getStackFrame(LocationContext const *ParentLC,
-                                         const ento::BlockDataRegion *BlockInvocationData,
-                                         const Expr *E, const CFGBlock *Blk,
-                                         unsigned BlockCount, unsigned Index);
-
-  /// \copydoc LocationContextManager::getBlockInvocationContext()
-  const BlockInvocationContext *
-  getBlockInvocationContext(const LocationContext *ParentLC,
-                            const BlockDecl *BD, const void *Data);
+  const StackFrameContext *
+  getStackFrame(LocationContext const *ParentLC,
+                const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
+                const CFGBlock *Blk, unsigned BlockCount, unsigned Index);
 
   /// \returns The specified analysis object, lazily running the analysis if
   /// necessary or nullptr if the analysis could not run.
@@ -219,7 +213,7 @@ private:
 /// model entering, leaving or inlining function calls.
 class LocationContext : public llvm::FoldingSetNode {
 public:
-  enum ContextKind { StackFrame, Block };
+  enum ContextKind { StackFrame };
 
 private:
   ContextKind Kind;
@@ -322,15 +316,19 @@ class StackFrameContext : public LocationContext {
   const unsigned Index;
 
   StackFrameContext(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-                    const ento::BlockDataRegion *BlockInvocationData, const Expr *E, const CFGBlock *Block, unsigned BlockCount,
+                    const ento::BlockDataRegion *BlockInvocationData,
+                    const Expr *E, const CFGBlock *Block, unsigned BlockCount,
                     unsigned Index, int64_t ID)
-      : LocationContext(StackFrame, ADC, ParentLC, ID), BlockInvocationData(BlockInvocationData), CallSite(E),
-        Block(Block), BlockCount(BlockCount), Index(Index) {}
+      : LocationContext(StackFrame, ADC, ParentLC, ID),
+        BlockInvocationData(BlockInvocationData), CallSite(E), Block(Block),
+        BlockCount(BlockCount), Index(Index) {}
 
 public:
   ~StackFrameContext() override = default;
 
-  const ento::BlockDataRegion* getBlockInvocationData() const { return BlockInvocationData; }
+  const ento::BlockDataRegion *getBlockInvocationData() const {
+    return BlockInvocationData;
+  }
 
   const Expr *getCallSite() const { return CallSite; }
 
@@ -345,8 +343,9 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) override;
 
   static void Profile(llvm::FoldingSetNodeID &ID, AnalysisDeclContext *ADC,
-                      const LocationContext *ParentLC, const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
-                      const CFGBlock *Block, unsigned BlockCount,
+                      const LocationContext *ParentLC,
+                      const ento::BlockDataRegion *BlockInvocationData,
+                      const Expr *E, const CFGBlock *Block, unsigned BlockCount,
                       unsigned Index) {
     ProfileCommon(ID, StackFrame, ADC, ParentLC, E);
     ID.AddPointer(BlockInvocationData);
@@ -357,41 +356,6 @@ public:
 
   static bool classof(const LocationContext *LC) {
     return LC->getKind() == StackFrame;
-  }
-};
-
-/// It represents a block invocation (based on BlockCall).
-class BlockInvocationContext : public LocationContext {
-  friend class LocationContextManager;
-
-  const BlockDecl *BD;
-
-  // FIXME: Come up with a more type-safe way to model context-sensitivity.
-  const void *Data;
-
-  BlockInvocationContext(AnalysisDeclContext *ADC,
-                         const LocationContext *ParentLC, const BlockDecl *BD,
-                         const void *Data, int64_t ID)
-      : LocationContext(Block, ADC, ParentLC, ID), BD(BD), Data(Data) {}
-
-public:
-  ~BlockInvocationContext() override = default;
-
-  const BlockDecl *getBlockDecl() const { return BD; }
-
-  const void *getData() const { return Data; }
-
-  void Profile(llvm::FoldingSetNodeID &ID) override;
-
-  static void Profile(llvm::FoldingSetNodeID &ID, AnalysisDeclContext *ADC,
-                      const LocationContext *ParentLC, const BlockDecl *BD,
-                      const void *Data) {
-    ProfileCommon(ID, Block, ADC, ParentLC, BD);
-    ID.AddPointer(Data);
-  }
-
-  static bool classof(const LocationContext *LC) {
-    return LC->getKind() == Block;
   }
 };
 
@@ -407,7 +371,8 @@ public:
   /// Obtain a context of the call stack using its parent context.
   ///
   /// \param ADC                 The AnalysisDeclContext.
-  /// \param ParentLC            The parent context of this newly created context.
+  /// \param ParentLC            The parent context of this newly created
+  /// context.
   /// \param BlockInvocationData Extra data in case this StackFrameContext is
   ///                            created for a BlockInvocation.
   /// \param E                   The call expression.
@@ -416,22 +381,10 @@ public:
   /// \param StmtIdx             The index of the call expression \p E among the
   ///                            statements of the CFGBlock \p Block.
   /// \returns The stack frame context corresponding to the call.
-  const StackFrameContext *getStackFrame(AnalysisDeclContext *ADC,
-                                         const LocationContext *ParentLC,
-                                         const ento::BlockDataRegion *BlockInvocationData,
-                                         const Expr *E, const CFGBlock *Block,
-                                         unsigned BlockCount, unsigned StmtIdx);
-
-  /// Obtain a context of the block invocation using its parent context.
-  ///
-  /// \param ADC      The AnalysisDeclContext.
-  /// \param ParentLC The parent context of this newly created context.
-  /// \param BD       The BlockDecl.
-  /// \param Data     The raw data to store as part of the context.
-  const BlockInvocationContext *
-  getBlockInvocationContext(AnalysisDeclContext *ADC,
-                            const LocationContext *ParentLC,
-                            const BlockDecl *BD, const void *Data);
+  const StackFrameContext *
+  getStackFrame(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
+                const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
+                const CFGBlock *Block, unsigned BlockCount, unsigned StmtIdx);
 
   /// Discard all previously created LocationContext objects.
   void clear();
@@ -483,8 +436,8 @@ public:
   ///
   /// \returns The top level stack frame for \p D.
   const StackFrameContext *getStackFrame(const Decl *D) {
-    return LocCtxMgr.getStackFrame(getContext(D), nullptr, nullptr, nullptr, nullptr, 0,
-                                   0);
+    return LocCtxMgr.getStackFrame(getContext(D), nullptr, nullptr, nullptr,
+                                   nullptr, 0, 0);
   }
 
   BodyFarm &getBodyFarm();

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -45,10 +45,6 @@ class StackFrameContext;
 class Stmt;
 class VarDecl;
 
-namespace ento {
-class BlockDataRegion;
-}
-
 /// The base class of a hierarchy of objects representing analyses tied
 /// to AnalysisDeclContext.
 class ManagedAnalysis {
@@ -181,10 +177,10 @@ public:
   const ImplicitParamDecl *getSelfDecl() const;
 
   /// \copydoc LocationContextManager::getStackFrame()
-  const StackFrameContext *
-  getStackFrame(LocationContext const *ParentLC,
-                const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
-                const CFGBlock *Blk, unsigned BlockCount, unsigned Index);
+  const StackFrameContext *getStackFrame(LocationContext const *ParentLC,
+                                         const void *Data, const Expr *E,
+                                         const CFGBlock *Blk,
+                                         unsigned BlockCount, unsigned Index);
 
   /// \returns The specified analysis object, lazily running the analysis if
   /// necessary or nullptr if the analysis could not run.
@@ -295,7 +291,7 @@ class StackFrameContext : public LocationContext {
   friend class LocationContextManager;
 
   // Extra data for BlockInvocations
-  const ento::BlockDataRegion *BlockInvocationData;
+  const void *Data;
 
   // The call site where this stack frame is established.
   const Expr *CallSite;
@@ -312,19 +308,15 @@ class StackFrameContext : public LocationContext {
   const unsigned Index;
 
   StackFrameContext(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-                    const ento::BlockDataRegion *BlockInvocationData,
-                    const Expr *E, const CFGBlock *Block, unsigned BlockCount,
-                    unsigned Index, int64_t ID)
-      : LocationContext(StackFrame, ADC, ParentLC, ID),
-        BlockInvocationData(BlockInvocationData), CallSite(E), Block(Block),
-        BlockCount(BlockCount), Index(Index) {}
+                    const void *Data, const Expr *E, const CFGBlock *Block,
+                    unsigned BlockCount, unsigned Index, int64_t ID)
+      : LocationContext(StackFrame, ADC, ParentLC, ID), Data(Data), CallSite(E),
+        Block(Block), BlockCount(BlockCount), Index(Index) {}
 
 public:
   ~StackFrameContext() override = default;
 
-  const ento::BlockDataRegion *getBlockInvocationData() const {
-    return BlockInvocationData;
-  }
+  const void *getData() const { return Data; }
 
   const Expr *getCallSite() const { return CallSite; }
 
@@ -339,12 +331,11 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) override;
 
   static void Profile(llvm::FoldingSetNodeID &ID, AnalysisDeclContext *ADC,
-                      const LocationContext *ParentLC,
-                      const ento::BlockDataRegion *BlockInvocationData,
+                      const LocationContext *ParentLC, const void *Data,
                       const Expr *E, const CFGBlock *Block, unsigned BlockCount,
                       unsigned Index) {
     ProfileCommon(ID, StackFrame, ADC, ParentLC, E);
-    ID.AddPointer(BlockInvocationData);
+    ID.AddPointer(Data);
     ID.AddPointer(Block);
     ID.AddInteger(BlockCount);
     ID.AddInteger(Index);
@@ -366,21 +357,22 @@ public:
 
   /// Obtain a context of the call stack using its parent context.
   ///
-  /// \param ADC                 The AnalysisDeclContext.
-  /// \param ParentLC            The parent context of this newly created
-  /// context.
-  /// \param BlockInvocationData Extra data in case this StackFrameContext is
-  ///                            created for a BlockInvocation.
-  /// \param E                   The call expression.
-  /// \param Block               The basic block.
-  /// \param BlockCount          The current count of entering into \p Block.
-  /// \param StmtIdx             The index of the call expression \p E among the
-  ///                            statements of the CFGBlock \p Block.
+  /// \param ADC        The AnalysisDeclContext.
+  /// \param ParentLC   The parent context of this newly created
+  ///                   context.
+  /// \param Data       Extra data in case this StackFrameContext is
+  ///                   created for a BlockInvocation.
+  /// \param E          The call expression.
+  /// \param Block      The basic block.
+  /// \param BlockCount The current count of entering into \p Block.
+  /// \param StmtIdx    The index of the call expression \p E among the
+  ///                   statements of the CFGBlock \p Block.
   /// \returns The stack frame context corresponding to the call.
-  const StackFrameContext *
-  getStackFrame(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-                const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
-                const CFGBlock *Block, unsigned BlockCount, unsigned StmtIdx);
+  const StackFrameContext *getStackFrame(AnalysisDeclContext *ADC,
+                                         const LocationContext *ParentLC,
+                                         const void *Data, const Expr *E,
+                                         const CFGBlock *Block,
+                                         unsigned BlockCount, unsigned StmtIdx);
 
   /// Discard all previously created LocationContext objects.
   void clear();

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -46,6 +46,10 @@ class StackFrameContext;
 class Stmt;
 class VarDecl;
 
+namespace ento {
+class BlockDataRegion;
+}
+
 /// The base class of a hierarchy of objects representing analyses tied
 /// to AnalysisDeclContext.
 class ManagedAnalysis {
@@ -299,6 +303,9 @@ public:
 class StackFrameContext : public LocationContext {
   friend class LocationContextManager;
 
+  // Extra data for BlockInvocations
+  const ento::BlockDataRegion *BlockInvocationData;
+
   // The call site where this stack frame is established.
   const Expr *CallSite;
 
@@ -314,9 +321,9 @@ class StackFrameContext : public LocationContext {
   const unsigned Index;
 
   StackFrameContext(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-                    const Expr *E, const CFGBlock *Block, unsigned BlockCount,
+                    const ento::BlockDataRegion *BlockInvocationData, const Expr *E, const CFGBlock *Block, unsigned BlockCount,
                     unsigned Index, int64_t ID)
-      : LocationContext(StackFrame, ADC, ParentLC, ID), CallSite(E),
+      : LocationContext(StackFrame, ADC, ParentLC, ID), BlockInvocationData(BlockInvocationData), CallSite(E),
         Block(Block), BlockCount(BlockCount), Index(Index) {}
 
 public:
@@ -335,10 +342,11 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) override;
 
   static void Profile(llvm::FoldingSetNodeID &ID, AnalysisDeclContext *ADC,
-                      const LocationContext *ParentLC, const Expr *E,
+                      const LocationContext *ParentLC, const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
                       const CFGBlock *Block, unsigned BlockCount,
                       unsigned Index) {
     ProfileCommon(ID, StackFrame, ADC, ParentLC, E);
+    ID.AddPointer(BlockInvocationData);
     ID.AddPointer(Block);
     ID.AddInteger(BlockCount);
     ID.AddInteger(Index);

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -312,9 +312,10 @@ BodyFarm &AnalysisDeclContextManager::getBodyFarm() { return FunctionBodyFarm; }
 
 const StackFrameContext *
 AnalysisDeclContext::getStackFrame(const LocationContext *ParentLC,
+                                   const ento::BlockDataRegion *BlockInvocationData,
                                    const Expr *E, const CFGBlock *Blk,
                                    unsigned BlockCount, unsigned Index) {
-  return getLocationContextManager().getStackFrame(this, ParentLC, E, Blk,
+  return getLocationContextManager().getStackFrame(this, ParentLC, BlockInvocationData, E, Blk,
                                                    BlockCount, Index);
 }
 
@@ -428,15 +429,15 @@ void BlockInvocationContext::Profile(llvm::FoldingSetNodeID &ID) {
 //===----------------------------------------------------------------------===//
 
 const StackFrameContext *LocationContextManager::getStackFrame(
-    AnalysisDeclContext *Ctx, const LocationContext *Parent, const Expr *E,
+    AnalysisDeclContext *Ctx, const LocationContext *Parent, const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
     const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
-  StackFrameContext::Profile(ID, Ctx, Parent, nullptr, E, Blk, BlockCount, StmtIdx);
+  StackFrameContext::Profile(ID, Ctx, Parent, BlockInvocationData, E, Blk, BlockCount, StmtIdx);
   void *InsertPos;
   auto *L =
    cast_or_null<StackFrameContext>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
   if (!L) {
-    L = new StackFrameContext(Ctx, Parent, nullptr, E, Blk, BlockCount, StmtIdx,
+    L = new StackFrameContext(Ctx, Parent, BlockInvocationData, E, Blk, BlockCount, StmtIdx,
                               ++NewID);
     Contexts.InsertNode(L, InsertPos);
   }

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -310,19 +310,12 @@ AnalysisDeclContext *AnalysisDeclContextManager::getContext(const Decl *D) {
 
 BodyFarm &AnalysisDeclContextManager::getBodyFarm() { return FunctionBodyFarm; }
 
-const StackFrameContext *
-AnalysisDeclContext::getStackFrame(const LocationContext *ParentLC,
-                                   const ento::BlockDataRegion *BlockInvocationData,
-                                   const Expr *E, const CFGBlock *Blk,
-                                   unsigned BlockCount, unsigned Index) {
-  return getLocationContextManager().getStackFrame(this, ParentLC, BlockInvocationData, E, Blk,
-                                                   BlockCount, Index);
-}
-
-const BlockInvocationContext *AnalysisDeclContext::getBlockInvocationContext(
-    const LocationContext *ParentLC, const BlockDecl *BD, const void *Data) {
-  return getLocationContextManager().getBlockInvocationContext(this, ParentLC,
-                                                               BD, Data);
+const StackFrameContext *AnalysisDeclContext::getStackFrame(
+    const LocationContext *ParentLC,
+    const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
+    const CFGBlock *Blk, unsigned BlockCount, unsigned Index) {
+  return getLocationContextManager().getStackFrame(
+      this, ParentLC, BlockInvocationData, E, Blk, BlockCount, Index);
 }
 
 bool AnalysisDeclContext::isInStdNamespace(const Decl *D) {
@@ -416,12 +409,8 @@ void LocationContext::ProfileCommon(llvm::FoldingSetNodeID &ID,
 }
 
 void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
-  Profile(ID, getAnalysisDeclContext(), getParent(), BlockInvocationData, CallSite, Block,
-          BlockCount, Index);
-}
-
-void BlockInvocationContext::Profile(llvm::FoldingSetNodeID &ID) {
-  Profile(ID, getAnalysisDeclContext(), getParent(), BD, Data);
+  Profile(ID, getAnalysisDeclContext(), getParent(), BlockInvocationData,
+          CallSite, Block, BlockCount, Index);
 }
 
 //===----------------------------------------------------------------------===//
@@ -429,32 +418,18 @@ void BlockInvocationContext::Profile(llvm::FoldingSetNodeID &ID) {
 //===----------------------------------------------------------------------===//
 
 const StackFrameContext *LocationContextManager::getStackFrame(
-    AnalysisDeclContext *Ctx, const LocationContext *Parent, const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
+    AnalysisDeclContext *Ctx, const LocationContext *Parent,
+    const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
     const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
-  StackFrameContext::Profile(ID, Ctx, Parent, BlockInvocationData, E, Blk, BlockCount, StmtIdx);
+  StackFrameContext::Profile(ID, Ctx, Parent, BlockInvocationData, E, Blk,
+                             BlockCount, StmtIdx);
   void *InsertPos;
   auto *L =
    cast_or_null<StackFrameContext>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
   if (!L) {
-    L = new StackFrameContext(Ctx, Parent, BlockInvocationData, E, Blk, BlockCount, StmtIdx,
-                              ++NewID);
-    Contexts.InsertNode(L, InsertPos);
-  }
-  return L;
-}
-
-const BlockInvocationContext *LocationContextManager::getBlockInvocationContext(
-    AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-    const BlockDecl *BD, const void *Data) {
-  llvm::FoldingSetNodeID ID;
-  BlockInvocationContext::Profile(ID, ADC, ParentLC, BD, Data);
-  void *InsertPos;
-  auto *L =
-    cast_or_null<BlockInvocationContext>(Contexts.FindNodeOrInsertPos(ID,
-                                                                    InsertPos));
-  if (!L) {
-    L = new BlockInvocationContext(ADC, ParentLC, BD, Data, ++NewID);
+    L = new StackFrameContext(Ctx, Parent, BlockInvocationData, E, Blk,
+                              BlockCount, StmtIdx, ++NewID);
     Contexts.InsertNode(L, InsertPos);
   }
   return L;
@@ -521,13 +496,6 @@ void LocationContext::dumpStack(raw_ostream &Out) const {
         printLocation(Out, SM, E->getBeginLoc());
       }
       break;
-    case Block:
-      Out << "Invoking block";
-      if (const Decl *D = cast<BlockInvocationContext>(LCtx)->getDecl()) {
-        Out << " defined at line ";
-        printLocation(Out, SM, D->getBeginLoc());
-      }
-      break;
     }
     Out << '\n';
   }
@@ -565,14 +533,6 @@ void LocationContext::printJson(raw_ostream &Out, const char *NL,
       }
 
       Out << ", \"items\": ";
-      break;
-    case Block:
-      Out << "Invoking block\" ";
-      if (const Decl *D = cast<BlockInvocationContext>(LCtx)->getDecl()) {
-        Out << ", \"location\": ";
-        printSourceLocationAsJson(Out, D->getBeginLoc(), SM);
-        Out << ' ';
-      }
       break;
     }
 

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -311,11 +311,10 @@ AnalysisDeclContext *AnalysisDeclContextManager::getContext(const Decl *D) {
 BodyFarm &AnalysisDeclContextManager::getBodyFarm() { return FunctionBodyFarm; }
 
 const StackFrameContext *AnalysisDeclContext::getStackFrame(
-    const LocationContext *ParentLC,
-    const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
+    const LocationContext *ParentLC, const void *Data, const Expr *E,
     const CFGBlock *Blk, unsigned BlockCount, unsigned Index) {
-  return getLocationContextManager().getStackFrame(
-      this, ParentLC, BlockInvocationData, E, Blk, BlockCount, Index);
+  return getLocationContextManager().getStackFrame(this, ParentLC, Data, E, Blk,
+                                                   BlockCount, Index);
 }
 
 bool AnalysisDeclContext::isInStdNamespace(const Decl *D) {
@@ -409,8 +408,8 @@ void LocationContext::ProfileCommon(llvm::FoldingSetNodeID &ID,
 }
 
 void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
-  Profile(ID, getAnalysisDeclContext(), getParent(), BlockInvocationData,
-          CallSite, Block, BlockCount, Index);
+  Profile(ID, getAnalysisDeclContext(), getParent(), Data, CallSite, Block,
+          BlockCount, Index);
 }
 
 //===----------------------------------------------------------------------===//
@@ -418,18 +417,17 @@ void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
 //===----------------------------------------------------------------------===//
 
 const StackFrameContext *LocationContextManager::getStackFrame(
-    AnalysisDeclContext *Ctx, const LocationContext *Parent,
-    const ento::BlockDataRegion *BlockInvocationData, const Expr *E,
-    const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
+    AnalysisDeclContext *Ctx, const LocationContext *Parent, const void *Data,
+    const Expr *E, const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
-  StackFrameContext::Profile(ID, Ctx, Parent, BlockInvocationData, E, Blk,
-                             BlockCount, StmtIdx);
+  StackFrameContext::Profile(ID, Ctx, Parent, Data, E, Blk, BlockCount,
+                             StmtIdx);
   void *InsertPos;
   auto *L =
    cast_or_null<StackFrameContext>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
   if (!L) {
-    L = new StackFrameContext(Ctx, Parent, BlockInvocationData, E, Blk,
-                              BlockCount, StmtIdx, ++NewID);
+    L = new StackFrameContext(Ctx, Parent, Data, E, Blk, BlockCount, StmtIdx,
+                              ++NewID);
     Contexts.InsertNode(L, InsertPos);
   }
   return L;

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -415,7 +415,7 @@ void LocationContext::ProfileCommon(llvm::FoldingSetNodeID &ID,
 }
 
 void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
-  Profile(ID, getAnalysisDeclContext(), getParent(), CallSite, Block,
+  Profile(ID, getAnalysisDeclContext(), getParent(), BlockInvocationData, CallSite, Block,
           BlockCount, Index);
 }
 
@@ -431,12 +431,12 @@ const StackFrameContext *LocationContextManager::getStackFrame(
     AnalysisDeclContext *Ctx, const LocationContext *Parent, const Expr *E,
     const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
-  StackFrameContext::Profile(ID, Ctx, Parent, E, Blk, BlockCount, StmtIdx);
+  StackFrameContext::Profile(ID, Ctx, Parent, nullptr, E, Blk, BlockCount, StmtIdx);
   void *InsertPos;
   auto *L =
    cast_or_null<StackFrameContext>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
   if (!L) {
-    L = new StackFrameContext(Ctx, Parent, E, Blk, BlockCount, StmtIdx,
+    L = new StackFrameContext(Ctx, Parent, nullptr, E, Blk, BlockCount, StmtIdx,
                               ++NewID);
     Contexts.InsertNode(L, InsertPos);
   }

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -186,7 +186,7 @@ CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
         break;
   assert(Idx < Sz);
 
-  return ADC->getStackFrame(LCtx, E, B, BlockCount, Idx);
+  return ADC->getStackFrame(LCtx, nullptr, E, B, BlockCount, Idx);
 }
 
 const ParamVarRegion

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -222,12 +222,6 @@ SVal ExprEngine::computeObjectUnderConstruction(
           // able to find construction context at all.
           break;
         }
-        if (isa<BlockInvocationContext>(CallerLCtx)) {
-          // Unwrap block invocation contexts. They're mostly part of
-          // the current stack frame.
-          CallerLCtx = CallerLCtx->getParent();
-          assert(!isa<BlockInvocationContext>(CallerLCtx));
-        }
 
         unsigned NVCaller = getNumVisited(CallerLCtx, SFC->getCallSiteBlock());
         return computeObjectUnderConstruction(
@@ -447,12 +441,6 @@ ProgramStateRef ExprEngine::updateObjectsUnderConstruction(
       auto RTC = (*SFC->getCallSiteBlock())[SFC->getIndex()]
                      .getAs<CFGCXXRecordTypedCall>();
       assert(RTC && "Could not have had a target region without it");
-      if (isa<BlockInvocationContext>(CallerLCtx)) {
-        // Unwrap block invocation contexts. They're mostly part of
-        // the current stack frame.
-        CallerLCtx = CallerLCtx->getParent();
-        assert(!isa<BlockInvocationContext>(CallerLCtx));
-      }
 
       return updateObjectsUnderConstruction(
           V, SFC->getCallSite(), State, CallerLCtx,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -542,7 +542,6 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
     BlockInvocationData = cast<BlockCall>(Call).getBlockRegion();
     assert(BlockInvocationData &&
            "If we have the block definition we should have its region");
-    AnalysisDeclContext *BlockCtx = AMgr.getAnalysisDeclContext(D);
     ParentOfCallee = CallerSFC;
   }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -539,13 +539,10 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   const BlockDataRegion *BlockInvocationData = nullptr;
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
-    const BlockDataRegion *BR = cast<BlockCall>(Call).getBlockRegion();
-    BlockInvocationData = BR;
-    assert(BR && "If we have the block definition we should have its region");
+    BlockInvocationData = cast<BlockCall>(Call).getBlockRegion();
+    assert(BlockInvocationData && "If we have the block definition we should have its region");
     AnalysisDeclContext *BlockCtx = AMgr.getAnalysisDeclContext(D);
-    ParentOfCallee = BlockCtx->getBlockInvocationContext(CallerSFC,
-                                                         cast<BlockDecl>(D),
-                                                         BR);
+    ParentOfCallee = CallerSFC;
   }
 
   // This may be NULL, but that's fine.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -540,7 +540,8 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
     BlockInvocationData = cast<BlockCall>(Call).getBlockRegion();
-    assert(BlockInvocationData && "If we have the block definition we should have its region");
+    assert(BlockInvocationData &&
+           "If we have the block definition we should have its region");
     AnalysisDeclContext *BlockCtx = AMgr.getAnalysisDeclContext(D);
     ParentOfCallee = CallerSFC;
   }
@@ -550,9 +551,9 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
 
   // Construct a new stack frame for the callee.
   AnalysisDeclContext *CalleeADC = AMgr.getAnalysisDeclContext(D);
-  const StackFrameContext *CalleeSFC =
-      CalleeADC->getStackFrame(ParentOfCallee, BlockInvocationData, CallE, getCurrBlock(),
-                               getNumVisitedCurrent(), currStmtIdx);
+  const StackFrameContext *CalleeSFC = CalleeADC->getStackFrame(
+      ParentOfCallee, BlockInvocationData, CallE, getCurrBlock(),
+      getNumVisitedCurrent(), currStmtIdx);
 
   CallEnter Loc(CallE, CalleeSFC, CurLC);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -536,9 +536,11 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   const LocationContext *CurLC = Pred->getLocationContext();
   const StackFrameContext *CallerSFC = CurLC->getStackFrame();
   const LocationContext *ParentOfCallee = CallerSFC;
+  const BlockDataRegion *BlockInvocationData = nullptr;
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
     const BlockDataRegion *BR = cast<BlockCall>(Call).getBlockRegion();
+    BlockInvocationData = BR;
     assert(BR && "If we have the block definition we should have its region");
     AnalysisDeclContext *BlockCtx = AMgr.getAnalysisDeclContext(D);
     ParentOfCallee = BlockCtx->getBlockInvocationContext(CallerSFC,
@@ -552,7 +554,7 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   // Construct a new stack frame for the callee.
   AnalysisDeclContext *CalleeADC = AMgr.getAnalysisDeclContext(D);
   const StackFrameContext *CalleeSFC =
-      CalleeADC->getStackFrame(ParentOfCallee, CallE, getCurrBlock(),
+      CalleeADC->getStackFrame(ParentOfCallee, BlockInvocationData, CallE, getCurrBlock(),
                                getNumVisitedCurrent(), currStmtIdx);
 
   CallEnter Loc(CallE, CalleeSFC, CurLC);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -535,14 +535,12 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
 
   const LocationContext *CurLC = Pred->getLocationContext();
   const StackFrameContext *CallerSFC = CurLC->getStackFrame();
-  const LocationContext *ParentOfCallee = CallerSFC;
   const BlockDataRegion *BlockInvocationData = nullptr;
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
     BlockInvocationData = cast<BlockCall>(Call).getBlockRegion();
     assert(BlockInvocationData &&
            "If we have the block definition we should have its region");
-    ParentOfCallee = CallerSFC;
   }
 
   // This may be NULL, but that's fine.
@@ -551,7 +549,7 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   // Construct a new stack frame for the callee.
   AnalysisDeclContext *CalleeADC = AMgr.getAnalysisDeclContext(D);
   const StackFrameContext *CalleeSFC = CalleeADC->getStackFrame(
-      ParentOfCallee, BlockInvocationData, CallE, getCurrBlock(),
+      CallerSFC, BlockInvocationData, CallE, getCurrBlock(),
       getNumVisitedCurrent(), currStmtIdx);
 
   CallEnter Loc(CallE, CalleeSFC, CurLC);

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1012,7 +1012,7 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
             if (VR->getDecl() == VD)
               return cast<VarRegion>(Var.getCapturedRegion());
           }
-        } 
+        }
       }
     }
 

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1004,16 +1004,15 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
     if (const auto *SFC = dyn_cast<StackFrameContext>(LC)) {
       if (cast<DeclContext>(SFC->getDecl()) == DC)
         return SFC;
-    }
-    if (const auto *BC = dyn_cast<BlockInvocationContext>(LC)) {
-      const auto *BR = static_cast<const BlockDataRegion *>(BC->getData());
-      // FIXME: This can be made more efficient.
-      for (auto Var : BR->referenced_vars()) {
-        const TypedValueRegion *OrigR = Var.getOriginalRegion();
-        if (const auto *VR = dyn_cast<VarRegion>(OrigR)) {
-          if (VR->getDecl() == VD)
-            return cast<VarRegion>(Var.getCapturedRegion());
-        }
+      if (SFC->getBlockInvocationData()) {
+        // FIXME: This can be made more efficient.
+        for (auto Var : SFC->getBlockInvocationData()->referenced_vars()) {
+          const TypedValueRegion *OrigR = Var.getOriginalRegion();
+          if (const auto *VR = dyn_cast<VarRegion>(OrigR)) {
+            if (VR->getDecl() == VD)
+              return cast<VarRegion>(Var.getCapturedRegion());
+          }
+        } 
       }
     }
 

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1004,9 +1004,10 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
     if (const auto *SFC = dyn_cast<StackFrameContext>(LC)) {
       if (cast<DeclContext>(SFC->getDecl()) == DC)
         return SFC;
-      if (SFC->getBlockInvocationData()) {
+      if (SFC->getData()) {
         // FIXME: This can be made more efficient.
-        for (auto Var : SFC->getBlockInvocationData()->referenced_vars()) {
+        for (auto Var : static_cast<const BlockDataRegion *>(SFC->getData())
+                            ->referenced_vars()) {
           const TypedValueRegion *OrigR = Var.getOriginalRegion();
           if (const auto *VR = dyn_cast<VarRegion>(OrigR)) {
             if (VR->getDecl() == VD)


### PR DESCRIPTION
At the moment, the execution stack in the analyzer is represented with the `LocationContext` base class and two of its sub-classes `StackFrameContext` and `BlockInvocationContext`. This hierarchy, however, is more complicated than necessary and, in issue #190973, a roadmap was created to reduce this hierarchy down to just a single `StackFrame` class.

This patch implements the first five steps of that roadmap. Specifically, the functionality of `BlockInvocationContext` was merged into the `StackFrameContext` class and the `BlockInvocationContext` class was removed together with its usages.