### PR TITLE
[LifetimeSafety] Add support for destructive function calls

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -104,6 +104,7 @@ private:
   void handleInvalidatingCall(const Expr *Call, const FunctionDecl *FD,
                               ArrayRef<const Expr *> Args);
 
+  // Detect explicit destructor calls/`std::destroy_at`
   void handleDestructiveCall(const Expr *Call, const FunctionDecl *FD,
                              ArrayRef<const Expr *> Args);
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -104,6 +104,9 @@ private:
   void handleInvalidatingCall(const Expr *Call, const FunctionDecl *FD,
                               ArrayRef<const Expr *> Args);
 
+  void handleDestructiveCall(const Expr *Call, const FunctionDecl *FD,
+                             ArrayRef<const Expr *> Args);
+
   template <typename Destination, typename Source>
   void flowOrigin(const Destination &D, const Source &S) {
     flow(getOriginsList(D), getOriginsList(S), /*Kill=*/false);

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -80,9 +80,9 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD);
 // https://en.cppreference.com/w/cpp/container#Iterator_invalidation
 bool isInvalidationMethod(const CXXMethodDecl &MD);
 
-// Returns true if the given function is a destructor/deleter (e.g.,
-// destroy_at).
-bool isDestructionFunc(const FunctionDecl &FD);
+// Returns true if the function destroys its first argument
+// (e.g., destructors via implicit 'this', std::destroy_at).
+bool destructsFirstArg(const FunctionDecl &FD);
 
 /// Returns true for standard library callable wrappers (e.g., std::function)
 /// that can propagate the stored lambda's origins.

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -80,6 +80,8 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD);
 // https://en.cppreference.com/w/cpp/container#Iterator_invalidation
 bool isInvalidationMethod(const CXXMethodDecl &MD);
 
+// Returns true if the given function is a destructor/deleter (destroy_at).
+bool isDestructionFunc(const FunctionDecl &FD);
 /// Returns true for standard library callable wrappers (e.g., std::function)
 /// that can propagate the stored lambda's origins.
 bool isStdCallableWrapperType(const CXXRecordDecl *RD);

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -80,7 +80,8 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD);
 // https://en.cppreference.com/w/cpp/container#Iterator_invalidation
 bool isInvalidationMethod(const CXXMethodDecl &MD);
 
-// Returns true if the given function is a destructor/deleter (destroy_at).
+// Returns true if the given function is a destructor/deleter (e.g.,
+// destroy_at).
 bool isDestructionFunc(const FunctionDecl &FD);
 
 /// Returns true for standard library callable wrappers (e.g., std::function)

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -82,6 +82,7 @@ bool isInvalidationMethod(const CXXMethodDecl &MD);
 
 // Returns true if the given function is a destructor/deleter (destroy_at).
 bool isDestructionFunc(const FunctionDecl &FD);
