### PR TITLE
Reduce false positives in ids-check workflow

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -3,8 +3,8 @@ name: "Check LLVM ABI annotations"
 # TODO(https://github.com/llvm/llvm-project/issues/109483): Re-enable on pull
 # requests once the workflow is less diruptive.
 on:
-  # pull_request:
-  workflow_dispatch:
+  pull_request:
+  # workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,16 +18,9 @@ jobs:
     if: github.repository_owner == 'llvm'
     name: Check LLVM_ABI annotations with ids
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          repository: compnerd/ids
-          path: ${{ github.workspace }}/ids
-          ref: b3bf35dd13d7ff244a6a6d106fe58d0eedb5743e # main
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -46,7 +39,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y clang-19 ninja-build libclang-19-dev
+          # Pull a recent clang from LLVM's apt repo so idt's parser stays in
+          # sync with the C++ language features used by current LLVM source.
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt update
+          # oprofile provides opagent.h, used by llvm/ExecutionEngine/OProfileWrapper.h
+          sudo apt install -y clang-22 lld-22 ninja-build libclang-22-dev oprofile
           pip install --require-hashes -r ${{ github.workspace }}/llvm-project/llvm/utils/git/requirements.txt
 
       - name: Configure and build minimal LLVM for use by ids
@@ -54,33 +56,54 @@ jobs:
           cmake -B ${{ github.workspace }}/llvm-project/build/ \
                 -S ${{ github.workspace }}/llvm-project/llvm/ \
                 -D CMAKE_BUILD_TYPE=Release \
-                -D CMAKE_C_COMPILER=clang \
-                -D CMAKE_CXX_COMPILER=clang++ \
+                -D CMAKE_C_COMPILER=clang-22 \
+                -D CMAKE_CXX_COMPILER=clang++-22 \
                 -D LLVM_ENABLE_PROJECTS=clang \
                 -D LLVM_TARGETS_TO_BUILD="host" \
+                -D LLVM_INCLUDE_TESTS=OFF \
+                -D LLVM_INCLUDE_BENCHMARKS=OFF \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -D CMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
                 -G Ninja
-          cd ${{ github.workspace }}/llvm-project/build/
-          ninja -t targets all | grep "CommonTableGen: phony$" | grep -v "/" | sed 's/:.*//'
 
