### PR TITLE
[Clang][Sema] Fix template-id disambiguation for nested class of current instantiation

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -556,6 +556,7 @@ Bug Fixes to C++ Support
 - Fixed a crash on ``typeid`` of incomplete local types during template instantiation. (#GH63242), (#GH176397)
 - Fixed a crash when an immediate-invoked ``consteval`` lambda is used as an invalid initializer. (#GH185270)
 - Fixed an assertion failure when using a global destructor with a target with a non-default program address space. (#GH186484)
+- Fixed a class member access bug where ``obj.id`` or ``obj->id`` followed by ``<`` was wrongly disambiguated as a template-id when ``obj`` had a type nested in the current class template (e.g. ``M<T>::E``) and a same-named template was visible in the surrounding scope (commonly ``::hash`` brought in by ``using namespace std;``). Per [basic.lookup.classref], the identifier is looked up in the class of the object expression first; the surrounding scope is consulted only when not found there.
 
 - Inherited constructors in ``dllexport`` classes are now exported for ABI-compatible cases, matching
   MSVC behavior. Constructors with variadic arguments or callee-cleanup parameters are not yet supported

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -406,6 +406,34 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     assert(SS.isEmpty() && "ObjectType and scope specifier cannot coexist");
     LookupCtx = computeDeclContext(ObjectType);
     IsDependent = !LookupCtx && ObjectType->isDependentType();
+
+    // [basic.lookup.classref] requires looking up the identifier first in the
+    // class of the object expression. If ObjectType is dependent only because
+    // it is a (transitively) nested class of the current instantiation, do
+    // qualified lookup against the underlying tag declaration so we don't
+    // wrongly fall through to surrounding-scope lookup and pick up a
+    // same-named template (e.g. ::hash from `using namespace std;`).
+    //
+    // This is restricted to the disambiguation case (no explicit `template`
+    // keyword): when the keyword is present the standard already requires
+    // treating `id` as a template-name and downstream code relies on the
+    // dependent path, so we leave that alone.
+    if (!LookupCtx && IsDependent && !RequiredTemplate.hasTemplateKeyword()) {
+      if (auto *RD =
+              dyn_cast_or_null<CXXRecordDecl>(ObjectType->getAsTagDecl())) {
+        for (DeclContext *Encl = RD->getDeclContext();
+             Encl && !Encl->isFileContext(); Encl = Encl->getParent()) {
+          auto *EnclRD = dyn_cast<CXXRecordDecl>(Encl);
+          if (EnclRD && EnclRD->isDependentContext() &&
+              EnclRD->isCurrentInstantiation(CurContext)) {
+            LookupCtx = RD;
+            IsDependent = false;
+            break;
+          }
+        }
+      }
+    }
+
     assert((IsDependent || !ObjectType->isIncompleteType() ||
             !ObjectType->getAs<TagType>() ||
             ObjectType->castAs<TagType>()->getDecl()->isEntityBeingDefined()) &&

--- a/clang/test/SemaCXX/member-access-template-id-classref.cpp
+++ b/clang/test/SemaCXX/member-access-template-id-classref.cpp
@@ -1,0 +1,66 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++17
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++20
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++23
+
+// Regression test: when `using namespace std;` brings the `std::hash` class
+// template into the global namespace, a member access of the form
+// `obj.hash < expr` (where `hash` is a non-template member of obj's class
+// type) must not be disambiguated as the start of a template-id.
+//
+// Per [basic.lookup.classref], the identifier `hash` after `.` or `->` is
+// looked up first in the class of the object expression. Only if it is not
+// found there is the surrounding scope consulted. Bug reported via
+// https://github.com/stephenberry/glaze/issues/2534
+
+// expected-no-diagnostics
+
+namespace std {
+  template <class T> struct hash {};
+}
+
+using namespace std;
+
+// Case 1: nested class inside a class template, accessed via `->` and `.`.
+template <class T>
+struct M1 {
+  struct E { unsigned hash; };
+  static const E *f(const E *p, unsigned t) {
+    if (p->hash < t) return p;
+    return nullptr;
+  }
+  static int g(E e, unsigned t) {
+    return (e.hash < t) ? 1 : 0;
+  }
+};
+
+// Case 2: nested class whose `hash` member type genuinely depends on T.
+template <class T>
+struct M2 {
+  struct E { T hash; };
+  static int g(E e, T t) {
+    return (e.hash < t) ? 1 : 0;
+  }
+};
+
+// Case 3: non-template, non-nested class. Sanity baseline (already worked
+// before the fix).
+struct E3 { unsigned hash; };
+static int f3(const E3 *p, unsigned t) {
+  if (p->hash < t) return 1;
+  return 0;
+}
+
+// Case 4: direct member of the current instantiation accessed via `this->`.
+// Sanity baseline (already worked before the fix).
+template <class T>
+struct M4 {
+  unsigned hash;
+  int g(unsigned t) const {
+    return (this->hash < t) ? 1 : 0;
+  }
+};
+
+// Force instantiation so any deferred lookup is exercised.
+template struct M1<int>;
+template struct M2<int>;
+template struct M4<int>;


### PR DESCRIPTION
## Summary

When parsing a class member access of the form `obj.id` or `obj->id` followed by `<`, [basic.lookup.classref] requires looking up `id` first in the class of the object expression; only if not found there is it looked up in the surrounding scope. `Sema::LookupTemplateName` would skip the class-side lookup whenever `Sema::computeDeclContext(ObjectType)` returned null and fall through to surrounding-scope lookup, which would incorrectly pick up a same-named class template (most commonly `::hash` brought into scope by `using namespace std;`) and treat `id <` as the start of a template-id.

This bites real-world code that does not itself write `using namespace std;` but transitively includes a header that does. Minimal reproducer:

```cpp
#include <functional>           // brings std::hash into ::std
using namespace std;            // hoists std::hash into ::

template <class T>
struct M {
    struct E { unsigned hash; };
    static const E* f(const E* p, unsigned target) {
        if (p->hash < target) return p;   // error before this patch
        return nullptr;
    }
};
```

```
error: expected '>'
    if (p->hash < target) return p;
                        ^
note: to match this '<'
    if (p->hash < target) return p;
                ^
```

## Root cause

`computeDeclContext(QualType)` returns null for any dependent type whose enclosing class isn't an exact ancestor of `CurContext`. For `M<T>::E` accessed from inside `M<T>`, that returns null even though the underlying record is fully knowable at parse time (it is a member of the current instantiation per [temp.dep.type]/9). With no `LookupCtx`, `LookupTemplateName` skips the class-side lookup, falls through to surrounding-scope `LookupName`, finds the global `::hash` class template, and returns `TNK_Type_template`. The parser then commits to template-id parsing of `hash<...>`.

## Fix

In `LookupTemplateName`, when `LookupCtx` is null and `ObjectType` is dependent, walk the enclosing classes of the object's tag decl. If any of them is the current instantiation, use the tag decl as the lookup context for the qualified lookup. Gated on `!RequiredTemplate.hasTemplateKeyword()` so the explicit-`template` path (`obj.template foo<X>()`) keeps the existing dependent-name behaviour — broadening the change to that path tripped a downstream `assert "dependent lookup context that isn't the current instantiation"` in `Sema::BuildMemberReferenceExpr` and a `findInstantiationOf` assertion exercised by `clang/test/SemaTemplate/alias-template-with-lambdas.cpp`.

## Test

`clang/test/SemaCXX/member-access-template-id-classref.cpp` covers four cases:

- nested class of `M<T>` accessed via `->` and `.`, both with non-dependent and dependent member type — these are the previously broken cases
- non-template, non-nested class — sanity baseline
- direct member of the current instantiation accessed via `this->` — sanity baseline

All four use `// expected-no-diagnostics` and the file forces instantiation of the templates so the path that previously crashed/errored is exercised.

## Test plan

- [x] `ninja check-clang` — 49,929 / 49,930 pass on Apple Silicon (the lone failure is the pre-existing macOS-only `CodeGen/2008-07-31-asm-labels.c` symbol-mangling test that fails on `main` too)
- [x] New regression test fails on `main` and passes with the patch
- [x] Reproducer above compiles cleanly with the patched compiler