### PR TITLE
[SandboxIR] Implement helper getLoadStoreAddressSpace()

### DIFF
--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -2746,6 +2746,20 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+//                          Helper functions
+//===----------------------------------------------------------------------===//
+
+/// A helper function that returns the address space of the pointer operand of
+/// load or store instruction.
+inline unsigned getLoadStoreAddressSpace(const Instruction *I) {
+  assert((isa<LoadInst>(I) || isa<StoreInst>(I)) &&
+         "Expected Load or Store instruction");
+  if (auto *LI = dyn_cast<LoadInst>(I))
+    return LI->getPointerAddressSpace();
+  return cast<StoreInst>(I)->getPointerAddressSpace();
+}
+
 } // namespace llvm::sandboxir
 
 #endif // LLVM_SANDBOXIR_INSTRUCTION_H

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/SeedCollection.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/SeedCollection.cpp
@@ -48,14 +48,6 @@ SeedCollection::SeedCollection(StringRef Pipeline, StringRef AuxArg)
   }
 }
 
-static unsigned getAddressSpace(const Instruction *I) {
-  if (auto *LI = dyn_cast<LoadInst>(I))
-    return LI->getPointerAddressSpace();
-  if (auto *SI = dyn_cast<StoreInst>(I))
-    return SI->getPointerAddressSpace();
-  return 0;
-}
-
 bool SeedCollection::runOnFunction(Function &F, const Analyses &A) {
   bool Change = false;
   const auto &DL = F.getParent()->getDataLayout();
@@ -71,7 +63,7 @@ bool SeedCollection::runOnFunction(Function &F, const Analyses &A) {
           Utils::getNumBits(VecUtils::getElementType(Utils::getExpectedType(
                                 Seeds[Seeds.getFirstUnusedElementIdx()])),
                             DL);
-      unsigned AS = getAddressSpace(Seeds[0]);
+      unsigned AS = getLoadStoreAddressSpace(Seeds[0]);
       unsigned VecRegBits = OverrideVecRegBits != 0
                                 ? OverrideVecRegBits
                                 : A.getTTI().getLoadStoreVecRegBitWidth(AS);

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -3229,6 +3229,8 @@ define void @foo(ptr %arg0, ptr %arg1) {
   // Check getPointerAddressSpace()
   EXPECT_EQ(NewLd->getPointerAddressSpace(),
             Arg1->getType()->getPointerAddressSpace());
+  // Check helper function getLoadStoreAddressSpace()
+  EXPECT_EQ(getLoadStoreAddressSpace(NewLd), NewLd->getPointerAddressSpace());
   EXPECT_EQ(NewLd->getAlign(), 8);
   EXPECT_EQ(NewLd->getName(), "NewLd");
   // Check create(InsertBefore, IsVolatile=true)
@@ -3299,6 +3301,15 @@ define void @foo(i8 %val, ptr %ptr) {
   // Check getPointerAddressSpace()
   EXPECT_EQ(St->getPointerAddressSpace(),
             Ptr->getType()->getPointerAddressSpace());
+  // Check helper function getLoadStoreAddressSpace(St)
+  EXPECT_EQ(getLoadStoreAddressSpace(St), St->getPointerAddressSpace());
+  EXPECT_EQ(
+      getLoadStoreAddressSpace(const_cast<const sandboxir::StoreInst *>(St)),
+      St->getPointerAddressSpace());
+#ifndef NDEBUG
+  // Check the assertion in getLoadStoreAddressSpace(Ret) if not a load or store
+  EXPECT_DEATH(getLoadStoreAddressSpace(Ret), ".*Expected.*");
+#endif
   // Check getAlign()
   EXPECT_EQ(St->getAlign(), 64);
   // Check create(InsertBefore)


### PR DESCRIPTION
This is similar to LLVM IR's getLoadStoreAddressSpace(), but with an `Instruction *` argument instead of a `Value *`.