### PR TITLE
[clang][bytecode] Fix a crash with addr label diffs

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -418,9 +418,14 @@ bool Sub(InterpState &S, CodePtr OpPC) {
     // a AddrLabelDiff integral.
     if (LHS.getKind() == IntegralKind::LabelAddress ||
         RHS.getKind() == IntegralKind::LabelAddress) {
-      const auto *A = reinterpret_cast<const Expr *>(LHS.getPtr());
-      const auto *B = reinterpret_cast<const Expr *>(RHS.getPtr());
-      if (!isa<AddrLabelExpr>(A) || !isa<AddrLabelExpr>(B))
+      const auto *A = LHS.getKind() == IntegralKind::LabelAddress
+                          ? reinterpret_cast<const Expr *>(LHS.getPtr())
+                          : nullptr;
+      const auto *B = RHS.getKind() == IntegralKind::LabelAddress
+                          ? reinterpret_cast<const Expr *>(RHS.getPtr())
+                          : nullptr;
+      if (!isa_and_nonnull<AddrLabelExpr>(A) ||
+          !isa_and_nonnull<AddrLabelExpr>(B))
         return false;
       const auto *LHSAddrExpr = cast<AddrLabelExpr>(A);
       const auto *RHSAddrExpr = cast<AddrLabelExpr>(B);

--- a/clang/test/AST/ByteCode/addr-label-diff.cpp
+++ b/clang/test/AST/ByteCode/addr-label-diff.cpp
@@ -14,3 +14,5 @@ void UnfoldableAddrLabelDiff2() { static short x = (long)&&a-(long)&&b; a:b:retu
 // CHECK: @_ZZ21FoldableAddrLabelDiffvE1x = internal global i64 sub (i64 ptrtoint (ptr blockaddress(@_Z21FoldableAddrLabelDiffv
 void FoldableAddrLabelDiff() { static long x = (long)&&a-(long)&&b; a:b:return;}
 
+typedef decltype(sizeof(int)) L;
+void foo1() { (L) & (*(int (*)[4]) nullptr)[0] - (L) && b; b:}


### PR DESCRIPTION
Can't call `getPtr()` on numbers.