### PR TITLE
[VPlan] Compute accurate cost for WideCanIV

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3885,10 +3885,7 @@ public:
 
   /// Return the cost of this VPWidenCanonicalIVPHIRecipe.
   InstructionCost computeCost(ElementCount VF,
-                              VPCostContext &Ctx) const override {
-    // TODO: Compute accurate cost after retiring the legacy cost model.
-    return 0;
-  }
+                              VPCostContext &Ctx) const override;
 
   /// Return the canonical IV being widened.
   VPRegionValue *getCanonicalIV() const {

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -4559,6 +4559,24 @@ void VPWidenCanonicalIVRecipe::execute(VPTransformState &State) {
   State.set(this, CanonicalVectorIV);
 }
 
+InstructionCost
+VPWidenCanonicalIVRecipe::computeCost(ElementCount VF,
+                                      VPCostContext &Ctx) const {
+  if (VF.isScalar())
+    return 0;
+  // execute() emits: broadcast of the scalar IV, a step vector and a vector
+  // add. Charge the broadcast and the add directly. The step vector is
+  // emitted as a VPInstruction::StepVector whose own cost migration is
+  // pending (see VPInstructionWithType::computeCost), so it is not charged
+  // here to avoid front-running that work.
+  Type *ScalarTy = Ctx.Types.inferScalarType(this);
+  auto *VectorTy = VectorType::get(ScalarTy, VF);
+  return Ctx.TTI.getShuffleCost(TargetTransformInfo::SK_Broadcast, VectorTy,
+                                VectorTy, {}, Ctx.CostKind) +
+         Ctx.TTI.getArithmeticInstrCost(Instruction::Add, VectorTy,
+                                        Ctx.CostKind);
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenCanonicalIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                            VPSlotTracker &SlotTracker) const {

--- a/llvm/test/Transforms/LoopVectorize/AArch64/induction-costs-sve.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/induction-costs-sve.ll
@@ -574,53 +574,7 @@ define void @exit_cond_zext_iv(ptr %dst, i64 %N) {
 ;
 ; PRED-LABEL: define void @exit_cond_zext_iv(
 ; PRED-SAME: ptr [[DST:%.*]], i64 [[N:%.*]]) {
-; PRED-NEXT:  [[ENTRY:.*:]]
-; PRED-NEXT:    [[UMAX1:%.*]] = call i64 @llvm.umax.i64(i64 [[N]], i64 1)
-; PRED-NEXT:    br label %[[VECTOR_SCEVCHECK:.*]]
-; PRED:       [[VECTOR_SCEVCHECK]]:
-; PRED-NEXT:    [[UMAX:%.*]] = call i64 @llvm.umax.i64(i64 [[N]], i64 1)
-; PRED-NEXT:    [[TMP0:%.*]] = add i64 [[UMAX]], -1
-; PRED-NEXT:    [[TMP1:%.*]] = trunc i64 [[TMP0]] to i32
-; PRED-NEXT:    [[TMP2:%.*]] = add i32 1, [[TMP1]]
-; PRED-NEXT:    [[TMP3:%.*]] = icmp ult i32 [[TMP2]], 1
-; PRED-NEXT:    [[TMP4:%.*]] = icmp ugt i64 [[TMP0]], 4294967295
-; PRED-NEXT:    [[TMP5:%.*]] = or i1 [[TMP3]], [[TMP4]]
-; PRED-NEXT:    br i1 [[TMP5]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
-; PRED:       [[VECTOR_PH]]:
-; PRED-NEXT:    [[N_RND_UP:%.*]] = add i64 [[UMAX1]], 1
-; PRED-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[N_RND_UP]], 2
-; PRED-NEXT:    [[N_VEC:%.*]] = sub i64 [[N_RND_UP]], [[N_MOD_VF]]
-; PRED-NEXT:    [[TRIP_COUNT_MINUS_1:%.*]] = sub i64 [[UMAX1]], 1
-; PRED-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i64> poison, i64 [[TRIP_COUNT_MINUS_1]], i64 0
-; PRED-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i64> [[BROADCAST_SPLATINSERT]], <2 x i64> poison, <2 x i32> zeroinitializer
-; PRED-NEXT:    br label %[[VECTOR_BODY:.*]]
-; PRED:       [[VECTOR_BODY]]:
-; PRED-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[PRED_STORE_CONTINUE5:.*]] ]
-; PRED-NEXT:    [[BROADCAST_SPLATINSERT2:%.*]] = insertelement <2 x i64> poison, i64 [[INDEX]], i64 0
-; PRED-NEXT:    [[BROADCAST_SPLAT3:%.*]] = shufflevector <2 x i64> [[BROADCAST_SPLATINSERT2]], <2 x i64> poison, <2 x i32> zeroinitializer
-; PRED-NEXT:    [[VEC_IV:%.*]] = add <2 x i64> [[BROADCAST_SPLAT3]], <i64 0, i64 1>
-; PRED-NEXT:    [[TMP6:%.*]] = icmp ule <2 x i64> [[VEC_IV]], [[BROADCAST_SPLAT]]
-; PRED-NEXT:    [[TMP7:%.*]] = extractelement <2 x i1> [[TMP6]], i64 0
-; PRED-NEXT:    br i1 [[TMP7]], label %[[PRED_STORE_IF:.*]], label %[[PRED_STORE_CONTINUE:.*]]
-; PRED:       [[PRED_STORE_IF]]:
-; PRED-NEXT:    [[TMP9:%.*]] = getelementptr { [100 x i32], i32, i32 }, ptr [[DST]], i64 [[INDEX]], i32 2
-; PRED-NEXT:    store i32 0, ptr [[TMP9]], align 8
-; PRED-NEXT:    br label %[[PRED_STORE_CONTINUE]]
-; PRED:       [[PRED_STORE_CONTINUE]]:
-; PRED-NEXT:    [[TMP10:%.*]] = extractelement <2 x i1> [[TMP6]], i64 1
-; PRED-NEXT:    br i1 [[TMP10]], label %[[PRED_STORE_IF4:.*]], label %[[PRED_STORE_CONTINUE5]]
-; PRED:       [[PRED_STORE_IF4]]:
-; PRED-NEXT:    [[TMP11:%.*]] = add i64 [[INDEX]], 1
-; PRED-NEXT:    [[TMP12:%.*]] = getelementptr { [100 x i32], i32, i32 }, ptr [[DST]], i64 [[TMP11]], i32 2
-; PRED-NEXT:    store i32 0, ptr [[TMP12]], align 8
-; PRED-NEXT:    br label %[[PRED_STORE_CONTINUE5]]
-; PRED:       [[PRED_STORE_CONTINUE5]]:
-; PRED-NEXT:    [[INDEX_NEXT]] = add i64 [[INDEX]], 2
-; PRED-NEXT:    [[TMP13:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
-; PRED-NEXT:    br i1 [[TMP13]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP4:![0-9]+]]
-; PRED:       [[MIDDLE_BLOCK]]:
-; PRED-NEXT:    br label %[[EXIT:.*]]
-; PRED:       [[SCALAR_PH]]:
+; PRED-NEXT:  [[SCALAR_PH:.*]]:
 ; PRED-NEXT:    br label %[[LOOP:.*]]
 ; PRED:       [[LOOP]]:
 ; PRED-NEXT:    [[IV_1:%.*]] = phi i32 [ 0, %[[SCALAR_PH]] ], [ [[IV_1_NEXT:%.*]], %[[LOOP]] ]
@@ -630,7 +584,7 @@ define void @exit_cond_zext_iv(ptr %dst, i64 %N) {
 ; PRED-NEXT:    [[IV_1_NEXT]] = add i32 [[IV_1]], 1
 ; PRED-NEXT:    [[IV_EXT]] = zext i32 [[IV_1_NEXT]] to i64
 ; PRED-NEXT:    [[C:%.*]] = icmp ult i64 [[IV_EXT]], [[N]]
-; PRED-NEXT:    br i1 [[C]], label %[[LOOP]], label %[[EXIT]], !llvm.loop [[LOOP5:![0-9]+]]
+; PRED-NEXT:    br i1 [[C]], label %[[LOOP]], label %[[EXIT:.*]]
 ; PRED:       [[EXIT]]:
 ; PRED-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/LoopVectorize/VPlan/widen-canonical-iv-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/widen-canonical-iv-cost.ll
@@ -1,0 +1,38 @@
+; REQUIRES: asserts
+; RUN: opt -passes=loop-vectorize -force-vector-width=4 \
+; RUN:   -force-target-supports-masked-memory-ops -tail-folding-policy=must-fold-tail \
+; RUN:   -debug-only=loop-vectorize -disable-output %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
+
+; Two reductions force the canonical IV to be widened so its lane values
+; can feed the active-lane-mask compare under tail folding. This pins the
+; cost reported for VPWidenCanonicalIVRecipe.
+
+; CHECK-LABEL: LV: Checking a loop in 'two_reductions'
+; CHECK:       Cost of 0 for VF 4: EMIT vp<{{.*}}> = WIDEN-CANONICAL-INDUCTION
+
+define i32 @two_reductions(i64 %N, ptr %a, ptr %b) {
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %sum.a = phi i32 [ 0, %entry ], [ %sum.a.next, %loop ]
+  %sum.b = phi i32 [ 0, %entry ], [ %sum.b.next, %loop ]
+  %ga = getelementptr inbounds i32, ptr %a, i64 %iv
+  %gb = getelementptr inbounds i32, ptr %b, i64 %iv
+  %la = load i32, ptr %ga, align 4
+  %lb = load i32, ptr %gb, align 4
+  %sum.a.next = add i32 %sum.a, %la
+  %sum.b.next = add i32 %sum.b, %lb
+  %iv.next = add nuw nsw i64 %iv, 1
+  %ec = icmp eq i64 %iv.next, %N
+  br i1 %ec, label %exit, label %loop
+
+exit:
+  %r.a = phi i32 [ %sum.a.next, %loop ]
+  %r.b = phi i32 [ %sum.b.next, %loop ]
+  %res = add i32 %r.a, %r.b
+  ret i32 %res
+}

--- a/llvm/test/Transforms/LoopVectorize/VPlan/widen-canonical-iv-cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/widen-canonical-iv-cost.ll
@@ -10,7 +10,7 @@ target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
 ; cost reported for VPWidenCanonicalIVRecipe.
 
 ; CHECK-LABEL: LV: Checking a loop in 'two_reductions'
-; CHECK:       Cost of 0 for VF 4: EMIT vp<{{.*}}> = WIDEN-CANONICAL-INDUCTION
+; CHECK:       Cost of 2 for VF 4: EMIT vp<{{.*}}> = WIDEN-CANONICAL-INDUCTION
 
 define i32 @two_reductions(i64 %N, ptr %a, ptr %b) {
 entry:


### PR DESCRIPTION
This two-commit PR 
1. Adds a test to check the cost of WIDEN-CANONICAL-INDUCTION. 
2. Second commit - Factors for the computation involved In WIDEN-CANONICAL-INDUCTION and returns the cost. 

Please note the changes in llvm/test/Transforms/LoopVectorize/AArch64/induction-costs-sve.ll which now becomes scalar loop thus vectorization is lost. I have not tested the patch fully and looking for suggestions. 