### PR TITLE
 [Lit] Enable users to supply custom in-process built-ins via the Lit config 

### DIFF
--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -1,87 +1,304 @@
+from __future__ import annotations
+
+import abc
 import getopt
+import io
 import os
 import pathlib
-import platform
 import shutil
 import stat
 import subprocess
-from io import StringIO
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 import lit.util
+from lit.ShCommands import Command
 from lit.ShellEnvironment import (
     InternalShellError,
-    ShellCommandResult,
-    expand_glob_expressions,
+    ShellEnvironment,
     kIsWindows,
-    processRedirects,
     updateEnv,
 )
 
 
-def executeBuiltinCd(cmd, shenv):
+class InprocBuiltinIOObject(abc.ABC):
+    """
+    Base class for IO streams used for in-process built-ins. This class has two
+    specializations: InprocBuiltinIOFile, wrapping a file open in text mode, and
+    InprocBuiltinIOMemory, wrapping a BytesIO object. These streams provide
+    a text IO interface, but support reading and writing binary data too.
+
+    The main reason that this exists is to solve the conflict that binary IO is
+    required for the daemonized testing project, as many tests involve tools
+    reading and writing binary files and piping binary data between themselves,
+    but for regular testing on z/OS, files must be opened in text mode so that
+    the character encoding is correct. So we need an IO object that can be both
+    a file open in text mode and a in-memory stream that can store binary data.
+    """
+
+    @abc.abstractmethod
+    def read(self) -> str:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def read_binary(self) -> bytes:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write(self, data: str) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write_binary(self, data: bytes) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def seek(self, pos: int):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def flush(self):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_filename(self) -> str | None:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_encoding(self) -> str | None:
+        raise NotImplemented
+
+
+@dataclass
+class InprocBuiltinIOFile(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping a file which is open in
+    text mode. Files must be opened in text mode so that character encoding
+    tags are correctly handled on z/OS. Binary IO is still supported via the
+    OS APIs (needed for daemonized testing).
+    """
+
+    file: io.TextIOBase
+
+    def read(self) -> str:
+        return self.file.read()
+
+    def read_binary(self) -> bytes:
+        self.file.flush()
+        data = bytearray()
+        chunk_size = 1024
+
+        while True:
+            chunk = os.read(self.file.fileno(), chunk_size)
+            if not chunk:
+                break
+            data.extend(chunk)
+
+        return bytes(data)
+
+    def write(self, data: str) -> int:
+        return self.file.write(data)
+
+    def write_binary(self, data: bytes) -> int:
+        self.file.flush()
+        return os.write(self.file.fileno(), data)
+
+    def seek(self, pos: int):
+        self.file.seek(pos)
+
+    def flush(self):
+        self.file.flush()
+
+    def get_filename(self) -> str | None:
+        if hasattr(self.file, "name") and isinstance(self.file.name, str):
+            return self.file.name
+        return None
+
+    def get_encoding(self) -> str | None:
+        return str(self.file.encoding)
+
+
+@dataclass
+class InprocBuiltinIOMemory(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping an in-memory binary stream.
+    """
+
+    obj: io.BytesIO
+    encoding: str = "utf-8"
+
+    def read(self) -> str:
+        return self.obj.read().decode(self.encoding, errors="replace")
+
+    def read_binary(self) -> bytes:
+        return self.obj.read()
+
+    def write(self, data: str) -> int:
+        return self.obj.write(data.encode(self.encoding, errors="replace"))
+
+    def write_binary(self, data: bytes) -> int:
+        return self.obj.write(data)
+
+    def seek(self, pos: int):
+        self.obj.seek(pos)
+
+    def flush(self):
+        pass
+
+    def get_filename(self) -> str | None:
+        return None
+
+    def get_encoding(self) -> str | None:
+        return self.encoding
+
+
+class InprocBuiltinIO:
+    """
+    Holds IO streams for an inproc builtin invocation.
+
+    NB: If stderr is redirected to be the same stream as stdout, then
+    `stder == stdout` is True.
+    """
+
+    stdin: InprocBuiltinIOObject
+    stdout: InprocBuiltinIOObject
+    stderr: InprocBuiltinIOObject
+
+    def __init__(self, stdin, stdout, stderr):
+        """
+        Configure the IO streams for an in-process builtin command in
+        the same way that IO streams are configured when calling
+        `subprocess.Popen`.
+
+        Each of stdin, stdout and stderr may be:
+        - A file object open in binary mode.
+        - `subprocess.PIPE`
+        - `subprocess.STDOUT` (for stderr)
+        - None
+        """
+
+        # If stderr is redirected to stdout, we make sure to use the same
+        # stream for both so that the order of output is preserved.
+        stderr_redirected_to_stdout = (
+            stdout == subprocess.PIPE and stderr == subprocess.STDOUT
+        )
+
+        # Replace sentinel values with in-memory streams.
+        def resolve_io_obj(stream) -> InprocBuiltinIOObject:
+            if stream == subprocess.PIPE or stream is None:
+                return InprocBuiltinIOMemory(io.BytesIO())
+            elif isinstance(stream, InprocBuiltinIOObject):
+                return stream
+            else:
+                return InprocBuiltinIOFile(stream)
+
+        self.stdin = resolve_io_obj(stdin)
+        self.stdout = resolve_io_obj(stdout)
+        if stderr_redirected_to_stdout:
+            # Make sure stderr and stdout are directed to the same stream.
+            self.stderr = self.stdout
+        else:
+            self.stderr = resolve_io_obj(stderr)
+
+
+InprocBuiltinExecuteFn = Callable[
+    [Command, "list[str]", ShellEnvironment, InprocBuiltinIO],
+    int,
+]
+"""
+Function called by an in-process builtin command.
+Parameters:
+    - `cmd`: The command itself.
+    - `args`: glob-expanded list of arguments (including argv[0] as the program name).
+    - `shenv`: The shell environment.
+    - `io`: Holds the input and output streams for the invocation. These are file-like objects (files, StringIO)
+
+The return value is the exit code.
+"""
+
+
+@dataclass
+class InprocBuiltin:
+    """
+    Represents a command that is run as an in-process builtins.
+    """
+
+    execute: InprocBuiltinExecuteFn
+
+
+def executeBuiltinCd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinCd - Change the current directory."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'cd' supports only one argument")
     # Update the cwd in the parent environment.
