### PR TITLE
Revert "Search for @_thisIsNotAPipe vs _thisIsNotAPipe"

### DIFF
--- a/clang/test/CodeGen/2008-07-31-asm-labels.c
+++ b/clang/test/CodeGen/2008-07-31-asm-labels.c
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -emit-llvm -o %t %s
 // RUN: not grep "@pipe()" %t
-// RUN: grep '@_thisIsNotAPipe' %t | count 3
+// RUN: grep '_thisIsNotAPipe' %t | count 3
 // RUN: not grep '@g0' %t
-// RUN: grep '@_renamed' %t | count 2
+// RUN: grep '_renamed' %t | count 2
 // RUN: %clang_cc1 -DUSE_DEF -emit-llvm -o %t %s
 // RUN: not grep "@pipe()" %t
-// RUN: grep '@_thisIsNotAPipe' %t | count 3
+// RUN: grep '_thisIsNotAPipe' %t | count 3
 // <rdr://6116729>
 
 void pipe() asm("_thisIsNotAPipe");


### PR DESCRIPTION
Reverts llvm/llvm-project#192132, which broke the `Clang :: CodeGen/2008-07-31-asm-labels.c` on mac.