### PR TITLE
[BOLT][AArch64] Refuse to run simplify-rodata-loads pass

### DIFF
--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1295,6 +1295,11 @@ bool SimplifyRODataLoads::simplifyRODataLoads(BinaryFunction &BF) {
 }
 
 Error SimplifyRODataLoads::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   for (auto &It : BC.getBinaryFunctions()) {
     BinaryFunction &Function = It.second;
     if (shouldOptimize(Function) && simplifyRODataLoads(Function))

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -7,11 +7,13 @@ RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-pre
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
 RUN: not llvm-bolt %t -o %t.bolt --indirect-call-promotion=all 2>&1 | FileCheck %s --check-prefix=CHECK-INDIRECT-CALL-PROMOTION
+RUN: not llvm-bolt %t -o %t.bolt --simplify-rodata-loads 2>&1 | FileCheck %s --check-prefix=CHECK-SIMPLIFY-RODATA-LOADS
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
 CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported only on X86
+CHECK-SIMPLIFY-RODATA-LOADS: BOLT-ERROR: simplify-read-only-loads is supported only on X86
 
 // Passes specific to X86 arch
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV


### PR DESCRIPTION
`--simplify-rodata-loads` on AArch64 hits an unreachable because AArch64 does not implement replaceMemOperandWithImm.

- Add a guard to simplify-rodata-loads
- Update unsupported-passes.test