### PR TITLE
[CIR] Add some missing NYIs for WeakRefAttr/AliasAttr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -989,6 +989,16 @@ LValue CIRGenFunction::emitDeclRefLValue(const DeclRefExpr *e) {
     }
   }
 
+  // FIXME: We should be able to assert this for FunctionDecls as well!
+  // FIXME: We should be able to assert this for all DeclRefExprs, not just
+  // those with a valid source location.
+  assert((nd->isUsed(false) || !isa<VarDecl>(nd) || e->isNonOdrUse() ||
+          !e->getLocation().isValid()) &&
+         "Should not use decl without marking it used!");
+
+  if (nd->hasAttr<WeakRefAttr>())
+    cgm.errorNYI(global->getSourceRange(), "emitGlobal: WeakRefAttr");
+
   if (const auto *vd = dyn_cast<VarDecl>(nd)) {
     // Checks for omitted feature handling
     assert(!cir::MissingFeatures::opAllocaStaticLocal());

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -997,7 +997,7 @@ LValue CIRGenFunction::emitDeclRefLValue(const DeclRefExpr *e) {
          "Should not use decl without marking it used!");
 
   if (nd->hasAttr<WeakRefAttr>())
-    cgm.errorNYI(global->getSourceRange(), "emitGlobal: WeakRefAttr");
+    cgm.errorNYI(nd->getSourceRange(), "emitGlobal: WeakRefAttr");
 
   if (const auto *vd = dyn_cast<VarDecl>(nd)) {
     // Checks for omitted feature handling

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -465,10 +465,10 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
   const auto *global = cast<ValueDecl>(gd.getDecl());
 
   if (global->hasAttr<WeakRefAttr>())
-    cgm.errorNYI(global->getSourceRange(), "emitGlobal: WeakRefAttr");
+    errorNYI(global->getSourceRange(), "emitGlobal: WeakRefAttr");
 
   if (global->hasAttr<AliasAttr>())
-    cgm.errorNYI(global->getSourceRange(), "emitGlobal: AliasAttr");
+    errorNYI(global->getSourceRange(), "emitGlobal: AliasAttr");
 
   // If this is CUDA, be selective about which declarations we emit.
   // Non-constexpr non-lambda implicit host device functions are not emitted

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -464,6 +464,12 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
 
   const auto *global = cast<ValueDecl>(gd.getDecl());
 
+  if (global->hasAttr<WeakRefAttr>())
+    cgm.errorNYI(global->getSourceRange(), "emitGlobal: WeakRefAttr");
+
+  if (global->hasAttr<AliasAttr>())
+    cgm.errorNYI(global->getSourceRange(), "emitGlobal: AliasAttr");
+
   // If this is CUDA, be selective about which declarations we emit.
   // Non-constexpr non-lambda implicit host device functions are not emitted
   // unless they are used on device side.

--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -2748,8 +2748,10 @@ Expr *GenerateReductionInitRecipeExpr(ASTContext &Context,
 VarDecl *CreateAllocaDecl(ASTContext &Ctx, DeclContext *DC,
                           SourceLocation BeginLoc, IdentifierInfo *VarName,
                           QualType VarTy) {
-  return VarDecl::Create(Ctx, DC, BeginLoc, BeginLoc, VarName, VarTy,
-                         Ctx.getTrivialTypeSourceInfo(VarTy), SC_Auto);
+  auto *VD = VarDecl::Create(Ctx, DC, BeginLoc, BeginLoc, VarName, VarTy,
+                             Ctx.getTrivialTypeSourceInfo(VarTy), SC_Auto);
+  VD->markUsed(Ctx);
+  return VD;
 }
 
 ExprResult FinishValueInit(Sema &S, InitializedEntity &Entity,


### PR DESCRIPTION
I found these while poking through something else, we should make sure these don't get lost, particularly as alias has some significant functionality.

Also, interestingly, this caught a case where the temporary declarations that we add for OpenACC weren't properly being marked as 'used' (the assert that was added), so this fixes that as well.