### PR TITLE
[NFC][HLSL] Remove dead branch for const return by value

### DIFF
--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -2263,8 +2263,6 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
     ReturnTy = AST.getLValueReferenceType(ReturnTy);
   } else {
     ReturnTy = ElemTy;
-    if (IsConstReturn)
-      ReturnTy.addConst();
   }
   MMB.ReturnTy = ReturnTy;
 

--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -2262,6 +2262,8 @@ BuiltinTypeDeclBuilder &BuiltinTypeDeclBuilder::addHandleAccessFunction(
       ReturnTy.addConst();
     ReturnTy = AST.getLValueReferenceType(ReturnTy);
   } else {
+    assert(!IsConstReturn && "There shouldn't be any resource methods with a "
+                             "const ref return value");
     ReturnTy = ElemTy;
   }
   MMB.ReturnTy = ReturnTy;


### PR DESCRIPTION
Remove unreachable addConst() on the by-value return path of addHandleAccessFunction. 
No caller passes IsConstReturn=true with IsRef=false. The existing AST tests ( StructuredBuffers-AST.hlsl, ByteAddressBuffers-AST.hlsl, TypedBuffers-AST.hlsl) already assert the by-value Load return type is non-const, so behavior is verified unchanged.


Assisted by: Github Copilot
Fixes https://github.com/llvm/llvm-project/issues/194982