### PR TITLE
[Flang][OpenMP] Add -fdo-concurrent alias for -fdo-concurrent-to-openmp

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7768,9 +7768,10 @@ defm unsafe_cray_pointers : BoolOptionWithoutMarshalling<"f", "unsafe-cray-point
 def fhermetic_module_files : Flag<["-"], "fhermetic-module-files">, Group<f_Group>,
   HelpText<"Emit hermetic module files (no nested USE association)">;
 
-def fdo_concurrent_to_openmp_EQ : Joined<["-"], "fdo-concurrent-to-openmp=">,
+def fdo_concurrent_EQ : Joined<["-"], "fdo-concurrent=">,
   HelpText<"Try to map `do concurrent` loops to OpenMP [none|host|device]">,
       Values<"none, host, device">;
+def fdo_concurrent_to_openmp_EQ : Joined<["-"], "fdo-concurrent-to-openmp=">, Flags<[HelpHidden]>, HelpText<"Alias for -fdo-concurrent">, Alias<fdo_concurrent_EQ>;
 } // let Visibility = [FC1Option, FlangOption]
 
 def J : JoinedOrSeparate<["-"], "J">,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -249,10 +249,15 @@ void Flang::addCodegenOptions(const ArgList &Args,
           << "-frepack-arrays-contiguity=" << arg;
     }
 
