### PR TITLE
[flang] Fix crash on PARAMETER attribute applied to POINTER

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5893,7 +5893,8 @@ bool DeclarationVisitor::Pre(const parser::NamedConstantDef &x) {
   auto &symbol{HandleAttributeStmt(Attr::PARAMETER, name)};
   ConvertToObjectEntity(symbol);
   auto *details{symbol.detailsIf<ObjectEntityDetails>()};
-  if (!details || symbol.test(Symbol::Flag::CrayPointer) ||
+  if (!details || symbol.attrs().test(Attr::POINTER) ||
+      symbol.test(Symbol::Flag::CrayPointer) ||
       symbol.test(Symbol::Flag::CrayPointee)) {
     SayWithDecl(
         name, symbol, "PARAMETER attribute not allowed on '%s'"_err_en_US);

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5893,8 +5893,7 @@ bool DeclarationVisitor::Pre(const parser::NamedConstantDef &x) {
   auto &symbol{HandleAttributeStmt(Attr::PARAMETER, name)};
   ConvertToObjectEntity(symbol);
   auto *details{symbol.detailsIf<ObjectEntityDetails>()};
-  if (!details || symbol.attrs().test(Attr::POINTER) ||
-      symbol.test(Symbol::Flag::CrayPointer) ||
+  if (!details || IsPointer(symbol) || symbol.test(Symbol::Flag::CrayPointer) ||
       symbol.test(Symbol::Flag::CrayPointee)) {
     SayWithDecl(
         name, symbol, "PARAMETER attribute not allowed on '%s'"_err_en_US);

--- a/flang/test/Semantics/resolve129.f90
+++ b/flang/test/Semantics/resolve129.f90
@@ -1,0 +1,10 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+
+! Test that POINTER with PARAMETER doesn't crash.
+
+subroutine s1
+  !ERROR: 'a' may not have both the POINTER and PARAMETER attributes
+  pointer a
+  !ERROR: PARAMETER attribute not allowed on 'a'
+  parameter(a=3)
+end subroutine

--- a/flang/test/Semantics/resolve129.f90
+++ b/flang/test/Semantics/resolve129.f90
@@ -8,3 +8,11 @@ subroutine s1
   !ERROR: PARAMETER attribute not allowed on 'a'
   parameter(a=3)
 end subroutine
+
+subroutine s2
+  !ERROR: 'b' may not have both the POINTER and PARAMETER attributes
+  integer, pointer :: b
+  !ERROR: PARAMETER attribute not allowed on 'b'
+  parameter(b=3)
+end subroutine
+


### PR DESCRIPTION
Issue #194725: Flang hits an internal assertion `CHECK(!IsPointer(symbol))` in check-expression.cpp when a variable is declared with both POINTER and PARAMETER attributes. This is an illegal attribute combination (a POINTER cannot be a PARAMETER). 
```
subroutine a7
  pointer A
  parameter (A=3)
end subroutine
```
The existing check for this attribute conflict in `CheckConflicting` runs too late — after `Pre(NamedConstantDef)`
has already called `EvaluateNonPointerInitializer` on the POINTER symbol, triggering the fatal assertion.

This patch adds a POINTER check to the existing early-out guard in `DeclarationVisitor::Pre(NamedConstantDef)` that already handles CrayPointer/CrayPointee, so the error is diagnosed and we return before reaching the assertion. A LIT test has been added as well.