### PR TITLE
[Clang-Tidy] Skip `misc-unused-parameters` in macro.

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
@@ -130,11 +130,13 @@ UnusedParametersCheck::UnusedParametersCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       StrictMode(Options.get("StrictMode", false)),
-      IgnoreVirtual(Options.get("IgnoreVirtual", false)) {}
+      IgnoreVirtual(Options.get("IgnoreVirtual", false)),
+      IgnoreMacroParameters(Options.get("IgnoreMacroParameters", false)) {}
 
 void UnusedParametersCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "StrictMode", StrictMode);
   Options.store(Opts, "IgnoreVirtual", IgnoreVirtual);
+  Options.store(Opts, "IgnoreMacroParameters", IgnoreMacroParameters);
 }
 
 void UnusedParametersCheck::warnOnUnusedParameter(
@@ -198,6 +200,8 @@ void UnusedParametersCheck::check(const MatchFinder::MatchResult &Result) {
       // type if we remove the preceding parameter name.
       continue;
     }
+    if (IgnoreMacroParameters && Param->getLocation().isMacroID())
+      continue;
 
     // In non-strict mode ignore function definitions with empty bodies
     // (constructor initializer counts for non-empty body).

--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.h
@@ -26,6 +26,7 @@ public:
 private:
   const bool StrictMode;
   const bool IgnoreVirtual;
+  const bool IgnoreMacroParameters;
   class IndexerVisitor;
   std::unique_ptr<IndexerVisitor> Indexer;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -393,6 +393,11 @@ Changes in existing checks
   - Fixed the `CheckThrowTemporaries` option to correctly reflect its
     configured value in exported settings.
 
+- Improved :doc:`misc-unused-parameters
+  <clang-tidy/checks/misc/unused-parameters>` check by adding
+  :option:`IgnoreMacroParameters` option to suppress warnings for unused
+  parameters whose declarations originate from macro expansions.
+
 - Improved :doc:`misc-unused-using-decls
   <clang-tidy/checks/misc/unused-using-decls>` to not diagnose ``using``
   declarations as unused if they're exported from a module.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -395,7 +395,7 @@ Changes in existing checks
 
 - Improved :doc:`misc-unused-parameters
   <clang-tidy/checks/misc/unused-parameters>` check by adding
-  :option:`IgnoreMacroParameters` option to suppress warnings for unused
+  `IgnoreMacroParameters` option to suppress warnings for unused
   parameters whose declarations originate from macro expansions.
 
 - Improved :doc:`misc-unused-using-decls

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -395,8 +395,8 @@ Changes in existing checks
 
 - Improved :doc:`misc-unused-parameters
   <clang-tidy/checks/misc/unused-parameters>` check by adding
-  `IgnoreMacroParameters` option to suppress warnings for unused
-  parameters whose declarations originate from macro expansions.
+  `IgnoreMacroParameters` option to suppress warnings for unused parameters
+  whose declarations originate from macro expansions.
 
 - Improved :doc:`misc-unused-using-decls
   <clang-tidy/checks/misc/unused-using-decls>` to not diagnose ``using``

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/unused-parameters.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/unused-parameters.rst
@@ -45,3 +45,11 @@ Options
 
   Determines whether virtual method parameters should be inspected.
   Set to `true` to ignore them. Default is `false`.
+
+.. option:: IgnoreMacroParameters
+
+  When `true`, the check will not report unused parameters whose declarations
+  originate from a macro expansion. This suppresses false positives in code
+  that uses macros to define function signatures where parameters are
+  structurally required by the macro but not used in every expansion.
+  Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters-macro.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters-macro.cpp
@@ -1,0 +1,21 @@
+// RUN: %check_clang_tidy %s misc-unused-parameters %t -- \
+// RUN:   -config="{CheckOptions: {misc-unused-parameters.IgnoreMacroParameters: true, \
+// RUN:             misc-unused-parameters.StrictMode: true}}" --
+
+// Parameters declared inside a macro expansion should not be reported when
+// IgnoreMacroParameters is enabled.
+
+#define HANDLER(RetType, ParamType, ParamName) \
+  RetType handler_##ParamName(ParamType ParamName) { return 0; }
+
+HANDLER(int, int, unused_from_macro)
+// No warning: parameter comes from macro expansion.
+
+#define WRAP_PARAM(type) type macro_arg
+void functionWithMacroParam(WRAP_PARAM(int)) {}
+// No warning: parameter name comes from macro expansion.
+
+// Regular unused parameter should still be reported.
+void normalFunction(int unused_normal) {}
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: parameter 'unused_normal' is unused [misc-unused-parameters]
+// CHECK-FIXES: void normalFunction(int  /*unused_normal*/) {}

--- a/clang-tools-extra/test/clang-tidy/infrastructure/dump-config-filtering.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/dump-config-filtering.cpp
@@ -2,6 +2,7 @@
 // RUN: clang-tidy -checks='-*' -dump-config %s -- 2>/dev/null | FileCheck %s --check-prefix=CHECK-DISABLED
 
 // CHECK: CheckOptions:
+// CHECK-NEXT:   misc-unused-parameters.IgnoreMacroParameters: 'false'
 // CHECK-NEXT:   misc-unused-parameters.IgnoreVirtual: 'false'
 // CHECK-NEXT:   misc-unused-parameters.StrictMode: 'false'
 // CHECK-NEXT: SystemHeaders:   false


### PR DESCRIPTION
The new parameter allows to skip the check for the cases when we need to use the macro, but there is no immediate way to fix the macro itself. It recently come up with a gradual adoption of clang-tidy and not all parts of the code could be fixed at once.

Simply enabling it using `clang-tidy-diff` is not enough, since `misc-unused-parameters` would cause false-positive, since the given diff didn't introduce the unused parameters and might be not easy to change.

The given parameters allow for better incremental adoption.