### PR TITLE
[VPlan] Include wide IVs with NUW as monotonic in verifier.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -148,7 +148,7 @@ static bool isKnownMonotonic(VPValue *V) {
     return true;
   // Only handle a subset of IVs until we can guarantee there's no overflow.
   if (auto *WidenIV = dyn_cast<VPWidenIntOrFpInductionRecipe>(V))
-    return WidenIV->isCanonical();
+    return WidenIV->isCanonical() || WidenIV->hasNoUnsignedWrap();
   if (auto *Steps = dyn_cast<VPScalarIVStepsRecipe>(V))
     return match(Steps->getOperand(0),
                  m_CombineOr(


### PR DESCRIPTION
This fixes a verifier failure after
https://github.com/llvm/llvm-project/pull/194267 due to a wide IV being narrowed during later optimizations.

This is in line how we treat other recipes, like adds, in the verifier check.

Should fix https://lab.llvm.org/buildbot/#/builders/187/builds/19595.