### PR TITLE
[llvm][OpenMP][SPIRV] Fix assertion for GPU reductions

### DIFF
--- a/clang/test/OpenMP/spirv_target_teams_reduction_addrspace.c
+++ b/clang/test/OpenMP/spirv_target_teams_reduction_addrspace.c
@@ -1,0 +1,34 @@
+// Test that target teams reduction codegen handles address space casts correctly.
+
+// RUN: %clang_cc1 -verify -fopenmp -x c -triple x86_64-unknown-linux -fopenmp-targets=spirv64-intel -emit-llvm-bc %s -o %t-host.bc
+// RUN: %clang_cc1 -verify -fopenmp -x c -triple spirv64-intel -fopenmp-targets=spirv64-intel -emit-llvm %s -fopenmp-is-target-device -fopenmp-host-ir-file-path %t-host.bc -o - | FileCheck %s
+
+// expected-no-diagnostics
+
+// Verify the kernel is generated
+// CHECK: define weak_odr protected spir_kernel void @__omp_offloading_{{.*}}_main_{{.*}}
+
+// Verify __kmpc_alloc_shared is called for reduction variable
+// The return type should be ptr addrspace(4) (generic pointer)
+// CHECK: call spir_func align 8 addrspace(9) ptr addrspace(4) @__kmpc_alloc_shared(i64 4)
+
+// Verify the reduction runtime function is called
+// CHECK: call spir_func addrspace(9) i32 @__kmpc_nvptx_teams_reduce_nowait_v2(
+
+// Verify __kmpc_free_shared is called
+// CHECK: call spir_func addrspace(9) void @__kmpc_free_shared(ptr addrspace(4)
+
+// Verify the reduction function is generated
+// This is where the address space cast fix is critical
+// CHECK: define internal void @{{.*}}reduction{{.*}}func
+
+int main() {
+  int x = 0;
+
+  #pragma omp target teams num_teams(2) reduction(+ : x)
+  {
+    x += 2;
+  }
+
+  return x;
+}

--- a/clang/test/OpenMP/spirv_target_teams_reduction_addrspace.c
+++ b/clang/test/OpenMP/spirv_target_teams_reduction_addrspace.c
@@ -5,21 +5,20 @@
 
 // expected-no-diagnostics
 
-// Verify the kernel is generated
+// Verify the kernel is generated.
 // CHECK: define weak_odr protected spir_kernel void @__omp_offloading_{{.*}}_main_{{.*}}
 
-// Verify __kmpc_alloc_shared is called for reduction variable
-// The return type should be ptr addrspace(4) (generic pointer)
+// Verify __kmpc_alloc_shared is called for reduction variable.
+// The return type should be ptr addrspace(4) (generic pointer).
 // CHECK: call spir_func align 8 addrspace(9) ptr addrspace(4) @__kmpc_alloc_shared(i64 4)
 
-// Verify the reduction runtime function is called
+// Verify the reduction runtime function is called.
 // CHECK: call spir_func addrspace(9) i32 @__kmpc_nvptx_teams_reduce_nowait_v2(
 
-// Verify __kmpc_free_shared is called
+// Verify __kmpc_free_shared is called.
 // CHECK: call spir_func addrspace(9) void @__kmpc_free_shared(ptr addrspace(4)
 
-// Verify the reduction function is generated
-// This is where the address space cast fix is critical
+// Verify the reduction function is generated.
 // CHECK: define internal void @{{.*}}reduction{{.*}}func
 
 int main() {

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4731,12 +4731,22 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createReductionsGPU(
                                              &LHSPtr, &RHSPtr, CurFunc));
 
       // Fix the CallBack code genereated to use the correct Values for the LHS
