### PR TITLE
[NFC][SPIR-V] Remove XFAIL from basic_float_types.ll test

### DIFF
--- a/llvm/test/CodeGen/SPIRV/basic_float_types.ll
+++ b/llvm/test/CodeGen/SPIRV/basic_float_types.ll
@@ -2,9 +2,6 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %s -o - -filetype=obj | spirv-val %}
 
-// TODO: Open bug bfloat16 cannot be stored to.
-XFAIL: *
-
 define void @main() {
 entry:
 


### PR DESCRIPTION
The XFAIL directive without the comment is invalid syntax in LLVM IR. The XFAIL itself introduced in https://github.com/llvm/llvm-project/pull/168428 is redundant as of today, the test is passing without it