### PR TITLE
[lldb] Remove name field from StatsSuccessFail

### DIFF
--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -112,13 +112,10 @@ public:
 
 /// A class to count success/fail statistics.
 struct StatsSuccessFail {
-  StatsSuccessFail(llvm::StringRef n) : name(n.str()) {}
-
   void NotifySuccess() { ++successes; }
   void NotifyFailure() { ++failures; }
 
   llvm::json::Value ToJSON() const;
-  std::string name;
   uint32_t successes = 0;
   uint32_t failures = 0;
 };
@@ -333,8 +330,8 @@ protected:
   std::optional<StatsTimepoint> m_launch_or_attach_time;
   std::optional<StatsTimepoint> m_first_private_stop_time;
   std::optional<StatsTimepoint> m_first_public_stop_time;
-  StatsSuccessFail m_expr_eval{"expressionEvaluation"};
-  StatsSuccessFail m_frame_var{"frameVariable"};
+  StatsSuccessFail m_expr_eval;
+  StatsSuccessFail m_frame_var;
   std::vector<intptr_t> m_module_identifiers;
   uint32_t m_source_map_deduce_count = 0;
   uint32_t m_source_realpath_attempt_count = 0;

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -129,8 +129,9 @@ TargetStats::ToJSON(Target &target,
     for (auto module_identifier : m_module_identifiers)
       json_module_uuid_array.emplace_back(module_identifier);
 
-    target_metrics_json.try_emplace(m_expr_eval.name, m_expr_eval.ToJSON());
-    target_metrics_json.try_emplace(m_frame_var.name, m_frame_var.ToJSON());
+    target_metrics_json.try_emplace("expressionEvaluation",
+                                    m_expr_eval.ToJSON());
+    target_metrics_json.try_emplace("frameVariable", m_frame_var.ToJSON());
     if (include_modules)
       target_metrics_json.try_emplace("moduleIdentifiers",
                                       std::move(json_module_uuid_array));


### PR DESCRIPTION
Each *Stats struct is supposed to serialize into JSON and contains the data to serialize *itself* into JSON. However, the StatsSuccessFail also contains a `name` field which is only interesting for the *parent* Stats class. This patch just removes the field as it is only used for storing a constant string that is only used once during serialization.