### PR TITLE
[RISCV] Remove isAsmParserOnly from LongBccPseudo and LongBcciPseudo.  NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1753,7 +1753,6 @@ class LongBccPseudo : Pseudo<(outs),
   let hasSideEffects = 0;
   let mayStore = 0;
   let mayLoad = 0;
-  let isAsmParserOnly = 1;
   let hasNoSchedulingInfo = 1;
 }
 
@@ -1767,7 +1766,6 @@ class LongBcciPseudo<DAGOperand InTyImm, int size>
   let hasSideEffects = 0;
   let mayStore = 0;
   let mayLoad = 0;
-  let isAsmParserOnly = 1;
   let hasNoSchedulingInfo = 1;
 }
 


### PR DESCRIPTION
These instructions are created by assembler relaxation. They aren't "parsed.". isAsmParserOnly suppresses the disassembler for these, but that was already suppressed by isPseudo and isCodeGenOnly.