### PR TITLE
[BOLT][AArch64] Refuse to run RegReAssign pass

### DIFF
--- a/bolt/lib/Passes/RegReAssign.cpp
+++ b/bolt/lib/Passes/RegReAssign.cpp
@@ -449,6 +449,11 @@ void RegReAssign::setupConservativePass(
 }
 
 Error RegReAssign::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   RegScore = std::vector<int64_t>(BC.MRI->getNumRegs(), 0);
   RankedRegs = std::vector<size_t>(BC.MRI->getNumRegs(), 0);
 

--- a/bolt/lib/Passes/RegReAssign.cpp
+++ b/bolt/lib/Passes/RegReAssign.cpp
@@ -450,7 +450,7 @@ void RegReAssign::setupConservativePass(
 
 Error RegReAssign::runOnFunctions(BinaryContext &BC) {
   if (!BC.isX86()) {
-    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    BC.errs() << "BOLT-ERROR: reg-reassign is supported only on X86\n";
     exit(1);
   }
 

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -15,7 +15,9 @@ CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported 
 
 // Passes specific to X86 arch
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
+RUN: not llvm-bolt %t -o %t.bolt --reg-reassign 2>&1 | FileCheck %s --check-prefix=CHECK-REG-REASSIGN
 CHECK-CMOV-CONV: BOLT-ERROR: CMOV conversion is supported only on X86
+CHECK-REG-REASSIGN: BOLT-ERROR: regreassign is supported only on X86
 
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -17,7 +17,7 @@ CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported 
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
 RUN: not llvm-bolt %t -o %t.bolt --reg-reassign 2>&1 | FileCheck %s --check-prefix=CHECK-REG-REASSIGN
 CHECK-CMOV-CONV: BOLT-ERROR: CMOV conversion is supported only on X86
-CHECK-REG-REASSIGN: BOLT-ERROR: regreassign is supported only on X86
+CHECK-REG-REASSIGN: BOLT-ERROR: reg-reassign is supported only on X86
 
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'


### PR DESCRIPTION
RegReAssign hits an unreachable on AArch64 as it is a pass (conceptually) specific to X86.

- Add a guard to RegReAssign for non-X86
- Update unsupported-passes.test