### PR TITLE
[clang][NFC] Mark CWG2780 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -194,6 +194,16 @@ int j = f('a', 2);
 #endif
 } // namespace cwg2770
 
+namespace cwg2780 { // cwg2780: 2.7
+
+void f();
+
+void(&g())(int) {
+  return reinterpret_cast<void(&)(int)>(f);
+}
+
+} // namespace cwg2780
+
 namespace cwg2789 { // cwg2789: 18
 #if __cplusplus >= 202302L
 template <typename T = int>

--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -198,8 +198,8 @@ namespace cwg2780 { // cwg2780: 2.7
 
 void f();
 
-void(&g())(int) {
-  return reinterpret_cast<void(&)(int)>(f);
+void g() {
+  (void)reinterpret_cast<void(&)(int)>(f);
 }
 
 } // namespace cwg2780

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19269,7 +19269,7 @@
     <td>[<a href="https://wg21.link/expr.reinterpret.cast">expr.reinterpret.cast</a>]</td>
     <td>CD7</td>
     <td><TT>reinterpret_cast</TT> to reference to function types</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr class="open" id="2781">
     <td><a href="https://cplusplus.github.io/CWG/issues/2781.html">2781</a></td>


### PR DESCRIPTION
[CWG2780](https://wg21.link/cwg2780) allows `reinterpret_cast`ing to a reference-to-function type. Clang already supports this: https://godbolt.org/z/c37hsvKnn