### PR TITLE
[LLVM][Intrinsics] Remove unused IIT_EMPTYSTRUCT

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -327,7 +327,7 @@ def IIT_V64 : IIT_Vec<64, 16>;
 def IIT_MMX : IIT_VT<x86mmx, 17>;
 def IIT_TOKEN : IIT_VT<token, 18>;
 def IIT_METADATA : IIT_VT<MetadataVT, 19>;
-def IIT_EMPTYSTRUCT : IIT_VT<OtherVT, 20>;
+// Note: Unused IIT code 20.
 def IIT_STRUCT : IIT_Base<21>;
 def IIT_EXTEND_ARG : IIT_Base<22>;
 def IIT_TRUNC_ARG : IIT_Base<23>;

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -400,9 +400,6 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
                                              /*Lo=*/OverloadIndex));
     return;
   }
-  case IIT_EMPTYSTRUCT:
-    OutputTable.push_back(IITDescriptor::get(IITDescriptor::Struct, 0));
-    return;
   case IIT_STRUCT: {
     unsigned StructElts = Infos[NextElt++] + 2;
 


### PR DESCRIPTION
Remove `IIT_EMPTYSTRUCT` as its not generated anywhere.