### PR TITLE
MCContext/TargetMachine: Take MCRegisterInfo and MCSubtargetInfo by reference. NFC

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1545,8 +1545,7 @@ public:
   /// won't be used in the main code emitter.
   IndependentCodeEmitter createIndependentMCCodeEmitter() const {
     IndependentCodeEmitter MCEInstance;
-    MCEInstance.LocalCtx.reset(
-        new MCContext(*TheTriple, *AsmInfo, MRI.get(), STI.get()));
+    MCEInstance.LocalCtx.reset(new MCContext(*TheTriple, *AsmInfo, *MRI, *STI));
     MCEInstance.LocalMOFI.reset(
         TheTarget->createMCObjectFileInfo(*MCEInstance.LocalCtx,
                                           /*PIC=*/!HasFixedLoadAddress));

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -255,7 +255,7 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
         Twine("BOLT-ERROR: no instruction info for target ", TripleName));
 
   std::unique_ptr<MCContext> Ctx(
-      new MCContext(TheTriple, *AsmInfo, MRI.get(), STI.get()));
+      new MCContext(TheTriple, *AsmInfo, *MRI, *STI));
   std::unique_ptr<MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(*Ctx, IsPIC));
   Ctx->setObjectFileInfo(MOFI.get());

--- a/clang/lib/Parse/ParseStmtAsm.cpp
+++ b/clang/lib/Parse/ParseStmtAsm.cpp
@@ -566,7 +566,7 @@ StmtResult Parser::ParseMicrosoftAsmStatement(SourceLocation AsmLoc) {
   }
 
   llvm::SourceMgr TempSrcMgr;
-  llvm::MCContext Ctx(TheTriple, *MAI, MRI.get(), STI.get(), &TempSrcMgr);
+  llvm::MCContext Ctx(TheTriple, *MAI, *MRI, *STI, &TempSrcMgr);
   std::unique_ptr<llvm::MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false));
   Ctx.setObjectFileInfo(MOFI.get());

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -144,9 +144,9 @@ static int PrintSupportedExtensions(std::string TargetStr) {
   std::unique_ptr<llvm::TargetMachine> TheTargetMachine(
       TheTarget->createTargetMachine(Triple, "", "", Options, std::nullopt));
   const llvm::Triple &MachineTriple = TheTargetMachine->getTargetTriple();
-  const llvm::MCSubtargetInfo *MCInfo = TheTargetMachine->getMCSubtargetInfo();
+  const llvm::MCSubtargetInfo &MCInfo = TheTargetMachine->getMCSubtargetInfo();
   const llvm::ArrayRef<llvm::SubtargetFeatureKV> Features =
-    MCInfo->getAllProcessorFeatures();
+      MCInfo.getAllProcessorFeatures();
 
   llvm::StringMap<llvm::StringRef> DescMap;
   for (const llvm::SubtargetFeatureKV &feature : Features)
@@ -187,13 +187,13 @@ static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
       TheTarget->createTargetMachine(Triple, TargetOpts.CPU, FeaturesStr,
                                      BackendOptions, std::nullopt));
   const llvm::Triple &MachineTriple = TheTargetMachine->getTargetTriple();
-  const llvm::MCSubtargetInfo *MCInfo = TheTargetMachine->getMCSubtargetInfo();
+  const llvm::MCSubtargetInfo &MCInfo = TheTargetMachine->getMCSubtargetInfo();
 
   // Extract the feature names that are enabled for the given target.
   // We do that by capturing the key from the set of SubtargetFeatureKV entries
   // provided by MCSubtargetInfo, which match the '-target-feature' values.
   const std::vector<llvm::SubtargetFeatureKV> Features =
-    MCInfo->getEnabledProcessorFeatures();
+      MCInfo.getEnabledProcessorFeatures();
   std::set<llvm::StringRef> EnabledFeatureNames;
   for (const llvm::SubtargetFeatureKV &feature : Features)
     EnabledFeatureNames.insert(feature.Key);

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -506,7 +506,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
            << Opts.CPU << FS.empty() << FS;
   }
 
