### PR TITLE
[libc] Implement sched_getcpu

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -39,6 +39,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sched.sched_get_priority_max
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_getaffinity
+    libc.src.sched.sched_getcpu
     libc.src.sched.sched_getparam
     libc.src.sched.sched_getscheduler
     libc.src.sched.sched_rr_get_interval

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -39,6 +39,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sched.sched_get_priority_max
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_getaffinity
+    libc.src.sched.sched_getcpu
     libc.src.sched.sched_getparam
     libc.src.sched.sched_getscheduler
     libc.src.sched.sched_rr_get_interval

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -41,6 +41,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sched.sched_get_priority_max
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_getaffinity
+    libc.src.sched.sched_getcpu
     libc.src.sched.sched_getparam
     libc.src.sched.sched_getscheduler
     libc.src.sched.sched_rr_get_interval

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -52,6 +52,12 @@ functions:
       - type: pid_t
       - type: size_t
       - type: cpu_set_t *
+  - name: sched_getcpu
+    standards:
+      - GNUExtensions
+    return_type: int
+    arguments:
+      - type: void
   - name: sched_getparam
     standards:
       - POSIX

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -17,6 +17,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  sched_getcpu
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.sched_getcpu
+)
+
+add_entrypoint_object(
   sched_setaffinity
   ALIAS
   DEPENDS

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -25,6 +25,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  sched_getcpu
+  SRCS
+    sched_getcpu.cpp
+  HDRS
+    ../sched_getcpu.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   sched_setaffinity
   SRCS
     sched_setaffinity.cpp

--- a/libc/src/sched/linux/sched_getcpu.cpp
+++ b/libc/src/sched/linux/sched_getcpu.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_getcpu.h"
+
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+#include <sys/syscall.h> // For syscall numbers.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, sched_getcpu, ()) {
+  int cpu = 0;
+  int ret =
+      LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, cpu, nullptr, nullptr);
+  if (ret < 0) {
+    libc_errno = -ret;
+    return -1;
+  }
+  return cpu;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_getcpu.cpp
+++ b/libc/src/sched/linux/sched_getcpu.cpp
@@ -18,9 +18,9 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, sched_getcpu, ()) {
-  int cpu = 0;
+  unsigned int cpu = 0;
   int ret =
-      LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, cpu, nullptr, nullptr);
+      LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, &cpu, nullptr, nullptr);
   if (ret < 0) {
     libc_errno = -ret;
     return -1;

--- a/libc/src/sched/sched_getcpu.h
+++ b/libc/src/sched/sched_getcpu.h
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_GETCPU_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_GETCPU_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int sched_getcpu(void);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_GETCPU_H

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -57,6 +57,18 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  sched_getcpu_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    sched_getcpu_test.cpp
+  DEPENDS
+    libc.src.errno.errno
+    libc.src.sched.sched_getcpu
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_unittest(
   scheduler_test
   SUITE
     libc_sched_unittests

--- a/libc/test/src/sched/sched_getcpu_test.cpp
+++ b/libc/test/src/sched/sched_getcpu_test.cpp
@@ -1,0 +1,19 @@
+//===-- Unittests for getcpu ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/OSUtil/syscall.h"
+#include "src/sched/sched_getcpu.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+
+using LlvmLibcSchedSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedSchedGetCpuTest, SmokeTest) {
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+  ASSERT_THAT(LIBC_NAMESPACE::sched_getcpu(), Succeeds());
+}

--- a/libc/test/src/sched/sched_getcpu_test.cpp
+++ b/libc/test/src/sched/sched_getcpu_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for getcpu ----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/OSUtil/syscall.h"
 #include "src/sched/sched_getcpu.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
@@ -14,6 +13,6 @@
 using LlvmLibcSchedSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcSchedSchedGetCpuTest, SmokeTest) {
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  ASSERT_THAT(LIBC_NAMESPACE::sched_getcpu(), Succeeds());
+  ASSERT_GT(LIBC_NAMESPACE::sched_getcpu(), 0);
+  ASSERT_ERRNO_SUCCESS();
 }

--- a/libc/test/src/sched/sched_getcpu_test.cpp
+++ b/libc/test/src/sched/sched_getcpu_test.cpp
@@ -13,6 +13,6 @@
 using LlvmLibcSchedSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcSchedSchedGetCpuTest, SmokeTest) {
-  ASSERT_GT(LIBC_NAMESPACE::sched_getcpu(), 0);
+  ASSERT_GE(LIBC_NAMESPACE::sched_getcpu(), 0);
   ASSERT_ERRNO_SUCCESS();
 }


### PR DESCRIPTION
This is extremely similar to getcpu, but was available in a much earlier glibc, so a lot more code depends on it. Do a similar implementation. We can only have a simple smoke test as the only documented failure mode in the man page is running on a kernel that does not support the system call, and such kernels (<2.6) are ancient at this point.