-    shenv.change_dir(cmd.args[1])
+    shenv.change_dir(args[1])
     # The cd builtin always succeeds. If the directory does not exist, the
     # following Popen calls will fail instead.
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinPushd(cmd, shenv):
+def executeBuiltinPushd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPushd - Change the current dir and save the old."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'pushd' supports only one argument")
     shenv.dirStack.append(shenv.cwd)
-    shenv.change_dir(cmd.args[1])
-    return ShellCommandResult(cmd, "", "", 0, False)
+    shenv.change_dir(args[1])
+    return 0
 
 
-def executeBuiltinPopd(cmd, shenv):
+def executeBuiltinPopd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPopd - Restore a previously saved working directory."""
-    if len(cmd.args) != 1:
+    if len(args) != 1:
         raise InternalShellError(cmd, "'popd' does not support arguments")
     if not shenv.dirStack:
         raise InternalShellError(cmd, "popd: directory stack empty")
     shenv.cwd = shenv.dirStack.pop()
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinExport(cmd, shenv):
+def executeBuiltinExport(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinExport - Set an environment variable."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'export' supports only one argument")
-    updateEnv(shenv, cmd.args)
-    return ShellCommandResult(cmd, "", "", 0, False)
+    updateEnv(shenv, args)
+    return 0
 
 
-def executeBuiltinEcho(cmd, shenv):
+def executeBuiltinEcho(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """Interpret a redirected echo or @echo command"""
     opened_files = []
-    stdin, stdout, stderr = processRedirects(cmd, subprocess.PIPE, shenv, opened_files)
-    if stdin != subprocess.PIPE or stderr != subprocess.PIPE:
-        raise InternalShellError(
-            cmd, f"stdin and stderr redirects not supported for {cmd.args[0]}"
-        )
 
-    # Some tests have un-redirected echo commands to help debug test failures.
-    # Buffer our output and return it to the caller.
-    is_redirected = True
-    if stdout == subprocess.PIPE:
-        is_redirected = False
-        stdout = StringIO()
-    elif kIsWindows:
+    stdout = io.stdout
+    if (
+        kIsWindows
+        and isinstance(io.stdout, InprocBuiltinIOFile)
+        and io.stdout.get_filename()
+    ):
         # Reopen stdout with `newline=""` to avoid CRLF translation.
         # The versions of echo we are replacing on Windows all emit plain LF,
         # and the LLVM tests now depend on this.
-        stdout = open(stdout.name, stdout.mode, encoding="utf-8", newline="")
+        stdout = open(
+            io.stdout.get_filename(),
+            io.stdout.file.mode,
+            encoding="utf-8",
+            newline="",
+        )
         opened_files.append((None, None, stdout, None))
 
     # Implement echo flags. We only support -e and -n, and not yet in
     # combination. We have to ignore unknown flags, because `echo "-D FOO"`
     # prints the dash.
-    args = cmd.args[1:]
+    args = args[1:]
     interpret_escapes = False
     write_newline = True
     while len(args) >= 1 and args[0] in ("-e", "-n"):
@@ -109,15 +326,15 @@ def executeBuiltinEcho(cmd, shenv):
     for name, mode, f, path in opened_files:
         f.close()
 
-    output = "" if is_redirected else stdout.getvalue()
-    return ShellCommandResult(cmd, output, "", 0, False)
+    return 0
 
 
-def executeBuiltinMkdir(cmd, cmd_shenv):
+def executeBuiltinMkdir(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinMkdir - Create new directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "p")
+        opts, args = getopt.gnu_getopt(args[1:], "p")
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'mkdir':  %s" % str(err))
 
@@ -131,7 +348,6 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
     if len(args) == 0:
         raise InternalShellError(cmd, "Error: 'mkdir' is missing an operand")
 
-    stderr = StringIO()
     exitCode = 0
     for dir in args:
         dir = pathlib.Path(dir)
@@ -144,16 +360,17 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
             try:
                 dir.mkdir(exist_ok=True)
             except OSError as err:
-                stderr.write("Error: 'mkdir' command failed, %s\n" % str(err))
+                io.stderr.write(("Error: 'mkdir' command failed, %s\n" % str(err)))
                 exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinRm(cmd, cmd_shenv):
+def executeBuiltinRm(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinRm - Removes (deletes) files or directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "frR", ["--recursive"])
+        opts, args = getopt.gnu_getopt(args[1:], "frR", ["--recursive"])
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'rm':  %s" % str(err))
 
@@ -176,7 +393,6 @@ def executeBuiltinRm(cmd, cmd_shenv):
         os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
         os.remove(path)
 
-    stderr = StringIO()
     exitCode = 0
     for path in args:
         cwd = cmd_shenv.cwd
@@ -189,9 +405,9 @@ def executeBuiltinRm(cmd, cmd_shenv):
                 os.remove(path)
             elif os.path.isdir(path):
                 if not recursive:
-                    stderr.write("Error: %s is a directory\n" % path)
+                    io.stderr.write(("Error: %s is a directory\n" % path))
                     exitCode = 1
-                if platform.system() == "Windows":
+                if kIsWindows:
                     # NOTE: use ctypes to access `SHFileOperationsW` on Windows to
                     # use the NT style path to get access to long file paths which
                     # cannot be removed otherwise.
@@ -255,26 +471,28 @@ def executeBuiltinRm(cmd, cmd_shenv):
                     os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
                 os.remove(path)
         except OSError as err:
-            stderr.write("Error: 'rm' command failed, %s" % str(err))
+            io.stderr.write(("Error: 'rm' command failed, %s" % str(err)))
             exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinUmask(cmd, shenv):
+def executeBuiltinUmask(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinUmask - Change the current umask."""
     if os.name != "posix":
         raise InternalShellError(cmd, "'umask' not supported on this system")
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'umask' supports only one argument")
     try:
         # Update the umask in the parent environment.
