### PR TITLE
[lldb] Use the index host shared cache for symbolication

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -16,6 +16,7 @@
 #include "lldb/Utility/UserIDResolver.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Errc.h"
 
@@ -263,6 +264,16 @@ public:
   /// did not match.
   static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
                                     lldb::SymbolSharedCacheUse sc_mode) {
+    return false;
+  }
+
+  /// Invoke \p callback with the retained dyld_image_t for a shared cache
+  /// image matching \p image_uuid. The image handle is only valid for the
+  /// duration of the callback. Returns true if the image was found.
+  static bool
+  WithSharedCacheImage(const UUID &image_uuid, const UUID &sc_uuid,
+                       lldb::SymbolSharedCacheUse sc_mode,
+                       llvm::function_ref<void(void *image)> callback) {
     return false;
   }
 

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -58,6 +58,11 @@ public:
   static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
                                     lldb::SymbolSharedCacheUse sc_mode);
 
+  static bool
+  WithSharedCacheImage(const UUID &image_uuid, const UUID &sc_uuid,
+                       lldb::SymbolSharedCacheUse sc_mode,
+                       llvm::function_ref<void(void *image)> callback);
+
   /// Check whether a bundle at the given path has a valid code signature that
   /// chains to a trusted anchor in the system trust store.
   static bool IsBundleCodeSignTrusted(const FileSpec &bundle_path);

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -717,6 +717,25 @@ public:
   /// system, open it and add all of the binary images to m_caches.
   bool CreateSharedCacheImageList(UUID uuid, std::string filepath);
 
+  /// Invoke \p callback with the retained dyld_image_t for the image matching
+  /// \p file_uuid in shared cache \p sc_uuid. Returns true if found.
+  bool WithImageBaton(UUID sc_uuid, UUID file_uuid,
+                      llvm::function_ref<void(void *image)> callback) {
+    llvm::sys::ScopedReader guard(m_mutex);
+    if (!sc_uuid)
+      sc_uuid = m_host_uuid;
+    if (!m_uuid_map.contains(sc_uuid))
+      return false;
+    if (!m_uuid_map[sc_uuid].contains(file_uuid))
+      return false;
+    size_t idx = m_uuid_map[sc_uuid][file_uuid];
+    void *baton = m_file_infos[sc_uuid][idx].GetImageBaton();
+    if (!baton)
+      return false;
+    callback(baton);
+    return true;
+  }
+
   SharedCacheInfo(SymbolSharedCacheUse sc_mode);
 
 private:
@@ -1097,6 +1116,13 @@ bool HostInfoMacOSX::SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
     return GetSharedCacheSingleton(sc_mode).CreateSharedCacheImageList(
         uuid, filepath.GetPath());
   return false;
+}
+
+bool HostInfoMacOSX::WithSharedCacheImage(
+    const UUID &image_uuid, const UUID &sc_uuid, SymbolSharedCacheUse sc_mode,
+    llvm::function_ref<void(void *image)> callback) {
+  return GetSharedCacheSingleton(sc_mode).WithImageBaton(sc_uuid, image_uuid,
+                                                         callback);
 }
 
 bool HostInfoMacOSX::IsBundleCodeSignTrusted(const FileSpec &bundle_path) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -15,11 +15,13 @@
 #include "Plugins/Process/Utility/RegisterContextDarwin_x86_64.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Progress.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Host/Host.h"
+#include "lldb/Host/HostInfo.h"
 #include "lldb/Symbol/DWARFCallFrameInfo.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/DynamicLoader.h"
@@ -2718,73 +2720,50 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     UndefinedNameToDescMap undefined_name_to_desc;
     SymbolIndexToName reexport_shlib_needs_fixup;
 
