### PR TITLE
[clang] Implement CWG2768

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -15466,11 +15466,14 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
     // The syntax only allows initializer lists on the RHS of assignment,
     // so we don't need to worry about accepting invalid code for
     // non-assignment operators.
-    // C++11 5.17p9:
-    //   The meaning of x = {v} [...] is that of x = T(v) [...]. The meaning
-    //   of x = {} is x = T().
-    InitializationKind Kind = InitializationKind::CreateDirectList(
-        RHSExpr->getBeginLoc(), RHSExpr->getBeginLoc(), RHSExpr->getEndLoc());
+    // C++ [expr.assign]/8:
+    //   A braced-init-list B may appear on the right-hand side of
+    //      - an assignment to a scalar of type T, in which case B shall have at
+    //        most a single element. The meaning of x = B is x = t, where t is
+    //        an invented temporary variable declared and initialized as T t =
+    //        B.
+    InitializationKind Kind =
+        InitializationKind::CreateCopy(RHSExpr->getBeginLoc(), OpLoc);
     InitializedEntity Entity =
         InitializedEntity::InitializeTemporary(LHSExpr->getType());
     InitializationSequence InitSeq(*this, Entity, Kind, RHSExpr);

--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -174,6 +174,27 @@ static_assert(!__is_layout_compatible(StructWithAnonUnion, StructWithAnonUnion3)
 #endif
 } // namespace cwg2759
 
+namespace cwg2768 { // cwg2768: 23
+#if __cplusplus >= 201103L
+void test() {
+  enum class E { E1 };
+
+  E e;
+  e = {0};
+  // expected-error@-1 {{cannot initialize a value of type 'E' with an rvalue of type 'int'}}
+
+  struct NotImplicitlyConvertibleToInt {
+    explicit operator int(); // #cwg2768-conversion-operator
+  };
+
+  int i;
+  i = {NotImplicitlyConvertibleToInt{}};
+  // expected-error@-1 {{no viable conversion from 'NotImplicitlyConvertibleToInt' to 'int'}}
+  //   expected-note@#cwg2768-conversion-operator {{explicit conversion function is not a candidate}}
+}
+#endif
+} // namespace cwg2768
+
 namespace cwg2770 { // cwg2770: 20 open 2023-07-14
 #if __cplusplus >= 202002L
 template<typename T>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19181,7 +19181,7 @@
     <td>[<a href="https://wg21.link/expr.assign">expr.assign</a>]</td>
     <td>CD7</td>
     <td>Assignment to enumeration variable with a <I>braced-init-list</I></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="unreleased" align="center">Clang 23</td>
   </tr>
   <tr class="open" id="2769">
     <td><a href="https://cplusplus.github.io/CWG/issues/2769.html">2769</a></td>


### PR DESCRIPTION
[CWG2768](https://wg21.link/cwg2768) changes the semantics of `foo = {...};` when `foo` has scalar type. It used to create a temporary via direct-list-initialization, now it's via copy-list-initialization.