+
 /// Returns true for standard library callable wrappers (e.g., std::function)
 /// that can propagate the stored lambda's origins.
 bool isStdCallableWrapperType(const CXXRecordDecl *RD);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -787,7 +787,7 @@ void FactsGenerator::handleInvalidatingCall(const Expr *Call,
 void FactsGenerator::handleDestructiveCall(const Expr *Call,
                                            const FunctionDecl *FD,
                                            ArrayRef<const Expr *> Args) {
-  if (!isDestructionFunc(*FD))
+  if (!destructsFirstArg(*FD))
     return;
   OriginList *ArgList = getOriginsList(*Args[0]);
   if (ArgList)

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -782,9 +782,9 @@ void FactsGenerator::handleInvalidatingCall(const Expr *Call,
   if (!DRE || DRE->getDecl()->getType()->isReferenceType())
     return;
 
-  if (OriginList *ThisList = getOriginsList(*Args[0]))
+  if (OriginList *ArgList = getOriginsList(*Args[0]))
     CurrentBlockFacts.push_back(FactMgr.createFact<InvalidateOriginFact>(
-        ThisList->getOuterOriginID(), Call));
+        ArgList->getOuterOriginID(), Call));
 }
 
 void FactsGenerator::handleImplicitObjectFieldUses(const Expr *Call,

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -768,21 +768,29 @@ void FactsGenerator::handleInvalidatingCall(const Expr *Call,
                                             const FunctionDecl *FD,
                                             ArrayRef<const Expr *> Args) {
   const auto *MD = dyn_cast<CXXMethodDecl>(FD);
-  const bool IsInvalidatingMethod = MD && isInvalidationMethod(*MD);
-  const bool IsDestruction = isDestructionFunc(*FD);
-  if (!IsInvalidatingMethod && !IsDestruction)
+  if (!MD || !MD->isInstance())
     return;
 
-  // `destroy_at` get an implicit cast for the object argument, methods already
-  // give us the right shape.
-  const Expr *Target = IsDestruction ? Args[0]->IgnoreImpCasts() : Args[0];
-
-  // Heuristics to turn down false positives.
-  const auto *DRE = dyn_cast<DeclRefExpr>(Target);
+  if (!isInvalidationMethod(*MD))
+    return;
+  // Heuristics to turn-down false positives.
+  auto *DRE = dyn_cast<DeclRefExpr>(Args[0]);
   if (!DRE || DRE->getDecl()->getType()->isReferenceType())
     return;
 
-  if (OriginList *ArgList = getOriginsList(*Args[0]))
+  OriginList *ThisList = getOriginsList(*Args[0]);
+  if (ThisList)
+    CurrentBlockFacts.push_back(FactMgr.createFact<InvalidateOriginFact>(
+        ThisList->getOuterOriginID(), Call));
+}
+
+void FactsGenerator::handleDestructiveCall(const Expr *Call,
+                                           const FunctionDecl *FD,
+                                           ArrayRef<const Expr *> Args) {
+  if (!isDestructionFunc(*FD))
+    return;
+  OriginList *ArgList = getOriginsList(*Args[0]);
+  if (ArgList)
     CurrentBlockFacts.push_back(FactMgr.createFact<InvalidateOriginFact>(
         ArgList->getOuterOriginID(), Call));
 }
@@ -832,6 +840,7 @@ void FactsGenerator::handleFunctionCall(const Expr *Call,
   for (const Expr *Arg : Args)
     handleUse(Arg);
   handleInvalidatingCall(Call, FD, Args);
+  handleDestructiveCall(Call, FD, Args);
   handleMovedArgsInCall(FD, Args);
   handleImplicitObjectFieldUses(Call, FD);
   if (!CallList)

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -768,18 +768,21 @@ void FactsGenerator::handleInvalidatingCall(const Expr *Call,
                                             const FunctionDecl *FD,
                                             ArrayRef<const Expr *> Args) {
   const auto *MD = dyn_cast<CXXMethodDecl>(FD);
-  if (!MD || !MD->isInstance())
+  const bool IsInvalidatingMethod = MD && isInvalidationMethod(*MD);
+  const bool IsDestruction = isDestructionFunc(*FD);
+  if (!IsInvalidatingMethod && !IsDestruction)
     return;
 
-  if (!isInvalidationMethod(*MD))
-    return;
-  // Heuristics to turn-down false positives.
-  auto *DRE = dyn_cast<DeclRefExpr>(Args[0]);
+  // `destroy_at` get an implicit cast for the object argument, methods already
+  // give us the right shape.
+  const Expr *Target = IsDestruction ? Args[0]->IgnoreImpCasts() : Args[0];
+
+  // Heuristics to turn down false positives.
+  const auto *DRE = dyn_cast<DeclRefExpr>(Target);
   if (!DRE || DRE->getDecl()->getType()->isReferenceType())
     return;
 
-  OriginList *ThisList = getOriginsList(*Args[0]);
-  if (ThisList)
+  if (OriginList *ThisList = getOriginsList(*Args[0]))
     CurrentBlockFacts.push_back(FactMgr.createFact<InvalidateOriginFact>(
         ThisList->getOuterOriginID(), Call));
 }

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -393,12 +393,10 @@ bool isInvalidationMethod(const CXXMethodDecl &MD) {
   return InvalidatingMethods->contains(MD.getName());
 }
 
-bool isDestructionFunc(const FunctionDecl &FD) {
+bool destructsFirstArg(const FunctionDecl &FD) {
   if (isa<CXXDestructorDecl>(FD))
     return true;
-  if (isInStlNamespace(&FD) && getName(FD) == "destroy_at")
-    return true;
-  return false;
+  return isInStlNamespace(&FD) && getName(FD) == "destroy_at";
 }
 
 bool isStdCallableWrapperType(const CXXRecordDecl *RD) {

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -268,6 +268,12 @@ static StringRef getName(const CXXRecordDecl &RD) {
   return "";
 }
 
+static StringRef getName(const FunctionDecl &FD) {
+  if (FD.getIdentifier())
+    return FD.getName();
+  return "";
+}
+
 static bool isStdUniquePtr(const CXXRecordDecl &RD) {
   return RD.isInStdNamespace() && getName(RD) == "unique_ptr";
 }
@@ -390,8 +396,7 @@ bool isInvalidationMethod(const CXXMethodDecl &MD) {
 bool isDestructionFunc(const FunctionDecl &FD) {
   if (isa<CXXDestructorDecl>(FD))
     return true;
-  if (const auto *II = FD.getIdentifier();
-      isInStlNamespace(&FD) && II && II->getName() == "destroy_at")
+  if (isInStlNamespace(&FD) && getName(FD) == "destroy_at")
     return true;
   return false;
 }

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -387,6 +387,15 @@ bool isInvalidationMethod(const CXXMethodDecl &MD) {
   return InvalidatingMethods->contains(MD.getName());
 }
 
+bool isDestructionFunc(const FunctionDecl &FD) {
+  if (isa<CXXDestructorDecl>(FD))
+    return true;
+  if (const auto *II = FD.getIdentifier();
+      isInStlNamespace(&FD) && II && II->getName() == "destroy_at")
+    return true;
+  return false;
+}
+
 bool isStdCallableWrapperType(const CXXRecordDecl *RD) {
   if (!RD || !isInStlNamespace(RD))
     return false;

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -214,6 +214,9 @@ unique_ptr<T> make_unique(Args&&... args) {
   return unique_ptr<T>(new T(args...));
 }
 
+template <class T>
+void destroy_at(T *);
+
 template<typename T>
 struct shared_ptr {
   shared_ptr();

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -593,13 +593,14 @@ void reference_destructor_invalidates_pointer() {
 }
 
 struct StringOwner {
-  std::string s;
+  std::string s, t;
 };
 
+// FIXME: False-positive
 void member_destructor_invalidates_pointer() {
-  StringOwner owner = {"42"};
+  StringOwner owner = {"42", "43"};
   const char *p = owner.s.data(); // expected-warning {{object whose reference is captured is later invalidated}}
-  owner.s.~basic_string();        // expected-note {{invalidated here}}
+  owner.t.~basic_string();        // expected-note {{invalidated here}}
   (void)*p;                       // expected-note {{later used here}}
 }
 

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -540,6 +540,73 @@ void function_captured_ref_invalidated() {
 
 } // namespace callable_wrappers
 
+namespace manual_destruction {
+
+void explicit_destructor_invalidates_pointer() {
+  std::string s = "42";
+  const char *p = s.data(); // expected-warning {{object whose reference is captured is later invalidated}}
+  s.~basic_string();        // expected-note {{invalidated here}}
+  (void)*p;                 // expected-note {{later used here}}
+}
+
+void pointer_destructor_invalidates_pointer() {
+  char storage[sizeof(std::string)];
+  std::string *obj = new (storage) std::string("42"); // expected-warning {{object whose reference is captured is later invalidated}}
+  const char *p = obj->data();
+  obj->~basic_string();                               // expected-note {{invalidated here}}
+  (void)*p;                                           // expected-note {{later used here}}
+}
+
+void destroy_at_invalidates_pointer() {
+  char storage[sizeof(std::string)];
+  std::string *obj = new (storage) std::string("42"); // expected-warning {{object whose reference is captured is later invalidated}}
+  const char *p = obj->data();
+  std::destroy_at(obj);                               // expected-note {{invalidated here}}
+  (void)*p;                                           // expected-note {{later used here}}
+}
+
+void destroy_at_then_placement_new_rescues_pointer() {
+  char storage[sizeof(std::string)];
+  std::string *obj = new (storage) std::string("42");
+  const char *p = obj->data();
+  std::destroy_at(obj);
+  obj = new (storage) std::string("23");
+  p = obj->data();
+  (void)*p;
+}
+
+// FIXME: False-negative
+void destroy_at_invalidates_array_pointer() {
+  std::string arr[1] = {"42"};
+  std::string (&arr_ref)[1] = arr;
+  const char *p = arr[0].data();
+  std::destroy_at(&arr_ref);
+  (void)*p;
+}
+
+// FIXME: False-negative
+void reference_destructor_invalidates_pointer() {
+  std::string s = "42";
+  std::string &ref = s;
+  const char *p = ref.data();
+  std::destroy_at(&ref);
+  (void)*p;
+}
+
+struct StringOwner {
+  std::string s;
+};
+
+// FIXME: False-negative
+void member_destructor_invalidates_pointer() {
+  StringOwner owner = {"42"};
+  const char *p = owner.s.data();
+  owner.s.~basic_string();
+  (void)*p;
+}
+
+} // namespace manual_destruction
+
 namespace unique_ptr_invalidation {
 
 void invalid_after_reset() {

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -592,6 +592,14 @@ void reference_destructor_invalidates_pointer() {
   (void)*p;                   // expected-note {{later used here}}
 }
 
+void destroy_at_ternary_operator(bool flag) {
+  std::string* str1 = new std::string; // expected-warning {{object whose reference is captured is later invalidated}}
+  std::string* str2 = new std::string;
+  const char *p = str1->data();
+  std::destroy_at(flag ? str1 : str2); // expected-note {{invalidated here}}
+  (void)*p;                            // expected-note {{later used here}}
+}
+
 struct StringOwner {
   std::string s, t;
 };

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -540,7 +540,8 @@ void function_captured_ref_invalidated() {
 
 } // namespace callable_wrappers
 
-namespace manual_destruction {
+// FIXME: does not report a double free
+namespace explicit_destructor {
 
 void explicit_destructor_invalidates_pointer() {
   std::string s = "42";
@@ -575,37 +576,34 @@ void destroy_at_then_placement_new_rescues_pointer() {
   (void)*p;
 }
 
-// FIXME: False-negative
 void destroy_at_invalidates_array_pointer() {
   std::string arr[1] = {"42"};
   std::string (&arr_ref)[1] = arr;
-  const char *p = arr[0].data();
-  std::destroy_at(&arr_ref);
-  (void)*p;
+  const char *p = arr[0].data(); // expected-warning {{object whose reference is captured is later invalidated}}
+  std::destroy_at(&arr_ref);     // expected-note {{invalidated here}}
+  (void)*p;                      // expected-note {{later used here}}
 }
 
-// FIXME: False-negative
 void reference_destructor_invalidates_pointer() {
   std::string s = "42";
-  std::string &ref = s;
+  std::string &ref = s;       // expected-warning {{object whose reference is captured is later invalidated}}
   const char *p = ref.data();
-  std::destroy_at(&ref);
-  (void)*p;
+  std::destroy_at(&ref);      // expected-note {{invalidated here}}
+  (void)*p;                   // expected-note {{later used here}}
 }
 
 struct StringOwner {
   std::string s;
 };
 
-// FIXME: False-negative
 void member_destructor_invalidates_pointer() {
   StringOwner owner = {"42"};
-  const char *p = owner.s.data();
-  owner.s.~basic_string();
-  (void)*p;
+  const char *p = owner.s.data(); // expected-warning {{object whose reference is captured is later invalidated}}
+  owner.s.~basic_string();        // expected-note {{invalidated here}}
+  (void)*p;                       // expected-note {{later used here}}
 }
 
-} // namespace manual_destruction
+} // namespace explicit_destructor
 
 namespace unique_ptr_invalidation {
 


### PR DESCRIPTION
Adds `handleDestructiveCall` function that detects invalidation caused by explicit destructive calls, such as explicit destructor calls and `std::destroy_at`. 

Comes as part of the completion of #164963.

Assisted-by: GPT-5.4 for writing some of the tests.