### PR TITLE
[libc] Enable socket entrypoints in overlay mode

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -278,8 +278,28 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.resource.getrlimit
     libc.src.sys.resource.setrlimit
 
-    # sys/sendfile entrypoints
+    # sys/sendfile.h entrypoints
     libc.src.sys.sendfile.sendfile
+
+    # sys/socket.h entrypoints
+    libc.src.sys.socket.accept
+    libc.src.sys.socket.accept4
+    libc.src.sys.socket.bind
+    libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.listen
+    libc.src.sys.socket.recv
+    libc.src.sys.socket.recvfrom
+    libc.src.sys.socket.send
+    libc.src.sys.socket.sendto
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socket
+    libc.src.sys.socket.socketpair
+    # TODO: These functions are not compatible with 64-bit musl. They need to
+    # be excluded if overlaying musl.
+    libc.src.sys.socket.recvmsg
+    libc.src.sys.socket.sendmsg
 
     # sys/stat.h entrypoints
     libc.src.sys.stat.chmod
@@ -1218,17 +1238,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/select.h entrypoints
     libc.src.sys.select.select
-
-    # sys/socket.h entrypoints
-    libc.src.sys.socket.accept
-    libc.src.sys.socket.accept4
-    libc.src.sys.socket.bind
-    libc.src.sys.socket.connect
-    libc.src.sys.socket.getsockopt
-    libc.src.sys.socket.listen
-    libc.src.sys.socket.setsockopt
-    libc.src.sys.socket.shutdown
-    libc.src.sys.socket.socket
   )
 endif()
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -278,8 +278,28 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.resource.getrlimit
     libc.src.sys.resource.setrlimit
 
-    # sys/sendfile entrypoints
+    # sys/sendfile.h entrypoints
     libc.src.sys.sendfile.sendfile
+
+    # sys/socket.h entrypoints
+    libc.src.sys.socket.accept
+    libc.src.sys.socket.accept4
+    libc.src.sys.socket.bind
+    libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.listen
+    libc.src.sys.socket.recv
+    libc.src.sys.socket.recvfrom
+    libc.src.sys.socket.send
+    libc.src.sys.socket.sendto
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socket
+    libc.src.sys.socket.socketpair
+    # TODO: These functions are not compatible with 64-bit musl. They need to
+    # be excluded if overlaying musl.
+    libc.src.sys.socket.recvmsg
+    libc.src.sys.socket.sendmsg
 
     # sys/stat.h entrypoints
     libc.src.sys.stat.chmod
@@ -1352,24 +1372,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/select.h entrypoints
     libc.src.sys.select.select
-
-    # sys/socket.h entrypoints
-    libc.src.sys.socket.accept
-    libc.src.sys.socket.accept4
-    libc.src.sys.socket.bind
-    libc.src.sys.socket.connect
-    libc.src.sys.socket.getsockopt
-    libc.src.sys.socket.listen
-    libc.src.sys.socket.setsockopt
-    libc.src.sys.socket.shutdown
-    libc.src.sys.socket.socket
-    libc.src.sys.socket.socketpair
-    libc.src.sys.socket.send
-    libc.src.sys.socket.sendto
-    libc.src.sys.socket.sendmsg
-    libc.src.sys.socket.recv
-    libc.src.sys.socket.recvfrom
-    libc.src.sys.socket.recvmsg
   )
 endif()
 

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -294,8 +294,28 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.sem.semctl
     libc.src.sys.sem.semop
 
-    # sys/sendfile entrypoints
+    # sys/sendfile.h entrypoints
     libc.src.sys.sendfile.sendfile
+
+    # sys/socket.h entrypoints
+    libc.src.sys.socket.accept
+    libc.src.sys.socket.accept4
+    libc.src.sys.socket.bind
+    libc.src.sys.socket.connect
+    libc.src.sys.socket.getsockopt
+    libc.src.sys.socket.listen
+    libc.src.sys.socket.recv
+    libc.src.sys.socket.recvfrom
+    libc.src.sys.socket.send
+    libc.src.sys.socket.sendto
+    libc.src.sys.socket.setsockopt
+    libc.src.sys.socket.shutdown
+    libc.src.sys.socket.socket
+    libc.src.sys.socket.socketpair
+    # TODO: These functions are not compatible with 64-bit musl. They need to
+    # be excluded if overlaying musl.
+    libc.src.sys.socket.recvmsg
+    libc.src.sys.socket.sendmsg
 
     # sys/stat.h entrypoints
     libc.src.sys.stat.chmod
