### PR TITLE
[Support] Introduce a function to reset all debug counters

### DIFF
--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -78,6 +78,14 @@ public:
     CounterInfo(StringRef Name, StringRef Desc) : Name(Name), Desc(Desc) {
       DebugCounter::registerCounter(this);
     }
+
+    void reset() {
+      Active = false;
+      IsSet = false;
+      Count = 0;
+      CurrChunkIdx = 0;
+      Chunks.clear();
+    }
   };
 
   LLVM_ABI static void
@@ -163,6 +171,11 @@ public:
   void activateAllCounters() {
     for (auto &[_, Counter] : Counters)
       Counter->Active = true;
+  }
+
+  void resetAllCounters() {
+    for (auto &[_, Counter] : Counters)
+      Counter->reset();
   }
 
 protected:

--- a/llvm/unittests/Support/DebugCounterTest.cpp
+++ b/llvm/unittests/Support/DebugCounterTest.cpp
@@ -35,6 +35,19 @@ TEST(DebugCounterTest, Basic) {
   llvm::raw_string_ostream OS(Str);
   DC->print(OS);
   EXPECT_TRUE(StringRef(Str).contains("{200,1:3-5:78:79:89:100-102:150}"));
+
+  DC->resetAllCounters();
+
+  // After resetting, counter is no longer set.
+  EXPECT_FALSE(DebugCounter::isCounterSet(TestCounter));
+
+  DC->push_back("test-counter=1");
+  EXPECT_TRUE(DebugCounter::isCounterSet(TestCounter));
+  EXPECT_EQ(DC->getCounterState(TestCounter).Count, 0);
+
+  DC->shouldExecute(TestCounter);
+
+  EXPECT_EQ(DC->getCounterState(TestCounter).Count, 1);
 }
 
 #endif


### PR DESCRIPTION
This PR adds a function to reset all debug counters, and extends the unit test to verify that the debug counters are reset as expected. This is required for running tools repeatedly in the same process.