### PR TITLE
[Driver] Disable -fobjc-constant-literals by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4278,7 +4278,7 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
     bool EnableConstantLiterals =
         Args.hasFlag(options::OPT_fobjc_constant_literals,
                      options::OPT_fno_objc_constant_literals,
-                     /*default=*/true) &&
+                     /*default=*/false) &&
         Runtime.hasConstantLiteralClasses();
     if (EnableConstantLiterals)
       CmdArgs.push_back("-fobjc-constant-literals");

--- a/clang/test/Driver/objc-constant-literals.m
+++ b/clang/test/Driver/objc-constant-literals.m
@@ -1,0 +1,21 @@
+// RUN: %clang -### -target arm64-apple-macosx11 -c %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -### -target arm64-apple-macosx11 -fobjc-constant-literals -c %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -### -target arm64-apple-macosx11 -fno-objc-constant-literals -c %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=DISABLED
+
+// DEFAULT-NOT: -fobjc-constant-literals
+// DEFAULT-NOT: -fconstant-nsnumber-literals
+// DEFAULT-NOT: -fconstant-nsarray-literals
+// DEFAULT-NOT: -fconstant-nsdictionary-literals
+
+// ENABLED: -fobjc-constant-literals
+// ENABLED: -fconstant-nsnumber-literals
+// ENABLED: -fconstant-nsarray-literals
+// ENABLED: -fconstant-nsdictionary-literals
+
+// DISABLED-NOT: -fobjc-constant-literals
+// DISABLED-NOT: -fconstant-nsnumber-literals
+// DISABLED-NOT: -fconstant-nsarray-literals
+// DISABLED-NOT: -fconstant-nsdictionary-literals


### PR DESCRIPTION
Disable the feature by default in the driver so it is no longer implicitly enabled for ObjC compilations as there are unresolved issues (see https://github.com/llvm/llvm-project/pull/185130#issuecomment-4298886165). Users can still opt in explicitly with -fobjc-constant-literals.