### PR TITLE
[RISCV] Remove isAsmParserOnly from isPseudo instructions. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -334,7 +334,6 @@ class PseudoLoad<string opcodestr, DAGOperand rdty = GPR>
   let mayLoad = 1;
   let mayStore = 0;
   let isCodeGenOnly = 0;
-  let isAsmParserOnly = 1;
 }
 
 class PseudoFloatLoad<string opcodestr, RegisterClass rdty>
@@ -343,7 +342,6 @@ class PseudoFloatLoad<string opcodestr, RegisterClass rdty>
   let mayLoad = 1;
   let mayStore = 0;
   let isCodeGenOnly = 0;
-  let isAsmParserOnly = 1;
 }
 
 // Pseudo store instructions.
@@ -353,7 +351,6 @@ class PseudoStore<string opcodestr, DAGOperand rsty = GPR>
   let mayLoad = 0;
   let mayStore = 1;
   let isCodeGenOnly = 0;
-  let isAsmParserOnly = 1;
 }
 
 // Instruction formats are listed in the order they appear in the RISC-V

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1025,7 +1025,7 @@ def DRET : Priv<"dret", 0b0111101>, Sched<[]> {
 // matter since PseudoLI is currently only used in the AsmParser where it gets
 // expanded to real instructions immediately.
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 32,
-    isCodeGenOnly = 0, isAsmParserOnly = 1 in
+    isCodeGenOnly = 0 in
 def PseudoLI : Pseudo<(outs GPR:$rd), (ins ixlenimm_li:$imm), [],
                       "li", "$rd, $imm">;
 
@@ -1888,14 +1888,14 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
 def PseudoMovImm : Pseudo<(outs GPR:$dst), (ins i32imm:$imm), []>,
                    Sched<[WriteIALU]>;
 
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLLA : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                        "lla", "$dst, $src">;
 
 // Refer to comment on PseudoLI for explanation of Size=32
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLLAImm : Pseudo<(outs GPR:$dst), (ins ixlenimm_li_restricted:$imm), [],
                           "lla", "$dst, $imm">;
 def : Pat<(riscv_lla tglobaladdr:$in), (PseudoLLA tglobaladdr:$in)>;
@@ -1903,29 +1903,29 @@ def : Pat<(riscv_lla tblockaddress:$in), (PseudoLLA tblockaddress:$in)>;
 def : Pat<(riscv_lla tjumptable:$in), (PseudoLLA tjumptable:$in)>;
 def : Pat<(riscv_lla tconstpool:$in), (PseudoLLA tconstpool:$in)>;
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLGA : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                        "lga", "$dst, $src">;
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLA : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                       "la", "$dst, $src">;
 
 // Refer to comment on PseudoLI for explanation of Size=32
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 32,
-    isCodeGenOnly = 0, isAsmParserOnly = 1 in
+    isCodeGenOnly = 0 in
 def PseudoLAImm : Pseudo<(outs GPR:$rd), (ins ixlenimm_li_restricted:$imm), [],
                          "la", "$rd, $imm">;
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLA_TLS_IE : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                              "la.tls.ie", "$dst, $src">;
 
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
+    isCodeGenOnly = 0 in
 def PseudoLA_TLS_GD : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                              "la.tls.gd", "$dst, $src">;
 
@@ -1965,7 +1965,7 @@ def PseudoTLSDESCCall : Pseudo<(outs GPR:$rd),
 // There are single-instruction versions of these in Zbb, so disable these
 // Pseudos if that extension is present.
 let hasSideEffects = 0, mayLoad = 0,
-    mayStore = 0, isCodeGenOnly = 0, isAsmParserOnly = 1 in {
+    mayStore = 0, isCodeGenOnly = 0 in {
 def PseudoSEXT_B : Pseudo<(outs GPR:$rd), (ins GPR:$rs), [], "sext.b", "$rd, $rs">;
 def PseudoSEXT_H : Pseudo<(outs GPR:$rd), (ins GPR:$rs), [], "sext.h", "$rd, $rs">;
 // rv64's sext.w is defined above, using InstAlias<"sext.w ...
@@ -1974,7 +1974,7 @@ def PseudoZEXT_H : Pseudo<(outs GPR:$rd), (ins GPR:$rs), [], "zext.h", "$rd, $rs
 } // hasSideEffects = 0, ...
 
 let Predicates = [IsRV64], hasSideEffects = 0, mayLoad = 0, mayStore = 0,
-  isCodeGenOnly = 0, isAsmParserOnly = 1 in {
+  isCodeGenOnly = 0 in {
 def PseudoZEXT_W : Pseudo<(outs GPR:$rd), (ins GPR:$rs), [], "zext.w", "$rd, $rs">;
 } // Predicates = [IsRV64], ...
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -344,8 +344,7 @@ def C_ADDI : RVInst16CI<0b000, OPC_C1, (outs GPRNoX0:$rd_wb),
 }
 
 // Alternate syntax for c.nop. Converted to C_NOP/C_NOP_HINT by the assembler.
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 0,
-    isAsmParserOnly = 1 in
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 0 in
 def PseudoC_ADDI_NOP : Pseudo<(outs GPRX0:$rd), (ins GPRX0:$rs1, simm6:$imm),
                               [], "c.addi", "$rd, $imm"> {
   let Constraints = "$rs1 = $rd";

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -1293,7 +1293,7 @@ def : InstAlias<"vmsge.vv $vd, $va, $vb$vm",
 
 let ElementsDependOn = EltDepsNone in {
 
-let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
+let isCodeGenOnly = 0, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0, DestEEW = EEW1 in {
 // For unsigned comparisons we need to special case 0 immediate to maintain
 // the always true/false semantics we would invert if we just decremented the
@@ -1316,7 +1316,7 @@ def PseudoVMSLT_VI : Pseudo<(outs VR:$vd),
                             [], "vmslt.vi", "$vd, $vs2, $imm$vm">;
 }
 
-let isCodeGenOnly = 0, isAsmParserOnly = 1, hasSideEffects = 0, mayLoad = 0,
+let isCodeGenOnly = 0, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0, DestEEW = EEW1 in {
 def PseudoVMSGEU_VX : Pseudo<(outs VR:$vd),
                              (ins VR:$vs2, GPR:$rs1),


### PR DESCRIPTION
isAsmParserOnly is only used to suppress DecoderEmiter, but that's already supressed by isPseudo. The real usage for this should be for instructions that have encoding information but we don't want to disassemble.

Many of these pseudos are emitted from codegen meaning they aren't really assembler only. So you can't argue this flag is good for documentation either.