### PR TITLE
[clang][deps] Call getMemBuffer with RequiresNullTerminator false

### DIFF
--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -179,7 +179,8 @@ public:
     }
     Size = Entry.Buffer->getBufferSize();
     ModTime = Entry.ModTime;
-    return llvm::MemoryBuffer::getMemBuffer(*Entry.Buffer);
+    return llvm::MemoryBuffer::getMemBuffer(*Entry.Buffer,
+                                            /* RequiresNullTerminator */ false);
   }
 };
 } // namespace


### PR DESCRIPTION
The getMemBuffer() has a default parameter RequiresNullTerminator which is set to true.

In ModuleCache the MemoryBuffer::getOpenFile is called with /* RequiresNullTerminator=*/false.

We have at one build with assertions enabled that is tripping over an assertion in MemoryBuffer that is checking for null termination. This failure is currently specific to this single machine and all attempts to reproduce have failed.

My working theory is that the length of path names are important so on most machines we may be adding trailing 0x0 bytes of padding which are being counted as null terminators.

Patch is in a draft state to see if we can tell if this fixes the problem.