### PR TITLE
[GlobalISel] Remove AssumptionCacheTracker from O0 pipeline

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -174,8 +174,8 @@ void IRTranslator::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<StackProtector>();
   AU.addRequired<TargetPassConfig>();
   AU.addRequired<GISelCSEAnalysisWrapperPass>();
-  AU.addRequired<AssumptionCacheTracker>();
   if (OptLevel != CodeGenOptLevel::None) {
+    AU.addRequired<AssumptionCacheTracker>();
     AU.addRequired<BranchProbabilityInfoWrapperPass>();
     AU.addRequired<AAResultsWrapperPass>();
   }
@@ -4221,13 +4221,13 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
   if (EnableOpts) {
     AA = &getAnalysis<AAResultsWrapperPass>().getAAResults();
     FuncInfo.BPI = &getAnalysis<BranchProbabilityInfoWrapperPass>().getBPI();
+    AC = &getAnalysis<AssumptionCacheTracker>().getAssumptionCache(
+        MF->getFunction());
   } else {
     AA = nullptr;
     FuncInfo.BPI = nullptr;
+    AC = nullptr;
   }
-
-  AC = &getAnalysis<AssumptionCacheTracker>().getAssumptionCache(
-      MF->getFunction());
   LibInfo = &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
   Libcalls = &getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(
       *F.getParent(), Subtarget);


### PR DESCRIPTION
This is for an optimizer hint that shouldn't be necessary at O0. Small -0.09% compile time improvement on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=4e6d3722fca73c97367720180a8d547057fda380&to=95b13462d4ff97f3fe5542e3eede0ad029a635f3&stat=instructions%3Au