-        shenv.umask = int(cmd.args[1], 8)
+        shenv.umask = int(args[1], 8)
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'umask': %s" % str(err))
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinUlimit(cmd, shenv):
+def executeBuiltinUlimit(cmd: Command, args: list[str], shenv, io: InprocBuiltinIO):
     """executeBuiltinUlimit - Change the current limits."""
     try:
         # Try importing the resource module (available on POSIX systems) and
@@ -282,34 +500,59 @@ def executeBuiltinUlimit(cmd, shenv):
         import resource
     except ImportError:
         raise InternalShellError(cmd, "'ulimit' not supported on this system")
-    if len(cmd.args) != 3:
+    if len(args) != 3:
         raise InternalShellError(cmd, "'ulimit' requires two arguments")
     try:
-        if cmd.args[2] == "unlimited":
+        if args[2] == "unlimited":
             new_limit = resource.RLIM_INFINITY
         else:
-            new_limit = int(cmd.args[2])
+            new_limit = int(args[2])
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'ulimit': %s" % str(err))
-    if cmd.args[1] == "-v":
+    if args[1] == "-v":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_AS"] = new_limit
-    elif cmd.args[1] == "-n":
+    elif args[1] == "-n":
         shenv.ulimit["RLIMIT_NOFILE"] = new_limit