+  // -fdo-concurrent and -fdo-concurrent-to-openmp are aliases. Make sure the
+  // correct alias (spelling) is added to the list of command arguments.
+  if (const Arg *A = Args.getLastArg(options::OPT_fdo_concurrent_EQ)) {
+    CmdArgs.push_back(Args.MakeArgString(A->getAsString(Args)));
+  }
+
   Args.addAllArgs(
       CmdArgs,
-      {options::OPT_fdo_concurrent_to_openmp_EQ,
-       options::OPT_flang_experimental_hlfir,
+      {options::OPT_flang_experimental_hlfir,
        options::OPT_flang_deprecated_no_hlfir,
        options::OPT_fno_ppc_native_vec_elem_order,
        options::OPT_fppc_native_vec_elem_order, options::OPT_finit_global_zero,

--- a/flang/docs/DoConcurrentConversionToOpenMP.md
+++ b/flang/docs/DoConcurrentConversionToOpenMP.md
@@ -27,7 +27,7 @@ are:
 ## Usage
 
 In order to enable `do concurrent` to OpenMP mapping, `flang` adds a new
-compiler flag: `-fdo-concurrent-to-openmp`. This flag has 3 possible values:
+compiler flag: `-fdo-concurrent` (and its alias `-fdo-concurrent-to-openmp`). This flag has 3 possible values:
 1. `host`: this maps `do concurrent` loops to run in parallel on the host CPU.
    This maps such loops to the equivalent of `omp parallel do`.
 2. `device`: this maps `do concurrent` loops to run in parallel on a target device.
@@ -36,9 +36,13 @@ compiler flag: `-fdo-concurrent-to-openmp`. This flag has 3 possible values:
 3. `none`: this disables `do concurrent` mapping altogether. In that case, such
    loops are emitted as sequential loops.
 
-The `-fdo-concurrent-to-openmp` compiler switch is currently available only when
+The `-fdo-concurrent` (or `-fdo-concurrent-to-openmp`) compiler switch is currently available only when
 OpenMP is also enabled. So you need to provide the following options to flang in
 order to enable it:
+```
+flang ... -fopenmp -fdo-concurrent=[host|device|none] ...
+```
+or using the alias:
 ```
 flang ... -fopenmp -fdo-concurrent-to-openmp=[host|device|none] ...
 ```

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -179,8 +179,7 @@ static bool parseDebugArgs(Fortran::frontend::CodeGenOptions &opts,
 static bool parseDoConcurrentMapping(Fortran::frontend::CodeGenOptions &opts,
                                      llvm::opt::ArgList &args,
                                      clang::DiagnosticsEngine &diags) {
-  llvm::opt::Arg *arg =
-      args.getLastArg(clang::options::OPT_fdo_concurrent_to_openmp_EQ);
+  llvm::opt::Arg *arg = args.getLastArg(clang::options::OPT_fdo_concurrent_EQ);
   if (!arg)
     return true;
 

--- a/flang/test/Driver/do_concurrent_to_omp_cli.f90
+++ b/flang/test/Driver/do_concurrent_to_omp_cli.f90
@@ -2,24 +2,35 @@
 
 ! RUN: %flang --help | FileCheck %s --check-prefix=FLANG
 
-! FLANG:      -fdo-concurrent-to-openmp=<value>
-! FLANG-NEXT:   Try to map `do concurrent` loops to OpenMP [none|host|device]
+! FLANG:      -fdo-concurrent=<value>
+! FLANG-SAME:   Try to map `do concurrent` loops to OpenMP [none|host|device]
 
 ! RUN: bbc --help | FileCheck %s --check-prefix=BBC
 
-! BBC:      -fdo-concurrent-to-openmp=<string>
+! BBC:      -fdo-concurrent=<string>
 ! BBC-SAME:   Try to map `do concurrent` loops to OpenMP [none|host|device]
 
-! RUN: %flang -c -fdo-concurrent-to-openmp=host %s 2>&1 \
+! RUN: %flang -c -fdo-concurrent=host %s 2>&1 \
 ! RUN: | FileCheck %s --check-prefix=OPT
 
 ! OPT: warning: OpenMP is required for lowering `do concurrent` loops to OpenMP.
 ! OPT-SAME:     Enable OpenMP using `-fopenmp`.
 
-! RUN: not %flang -c -fopenmp -fdo-concurrent-to-openmp=devic,e %s 2>&1 \
+! RUN: not %flang -c -fopenmp -fdo-concurrent=devic,e %s 2>&1 \
 ! RUN: | FileCheck %s --check-prefix=BADVAL
 
-! BADVAL: error: invalid value 'devic,e' in '-fdo-concurrent-to-openmp{{.*}}'
+! BADVAL: error: invalid value 'devic,e' in '-fdo-concurrent{{.*}}'
+
+! RUN: %flang -c -fdo-concurrent-to-openmp=host %s 2>&1 \
+! RUN: | FileCheck %s --check-prefix=OPT-ALIAS
+
+! OPT-ALIAS: warning: OpenMP is required for lowering `do concurrent` loops to OpenMP.
+! OPT-ALIAS-SAME:     Enable OpenMP using `-fopenmp`.
+
+! RUN: not %flang -c -fopenmp -fdo-concurrent-to-openmp=devic,e %s 2>&1 \
+! RUN: | FileCheck %s --check-prefix=BADVAL-ALIAS
+
+! BADVAL-ALIAS: error: invalid value 'devic,e' in '-fdo-concurrent-to-openmp{{.*}}'
 
 program test_cli
 end program

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -145,10 +145,14 @@ static llvm::cl::opt<bool>
                        llvm::cl::init(false));
 
 static llvm::cl::opt<std::string> enableDoConcurrentToOpenMPConversion(
-    "fdo-concurrent-to-openmp",
+    "fdo-concurrent",
     llvm::cl::desc(
         "Try to map `do concurrent` loops to OpenMP [none|host|device]"),
     llvm::cl::init("none"));
+
+static llvm::cl::alias enableDoConcurrentToOpenMPConversionAlias(
+    "fdo-concurrent-to-openmp", llvm::cl::desc("Alias for -fdo-concurrent"),
+    llvm::cl::aliasopt(enableDoConcurrentToOpenMPConversion), llvm::cl::Hidden);
 
 static llvm::cl::opt<bool>
     enableOpenMPGPU("fopenmp-is-gpu",


### PR DESCRIPTION
Adds the shorter -fdo-concurrent alias to map DO CONCURRENT loops to OpenMP.

Co-authored-by: Gemini 3.1 Pro