### PR TITLE
[LV] Remove some unneeded logs

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -748,7 +748,7 @@ void reportVectorizationFailure(const StringRef DebugMsg,
                                 OptimizationRemarkEmitter *ORE, Loop *TheLoop,
                                 Instruction *I) {
   LLVM_DEBUG(debugVectorizationMessage("Not vectorizing: ", DebugMsg, I));
-  LoopVectorizeHints Hints(TheLoop, true /* doesn't matter */, *ORE);
+  LoopVectorizeHints Hints(TheLoop, false /* doesn't matter */, *ORE);
   ORE->emit(
       createLVAnalysis(Hints.vectorizeAnalysisPassName(), ORETag, TheLoop, I)
       << "loop not vectorized: " << OREMsg);
@@ -758,7 +758,7 @@ void reportVectorizationInfo(const StringRef Msg, const StringRef ORETag,
                              OptimizationRemarkEmitter *ORE,
                              const Loop *TheLoop, Instruction *I, DebugLoc DL) {
   LLVM_DEBUG(debugVectorizationMessage("", Msg, I));
-  LoopVectorizeHints Hints(TheLoop, true /* doesn't matter */, *ORE);
+  LoopVectorizeHints Hints(TheLoop, false /* doesn't matter */, *ORE);
   ORE->emit(createLVAnalysis(Hints.vectorizeAnalysisPassName(), ORETag, TheLoop,
                              I, DL)
             << Msg);

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1788,7 +1788,8 @@ void LoopVectorizationPlanner::updateLoopMetadataAndProfileInfo(
       if (DisableRuntimeUnroll)
         addRuntimeUnrollDisableMetaData(OrigLoop);
 
-      LoopVectorizeHints Hints(OrigLoop, true, *ORE);
+      LoopVectorizeHints Hints(OrigLoop, /*InterleaveOnlyWhenForced*/ false,
+                               *ORE);
       Hints.setAlreadyVectorized();
     }
   }
@@ -1807,7 +1808,8 @@ void LoopVectorizationPlanner::updateLoopMetadataAndProfileInfo(
       VectorLoop->setLoopID(OrigLoopID);
 
     if (!VectorizingEpilogue) {
-      LoopVectorizeHints Hints(VectorLoop, true, *ORE);
+      LoopVectorizeHints Hints(VectorLoop, /*InterleaveOnlyWhenForced*/ false,
+                               *ORE);
       Hints.setAlreadyVectorized();
     }
   }

--- a/llvm/test/Transforms/LoopVectorize/interleave-when-forced-opt.ll
+++ b/llvm/test/Transforms/LoopVectorize/interleave-when-forced-opt.ll
@@ -1,0 +1,26 @@
+; REQUIRES: asserts
+; RUN: opt -passes='loop-vectorize<interleave-forced-only>' -debug-only=loop-vectorize --disable-output -S %s 2>&1 | FileCheck --check-prefix=CHECK-INTERLEAVE-FORCED %s
+; RUN: opt -passes=loop-vectorize -debug-only=loop-vectorize --disable-output -S %s 2>&1 | FileCheck --check-prefix=CHECK-INTERLEAVE-NOT-FORCED %s
+
+
+; CHECK-INTERLEAVE-FORCED-LABEL: LV: Checking a loop in 'test_interleave_when_forced_opt'
+; CHECK-INTERLEAVE-FORCED:  LV: Interleaving disabled by the pass manager
+
+; CHECK-INTERLEAVE-NOT-FORCED-LABEL: LV: Checking a loop in 'test_interleave_when_forced_opt'
+; CHECK-INTERLEAVE-NOT-FORCED-NOT:  LV: Interleaving disabled by the pass manager
+
+define void @test_interleave_when_forced_opt(ptr %dst, i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add i64 %iv, 1
+  %gep = getelementptr i8, ptr %dst, i64 %iv
+  store i8 0, ptr %gep, align 1
+  %ec = icmp ult i64 %iv.next, %n
+  br i1 %ec, label %loop, label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/LoopVectorize/uncountable-single-exit-loops.ll
+++ b/llvm/test/Transforms/LoopVectorize/uncountable-single-exit-loops.ll
@@ -5,14 +5,12 @@
 ; CHECK-LABEL: LV: Checking a loop in 'latch_exit_cannot_compute_btc_due_to_step'
 ; CHECK: 	   LV: Did not find one integer induction var.
 ; CHECK-NEXT:  LV: Not vectorizing: Cannot vectorize uncountable loop.
-; CHECK-NEXT:  LV: Interleaving disabled by the pass manager
 ; CHECK-NEXT:  LV: Not vectorizing: Cannot prove legality.
 
 ; CHECK-LABEL: LV: Checking a loop in 'header_exit_cannot_compute_btc_due_to_step'
 ; CHECK:       LV: Found an induction variable.
 ; CHECK-NEXT:  LV: Did not find one integer induction var.
 ; CHECK-NEXT:  LV: Not vectorizing: Cannot vectorize uncountable loop.
-; CHECK-NEXT:  LV: Interleaving disabled by the pass manager
 ; CHECK-NEXT:  LV: Not vectorizing: Cannot prove legality.
 
 ; CHECK-NOT: vector.body


### PR DESCRIPTION
Sometimes we get interleave-related logs just because we initialize `LoopVectorizeHints` instance which emits logs.
Change the initialization a little to prevent the logs.