### PR TITLE
Fix memcpy-operator= generation with restrict parameters.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -567,6 +567,7 @@ Bug Fixes to C++ Support
   conforming and could lead to recursive constraint satisfaction checking. (#GH149443)
 - Fixed a crash in Itanium C++ name mangling for a lambda in a local class field initializer inside a constructor/destructor. (#GH176395)
 - Fixed crashes in Itanium C++ name mangling for lambdas with trailing requires-clauses involving requires-expressions. (#GH100774) (#GH123854)
+- Fixed an invalid rejection and assertion failure while generating ``operator=`` for fields with the ``__restrict`` qualifier. (#GH37979)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -14928,6 +14928,23 @@ buildMemcpyForAssignmentOp(Sema &S, SourceLocation Loc, QualType T,
       S.Context, To, UO_AddrOf, S.Context.getPointerType(To->getType()),
       VK_PRValue, OK_Ordinary, Loc, false, S.CurFPFeatureOverrides());
 
+  // If this is restrict qualified, the call to memcpy will fail as this ends up
+  // being an illegal pointer cast (as it has non-local qualifiers in
+  // difference). Sema rules prevent us from calling this with anything other
+  // than the restrict qualifiers as far as I can tell(fields cant have an AS,
+  // copy is deleted if it is const, OBJC can't get here, pointer-auth can't be
+  // applied to any problematic things). In order to avoid that problem, we can
+  // just insert a cast directly to const void * / void *.
+  if (T.isRestrictQualified()) {
+    From = ImplicitCastExpr::Create(
+        S.Context, S.Context.getPointerType(S.Context.VoidTy.withConst()),
+        CK_BitCast, From, /*BasePath=*/nullptr, VK_PRValue,
+        FPOptionsOverride());
+    To = ImplicitCastExpr::Create(
+        S.Context, S.Context.VoidPtrTy, CK_BitCast, To,
+        /*BasePath=*/nullptr, VK_PRValue, FPOptionsOverride());
+  }
+
   bool NeedsCollectableMemCpy = false;
   if (auto *RD = T->getBaseElementTypeUnsafe()->getAsRecordDecl())
     NeedsCollectableMemCpy = RD->hasObjectMember();

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -15180,8 +15180,8 @@ buildSingleCopyAssign(Sema &S, SourceLocation Loc, QualType T,
                       const ExprBuilder &To, const ExprBuilder &From,
                       bool CopyingBaseSubobject, bool Copying) {
   // Maybe we should use a memcpy?
-  if (T->isArrayType() && !T.isConstQualified() && !T.isVolatileQualified() &&
-      !T.isRestrictQualified() && T.isTriviallyCopyableType(S.Context))
+  if (T->isArrayType() && !T.hasQualifiers() &&
+      T.isTriviallyCopyableType(S.Context))
     return buildMemcpyForAssignmentOp(S, Loc, T, To, From);
 
   StmtResult Result(buildSingleCopyAssignRecursively(S, Loc, T, To, From,

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -14928,23 +14928,6 @@ buildMemcpyForAssignmentOp(Sema &S, SourceLocation Loc, QualType T,
       S.Context, To, UO_AddrOf, S.Context.getPointerType(To->getType()),
       VK_PRValue, OK_Ordinary, Loc, false, S.CurFPFeatureOverrides());
 
-  // If this is restrict qualified, the call to memcpy will fail as this ends up
-  // being an illegal pointer cast (as it has non-local qualifiers in
-  // difference). Sema rules prevent us from calling this with anything other
-  // than the restrict qualifiers as far as I can tell(fields cant have an AS,
-  // copy is deleted if it is const, OBJC can't get here, pointer-auth can't be
-  // applied to any problematic things). In order to avoid that problem, we can
-  // just insert a cast directly to const void * / void *.
-  if (T.isRestrictQualified()) {
-    From = ImplicitCastExpr::Create(
-        S.Context, S.Context.getPointerType(S.Context.VoidTy.withConst()),
-        CK_BitCast, From, /*BasePath=*/nullptr, VK_PRValue,
-        FPOptionsOverride());
-    To = ImplicitCastExpr::Create(
-        S.Context, S.Context.VoidPtrTy, CK_BitCast, To,
-        /*BasePath=*/nullptr, VK_PRValue, FPOptionsOverride());
-  }
-
   bool NeedsCollectableMemCpy = false;
   if (auto *RD = T->getBaseElementTypeUnsafe()->getAsRecordDecl())
     NeedsCollectableMemCpy = RD->hasObjectMember();
@@ -15198,7 +15181,7 @@ buildSingleCopyAssign(Sema &S, SourceLocation Loc, QualType T,
                       bool CopyingBaseSubobject, bool Copying) {
   // Maybe we should use a memcpy?
   if (T->isArrayType() && !T.isConstQualified() && !T.isVolatileQualified() &&
-      T.isTriviallyCopyableType(S.Context))
+      !T.isRestrictQualified() && T.isTriviallyCopyableType(S.Context))
     return buildMemcpyForAssignmentOp(S, Loc, T, To, From);
 
   StmtResult Result(buildSingleCopyAssignRecursively(S, Loc, T, To, From,

--- a/clang/test/SemaCXX/GH37979.cpp
+++ b/clang/test/SemaCXX/GH37979.cpp
@@ -10,16 +10,7 @@ void do_copy() {
     // CHECK-LABEL: CXXMethodDecl{{.*}} implicit used constexpr operator= 'Obj &(const Obj &) noexcept'
     // CHECK-NEXT: ParmVarDecl
     // CHECK-NEXT: CompoundStmt
-    // CHECK-NEXT: CallExpr
-    // CHECK-NEXT: ImplicitCastExpr{{.*}}<BuiltinFnToFnPtr>
-    // CHECK-NEXT: DeclRefExpr{{.*}}__builtin_memcpy
-    // CHECK-NEXT: ImplicitCastExpr{{.*}}'void *' <BitCast>
-    // CHECK-NEXT: UnaryOperator{{.*}} 'int *__restrict (*)[2]' prefix '&'
-    // CHECK-NEXT: MemberExpr{{.*}} 'int *__restrict[2]' lvalue ->myPtr
-    // CHECK-NEXT: CXXThisExpr{{.*}} 'Obj *' this
-    //
-    // CHECK-NEXT: ImplicitCastExpr{{.*}}'const void *' <BitCast>
-    // CHECK-NEXT: UnaryOperator{{.*}} 'int *__restrict const __restrict (*)[2]' prefix '&'
-    // CHECK-NEXT: MemberExpr{{.*}} 'int *__restrict const __restrict[2]' lvalue .myPtr
-    // CHECK-NEXT: DeclRefExpr{{.*}} 'const Obj' lvalue ParmVar
+    // Make sure that this uses the for-loop in the AST rather than trying to do
+    // the early builtin_memcpy opt.
+    // CHECK-NEXT: ForStmt
 }

--- a/clang/test/SemaCXX/GH37979.cpp
+++ b/clang/test/SemaCXX/GH37979.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -pedantic %s
+// RUN: %clang_cc1 -fsyntax-only -ast-dump  %s | FileCheck %s
+// expected-no-diagnostics
+
+struct Obj { int * __restrict myPtr[2]; };
+
+void do_copy() {
+    Obj a, b;
+    a = b;
+    // CHECK-LABEL: CXXMethodDecl{{.*}} implicit used constexpr operator= 'Obj &(const Obj &) noexcept'
+    // CHECK-NEXT: ParmVarDecl
+    // CHECK-NEXT: CompoundStmt
+    // CHECK-NEXT: CallExpr
+    // CHECK-NEXT: ImplicitCastExpr{{.*}}<BuiltinFnToFnPtr>
+    // CHECK-NEXT: DeclRefExpr{{.*}}__builtin_memcpy
+    // CHECK-NEXT: ImplicitCastExpr{{.*}}'void *' <BitCast>
+    // CHECK-NEXT: UnaryOperator{{.*}} 'int *__restrict (*)[2]' prefix '&'
+    // CHECK-NEXT: MemberExpr{{.*}} 'int *__restrict[2]' lvalue ->myPtr
+    // CHECK-NEXT: CXXThisExpr{{.*}} 'Obj *' this
+    //
+    // CHECK-NEXT: ImplicitCastExpr{{.*}}'const void *' <BitCast>
+    // CHECK-NEXT: UnaryOperator{{.*}} 'int *__restrict const __restrict (*)[2]' prefix '&'
+    // CHECK-NEXT: MemberExpr{{.*}} 'int *__restrict const __restrict[2]' lvalue .myPtr
+    // CHECK-NEXT: DeclRefExpr{{.*}} 'const Obj' lvalue ParmVar
+}


### PR DESCRIPTION
The below issue (and #63884) both report that we reject (and also assert, because the memcpy failed) the memcpy we're generating for a restrict field of a type with an implicit copy constructor.

First, we shouldn't be rejecting it this late, IF we wanted to reject it (I contend we do not), we should do it at the same time we reject const-members/make this a deleted operator.  Second, of course we shouldn't fail.

This patch NOW works by just having us skip the premature 'memcpy' optimization here.  In the end, the memcpy is generally skipped by `CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr` in the example (as this is a trivial type), but this reverts it to using a 'for' loop for restrict, as it does for const, and volatile qualified values.

We perhaps might think about doing this for address-spaces/ptr-auth, but at the moment, this fixes restrict version.

Fixes: #37979