### PR TITLE
[SPIR-V] Register __spirv_* arithmetic builtins for GLSL_std_450

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -687,11 +687,15 @@ defm : DemangledNativeBuiltin<"__spirv_ControlBarrier", OpenCL_std, Barrier, 3, 
 
 // ICarryBorrow builtin record:
 defm : DemangledNativeBuiltin<"__spirv_IAddCarry", OpenCL_std, ICarryBorrow, 3, 3, OpIAddCarryS>;
+defm : DemangledNativeBuiltin<"__spirv_IAddCarry", GLSL_std_450, ICarryBorrow, 3, 3, OpIAddCarryS>;
 defm : DemangledNativeBuiltin<"__spirv_ISubBorrow", OpenCL_std, ICarryBorrow, 3, 3, OpISubBorrowS>;
+defm : DemangledNativeBuiltin<"__spirv_ISubBorrow", GLSL_std_450, ICarryBorrow, 3, 3, OpISubBorrowS>;
 
 // MulExtended builtin records:
 defm : DemangledNativeBuiltin<"__spirv_UMulExtended", OpenCL_std, MulExtended, 2, 3, OpUMulExtended>;
+defm : DemangledNativeBuiltin<"__spirv_UMulExtended", GLSL_std_450, MulExtended, 2, 3, OpUMulExtended>;
 defm : DemangledNativeBuiltin<"__spirv_SMulExtended", OpenCL_std, MulExtended, 2, 3, OpSMulExtended>;
+defm : DemangledNativeBuiltin<"__spirv_SMulExtended", GLSL_std_450, MulExtended, 2, 3, OpSMulExtended>;
 
 // cl_intel_split_work_group_barrier
 defm : DemangledNativeBuiltin<"intel_work_group_barrier_arrive", OpenCL_std, Barrier, 1, 2, OpControlBarrierArriveINTEL>;
@@ -1641,6 +1645,7 @@ defm : DemangledNativeBuiltin<"__spirv_UConvert", OpenCL_std, Convert, 1, 1, OpU
 defm : DemangledNativeBuiltin<"__spirv_SConvert", OpenCL_std, Convert, 1, 1, OpSConvert>;
 defm : DemangledNativeBuiltin<"__spirv_FConvert", OpenCL_std, Convert, 1, 1, OpFConvert>;
 defm : DemangledNativeBuiltin<"__spirv_QuantizeToF16", OpenCL_std, Convert, 1, 1, OpQuantizeToF16>;
+defm : DemangledNativeBuiltin<"__spirv_QuantizeToF16", GLSL_std_450, Convert, 1, 1, OpQuantizeToF16>;
 defm : DemangledNativeBuiltin<"__spirv_ConvertPtrToU", OpenCL_std, Convert, 1, 1, OpConvertPtrToU>;
 defm : DemangledNativeBuiltin<"__spirv_SatConvertSToU", OpenCL_std, Convert, 1, 1, OpSatConvertSToU>;
 defm : DemangledNativeBuiltin<"__spirv_SatConvertUToS", OpenCL_std, Convert, 1, 1, OpSatConvertUToS>;

--- a/llvm/test/CodeGen/SPIRV/iaddcarry-builtin.ll
+++ b/llvm/test/CodeGen/SPIRV/iaddcarry-builtin.ll
@@ -2,6 +2,11 @@
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+;; TODO: Enable Vulkan spirv-val once test_builtin_iaddcarry_anon no longer uses
+;; an addrspace(4) sret pointer; generic pointers require the Kernel-only
+;; GenericPointer capability and are rejected by Vulkan validation.
+; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
 %i8struct = type {i8, i8}
 %i16struct = type {i16, i16}

--- a/llvm/test/CodeGen/SPIRV/instructions/quantizeto16.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/quantizeto16.ll
@@ -1,9 +1,6 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
-; TODO:  Implement support for the SPIR-V QuantizeToF16 operation
-; XFAIL: *
-
 ; CHECK-DAG: [[F32:%.*]] = OpTypeFloat 32
 ; CHECK: %[[#]] = OpQuantizeToF16 [[F32]] %[[#]]
 define spir_func void @test_wrappers() {

--- a/llvm/test/CodeGen/SPIRV/isubborrow-builtin.ll
+++ b/llvm/test/CodeGen/SPIRV/isubborrow-builtin.ll
@@ -1,5 +1,10 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+;; TODO: Enable Vulkan spirv-val once test_builtin_isubborrow_anon no longer uses
+;; an addrspace(4) sret pointer; generic pointers require the Kernel-only
+;; GenericPointer capability and are rejected by Vulkan validation.
+; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
 %i8struct = type {i8, i8}
 %i16struct = type {i16, i16}

--- a/llvm/test/CodeGen/SPIRV/smulextended-builtin.ll
+++ b/llvm/test/CodeGen/SPIRV/smulextended-builtin.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
 %i8struct = type {i8, i8}
 %i16struct = type {i16, i16}

--- a/llvm/test/CodeGen/SPIRV/umulextended-builtin.ll
+++ b/llvm/test/CodeGen/SPIRV/umulextended-builtin.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
 %i8struct = type {i8, i8}
 %i16struct = type {i16, i16}


### PR DESCRIPTION
Register __spirv_QuantizeToF16, __spirv_IAddCarry, __spirv_ISubBorrow, __spirv_UMulExtended and __spirv_SMulExtended under GLSL_std_450 in addition to OpenCL_std so they lower to their core SPIR-V opcodes under the Vulkan/Shader environment as well