### PR TITLE
[CIR] Relax end_catch assertion in flattenCatchHandler

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1585,6 +1585,10 @@ public:
         // blocks), verifying that each intermediate block contains only a
         // branch terminator, until we find end_catch as the last
         // non-terminator in some block.
+        // Verify that end_catch is reachable on some predecessor path
+        // before this yield.  After cleanup scope flattening, end_catch
+        // may be separated from yield by conditional branches (e.g.,
+        // from flattened cir.if inside the catch body).
         assert(([&]() {
                  if (mlir::Operation *prev = yieldOp->getPrevNode())
                    return isa<cir::EndCatchOp>(prev);
@@ -1597,17 +1601,17 @@ public:
                    if (!visited.insert(b).second)
                      continue;
                    mlir::Operation *term = b->getTerminator();
-                   if (mlir::Operation *prev = term->getPrevNode())
-                     return isa<cir::EndCatchOp>(prev);
-                   if (!isa<cir::BrOp>(term))
-                     return false;
+                   if (mlir::Operation *prev = term->getPrevNode()) {
+                     if (isa<cir::EndCatchOp>(prev))
+                       return true;
+                   }
                    for (mlir::Block *pred : b->getPredecessors())
                      worklist.push_back(pred);
                  }
                  return false;
                }()) &&
-               "expected end_catch as last operation before yield "
-               "in catch handler, with only branches in between");
+               "expected end_catch reachable before yield "
+               "in catch handler");
         rewriter.setInsertionPoint(yieldOp);
         rewriter.replaceOpWithNewOp<cir::BrOp>(yieldOp, continueBlock);
       }

--- a/clang/test/CIR/CodeGen/catch-in-loop.cpp
+++ b/clang/test/CIR/CodeGen/catch-in-loop.cpp
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++14 -fcxx-exceptions -fexceptions -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++14 -fcxx-exceptions -fexceptions -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=LLVM %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++14 -fcxx-exceptions -fexceptions -emit-llvm %s -o %t-ogcg.ll
+// RUN: FileCheck --input-file=%t-ogcg.ll --check-prefix=OGCG %s
+
+// Regression test: try/catch inside a do-while loop with a conditional
+// return in the catch handler was triggering an assertion in
+// flattenCatchHandler.  The assertion required end_catch to be
+// reachable through only cir.br predecessors, but flattened cir.if
+// produces conditional branches on the path.
+
+namespace std { class bad_alloc {}; }
+void may_throw();
+bool check();
+
+int test_catch_in_loop() {
+  int tries = 0;
+  do {
+    try {
+      may_throw();
+    } catch (std::bad_alloc &) {
+      tries += 1;
+      if (tries > 10)
+        return -1;
+    }
+  } while (!check());
+  return 0;
+}
+
+// Verify the catch handler has begin_catch, end_catch, and the
+// cleanup scope with the conditional return.
+// CIR: cir.func {{.*}} @_Z18test_catch_in_loopv
+// CIR: cir.try
+// CIR: cir.call @_Z9may_throwv
+// CIR: cir.begin_catch
+// CIR: cir.cleanup.scope
+// CIR: cir.if
+// CIR: cir.return
+// CIR: cir.end_catch
+
+// LLVM: define {{.*}} @_Z18test_catch_in_loopv()
+// LLVM: invoke void @_Z9may_throwv()
+// LLVM: landingpad
+// LLVM: call ptr @__cxa_begin_catch
+// LLVM: call void @__cxa_end_catch()
+// LLVM: ret i32
+
+// OGCG: define {{.*}} @_Z18test_catch_in_loopv()
+// OGCG: invoke void @_Z9may_throwv()
+// OGCG: landingpad
+// OGCG: call ptr @__cxa_begin_catch
+// OGCG: call void @__cxa_end_catch()
+// OGCG: ret i32


### PR DESCRIPTION
Follow-up to #193796.  The end_catch predecessor walk in `flattenCatchHandler` returned false on blocks with non-`BrOp` terminators or non-`EndCatchOp` content before the terminator.  Catch handlers with control flow — e.g., try/catch inside a do-while loop with a conditional return, as used by Eigen's SparseLU memory allocator — produce conditional branches on the path after cleanup scope flattening, tripping the assertion.

Relaxes the walk to continue through all predecessor paths and return true when `end_catch` is found on any path, preserving the reachability invariant.