-  MCContext Ctx(Triple(Opts.Triple), *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext Ctx(Triple(Opts.Triple), *MAI, *MRI, *STI, &SrcMgr);
 
   bool PIC = false;
   if (Opts.RelocationModel == "static") {

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1283,9 +1283,8 @@ DisassemblerLLVMC::MCDisasmInstance::Create(const char *triple_name,
   if (!asm_info_up)
     return Instance();
 
-  std::unique_ptr<llvm::MCContext> context_up(
-      new llvm::MCContext(llvm::Triple(triple), *asm_info_up, reg_info_up.get(),
-                          subtarget_info_up.get()));
+  std::unique_ptr<llvm::MCContext> context_up(new llvm::MCContext(
+      llvm::Triple(triple), *asm_info_up, *reg_info_up, *subtarget_info_up));
   if (!context_up)
     return Instance();
 

--- a/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
@@ -157,8 +157,8 @@ EmulateInstructionMIPS::EmulateInstructionMIPS(
   m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 
-  m_context = std::make_unique<llvm::MCContext>(
-      triple, *m_asm_info, m_reg_info.get(), m_subtype_info.get());
+  m_context = std::make_unique<llvm::MCContext>(triple, *m_asm_info,
+                                                *m_reg_info, *m_subtype_info);
   assert(m_context.get());
 
   m_disasm.reset(target->createMCDisassembler(*m_subtype_info, *m_context));

--- a/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
@@ -161,8 +161,8 @@ EmulateInstructionMIPS64::EmulateInstructionMIPS64(
   m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 
-  m_context = std::make_unique<llvm::MCContext>(
-      triple, *m_asm_info, m_reg_info.get(), m_subtype_info.get());
+  m_context = std::make_unique<llvm::MCContext>(triple, *m_asm_info,
+                                                *m_reg_info, *m_subtype_info);
   assert(m_context.get());
 
   m_disasm.reset(target->createMCDisassembler(*m_subtype_info, *m_context));

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -377,8 +377,8 @@ private:
 
 public:
   LLVM_ABI explicit MCContext(const Triple &TheTriple, const MCAsmInfo &MAI,
-                              const MCRegisterInfo *MRI,
-                              const MCSubtargetInfo *MSTI,
+                              const MCRegisterInfo &MRI,
+                              const MCSubtargetInfo &MSTI,
                               const SourceMgr *Mgr = nullptr,
                               bool DoAutoReset = true,
                               StringRef Swift5ReflSegmentName = {});

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -239,9 +239,9 @@ public:
   /// Return target specific asm information.
   const MCAsmInfo &getMCAsmInfo() const { return *AsmInfo; }
 
-  const MCRegisterInfo *getMCRegisterInfo() const { return MRI.get(); }
+  const MCRegisterInfo &getMCRegisterInfo() const { return *MRI; }
   const MCInstrInfo *getMCInstrInfo() const { return MII.get(); }
-  const MCSubtargetInfo *getMCSubtargetInfo() const { return STI.get(); }
+  const MCSubtargetInfo &getMCSubtargetInfo() const { return *STI; }
 
   /// Return the ExceptionHandling to use, considering TargetOptions and the
   /// Triple's default.

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -558,7 +558,7 @@ bool AsmPrinter::doInitialization(Module &M) {
   // information (such as the embedded command line) to be associated
   // with all sections in the object file rather than a single section.
   if (!Target.isOSBinFormatXCOFF())
-    OutStreamer->initSections(*TM.getMCSubtargetInfo());
+    OutStreamer->initSections(TM.getMCSubtargetInfo());
 
   // Emit the version-min deployment target directive if needed.
   //
@@ -627,7 +627,7 @@ bool AsmPrinter::doInitialization(Module &M) {
     OutStreamer->AddComment("Start of file scope inline assembly");
     OutStreamer->addBlankLine();
     emitInlineAsm(
-        M.getModuleInlineAsm() + "\n", *TM.getMCSubtargetInfo(),
+        M.getModuleInlineAsm() + "\n", TM.getMCSubtargetInfo(),
         TM.Options.MCOptions, nullptr,
         InlineAsm::AsmDialect(TM.getMCAsmInfo().getAssemblerDialect()));
     OutStreamer->AddComment("End of file scope inline assembly");
@@ -2089,7 +2089,7 @@ void AsmPrinter::emitFunctionBody() {
   if (this->MF)
     STI = &getSubtargetInfo();
   else
-    STI = TM.getMCSubtargetInfo();
+    STI = &TM.getMCSubtargetInfo();
 
   bool CanDoExtraAnalysis = ORE->allowExtraAnalysis(DEBUG_TYPE);
   // Create a slot for the entry basic block section so that the section
@@ -3845,7 +3845,7 @@ Align AsmPrinter::emitAlignment(Align Alignment, const GlobalObject *GV,
     if (this->MF)
       STI = &getSubtargetInfo();
     else
-      STI = TM.getMCSubtargetInfo();
+      STI = &TM.getMCSubtargetInfo();
     OutStreamer->emitCodeAlignment(Alignment, STI, MaxBytesToEmit);
   } else
     OutStreamer->emitValueToAlignment(Alignment, 0, 1, MaxBytesToEmit);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -344,7 +344,7 @@ void DwarfCompileUnit::addLocationAttribute(
         // Base register
         Register BaseReg = Asm->getObjFileLowering().getStaticBase();
         unsigned DwarfBaseReg =
-            Asm->TM.getMCRegisterInfo()->getDwarfRegNum(BaseReg, false);
+            Asm->TM.getMCRegisterInfo().getDwarfRegNum(BaseReg, false);
         addUInt(*Loc, dwarf::DW_FORM_data1, dwarf::DW_OP_breg0 + DwarfBaseReg);
         // Offset from base register
         addSInt(*Loc, dwarf::DW_FORM_sdata, 0);

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -169,9 +169,9 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
                                            raw_pwrite_stream *DwoOut,
                                            CodeGenFileType FileType,
                                            MCContext &Context) {
-  const MCSubtargetInfo &STI = *getMCSubtargetInfo();
+  const MCSubtargetInfo &STI = getMCSubtargetInfo();
   const MCAsmInfo &MAI = getMCAsmInfo();
-  const MCRegisterInfo &MRI = *getMCRegisterInfo();
+  const MCRegisterInfo &MRI = getMCRegisterInfo();
   const MCInstrInfo &MII = *getMCInstrInfo();
 
   std::unique_ptr<MCStreamer> AsmStreamer;
@@ -279,8 +279,8 @@ bool CodeGenTargetMachineImpl::addPassesToEmitMC(PassManagerBase &PM,
 
   // Create the code emitter for the target if it exists.  If not, .o file
   // emission fails.
-  const MCSubtargetInfo &STI = *getMCSubtargetInfo();
-  const MCRegisterInfo &MRI = *getMCRegisterInfo();
+  const MCSubtargetInfo &STI = getMCSubtargetInfo();
+  const MCRegisterInfo &MRI = getMCRegisterInfo();
   std::unique_ptr<MCCodeEmitter> MCE(
       getTarget().createMCCodeEmitter(*getMCInstrInfo(), *Ctx));
   if (!MCE)

--- a/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
@@ -75,7 +75,7 @@ Error DwarfStreamer::init(Triple TheTriple,
                              "no subtarget info for target %s",
                              TripleName.c_str());
 
-  MC.reset(new MCContext(TheTriple, *MAI, MRI.get(), MSTI.get(), nullptr, true,
+  MC.reset(new MCContext(TheTriple, *MAI, *MRI, *MSTI, nullptr, true,
                          Swift5ReflectionSegmentName));
   MOFI.reset(TheTarget->createMCObjectFileInfo(*MC, /*PIC=*/false, false));
   MC->setObjectFileInfo(MOFI.get());

--- a/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
@@ -55,7 +55,7 @@ Error DwarfEmitterImpl::init(Triple TheTriple,
                              "no subtarget info for target %s",
                              TripleName.c_str());
 
-  MC.reset(new MCContext(TheTriple, *MAI, MRI.get(), MSTI.get(), nullptr, true,
+  MC.reset(new MCContext(TheTriple, *MAI, *MRI, *MSTI, nullptr, true,
                          Swift5ReflectionSegmentName));
   MOFI.reset(TheTarget->createMCObjectFileInfo(*MC, /*PIC=*/false, false));
   MC->setObjectFileInfo(MOFI.get());

--- a/llvm/lib/DWARFLinker/Parallel/DebugLineSectionEmitter.h
+++ b/llvm/lib/DWARFLinker/Parallel/DebugLineSectionEmitter.h
@@ -91,8 +91,8 @@ private:
                                "no subtarget info for target %s",
                                TripleName.c_str());
 
-    MC.reset(new MCContext(TheTriple, *MAI, MRI.get(), MSTI.get(), nullptr,
-                           true, "__DWARF"));
+    MC.reset(
+        new MCContext(TheTriple, *MAI, *MRI, *MSTI, nullptr, true, "__DWARF"));
 
     return Error::success();
   }

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
@@ -313,8 +313,7 @@ Error LVBinaryReader::loadGenericTargetInfo(StringRef TripleName,
                              "no instruction info for target " + TripleName);
   MII.reset(InstructionInfo);
 
-  MC = std::make_unique<MCContext>(Triple(TheTriple), *MAI, MRI.get(),
-                                   STI.get());
+  MC = std::make_unique<MCContext>(Triple(TheTriple), *MAI, *MRI, *STI);
 
   // Assembler.
   MCDisassembler *DisAsm(TheTarget->createMCDisassembler(*STI, *MC));

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -785,8 +785,7 @@ private:
                                          TT.str(),
                                      inconvertibleErrorCode());
 
-    auto Ctx = std::make_unique<MCContext>(Triple(TT.str()), *MAI, MRI.get(),
-                                           STI.get());
+    auto Ctx = std::make_unique<MCContext>(Triple(TT.str()), *MAI, *MRI, *STI);
 
     std::unique_ptr<MCDisassembler> Disassembler(
         TheTarget->createMCDisassembler(*STI, *Ctx));

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -63,12 +63,12 @@ static void defaultDiagHandler(const SMDiagnostic &SMD, bool, const SourceMgr &,
 }
 
 MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo &mai,
-                     const MCRegisterInfo *mri, const MCSubtargetInfo *msti,
+                     const MCRegisterInfo &mri, const MCSubtargetInfo &msti,
                      const SourceMgr *mgr, bool DoAutoReset,
                      StringRef Swift5ReflSegmentName)
     : Swift5ReflectionSegmentName(Swift5ReflSegmentName), TT(TheTriple),
       SrcMgr(mgr), InlineSrcMgr(nullptr), DiagHandler(defaultDiagHandler),
-      MAI(mai), MRI(mri), MSTI(msti), Symbols(Allocator),
+      MAI(mai), MRI(&mri), MSTI(&msti), Symbols(Allocator),
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
       AutoReset(DoAutoReset) {

--- a/llvm/lib/MC/MCDisassembler/Disassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/Disassembler.cpp
@@ -74,8 +74,7 @@ LLVMCreateDisasmCPUFeatures(const char *TT, const char *CPU,
     return nullptr;
 
   // Set up the MCContext for creating symbols and MCExpr's.
-  std::unique_ptr<MCContext> Ctx(
-      new MCContext(TheTriple, *MAI, MRI.get(), STI.get()));
+  std::unique_ptr<MCContext> Ctx(new MCContext(TheTriple, *MAI, *MRI, *STI));
   if (!Ctx)
     return nullptr;
 

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -103,7 +103,7 @@ initializeRecordStreamer(const Module &M,
   SourceMgr SrcMgr;
   SrcMgr.AddNewSourceBuffer(std::move(Buffer), SMLoc());
 
-  MCContext MCCtx(TT, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext MCCtx(TT, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> MOFI(
       T->createMCObjectFileInfo(MCCtx, /*PIC=*/false));
   MCCtx.setObjectFileInfo(MOFI.get());

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
@@ -37,7 +37,7 @@ void AArch64_ELFTargetObjectFile::Initialize(MCContext &Ctx,
   // Make sure the implicitly created empty .text section has the
   // SHF_AARCH64_PURECODE flag set if the "+execute-only" target feature is
   // present.
-  if (TM.getMCSubtargetInfo()->hasFeature(AArch64::FeatureExecuteOnly)) {
+  if (TM.getMCSubtargetInfo().hasFeature(AArch64::FeatureExecuteOnly)) {
     auto *Text = static_cast<MCSectionELF *>(TextSection);
     Text->setFlags(Text->getFlags() | ELF::SHF_AARCH64_PURECODE);
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -122,7 +122,7 @@ StringRef AMDGPUAsmPrinter::getPassName() const {
 }
 
 const MCSubtargetInfo *AMDGPUAsmPrinter::getGlobalSTI() const {
-  return TM.getMCSubtargetInfo();
+  return &TM.getMCSubtargetInfo();
 }
 
 AMDGPUTargetStreamer *AMDGPUAsmPrinter::getTargetStreamer() const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
@@ -77,7 +77,7 @@ bool AMDGPUResourceUsageAnalysisWrapperPass::runOnMachineFunction(
     return false;
 
   const TargetMachine &TM = TPC->getTM<TargetMachine>();
-  const MCSubtargetInfo &STI = *TM.getMCSubtargetInfo();
+  const MCSubtargetInfo &STI = TM.getMCSubtargetInfo();
 
   // By default, for code object v5 and later, track only the minimum scratch
   // size
@@ -104,7 +104,7 @@ AnalysisKey AMDGPUResourceUsageAnalysis::Key;
 AMDGPUResourceUsageAnalysis::Result
 AMDGPUResourceUsageAnalysis::run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM) {
-  const MCSubtargetInfo &STI = *TM.getMCSubtargetInfo();
+  const MCSubtargetInfo &STI = TM.getMCSubtargetInfo();
 
   // By default, for code object v5 and later, track only the minimum scratch
   // size

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -878,9 +878,9 @@ AMDGPUTargetMachine::AMDGPUTargetMachine(const Target &T, const Triple &TT,
       TLOF(createTLOF(getTargetTriple())) {
   initAsmInfo();
   if (TT.isAMDGCN()) {
-    if (getMCSubtargetInfo()->checkFeatures("+wavefrontsize64"))
+    if (getMCSubtargetInfo().checkFeatures("+wavefrontsize64"))
       MRI.reset(llvm::createGCNMCRegisterInfo(AMDGPUDwarfFlavour::Wave64));
-    else if (getMCSubtargetInfo()->checkFeatures("+wavefrontsize32"))
+    else if (getMCSubtargetInfo().checkFeatures("+wavefrontsize32"))
       MRI.reset(llvm::createGCNMCRegisterInfo(AMDGPUDwarfFlavour::Wave32));
   }
 }

--- a/llvm/lib/Target/ARM/ARMTargetObjectFile.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetObjectFile.cpp
@@ -38,7 +38,7 @@ void ARMElfTargetObjectFile::Initialize(MCContext &Ctx,
   const ARMBaseTargetMachine &ARM_TM = static_cast<const ARMBaseTargetMachine &>(TM);
   bool isAAPCS_ABI = ARM_TM.TargetABI == ARM::ARMABI::ARM_ABI_AAPCS;
   bool genExecuteOnly =
-      ARM_TM.getMCSubtargetInfo()->hasFeature(ARM::FeatureExecuteOnly);
+      ARM_TM.getMCSubtargetInfo().hasFeature(ARM::FeatureExecuteOnly);
 
   TargetLoweringObjectFileELF::Initialize(Ctx, TM);
   InitializeELF(isAAPCS_ABI);

--- a/llvm/lib/Target/AVR/AVRAsmPrinter.cpp
+++ b/llvm/lib/Target/AVR/AVRAsmPrinter.cpp
@@ -48,7 +48,7 @@ namespace {
 class AVRAsmPrinter : public AsmPrinter {
 public:
   AVRAsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer)
-      : AsmPrinter(TM, std::move(Streamer), ID), MRI(*TM.getMCRegisterInfo()) {}
+      : AsmPrinter(TM, std::move(Streamer), ID), MRI(TM.getMCRegisterInfo()) {}
 
   StringRef getPassName() const override { return "AVR Assembly Printer"; }
 

--- a/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
+++ b/llvm/lib/Target/CSKY/CSKYAsmPrinter.cpp
@@ -47,7 +47,7 @@ bool CSKYAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
   // Set the current MCSubtargetInfo to a copy which has the correct
   // feature bits for the current MachineFunction
   MCSubtargetInfo &NewSTI =
-      OutStreamer->getContext().getSubtargetCopy(*TM.getMCSubtargetInfo());
+      OutStreamer->getContext().getSubtargetCopy(TM.getMCSubtargetInfo());
   NewSTI.setFeatureBits(MF.getSubtarget().getFeatureBits());
   Subtarget = &NewSTI;
 

--- a/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
@@ -798,7 +798,7 @@ void HexagonAsmPrinter::emitEndOfAsmFile(Module &M) {
 void HexagonAsmPrinter::emitAttributes() {
   HexagonTargetStreamer &HTS =
       static_cast<HexagonTargetStreamer &>(*OutStreamer->getTargetStreamer());
-  HTS.emitTargetAttributes(*TM.getMCSubtargetInfo());
+  HTS.emitTargetAttributes(TM.getMCSubtargetInfo());
 }
 
 void HexagonAsmPrinter::EmitSled(const MachineInstr &MI, SledKind Kind) {

--- a/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.h
+++ b/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.h
@@ -31,7 +31,8 @@ private:
 public:
   explicit LoongArchAsmPrinter(TargetMachine &TM,
                                std::unique_ptr<MCStreamer> Streamer)
-      : AsmPrinter(TM, std::move(Streamer), ID), STI(TM.getMCSubtargetInfo()) {}
+      : AsmPrinter(TM, std::move(Streamer), ID), STI(&TM.getMCSubtargetInfo()) {
+  }
 
   StringRef getPassName() const override {
     return "LoongArch Assembly Printer";

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -457,7 +457,7 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
 bool RISCVAsmPrinter::emitDirectiveOptionArch() {
   RISCVTargetStreamer &RTS = getTargetStreamer();
   SmallVector<RISCVOptionArchArg> NeedEmitStdOptionArgs;
-  const MCSubtargetInfo &MCSTI = *TM.getMCSubtargetInfo();
+  const MCSubtargetInfo &MCSTI = TM.getMCSubtargetInfo();
   for (const auto &Feature : RISCVFeatureKV) {
     if (STI->hasFeature(Feature.Value) == MCSTI.hasFeature(Feature.Value))
       continue;
@@ -556,7 +556,7 @@ void RISCVAsmPrinter::emitStartOfAsmFile(Module &M) {
           dyn_cast_or_null<MDString>(M.getModuleFlag("target-abi")))
     RTS.setTargetABI(RISCVABI::getTargetABI(ModuleTargetABI->getString()));
 
-  MCSubtargetInfo SubtargetInfo = *TM.getMCSubtargetInfo();
+  MCSubtargetInfo SubtargetInfo = TM.getMCSubtargetInfo();
 
   // Use module flag to update feature bits.
   if (auto *MD = dyn_cast_or_null<MDNode>(M.getModuleFlag("riscv-isa"))) {
@@ -730,7 +730,7 @@ void RISCVAsmPrinter::EmitHwasanMemaccessSymbols(Module &M) {
   // Use MCSubtargetInfo from TargetMachine. Individual functions may have
   // attributes that differ from other functions in the module and we have no
   // way to know which function is correct.
-  const MCSubtargetInfo &MCSTI = *TM.getMCSubtargetInfo();
+  const MCSubtargetInfo &MCSTI = TM.getMCSubtargetInfo();
 
   MCSymbol *HwasanTagMismatchV2Sym =
       OutContext.getOrCreateSymbol("__hwasan_tag_mismatch_v2");

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -9018,12 +9018,11 @@ SDValue RISCVTargetLowering::lowerINIT_TRAMPOLINE(SDValue Op,
   const unsigned StaticChainOffset = StaticChainIdx * 4;
   const unsigned FunctionAddressOffset = StaticChainOffset + 8;
 
-  const MCSubtargetInfo *STI = getTargetMachine().getMCSubtargetInfo();
-  assert(STI);
+  const MCSubtargetInfo &STI = getTargetMachine().getMCSubtargetInfo();
   auto GetEncoding = [&](const MCInst &MC) {
     SmallVector<char, 4> CB;
     SmallVector<MCFixup> Fixups;
-    CodeEmitter->encodeInstruction(MC, CB, Fixups, *STI);
+    CodeEmitter->encodeInstruction(MC, CB, Fixups, STI);
     uint32_t Encoding = support::endian::read32le(CB.data());
     return Encoding;
   };

--- a/llvm/lib/Target/Sparc/SparcSubtarget.cpp
+++ b/llvm/lib/Target/Sparc/SparcSubtarget.cpp
@@ -56,7 +56,7 @@ SparcSubtarget &SparcSubtarget::initializeSubtargetDependencies(
 SparcSubtarget::SparcSubtarget(const StringRef &CPU, const StringRef &TuneCPU,
                                const StringRef &FS, const TargetMachine &TM)
     : SparcGenSubtargetInfo(TM.getTargetTriple(), CPU, TuneCPU, FS),
-      ReserveRegister(TM.getMCRegisterInfo()->getNumRegs()),
+      ReserveRegister(TM.getMCRegisterInfo().getNumRegs()),
       InstrInfo(initializeSubtargetDependencies(CPU, TuneCPU, FS)),
       TLInfo(TM, *this), FrameLowering(*this) {
   TSInfo = std::make_unique<SparcSelectionDAGInfo>();

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -959,8 +959,8 @@ void SystemZAsmPrinter::LowerPATCHABLE_FUNCTION_ENTER(
   // Update compiler-rt/lib/xray/xray_s390x.cpp accordingly when number
   // of instructions change.
   bool HasVectorFeature =
-      TM.getMCSubtargetInfo()->hasFeature(SystemZ::FeatureVector) &&
-      !TM.getMCSubtargetInfo()->hasFeature(SystemZ::FeatureSoftFloat);
+      TM.getMCSubtargetInfo().hasFeature(SystemZ::FeatureVector) &&
+      !TM.getMCSubtargetInfo().hasFeature(SystemZ::FeatureSoftFloat);
   MCSymbol *FuncEntry = OutContext.getOrCreateSymbol(
       HasVectorFeature ? "__xray_FunctionEntryVec" : "__xray_FunctionEntry");
   MCSymbol *BeginOfSled = OutContext.createTempSymbol("xray_sled_", true);
@@ -1004,8 +1004,8 @@ void SystemZAsmPrinter::LowerPATCHABLE_RET(const MachineInstr &MI,
   // Update compiler-rt/lib/xray/xray_s390x.cpp accordingly when number
   // of instructions change.
   bool HasVectorFeature =
-      TM.getMCSubtargetInfo()->hasFeature(SystemZ::FeatureVector) &&
-      !TM.getMCSubtargetInfo()->hasFeature(SystemZ::FeatureSoftFloat);
+      TM.getMCSubtargetInfo().hasFeature(SystemZ::FeatureVector) &&
+      !TM.getMCSubtargetInfo().hasFeature(SystemZ::FeatureSoftFloat);
   MCSymbol *FuncExit = OutContext.getOrCreateSymbol(
       HasVectorFeature ? "__xray_FunctionExitVec" : "__xray_FunctionExit");
   MCSymbol *BeginOfSled = OutContext.createTempSymbol("xray_sled_", true);
@@ -1029,7 +1029,7 @@ void SystemZAsmPrinter::LowerPATCHABLE_RET(const MachineInstr &MI,
 void SystemZAsmPrinter::emitAttributes(Module &M) {
   if (M.getModuleFlag("s390x-visible-vector-ABI")) {
     bool HasVectorFeature =
-      TM.getMCSubtargetInfo()->hasFeature(SystemZ::FeatureVector);
+        TM.getMCSubtargetInfo().hasFeature(SystemZ::FeatureVector);
     OutStreamer->emitGNUAttribute(8, HasVectorFeature ? 2 : 1);
   }
 }
@@ -1177,7 +1177,7 @@ static void printAddress(const MCAsmInfo *MAI, unsigned Base,
 bool SystemZAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
                                         const char *ExtraCode,
                                         raw_ostream &OS) {
-  const MCRegisterInfo &MRI = *TM.getMCRegisterInfo();
+  const MCRegisterInfo &MRI = TM.getMCRegisterInfo();
   const MachineOperand &MO = MI->getOperand(OpNo);
   MCOperand MCOp;
   if (ExtraCode) {

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -966,7 +966,7 @@ void X86AsmPrinter::LowerASAN_CHECK_MEMACCESS(const MachineInstr &MI) {
   StringRef Op = OrShadowOffset ? "or" : "add";
   std::string SymName = ("__asan_check_" + Name + "_" + Op + "_" +
                          Twine(1ULL << AccessInfo.AccessSizeIndex) + "_" +
-                         TM.getMCRegisterInfo()->getName(Reg.asMCReg()))
+                         TM.getMCRegisterInfo().getName(Reg.asMCReg()))
                             .str();
   if (OrShadowOffset)
     report_fatal_error(

--- a/llvm/lib/Target/Xtensa/XtensaAsmPrinter.h
+++ b/llvm/lib/Target/Xtensa/XtensaAsmPrinter.h
@@ -33,7 +33,8 @@ public:
 
   explicit XtensaAsmPrinter(TargetMachine &TM,
                             std::unique_ptr<MCStreamer> Streamer)
-      : AsmPrinter(TM, std::move(Streamer), ID), STI(TM.getMCSubtargetInfo()) {}
+      : AsmPrinter(TM, std::move(Streamer), ID), STI(&TM.getMCSubtargetInfo()) {
+  }
 
   StringRef getPassName() const override { return "Xtensa Assembly Printer"; }
   void emitInstruction(const MachineInstr *MI) override;

--- a/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
+++ b/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
@@ -412,8 +412,8 @@ Error FileAnalysis::initialiseDisassemblyMembers() {
   if (!MII)
     return make_error<UnsupportedDisassembly>("Failed to initialise MII.");
 
-  Context.reset(new MCContext(Triple(TripleName), *AsmInfo, RegisterInfo.get(),
-                              SubtargetInfo.get()));
+  Context.reset(new MCContext(Triple(TripleName), *AsmInfo, *RegisterInfo,
+                              *SubtargetInfo));
 
   Disassembler.reset(
       ObjectTarget->createMCDisassembler(*SubtargetInfo, *Context));

--- a/llvm/tools/llvm-exegesis/lib/Assembler.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.cpp
@@ -292,7 +292,7 @@ Error assembleToStream(const ExegesisTarget &ET,
   }
 
   const bool IsSnippetSetupComplete = generateSnippetSetupCode(
-      ET, TM->getMCSubtargetInfo(), Entry, Key, GenerateMemoryInstructions);
+      ET, &TM->getMCSubtargetInfo(), Entry, Key, GenerateMemoryInstructions);
 
   // If the snippet setup is not complete, we disable liveliness tracking. This
   // means that we won't know what values are in the registers.

--- a/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
+++ b/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
@@ -22,8 +22,8 @@ DisassemblerHelper::DisassemblerHelper(const LLVMState &State) : State_(State) {
       Triple, 0 /*default variant*/, *AsmInfo_, State_.getInstrInfo(),
       State_.getRegInfo()));
 
-  Context_ = std::make_unique<MCContext>(
-      Triple, *AsmInfo_, &State_.getRegInfo(), &State_.getSubtargetInfo());
+  Context_ = std::make_unique<MCContext>(Triple, *AsmInfo_, State_.getRegInfo(),
+                                         State_.getSubtargetInfo());
   Disasm_.reset(TM.getTarget().createMCDisassembler(State_.getSubtargetInfo(),
                                                     *Context_));
   assert(Disasm_ && "cannot create MCDisassembler. missing call to "

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -157,7 +157,7 @@ bool LLVMState::canAssemble(const MCInst &Inst) const {
   SmallVector<char, 16> Tmp;
   SmallVector<MCFixup, 4> Fixups;
   CodeEmitter->encodeInstruction(Inst, Tmp, Fixups,
-                                 *TheTargetMachine->getMCSubtargetInfo());
+                                 TheTargetMachine->getMCSubtargetInfo());
   return Tmp.size() > 0;
 }
 

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.h
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.h
@@ -60,10 +60,10 @@ public:
     return *TheTargetMachine->getMCInstrInfo();
   }
   const MCRegisterInfo &getRegInfo() const {
-    return *TheTargetMachine->getMCRegisterInfo();
+    return TheTargetMachine->getMCRegisterInfo();
   }
   const MCSubtargetInfo &getSubtargetInfo() const {
-    return *TheTargetMachine->getMCSubtargetInfo();
+    return TheTargetMachine->getMCSubtargetInfo();
   }
 
   const RegisterAliasingTrackerCache &getRATC() const { return *RATC; }

--- a/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
@@ -133,7 +133,7 @@ static void appendCodeTemplates(const LLVMState &State,
       unsigned ScratchMemoryRegister = ET.getScratchMemoryRegister(
           State.getTargetMachine().getTargetTriple());
       const llvm::MCRegisterClass &RegClass =
-          State.getTargetMachine().getMCRegisterInfo()->getRegClass(
+          State.getTargetMachine().getMCRegisterInfo().getRegClass(
               DefOp.getExplicitOperandInfo().RegClass);
 
       // Register classes of def operand and memory operand must be the same

--- a/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
@@ -257,7 +257,7 @@ Expected<std::vector<BenchmarkCode>> readSnippets(const LLVMState &State,
   const std::unique_ptr<MCInstPrinter> InstPrinter(
       TM.getTarget().createMCInstPrinter(
           TM.getTargetTriple(), TM.getMCAsmInfo().getAssemblerDialect(),
-          TM.getMCAsmInfo(), *TM.getMCInstrInfo(), *TM.getMCRegisterInfo()));
+          TM.getMCAsmInfo(), *TM.getMCInstrInfo(), TM.getMCRegisterInfo()));
   // The following call will take care of calling Streamer.setTargetStreamer.
   TM.getTarget().createAsmTargetStreamer(Streamer, InstPrinterOStream,
                                          InstPrinter.get());
@@ -271,7 +271,7 @@ Expected<std::vector<BenchmarkCode>> readSnippets(const LLVMState &State,
   AsmParser->getLexer().setCommentConsumer(&Streamer);
 
   const std::unique_ptr<MCTargetAsmParser> TargetAsmParser(
-      TM.getTarget().createMCAsmParser(*TM.getMCSubtargetInfo(), *AsmParser,
+      TM.getTarget().createMCAsmParser(TM.getMCSubtargetInfo(), *AsmParser,
                                        *TM.getMCInstrInfo()));
 
   if (!TargetAsmParser)

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -2756,8 +2756,7 @@ getTargetInfo(const Triple &TT,
         make_error<StringError>("Unable to create target asm info " + TT.str(),
                                 inconvertibleErrorCode()));
 
-  auto Ctx =
-      std::make_unique<MCContext>(Triple(TT.str()), *MAI, MRI.get(), STI.get());
+  auto Ctx = std::make_unique<MCContext>(Triple(TT.str()), *MAI, *MRI, *STI);
 
   std::unique_ptr<MCDisassembler> Disassembler(
       TheTarget->createMCDisassembler(*STI, *Ctx));

--- a/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
+++ b/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
@@ -176,7 +176,7 @@ int AssembleOneInput(const uint8_t *Data, size_t Size) {
     abort();
   }
 
-  MCContext Ctx(TheTriple, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext Ctx(TheTriple, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false));
   Ctx.setObjectFileInfo(MOFI.get());

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -491,7 +491,7 @@ int main(int argc, char **argv) {
 
   // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
   // MCObjectFileInfo needs a MCContext reference in order to initialize itself.
-  MCContext Ctx(TheTriple, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext Ctx(TheTriple, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(Ctx, PIC, LargeCodeModel));
   Ctx.setObjectFileInfo(MOFI.get());

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -486,7 +486,7 @@ int main(int argc, char **argv) {
   }
 
   // Parse the input and create CodeRegions that llvm-mca can analyze.
-  MCContext ACtx(TheTriple, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext ACtx(TheTriple, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> AMOFI(
       TheTarget->createMCObjectFileInfo(ACtx, /*PIC=*/false));
   ACtx.setObjectFileInfo(AMOFI.get());
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
 
   // Parse the input and create InstrumentRegion that llvm-mca
   // can use to improve analysis.
-  MCContext ICtx(TheTriple, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext ICtx(TheTriple, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> IMOFI(
       TheTarget->createMCObjectFileInfo(ICtx, /*PIC=*/false));
   ICtx.setObjectFileInfo(IMOFI.get());

--- a/llvm/tools/llvm-ml/Disassembler.cpp
+++ b/llvm/tools/llvm-ml/Disassembler.cpp
@@ -143,7 +143,7 @@ int Disassembler::disassemble(const Target &T, const std::string &TripleName,
   }
 
   // Set up the MCContext for creating symbols and MCExpr's.
-  MCContext Ctx(Triple(TripleName), *MAI, MRI.get(), &STI);
+  MCContext Ctx(Triple(TripleName), *MAI, *MRI, STI);
 
   std::unique_ptr<const MCDisassembler> DisAsm(
       T.createMCDisassembler(STI, Ctx));

--- a/llvm/tools/llvm-ml/llvm-ml.cpp
+++ b/llvm/tools/llvm-ml/llvm-ml.cpp
@@ -334,7 +334,7 @@ int llvm_ml_main(int Argc, char **Argv, const llvm::ToolContext &) {
 
   // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
   // MCObjectFileInfo needs a MCContext reference in order to initialize itself.
-  MCContext Ctx(TheTriple, *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext Ctx(TheTriple, *MAI, *MRI, *STI, &SrcMgr);
   std::unique_ptr<MCObjectFileInfo> MOFI(TheTarget->createMCObjectFileInfo(
       Ctx, /*PIC=*/false, /*LargeCodeModel=*/true));
   Ctx.setObjectFileInfo(MOFI.get());

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7328,7 +7328,7 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
   std::unique_ptr<const MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TheTriple, MachOMCPU, FeaturesStr));
   CHECK_TARGET_INFO_CREATION(STI);
-  MCContext Ctx(TheTriple, *AsmInfo, MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, *AsmInfo, *MRI, *STI);
   std::unique_ptr<MCDisassembler> DisAsm(
       TheTarget->createMCDisassembler(*STI, Ctx));
   CHECK_TARGET_INFO_CREATION(DisAsm);
@@ -7382,8 +7382,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
     ThumbSTI.reset(ThumbTarget->createMCSubtargetInfo(ThumbTriple, MachOMCPU,
                                                       FeaturesStr));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbSTI);
-    ThumbCtx.reset(new MCContext(ThumbTriple, *ThumbAsmInfo, ThumbMRI.get(),
-                                 ThumbSTI.get()));
+    ThumbCtx.reset(
+        new MCContext(ThumbTriple, *ThumbAsmInfo, *ThumbMRI, *ThumbSTI));
     ThumbDisAsm.reset(ThumbTarget->createMCDisassembler(*ThumbSTI, *ThumbCtx));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbDisAsm);
     MCContext *PtrThumbCtx = ThumbCtx.get();

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1186,8 +1186,8 @@ DisassemblerTarget::DisassemblerTarget(const Target *TheTarget, ObjectFile &Obj,
   if (!InstrInfo)
     reportError(Obj.getFileName(),
                 "no instruction info for target " + TripleName);
-  Context = std::make_shared<MCContext>(TheTriple, *AsmInfo, RegisterInfo.get(),
-                                        SubtargetInfo.get());
+  Context = std::make_shared<MCContext>(TheTriple, *AsmInfo, *RegisterInfo,
+                                        *SubtargetInfo);
 
   // FIXME: for now initialize MCObjectFileInfo with default values
   ObjectFileInfo.reset(

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -755,7 +755,7 @@ void ProfiledBinary::setUpDisassembler(const ObjectFile *Obj) {
     exitWithError("no instruction info for target " + TheTriple.str(),
                   FileName);
 
-  MCContext Ctx(TheTriple, *AsmInfo, MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, *AsmInfo, *MRI, *STI);
   std::unique_ptr<MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false));
   Ctx.setObjectFileInfo(MOFI.get());

--- a/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
+++ b/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
@@ -805,7 +805,7 @@ static int linkAndVerify() {
   if (!MAI)
     ErrorAndExit("Unable to create target asm info!");
 
-  MCContext Ctx(TheTriple, *MAI, MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, *MAI, *MRI, *STI);
 
   std::unique_ptr<MCDisassembler> Disassembler(
     TheTarget->createMCDisassembler(*STI, Ctx));

--- a/llvm/tools/sancov/sancov.cpp
+++ b/llvm/tools/sancov/sancov.cpp
@@ -769,7 +769,7 @@ static void getObjectCoveragePoints(const object::ObjectFile &O,
       TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   failIfEmpty(AsmInfo, "no asm info for target " + TripleName);
 
-  MCContext Ctx(TheTriple, *AsmInfo, MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, *AsmInfo, *MRI, *STI);
   std::unique_ptr<MCDisassembler> DisAsm(
       TheTarget->createMCDisassembler(*STI, Ctx));
   failIfEmpty(DisAsm, "no disassembler info for target " + TripleName);

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -116,9 +116,15 @@ public:
             Target(), "", Triple(""), "", "", getTargetOptionsForBogusMachine(),
             Reloc::Static, CodeModel::Small, CodeGenOptLevel::Default),
         ST(*this) {
-    // With an empty Triple, `initAsmInfo` cannot be called. Provide a
-    // default MCAsmInfo so that MCContext can be created.
+    // With an empty Triple, `initAsmInfo` cannot be called. Provide
+    // default MC{AsmInfo,RegisterInfo,SubtargetInfo} so MCContext can be
+    // created.
     AsmInfo = std::make_unique<MCAsmInfo>(Options.MCOptions);
+    MRI = std::make_unique<MCRegisterInfo>();
+    STI = std::make_unique<MCSubtargetInfo>(
+        Triple(""), "", "", "", ArrayRef<StringRef>{},
+        ArrayRef<SubtargetFeatureKV>{}, ArrayRef<SubtargetSubTypeKV>{}, nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr);
   }
 
   ~BogusTargetMachine() override = default;

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -42,8 +42,11 @@ MCTargetOptions MCOptions;
 std::unique_ptr<MCContext> createMCContext(const MCAsmInfo &AsmInfo) {
   Triple TheTriple(/*ArchStr=*/"", /*VendorStr=*/"", /*OSStr=*/"",
                    /*EnvironmentStr=*/"elf");
-  return std::make_unique<MCContext>(TheTriple, AsmInfo, nullptr, nullptr,
-                                     nullptr, false);
+  static MCRegisterInfo MRI;
+  static const MCSubtargetInfo STI(TheTriple, "", "", "", {}, {}, {}, nullptr,
+                                   nullptr, nullptr, nullptr, nullptr, nullptr);
+  return std::make_unique<MCContext>(TheTriple, AsmInfo, MRI, STI, nullptr,
+                                     false);
 }
 
 // This test makes sure that MachineInstr::isIdenticalTo handles Defs correctly

--- a/llvm/unittests/CodeGen/MachineOperandTest.cpp
+++ b/llvm/unittests/CodeGen/MachineOperandTest.cpp
@@ -351,8 +351,11 @@ TEST(MachineOperandTest, PrintMetadata) {
 TEST(MachineOperandTest, PrintMCSymbol) {
   MCTargetOptions MCOptions;
   MCAsmInfo MAI(MCOptions);
+  MCRegisterInfo MRI;
   Triple T = Triple("unknown-unknown-unknown");
-  MCContext Ctx(T, MAI, /*MRI=*/nullptr, /*MSTI=*/nullptr);
+  MCSubtargetInfo STI(T, "", "", "", {}, {}, {}, nullptr, nullptr, nullptr,
+                      nullptr, nullptr, nullptr);
+  MCContext Ctx(T, MAI, MRI, STI);
   MCSymbol *Sym = Ctx.getOrCreateSymbol("foo");
 
   // Create a MachineOperand with a metadata and print it.

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
@@ -101,8 +101,7 @@ public:
 DWARFExpressionCopyBytesTest::StreamerContext
 DWARFExpressionCopyBytesTest::createStreamer(raw_pwrite_stream &OS) {
   StreamerContext Res;
-  Res.Ctx = std::make_unique<MCContext>(Triple(TripleName), *MAI, MRI.get(),
-                                        /*MSTI=*/nullptr);
+  Res.Ctx = std::make_unique<MCContext>(Triple(TripleName), *MAI, *MRI, *STI);
   Res.MOFI.reset(TheTarget->createMCObjectFileInfo(*Res.Ctx,
                                                    /*PIC=*/false));
   Res.Ctx->setObjectFileInfo(Res.MOFI.get());

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
@@ -488,7 +488,7 @@ llvm::Error dwarfgen::Generator::init(Triple TheTriple, uint16_t V) {
     return make_error<StringError>("no target machine for target " + TripleName,
                                    inconvertibleErrorCode());
 
-  MC.reset(new MCContext(TheTriple, *MAI, MRI.get(), MSTI.get()));
+  MC.reset(new MCContext(TheTriple, *MAI, *MRI, *MSTI));
   TLOF = TM->getObjFileLowering();
   TLOF->Initialize(*MC, *TM);
   MC->setObjectFileInfo(TLOF);

--- a/llvm/unittests/MC/AMDGPU/Disassembler.cpp
+++ b/llvm/unittests/MC/AMDGPU/Disassembler.cpp
@@ -85,7 +85,7 @@ TEST(AMDGPUDisassembler, MultiDisassembler) {
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TT, CPUName, ""));
-  auto Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(), STI.get());
+  auto Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
 
   int AsmPrinterVariant = MAI->getAssemblerDialect();
   std::unique_ptr<MCInstPrinter> IP(
@@ -157,7 +157,7 @@ TEST(AMDGPUDisassembler, UCVersionOverride) {
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TT, CPUName, ""));
-  auto Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(), STI.get());
+  auto Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
 
   // Define custom UC_VERSION before initializing disassembler.
   const uint8_t UC_VERSION_GFX10_DEFAULT = 0x04;

--- a/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
+++ b/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
@@ -46,17 +46,17 @@ TEST(AMDGPUDwarfRegMappingTests, TestWave64DwarfRegMapping) {
   for (auto Triple :
        {"amdgcn-amd-", "amdgcn-amd-amdhsa", "amdgcn-amd-amdpal"}) {
     auto TM = createTargetMachine(Triple, "gfx1010", "+wavefrontsize64");
-    if (TM && TM->getMCRegisterInfo()) {
-      auto MRI = TM->getMCRegisterInfo();
+    if (TM) {
+      const auto &MRI = TM->getMCRegisterInfo();
       // Wave64 Dwarf register mapping test numbers
       // PC_64 => 16, EXEC_MASK_64 => 17, S0 => 32, S63 => 95,
       // S64 => 1088, S105 => 1129, V0 => 2560, V255 => 2815,
       // A0 => 3072, A255 => 3327
       for (int DwarfEncoding :
            {16, 17, 32, 95, 1088, 1129, 2560, 2815, 3072, 3327}) {
-        MCRegister Reg = *MRI->getLLVMRegNum(DwarfEncoding, false);
-        EXPECT_EQ(DwarfEncoding, MRI->getDwarfRegNum(Reg, false));
-        EXPECT_EQ(DwarfEncoding, MRI->getDwarfRegNum(Reg, true));
+        MCRegister Reg = *MRI.getLLVMRegNum(DwarfEncoding, false);
+        EXPECT_EQ(DwarfEncoding, MRI.getDwarfRegNum(Reg, false));
+        EXPECT_EQ(DwarfEncoding, MRI.getDwarfRegNum(Reg, true));
       }
     }
   }
@@ -66,17 +66,17 @@ TEST(AMDGPUDwarfRegMappingTests, TestWave32DwarfRegMapping) {
   for (auto Triple :
        {"amdgcn-amd-", "amdgcn-amd-amdhsa", "amdgcn-amd-amdpal"}) {
     auto TM = createTargetMachine(Triple, "gfx1010", "+wavefrontsize32");
-    if (TM && TM->getMCRegisterInfo()) {
-      auto MRI = TM->getMCRegisterInfo();
+    if (TM) {
+      const auto &MRI = TM->getMCRegisterInfo();
       // Wave32 Dwarf register mapping test numbers
       // PC_64 => 16, EXEC_MASK_32 => 1, S0 => 32, S63 => 95,
       // S64 => 1088, S105 => 1129, V0 => 1536, V255 => 1791,
       // A0 => 2048, A255 => 2303
       for (int DwarfEncoding :
            {16, 1, 32, 95, 1088, 1129, 1536, 1791, 2048, 2303}) {
-        MCRegister Reg = *MRI->getLLVMRegNum(DwarfEncoding, false);
-        EXPECT_EQ(DwarfEncoding, MRI->getDwarfRegNum(Reg, false));
-        EXPECT_EQ(DwarfEncoding, MRI->getDwarfRegNum(Reg, true));
+        MCRegister Reg = *MRI.getLLVMRegNum(DwarfEncoding, false);
+        EXPECT_EQ(DwarfEncoding, MRI.getDwarfRegNum(Reg, false));
+        EXPECT_EQ(DwarfEncoding, MRI.getDwarfRegNum(Reg, true));
       }
     }
   }

--- a/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
+++ b/llvm/unittests/MC/DwarfDebugFrameCIE.cpp
@@ -75,8 +75,7 @@ public:
 
   StreamerContext createStreamer(raw_pwrite_stream &OS) {
     StreamerContext Res;
-    Res.Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(),
-                                          /*MSTI=*/nullptr);
+    Res.Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
     Res.MOFI.reset(TheTarget->createMCObjectFileInfo(*Res.Ctx, /*PIC=*/false));
     Res.Ctx->setObjectFileInfo(Res.MOFI.get());
 

--- a/llvm/unittests/MC/DwarfLineTableHeaders.cpp
+++ b/llvm/unittests/MC/DwarfLineTableHeaders.cpp
@@ -70,8 +70,7 @@ public:
   /// Create all data structures necessary to operate an assembler
   StreamerContext createStreamer(raw_pwrite_stream &OS) {
     StreamerContext Res;
-    Res.Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(),
-                                          /*MSTI=*/nullptr);
+    Res.Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
     Res.MOFI.reset(TheTarget->createMCObjectFileInfo(*Res.Ctx,
                                                      /*PIC=*/false));
     Res.Ctx->setObjectFileInfo(Res.MOFI.get());

--- a/llvm/unittests/MC/DwarfLineTables.cpp
+++ b/llvm/unittests/MC/DwarfLineTables.cpp
@@ -13,6 +13,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
@@ -26,6 +27,7 @@ struct Context {
   Triple TT;
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
+  std::unique_ptr<MCSubtargetInfo> STI;
   std::unique_ptr<MCContext> Ctx;
 
   Context() : TT(TripleName) {
@@ -42,8 +44,8 @@ struct Context {
     MRI.reset(TheTarget->createMCRegInfo(TT));
     MCTargetOptions MCOptions;
     MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
-    Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(),
-                                      /*MSTI=*/nullptr);
+    STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
+    Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
   }
 
   operator bool() { return Ctx.get(); }

--- a/llvm/unittests/MC/SystemZ/SystemZAsmLexerTest.cpp
+++ b/llvm/unittests/MC/SystemZ/SystemZAsmLexerTest.cpp
@@ -81,7 +81,7 @@ protected:
     SrcMgr.AddNewSourceBuffer(std::move(Buffer), SMLoc());
     EXPECT_EQ(Buffer, nullptr);
 
-    Ctx.reset(new MCContext(Triple, *MAI, MRI.get(), STI.get(), &SrcMgr));
+    Ctx.reset(new MCContext(Triple, *MAI, *MRI, *STI, &SrcMgr));
     MOFI.reset(TheTarget->createMCObjectFileInfo(*Ctx, /*PIC=*/false,
                                                  /*LargeCodeModel=*/false));
     Ctx->setObjectFileInfo(MOFI.get());

--- a/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
@@ -46,7 +46,7 @@ struct Context {
     MRI.reset(TheTarget->createMCRegInfo(TT));
     MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
-    Ctx = std::make_unique<MCContext>(TT, *MAI, MRI.get(), STI.get());
+    Ctx = std::make_unique<MCContext>(TT, *MAI, *MRI, *STI);
 
     DisAsm.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
   }

--- a/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
@@ -46,7 +46,7 @@ struct Context {
     MRI.reset(TheTarget->createMCRegInfo(TheTriple));
     MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
-    Ctx = std::make_unique<MCContext>(TheTriple, *MAI, MRI.get(), STI.get());
+    Ctx = std::make_unique<MCContext>(TheTriple, *MAI, *MRI, *STI);
 
     DisAsm.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
   }

--- a/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64InstPrinterTest.cpp
@@ -40,7 +40,7 @@ static std::string AArch64InstPrinterTestPrintAlignedLabel(uint64_t value) {
   MCRegisterInfo MRI;
   MCSubtargetInfo STI(Triple(""), "", "", "", {}, {}, {}, nullptr, nullptr,
                       nullptr, nullptr, nullptr, nullptr);
-  MCContext Ctx(Triple(""), MAI, &MRI, &STI);
+  MCContext Ctx(Triple(""), MAI, MRI, STI);
   MCInst MI;
 
   MI.addOperand(MCOperand::createExpr(MCConstantExpr::create(value, Ctx)));

--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -57,8 +57,8 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
   std::unique_ptr<AArch64InstrInfo> II = createInstrInfo(TM.get());
   ASSERT_TRUE(II);
 
-  const MCSubtargetInfo *STI = TM->getMCSubtargetInfo();
-  MCSchedModel SchedModel = STI->getSchedModel();
+  const MCSubtargetInfo &STI = TM->getMCSubtargetInfo();
+  MCSchedModel SchedModel = STI.getSchedModel();
 
   for (unsigned i = 0; i < AArch64::INSTRUCTION_LIST_END; ++i) {
     // Check if instruction is in the pseudo table
@@ -72,7 +72,7 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
     // model for the CPU we're testing. This avoids this test from failing when
     // new instructions are added that are not yet covered by the scheduler
     // model.
-    if (!isInstructionSupportedByCPU(OrigInstr, STI->getFeatureBits()))
+    if (!isInstructionSupportedByCPU(OrigInstr, STI.getFeatureBits()))
       continue;
 
     const MCInstrDesc &Desc = II->get(i);
@@ -90,9 +90,9 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
     for (unsigned DefIdx = 0, DefEnd = SCDesc->NumWriteLatencyEntries;
          DefIdx != DefEnd; ++DefIdx) {
       const MCWriteLatencyEntry *WLEntry =
-          STI->getWriteLatencyEntry(SCDesc, DefIdx);
+          STI.getWriteLatencyEntry(SCDesc, DefIdx);
       const MCWriteLatencyEntry *WLEntryOrig =
-          STI->getWriteLatencyEntry(SCDescOrig, DefIdx);
+          STI.getWriteLatencyEntry(SCDescOrig, DefIdx);
       Latency = std::max(Latency, static_cast<int>(WLEntry->Cycles));
       LatencyOrig = std::max(Latency, static_cast<int>(WLEntryOrig->Cycles));
     }

--- a/llvm/unittests/tools/llvm-mca/MCATestBase.cpp
+++ b/llvm/unittests/tools/llvm-mca/MCATestBase.cpp
@@ -42,7 +42,7 @@ void MCATestBase::SetUp() {
   MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   ASSERT_TRUE(MAI);
 
-  Ctx = std::make_unique<MCContext>(TheTriple, *MAI, MRI.get(), STI.get());
+  Ctx = std::make_unique<MCContext>(TheTriple, *MAI, *MRI, *STI);
   MOFI.reset(TheTarget->createMCObjectFileInfo(*Ctx, /*PIC=*/false));
   Ctx->setObjectFileInfo(MOFI.get());
 

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -303,7 +303,7 @@ mlir::ROCDL::assembleIsa(StringRef isa, StringRef targetTriple, StringRef chip,
   std::unique_ptr<llvm::MCSubtargetInfo> sti(
       target->createMCSubtargetInfo(triple, chip, features));
 
-  llvm::MCContext ctx(triple, *mai, mri.get(), sti.get(), &srcMgr);
+  llvm::MCContext ctx(triple, *mai, *mri, *sti, &srcMgr);
   std::unique_ptr<llvm::MCObjectFileInfo> mofi(target->createMCObjectFileInfo(
       ctx, /*PIC=*/false, /*LargeCodeModel=*/false));
   ctx.setObjectFileInfo(mofi.get());

--- a/mlir/lib/Target/LLVMIR/Transforms/TargetToTargetFeatures.cpp
+++ b/mlir/lib/Target/LLVMIR/Transforms/TargetToTargetFeatures.cpp
@@ -53,11 +53,11 @@ struct TargetToTargetFeaturesPass
       return signalPassFailure();
     }
 
-    llvm::MCSubtargetInfo const *subTargetInfo =
+    llvm::MCSubtargetInfo const &subTargetInfo =
         (*targetMachine)->getMCSubtargetInfo();
 
     const std::vector<llvm::SubtargetFeatureKV> enabledFeatures =
-        subTargetInfo->getEnabledProcessorFeatures();
+        subTargetInfo.getEnabledProcessorFeatures();
 
     auto plussedFeatures = llvm::map_to_vector(
         enabledFeatures, [](llvm::SubtargetFeatureKV feature) {


### PR DESCRIPTION
Both MCRegisterInfo and MCSubtargetInfo are non-null at every callsite
that matters (only nullable in unit tests like
`llvm/unittests/CodeGen/MFCommon.inc`), mirroring the recent `const
MCAsmInfo &` cleanup.

* TargetMachine::getMCRegisterInfo and getMCSubtargetInfo return
  references.
* MCContext's constructor takes const MCRegisterInfo & and
  const MCSubtargetInfo &.
