### PR TITLE
[AMDGPU] Mark WAIT_ASYNCMARK as zero-size instruction

### DIFF
--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -1736,6 +1736,7 @@ def ASYNCMARK : SPseudoInstSI<(outs), (ins),
 def WAIT_ASYNCMARK : SOPP_Pseudo <"", (ins s16imm:$simm16), "$simm16",
     [(int_amdgcn_wait_asyncmark timm:$simm16)]> {
     let maybeAtomic = 0;
+    let Size = 0;
     let isMeta = 1;
 }
 }

--- a/llvm/test/CodeGen/AMDGPU/code-size-estimate.mir
+++ b/llvm/test/CodeGen/AMDGPU/code-size-estimate.mir
@@ -32,6 +32,21 @@ body:             |
   WAVE_BARRIER
 ...
 
+# WAIT_ASYNCMARK is a meta instruction that emits zero bytes.
+# codeLenInByte = s_waitcnt (4) + WAIT_ASYNCMARK (0) = 4.
+# CHECK: wait_asyncmark_meta:                    ; @wait_asyncmark_meta
+# CHECK: ; wait_asyncmark(1)
+# CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0) ; encoding: [0x00,0x00,0x8c,0xbf]
+# CHECK: ; codeLenInByte = 4
+---
+name:            wait_asyncmark_meta
+tracksRegLiveness: true
+body:             |
+  bb.0:
+
+  WAIT_ASYNCMARK 1
+...
+
 # CHECK: align4:                                 ; @align4
 # CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0) ; encoding: [0x00,0x00,0x8c,0xbf]
 # CHECK: s_cbranch_scc1 .LBB{{[0-9_]+}}          ; encoding: [A,A,0x85,0xbf]


### PR DESCRIPTION
`WAIT_ASYNCMARK` emits no bytes but was inheriting `Size = 4` from `SOPP_Pseudo`.

Without the fix, #194362 causes: `Size mismatch for: WAIT_ASYNCMARK 1 Expected exact size: 4 Actual size: 0`