### PR TITLE
[SPIR-V] Recover aggregate type for stores of undef/composite constants

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -552,8 +552,16 @@ static inline Type *restoreMutatedType(SPIRVGlobalRegistry *GR, Instruction *I,
 Type *SPIRVEmitIntrinsics::reconstructType(Value *Op, bool UnknownElemTypeI8,
                                            bool IsPostprocessing) {
   Type *Ty = Op->getType();
-  if (auto *OpI = dyn_cast<Instruction>(Op))
+  if (auto *OpI = dyn_cast<Instruction>(Op)) {
     Ty = restoreMutatedType(GR, OpI, Ty);
+    // Aggregate undef/constant values are lowered to spv_undef/
+    // spv_const_composite intrinsics whose return type is i32; recover the
+    // original aggregate type so downstream pointee deduction sees it.
+    if (match(OpI, m_CombineOr(m_Intrinsic<Intrinsic::spv_undef>(),
+                               m_Intrinsic<Intrinsic::spv_const_composite>())))
+      if (auto It = AggrConstTypes.find(OpI); It != AggrConstTypes.end())
+        Ty = It->second;
+  }
   if (!isUntypedPointerTy(Ty))
     return Ty;
   // try to find the pointee type
@@ -2039,6 +2047,15 @@ void SPIRVEmitIntrinsics::insertPtrCastOrAssignTypeInstr(Instruction *I,
     Type *OpTy = Op->getType();
     if (auto *OpI = dyn_cast<Instruction>(Op))
       OpTy = restoreMutatedType(GR, OpI, OpTy);
+    // Aggregate undef/constant values were lowered by preprocessUndefs/
+    // preprocessCompositeConstants to spv_undef/spv_const_composite calls
+    // returning i32; recover the original aggregate type so the pointee type
+    // assigned to the store's pointer operand reflects the value being stored.
+    if (match(Op, m_CombineOr(m_Intrinsic<Intrinsic::spv_undef>(),
+                              m_Intrinsic<Intrinsic::spv_const_composite>())))
+      if (auto It = AggrConstTypes.find(cast<Instruction>(Op));
+          It != AggrConstTypes.end())
+        OpTy = It->second;
     if (OpTy == Op->getType())
       OpTy = deduceElementTypeByValueDeep(OpTy, Op, false);
     replacePointerOperandWithPtrCast(I, Pointer, OpTy, 1, B);

--- a/llvm/test/CodeGen/SPIRV/pointers/store-operand-ptr-to-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/store-operand-ptr-to-struct.ll
@@ -7,11 +7,22 @@
 ; CHECK-DAG: %[[#NESTED:]] = OpTypeStruct %[[#STRUCT]] %[[#I16]]
 ; CHECK-DAG: %[[#PTR:]] = OpTypePointer Function %[[#NESTED]]
 ; CHECK-DAG: %[[#UNDEF:]] = OpUndef %[[#NESTED]]
+; CHECK-DAG: %[[#C_I32_1:]] = OpConstant %[[#I32]] 1
+; CHECK-DAG: %[[#C_I16_2:]] = OpConstant %[[#I16]] 2
+; CHECK-DAG: %[[#C_I16_3:]] = OpConstant %[[#I16]] 3
+; CHECK-DAG: %[[#INNER:]] = OpConstantComposite %[[#STRUCT]] %[[#C_I32_1]] %[[#C_I16_2]]
+; CHECK-DAG: %[[#OUTER:]] = OpConstantComposite %[[#NESTED]] %[[#INNER]] %[[#C_I16_3]]
 
 ; CHECK: OpFunction
 ; CHECK: %[[#PARAM:]] = OpFunctionParameter %[[#PTR]]
 ; CHECK-NOT: OpBitcast
 ; CHECK: OpStore %[[#PARAM]] %[[#UNDEF]]
+; CHECK: OpFunctionEnd
+
+; CHECK: OpFunction
+; CHECK: %[[#PARAM2:]] = OpFunctionParameter %[[#PTR]]
+; CHECK-NOT: OpBitcast
+; CHECK: OpStore %[[#PARAM2]] %[[#OUTER]]
 ; CHECK: OpFunctionEnd
 
 %struct = type {
@@ -26,5 +37,10 @@
 
 define void @foo(ptr %ptr) {
   store %nested_struct undef, ptr %ptr
+  ret void
+}
+
+define void @bar(ptr %ptr) {
+  store %nested_struct { %struct { i32 1, i16 2 }, i16 3 }, ptr %ptr
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/store-operand-ptr-to-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/store-operand-ptr-to-struct.ll
@@ -1,8 +1,18 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; TODO: OpFunctionParameter should be a pointer of struct base type.
-; XFAIL: *
+; CHECK-DAG: %[[#I16:]] = OpTypeInt 16 0
+; CHECK-DAG: %[[#I32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I32]] %[[#I16]]
+; CHECK-DAG: %[[#NESTED:]] = OpTypeStruct %[[#STRUCT]] %[[#I16]]
+; CHECK-DAG: %[[#PTR:]] = OpTypePointer Function %[[#NESTED]]
+; CHECK-DAG: %[[#UNDEF:]] = OpUndef %[[#NESTED]]
+
+; CHECK: OpFunction
+; CHECK: %[[#PARAM:]] = OpFunctionParameter %[[#PTR]]
+; CHECK-NOT: OpBitcast
+; CHECK: OpStore %[[#PARAM]] %[[#UNDEF]]
+; CHECK: OpFunctionEnd
 
 %struct = type {
   i32,


### PR DESCRIPTION
preprocessUndefs/preprocessCompositeConstants lower aggregate values to spv_undef/spv_const_composite calls returning i32, stashing the original type in AggrConstTypes