### PR TITLE
[clang][deps] Value-compare buffers in the in-process module cache

### DIFF
--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -145,7 +145,8 @@ public:
     ModuleCacheEntry &Entry = getOrCreateEntry(Path);
     std::lock_guard<std::mutex> Lock(Entry.Mutex);
     if (Entry.State == ModuleCacheEntry::S_Written) {
-      assert(Entry.Buffer && *Entry.Buffer == Buffer &&
+      assert(Entry.Buffer && "Wrote PCM with no contents");
+      assert(Entry.Buffer->getBuffer() == Buffer.getBuffer() &&
              "Wrote the same PCM with different contents");
       Size = Entry.Buffer->getBufferSize();
       ModTime = Entry.ModTime;


### PR DESCRIPTION
The `MemoryBufferRef::operator==()` function performs pointer comparison instead of value comparison. This means that the assertion in `InProcessModuleCache` always fires if there's a race between two producers of a PCM. This PR makes sure to value-compare the contained `StringRef` buffers.