### PR TITLE
[Clang][AArch64] Fix wrong SIMD register counting for MFloat8

### DIFF
--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -412,6 +412,9 @@ ABIArgInfo AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadicFn,
         case BuiltinType::SveBoolx4:
           NPRN = std::min(NPRN + 4, 4u);
           break;
+        case BuiltinType::MFloat8:
+          NSRN = std::min(NSRN + 1, 8u);
+          break;
         default:
           if (BT->isSVESizelessBuiltinType())
             NSRN = std::min(

--- a/clang/test/CodeGen/AArch64/pure-scalable-args.c
+++ b/clang/test/CodeGen/AArch64/pure-scalable-args.c
@@ -478,3 +478,15 @@ void test_tuple_reg_count_bool(svboolx4_t x, svboolx4_t y) {
 }
 // CHECK-AAPCS:  declare void @test_tuple_reg_count_bool_callee(<vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, ptr noundef dead_on_return)
 // CHECK-DARWIN: declare void @test_tuple_reg_count_bool_callee(<vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>, <vscale x 16 x i1>)
+
+// Regression test for incorrect counting of SIMD registers (NSRN) when consumerd by `__mfp8`.
+//   0.0 -> d0-d6
+//   x   -> v7
+//   *p  -> memory, address -> x0
+void test_mfp8_reg_count(SmallPST *p, __mfp8 x) {
+    void test_mfp8_reg_count_callee(double, double, double, double, double,
+                                     double, double, __mfp8, SmallPST);
+    test_mfp8_reg_count_callee(.0, .0, .0, .0, .0, .0, .0, x, *p);
+}
+// CHECK-AAPCS:  declare void @test_mfp8_reg_count_callee(double noundef, double noundef, double noundef, double noundef, double noundef, double noundef, double noundef, <1 x i8>, ptr noundef dead_on_return)
+// CHECK-DARWIN: declare void @test_mfp8_reg_count_callee(double noundef, double noundef, double noundef, double noundef, double noundef, double noundef, double noundef, <1 x i8>, i128)


### PR DESCRIPTION
The `__mfp8` type is passed in SIMD registers, but the ABI handling code did not account for it, which caused wrong register counting and thus wrong argument passing codegen for some cases, e.g. for Pure Scalable Types, which depend on precise counting.