### PR TITLE
[flang][debug] Only import debug info for specified renamed variables

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3314,12 +3314,14 @@ def fir_UseStmtOp
   }];
 
   let arguments = (ins StrAttr:$module_name,
-      OptionalAttr<ArrayAttr>:$only_symbols, OptionalAttr<ArrayAttr>:$renames);
+      OptionalAttr<ArrayAttr>:$only_symbols, OptionalAttr<ArrayAttr>:$renames,
+      DefaultValuedAttr<BoolAttr, "false">:$hasOnlyWithRenames);
 
   let assemblyFormat = [{
     $module_name
     (`only_symbols` `[` $only_symbols^ `]`)?
     (`renames` `[` $renames^ `]`)?
+    (`hasOnlyWithRenames` $hasOnlyWithRenames^)?
     attr-dict
   }];
 
@@ -3332,6 +3334,9 @@ def fir_UseStmtOp
 
     /// Returns true if this imports the entire module (no ONLY clause)
     bool importsAll() { return !hasOnlyClause(); }
+
+    /// Returns true if this USE statement has both ONLY clause and renames
+    bool hasOnlyWithRenames() { return getHasOnlyWithRenames(); }
   }];
 }
 

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3333,7 +3333,7 @@ def fir_UseStmtOp
     bool hasRenames() { return getRenames().has_value(); }
 
     /// Returns true if this imports the entire module (no ONLY clause)
-    bool importsAll() { return !hasOnlyClause(); }
+    bool importsAll() { return !(hasOnlyClause() || getHasOnlyWithRenames()); }
 
     /// Returns true if this USE statement has both ONLY clause and renames
     bool hasOnlyWithRenames() { return getHasOnlyWithRenames(); }

--- a/flang/include/flang/Semantics/scope.h
+++ b/flang/include/flang/Semantics/scope.h
@@ -60,6 +60,7 @@ struct PreservedUseStmt {
   std::string moduleName;
   std::vector<std::string> onlyNames; // For USE ONLY
   std::vector<std::string> renames; // local_name (resolved via GetUltimate)
+  bool hasOnlyWithRenames{false}; // true if there are renames in an ONLY clause
 
   PreservedUseStmt(std::string modName) : moduleName(std::move(modName)) {}
 };

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -283,9 +283,11 @@ static void emitUseStmtOp(Fortran::lower::AbstractConverter &converter,
   mlir::ArrayAttr renamesAttr =
       renameAttrs.empty() ? mlir::ArrayAttr()
                           : mlir::ArrayAttr::get(context, renameAttrs);
+  mlir::BoolAttr hasOnlyWithRenamesAttr =
+      mlir::BoolAttr::get(context, stmt.hasOnlyWithRenames);
 
   fir::UseStmtOp::create(builder, loc, moduleNameAttr, onlySymbolsAttr,
-                         renamesAttr);
+                         renamesAttr, hasOnlyWithRenamesAttr);
 }
 
 /// Emit fir.module_debug_imports for USE statements in a module.

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -253,6 +253,7 @@ public:
                             std::string localName{
                                 std::get<0>(names.t).source.ToString()};
                             stmt.renames.push_back(localName);
