### PR TITLE
[docs] Document the usage of operators on RVV sized types

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -554,7 +554,7 @@ They are only supported in C++. ``__char8_t`` is not available.
 Vectors and Extended Vectors
 ============================
 
-Supports the GCC, OpenCL, AltiVec, NEON and SVE vector extensions.
+Supports the GCC, OpenCL, AltiVec, NEON, SVE and RVV vector extensions.
 
 OpenCL vector types are created using the ``ext_vector_type`` attribute.  It
 supports the ``V.xyzw`` syntax and other tidbits as seen in OpenCL.  An example
@@ -702,36 +702,45 @@ The table below shows the support for each operation by vector extension.  A
 dash indicates that an operation is not accepted according to a corresponding
 specification.
 
-============================== ======= ======= ============= ======= =====
-         Operator              OpenCL  AltiVec     GCC        NEON    SVE
-============================== ======= ======= ============= ======= =====
-[]                               yes     yes       yes         yes    yes
-unary operators +, --            yes     yes       yes         yes    yes
-++, -- --                        yes     yes       yes         no     no
-+,--,*,/,%                       yes     yes       yes         yes    yes
-bitwise operators &,|,^,~        yes     yes       yes         yes    yes
->>,<<                            yes     yes       yes         yes    yes
-!, &&, ||                        yes     --        yes         yes    yes
-==, !=, >, <, >=, <=             yes     yes       yes         yes    yes
-=                                yes     yes       yes         yes    yes
-?: [#]_                          yes     --        yes         yes    yes
-sizeof                           yes     yes       yes         yes    yes [#]_
-C-style cast                     yes     yes       yes         no     no
-reinterpret_cast                 yes     no        yes         no     no
-static_cast                      yes     no        yes         no     no
-const_cast                       no      no        no          no     no
-address &v[i]                    no      no        no [#]_     no     no
-============================== ======= ======= ============= ======= =====
+============================== ======= ======= ============= ======= ========== =====
+         Operator              OpenCL  AltiVec     GCC        NEON    SVE        RVV
+============================== ======= ======= ============= ======= ========== =====
+[]                               yes     yes       yes         yes    yes        yes
+unary operators +, --            yes     yes       yes         yes    yes        yes
+++, -- --                        yes     yes       yes         no     no         no
++,--,*,/,%                       yes     yes       yes         yes    yes        yes
+bitwise operators &,|,^,~        yes     yes       yes         yes    yes        yes
+>>,<<                            yes     yes       yes         yes    yes        yes
+!, &&, ||                        yes     --        yes         yes    yes        yes
+==, !=, >, <, >=, <=             yes     yes       yes         yes    yes        yes
+=                                yes     yes       yes         yes    yes        yes
+?: [#]_                          yes     --        yes         yes    yes        yes
+sizeof                           yes     yes       yes         yes    yes [#]_   yes
+C-style cast                     yes     yes       yes         no     no         yes
+reinterpret_cast                 yes     no        yes         no     no         yes
+static_cast                      yes     no        yes         no     no         yes
+const_cast                       no      no        no          no     no         no
+address &v[i]                    no      no        no [#]_     no     no         no
+============================== ======= ======= ============= ======= ========== =====
+
+Both SVE and RVV define sizeless vector types which cannot be used in globals,
+structs, unions, or arrays.  Both provide an attribute (``arm_sve_vector_bits``
+and ``riscv_rvv_vector_bits`` respectively) to create fixed-length
+vector-length-specific (VLS) variants that remove these restrictions.  Using
+these attributes requires the command line option ``-msve-vector-bits=<N>`` or
+``-mrvv-vector-bits=<N>`` respectively.  For SVE, the operators above are
+supported on both sizeless and VLS types.  For RVV, the operators are only
+supported on VLS types.
 
 See also :ref:`langext-__builtin_shufflevector`, :ref:`langext-__builtin_convertvector`.
 
 .. [#] ternary operator(?:) has different behaviors depending on the condition
   operand's vector type. If the condition is a GNU vector (i.e., ``__vector_size__``),
-  a NEON vector or an SVE vector, it's only available in C++ and uses normal bool
-  conversions (that is, != 0).
+  a NEON vector, an SVE vector or an RVV vector, it's only available in C++
+  and uses normal bool conversions (that is, != 0).
   If it's an extension (OpenCL) vector, it's only available in C and OpenCL C.
   And it selects based on the signedness of the condition operands (OpenCL v1.1 s6.3.9).
-.. [#] sizeof can only be used on vector length specific SVE types.
+.. [#] sizeof can only be used on vector length specific SVE and RVV types.
 .. [#] Clang does not allow the address of an element to be taken while GCC
    allows this. This is intentional for vectors with a boolean element type and
    not implemented otherwise.

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -715,7 +715,7 @@ bitwise operators &,|,^,~        yes     yes       yes         yes    yes       
 ==, !=, >, <, >=, <=             yes     yes       yes         yes    yes        yes
 =                                yes     yes       yes         yes    yes        yes
 ?: [#]_                          yes     --        yes         yes    yes        yes
-sizeof                           yes     yes       yes         yes    yes [#]_   yes
+sizeof                           yes     yes       yes         yes    yes [#vls]_ yes [#vls]_
 C-style cast                     yes     yes       yes         no     no         yes
 reinterpret_cast                 yes     no        yes         no     no         yes
 static_cast                      yes     no        yes         no     no         yes
@@ -740,7 +740,7 @@ See also :ref:`langext-__builtin_shufflevector`, :ref:`langext-__builtin_convert
   and uses normal bool conversions (that is, != 0).
   If it's an extension (OpenCL) vector, it's only available in C and OpenCL C.
   And it selects based on the signedness of the condition operands (OpenCL v1.1 s6.3.9).
-.. [#] sizeof can only be used on vector length specific SVE and RVV types.
+.. [#vls] sizeof can only be used on vector length specific SVE and RVV types.
 .. [#] Clang does not allow the address of an element to be taken while GCC
    allows this. This is intentional for vectors with a boolean element type and
    not implemented otherwise.

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -702,9 +702,9 @@ The table below shows the support for each operation by vector extension.  A
 dash indicates that an operation is not accepted according to a corresponding
 specification.
 
-============================== ======= ======= ============= ======= ========== =====
+============================== ======= ======= ============= ======= ========== ===========
          Operator              OpenCL  AltiVec     GCC        NEON    SVE        RVV
-============================== ======= ======= ============= ======= ========== =====
+============================== ======= ======= ============= ======= ========== ===========
 []                               yes     yes       yes         yes    yes        yes
 unary operators +, --            yes     yes       yes         yes    yes        yes
 ++, -- --                        yes     yes       yes         no     no         no
@@ -721,7 +721,7 @@ reinterpret_cast                 yes     no        yes         no     no        
 static_cast                      yes     no        yes         no     no         yes
 const_cast                       no      no        no          no     no         no
 address &v[i]                    no      no        no [#]_     no     no         no
-============================== ======= ======= ============= ======= ========== =====
+============================== ======= ======= ============= ======= ========== ===========
 
 Both SVE and RVV define sizeless vector types which cannot be used in globals,
 structs, unions, or arrays.  Both provide an attribute (``arm_sve_vector_bits``

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -702,26 +702,26 @@ The table below shows the support for each operation by vector extension.  A
 dash indicates that an operation is not accepted according to a corresponding
 specification.
 
-============================== ======= ======= ============= ======= ========== ===========
-         Operator              OpenCL  AltiVec     GCC        NEON    SVE        RVV
-============================== ======= ======= ============= ======= ========== ===========
-[]                               yes     yes       yes         yes    yes        yes
-unary operators +, --            yes     yes       yes         yes    yes        yes
-++, -- --                        yes     yes       yes         no     no         no
-+,--,*,/,%                       yes     yes       yes         yes    yes        yes
-bitwise operators &,|,^,~        yes     yes       yes         yes    yes        yes
->>,<<                            yes     yes       yes         yes    yes        yes
-!, &&, ||                        yes     --        yes         yes    yes        yes
-==, !=, >, <, >=, <=             yes     yes       yes         yes    yes        yes
-=                                yes     yes       yes         yes    yes        yes
-?: [#]_                          yes     --        yes         yes    yes        yes
-sizeof                           yes     yes       yes         yes    yes [#vls]_ yes [#vls]_
-C-style cast                     yes     yes       yes         no     no         yes
-reinterpret_cast                 yes     no        yes         no     no         yes
-static_cast                      yes     no        yes         no     no         yes
-const_cast                       no      no        no          no     no         no
-address &v[i]                    no      no        no [#]_     no     no         no
-============================== ======= ======= ============= ======= ========== ===========
+============================== ======= ======= ============= ======= ============ ===========
+         Operator              OpenCL  AltiVec     GCC        NEON    SVE          RVV
+============================== ======= ======= ============= ======= ============ ===========
+[]                               yes     yes       yes         yes    yes          yes
+unary operators +, --            yes     yes       yes         yes    yes          yes
+++, -- --                        yes     yes       yes         no     no           no
++,--,*,/,%                       yes     yes       yes         yes    yes          yes
+bitwise operators &,|,^,~        yes     yes       yes         yes    yes          yes
+>>,<<                            yes     yes       yes         yes    yes          yes
+!, &&, ||                        yes     --        yes         yes    yes          yes
+==, !=, >, <, >=, <=             yes     yes       yes         yes    yes          yes
+=                                yes     yes       yes         yes    yes          yes
+?: [#]_                          yes     --        yes         yes    yes          yes
+sizeof                           yes     yes       yes         yes    yes [#vls]_  yes [#vls]_
+C-style cast                     yes     yes       yes         no     no           yes
+reinterpret_cast                 yes     no        yes         no     no           yes
+static_cast                      yes     no        yes         no     no           yes
+const_cast                       no      no        no          no     no           no
+address &v[i]                    no      no        no [#]_     no     no           no
+============================== ======= ======= ============= ======= ============ ===========
 
 Both SVE and RVV define sizeless vector types which cannot be used in globals,
 structs, unions, or arrays.  Both provide an attribute (``arm_sve_vector_bits``


### PR DESCRIPTION
We have existing support in clang for operator overloading on RVV builtin types when those types are sized.  This can be achieved through a combination of the -mrvv-vector-bits=N command line (to communicate exact VLEN to the compiler) and the riscv_rvv_vector_bits attribute on the types themselves.  We have fairly complete test coverage for this in clang/test/CodeGen/RISCV/rvv-vls-*.ll.

Our documentation did not reflect this reality, so this patch updates the documentation to match the actual support.

Patch written by Claude, with minor sanity checking by me.