### PR TITLE
[AArch64][GlobalISel] Use generic matchinfo. NFC

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Combine.td
+++ b/llvm/lib/Target/AArch64/AArch64Combine.td
@@ -17,9 +17,8 @@ def fconstant_to_constant : GICombineRule<
          [{ return matchFConstantToConstant(*${root}, MRI); }]),
   (apply [{ applyFConstantToConstant(*${root}); }])>;
 
-def icmp_redundant_trunc_matchdata : GIDefMatchData<"Register">;
 def icmp_redundant_trunc : GICombineRule<
-  (defs root:$root, icmp_redundant_trunc_matchdata:$matchinfo),
+  (defs root:$root, register_matchinfo:$matchinfo),
   (match (G_ICMP $dst, $tst, $src1, $src2):$root,
          [{ return matchICmpRedundantTrunc(*${root}, MRI, Helper.getValueTracking(), ${matchinfo}); }]),
   (apply [{ applyICmpRedundantTrunc(*${root}, MRI, B, Observer, ${matchinfo}); }])>;
@@ -157,9 +156,8 @@ def shuf_to_ins: GICombineRule <
   (apply [{ applyINS(*${root}, MRI, B, ${matchinfo}); }])
 >;
 
-def vashr_vlshr_imm_matchdata : GIDefMatchData<"int64_t">;
 def vashr_vlshr_imm : GICombineRule<
-  (defs root:$root, vashr_vlshr_imm_matchdata:$matchinfo),
+  (defs root:$root, int64_matchinfo:$matchinfo),
   (match (wip_match_opcode G_ASHR, G_LSHR):$root,
           [{ return matchVAshrLshrImm(*${root}, MRI, ${matchinfo}); }]),
   (apply [{ applyVAshrLshrImm(*${root}, MRI, ${matchinfo}); }])
@@ -282,9 +280,8 @@ def lower_vector_fcmp : GICombineRule<
     [{ return matchLowerVectorFCMP(*${root}, MRI, B); }]),
   (apply [{ applyLowerVectorFCMP(*${root}, MRI, B); }])>;
 
-def form_truncstore_matchdata : GIDefMatchData<"Register">;
 def form_truncstore : GICombineRule<
-  (defs root:$root, form_truncstore_matchdata:$matchinfo),
+  (defs root:$root, register_matchinfo:$matchinfo),
   (match (G_STORE $src, $addr):$root,
           [{ return matchFormTruncstore(*${root}, MRI, ${matchinfo}); }]),
   (apply [{ applyFormTruncstore(*${root}, MRI, B, Observer, ${matchinfo}); }])
@@ -318,9 +315,8 @@ def vector_sext_inreg_to_shift : GICombineRule<
   (apply [{ applyVectorSextInReg(*${d}, MRI, B, Observer); }])
 >;
 
-def unmerge_ext_to_unmerge_matchdata : GIDefMatchData<"Register">;
 def unmerge_ext_to_unmerge : GICombineRule<
-  (defs root:$d, unmerge_ext_to_unmerge_matchdata:$matchinfo),
+  (defs root:$d, register_matchinfo:$matchinfo),
   (match (wip_match_opcode G_UNMERGE_VALUES):$d,
           [{ return matchUnmergeExtToUnmerge(*${d}, MRI, ${matchinfo}); }]),
   (apply [{ applyUnmergeExtToUnmerge(*${d}, MRI, B, Observer, ${matchinfo}); }])


### PR DESCRIPTION
This removes some of the simple AArch64 matchinfo's, using the generic
alternatives instead.