-    elif cmd.args[1] == "-s":
+    elif args[1] == "-s":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_STACK"] = new_limit
-    elif cmd.args[1] == "-f":
+    elif args[1] == "-f":
         shenv.ulimit["RLIMIT_FSIZE"] = new_limit
     else:
-        raise InternalShellError(
-            cmd, "'ulimit' does not support option: %s" % cmd.args[1]
-        )
-    return ShellCommandResult(cmd, "", "", 0, False)
+        raise InternalShellError(cmd, "'ulimit' does not support option: %s" % args[1])
+    return 0
 
 
-def executeBuiltinColon(cmd, cmd_shenv):
+def executeBuiltinColon(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinColon - Discard arguments and exit with status 0."""
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
+
+
+def get_default_inproc_builtins() -> dict[str, InprocBuiltin]:
+    """
+    get_default_inproc_builtins - Returns the map of command names to Lit's
+    in-process built-in implementations.
+    The entries are a pair of the callable for the builtin and a bool
+    that determines whether this inproc builtin may fall back to a
+    command of the same name in cases where in-proc builtins cannot be
+    used (e.g. as the argument to not --crash).
+    """
+
+    return {
+        "@echo": InprocBuiltin(executeBuiltinEcho),
+        "cd": InprocBuiltin(executeBuiltinCd),
+        "export": InprocBuiltin(executeBuiltinExport),
+        "echo": InprocBuiltin(executeBuiltinEcho),
+        "mkdir": InprocBuiltin(executeBuiltinMkdir),
+        "popd": InprocBuiltin(executeBuiltinPopd),
+        "pushd": InprocBuiltin(executeBuiltinPushd),
+        "rm": InprocBuiltin(executeBuiltinRm),
+        "ulimit": InprocBuiltin(executeBuiltinUlimit),
+        "umask": InprocBuiltin(executeBuiltinUmask),
+        ":": InprocBuiltin(executeBuiltinColon),
+    }

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1862,7 +1862,7 @@ def _runShTest(
     useExternalSh,
     script,
     tmpBase,
-    extra_inproc_builtins,
+    extra_inproc_builtins={},
 ) -> lit.Test.Result:
     # Always returns the tuple (out, err, exitCode, timeoutInfo, status).
     def runOnce(
@@ -2024,5 +2024,10 @@ def executeShTest(
             script[index] = _expandLateSubstitutionsExternal(command)
 
     return _runShTest(
-        test, litConfig, useExternalSh, script, tmpBase, extra_inproc_builtins
+        test,
+        litConfig,
+        useExternalSh,
+        script,
+        tmpBase,
+        extra_inproc_builtins=extra_inproc_builtins,
     )

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -159,7 +159,7 @@ class TimeoutHelper(object):
             self._doneKillPass = True
 
 
-def executeShCmd(cmd, shenv, results, timeout=0):
+def executeShCmd(cmd, shenv, results, timeout=0, extra_inproc_builtins={}):
     """
     Wrapper around _executeShCmd that handles
     timeout
@@ -170,7 +170,9 @@ def executeShCmd(cmd, shenv, results, timeout=0):
     if timeout > 0:
         timeoutHelper.startTimer()
     try:
-        finalExitCode = _executeShCmd(cmd, shenv, results, timeoutHelper)
+        finalExitCode = _executeShCmd(
+            cmd, shenv, results, timeoutHelper, extra_inproc_builtins
+        )
     except InternalShellError:
         e = sys.exc_info()[1]
         finalExitCode = 127
@@ -211,7 +213,7 @@ def _expandLateSubstitutions(cmd, arguments, cwd, normalize_slashes=False):
     return arguments
 
 
-def _executeShCmd(cmd, shenv, results, timeoutHelper):
+def _executeShCmd(cmd, shenv, results, timeoutHelper, extra_inproc_builtins):
     if timeoutHelper.timeoutReached():
         # Prevent further recursion if the timeout has been hit
         # as we should try avoid launching more processes.
@@ -219,25 +221,37 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     if isinstance(cmd, ShUtil.Seq):
         if cmd.op == ";":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
-            return _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
+            return _executeShCmd(
+                cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
 
         if cmd.op == "&":
             raise InternalShellError(cmd, "unsupported shell operator: '&'")
 
         if cmd.op == "||":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res != 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         if cmd.op == "&&":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res is None:
                 return res
 
             if res == 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         raise ValueError("Unknown shell command: %r" % cmd.op)
@@ -255,6 +269,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         os.path.dirname(os.path.abspath(__file__)), "builtin_commands"
     )
     inproc_builtins = get_default_inproc_builtins()
+    inproc_builtins.update(extra_inproc_builtins)
     # To avoid deadlock, we use a single stderr stream for piped
     # output. This is null until we have seen some output using
     # stderr.
@@ -680,7 +695,13 @@ def formatOutput(title, data, limit=None):
 # function), out contains only stdout from the script, err contains only stderr
 # from the script, and there is no execution trace.
 def executeScriptInternal(
-    test, litConfig, tmpBase, commands, cwd, debug=True
+    test,
+    litConfig,
+    tmpBase,
+    commands,
+    cwd,
+    debug=True,
+    extra_inproc_builtins={},
 ) -> tuple[str, str, int, str | None, str | None]:
     cmds = []
     update_output = None
@@ -725,7 +746,11 @@ def executeScriptInternal(
     shenv.env["LIT_CURRENT_TESTCASE"] = test.getFullName()
 
     exitCode, timeoutInfo = executeShCmd(
-        cmd, shenv, results, timeout=litConfig.maxIndividualTestTime
+        cmd,
+        shenv,
+        results,
+        timeout=litConfig.maxIndividualTestTime,
+        extra_inproc_builtins=extra_inproc_builtins,
     )
 
     out = err = ""
@@ -1831,7 +1856,14 @@ def parseIntegratedTestScript(test, additional_parsers=[], require_script=True):
     return script
 
 
-def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Result:
+def _runShTest(
+    test,
+    litConfig,
+    useExternalSh,
+    script,
+    tmpBase,
+    extra_inproc_builtins,
+) -> lit.Test.Result:
     # Always returns the tuple (out, err, exitCode, timeoutInfo, status).
     def runOnce(
         execdir,
@@ -1867,7 +1899,12 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Resu
                 res = executeScript(test, litConfig, tmpBase, scriptCopy, execdir)
             else:
                 res = executeScriptInternal(
-                    test, litConfig, tmpBase, scriptCopy, execdir
+                    test,
+                    litConfig,
+                    tmpBase,
+                    scriptCopy,
+                    execdir,
+                    extra_inproc_builtins=extra_inproc_builtins,
                 )
         except ScriptFatal as e:
             out = f"# " + "\n# ".join(str(e).splitlines()) + "\n"
@@ -1944,7 +1981,12 @@ def _expandLateSubstitutionsExternal(commandLine):
     return commandLine
 
 def executeShTest(
-    test, litConfig, useExternalSh, extra_substitutions=[], preamble_commands=[]
+    test,
+    litConfig,
+    useExternalSh,
+    extra_substitutions=[],
+    preamble_commands=[],
+    extra_inproc_builtins={},
 ):
     if test.config.unsupported:
         return lit.Test.Result(Test.UNSUPPORTED, "Test is unsupported")
@@ -1981,4 +2023,6 @@ def executeShTest(
         for index, command in enumerate(script):
             script[index] = _expandLateSubstitutionsExternal(command)
 
-    return _runShTest(test, litConfig, useExternalSh, script, tmpBase)
+    return _runShTest(
+        test, litConfig, useExternalSh, script, tmpBase, extra_inproc_builtins
+    )

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -11,11 +11,11 @@ import tempfile
 import threading
 import traceback
 
-import lit.InprocBuiltins as InprocBuiltins
 import lit.ShUtil as ShUtil
 import lit.Test as Test
 import lit.util
 from lit.BooleanExpression import BooleanExpression
+from lit.InprocBuiltins import InprocBuiltinIO, get_default_inproc_builtins
 from lit.ShCommands import Command
 from lit.ShellEnvironment import (
     InternalShellError,
@@ -254,19 +254,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
     builtin_commands_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "builtin_commands"
     )
-    inproc_builtins = {
-        "cd": InprocBuiltins.executeBuiltinCd,
-        "export": InprocBuiltins.executeBuiltinExport,
-        "echo": InprocBuiltins.executeBuiltinEcho,
-        "@echo": InprocBuiltins.executeBuiltinEcho,
-        "mkdir": InprocBuiltins.executeBuiltinMkdir,
-        "popd": InprocBuiltins.executeBuiltinPopd,
-        "pushd": InprocBuiltins.executeBuiltinPushd,
-        "rm": InprocBuiltins.executeBuiltinRm,
-        "ulimit": InprocBuiltins.executeBuiltinUlimit,
-        "umask": InprocBuiltins.executeBuiltinUmask,
-        ":": InprocBuiltins.executeBuiltinColon,
-    }
+    inproc_builtins = get_default_inproc_builtins()
     # To avoid deadlock, we use a single stderr stream for piped
     # output. This is null until we have seen some output using
     # stderr.
@@ -354,9 +342,43 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     j,
                     "Unsupported: '{}' cannot be part" " of a pipeline".format(args[0]),
                 )
-            result = inproc_builtin(Command(args, j.redirects), cmd_shenv)
+
+            stdin, stdout, stderr = processRedirects(
+                j, subprocess.PIPE, shenv, opened_files
+            )
+
+            builtin_io = InprocBuiltinIO(stdin, stdout, stderr)
+
+            args = expand_glob_expressions(args, cmd_shenv.cwd)
+
+            exit_code = inproc_builtin.execute(
+                Command(args, j.redirects), args, cmd_shenv, builtin_io
+            )
+
+            builtin_io.stdout.flush()
+            builtin_io.stderr.flush()
+
             if not_count % 2:
-                result.exitCode = int(not result.exitCode)
+                exit_code = int(not exit_code)
+
+            # Gather output from the streams.
+            out = ""
+            if stdout == subprocess.PIPE:
+                builtin_io.stdout.seek(0)
+                out = builtin_io.stdout.read()
+
+            err = ""
+            if stderr == subprocess.PIPE:
+                builtin_io.stderr.seek(0)
+                err = builtin_io.stderr.read()
+
+            result = ShellCommandResult(
+                j,
+                out,
+                err,
+                exit_code,
+                False,
+            )
             result.command.args = j.args
             results.append(result)
             return result.exitCode

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -19,11 +19,16 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
+        self,
+        execute_external=False,
+        extra_substitutions=[],
+        preamble_commands=[],
+        extra_inproc_builtins={},
     ):
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands
+        self.extra_inproc_builtins = extra_inproc_builtins
 
     def execute(self, test, litConfig):
         return lit.TestRunner.executeShTest(
@@ -32,4 +37,5 @@ class ShTest(FileBasedTest):
             self.execute_external,
             self.extra_substitutions,
             self.preamble_commands,
+            self.extra_inproc_builtins,
         )

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment
+
+
+def returns_0(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 0
+
+
+def returns_1(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 1
+
+
+def custom_echo(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stdout.write(args[1])
+    return 0
+
+
+def echo_to_stderr(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stderr.write(args[1])
+    return 0

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
@@ -1,0 +1,23 @@
+import os
+import sys
+import lit.formats
+from lit.InprocBuiltins import InprocBuiltin
+
+# Import the module containing the custom in-process builtins.
+# NB: These cannot be defined in the lit.cfg module.
+sys.path.append(os.path.dirname(__file__))
+import custom_inproc_builtins
+
+config.name = "shtest-custom-inproc-builtins"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(
+    extra_inproc_builtins={
+        "returns_0": InprocBuiltin(custom_inproc_builtins.returns_0),
+        "returns_1": InprocBuiltin(custom_inproc_builtins.returns_1),
+        "custom_echo": InprocBuiltin(custom_inproc_builtins.custom_echo),
+        "echo_to_stderr": InprocBuiltin(custom_inproc_builtins.echo_to_stderr),
+    }
+)
+config.test_source_root = None
+config.test_exec_root = None
+

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
@@ -1,0 +1,13 @@
+RUN: returns_0
+RUN: not returns_1
+
+RUN: custom_echo "hello" > %t1
+RUN: grep -x "hello" < %t1
+
+RUN: custom_echo ", world" >> %t1
+RUN: grep -x "hello, world" < %t1
+
+RUN: echo_to_stderr "goodbye" 2> %t2
+RUN: grep -x "goodbye" < %t2
+RUN: echo_to_stderr ", for now" 2>> %t2
+RUN: grep -x "goodbye, for now" < %t2

--- a/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
+++ b/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
@@ -1,0 +1,10 @@
+## This test provides some custom in-process built-ins via the lit.cfg, and
+## verifies that their output can be redirected correctly.
+#
+# RUN: %{lit} -v %{inputs}/shtest-custom-inproc-builtins \
+# RUN: | FileCheck -match-full-lines %s
+# END.
+
+# CHECK: PASS: shtest-custom-inproc-builtins :: use-custom-inproc-builtins.txt ({{[^)]*}})
+
+# CHECK: Passed: 1 ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-glob.py
+++ b/llvm/utils/lit/tests/shtest-glob.py
@@ -4,8 +4,7 @@
 # RUN: | FileCheck -dump-input=fail -match-full-lines --implicit-check-not=Error: %s
 # END.
 
-# CHECK: UNRESOLVED: shtest-glob :: glob-echo.txt ({{[^)]*}})
-# CHECK: TypeError: string argument expected, got 'GlobItem'
+# CHECK: PASS: shtest-glob :: glob-echo.txt ({{[^)]*}})
 
 # CHECK:      FAIL: shtest-glob :: glob-mkdir.txt ({{[^)]*}})
 # CHECK:      # | Error: 'mkdir' command failed, {{.*}}example_file1.input'

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -497,37 +497,10 @@
 # CHECK-NEXT: # error: command failed with exit status: 1
 #      CHECK: ***
 
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stderr.txt' FAILED ***
-# CHECK: @echo 2> {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stdin.txt' FAILED ***
-# CHECK: @echo < {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stderr.txt' FAILED ***
-# CHECK: echo 2> {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stdin.txt' FAILED ***
-# CHECK: echo < {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stdin.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stdin.txt
 
 # CHECK: FAIL: shtest-shell :: error-0.txt
 # CHECK: *** TEST 'shtest-shell :: error-0.txt' FAILED ***
@@ -634,4 +607,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (37)
+# CHECK: Failed Tests (33)


### PR DESCRIPTION
This PR enables Lit users to supply new in-process built-ins via the constructor of lit.formats.ShTest. This will be used by the LLVM Lit configs to supply the in-process built-ins responsible for invoking the daemon to Lit. I've also added a new test case which registers some custom in-process built-ins and verifies they work as expected.

This PR is blocked on https://github.com/llvm/llvm-project/pull/194664; the changes in the first commit in this PR are from that one, so please review only the second commit on this PR and onward. Once that PR is merged, I will rebase this branch to remove the other commits.

This PR is part of a series of patches upgrading Lit's in-process built-ins to be able to run with piped input/output and full redirection support, and to allow custom in-process builtns to be provided via the Lit config. The remaining patches to Lit's test runner can be found [here](https://github.com/BStott6/llvm-project/compare/lit-inproc-builtins). This is part of the [Lit daemonized testing project](https://discourse.llvm.org/t/rfc-reducing-process-creation-overhead-in-llvm-regression-tests/88612/9).

Update: I've force-updated this branch due to chagnes 