### PR TITLE
[VPlan] Determine WidenGEP::usesFirstLaneOnly cheaply (NFCI)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2608,7 +2608,7 @@ void VPScalarIVStepsRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
 
 bool VPWidenGEPRecipe::usesFirstLaneOnly(const VPValue *Op) const {
   assert(is_contained(operands(), Op) && "Op must be an operand of the recipe");
-  return vputils::isSingleScalar(Op);
+  return Op->isDefinedOutsideLoopRegions();
 }
 
 void VPWidenGEPRecipe::execute(VPTransformState &State) {


### PR DESCRIPTION
Using vputils::isSingleScalar to determine if only the first lane of an operand is wasteful, considering that all operands are integers with the exception of the first operand, which is a pointer: these will be maximally narrowed by narrowToSingleScalars, and maximally hoisted or sunk by licm.