### PR TITLE
[lldb][windows] fix command source hitting EOF

### DIFF
--- a/lldb/include/lldb/Host/FileBase.h
+++ b/lldb/include/lldb/Host/FileBase.h
@@ -374,6 +374,9 @@ protected:
   /// appropriate platform-specific terminal probing.
   virtual void CalculateInteractiveAndTerminal();
 
+  /// Called after a stream is successfully opened from a descriptor.
+  virtual void OnStreamOpened() {}
+
 private:
   File(const File &) = delete;
   const File &operator=(const File &) = delete;

--- a/lldb/include/lldb/Host/windows/FileWindows.h
+++ b/lldb/include/lldb/Host/windows/FileWindows.h
@@ -48,6 +48,8 @@ protected:
   bool TryWriteStreamUnlocked(const void *buf, size_t &num_bytes,
                               Status &error) override;
 
+  void OnStreamOpened() override;
+
 private:
   /// Set when this file wraps stdin/stdout/stderr connected to a console;
   /// triggers the raw_fd_ostream path for correct non-ASCII output.

--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -288,7 +288,7 @@ FILE *NativeFileBase::GetStream() {
       llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor, mode.get());
 
   // If we got a stream, then we own the stream and should no longer own
-  // the descriptor because fclose() will close it for us
+  // the descriptor because fclose() will close it for us.
   if (m_stream) {
     m_own_stream = true;
     m_own_descriptor = false;

--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -264,30 +264,34 @@ IOObject::WaitableHandle NativeFileBase::GetWaitableHandle() {
 
 FILE *NativeFileBase::GetStream() {
   ValueGuard stream_guard = StreamIsValid();
-  if (!stream_guard) {
-    if (ValueGuard descriptor_guard = DescriptorIsValid()) {
-      auto mode = GetStreamOpenModeFromOptions(m_options);
-      if (!mode)
-        llvm::consumeError(mode.takeError());
-      else {
-        if (!m_own_descriptor) {
-          // We must duplicate the file descriptor if we don't own it because
-          // when you call fdopen, the stream will own the fd.
-          m_descriptor = Dup(m_descriptor);
-          m_own_descriptor = true;
-        }
+  if (stream_guard)
+    return m_stream;
 
-        m_stream = llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor,
-                                               mode.get());
+  ValueGuard descriptor_guard = DescriptorIsValid();
+  if (!descriptor_guard)
+    return m_stream;
 
-        // If we got a stream, then we own the stream and should no longer own
-        // the descriptor because fclose() will close it for us
+  auto mode = GetStreamOpenModeFromOptions(m_options);
+  if (!mode)
+    llvm::consumeError(mode.takeError());
+  else {
+    if (!m_own_descriptor) {
+      // We must duplicate the file descriptor if we don't own it because
+      // when you call fdopen, the stream will own the fd.
+      m_descriptor = Dup(m_descriptor);
+      m_own_descriptor = true;
+    }
 
-        if (m_stream) {
-          m_own_stream = true;
-          m_own_descriptor = false;
-        }
-      }
+    m_stream = llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor,
+                                           mode.get());
+
+    // If we got a stream, then we own the stream and should no longer own
+    // the descriptor because fclose() will close it for us
+
+    if (m_stream) {
+      m_own_stream = true;
+      m_own_descriptor = false;
+      OnStreamOpened();
     }
   }
   return m_stream;

--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -272,28 +272,29 @@ FILE *NativeFileBase::GetStream() {
     return m_stream;
 
   auto mode = GetStreamOpenModeFromOptions(m_options);
-  if (!mode)
+  if (!mode) {
     llvm::consumeError(mode.takeError());
-  else {
-    if (!m_own_descriptor) {
-      // We must duplicate the file descriptor if we don't own it because
-      // when you call fdopen, the stream will own the fd.
-      m_descriptor = Dup(m_descriptor);
-      m_own_descriptor = true;
-    }
-
-    m_stream = llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor,
-                                           mode.get());
-
-    // If we got a stream, then we own the stream and should no longer own
-    // the descriptor because fclose() will close it for us
-
-    if (m_stream) {
-      m_own_stream = true;
-      m_own_descriptor = false;
-      OnStreamOpened();
-    }
+    return m_stream;
   }
+
+  if (!m_own_descriptor) {
+    // We must duplicate the file descriptor if we don't own it because
+    // when you call fdopen, the stream will own the fd.
+    m_descriptor = Dup(m_descriptor);
+    m_own_descriptor = true;
+  }
+
+  m_stream =
+      llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor, mode.get());
+
+  // If we got a stream, then we own the stream and should no longer own
+  // the descriptor because fclose() will close it for us
+  if (m_stream) {
+    m_own_stream = true;
+    m_own_descriptor = false;
+    OnStreamOpened();
+  }
+
   return m_stream;
 }
 

--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/FileSpec.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/VASPrintf.h"
 #include "llvm/ADT/StringExtras.h"
@@ -271,11 +272,13 @@ FILE *NativeFileBase::GetStream() {
   if (!descriptor_guard)
     return m_stream;
 
-  auto mode = GetStreamOpenModeFromOptions(m_options);
-  if (!mode) {
-    llvm::consumeError(mode.takeError());
+  auto mode_or_err = GetStreamOpenModeFromOptions(m_options);
+  if (!mode_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Object), mode_or_err.takeError(),
+                   "Failed to get stream options: {0}");
     return m_stream;
   }
+  const char *mode = *mode_or_err;
 
   if (!m_own_descriptor) {
     // We must duplicate the file descriptor if we don't own it because
@@ -284,8 +287,7 @@ FILE *NativeFileBase::GetStream() {
     m_own_descriptor = true;
   }
 
-  m_stream =
-      llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor, mode.get());
+  m_stream = llvm::sys::RetryAfterSignal(nullptr, ::fdopen, m_descriptor, mode);
 
   // If we got a stream, then we own the stream and should no longer own
   // the descriptor because fclose() will close it for us.

--- a/lldb/source/Host/windows/FileWindows.cpp
+++ b/lldb/source/Host/windows/FileWindows.cpp
@@ -143,4 +143,9 @@ Status NativeFileWindows::Write(const void *buf, size_t &num_bytes,
   return error;
 }
 
+void NativeFileWindows::OnStreamOpened() {
+  if ((m_options & OpenOptionsModeMask) == eOpenOptionReadOnly)
+    setvbuf(m_stream, nullptr, _IONBF, 0);
+}
+
 char NativeFileWindows::ID = 0;

--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -679,7 +679,6 @@ class FileHandleTestCase(lldbtest.TestBase):
             lines = [x for x in f.read().strip().split() if x != "7"]
             self.assertEqual(lines, ["foobar"])
 
-    @skipIf(hostoslist=["windows"])
     def test_stdout_file_interactive(self):
         """Ensure when we read stdin from a file, outputs from python goes to the right I/O stream."""
         with open(self.in_filename, "w") as f:


### PR DESCRIPTION
When a command source file contained `script --language python --`, Python's interactive REPL would exit immediately on Windows.

Disabling buffering on read-only file fixes the issue. `fgets` now makes one OS read per line and the fd stays in sync with was has been logically consumed.

rdar://168064451