### PR TITLE
[mlir][test] Ignore NaN sign in test case

### DIFF
--- a/mlir/test/mlir-runner/test-expand-math-approx.mlir
+++ b/mlir/test/mlir-runner/test-expand-math-approx.mlir
@@ -233,12 +233,12 @@ func.func @powf() {
   %g_p = arith.constant 23598.0 : f64
   call @func_powff64(%g, %g_p) : (f64, f64) -> ()
 
-  // CHECK-NEXT: -nan
+  // CHECK-NEXT: {{-?}}nan
   %h = arith.constant 1.0 : f64
   %h_p = arith.constant 0xfff0000001000000 : f64
   call @func_powff64(%h, %h_p) : (f64, f64) -> ()
 
-  // CHECK-NEXT: -nan
+  // CHECK-NEXT: {{-?}}nan
   %i = arith.constant 1.0 : f32
   %i_p = arith.constant 0xffffffff : f32
   call @func_powff32(%i, %i_p) : (f32, f32) -> ()


### PR DESCRIPTION
IEEE 754-2008 (section 6.3) does not specify the sign bit of a NaN result for most floating-point operations. While certain bitwise operations (e.g., copy, negate, abs, copySign) may define or propagate the sign bit, general arithmetic operations are not required to do so.

This test currently assumes a specific NaN sign, which is not portable across targets. It fails on RISC-V due to differing NaN sign behavior.

Relax the test to ignore the NaN sign.