-    dyld_for_each_installed_shared_cache(^(dyld_shared_cache_t shared_cache) {
-      uuid_t cache_uuid;
-      dyld_shared_cache_copy_uuid(shared_cache, &cache_uuid);
-      if (found_image)
+    auto nlist_extraction_block = ^(const void *nlistStart, uint64_t nlistCount,
+                                    const char *stringTable) {
+      if (!nlistStart || !nlistCount)
         return;
 
-        if (process_shared_cache_uuid.IsValid() &&
-          process_shared_cache_uuid != UUID(&cache_uuid, 16))
+      kern_return_t ret = vm_read(mach_task_self(), (vm_address_t)nlistStart,
+                                  nlist_byte_size * nlistCount,
+                                  &vm_nlist_memory, &vm_nlist_bytes_read);
+      if (ret != KERN_SUCCESS)
+        return;
+      assert(vm_nlist_bytes_read == nlist_byte_size * nlistCount);
+
+      vm_address_t string_address = (vm_address_t)stringTable;
+      vm_size_t region_size;
+      mach_msg_type_number_t info_count = VM_REGION_BASIC_INFO_COUNT_64;
+      vm_region_basic_info_data_t info;
+      memory_object_name_t object;
+      ret = vm_region_64(mach_task_self(), &string_address, &region_size,
+                         VM_REGION_BASIC_INFO_64, (vm_region_info_t)&info,
+                         &info_count, &object);
+      if (ret != KERN_SUCCESS)
         return;
 
-      dyld_shared_cache_for_each_image(shared_cache, ^(dyld_image_t image) {
-        uuid_t dsc_image_uuid;
-        if (found_image)
-          return;
+      ret = vm_read(mach_task_self(), (vm_address_t)stringTable,
+                    region_size - ((vm_address_t)stringTable - string_address),
+                    &vm_string_memory, &vm_string_bytes_read);
+      if (ret != KERN_SUCCESS)
+        return;
 
-        dyld_image_copy_uuid(image, &dsc_image_uuid);
-        if (image_uuid != UUID(dsc_image_uuid, 16))
-          return;
+      nlist_buffer = (void *)vm_nlist_memory;
+      string_table = (char *)vm_string_memory;
+      nlist_count = nlistCount;
+    };
 
-        found_image = true;
+    // Use the host shared cache to look up the image directly by UUID, avoiding
+    // the expensive iteration through all installed shared caches.
+    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
+                                       .GetSharedCacheBinaryLoading();
+    found_image = HostInfo::WithSharedCacheImage(
+        image_uuid, process_shared_cache_uuid, sc_mode, [&](void *image) {
+          dyld_image_local_nlist_content_4Symbolication((dyld_image_t)image,
+                                                        nlist_extraction_block);
+        });
 
-        // Compute the size of the string table. We need to ask dyld for a
-        // new SPI to avoid this step.
-        dyld_image_local_nlist_content_4Symbolication(
-            image, ^(const void *nlistStart, uint64_t nlistCount,
-                     const char *stringTable) {
-              if (!nlistStart || !nlistCount)
-                return;
-
-              // The buffers passed here are valid only inside the block.
-              // Use vm_read to make a cheap copy of them available for our
-              // processing later.
-              kern_return_t ret =
-                  vm_read(mach_task_self(), (vm_address_t)nlistStart,
-                          nlist_byte_size * nlistCount, &vm_nlist_memory,
-                          &vm_nlist_bytes_read);
-              if (ret != KERN_SUCCESS)
-                return;
-              assert(vm_nlist_bytes_read == nlist_byte_size * nlistCount);
-
-              // We don't know the size of the string table. It's cheaper
-              // to map the whole VM region than to determine the size by
-              // parsing all the nlist entries.
-              vm_address_t string_address = (vm_address_t)stringTable;
-              vm_size_t region_size;
-              mach_msg_type_number_t info_count = VM_REGION_BASIC_INFO_COUNT_64;
-              vm_region_basic_info_data_t info;
-              memory_object_name_t object;
-              ret = vm_region_64(mach_task_self(), &string_address,
-                                 &region_size, VM_REGION_BASIC_INFO_64,
-                                 (vm_region_info_t)&info, &info_count, &object);
-              if (ret != KERN_SUCCESS)
-                return;
-
-              ret = vm_read(mach_task_self(), (vm_address_t)stringTable,
-                            region_size -
-                                ((vm_address_t)stringTable - string_address),
-                            &vm_string_memory, &vm_string_bytes_read);
-              if (ret != KERN_SUCCESS)
-                return;
-
-              nlist_buffer = (void *)vm_nlist_memory;
-              string_table = (char *)vm_string_memory;
-              nlist_count = nlistCount;
-            });
-      });
-    });
     if (nlist_buffer) {
       DataExtractor dsc_local_symbols_data(nlist_buffer,
                                            nlist_count * nlist_byte_size,


### PR DESCRIPTION
Add HostInfo::WithSharedCacheImage to look up a dyld shared cache image directly by UUID, replacing the expensive repeated loading of the SC in ObjectFileMachO's symbol table parsing. The new API takes a callback that receives the retained image handle, ensuring it remains valid for the duration of the call.