### PR TITLE
[LV][NFC] Remove unused -simplifycfg-*** option from tests

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/if-pred-not-when-safe.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-pred-not-when-safe.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -force-vector-width=2 -force-vector-interleave=1 -passes=loop-vectorize -verify-loop-info -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck %s
+; RUN: opt -S -force-vector-width=2 -force-vector-interleave=1 -passes=loop-vectorize -verify-loop-info < %s | FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/llvm/test/Transforms/LoopVectorize/vectorize-once.ll
+++ b/llvm/test/Transforms/LoopVectorize/vectorize-once.ll
@@ -1,4 +1,4 @@
-; RUN: opt < %s -passes=loop-vectorize -force-vector-interleave=1 -force-vector-width=4 -S -simplifycfg-require-and-preserve-domtree=1 | FileCheck %s
+; RUN: opt < %s -passes=loop-vectorize -force-vector-interleave=1 -force-vector-width=4 -S | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 


### PR DESCRIPTION
The -simplifycfg-require-and-preserve-domtree=1 option used in two tests had no effect.