### PR TITLE
[Flang][Fir] Set default alignment of array globals to 64 bytes

### DIFF
--- a/flang/include/flang/Lower/ConvertConstant.h
+++ b/flang/include/flang/Lower/ConvertConstant.h
@@ -65,7 +65,8 @@ fir::GlobalOp tryCreatingDenseGlobal(fir::FirOpBuilder &builder,
                                      llvm::StringRef globalName,
                                      mlir::StringAttr linkage, bool isConst,
                                      const Fortran::lower::SomeExpr &initExpr,
-                                     cuf::DataAttributeAttr dataAttr = {});
+                                     cuf::DataAttributeAttr dataAttr = {},
+                                     bool setDefaultAlignment = true);
 
 /// Lower a StructureConstructor that must be lowered in read only data although
 /// it may not be wrapped into a Constant<T> (this may be the case for derived

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -40,6 +40,8 @@ class ExtendedValue;
 class MutableBoxValue;
 class BoxValue;
 
+/// Default alignment (in bytes) applied to array globals.
+constexpr unsigned defaultArrayGlobalAlignment = 64;
 /// Get the integer type with a pointer size.
 inline mlir::Type getIntPtrType(mlir::OpBuilder &builder) {
   // TODO: Delay the need of such type until codegen or find a way to use
@@ -333,13 +335,15 @@ public:
                              mlir::StringAttr linkage = {},
                              mlir::Attribute value = {}, bool isConst = false,
                              bool isTarget = false,
-                             cuf::DataAttributeAttr dataAttr = {});
+                             cuf::DataAttributeAttr dataAttr = {},
+                             bool setDefaultAlignment = true);
 
   fir::GlobalOp createGlobal(mlir::Location loc, mlir::Type type,
                              llvm::StringRef name, bool isConst, bool isTarget,
                              std::function<void(FirOpBuilder &)> bodyBuilder,
                              mlir::StringAttr linkage = {},
-                             cuf::DataAttributeAttr dataAttr = {});
+                             cuf::DataAttributeAttr dataAttr = {},
+                             bool setDefaultAlignment = true);
 
   /// Create a global constant (read-only) value.
   fir::GlobalOp createGlobalConstant(mlir::Location loc, mlir::Type type,

--- a/flang/lib/Lower/ConvertConstant.cpp
+++ b/flang/lib/Lower/ConvertConstant.cpp
@@ -101,12 +101,11 @@ namespace {
 /// It does not currently support nested structures.
 class DenseGlobalBuilder {
 public:
-  static fir::GlobalOp tryCreating(fir::FirOpBuilder &builder,
-                                   mlir::Location loc, mlir::Type symTy,
-                                   llvm::StringRef globalName,
-                                   mlir::StringAttr linkage, bool isConst,
-                                   const Fortran::lower::SomeExpr &initExpr,
-                                   cuf::DataAttributeAttr dataAttr) {
+  static fir::GlobalOp
+  tryCreating(fir::FirOpBuilder &builder, mlir::Location loc, mlir::Type symTy,
+              llvm::StringRef globalName, mlir::StringAttr linkage,
+              bool isConst, const Fortran::lower::SomeExpr &initExpr,
+              cuf::DataAttributeAttr dataAttr, bool setDefaultAlignment) {
     DenseGlobalBuilder globalBuilder;
     Fortran::common::visit(
         Fortran::common::visitors{
@@ -123,7 +122,8 @@ public:
         },
         initExpr.u);
     return globalBuilder.tryCreatingGlobal(builder, loc, symTy, globalName,
-                                           linkage, isConst, dataAttr);
+                                           linkage, isConst, dataAttr,
+                                           setDefaultAlignment);
   }
 
   template <Fortran::common::TypeCategory TC, int KIND>
@@ -132,11 +132,12 @@ public:
       llvm::StringRef globalName, mlir::StringAttr linkage, bool isConst,
       const Fortran::evaluate::Constant<Fortran::evaluate::Type<TC, KIND>>
           &constant,
-      cuf::DataAttributeAttr dataAttr) {
+      cuf::DataAttributeAttr dataAttr, bool setDefaultAlignment = true) {
     DenseGlobalBuilder globalBuilder;
     globalBuilder.tryConvertingToAttributes(builder, constant);
     return globalBuilder.tryCreatingGlobal(builder, loc, symTy, globalName,
-                                           linkage, isConst, dataAttr);
+                                           linkage, isConst, dataAttr,
+                                           setDefaultAlignment);
   }
 
 private:
@@ -201,7 +202,8 @@ private:
                                   mlir::Location loc, mlir::Type symTy,
                                   llvm::StringRef globalName,
                                   mlir::StringAttr linkage, bool isConst,
-                                  cuf::DataAttributeAttr dataAttr) const {
+                                  cuf::DataAttributeAttr dataAttr,
+                                  bool setDefaultAlignment) const {
     // Not a "trivial" intrinsic constant array, or empty array.
     if (!attributeElementType || attributes.empty())
       return {};
@@ -214,7 +216,8 @@ private:
         mlir::RankedTensorType::get(tensorShape, attributeElementType);
     auto init = mlir::DenseElementsAttr::get(tensorTy, attributes);
     return builder.createGlobal(loc, symTy, globalName, linkage, init, isConst,
-                                /*isTarget=*/false, dataAttr);
+                                /*isTarget=*/false, dataAttr,
+                                setDefaultAlignment);
   }
 
   llvm::SmallVector<mlir::Attribute> attributes;
@@ -225,9 +228,11 @@ private:
 fir::GlobalOp Fortran::lower::tryCreatingDenseGlobal(
     fir::FirOpBuilder &builder, mlir::Location loc, mlir::Type symTy,
     llvm::StringRef globalName, mlir::StringAttr linkage, bool isConst,
-    const Fortran::lower::SomeExpr &initExpr, cuf::DataAttributeAttr dataAttr) {
+    const Fortran::lower::SomeExpr &initExpr, cuf::DataAttributeAttr dataAttr,
+    bool setDefaultAlignment) {
   return DenseGlobalBuilder::tryCreating(builder, loc, symTy, globalName,
-                                         linkage, isConst, initExpr, dataAttr);
+                                         linkage, isConst, initExpr, dataAttr,
+                                         setDefaultAlignment);
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -215,9 +215,11 @@ static fir::GlobalOp declareGlobal(Fortran::lower::AbstractConverter &converter,
       !Fortran::semantics::IsProcedurePointer(ultimate))
     mlir::emitError(loc, "processing global declaration: symbol '")
         << toStringRef(sym.name()) << "' has unexpected details\n";
+  bool isBindC = sym.attrs().test(Fortran::semantics::Attr::BIND_C);
   fir::GlobalOp global = builder.createGlobal(
       loc, converter.genType(var), globalName, linkage, mlir::Attribute{},
-      isConstant(ultimate), var.isTarget(), dataAttr);
+      isConstant(ultimate), var.isTarget(), dataAttr,
+      /*setDefaultAlignment=*/!isBindC);
   attachAccDeclareAttribute(builder, global, sym);
   return global;
 }
