### PR TITLE
[libc][libcxx] Use raw pointer thread handles

### DIFF
--- a/libc/include/llvm-libc-types/__thread_type.h
+++ b/libc/include/llvm-libc-types/__thread_type.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_TYPES___THREAD_TYPE_H
 #define LLVM_LIBC_TYPES___THREAD_TYPE_H
 
-typedef struct {
-  void *__attrib;
-} __thread_type;
+typedef void *__thread_type;
 
 #endif // LLVM_LIBC_TYPES___THREAD_TYPE_H

--- a/libc/src/pthread/pthread_self.cpp
+++ b/libc/src/pthread/pthread_self.cpp
@@ -20,8 +20,7 @@ static_assert(sizeof(pthread_t) == sizeof(LIBC_NAMESPACE::Thread),
               "Mismatch between pthread_t and internal Thread.");
 
 LLVM_LIBC_FUNCTION(pthread_t, pthread_self, ()) {
-  pthread_t th;
-  th.__attrib = self.attrib;
+  pthread_t th = self.attrib;
   return th;
 }
 

--- a/libc/src/threads/thrd_current.cpp
+++ b/libc/src/threads/thrd_current.cpp
@@ -19,8 +19,7 @@ static_assert(sizeof(thrd_t) == sizeof(LIBC_NAMESPACE::Thread),
               "Mismatch between thrd_t and internal Thread.");
 
 LLVM_LIBC_FUNCTION(thrd_t, thrd_current, ()) {
-  thrd_t th;
-  th.__attrib = self.attrib;
+  thrd_t th = self.attrib;
   return th;
 }
 

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.tests.h
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.tests.h
@@ -22,7 +22,7 @@ void format_tests(TestFunction check, ExceptionTest check_exception) {
   std::thread::id input{};
 
   /***** Test the type specific part *****/
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__LLVM_LIBC__)
   check(SV("0"), SV("{}"), input);
   check(SV("0^42"), SV("{}^42"), input);
   check(SV("0^42"), SV("{:}^42"), input);

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.pass.cpp
@@ -52,7 +52,7 @@ void test_format(StringViewT expected, std::thread::id arg) {
 
 template <class CharT>
 void test_fmt() {
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined (__LLVM_LIBC__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__LLVM_LIBC__)
   test_format(SV("0"), std::thread::id());
 #else
   test_format(SV("0x0"), std::thread::id());

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.pass.cpp
@@ -52,7 +52,7 @@ void test_format(StringViewT expected, std::thread::id arg) {
 
 template <class CharT>
 void test_fmt() {
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined (__LLVM_LIBC__)
   test_format(SV("0"), std::thread::id());
 #else
   test_format(SV("0x0"), std::thread::id());


### PR DESCRIPTION
This PR fixes the threading support related to building libc++ with libc. LLVM-libc also utilizes pointer based thread IDs. The patch contains two parts of changes:

- On libc part, expose `void *` as thread type directly; because libc++ assumes that thread ids are
  - comparable
  - formattable
  - zero initializable
- On libc++ part, always use pointer format if `__LLVM_LIBC__` is defined.

For more context, please refer to https://discourse.llvm.org/t/building-libcxx-with-llvms-libc.

Assisted-by: Codex with gpt-5.5 high fast