### PR TITLE
[libc] Move function argument from rpc::dispatch to template

### DIFF
--- a/flang-rt/lib/runtime/io-api-gpu.cpp
+++ b/flang-rt/lib/runtime/io-api-gpu.cpp
@@ -28,91 +28,92 @@ RT_EXT_API_GROUP_BEGIN
 
 Cookie IODEF(BeginExternalListOutput)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
-  return rpc::dispatch<BeginExternalListOutput_Opcode>(client,
-      IONAME(BeginExternalListOutput), unitNumber, sourceFile, sourceLine);
+  return rpc::dispatch<BeginExternalListOutput_Opcode,
+      IONAME(BeginExternalListOutput)>(
+      client, unitNumber, sourceFile, sourceLine);
 }
 
 Cookie IODEF(BeginExternalFormattedOutput)(const char *format,
     std::size_t formatLength, const Descriptor *formatDescriptor,
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
-  return rpc::dispatch<BeginExternalFormattedOutput_Opcode>(client,
-      IONAME(BeginExternalFormattedOutput),
+  return rpc::dispatch<BeginExternalFormattedOutput_Opcode,
+      IONAME(BeginExternalFormattedOutput)>(client,
       rpc::span<const char>{format, formatLength}, formatLength,
       formatDescriptor, unitNumber, sourceFile, sourceLine);
 }
 
 void IODEF(EnableHandlers)(Cookie cookie, bool hasIoStat, bool hasErr,
     bool hasEnd, bool hasEor, bool hasIoMsg) {
-  return rpc::dispatch<EnableHandlers_Opcode>(client, IONAME(EnableHandlers),
-      cookie, hasIoStat, hasErr, hasEnd, hasEor, hasIoMsg);
+  return rpc::dispatch<EnableHandlers_Opcode, IONAME(EnableHandlers)>(
+      client, cookie, hasIoStat, hasErr, hasEnd, hasEor, hasIoMsg);
 }
 
 enum Iostat IODEF(EndIoStatement)(Cookie cookie) {
-  return rpc::dispatch<EndIoStatement_Opcode>(
-      client, IONAME(EndIoStatement), cookie);
+  return rpc::dispatch<EndIoStatement_Opcode, IONAME(EndIoStatement)>(
+      client, cookie);
 }
 
 bool IODEF(OutputInteger8)(Cookie cookie, std::int8_t n) {
-  return rpc::dispatch<OutputInteger8_Opcode>(
-      client, IONAME(OutputInteger8), cookie, n);
+  return rpc::dispatch<OutputInteger8_Opcode, IONAME(OutputInteger8)>(
+      client, cookie, n);
 }
 
 bool IODEF(OutputInteger16)(Cookie cookie, std::int16_t n) {
-  return rpc::dispatch<OutputInteger16_Opcode>(
-      client, IONAME(OutputInteger16), cookie, n);
+  return rpc::dispatch<OutputInteger16_Opcode, IONAME(OutputInteger16)>(
+      client, cookie, n);
 }
 
 bool IODEF(OutputInteger32)(Cookie cookie, std::int32_t n) {
-  return rpc::dispatch<OutputInteger32_Opcode>(
-      client, IONAME(OutputInteger32), cookie, n);
+  return rpc::dispatch<OutputInteger32_Opcode, IONAME(OutputInteger32)>(
+      client, cookie, n);
 }
 
 bool IODEF(OutputInteger64)(Cookie cookie, std::int64_t n) {
-  return rpc::dispatch<OutputInteger64_Opcode>(
-      client, IONAME(OutputInteger64), cookie, n);
+  return rpc::dispatch<OutputInteger64_Opcode, IONAME(OutputInteger64)>(
+      client, cookie, n);
 }
 
 #ifdef __SIZEOF_INT128__
 bool IODEF(OutputInteger128)(Cookie cookie, common::int128_t n) {
-  return rpc::dispatch<OutputInteger128_Opcode>(
-      client, IONAME(OutputInteger128), cookie, n);
+  return rpc::dispatch<OutputInteger128_Opcode, IONAME(OutputInteger128)>(
+      client, cookie, n);
 }
 #endif
 
 bool IODEF(OutputReal32)(Cookie cookie, float x) {
-  return rpc::dispatch<OutputReal32_Opcode>(
-      client, IONAME(OutputReal32), cookie, x);
+  return rpc::dispatch<OutputReal32_Opcode, IONAME(OutputReal32)>(
+      client, cookie, x);
 }
 
 bool IODEF(OutputReal64)(Cookie cookie, double x) {
-  return rpc::dispatch<OutputReal64_Opcode>(
-      client, IONAME(OutputReal64), cookie, x);
+  return rpc::dispatch<OutputReal64_Opcode, IONAME(OutputReal64)>(
+      client, cookie, x);
 }
 
 bool IODEF(OutputComplex32)(Cookie cookie, float re, float im) {
-  return rpc::dispatch<OutputComplex32_Opcode>(
-      client, IONAME(OutputComplex32), cookie, re, im);
+  return rpc::dispatch<OutputComplex32_Opcode, IONAME(OutputComplex32)>(
+      client, cookie, re, im);
 }
 
 bool IODEF(OutputComplex64)(Cookie cookie, double re, double im) {
-  return rpc::dispatch<OutputComplex64_Opcode>(
-      client, IONAME(OutputComplex64), cookie, re, im);
+  return rpc::dispatch<OutputComplex64_Opcode, IONAME(OutputComplex64)>(
+      client, cookie, re, im);
 }
 
 bool IODEF(OutputAscii)(Cookie cookie, const char *x, std::size_t length) {
-  return rpc::dispatch<OutputAscii_Opcode>(client, IONAME(OutputAscii), cookie,
-      rpc::span<const char>{x, length}, length);
+  return rpc::dispatch<OutputAscii_Opcode, IONAME(OutputAscii)>(
+      client, cookie, rpc::span<const char>{x, length}, length);
 }
 
 bool IODEF(OutputCharacter)(
     Cookie cookie, const char *x, std::size_t length, int kind) {
-  return rpc::dispatch<OutputCharacter_Opcode>(client, IONAME(OutputCharacter),
-      cookie, rpc::span<const char>{x, length * kind}, length, kind);
+  return rpc::dispatch<OutputCharacter_Opcode, IONAME(OutputCharacter)>(
+      client, cookie, rpc::span<const char>{x, length * kind}, length, kind);
 }
 
 bool IODEF(OutputLogical)(Cookie cookie, bool truth) {
-  return rpc::dispatch<OutputLogical_Opcode>(
-      client, IONAME(OutputLogical), cookie, truth);
+  return rpc::dispatch<OutputLogical_Opcode, IONAME(OutputLogical)>(
+      client, cookie, truth);
 }
 
 RT_EXT_API_GROUP_END

--- a/libc/docs/gpu/rpc.rst
+++ b/libc/docs/gpu/rpc.rst
@@ -177,7 +177,7 @@ than submitting asynchronously.
 
   // Client-side dispatch.
   double fn(int x, long y, char c, double d) {
-    return rpc::dispatch<OPCODE>(client, fn, x, y, c, d);
+    return rpc::dispatch<OPCODE, fn>(client, x, y, c, d);
   }
 
   // Server-side handling.

--- a/libc/shared/rpc_dispatch.h
+++ b/libc/shared/rpc_dispatch.h
@@ -194,10 +194,10 @@ RPC_ATTRS constexpr void finish_args(rpc::Server::Port &port, State &&state,
 
 // Dispatch a function call to the server through the RPC mechanism. Copies the
 // argument list through the RPC interface.
-template <uint32_t OPCODE, typename FnTy, typename... CallArgs>
-RPC_ATTRS constexpr typename function_traits<FnTy>::return_type
-dispatch(rpc::Client &client, FnTy, CallArgs... args) {
-  using Traits = function_traits<FnTy>;
+template <uint32_t OPCODE, auto Fn, typename... CallArgs>
+RPC_ATTRS constexpr typename function_traits<decltype(Fn)>::return_type
+dispatch(rpc::Client &client, CallArgs... args) {
+  using Traits = function_traits<decltype(Fn)>;
   using RetTy = typename Traits::return_type;
   using TupleTy = typename Traits::arg_types;
   using Bytes = tuple_bytes<rpc::remove_span_t<CallArgs>...>;

--- a/offload/test/libc/rpc_callback.cpp
+++ b/offload/test/libc/rpc_callback.cpp
@@ -98,32 +98,32 @@ int sum_array(const int *arr, int n) {
 
 #pragma omp begin declare variant match(device = {kind(gpu)})
 int foo(int x, double d, char c) {
-  return rpc::dispatch<FOO_OPCODE>(client, foo, x, d, c);
+  return rpc::dispatch<FOO_OPCODE, foo>(client, x, d, c);
 }
 
-void void_fn(int x) { rpc::dispatch<VOID_OPCODE>(client, void_fn, x); }
+void void_fn(int x) { rpc::dispatch<VOID_OPCODE, void_fn>(client, x); }
 
 void writeback_fn(int *out) {
-  rpc::dispatch<WRITEBACK_OPCODE>(client, writeback_fn, out);
+  rpc::dispatch<WRITEBACK_OPCODE, writeback_fn>(client, out);
 }
 
 int sum_const(const S *p) {
-  return rpc::dispatch<CONST_PTR_OPCODE>(client, sum_const, p);
+  return rpc::dispatch<CONST_PTR_OPCODE, sum_const>(client, p);
 }
 
 int c_string(const char *s) {
-  return rpc::dispatch<STRING_OPCODE>(client, c_string, s);
+  return rpc::dispatch<STRING_OPCODE, c_string>(client, s);
 }
 
-int empty() { return rpc::dispatch<EMPTY_OPCODE>(client, empty); }
+int empty() { return rpc::dispatch<EMPTY_OPCODE, empty>(client); }
 
 void divergent(int *p) {
-  rpc::dispatch<DIVERGENT_OPCODE>(client, divergent, p);
+  rpc::dispatch<DIVERGENT_OPCODE, divergent>(client, p);
 }
 
 int sum_array(const int *arr, int n) {
-  return rpc::dispatch<ARRAY_SUM_OPCODE>(
-      client, sum_array, rpc::span<const int>{arr, uint64_t(n)}, n);
+  return rpc::dispatch<ARRAY_SUM_OPCODE, sum_array>(
+      client, rpc::span<const int>{arr, uint64_t(n)}, n);
 }
 #pragma omp end declare variant
 


### PR DESCRIPTION
Summary:
This was previous put here for ergnomics as to put it in the template
required decltype. However, this has the effect of putting an actual
functoin pointer in an escaping context if it is not fully removed or
inlined. C++17 has a non-type-template parameter that we can use to
keep the interface clean. Use that instead.
