### PR TITLE
[PowerPC] Remove duplicate patterns for atomic_swap

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -265,10 +265,11 @@ def : Pat<(PPCcall_nop_rm (i64 mcsym:$dst)),
 // clean this up in PPCMIPeephole with calls to
 // PPCInstrInfo::convertToImmediateForm() but we should probably not emit them
 // in the first place.
-foreach op = ["add", "sub", "and", "or", "xor", "nand", "min", "max", "umax",
-              "umin"] in {
-  defvar pat = !cast<PatFrag>("atomic_load_"#op#"_i64");
-  defvar pseudo = "ATOMIC_LOAD_"#!toupper(op)#"_I64";
+foreach op = ["load_add", "load_sub", "load_and", "load_or", "load_xor",
+              "load_nand", "load_min", "load_max", "load_umax", "load_umin",
+              "swap"] in {
+  defvar pat = !cast<PatFrag>("atomic_"#op#"_i64");
+  defvar pseudo = "ATOMIC_"#!toupper(op)#"_I64";
   let Defs = [CR0] in
     def pseudo : PPCCustomInserterPseudo<
         (outs g8rc:$dst), (ins memrr:$ptr, i32imm:$sz, g8rc:$incr),
@@ -277,20 +278,13 @@ foreach op = ["add", "sub", "and", "or", "xor", "nand", "min", "max", "umax",
           (!cast<Instruction>(pseudo) memrr:$ptr, 8, g8rc:$incr)>;
 }
 
-let Defs = [CR0] in {
+let Defs = [CR0] in
   def ATOMIC_CMP_SWAP_I64 : PPCCustomInserterPseudo<
     (outs g8rc:$dst), (ins memrr:$ptr, g8rc:$old, g8rc:$new),
     "#" # NAME, []>;
 
-  def ATOMIC_SWAP_I64 : PPCCustomInserterPseudo<
-    (outs g8rc:$dst), (ins memrr:$ptr, i32imm:$sz, g8rc:$new),
-    "#" # NAME, []>;
-}
-
 def : Pat<(i64 (atomic_cmp_swap_i64 ForceXForm:$ptr, g8rc:$old, g8rc:$new)),
           (ATOMIC_CMP_SWAP_I64 memrr:$ptr, i64:$old, i64:$new)>;
-def : Pat<(i64 (atomic_swap_i64 ForceXForm:$ptr, g8rc:$new)),
-          (ATOMIC_SWAP_I64 memrr:$ptr, 8, i64:$new)>;
 
 // Instructions to support atomic operations
 let mayLoad = 1, mayStore = 1, hasSideEffects = 1 in {

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2017,10 +2017,11 @@ def : Pat<(int_ppc_dcbtst_with_hint xoaddr:$dst, i32:$TH),
 // For example for operation AND, ATOMIC_LOAD_AND_NOWP is only matched for sizes
 // 8 and 16 bit if the word part feature is not available. In all other cases,
 // ATOMIC_LOAD_AND is matched.
-foreach op = ["add", "sub", "and", "or", "xor", "nand", "min", "max", "umax",
-              "umin"] in {
-  defvar atomic_load = "ATOMIC_LOAD_"#!toupper(op);
-  defvar atomic_load_nowp = "ATOMIC_LOAD_"#!toupper(op)#"_NOWP";
+foreach op = ["load_add", "load_sub", "load_and", "load_or", "load_xor",
+              "load_nand", "load_min", "load_max", "load_umax", "load_umin",
+              "swap"] in {
+  defvar atomic_load = "ATOMIC_"#!toupper(op);
+  defvar atomic_load_nowp = "ATOMIC_"#!toupper(op)#"_NOWP";
   let Defs = [CR0] in {
     def atomic_load : PPCCustomInserterPseudo<
         (outs gprc:$dst), (ins memrr:$ptr, i32imm:$sz, gprc:$incr),
@@ -2053,25 +2054,6 @@ foreach bitsz = [8, 16, 32] in {
   def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$old, gprc:$new)),
           (!cast<Instruction>(pseudo) memrr:$ptr, gprc:$old, gprc:$new)>;
 }
-
-let Defs = [CR0] in {
-  def ATOMIC_SWAP : PPCCustomInserterPseudo<
-      (outs gprc:$dst), (ins memrr:$ptr, i32imm:$sz, gprc:$new),
-      "#" # NAME,[]>;
-  def ATOMIC_SWAP_NOWP : PPCCustomInserterPseudo<
-      (outs gprc:$dst), (ins memrr:$ptr, i32imm:$sz, gprc:$new),
-      "#" # NAME,[]>;
-}
-foreach bitsz = [8, 16] in {
-  defvar pat = !cast<PatFrag>("atomic_swap_i"#bitsz);
-  def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$new)),
-          (ATOMIC_SWAP memrr:$ptr, !div(bitsz, 8), gprc:$new)>,
-           Requires<[HasPartwordAtomics]>;
-  def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$new)),
-          (ATOMIC_SWAP_NOWP memrr:$ptr, !div(bitsz, 8), gprc:$new)>;
-}
-def : Pat<(i32 (atomic_swap_i32 ForceXForm:$ptr, gprc:$new)),
-          (ATOMIC_SWAP memrr:$ptr, 4, gprc:$new)>;
 
 def : Pat<(PPCatomicCmpSwap_8 ForceXForm:$ptr, i32:$old, i32:$new),
         (ATOMIC_CMP_SWAP_I8 ForceXForm:$ptr, i32:$old, i32:$new)>;


### PR DESCRIPTION
The definition and implementation of atomic_load_* and atomic_swap is basically similar. Changing the way how the operations are enumerated makes it possible to remove the separate patterns for atomic_swap.