### PR TITLE
[clang][deps] Call getMemBuffer with RequiresNullTerminator false

### DIFF
--- a/clang/lib/DependencyScanning/InProcessModuleCache.cpp
+++ b/clang/lib/DependencyScanning/InProcessModuleCache.cpp
@@ -179,7 +179,8 @@ public:
     }
     Size = Entry.Buffer->getBufferSize();
     ModTime = Entry.ModTime;
-    return llvm::MemoryBuffer::getMemBuffer(*Entry.Buffer);
+    return llvm::MemoryBuffer::getMemBuffer(*Entry.Buffer,
+                                            /* RequiresNullTerminator */ false);
   }
 };
 } // namespace


### PR DESCRIPTION
The getMemBuffer() has a default parameter RequiresNullTerminator which is set to true.

In ModuleCache the MemoryBuffer::getOpenFile is called with /* RequiresNullTerminator=*/false. This means that initial contents of the MemoryBuffer may not have a trailing 0x0 at the end of the file.

When assertions are enabled and RequiresNullTerminator is true the MemoryBuffer will trigger a "Buffer is not null terminated!" assertion failure if BufEnd[0] != 0.

We have at one build with assertions enabled that is triggering this MemoryBuffer assertion failure in the check-clang tests:
* ClangScanDeps/modules-dep-args.c
* Driver/modules-driver-import-std.cpp

The failure is specific to one particular machine, we have not been able to reproduce locally. It is possible that the failure is filesystem type or path length dependent.

Changing the RequiresNullTerminator in getMemBuffer to false to match the value of RequiresNullTerminator in getOpenFile fixes the problem and all tests pass.