+                            stmt.onlyNames.push_back(localName);
                           },
                           [&](const parser::Rename::Operators &) {
                             // Operator renames - not commonly needed for debug

--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -253,7 +253,7 @@ public:
                             std::string localName{
                                 std::get<0>(names.t).source.ToString()};
                             stmt.renames.push_back(localName);
-                            stmt.onlyNames.push_back(localName);
+                            stmt.hasOnlyWithRenames = true;
                           },
                           [&](const parser::Rename::Operators &) {
                             // Operator renames - not commonly needed for debug

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -823,8 +823,12 @@ void AddDebugInfoPass::handleOnlyClause(
     fir::UseStmtOp useOp, mlir::LLVM::DISubprogramAttr spAttr,
     mlir::LLVM::DIFileAttr fileAttr, mlir::SymbolTable *symbolTable,
     llvm::DenseSet<mlir::LLVM::DIImportedEntityAttr> &importedModules) {
+
+  auto onlySymbols = useOp.getOnlySymbols();
+  auto renames = useOp.getRenames();
+
   // Process ONLY symbols (without renames)
-  if (auto onlySymbols = useOp.getOnlySymbols()) {
+  if (onlySymbols && !renames) {
     for (mlir::Attribute attr : *onlySymbols) {
       auto symbolRef = mlir::cast<mlir::FlatSymbolRefAttr>(attr);
       if (auto importedDecl = createImportedDeclForGlobal(
@@ -835,7 +839,7 @@ void AddDebugInfoPass::handleOnlyClause(
   }
 
   // Process renames within ONLY clause
-  if (auto renames = useOp.getRenames()) {
+  if (renames) {
     for (auto attr : *renames) {
       auto renameAttr = mlir::cast<fir::UseRenameAttr>(attr);
       if (auto importedDecl = createImportedDeclForGlobal(

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -844,10 +844,10 @@ void AddDebugInfoPass::handleOnlyClause(
         }
       }
 
-    if (isInRenames)
-      continue;
+      if (isInRenames)
+        continue;
 
-    if (auto importedDecl = createImportedDeclForGlobal(
+      if (auto importedDecl = createImportedDeclForGlobal(
               symbolRef.getValue(), spAttr, fileAttr, mlir::StringAttr(),
               symbolTable))
         importedModules.insert(*importedDecl);

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -824,11 +824,8 @@ void AddDebugInfoPass::handleOnlyClause(
     mlir::LLVM::DIFileAttr fileAttr, mlir::SymbolTable *symbolTable,
     llvm::DenseSet<mlir::LLVM::DIImportedEntityAttr> &importedModules) {
 
-  auto onlySymbols = useOp.getOnlySymbols();
-  auto renames = useOp.getRenames();
-
   // Process ONLY symbols (without renames)
-  if (onlySymbols) {
+  if (auto onlySymbols = useOp.getOnlySymbols()) {
     for (mlir::Attribute attr : *onlySymbols) {
       auto symbolRef = mlir::cast<mlir::FlatSymbolRefAttr>(attr);
 
@@ -840,7 +837,7 @@ void AddDebugInfoPass::handleOnlyClause(
   }
 
   // Process renames within ONLY clause
-  if (renames) {
+  if (auto renames = useOp.getRenames()) {
     for (auto attr : *renames) {
       auto renameAttr = mlir::cast<fir::UseRenameAttr>(attr);
       if (auto importedDecl = createImportedDeclForGlobal(

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -832,21 +832,6 @@ void AddDebugInfoPass::handleOnlyClause(
     for (mlir::Attribute attr : *onlySymbols) {
       auto symbolRef = mlir::cast<mlir::FlatSymbolRefAttr>(attr);
 
-      // Check if this symbol is also in renames, if so skip it
-      bool isInRenames = false;
-      if (renames) {
-        for (auto renameAttr : *renames) {
-          auto rename = mlir::cast<fir::UseRenameAttr>(renameAttr);
-          if (rename.getSymbol().getValue() == symbolRef.getValue()) {
-            isInRenames = true;
-            break;
-          }
-        }
-      }
-
-      if (isInRenames)
-        continue;
-
       if (auto importedDecl = createImportedDeclForGlobal(
               symbolRef.getValue(), spAttr, fileAttr, mlir::StringAttr(),
               symbolTable))
@@ -928,7 +913,7 @@ void AddDebugInfoPass::expandUseStmtForDebug(
                             /*decl=*/true);
 
   llvm::DenseSet<mlir::LLVM::DIImportedEntityAttr> importedModules;
-  if (useOp.hasOnlyClause())
+  if (useOp.hasOnlyClause() || useOp.getHasOnlyWithRenames())
     handleOnlyClause(useOp, spAttr, fileAttr, symbolTable, importedModules);
   else if (useOp.hasRenames())
     handleRenamesWithoutOnly(useOp, spAttr, modAttr, fileAttr, symbolTable,

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -828,10 +828,26 @@ void AddDebugInfoPass::handleOnlyClause(
   auto renames = useOp.getRenames();
 
   // Process ONLY symbols (without renames)
-  if (onlySymbols && !renames) {
+  if (onlySymbols) {
     for (mlir::Attribute attr : *onlySymbols) {
       auto symbolRef = mlir::cast<mlir::FlatSymbolRefAttr>(attr);
-      if (auto importedDecl = createImportedDeclForGlobal(
+
+      // Check if this symbol is also in renames, if so skip it
+      bool isInRenames = false;
+      if (renames) {
+        for (auto renameAttr : *renames) {
+          auto rename = mlir::cast<fir::UseRenameAttr>(renameAttr);
+          if (rename.getSymbol().getValue() == symbolRef.getValue()) {
+            isInRenames = true;
+            break;
+          }
+        }
+      }
+
+    if (isInRenames)
+      continue;
+
+    if (auto importedDecl = createImportedDeclForGlobal(
               symbolRef.getValue(), spAttr, fileAttr, mlir::StringAttr(),
               symbolTable))
         importedModules.insert(*importedDecl);

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -823,12 +823,10 @@ void AddDebugInfoPass::handleOnlyClause(
     fir::UseStmtOp useOp, mlir::LLVM::DISubprogramAttr spAttr,
     mlir::LLVM::DIFileAttr fileAttr, mlir::SymbolTable *symbolTable,
     llvm::DenseSet<mlir::LLVM::DIImportedEntityAttr> &importedModules) {
-
   // Process ONLY symbols (without renames)
   if (auto onlySymbols = useOp.getOnlySymbols()) {
     for (mlir::Attribute attr : *onlySymbols) {
       auto symbolRef = mlir::cast<mlir::FlatSymbolRefAttr>(attr);
-
       if (auto importedDecl = createImportedDeclForGlobal(
               symbolRef.getValue(), spAttr, fileAttr, mlir::StringAttr(),
               symbolTable))

--- a/flang/test/Integration/debug-use-stmt.f90
+++ b/flang/test/Integration/debug-use-stmt.f90
@@ -26,6 +26,8 @@ end program
 
 ! CHECK-DAG: [[SP:![0-9]+]] = distinct !DISubprogram(name: "TEST_USE", linkageName: "_QQmain"{{.*}}retainedNodes:
 
+! Check that the full testmod module is not imported
+! CHECK-NOT: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[SP]], entity: [[TESTMOD]]
 ! Check testmod imports: var_b directly (no rename), var_d as rename of var_c
 ! CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[SP]], entity: [[VAR_B]],{{.*}}file:{{.*}}line:
 ! CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var_d", scope: [[SP]], entity: [[VAR_C]],{{.*}}file:{{.*}}line:

--- a/flang/test/Lower/debug-use-stmt.f90
+++ b/flang/test/Lower/debug-use-stmt.f90
@@ -73,8 +73,8 @@ end subroutine
 ! NO_DEBUG-NOT: fir.use_stmt
 
 ! WITH_DEBUG-LABEL: func.func @_QPtest_only_rename()
-! WITH_DEBUG-DAG: fir.use_stmt "mod1" only_symbols{{\[}}[@_QMmod1Eb, @_QMmod1Ec, @_QMmod1Ea]] renames{{\[}}[#fir.use_rename<"local_b", @_QMmod1Eb>, #fir.use_rename<"local_a", @_QMmod1Ea>]]
-! WITH_DEBUG-DAG: fir.use_stmt "mod2" only_symbols{{\[}}[@_QMmod2Ex, @_QMmod2Ey]] renames{{\[}}[#fir.use_rename<"local_x", @_QMmod2Ex>, #fir.use_rename<"local_y", @_QMmod2Ey>]]
+! WITH_DEBUG-DAG: fir.use_stmt "mod1" only_symbols{{\[}}[@_QMmod1Ec]] renames{{\[}}[#fir.use_rename<"local_b", @_QMmod1Eb>, #fir.use_rename<"local_a", @_QMmod1Ea>]] hasOnlyWithRenames true
+! WITH_DEBUG-DAG: fir.use_stmt "mod2" renames{{\[}}[#fir.use_rename<"local_x", @_QMmod2Ex>, #fir.use_rename<"local_y", @_QMmod2Ey>]] hasOnlyWithRenames true
 
 ! NO_DEBUG-LABEL: func.func @_QPtest_only_rename()
 ! NO_DEBUG-NOT: fir.use_stmt

--- a/flang/test/Lower/debug-use-stmt.f90
+++ b/flang/test/Lower/debug-use-stmt.f90
@@ -73,8 +73,8 @@ end subroutine
 ! NO_DEBUG-NOT: fir.use_stmt
 
 ! WITH_DEBUG-LABEL: func.func @_QPtest_only_rename()
-! WITH_DEBUG-DAG: fir.use_stmt "mod1" only_symbols{{\[}}[@_QMmod1Ec]] renames{{\[}}[#fir.use_rename<"local_b", @_QMmod1Eb>, #fir.use_rename<"local_a", @_QMmod1Ea>]]
-! WITH_DEBUG-DAG: fir.use_stmt "mod2" renames{{\[}}[#fir.use_rename<"local_x", @_QMmod2Ex>, #fir.use_rename<"local_y", @_QMmod2Ey>]]
+! WITH_DEBUG-DAG: fir.use_stmt "mod1" only_symbols{{\[}}[@_QMmod1Eb, @_QMmod1Ec, @_QMmod1Ea]] renames{{\[}}[#fir.use_rename<"local_b", @_QMmod1Eb>, #fir.use_rename<"local_a", @_QMmod1Ea>]]
+! WITH_DEBUG-DAG: fir.use_stmt "mod2" only_symbols{{\[}}[@_QMmod2Ex, @_QMmod2Ey]] renames{{\[}}[#fir.use_rename<"local_x", @_QMmod2Ex>, #fir.use_rename<"local_y", @_QMmod2Ey>]]
 
 ! NO_DEBUG-LABEL: func.func @_QPtest_only_rename()
 ! NO_DEBUG-NOT: fir.use_stmt


### PR DESCRIPTION
Given the following:

USE mod, ONLY : alias => var

Currently, flang will create a DW_TAG_imported_module tag for mod when it should only be creating a list of DW_TAG_imported_declaration tags for each imported variable.  This causes erroneous variables from mod to be visible in the debugger with undefined information.

The correct logic to do this was previously implemented at line 837 in flang/lib/Optimizer/Transforms/AddDebugInfo.cpp under the comment "// Process renames within ONLY clause".  But this code block would never be invoked as the function handleOnlyClause would never be called as only one of renames or ONLY clauses could be present at once, not both.  This commit fixes the logic and allows the proper code block to be called.

Fixes #180836