### PR TITLE
[flang][coarray] Fix error fir.store mismatch memory reference type in genCoBounds #193131

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -512,7 +512,8 @@ private:
     if (alloc.hasCoarraySpec()) {
       stat = Fortran::lower::genAllocateCoarray(
           converter, loc, alloc.getSymbol(), box.getAddr(),
-          alloc.getCoarraySpec(), errorManager.errMsgAddr);
+          alloc.getCoarraySpec(), errorManager.errMsgAddr,
+          errorManager.hasStatSpec());
     } else if (!isCudaAllocate) {
       stat = genRuntimeAllocate(builder, loc, box, errorManager);
       setPinnedToFalse();
@@ -659,7 +660,8 @@ private:
     if (alloc.hasCoarraySpec()) {
       stat = Fortran::lower::genAllocateCoarray(
           converter, loc, alloc.getSymbol(), box.getAddr(),
-          alloc.getCoarraySpec(), errorManager.errMsgAddr);
+          alloc.getCoarraySpec(), errorManager.errMsgAddr,
+          errorManager.hasStatSpec());
     } else if (Fortran::semantics::HasCUDAAttr(alloc.getSymbol()) ||
                sourceIsDevice) {
       stat =

--- a/flang/lib/Lower/MultiImageFortran.cpp
+++ b/flang/lib/Lower/MultiImageFortran.cpp
@@ -410,6 +410,8 @@ genCoBounds(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
             std::get<1>(allocSpec.t)) {
       auto expr = Fortran::semantics::GetExpr(*lastCobound);
       lb = fir::getBase(converter.genExprValue(loc, expr, stmtCtx));
+      if (lb.getType() != i64Ty)
+        lb = fir::ConvertOp::create(builder, loc, i64Ty, lb);
     }
     mlir::Value index =
         builder.createIntegerConstant(loc, builder.getIndexType(), i);

--- a/flang/lib/Lower/MultiImageFortran.cpp
+++ b/flang/lib/Lower/MultiImageFortran.cpp
@@ -410,8 +410,7 @@ genCoBounds(Fortran::lower::AbstractConverter &converter, mlir::Location loc,
             std::get<1>(allocSpec.t)) {
       auto expr = Fortran::semantics::GetExpr(*lastCobound);
       lb = fir::getBase(converter.genExprValue(loc, expr, stmtCtx));
-      if (lb.getType() != i64Ty)
-        lb = fir::ConvertOp::create(builder, loc, i64Ty, lb);
+      lb = fir::ConvertOp::create(builder, loc, i64Ty, lb);
     }
     mlir::Value index =
         builder.createIntegerConstant(loc, builder.getIndexType(), i);

--- a/flang/test/Lower/MIF/coarray_allocation.f90
+++ b/flang/test/Lower/MIF/coarray_allocation.f90
@@ -60,4 +60,12 @@ program alloc_test
   ! CHECK: mif.dealloc_coarray %[[VAL_14]] stat %[[STAT:.*]] errmsg %[[ERRMSG:.*]] : (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<i32>, !fir.box<none>) -> ()
   deallocate(d%z%co)
   
-end program 
+end program
+
+! CHECK-LABEL: func.func @_QPtest_alloc2()
+subroutine test_alloc2
+  class(*),allocatable :: a[:]
+
+  ! CHECK: mif.alloc_coarray %[[VAL_1:.*]]#0 lcobounds %[[LCOBOUNDS:.*]] ucobounds %[[UCOBOUNDS:.*]] errmsg %[[ERRMSG:.*]] {uniq_name = "_QFtest_alloc2Ea"} : (!fir.ref<!fir.class<!fir.heap<none>>>, !fir.box<!fir.array<1xi64>>, !fir.box<!fir.array<0xi64>>, !fir.box<none>) -> ()
+  allocate(real::a[1:*])
+end subroutine

--- a/flang/test/Lower/MIF/coarray_allocation.f90
+++ b/flang/test/Lower/MIF/coarray_allocation.f90
@@ -65,7 +65,12 @@ end program
 ! CHECK-LABEL: func.func @_QPtest_alloc2()
 subroutine test_alloc2
   class(*),allocatable :: a[:]
+  class(*),allocatable :: b[:]
+  integer :: ierr
 
   ! CHECK: mif.alloc_coarray %[[VAL_1:.*]]#0 lcobounds %[[LCOBOUNDS:.*]] ucobounds %[[UCOBOUNDS:.*]] errmsg %[[ERRMSG:.*]] {uniq_name = "_QFtest_alloc2Ea"} : (!fir.ref<!fir.class<!fir.heap<none>>>, !fir.box<!fir.array<1xi64>>, !fir.box<!fir.array<0xi64>>, !fir.box<none>) -> ()
   allocate(real::a[1:*])
+  
+  ! CHECK: mif.alloc_coarray %[[VAL_2:.*]]#0 lcobounds %[[LCOBOUNDS2:.*]] ucobounds %[[UCOBOUNDS2:.*]] stat %[[STAT:.*]] errmsg %[[ERRMSG2:.*]] {uniq_name = "_QFtest_alloc2Eb"} : (!fir.ref<!fir.class<!fir.heap<none>>>, !fir.box<!fir.array<1xi64>>, !fir.box<!fir.array<0xi64>>, !fir.ref<i32>, !fir.box<none>) -> ()
+  allocate(real::b[2:*], STAT=ierr)
 end subroutine


### PR DESCRIPTION
The error mentioned in issue #193131 occurs when the lower bound of a coarray is specified and its corank is 1. A conversion operation was missing.
I noticed that the hasStat argument wasn't being taken into account in Allocatable.cpp