-      // and RHS
-      LHSPtr->replaceUsesWithIf(RedValue, [ReductionFunc](const Use &U) {
+      // and RHS. Cast to match types before replacing (necessary to handle SPIRV address
+      // spaces).
+      Value *CastRedValue = RedValue;
+      if (LHSPtr->getType() != RedValue->getType())
+        CastRedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(
+            RedValue, LHSPtr->getType());
+      Value *CastRHS = RHS;
+      if (RHSPtr->getType() != RHS->getType())
+        CastRHS =
+            Builder.CreatePointerBitCastOrAddrSpaceCast(RHS, RHSPtr->getType());
+
+      LHSPtr->replaceUsesWithIf(CastRedValue, [ReductionFunc](const Use &U) {
         return cast<Instruction>(U.getUser())->getParent()->getParent() ==
                ReductionFunc;
       });
-      RHSPtr->replaceUsesWithIf(RHS, [ReductionFunc](const Use &U) {
+      RHSPtr->replaceUsesWithIf(CastRHS, [ReductionFunc](const Use &U) {
         return cast<Instruction>(U.getUser())->getParent()->getParent() ==
                ReductionFunc;
       });

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4731,8 +4731,8 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createReductionsGPU(
                                              &LHSPtr, &RHSPtr, CurFunc));
 
       // Fix the CallBack code genereated to use the correct Values for the LHS
-      // and RHS. Cast to match types before replacing (necessary to handle SPIRV address
-      // spaces).
+      // and RHS. Cast to match types before replacing (necessary to handle
+      // SPIRV address spaces).
       Value *CastRedValue = RedValue;
       if (LHSPtr->getType() != RedValue->getType())
         CastRedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4733,16 +4733,15 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createReductionsGPU(
       // Fix the CallBack code genereated to use the correct Values for the LHS
       // and RHS. Cast to match types before replacing (necessary to handle
       // different address spaces).
-      Value *CastRedValue = RedValue;
       if (LHSPtr->getType() != RedValue->getType())
-        CastRedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(
+        RedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(
             RedValue, LHSPtr->getType());
       Value *CastRHS = RHS;
       if (RHSPtr->getType() != RHS->getType())
         CastRHS =
             Builder.CreatePointerBitCastOrAddrSpaceCast(RHS, RHSPtr->getType());
 
-      LHSPtr->replaceUsesWithIf(CastRedValue, [ReductionFunc](const Use &U) {
+      LHSPtr->replaceUsesWithIf(RedValue, [ReductionFunc](const Use &U) {
         return cast<Instruction>(U.getUser())->getParent()->getParent() ==
                ReductionFunc;
       });

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4732,7 +4732,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createReductionsGPU(
 
       // Fix the CallBack code genereated to use the correct Values for the LHS
       // and RHS. Cast to match types before replacing (necessary to handle
-      // SPIRV address spaces).
+      // different address spaces).
       Value *CastRedValue = RedValue;
       if (LHSPtr->getType() != RedValue->getType())
         CastRedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4736,16 +4736,15 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createReductionsGPU(
       if (LHSPtr->getType() != RedValue->getType())
         RedValue = Builder.CreatePointerBitCastOrAddrSpaceCast(
             RedValue, LHSPtr->getType());
-      Value *CastRHS = RHS;
       if (RHSPtr->getType() != RHS->getType())
-        CastRHS =
+        RHS =
             Builder.CreatePointerBitCastOrAddrSpaceCast(RHS, RHSPtr->getType());
 
       LHSPtr->replaceUsesWithIf(RedValue, [ReductionFunc](const Use &U) {
         return cast<Instruction>(U.getUser())->getParent()->getParent() ==
                ReductionFunc;
       });
-      RHSPtr->replaceUsesWithIf(CastRHS, [ReductionFunc](const Use &U) {
+      RHSPtr->replaceUsesWithIf(RHS, [ReductionFunc](const Use &U) {
         return cast<Instruction>(U.getUser())->getParent()->getParent() ==
                ReductionFunc;
       });


### PR DESCRIPTION
Currenty compiling a `target reduction` results in the following assert for spirv64-intel target: 

> Assertion `New->getType() == getType() && "replaceUses of value with new value of different type!"' failed.

This patch fixes it by adding an addrespace cast where necessary to make the types of the expressions match.

Assisted-by: claude-sonnet-4-5