### PR TITLE
[libcxx] Remove NODEBUG, ALWAYS_INLINE from __swap_layouts

### DIFF
--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -814,7 +814,7 @@ private:
     return __p;
   }
 
-  _LIBCPP_NODEBUG _LIBCPP_ALWAYS_INLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
   __swap_layouts(_SplitBuffer& __sb) {
     __sb.__swap_layouts(__begin_, __end_, __cap_);
   }

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -814,8 +814,7 @@ private:
     return __p;
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
-  __swap_layouts(_SplitBuffer& __sb) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __swap_layouts(_SplitBuffer& __sb) {
     __sb.__swap_layouts(__begin_, __end_, __cap_);
   }
 };


### PR DESCRIPTION
This addresses reviewer feedback on #180102.

We've seen

```
error: No debug information found in function
_ZNSt4__Cr6vectorIN4bssl3der5InputENS_9allocatorIS3_EEE14__swap_layoutsERNS_14__split_bufferIS3_S5_NS_29__split_buffer_pointer_layoutEEE:
Function profile not used [-Werror,-Wbackend-plugin]
```

on an internal bot due to the _LIBCPP_NODEBUG.