### PR TITLE
[Offload] Remove use of raw Linux fd for error reporting

### DIFF
--- a/offload/plugins-nextgen/common/include/ErrorReporting.h
+++ b/offload/plugins-nextgen/common/include/ErrorReporting.h
@@ -28,7 +28,6 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <unistd.h>
 
 namespace llvm {
 namespace omp {
@@ -83,7 +82,7 @@ class ErrorReporter {
   [[gnu::format(__printf__, 1, 2)]]
 #endif
   static void print(const char *Format, ArgsTy &&...Args) {
-    raw_fd_ostream OS(STDERR_FILENO, false);
+    auto &OS = llvm::errs();
     OS << llvm::format(Format, Args...);
   }
 
@@ -94,7 +93,7 @@ class ErrorReporter {
   [[gnu::format(__printf__, 2, 3)]]
 #endif
   static void print(ColorTy Color, const char *Format, ArgsTy &&...Args) {
-    raw_fd_ostream OS(STDERR_FILENO, false);
+    auto &OS = llvm::errs();
     WithColor(OS, HighlightColor(Color)) << llvm::format(Format, Args...);
   }
 


### PR DESCRIPTION
Summary:
This is a blocker on builiding Windows, we should be able to share the
common err stream tha LLVM provides
