### PR TITLE
[lldb][windows] fix yaml2macho not loading file

### DIFF
--- a/lldb/tools/yaml2macho-core/yaml2macho.cpp
+++ b/lldb/tools/yaml2macho-core/yaml2macho.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
-  FILE *input = fopen(InputFilename.c_str(), "r");
+  FILE *input = fopen(InputFilename.c_str(), "rb");
   if (!input) {
     fprintf(stderr, "Unable to open %s, exiting\n", InputFilename.c_str());
     exit(1);


### PR DESCRIPTION
This only triggers on Windows because of git using `autocrlf` by default:
- stat() returns the on-disk file size (including the `\r\n`).
- `fopen(file, "r")` opens in text mode, translating `\r\n` to `\n`.
- `fread(bug, sb.st_size, 1, file)` reads fewer bytes than expected due to the translation above.

Switching to `"rb"` fixes the issue.