-      - name: Configure ids
+          # Build the generated-header prerequisites that idt needs to parse
+          # LLVM source.
+          BUILD_DIR=${{ github.workspace }}/llvm-project/build
+          ninja -C "$BUILD_DIR" \
+            llvm_vcsrevision_h \
+            intrinsics_gen omp_gen acc_gen analysis_gen target_parser_gen vt_gen \
+            DllOptionsTableGen LibOptionsTableGen \
+            clang-tablegen-targets \
+            lib/ExecutionEngine/JITLink/COFFOptions.inc
+
+          # Build per-target tablegen output for every enabled target.
+          # Each enabled target exposes a top-level `<Target>CommonTableGen`
+          # phony rule (e.g. `X86CommonTableGen`); discover them from the
+          # ninja graph.
+          TABLEGEN_TARGETS=$(ninja -C "$BUILD_DIR" -t targets all \
+            | awk -F: '
+                $2 ~ /phony/ &&            # phony rules only
+                $1 !~ /\// &&              # top-level (skip nested paths)
+                $1 ~ /CommonTableGen$/ {   # per-target tablegen aggregator
+                  print $1
+                }')
+          ninja -C "$BUILD_DIR" $TABLEGEN_TARGETS
+
+      - name: Configure and build idt
         run: |
-          cmake -B ${{ github.workspace }}/ids/build/ \
-                -S ${{ github.workspace }}/ids/ \
+          # idt lives in-tree under llvm/utils/idt as a vendored standalone
+          # CMake project. It links against the apt-installed libclang-22-dev,
+          # not the just-configured LLVM build, so the build is small.
+          IDT_SRC=${{ github.workspace }}/llvm-project/llvm/utils/idt
+          cmake -B "$IDT_SRC/build" -S "$IDT_SRC" \
                 -D CMAKE_BUILD_TYPE=Release \
-                -D CMAKE_C_COMPILER=clang \
-                -D CMAKE_CXX_COMPILER=clang++ \
+                -D CMAKE_C_COMPILER=clang-22 \
+                -D CMAKE_CXX_COMPILER=clang++-22 \
                 -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
-                -D LLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/ \
-                -D Clang_DIR=/usr/lib/llvm-19/lib/cmake/clang/ \
-                -D FILECHECK_EXECUTABLE=$(which FileCheck-19) \
-                -D LIT_EXECUTABLE=$(which lit) \
+                -D LLVM_DIR=/usr/lib/llvm-22/lib/cmake/llvm/ \
+                -D Clang_DIR=/usr/lib/llvm-22/lib/cmake/clang/ \
                 -G Ninja
-
-      # TODO: Use an image with a prebuilt idt.
-      - name: Build ids
-        run: |
-          ninja -C ${{ github.workspace }}/ids/build/ all
+          ninja -C "$IDT_SRC/build"
 
       - name: Run ids check
         env:
@@ -92,7 +115,7 @@ jobs:
           python llvm/utils/git/ids-check-helper.py \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --issue-number $GITHUB_PR_NUMBER \
-            --idt-path ${{ github.workspace }}/ids/build/bin/idt \
+            --idt-path ${{ github.workspace }}/llvm-project/llvm/utils/idt/build/bin/idt \
             --compile-commands ${{ github.workspace }}/llvm-project/build/compile_commands.json \
             --start-rev HEAD~1 \
             --end-rev HEAD \

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -206,8 +206,8 @@ private:
   StringRef Description;
 
 protected:
-  LLVM_ABI void registerSubCommand();
-  LLVM_ABI void unregisterSubCommand();
+  void registerSubCommand();
+  void unregisterSubCommand();
 
 public:
   SubCommand(StringRef Name, StringRef Description = "")

--- a/llvm/utils/git/ids-check-helper.py
+++ b/llvm/utils/git/ids-check-helper.py
@@ -8,26 +8,202 @@ import argparse
 import os
 import subprocess
 import sys
+from collections import defaultdict
+from pathlib import Path
 from typing import List, Optional
 
 """
-This script is run by GitHub actions to ensure that the code in PRs properly
-labels LLVM APIs with `LLVM_ABI` so as not to break the LLVM DLL build. It can
-also be installed as a pre-commit git hook to check ABI annotations before
-submitting. The canonical source of this script is in the LLVM source tree
-under llvm/utils/git.
+Run idt on the headers changed in a PR and (optionally) post the resulting
+LLVM_ABI annotation diff as a PR comment.
 
-This script uses the idt (Interface Diff Tool) to check for missing LLVM_ABI,
-LLVM_C_ABI, and DEMANGLE_ABI annotations in header files.
+The heavy lifting (per-category clang flags, system-header-prefix isolation,
+output filtering, the `hasBody` / out-of-line distinction) lives in
+`llvm/utils/idt/idt.cc`. This script is a thin orchestrator: it picks which
+headers to check, finds a translation unit for each (since LLVM's compile
+database doesn't list headers), and forwards the list to idt batched by
+category.
 
-You can install this script as a git hook by symlinking it to the .git/hooks
-directory:
+Usage as a git pre-commit hook:
 
-ln -s $(pwd)/llvm/utils/git/ids-check-helper.py .git/hooks/pre-commit
+    ln -s $(pwd)/llvm/utils/git/ids-check-helper.py .git/hooks/pre-commit
 
-You can control the exact path to idt and compile_commands.json with the
-following environment variables: $IDT_PATH and $COMPILE_COMMANDS_PATH.
+Environment variables `IDT_PATH` and `COMPILE_COMMANDS_PATH` may be used in
+place of the matching command-line arguments.
 """
+
+
+# Headers we skip outright. Each entry is matched against the changed-file
+# path with `startswith`, so it can be either a directory prefix (trailing /)
+# or a specific file path.
+SKIP_HEADERS = [
+    # PDB DIA requires Windows ATL (atlbase.h), unbuildable on Linux runners.
+    # The direct mapping picks lib/DebugInfo/PDB/DIA/*.cpp which can't parse.
+    "llvm/include/llvm/DebugInfo/PDB/DIA/",
+    # No in-tree non-tools/non-target source #includes these headers, so we
+    # can't run idt on a TU that pulls them in.
+    "llvm/include/llvm/ExecutionEngine/Interpreter.h",  # only lli.cpp
+    "llvm/include/llvm/Support/DebugLog.h",             # only lib/Target/RISCV/
+    "llvm/include/llvm/Support/TargetSelect.h",         # only target-registration sources
+]
+
+
+# Manual header -> source mappings for headers that don't fit the conventional
+# `llvm/include/llvm/<Subsystem>/<Bar>.h` -> `llvm/lib/<Subsystem>/<Bar>.cpp`
+# layout. Used when neither the direct mapping nor the same-subdirectory
+# grep fallback finds a workable source.
+HEADER_SOURCE_OVERRIDES = {
+    # LLVM-C headers
+    "llvm/include/llvm-c/Analysis.h":          "llvm/lib/Analysis/Analysis.cpp",
+    "llvm/include/llvm-c/BitReader.h":         "llvm/lib/Bitcode/Reader/BitReader.cpp",
+    "llvm/include/llvm-c/BitWriter.h":         "llvm/lib/Bitcode/Writer/BitWriter.cpp",
+    "llvm/include/llvm-c/Comdat.h":            "llvm/lib/IR/Comdat.cpp",
+    "llvm/include/llvm-c/Core.h":              "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm-c/DebugInfo.h":         "llvm/lib/IR/DebugInfo.cpp",
+    "llvm/include/llvm-c/Disassembler.h":      "llvm/lib/MC/MCDisassembler/Disassembler.cpp",
+    "llvm/include/llvm-c/ErrorHandling.h":     "llvm/lib/Support/ErrorHandling.cpp",
+    "llvm/include/llvm-c/ExecutionEngine.h":   "llvm/lib/ExecutionEngine/ExecutionEngineBindings.cpp",
+    "llvm/include/llvm-c/IRReader.h":          "llvm/lib/IRReader/IRReader.cpp",
+    "llvm/include/llvm-c/LLJIT.h":             "llvm/lib/ExecutionEngine/Orc/LLJITUtilsCBindings.cpp",
+    "llvm/include/llvm-c/LLJITUtils.h":        "llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp",
+    "llvm/include/llvm-c/Linker.h":            "llvm/lib/Linker/LinkModules.cpp",
+    "llvm/include/llvm-c/Object.h":            "llvm/lib/Object/Object.cpp",
+    "llvm/include/llvm-c/Orc.h":               "llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp",
+    "llvm/include/llvm-c/OrcEE.h":             "llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp",
+    "llvm/include/llvm-c/Remarks.h":           "llvm/lib/Remarks/RemarkParser.cpp",
+    "llvm/include/llvm-c/Support.h":           "llvm/lib/Support/CommandLine.cpp",
+    "llvm/include/llvm-c/Target.h":            "llvm/lib/Target/Target.cpp",
+    "llvm/include/llvm-c/TargetMachine.h":     "llvm/lib/Target/TargetMachineC.cpp",
+    "llvm/include/llvm-c/Transforms/PassBuilder.h": "llvm/lib/Passes/PassBuilderBindings.cpp",
+    "llvm/include/llvm-c/Types.h":             "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm-c/lto.h":               "llvm/tools/lto/lto.cpp",
+
+    # Top-level llvm/ headers
+    "llvm/include/llvm/Pass.h":                "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/PassAnalysisSupport.h": "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/PassRegistry.h":        "llvm/lib/IR/PassRegistry.cpp",
+    "llvm/include/llvm/PassSupport.h":         "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/InitializePasses.h":    "llvm/lib/Analysis/Analysis.cpp",
+    "llvm/include/llvm/LinkAllIR.h":           "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm/LinkAllPasses.h":       "llvm/lib/IR/Pass.cpp",
+
+    # Headers under llvm/include/llvm/Target/ whose same-subdir grep fallback
+    # picks per-target sources (e.g. X86, AArch64). Redirect to lib/CodeGen/.
+    "llvm/include/llvm/Target/CGPassBuilderOption.h": "llvm/lib/CodeGen/TargetPassConfig.cpp",
+    "llvm/include/llvm/Target/TargetOptions.h":       "llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp",
+
+    # Headers pulled in transitively by a small set of "umbrella" sources.
+    "llvm/include/llvm/ADT/ilist_node_base.h":                    "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/Analysis/SimplifyQuery.h":                 "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/CodeGenTypes/MachineValueType.h":          "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/Analysis.h":                            "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/ConstantFolder.h":                      "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/FMF.h":                                 "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/GenericFloatingPointPredicateUtils.h":  "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/IRBuilderFolder.h":                     "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/Support/Recycler.h":                       "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm-c/Error.h":                                "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm-c/Visibility.h":                           "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+
+    # DTLTO drags in Any/LTO/FormatVariadic.
+    "llvm/include/llvm/ADT/Any.h":                                "llvm/lib/DTLTO/DTLTO.cpp",
+    "llvm/include/llvm/LTO/Config.h":                             "llvm/lib/DTLTO/DTLTO.cpp",
+    "llvm/include/llvm/Support/FormatVariadicDetails.h":          "llvm/lib/DTLTO/DTLTO.cpp",
+
+    # Orc debugging / executor-side helpers.
+    "llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h":
+        "llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp",
+    "llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h":
+        "llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp",
+    "llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h":
+        "llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp",
+    "llvm/include/llvm-c/blake3.h":
+        "llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp",
+    "llvm/include/llvm/CodeGen/AsmPrinterHandler.h":
+        "llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp",
+}
+
+
+# Include subdir -> lib subdir remap for cases where the names diverge.
+# ADT has no `llvm/lib/ADT/`; its few non-inline implementations live under
+# `llvm/lib/Support/`.
+INCLUDE_TO_LIB_SUBDIR = {
+    "ADT": "Support",
+}
+
+
+# Categories must match `kLlvmCategories` in `llvm/utils/idt/idt.cc`. We
+# duplicate the table here only to batch headers per category before
+# invoking idt; idt itself derives the export macro / include header / system
+# prefixes from the same path-fragment match. Order matters: more specific
+# fragments first.
+CATEGORIES = [
+    ("Demangle", "llvm/Demangle/"),
+    ("LLVM-C",   "llvm-c/"),
+    ("LLVM",     "llvm/"),
+]
+
+
+def categorize_header(path: str) -> Optional[str]:
+    """Return the category name (LLVM/LLVM-C/Demangle) for a header, or None
+    if the path doesn't fall under any known category."""
+    for name, fragment in CATEGORIES:
+        if fragment in path:
+            return name
+    return None
+
+
+def find_source_for_header(header: str) -> Optional[str]:
+    """Return a source file (relative path) that includes the given header,
+    or None if no good match.
+
+    LLVM doesn't list headers in compile_commands.json, so idt needs a
+    source TU to parse. With the `hasBody` / out-of-line distinction inside
+    idt, we can pick the conventional `Foo.cpp` partner without losing
+    coverage of `Foo.h`'s own symbols.
+
+    Resolution order:
+    1. Manual override in HEADER_SOURCE_OVERRIDES.
+    2. Direct mapping: llvm/include/llvm/Foo/Bar.h -> llvm/lib/Foo/Bar.cpp,
+       with INCLUDE_TO_LIB_SUBDIR applied (e.g. ADT -> Support).
+    3. Same-subdirectory grep: any .cpp under llvm/lib/Foo/ that
+       `#include`s the header. Constrained to the matching subdirectory
+       so we don't accidentally pick a target-specific source as a
+       generic fallback.
+    4. Bail (returns None; the header is silently skipped).
+    """
+    if header in HEADER_SOURCE_OVERRIDES:
+        return HEADER_SOURCE_OVERRIDES[header]
+
+    if not header.startswith("llvm/include/llvm/"):
+        return None
+
+    sub = header[len("llvm/include/llvm/"):]
+    first_part, _, rest = sub.partition("/")
+    remap = INCLUDE_TO_LIB_SUBDIR.get(first_part)
+    sub_remapped = f"{remap}/{rest}" if remap and rest else sub
+    for ext in (".cpp", ".cc"):
+        candidate = Path("llvm/lib") / Path(sub_remapped).with_suffix(ext)
+        if candidate.exists():
+            return str(candidate)
+
+    lib_subdir = f"llvm/lib/{INCLUDE_TO_LIB_SUBDIR.get(first_part, first_part)}"
+    if not Path(lib_subdir).is_dir():
+        return None
+
+    inc = header.removeprefix("llvm/include/")
+    try:
+        result = subprocess.run(
+            ["git", "grep", "-l", f'#include "{inc}"', "--", lib_subdir],
+            capture_output=True, text=True, timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    for line in result.stdout.splitlines():
+        if line.endswith((".cpp", ".cc")):
+            return line
+    return None
 
 
 class IdsCheckArgs:
@@ -54,17 +230,12 @@ class IdsCheckArgs:
 
 
 class IdsChecker:
-    """
-    Checker for LLVM ABI annotations using the idt tool.
-    """
+    """Thin orchestrator around the idt binary."""
 
     COMMENT_TAG = "<!--LLVM IDS CHECK COMMENT-->"
     name = "ids-check"
     friendly_name = "LLVM ABI annotation checker"
     comment: dict = {}
-
-    # Macro definition used for all export macros
-    MACRO_DEFINITION = '__attribute__((visibility("default")))'
 
     @property
     def comment_tag(self) -> str:
@@ -72,9 +243,11 @@ class IdsChecker:
 
     @property
     def instructions(self) -> str:
-        # Provide basic usage instructions
-        return f"""git diff origin/main HEAD -- 'llvm/include/llvm/**/*.h' 'llvm/include/llvm-c/**/*.h' 'llvm/include/llvm/Demangle/**/*.h'
-Then run idt on the changed files with appropriate --export-macro and --include-header flags."""
+        return (
+            "Build idt under llvm/utils/idt/, then for each changed header:\n"
+            "    idt --header <header> -p build/compile_commands.json \\\n"
+            "        --apply-fixits --inplace <matching-source.cpp>"
+        )
 
     def pr_comment_text_for_diff(self, diff: str) -> str:
         return f"""
@@ -88,12 +261,6 @@ You can test this locally with the following command:
 ``````````bash
 {self.instructions}
 ``````````
-
-:warning:
-The reproduction instructions above might return results for more than one PR
-in a stack if you are using a stacked PR workflow. You can limit the results by
-changing `origin/main` to the base branch/commit you want to compare against.
-:warning:
 
 </details>
 
@@ -130,218 +297,135 @@ View the diff from {self.name} here.
         elif create_new:
             self.comment = {"body": comment_text}
 
-    # Define the file categories and their corresponding configurations
-    FILE_CATEGORIES = [
-        {
-            "name": "LLVM headers",
-            "patterns": ["llvm/include/llvm/**/*.h"],
-            "excludes": [
-                "llvm/include/llvm/Debuginfod/",
-                "llvm/include/llvm/Demangle/",
-            ],
-            "export_macro": "LLVM_ABI",
-            "include_header": "llvm/Support/Compiler.h",
-        },
-        {
-            "name": "LLVM-C headers",
-            "patterns": ["llvm/include/llvm-c/**/*.h"],
-            "excludes": [],
-            "export_macro": "LLVM_C_ABI",
-            "include_header": "llvm-c/Visibility.h",
-        },
-        {
-            "name": "LLVM Demangle headers",
-            "patterns": ["llvm/include/llvm/Demangle/**/*.h"],
-            "excludes": [],
-            "export_macro": "DEMANGLE_ABI",
-            "include_header": "llvm/Demangle/Visibility.h",
-        },
-    ]
+    def run_idt_for_category(
+        self, category: str, header_source_pairs: List[tuple],
+        args: IdsCheckArgs, idt_path: str, compile_commands: str,
+    ) -> None:
+        """Invoke idt once for all headers in a category. idt is told the full
+        list of headers via repeated --header, and the full list of unique
+        source TUs as positional arguments. idt scopes its diagnostics to the
+        listed headers and applies fix-its in place."""
+        if not header_source_pairs:
+            return
 
-    def filter_files_for_category(
-        self, changed_files: List[str], category: dict
-    ) -> List[str]:
-        """Filter changed files based on category patterns and excludes."""
-        filtered = []
-        for path in changed_files:
-            # Check if file matches any pattern
-            matches_pattern = False
-            for pattern in category["patterns"]:
-                # Simple pattern matching for **/*.h style patterns
-                pattern_prefix = pattern.replace("**/*.h", "")
-                if path.startswith(pattern_prefix) and path.endswith(".h"):
-                    matches_pattern = True
-                    break
-
-            if not matches_pattern:
-                continue
-
-            # Check if file should be excluded
-            excluded = False
-            for exclude in category["excludes"]:
-                if path.startswith(exclude):
-                    excluded = True
-                    break
-
-            if not excluded:
-                filtered.append(path)
-
-        return filtered
-
-    def run_idt_on_files(
-        self,
-        files: List[str],
-        category: dict,
-        args: IdsCheckArgs,
-        idt_path: str,
-        compile_commands: str,
-    ) -> bool:
-        """Run idt tool on the given files with category-specific configuration."""
-        if not files:
-            return True
+        sources = sorted({s for _, s in header_source_pairs})
+        cmd = [idt_path, "-p", compile_commands, "--apply-fixits", "--inplace"]
+        for h, _ in header_source_pairs:
+            cmd += [f"--header={h}"]
+        cmd += sources
 
         if args.verbose:
             print(
-                f"Running idt on {len(files)} {category['name']} file(s)...",
+                f"Running idt on {len(header_source_pairs)} {category} header(s) "
+                f"via {len(sources)} source TU(s)...",
                 file=sys.stderr,
             )
 
-        for file in files:
-            cmd = [
-                idt_path,
-                "-p",
-                compile_commands,
-                "--apply-fixits",
-                "--inplace",
-                f"--export-macro={category['export_macro']}",
-                f"--include-header={category['include_header']}",
-                f"--extra-arg=-D{category['export_macro']}={self.MACRO_DEFINITION}",
-                "--extra-arg=-Wno-macro-redefined",
-                file,
-            ]
-
-            if args.verbose:
-                print(f"Running: {' '.join(cmd)}", file=sys.stderr)
-
-            subprocess.run(cmd)
-
-        return True
+        subprocess.run(cmd)
 
     def get_changed_files(self, args: IdsCheckArgs) -> List[str]:
-        """Get list of changed files between revisions."""
         if args.changed_files:
             return args.changed_files
 
         cmd = ["git", "diff", "--name-only", args.start_rev, args.end_rev]
         if args.verbose:
             print(f"Running: {' '.join(cmd)}", file=sys.stderr)
-
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if proc.returncode != 0:
             print("Error: Failed to get changed files", file=sys.stderr)
             sys.stderr.write(proc.stderr.decode("utf-8"))
             return []
-
         files = proc.stdout.decode("utf-8").strip().split("\n")
         return [f for f in files if f]
 
     def check_for_diff(self) -> Optional[str]:
-        """Check if there are any uncommitted changes after running idt."""
-        cmd = ["git", "diff"]
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
+        proc = subprocess.run(["git", "diff"], stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
         diff = proc.stdout.decode("utf-8")
-        if diff:
-            return diff
-        return None
+        return diff if diff else None
 
     def run(self, args: IdsCheckArgs) -> int:
-        """Main entry point for running ids check."""
-        # Resolve idt path: prefer command line arg, then env var
         idt_path = args.idt_path or os.environ.get("IDT_PATH")
         if not idt_path:
-            print(
-                "Error: idt path not specified. Use --idt-path argument or set IDT_PATH environment variable",
-                file=sys.stderr,
-            )
+            print("Error: idt path not specified. Use --idt-path or set IDT_PATH.",
+                  file=sys.stderr)
             return 1
-
         if not os.path.exists(idt_path):
             print(f"Error: idt tool not found at {idt_path}", file=sys.stderr)
             return 1
 
-        # Resolve compile_commands path: prefer command line arg, then env var
         compile_commands = args.compile_commands or os.environ.get(
             "COMPILE_COMMANDS_PATH"
         )
         if not compile_commands:
-            print(
-                "Error: compile_commands.json path not specified. Use --compile-commands argument or set COMPILE_COMMANDS_PATH environment variable",
-                file=sys.stderr,
-            )
+            print("Error: --compile-commands not specified.", file=sys.stderr)
             return 1
-
         if not os.path.exists(compile_commands):
-            print(
-                f"Error: compile_commands.json not found at {compile_commands}",
-                file=sys.stderr,
-            )
+            print(f"Error: compile_commands.json not found at {compile_commands}",
+                  file=sys.stderr)
             return 1
 
-        # Get changed files
         changed_files = self.get_changed_files(args)
         if not changed_files:
             if args.verbose:
                 print("No files changed, skipping ids check", file=sys.stderr)
             return 0
 
-        # Process each category
-        any_processed = False
-        for category in self.FILE_CATEGORIES:
-            filtered_files = self.filter_files_for_category(changed_files, category)
-            if filtered_files:
-                any_processed = True
-                if not self.run_idt_on_files(
-                    filtered_files, category, args, idt_path, compile_commands
-                ):
-                    return 1
+        # Filter to relevant headers and group by category.
+        per_category = defaultdict(list)
+        for path in changed_files:
+            if not path.endswith(".h"):
+                continue
+            if not path.startswith(("llvm/include/llvm/", "llvm/include/llvm-c/")):
+                continue
+            if any(path.startswith(p) for p in SKIP_HEADERS):
+                continue
+            category = categorize_header(path)
+            if category is None:
+                continue
+            source = find_source_for_header(path)
+            if source is None:
+                if args.verbose:
+                    print(f"  Skipping {path}: no matching source",
+                          file=sys.stderr)
+                continue
+            per_category[category].append((path, source))
 
-        if not any_processed:
+        if not per_category:
             if args.verbose:
-                print(
-                    "No relevant header files changed, skipping ids check",
-                    file=sys.stderr,
-                )
+                print("No relevant header files changed, skipping ids check",
+                      file=sys.stderr)
             return 0
 
-        # Check for differences
+        for category, pairs in per_category.items():
+            self.run_idt_for_category(
+                category, pairs, args, idt_path, compile_commands
+            )
+
         diff = self.check_for_diff()
         should_update_gh = args.token is not None and args.repo is not None
 
         if diff:
             if should_update_gh:
-                comment_text = self.pr_comment_text_for_diff(diff)
-                self.update_pr(comment_text, args, create_new=True)
+                self.update_pr(self.pr_comment_text_for_diff(diff),
+                               args, create_new=True)
             else:
-                print(
-                    "\nError: idt found missing LLVM_ABI annotations", file=sys.stderr
-                )
-                print(
-                    "Apply the following diff to fix the LLVM_ABI annotations:\n",
-                    file=sys.stderr,
-                )
+                print("\nError: idt found missing LLVM_ABI annotations",
+                      file=sys.stderr)
+                print("Apply the following diff to fix the LLVM_ABI annotations:\n",
+                      file=sys.stderr)
                 print(diff)
             return 1
-        else:
-            if should_update_gh:
-                comment_text = (
-                    ":white_check_mark: With the latest revision "
-                    f"this PR passed the {self.friendly_name}."
-                )
-                self.update_pr(comment_text, args, create_new=False)
-            if args.verbose:
-                print("All files pass ids check", file=sys.stderr)
-            return 0
+
+        if should_update_gh:
+            self.update_pr(
+                ":white_check_mark: With the latest revision "
+                f"this PR passed the {self.friendly_name}.",
+                args, create_new=False,
+            )
+        if args.verbose:
+            print("All files pass ids check", file=sys.stderr)
+        return 0
 
 
 if __name__ == "__main__":
@@ -353,43 +437,24 @@ if __name__ == "__main__":
         "--repo",
         type=str,
         default=os.getenv("GITHUB_REPOSITORY", "llvm/llvm-project"),
-        help="The GitHub repository that we are working with in the form of <owner>/<repo> (e.g. llvm/llvm-project)",
+        help="GitHub repository <owner>/<repo>",
     )
     parser.add_argument("--issue-number", type=int, help="GitHub issue/PR number")
-    parser.add_argument(
-        "--start-rev",
-        type=str,
-        required=True,
-        help="Compute changes from this revision",
-    )
-    parser.add_argument(
-        "--end-rev",
-        type=str,
-        required=True,
-        help="Compute changes to this revision",
-    )
-    parser.add_argument(
-        "--changed-files",
-        type=str,
-        help="Comma separated list of files that have been changed",
-    )
-    parser.add_argument(
-        "--idt-path",
-        type=str,
-        help="Path to the idt executable (can also be set via IDT_PATH environment variable)",
-    )
-    parser.add_argument(
-        "--compile-commands",
-        type=str,
-        help="Path to compile_commands.json (can also be set via COMPILE_COMMANDS_PATH environment variable)",
-    )
-    parser.add_argument(
-        "--verbose", action="store_true", default=True, help="Enable verbose output"
-    )
+    parser.add_argument("--start-rev", type=str, required=True,
+                        help="Compute changes from this revision")
+    parser.add_argument("--end-rev", type=str, required=True,
+                        help="Compute changes to this revision")
+    parser.add_argument("--changed-files", type=str,
+                        help="Comma separated list of files that have been changed")
+    parser.add_argument("--idt-path", type=str,
+                        help="Path to the idt executable (or set IDT_PATH)")
+    parser.add_argument("--compile-commands", type=str,
+                        help="Path to compile_commands.json (or set COMPILE_COMMANDS_PATH)")
+    parser.add_argument("--verbose", action="store_true", default=True,
+                        help="Enable verbose output")
 
     parsed_args = parser.parse_args()
 
-    # Parse changed files if provided
     if parsed_args.changed_files:
         parsed_args.changed_files = [
             f.strip() for f in parsed_args.changed_files.split(",") if f.strip()
@@ -404,7 +469,6 @@ if __name__ == "__main__":
     if checker.comment:
         with open("comments", "w") as f:
             import json
-
             json.dump([checker.comment], f)
 
     sys.exit(exit_code)


### PR DESCRIPTION
The ids-check workflow is meant to signal when LLVM APIs are missing
from a header modified in a PR. However, there were a few issues with
the initial implementation:
* LLVM_ABI annotations were incorrectly suggested for headers that
  should not have them.
* Unmodified headers were also signaled as missing LLVM_ABI annotations.

These changes attempt to remedy the situation by excluding whole
categories of headers for which the workflow does not work properly and
improving the way headers are parsed.

These changes do not re-enable the workflow yet. This will be done
after all of the missing LLVM_ABI annotations have been added, using the
changes to the script.