@@ -503,6 +505,7 @@ fir::GlobalOp Fortran::lower::defineGlobal(
   const Fortran::semantics::Symbol &sym = var.getSymbol();
   mlir::Location loc = genLocation(converter, sym);
   bool isConst = isConstant(sym);
+  bool isBindC = sym.attrs().test(Fortran::semantics::Attr::BIND_C);
   fir::GlobalOp global = builder.getNamedGlobal(globalName);
   mlir::Type symTy = converter.genType(var);
 
@@ -524,7 +527,8 @@ fir::GlobalOp Fortran::lower::defineGlobal(
       if (oeDetails && oeDetails->init()) {
         global = Fortran::lower::tryCreatingDenseGlobal(
             builder, loc, symTy, globalName, linkage, isConst,
-            oeDetails->init().value(), dataAttr);
+            oeDetails->init().value(), dataAttr,
+            /*setDefaultAlignment=*/!isBindC);
         if (global) {
           global.setVisibility(mlir::SymbolTable::Visibility::Public);
           return global;
@@ -535,7 +539,8 @@ fir::GlobalOp Fortran::lower::defineGlobal(
   if (!global)
     global =
         builder.createGlobal(loc, symTy, globalName, linkage, mlir::Attribute{},
-                             isConst, var.isTarget(), dataAttr);
+                             isConst, var.isTarget(), dataAttr,
+                             /*setDefaultAlignment=*/!isBindC);
   if (Fortran::semantics::IsAllocatableOrPointer(sym) &&
       !Fortran::semantics::IsProcedure(sym)) {
     if (oeDetails && oeDetails->init()) {

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -448,7 +448,7 @@ void fir::FirOpBuilder::genStackRestore(mlir::Location loc,
 fir::GlobalOp fir::FirOpBuilder::createGlobal(
     mlir::Location loc, mlir::Type type, llvm::StringRef name,
     mlir::StringAttr linkage, mlir::Attribute value, bool isConst,
-    bool isTarget, cuf::DataAttributeAttr dataAttr) {
+    bool isTarget, cuf::DataAttributeAttr dataAttr, bool setDefaultAlignment) {
   if (auto global = getNamedGlobal(name))
     return global;
   auto module = getModule();
@@ -463,6 +463,9 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
   }
   auto glob = fir::GlobalOp::create(*this, loc, name, isConst, isTarget, type,
                                     value, linkage, attrs);
+  // Set default alignment for array globals.
+  if (setDefaultAlignment && mlir::isa<fir::SequenceType>(type))
+    glob.setAlignment(fir::defaultArrayGlobalAlignment);
   restoreInsertionPoint(insertPt);
   if (symbolTable)
     symbolTable->insert(glob);
@@ -472,7 +475,8 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
 fir::GlobalOp fir::FirOpBuilder::createGlobal(
     mlir::Location loc, mlir::Type type, llvm::StringRef name, bool isConst,
     bool isTarget, std::function<void(FirOpBuilder &)> bodyBuilder,
-    mlir::StringAttr linkage, cuf::DataAttributeAttr dataAttr) {
+    mlir::StringAttr linkage, cuf::DataAttributeAttr dataAttr,
+    bool setDefaultAlignment) {
   if (auto global = getNamedGlobal(name))
     return global;
   auto module = getModule();
@@ -480,6 +484,9 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
   setInsertionPoint(module.getBody(), module.getBody()->end());
   auto glob = fir::GlobalOp::create(*this, loc, name, isConst, isTarget, type,
                                     mlir::Attribute{}, linkage);
+  // Set default alignment for array globals.
+  if (setDefaultAlignment && mlir::isa<fir::SequenceType>(type))
+    glob.setAlignment(fir::defaultArrayGlobalAlignment);
   auto &region = glob.getRegion();
   region.push_back(new mlir::Block);
   auto &block = glob.getRegion().back();

--- a/flang/test/Lower/CUDA/cuda-data-attribute.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-attribute.cuf
@@ -117,7 +117,7 @@ end subroutine
 ! CHECK: fir.global @_QMcuda_varEmod_b_ra {data_attr = #cuf.cuda<device>} : f32
 ! CHECK: fir.global @_QMcuda_varEmod_c_rm {data_attr = #cuf.cuda<managed>} : !fir.box<!fir.heap<f32>>
 
-! CHECK: fir.global @_QMcuda_varEmod_d_i_init(dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]> : tensor<10xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<10xi32>
-! CHECK: fir.global @_QMcuda_varEmod_d_rinit(dense<[{{.*}}]> : tensor<10xf32>) {data_attr = #cuf.cuda<device>} : !fir.array<10xf32>
+! CHECK: fir.global @_QMcuda_varEmod_d_i_init(dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]> : tensor<10xi32>) {alignment = 64 : i64, data_attr = #cuf.cuda<device>} : !fir.array<10xi32>
+! CHECK: fir.global @_QMcuda_varEmod_d_rinit(dense<[{{.*}}]> : tensor<10xf32>) {alignment = 64 : i64, data_attr = #cuf.cuda<device>} : !fir.array<10xf32>
 ! CHECK: fir.global @_QMcuda_varEmod_d_rp {data_attr = #cuf.cuda<pinned>} : !fir.box<!fir.heap<f32>>
-! CHECK: fir.global @_QMcuda_varEmod_d_t {data_attr = #cuf.cuda<device>} : !fir.array<2x!fir.type<_QMcuda_varTt1{a:i32}>>
+! CHECK: fir.global @_QMcuda_varEmod_d_t {alignment = 64 : i64, data_attr = #cuf.cuda<device>} : !fir.array<2x!fir.type<_QMcuda_varTt1{a:i32}>>

--- a/flang/test/Lower/CUDA/cuda-program-global.cuf
+++ b/flang/test/Lower/CUDA/cuda-program-global.cuf
@@ -23,5 +23,5 @@ end
 ! CHECK: cuf.alloc !fir.array<10xi32> {bindc_name = "u", data_attr = #cuf.cuda<unified>, uniq_name = "_QFEu"} -> !fir.ref<!fir.array<10xi32>>
 
 ! CHECK-NOT: fir.global internal @_QFEa {data_attr = #cuf.cuda<device>} : !fir.array<10xi32> {{{$}}
-! CHECK: fir.global internal @_QFEb : !fir.array<10xi32> {{{$}}
+! CHECK: fir.global internal @_QFEb {alignment = 64 : i64} : !fir.array<10xi32> {{{$}}
 ! CHECK-NOT: fir.global internal @_QFEu {data_attr = #cuf.cuda<unified>}

--- a/flang/test/Lower/HLFIR/tdesc-character-comp-init.f90
+++ b/flang/test/Lower/HLFIR/tdesc-character-comp-init.f90
@@ -9,5 +9,5 @@ subroutine test()
   end type
   type(t) :: x
 end subroutine
-! CHECK-LABEL: fir.global {{.*}} @_QFtestE.c.t constant
+! CHECK-LABEL: fir.global {{.*}} @_QFtestE.c.t {alignment = 64 : i64} constant
 ! CHECK: fir.address_of(@_QFtestE.di.t.character_comp) : !fir.ref<!fir.char<1,5>>

--- a/flang/test/Lower/Intrinsics/ieee_class.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class.f90
@@ -127,5 +127,5 @@ program p
   enddo
 end
 
-! CHECK: fir.global linkonce @_FortranAIeeeClassTable(dense<[7, 8, 8, 8, 11, 11, 11, 11, 9, 9, 9, 9, 10, 2, 1, 2, 6, 5, 5, 5, 11, 11, 11, 11, 4, 4, 4, 4, 3, 2, 1, 2]> : tensor<32xi8>) constant : !fir.array<32xi8>
-! CHECK: fir.global linkonce @_FortranAIeeeValueTable_8(dense<[0, 9219994337134247936, 9221120237041090560, -4503599627370496, -4616189618054758400, -9221120237041090560, -9223372036854775808, 0, 2251799813685248, 4607182418800017408, 9218868437227405312, 0]> : tensor<12xi64>) constant : !fir.array<12xi64>
+! CHECK: fir.global linkonce @_FortranAIeeeClassTable(dense<[7, 8, 8, 8, 11, 11, 11, 11, 9, 9, 9, 9, 10, 2, 1, 2, 6, 5, 5, 5, 11, 11, 11, 11, 4, 4, 4, 4, 3, 2, 1, 2]> : tensor<32xi8>) {alignment = 64 : i64} constant : !fir.array<32xi8>
+! CHECK: fir.global linkonce @_FortranAIeeeValueTable_8(dense<[0, 9219994337134247936, 9221120237041090560, -4503599627370496, -4616189618054758400, -9221120237041090560, -9223372036854775808, 0, 2251799813685248, 4607182418800017408, 9218868437227405312, 0]> : tensor<12xi64>) {alignment = 64 : i64} constant : !fir.array<12xi64>

--- a/flang/test/Lower/OpenACC/acc-declare-globals.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-globals.f90
@@ -42,7 +42,7 @@ module acc_declare_test
  !$acc declare create(data1)
 end module
 
-! CHECK-LABEL: fir.global @_QMacc_declare_testEdata1 {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<100000xf32>
+! CHECK-LABEL: fir.global @_QMacc_declare_testEdata1 {acc.declare = #acc.declare<dataClause = acc_create>, alignment = 64 : i64} : !fir.array<100000xf32>
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_testEdata1) {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.ref<!fir.array<100000xf32>>
@@ -86,7 +86,7 @@ module acc_declare_device_resident_test
  !$acc declare device_resident(data1)
 end module
 
-! CHECK-LABEL: fir.global @_QMacc_declare_device_resident_testEdata1 {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>} : !fir.array<5000xi32>
+! CHECK-LABEL: fir.global @_QMacc_declare_device_resident_testEdata1 {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>, alignment = 64 : i64} : !fir.array<5000xi32>
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_device_resident_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_device_resident_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_declare_device_resident>} : !fir.ref<!fir.array<5000xi32>>
@@ -109,7 +109,7 @@ module acc_declare_device_link_test
  !$acc declare link(data1)
 end module
 
-! CHECK-LABEL: fir.global @_QMacc_declare_device_link_testEdata1 {acc.declare = #acc.declare<dataClause =  acc_declare_link>} : !fir.array<5000xi32> {
+! CHECK-LABEL: fir.global @_QMacc_declare_device_link_testEdata1 {acc.declare = #acc.declare<dataClause =  acc_declare_link>, alignment = 64 : i64} : !fir.array<5000xi32> {
 
 ! CHECK-LABEL: acc.global_ctor @_QMacc_declare_device_link_testEdata1_acc_ctor {
 ! CHECK:         %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_device_link_testEdata1) {acc.declare = #acc.declare<dataClause =  acc_declare_link>} : !fir.ref<!fir.array<5000xi32>>

--- a/flang/test/Lower/OpenACC/acc-declare-use-associated.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-use-associated.f90
@@ -25,5 +25,5 @@ subroutine use_mod()
   end do
 end subroutine
 
-! CHECK: fir.global @_QMacc_declare_modEaa {acc.declare = #acc.declare<dataClause = acc_create>} : !fir.array<100xf32>
+! CHECK: fir.global @_QMacc_declare_modEaa {acc.declare = #acc.declare<dataClause = acc_create>, alignment = 64 : i64} : !fir.array<100xf32>
 ! CHECK: fir.global @_QMacc_declare_modEcoef {acc.declare = #acc.declare<dataClause = acc_copyin>} : f32

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map-2.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map-2.f90
@@ -14,8 +14,8 @@ module test_data
 end module
 
 ! CHECK-MOD: module {{.*}}
-! CHECK-MOD: fir.global @_QMtest_dataEj : !fir.array<200xi8> {
-! CHECK-MOD: fir.global @_QMtest_dataEi : !fir.array<10x10xf32> {
+! CHECK-MOD: fir.global @_QMtest_dataEj {alignment = 64 : i64} : !fir.array<200xi8> {
+! CHECK-MOD: fir.global @_QMtest_dataEi {alignment = 64 : i64} : !fir.array<10x10xf32> {
 ! CHECK-MOD: fir.global @_QMtest_dataEz : i32 {
 
 !--- imp_scalar_map_target.f90

--- a/flang/test/Lower/OpenMP/cray-pointers01.f90
+++ b/flang/test/Lower/OpenMP/cray-pointers01.f90
@@ -56,7 +56,7 @@ program test_cray_pointers_01
     ! CHECK:   omp.terminator
     ! CHECK: }
     ! CHECK-LABEL: fir.global @_QMtest_host_assoc_cray_pointerEivar : i64
-    ! CHECK-LABEL: fir.global  @_QMtest_host_assoc_cray_pointerEvar : !fir.array<?xf64>
+    ! CHECK-LABEL: fir.global  @_QMtest_host_assoc_cray_pointerEvar {alignment = 64 : i64} : !fir.array<?xf64>
 
 
   !$omp end parallel

--- a/flang/test/Lower/OpenMP/declare-target-data.f90
+++ b/flang/test/Lower/OpenMP/declare-target-data.f90
@@ -8,11 +8,11 @@ module test_0
 INTEGER :: data_int = 10
 !$omp declare target link(data_int)
 
-!CHECK-DAG: fir.global @_QMtest_0Earray_1d({{.*}}) {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : !fir.array<3xi32>
+!CHECK-DAG: fir.global @_QMtest_0Earray_1d({{.*}}) {alignment = 64 : i64, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : !fir.array<3xi32>
 INTEGER :: array_1d(3) = (/1,2,3/)
 !$omp declare target link(array_1d)
 
-!CHECK-DAG: fir.global @_QMtest_0Earray_2d({{.*}}) {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : !fir.array<2x2xi32>
+!CHECK-DAG: fir.global @_QMtest_0Earray_2d({{.*}}) {alignment = 64 : i64, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link), automap = false>} : !fir.array<2x2xi32>
 INTEGER :: array_2d(2,2) = reshape((/1,2,3,4/), (/2,2/))
 !$omp declare target link(array_2d)
 

--- a/flang/test/Lower/OpenMP/threadprivate-char-array-chararray.f90
+++ b/flang/test/Lower/OpenMP/threadprivate-char-array-chararray.f90
@@ -11,8 +11,8 @@ module test
   !$omp threadprivate(x, y, z)
 
 !CHECK-DAG: fir.global @_QMtestEx : !fir.char<1> {
-!CHECK-DAG: fir.global @_QMtestEy : !fir.array<5xi32> {
-!CHECK-DAG: fir.global @_QMtestEz : !fir.array<5x!fir.char<1,5>> {
+!CHECK-DAG: fir.global @_QMtestEy {alignment = 64 : i64} : !fir.array<5xi32> {
+!CHECK-DAG: fir.global @_QMtestEz {alignment = 64 : i64} : !fir.array<5x!fir.char<1,5>> {
 
 contains
   subroutine sub()

--- a/flang/test/Lower/OpenMP/wsloop-reduction-multiple-clauses.f90
+++ b/flang/test/Lower/OpenMP/wsloop-reduction-multiple-clauses.f90
@@ -155,7 +155,7 @@ endprogram
 ! CHECK:             omp.terminator
 ! CHECK:           }
 
-! CHECK-LABEL:   fir.global internal @_QFEarray : !fir.array<3x3xf64> {
+! CHECK-LABEL:   fir.global internal @_QFEarray {alignment = 64 : i64} : !fir.array<3x3xf64> {
 ! CHECK:           %[[VAL_0:.*]] = fir.zero_bits !fir.array<3x3xf64>
 ! CHECK:           fir.has_value %[[VAL_0]] : !fir.array<3x3xf64>
 ! CHECK:         }

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -109,7 +109,7 @@ end
 ! CHECK:           return
 ! CHECK:         }
 
-! CHECK: fir.global internal @_QQro.4x3xc1.0 constant : !fir.array<4x!fir.char<1,3>>
+! CHECK: fir.global internal @_QQro.4x3xc1.0 {alignment = 64 : i64} constant : !fir.array<4x!fir.char<1,3>>
 ! CHECK: AA
 ! CHECK: MM
 ! CHECK: ZZ

--- a/flang/test/Lower/array-constructor-1.f90
+++ b/flang/test/Lower/array-constructor-1.f90
@@ -42,6 +42,6 @@ program prog
   call zero
 end
 
-! CHECK: fir.global internal @_QFzeroECa constant : !fir.array<0xcomplex<f32>>
+! CHECK: fir.global internal @_QFzeroECa {alignment = 64 : i64} constant : !fir.array<0xcomplex<f32>>
 ! CHECK:   %0 = fir.undefined !fir.array<0xcomplex<f32>>
 ! CHECK:   fir.has_value %0 : !fir.array<0xcomplex<f32>>

--- a/flang/test/Lower/array-constructor-2.f90
+++ b/flang/test/Lower/array-constructor-2.f90
@@ -153,6 +153,6 @@ subroutine test7(a, n)
   a = (/ (CHAR(i), i=1,n) /)
 end subroutine test7
 
-! CHECK: fir.global internal @_QQro.3xr4.0(dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>) constant : !fir.array<3xf32>
+! CHECK: fir.global internal @_QQro.3xr4.0(dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>) {alignment = 64 : i64} constant : !fir.array<3xf32>
 
-! CHECK: fir.global internal @_QQro.4xi4.1(dense<[6, 7, 42, 9]> : tensor<4xi32>) constant : !fir.array<4xi32>
+! CHECK: fir.global internal @_QQro.4xi4.1(dense<[6, 7, 42, 9]> : tensor<4xi32>) {alignment = 64 : i64} constant : !fir.array<4xi32>

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -151,23 +151,23 @@ block data
 end
 
 ! c1 data
-! CHECK: fir.global internal @_QFrangeEc1(dense<(0.000000e+00,0.000000e+00)> : tensor<3x2xcomplex<f32>>) : !fir.array<2x3xcomplex<f32>>
+! CHECK: fir.global internal @_QFrangeEc1(dense<(0.000000e+00,0.000000e+00)> : tensor<3x2xcomplex<f32>>) {alignment = 64 : i64} : !fir.array<2x3xcomplex<f32>>
 
 ! a0 array constructor
-! CHECK: fir.global internal @_QQro.10xi4.{{.*}}(dense<[1, 2, 3, 3, 3, 3, 3, 3, 3, 3]> : tensor<10xi32>) constant : !fir.array<10xi32>
+! CHECK: fir.global internal @_QQro.10xi4.{{.*}}(dense<[1, 2, 3, 3, 3, 3, 3, 3, 3, 3]> : tensor<10xi32>) {alignment = 64 : i64} constant : !fir.array<10xi32>
 
 ! a1 array constructor
-! CHECK: fir.global internal @_QQro.2x3xr4.{{.*}}(dense<3.500000e+00> : tensor<3x2xf32>) constant : !fir.array<2x3xf32>
+! CHECK: fir.global internal @_QQro.2x3xr4.{{.*}}(dense<3.500000e+00> : tensor<3x2xf32>) {alignment = 64 : i64} constant : !fir.array<2x3xf32>
 
 ! a2 array constructor
-! CHECK: fir.global internal @_QQro.3x4xi4.{{.*}}(dense<{{\[\[1, 3, 3], \[5, 3, 3], \[3, 3, 9], \[9, 9, 8]]}}> : tensor<4x3xi32>) constant : !fir.array<3x4xi32>
+! CHECK: fir.global internal @_QQro.3x4xi4.{{.*}}(dense<{{\[\[1, 3, 3], \[5, 3, 3], \[3, 3, 9], \[9, 9, 8]]}}> : tensor<4x3xi32>) {alignment = 64 : i64} constant : !fir.array<3x4xi32>
 
 ! a3 array constructor
-! CHECK: fir.global internal @_QQro.2x3x4xi4.{{.*}}(dense<{{\[\[\[1, 1], \[2, 2], \[3, 3]], \[\[4, 4], \[5, 5], \[6, 6]], \[\[7, 7], \[8, 8], \[9, 9]], \[\[10, 10], \[11, 11], \[12, 12]]]}}> : tensor<4x3x2xi32>) constant : !fir.array<2x3x4xi32>
+! CHECK: fir.global internal @_QQro.2x3x4xi4.{{.*}}(dense<{{\[\[\[1, 1], \[2, 2], \[3, 3]], \[\[4, 4], \[5, 5], \[6, 6]], \[\[7, 7], \[8, 8], \[9, 9]], \[\[10, 10], \[11, 11], \[12, 12]]]}}> : tensor<4x3x2xi32>) {alignment = 64 : i64} constant : !fir.array<2x3x4xi32>
 
 ! c0 array constructor
-! CHECK: fir.global internal @_QQro.2x3xz4.{{.*}}(dense<{{\[}}[(1.000000e+00,1.500000e+00), (2.000000e+00,2.500000e+00)], [(3.000000e+00,3.500000e+00), (4.000000e+00,4.500000e+00)], [(5.000000e+00,5.500000e+00), (6.000000e+00,6.500000e+00)]]> : tensor<3x2xcomplex<f32>>) constant : !fir.array<2x3xcomplex<f32>>
+! CHECK: fir.global internal @_QQro.2x3xz4.{{.*}}(dense<{{\[}}[(1.000000e+00,1.500000e+00), (2.000000e+00,2.500000e+00)], [(3.000000e+00,3.500000e+00), (4.000000e+00,4.500000e+00)], [(5.000000e+00,5.500000e+00), (6.000000e+00,6.500000e+00)]]> : tensor<3x2xcomplex<f32>>) {alignment = 64 : i64} constant : !fir.array<2x3xcomplex<f32>>
 
-! CHECK: fir.global internal @_QFrangeglobal{{.*}}(dense<[1, 1, 2, 2, 3, 3]> : tensor<6xi32>) : !fir.array<6xi32>
+! CHECK: fir.global internal @_QFrangeglobal{{.*}}(dense<[1, 1, 2, 2, 3, 3]> : tensor<6xi32>) {alignment = 64 : i64} : !fir.array<6xi32>
 
-! CHECK: fir.global internal @_QQro.500x500xi4.{{.*}}(dense<{{.*}}> : tensor<500x500xi32>) constant : !fir.array<500x500xi32>
+! CHECK: fir.global internal @_QQro.500x500xi4.{{.*}}(dense<{{.*}}> : tensor<500x500xi32>) {alignment = 64 : i64} constant : !fir.array<500x500xi32>

--- a/flang/test/Lower/constant-literal-mangling.f90
+++ b/flang/test/Lower/constant-literal-mangling.f90
@@ -78,24 +78,24 @@ end type emptyType2
   print *, [emptyType2()]
 end
 
-! CHECK: fir.global internal @_QQro.1x_QFTsometype.10 constant : !fir.array<1x!fir.type<_QFTsometype{i:i32}>> {
+! CHECK: fir.global internal @_QQro.1x_QFTsometype.10 {alignment = 64 : i64} constant : !fir.array<1x!fir.type<_QFTsometype{i:i32}>> {
 ! CHECK:   %{{.*}} = arith.constant 11 : i32
 ! CHECK: }
 
-! CHECK: fir.global internal @_QQro.1x_QFTsometype.11 constant : !fir.array<1x!fir.type<_QFTsometype{i:i32}>> {
+! CHECK: fir.global internal @_QQro.1x_QFTsometype.11 {alignment = 64 : i64} constant : !fir.array<1x!fir.type<_QFTsometype{i:i32}>> {
 ! CHECK:   %{{.*}} = arith.constant 42 : i32
 ! CHECK: }
 
-! CHECK: fir.global internal @_QQro.0x4xc1.null.12 constant : !fir.array<0x!fir.char<1,4>> {
+! CHECK: fir.global internal @_QQro.0x4xc1.null.12 {alignment = 64 : i64} constant : !fir.array<0x!fir.char<1,4>> {
 ! CHECK:   %[[T1:.*]] = fir.undefined !fir.array<0x!fir.char<1,4>>
 ! CHECK:   fir.has_value %[[T1]] : !fir.array<0x!fir.char<1,4>>
 ! CHECK: }
 
-! CHECK: fir.global internal @_QQro.0x2xc1.null.13 constant : !fir.array<0x!fir.char<1,2>> {
+! CHECK: fir.global internal @_QQro.0x2xc1.null.13 {alignment = 64 : i64} constant : !fir.array<0x!fir.char<1,2>> {
 ! CHECK:   %[[T2:.*]] = fir.undefined !fir.array<0x!fir.char<1,2>>
 ! CHECK:   fir.has_value %[[T2]] : !fir.array<0x!fir.char<1,2>>
 ! CHECK: }
 
-! CHECK: fir.global internal @_QQro.1x_QFTothertype.14 constant : !fir.array<1x!fir.type<_QFTothertype{i:i32}>> {
+! CHECK: fir.global internal @_QQro.1x_QFTothertype.14 {alignment = 64 : i64} constant : !fir.array<1x!fir.type<_QFTothertype{i:i32}>> {
 ! CHECK:   %{{.*}} = arith.constant 42 : i32
 ! CHECK: }

--- a/flang/test/Lower/constant-logical-transfer.f90
+++ b/flang/test/Lower/constant-logical-transfer.f90
@@ -20,4 +20,4 @@ end module
 ! CHECK:          %[[BITCAST_1:.*]] = fir.bitcast %[[CONSTANT_1]] : (i64) -> !fir.logical<8>
 ! CHECK:          hlfir.assign %[[BITCAST_1]] to %{{.*}} : !fir.logical<8>, !fir.ref<!fir.logical<8>>
 
-! CHECK:        fir.global @_QMconstant_logicalEvar(dense<[1, 3, 0]> : tensor<3xi32>) : !fir.array<3x!fir.logical<4>>
+! CHECK:        fir.global @_QMconstant_logicalEvar(dense<[1, 3, 0]> : tensor<3xi32>) {alignment = 64 : i64} : !fir.array<3x!fir.logical<4>>

--- a/flang/test/Lower/convert.f90
+++ b/flang/test/Lower/convert.f90
@@ -14,7 +14,7 @@ end
 ! ALL:  %0 = fir.address_of(@_QQEnvironmentDefaults.list) : !fir.ref<tuple<i32, !fir.ref<!fir.array<1xtuple<!fir.ref<i8>, !fir.ref<i8>>>>>>
 ! ALL: fir.call @_FortranAProgramStart(%arg0, %arg1, %arg2, %0)
 
-! ALL: fir.global linkonce @_QQEnvironmentDefaults.items constant : !fir.array<1xtuple<!fir.ref<i8>, !fir.ref<i8>>> {
+! ALL: fir.global linkonce @_QQEnvironmentDefaults.items {alignment = 64 : i64} constant : !fir.array<1xtuple<!fir.ref<i8>, !fir.ref<i8>>> {
 ! ALL: %[[VAL_0:.*]] = fir.undefined !fir.array<1xtuple<!fir.ref<i8>, !fir.ref<i8>>>
 ! ALL: %[[VAL_1:.*]] = fir.address_of(@[[FC_STR:.*]]) : !fir.ref<!fir.char<1,13>>
 ! ALL: %[[VAL_3:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>

--- a/flang/test/Lower/default-initialization-globals.f90
+++ b/flang/test/Lower/default-initialization-globals.f90
@@ -72,7 +72,7 @@ module tinit
 
   ! Test array with default init
   type(t0) :: bt0(100)
-! CHECK-LABEL: @_QMtinitEbt0 : !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>> {
+! CHECK-LABEL: @_QMtinitEbt0 {alignment = 64 : i64} : !fir.array<100x!fir.type<_QMtinitTt0{k:i32}>> {
   ! CHECK: %[[VAL_4:.*]] = fir.undefined !fir.type<_QMtinitTt0{k:i32}>
   ! CHECK: %[[VAL_3:.*]] = arith.constant 66 : i32
   ! CHECK: %[[VAL_5:.*]] = fir.insert_value %[[VAL_4]], %[[VAL_3]], ["k", !fir.type<_QMtinitTt0{k:i32}>] : (!fir.type<_QMtinitTt0{k:i32}>, i32) -> !fir.type<_QMtinitTt0{k:i32}>
@@ -171,7 +171,7 @@ subroutine eqv()
   type(tseq), save :: somet
   integer :: i(2)
   equivalence (somet, i)
-! CHECK-LABEL: fir.global internal @_QFeqvEi : !fir.array<2xi32> {
+! CHECK-LABEL: fir.global internal @_QFeqvEi {alignment = 64 : i64} : !fir.array<2xi32> {
   ! CHECK: %[[VAL_52:.*]] = fir.undefined !fir.array<2xi32>
   ! CHECK: %[[VAL_50:.*]] = arith.constant 2 : i32
   ! CHECK: %[[VAL_53:.*]] = fir.insert_value %[[VAL_52]], %[[VAL_50]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
@@ -185,7 +185,7 @@ subroutine eqv_explicit_init()
   type(tseq), save :: somet
   integer :: i(2) = [4, 5]
   equivalence (somet, i)
-! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi : !fir.array<2xi32> {
+! CHECK-LABEL: fir.global internal @_QFeqv_explicit_initEi {alignment = 64 : i64} : !fir.array<2xi32> {
   ! CHECK: %[[VAL_59:.*]] = fir.undefined !fir.array<2xi32>
   ! CHECK: %[[VAL_57:.*]] = arith.constant 4 : i32
   ! CHECK: %[[VAL_60:.*]] = fir.insert_value %[[VAL_59]], %[[VAL_57]], [0 : index] : (!fir.array<2xi32>, i32) -> !fir.array<2xi32>
@@ -198,7 +198,7 @@ subroutine eqv_same_default_init()
   use tinit
   type(tseq), save :: somet1(2), somet2
   equivalence (somet1(1), somet2)
-! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 : !fir.array<2xi64> {
+! CHECK-LABEL: fir.global internal @_QFeqv_same_default_initEsomet1 {alignment = 64 : i64} : !fir.array<2xi64> {
   ! CHECK: %[[VAL_63:.*]] = fir.undefined !fir.array<2xi64>
   ! CHECK-LE: %[[VAL_62:.*]] = arith.constant 12884901890 : i64
   ! CHECK-BE: %[[VAL_62:.*]] = arith.constant 8589934595 : i64
@@ -219,7 +219,7 @@ subroutine eqv_full_overlaps_with_explicit_init()
   equivalence (i, link(1))
   equivalence (somet, link(2))
   equivalence (j, link(3))
-! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi : !fir.array<4xi32> {
+! CHECK-LABEL: fir.global internal @_QFeqv_full_overlaps_with_explicit_initEi {alignment = 64 : i64} : !fir.array<4xi32> {
   ! CHECK: %[[VAL_77:.*]] = fir.undefined !fir.array<4xi32>
   ! CHECK: %[[VAL_73:.*]] = arith.constant 5 : i32
   ! CHECK: %[[VAL_78:.*]] = fir.insert_value %[[VAL_77]], %[[VAL_73]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>
@@ -248,7 +248,7 @@ subroutine eqv_partial_overlaps_with_explicit_init()
   equivalence (i, link(1))
   equivalence (somet, link(2))
   equivalence (j, link(4))
-! CHECK-LABEL: fir.global internal @_QFeqv_partial_overlaps_with_explicit_initEi : !fir.array<4xi32>
+! CHECK-LABEL: fir.global internal @_QFeqv_partial_overlaps_with_explicit_initEi {alignment = 64 : i64} : !fir.array<4xi32>
    ! CHECK: %[[VAL_86:.*]] = fir.undefined !fir.array<4xi32>
    ! CHECK: %[[VAL_82:.*]] = arith.constant 5 : i32
    ! CHECK: %[[VAL_87:.*]] = fir.insert_value %[[VAL_86]], %[[VAL_82]], [0 : index] : (!fir.array<4xi32>, i32) -> !fir.array<4xi32>

--- a/flang/test/Lower/dense-array-any-rank.f90
+++ b/flang/test/Lower/dense-array-any-rank.f90
@@ -13,13 +13,13 @@ subroutine test()
 end subroutine
 
 ! a1 array constructor
-! CHECK-FIR: fir.global internal @_QQro.10xi4.{{.*}}(dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]> : tensor<10xi32>) constant : !fir.array<10xi32>
+! CHECK-FIR: fir.global internal @_QQro.10xi4.{{.*}}(dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]> : tensor<10xi32>) {alignment = 64 : i64} constant : !fir.array<10xi32>
 ! CHECK-LLVMIR: @_QQroX10xi4X0 = internal constant [10 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10]
 
 ! a2 array constructor
-! CHECK-FIR: fir.global internal @_QQro.3x4xi4.{{.*}}(dense<{{\[\[11, 12, 13], \[21, 22, 23], \[31, 32, 33], \[41, 42, 43]]}}> : tensor<4x3xi32>) constant : !fir.array<3x4xi32>
+! CHECK-FIR: fir.global internal @_QQro.3x4xi4.{{.*}}(dense<{{\[\[11, 12, 13], \[21, 22, 23], \[31, 32, 33], \[41, 42, 43]]}}> : tensor<4x3xi32>) {alignment = 64 : i64} constant : !fir.array<3x4xi32>
 ! CHECK-LLVMIR: @_QQroX3x4xi4X1 = internal constant [4 x [3 x i32]] {{\[\[3 x i32] \[i32 11, i32 12, i32 13], \[3 x i32] \[i32 21, i32 22, i32 23], \[3 x i32] \[i32 31, i32 32, i32 33], \[3 x i32] \[i32 41, i32 42, i32 43]]}}
 
 ! a3 array constructor
-! CHECK-FIR: fir.global internal @_QQro.2x3x4xi4.{{.*}}(dense<{{\[\[\[111, 112], \[121, 122], \[131, 132]], \[\[211, 212], \[221, 222], \[231, 232]], \[\[311, 312], \[321, 322], \[331, 332]], \[\[411, 412], \[421, 422], \[431, 432]]]}}> : tensor<4x3x2xi32>) constant : !fir.array<2x3x4xi32>
+! CHECK-FIR: fir.global internal @_QQro.2x3x4xi4.{{.*}}(dense<{{\[\[\[111, 112], \[121, 122], \[131, 132]], \[\[211, 212], \[221, 222], \[231, 232]], \[\[311, 312], \[321, 322], \[331, 332]], \[\[411, 412], \[421, 422], \[431, 432]]]}}> : tensor<4x3x2xi32>) {alignment = 64 : i64} constant : !fir.array<2x3x4xi32>
 ! CHECK-LLVMIR: @_QQroX2x3x4xi4X2 = internal constant [4 x [3 x [2 x i32]]] {{\[\[3 x \[2 x i32]] \[\[2 x i32] \[i32 111, i32 112], \[2 x i32] \[i32 121, i32 122], \[2 x i32] \[i32 131, i32 132]], \[3 x \[2 x i32]] \[\[2 x i32] \[i32 211, i32 212], \[2 x i32] \[i32 221, i32 222], \[2 x i32] \[i32 231, i32 232]], \[3 x \[2 x i32]] \[\[2 x i32] \[i32 311, i32 312], \[2 x i32] \[i32 321, i32 322], \[2 x i32] \[i32 331, i32 332]], \[3 x \[2 x i32]] \[\[2 x i32] \[i32 411, i32 412], \[2 x i32] \[i32 421, i32 422], \[2 x i32] \[i32 431, i32 432]]]}}

--- a/flang/test/Lower/dense-attributed-array.f90
+++ b/flang/test/Lower/dense-attributed-array.f90
@@ -19,5 +19,5 @@ end
 !CHECK:  %[[c0:.*]] = arith.constant 53 : i32
 !CHECK:  hlfir.assign %[[c0]] to %[[d0]]#0 : i32, !fir.ref<i32>
 !CHECK:  return
-!CHECK: fir.global @_QMmmECqq(dense<[51, 52, 53]> : tensor<3xi32>) constant : !fir.array<3xi32>
+!CHECK: fir.global @_QMmmECqq(dense<[51, 52, 53]> : tensor<3xi32>) {alignment = 64 : i64} constant : !fir.array<3xi32>
 !CHECK: }

--- a/flang/test/Lower/derived-type-descriptor.f90
+++ b/flang/test/Lower/derived-type-descriptor.f90
@@ -31,7 +31,7 @@ end subroutine
   !CHECK: fir.address_of(@_QFfooE.c.sometype)
 ! CHECK:}
 
-! CHECK-LABEL: fir.global linkonce_odr @_QFfooE.c.sometype constant {{.*}} {
+! CHECK-LABEL: fir.global linkonce_odr @_QFfooE.c.sometype {alignment = 64 : i64} constant {{.*}} {
   ! CHECK: fir.address_of(@_QFfooE.n.num)
   ! CHECK: fir.address_of(@_QFfooE.di.sometype.num) : !fir.ref<i32>
   ! CHECK: fir.address_of(@_QFfooE.n.values)
@@ -50,6 +50,6 @@ end subroutine
 ! CHECK: %[[res:.*]] = fir.string_lit "Empty   "(8) : !fir.char<1,8>
 ! CHECK: fir.has_value %[[res]] : !fir.char<1,8>
 
-! CHECK-LABEL: fir.global linkonce_odr @_QFchar_comp_initE.c.t constant target : {{.*}} {
+! CHECK-LABEL: fir.global linkonce_odr @_QFchar_comp_initE.c.t {alignment = 64 : i64} constant target : {{.*}} {
   ! CHECK: fir.address_of(@_QFchar_comp_initE.di.t.name) : !fir.ref<!fir.char<1,8>>
 ! CHECK: }

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -59,7 +59,7 @@ SUBROUTINE s3
 END SUBROUTINE s3
 
 ! test that equivalence in main program containing arrays are placed in global memory.
-! CHECK: fir.global internal @_QFEa : !fir.array<400000000xi8>
+! CHECK: fir.global internal @_QFEa {alignment = 64 : i64} : !fir.array<400000000xi8>
   integer :: a, b(100000000)
   equivalence (a, b)
   b(1) = 42

--- a/flang/test/Lower/equivalence-static-init.f90
+++ b/flang/test/Lower/equivalence-static-init.f90
@@ -7,7 +7,7 @@ module module_without_init
   integer :: i(2)
   equivalence(i(1), x)
 end module
-! CHECK-LABEL: fir.global @_QMmodule_without_initEi : !fir.array<8xi8> {
+! CHECK-LABEL: fir.global @_QMmodule_without_initEi {alignment = 64 : i64} : !fir.array<8xi8> {
   ! CHECK: %0 = fir.zero_bits !fir.array<8xi8>
   ! CHECK: fir.has_value %0 : !fir.array<8xi8>
 ! CHECK: }
@@ -21,7 +21,7 @@ subroutine test_eqv_init
   equivalence (i, link(3))
 end subroutine
 
-! CHECK-LABEL: fir.global internal @_QFtest_eqv_initEi : !fir.array<3xi32> {
+! CHECK-LABEL: fir.global internal @_QFtest_eqv_initEi {alignment = 64 : i64} : !fir.array<3xi32> {
     ! CHECK: %[[VAL_1:.*]] = fir.undefined !fir.array<3xi32>
     ! CHECK: %[[VAL_2:.*]] = fir.insert_value %0, %c7{{.*}}, [0 : index] : (!fir.array<3xi32>, i32) -> !fir.array<3xi32>
     ! CHECK: %[[VAL_3:.*]] = fir.insert_value %1, %c0{{.*}}, [1 : index] : (!fir.array<3xi32>, i32) -> !fir.array<3xi32>

--- a/flang/test/Lower/global-alignment.f90
+++ b/flang/test/Lower/global-alignment.f90
@@ -1,0 +1,60 @@
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
+
+module m
+  implicit none
+
+  ! Array globals that should get alignment 64 by default.
+  integer :: int_array(10)
+  ! CHECK-DAG: fir.global @_QMmEint_array {alignment = 64 : i64} : !fir.array<10xi32>
+  real :: real_array(5, 5)
+  ! CHECK-DAG: fir.global @_QMmEreal_array {alignment = 64 : i64} : !fir.array<5x5xf32>
+  complex :: complex_array(3)
+  ! CHECK-DAG: fir.global @_QMmEcomplex_array {alignment = 64 : i64} : !fir.array<3xcomplex<f32>>
+  logical :: logical_array(4)
+  ! CHECK-DAG: fir.global @_QMmElogical_array {alignment = 64 : i64} : !fir.array<4x!fir.logical<4>>
+  character(len=10) :: char_array(2)
+  ! CHECK-DAG: fir.global @_QMmEchar_array {alignment = 64 : i64} : !fir.array<2x!fir.char<1,10>>
+
+  integer, target :: target_array(8)
+  ! CHECK-DAG: fir.global @_QMmEtarget_array {alignment = 64 : i64} target : !fir.array<8xi32>
+
+  ! Currently not align 64
+  integer, allocatable :: alloc_array(:)
+  ! CHECK-DAG: fir.global @_QMmEalloc_array : !fir.box<!fir.heap<!fir.array<?xi32>>>
+
+  ! Non-array globals should not get alignment
+  integer :: scalar_var
+  ! CHECK-DAG: fir.global @_QMmEscalar_var : i32
+
+  ! BIND(C) globals should not get alignment (C ABI)
+  integer, bind(c, name="c_int_array") :: bind_c_int_array(10)
+  ! CHECK-DAG: fir.global common @c_int_array : !fir.array<10xi32>
+  real, bind(c, name="c_real_array") :: bind_c_real_array(5)
+  ! CHECK-DAG: fir.global common @c_real_array : !fir.array<5xf32>
+
+  ! BIND(C) arrays with initializers (exercises tryCreatingDenseGlobal path)
+  integer, bind(c, name="c_init_array") :: bind_c_init_array(5) = [1,2,3,4,5]
+  ! CHECK-DAG: fir.global @c_init_array(dense<[1, 2, 3, 4, 5]> : tensor<5xi32>) : !fir.array<5xi32>
+  real, bind(c, name="c_real_init") :: bind_c_real_init(3) = [1.0, 2.0, 3.0]
+  ! CHECK-DAG: fir.global @c_real_init(dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>) : !fir.array<3xf32>
+
+  integer, bind(c, name="c_scalar") :: bind_c_scalar
+  ! CHECK-DAG: fir.global common @c_scalar : i32
+end module
+
+subroutine sub_with_common()
+  implicit none
+  ! Common block (alignment from semantics, not 64)
+  integer :: cb_int(10)
+  real :: cb_real
+  common /myblock/ cb_int, cb_real
+  ! CHECK-DAG: fir.global common @myblock_(dense<0> : vector<44xi8>) {alignment = 4 : i64} : !fir.array<44xi8>
+end subroutine
+
+block data
+  implicit none
+  integer :: bd_array(5)
+  common /initblock/ bd_array
+  data bd_array /1, 2, 3, 4, 5/
+  ! CHECK-DAG: fir.global @initblock_ {alignment = 4 : i64} : tuple<!fir.array<5xi32>>
+end block data

--- a/flang/test/Lower/io-derived-type.f90
+++ b/flang/test/Lower/io-derived-type.f90
@@ -128,8 +128,8 @@ program p
   print *, y(2:3)
 end
 
-! CHECK: fir.global linkonce @_QQMmFtest1.nonTbpDefinedIoTable.list constant : !fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>
+! CHECK: fir.global linkonce @_QQMmFtest1.nonTbpDefinedIoTable.list {alignment = 64 : i64} constant : !fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>
 ! CHECK: fir.global linkonce @_QQMmFtest1.nonTbpDefinedIoTable constant : tuple<i64, !fir.ref<!fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>>, i1>
 ! CHECK: fir.global linkonce @_QQdefault.nonTbpDefinedIoTable constant : tuple<i64, !fir.ref<!fir.array<0xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>>, i1>
-! CHECK: fir.global linkonce @_QQF.nonTbpDefinedIoTable.list constant : !fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>
+! CHECK: fir.global linkonce @_QQF.nonTbpDefinedIoTable.list {alignment = 64 : i64} constant : !fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>
 ! CHECK: fir.global linkonce @_QQF.nonTbpDefinedIoTable constant : tuple<i64, !fir.ref<!fir.array<1xtuple<!fir.ref<none>, !fir.ref<none>, i32, i8>>>, i1>

--- a/flang/test/Lower/module_definition.f90
+++ b/flang/test/Lower/module_definition.f90
@@ -30,7 +30,7 @@ module m1
   integer :: y(100)
 end module
 ! CHECK: fir.global @_QMm1Ex : f32
-! CHECK: fir.global @_QMm1Ey : !fir.array<100xi32>
+! CHECK: fir.global @_QMm1Ey {alignment = 64 : i64} : !fir.array<100xi32>
 
 ! Module modEq1 defines data that is equivalenced and not used in this
 ! file.
@@ -42,8 +42,8 @@ module modEq1
   real :: y2(10)
   equivalence (x1(1), x2(5), x3(10)), (y1, y2(5))
 end module
-! CHECK-LABEL: fir.global @_QMmodeq1Ex1 : !fir.array<76xi8>
-! CHECK-LABEL: fir.global @_QMmodeq1Ey1 : !fir.array<10xi32> {
+! CHECK-LABEL: fir.global @_QMmodeq1Ex1 {alignment = 64 : i64} : !fir.array<76xi8>
+! CHECK-LABEL: fir.global @_QMmodeq1Ey1 {alignment = 64 : i64} : !fir.array<10xi32> {
   ! CHECK: %[[undef:.*]] = fir.undefined !fir.array<10xi32>
   ! CHECK: %[[v1:.*]] = fir.insert_on_range %0, %c0{{.*}} from (0) to (3) : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>
   ! CHECK: %[[v2:.*]] = fir.insert_value %1, %c1109917696{{.*}}, [4 : index] : (!fir.array<10xi32>, i32) -> !fir.array<10xi32>

--- a/flang/test/Lower/module_use.f90
+++ b/flang/test/Lower/module_use.f90
@@ -41,4 +41,4 @@ end function
 
 
 ! CHECK-DAG: fir.global @_QMm1Ex : f32
-! CHECK-DAG: fir.global @_QMm1Ey : !fir.array<100xi32>
+! CHECK-DAG: fir.global @_QMm1Ey {alignment = 64 : i64} : !fir.array<100xi32>

--- a/flang/test/Lower/namelist-common-block.f90
+++ b/flang/test/Lower/namelist-common-block.f90
@@ -17,7 +17,7 @@ contains
   end subroutine
 end
 
-! CHECK-LABEL: fir.global linkonce @_QFNt.list constant : !fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>> {
+! CHECK-LABEL: fir.global linkonce @_QFNt.list {alignment = 64 : i64} constant : !fir.array<2xtuple<!fir.ref<i8>, !fir.ref<!fir.box<none>>>> {
 ! CHECK: %[[CB_ADDR:.*]] = fir.address_of(@c_) : !fir.ref<!fir.array<56xi8>>
 ! CHECK: %[[CB_CAST:.*]] = fir.convert %[[CB_ADDR]] : (!fir.ref<!fir.array<56xi8>>) -> !fir.ref<!fir.array<?xi8>>
 ! CHECK: %[[OFFSET:.*]] = arith.constant 8 : index


### PR DESCRIPTION
This commit implements the proposal from the RFC:
https://discourse.llvm.org/t/rfc-alignment-of-global-arrays/90397/13

This PR sets the alignment of all global arrays to 64 bytes (except for BIND(C) and common blocks). This Mirrors the execution of other fortran compilers (CCE, gfortran, nvfortran and ifx).