@@ -1428,24 +1448,6 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sys/select.h entrypoints
     libc.src.sys.select.select
-
-    # sys/socket.h entrypoints
-    libc.src.sys.socket.accept
-    libc.src.sys.socket.accept4
-    libc.src.sys.socket.socket
-    libc.src.sys.socket.bind
-    libc.src.sys.socket.connect
-    libc.src.sys.socket.getsockopt
-    libc.src.sys.socket.listen
-    libc.src.sys.socket.shutdown
-    libc.src.sys.socket.socketpair
-    libc.src.sys.socket.setsockopt
-    libc.src.sys.socket.send
-    libc.src.sys.socket.sendto
-    libc.src.sys.socket.sendmsg
-    libc.src.sys.socket.recv
-    libc.src.sys.socket.recvfrom
-    libc.src.sys.socket.recvmsg
 
     # wchar.h entrypoints
     libc.src.wchar.mblen

--- a/libc/test/src/sys/socket/linux/shutdown_test.cpp
+++ b/libc/test/src/sys/socket/linux/shutdown_test.cpp
@@ -32,7 +32,7 @@ TEST_F(LlvmLibcShutdownTest, ShutWrProducesEOF) {
   // Reading from sv[1] should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_THAT(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
-              Succeeds(0));
+              Succeeds<ssize_t>(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
@@ -49,7 +49,7 @@ TEST_F(LlvmLibcShutdownTest, ShutRdPreventsReading) {
   // Reading from sv[0] should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_THAT(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
-              Succeeds(0));
+              Succeeds<ssize_t>(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));
@@ -66,9 +66,9 @@ TEST_F(LlvmLibcShutdownTest, ShutRdWrDoesBoth) {
   // Both descriptors should report end-of-file by returning 0.
   char read_buf[10];
   ASSERT_THAT(LIBC_NAMESPACE::read(sv[0], read_buf, sizeof(read_buf)),
-              Succeeds(0));
+              Succeeds<ssize_t>(0));
   ASSERT_THAT(LIBC_NAMESPACE::read(sv[1], read_buf, sizeof(read_buf)),
-              Succeeds(0));
+              Succeeds<ssize_t>(0));
 
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[0]), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(sv[1]), Succeeds(0));

--- a/libc/test/src/sys/socket/linux/socketopt_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketopt_test.cpp
@@ -48,7 +48,7 @@ TEST_F(LlvmLibcSocketOptTest, BasicSocketOpt) {
   ASSERT_THAT(
       LIBC_NAMESPACE::getsockopt(sock, SOL_SOCKET, SO_TYPE, &optval, &optlen),
       Succeeds(0));
-  ASSERT_EQ(optval, SOCK_STREAM);
+  ASSERT_EQ(optval, static_cast<int>(SOCK_STREAM));
   ASSERT_EQ(optlen, static_cast<socklen_t>(sizeof(optval)));
 
   optval = SOCK_DGRAM;


### PR DESCRIPTION
This is slightly tricky in that many of these functions depend on types (struct sockaddrs, msghdr, ...) and we cannot overlay types. However, this works because these functions are simple syscall wrappers which simply forward the data to the kernel -- so it's really the kernel that's defining these structures.

This approach is compatible with libraries which implement these functions the same way, this includes at least glibc (on all architectures) and musl (on 32-bit architectures). 64-bit musl repacks the [c]msghdr structures to zero out padding fields, and overlaying that can lead to subtle bugs. However, I believe that overlaying musl is not a very interesting use case, so I'm leaving that as a TODO. If someone is interested in doing that, they can either exclude these entrypoints from the overlay or implement the musl-compatible repacking code.