### PR TITLE
[lldb] Remove verbose DWARF spec comments from evaluator (NFC)

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// The DWARF expression opcodes evaluated in this file are defined by the DWARF
+// Debugging Information Format specification, available at:
+//
+//   https://dwarfstd.org/
+//
+//===----------------------------------------------------------------------===//
 
 #include "lldb/Expression/DWARFExpression.h"
 
@@ -1328,8 +1335,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     }
 
     switch (opcode) {
-    // The DW_OP_addr operation has a single operand that encodes a machine
-    // address and whose size is the size of an address on the target machine.
     case DW_OP_addr:
       stack.push_back(Scalar(op->getRawOperand(0)));
       if (target &&
@@ -1342,12 +1347,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
       break;
 
-    // OPCODE: DW_OP_deref
-    // OPERANDS: none
-    // DESCRIPTION: Pops the top stack entry and treats it as an address.
-    // The value retrieved from that address is pushed. The size of the data
-    // retrieved from the dereferenced address is the size of an address on the
-    // target machine.
     case DW_OP_deref: {
       size_t size = address_size;
       if (llvm::Error err = Evaluate_DW_OP_deref_size(
@@ -1356,18 +1355,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return err;
     } break;
 
-    // OPCODE: DW_OP_deref_size
-    // OPERANDS: 1
-    //  1 - uint8_t that specifies the size of the data to dereference.
-    // DESCRIPTION: Behaves like the DW_OP_deref operation: it pops the top
-    // stack entry and treats it as an address. The value retrieved from that
-    // address is pushed. In the DW_OP_deref_size operation, however, the size
-    // in bytes of the data retrieved from the dereferenced address is
-    // specified by the single operand. This operand is a 1-byte unsigned
-    // integral constant whose value may not be larger than the size of an
-    // address on the target machine. The data retrieved is zero extended to
-    // the size of an address on the target machine before being pushed on the
-    // expression stack.
     case DW_OP_deref_size: {
       size_t size = op->getRawOperand(0);
       if (llvm::Error err = Evaluate_DW_OP_deref_size(
@@ -1376,49 +1363,11 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return err;
     } break;
 
-    // OPCODE: DW_OP_xderef_size
-    // OPERANDS: 1
-    //  1 - uint8_t that specifies the size of the data to dereference.
-    // DESCRIPTION: Behaves like the DW_OP_xderef operation: the entry at
-    // the top of the stack is treated as an address. The second stack entry is
-    // treated as an "address space identifier" for those architectures that
-    // support multiple address spaces. The top two stack elements are popped,
-    // a data item is retrieved through an implementation-defined address
-    // calculation and pushed as the new stack top. In the DW_OP_xderef_size
-    // operation, however, the size in bytes of the data retrieved from the
-    // dereferenced address is specified by the single operand. This operand is
-    // a 1-byte unsigned integral constant whose value may not be larger than
-    // the size of an address on the target machine. The data retrieved is zero
-    // extended to the size of an address on the target machine before being
-    // pushed on the expression stack.
     case DW_OP_xderef_size:
       return llvm::createStringError("unimplemented opcode: DW_OP_xderef_size");
-    // OPCODE: DW_OP_xderef
-    // OPERANDS: none
-    // DESCRIPTION: Provides an extended dereference mechanism. The entry at
-    // the top of the stack is treated as an address. The second stack entry is
-    // treated as an "address space identifier" for those architectures that
-    // support multiple address spaces. The top two stack elements are popped,
-    // a data item is retrieved through an implementation-defined address
-    // calculation and pushed as the new stack top. The size of the data
-    // retrieved from the dereferenced address is the size of an address on the
-    // target machine.
     case DW_OP_xderef:
       return llvm::createStringError("unimplemented opcode: DW_OP_xderef");
 
-    // All DW_OP_constXXX opcodes have a single operand as noted below:
-    //
-    // Opcode           Operand 1
-    // DW_OP_const1u    1-byte unsigned integer constant
-    // DW_OP_const1s    1-byte signed integer constant
-    // DW_OP_const2u    2-byte unsigned integer constant
-    // DW_OP_const2s    2-byte signed integer constant
-    // DW_OP_const4u    4-byte unsigned integer constant
-    // DW_OP_const4s    4-byte signed integer constant
-    // DW_OP_const8u    8-byte unsigned integer constant
-    // DW_OP_const8s    8-byte signed integer constant
-    // DW_OP_constu     unsigned LEB128 integer constant
-    // DW_OP_consts     signed LEB128 integer constant
     case DW_OP_const1u:
       stack.push_back(to_generic(op->getRawOperand(0)));
       break;
@@ -1452,9 +1401,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       stack.push_back(Scalar(static_cast<int64_t>(op->getRawOperand(0))));
       break;
 
-    // OPCODE: DW_OP_dup
-    // OPERANDS: none
-    // DESCRIPTION: duplicates the value at the top of the stack
     case DW_OP_dup:
       if (stack.empty()) {
         return llvm::createStringError("expression stack empty for DW_OP_dup");
@@ -1462,9 +1408,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         stack.push_back(stack.back());
       break;
 
-    // OPCODE: DW_OP_drop
-    // OPERANDS: none
-    // DESCRIPTION: pops the value at the top of the stack
     case DW_OP_drop:
       if (stack.empty()) {
         return llvm::createStringError("expression stack empty for DW_OP_drop");
@@ -1472,18 +1415,10 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         stack.pop_back();
       break;
 
-    // OPCODE: DW_OP_over
-    // OPERANDS: none
-    // DESCRIPTION: Duplicates the entry currently second in the stack at
-    // the top of the stack.
     case DW_OP_over:
       stack.push_back(stack[stack.size() - 2]);
       break;
 
-    // OPCODE: DW_OP_pick
-    // OPERANDS: uint8_t index into the current stack
-    // DESCRIPTION: The stack entry with the specified index (0 through 255,
-    // inclusive) is pushed on the stack
     case DW_OP_pick: {
       uint8_t pick_idx = op->getRawOperand(0);
       if (pick_idx < stack.size())
@@ -1494,23 +1429,12 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
     } break;
 
-    // OPCODE: DW_OP_swap
-    // OPERANDS: none
-    // DESCRIPTION: swaps the top two stack entries. The entry at the top
-    // of the stack becomes the second stack entry, and the second entry
-    // becomes the top of the stack
     case DW_OP_swap:
       tmp = stack.back();
       stack.back() = stack[stack.size() - 2];
       stack[stack.size() - 2] = tmp;
       break;
 
-    // OPCODE: DW_OP_rot
-    // OPERANDS: none
-    // DESCRIPTION: Rotates the first three stack entries. The entry at
-    // the top of the stack becomes the third stack entry, the second entry
-    // becomes the top of the stack, and the third entry becomes the second
-    // entry.
     case DW_OP_rot: {
       size_t last_idx = stack.size() - 1;
       Value old_top = stack[last_idx];
@@ -1519,11 +1443,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       stack[last_idx - 2] = old_top;
     } break;
 
-    // OPCODE: DW_OP_abs
-    // OPERANDS: none
-    // DESCRIPTION: pops the top stack entry, interprets it as a signed
-    // value and pushes its absolute value. If the absolute value can not be
-    // represented, the result is undefined.
     case DW_OP_abs:
       if (!stack.back().GetScalar().AbsoluteValue()) {
         return llvm::createStringError(
@@ -1531,21 +1450,12 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
       break;
 
-    // OPCODE: DW_OP_and
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, performs a bitwise and
-    // operation on the two, and pushes the result.
     case DW_OP_and:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() & tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_div
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, divides the former second
-    // entry by the former top of the stack using signed division, and pushes
-    // the result.
     case DW_OP_div: {
       tmp = stack.back();
       if (tmp.GetScalar().IsZero())
@@ -1563,78 +1473,46 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return llvm::createStringError("divide failed");
     } break;
 
-    // OPCODE: DW_OP_minus
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, subtracts the former top
-    // of the stack from the former second entry, and pushes the result.
     case DW_OP_minus:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() - tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_mod
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values and pushes the result of
-    // the calculation: former second stack entry modulo the former top of the
-    // stack.
     case DW_OP_mod:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() % tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_mul
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, multiplies them
-    // together, and pushes the result.
     case DW_OP_mul:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() * tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_neg
-    // OPERANDS: none
-    // DESCRIPTION: pops the top stack entry, and pushes its negation.
     case DW_OP_neg:
       if (!stack.back().GetScalar().UnaryNegate())
         return llvm::createStringError("unary negate failed");
       break;
 
-    // OPCODE: DW_OP_not
-    // OPERANDS: none
-    // DESCRIPTION: pops the top stack entry, and pushes its bitwise
-    // complement
     case DW_OP_not:
       if (!stack.back().GetScalar().OnesComplement())
         return llvm::createStringError("logical NOT failed");
       break;
 
-    // OPCODE: DW_OP_or
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, performs a bitwise or
-    // operation on the two, and pushes the result.
     case DW_OP_or:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() | tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_plus
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, adds them together, and
-    // pushes the result.
     case DW_OP_plus:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() += tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_plus_uconst
-    // OPERANDS: none
-    // DESCRIPTION: pops the top stack entry, adds it to the unsigned LEB128
-    // constant operand and pushes the result.
     case DW_OP_plus_uconst: {
       const uint64_t uconst_value = op->getRawOperand(0);
       // Implicit conversion from a UINT to a Scalar...
@@ -1643,22 +1521,12 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return llvm::createStringError("DW_OP_plus_uconst failed");
     } break;
 
-    // OPCODE: DW_OP_shl
-    // OPERANDS: none
-    // DESCRIPTION:  pops the top two stack entries, shifts the former
-    // second entry left by the number of bits specified by the former top of
-    // the stack, and pushes the result.
     case DW_OP_shl:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() <<= tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_shr
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, shifts the former second
-    // entry right logically (filling with zero bits) by the number of bits
-    // specified by the former top of the stack, and pushes the result.
     case DW_OP_shr:
       tmp = stack.back();
       stack.pop_back();
@@ -1666,34 +1534,18 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return llvm::createStringError("DW_OP_shr failed");
       break;
 
-    // OPCODE: DW_OP_shra
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, shifts the former second
-    // entry right arithmetically (divide the magnitude by 2, keep the same
-    // sign for the result) by the number of bits specified by the former top
-    // of the stack, and pushes the result.
     case DW_OP_shra:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() >>= tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_xor
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack entries, performs the bitwise
-    // exclusive-or operation on the two, and pushes the result.
     case DW_OP_xor:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() ^ tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_skip
-    // OPERANDS: int16_t
-    // DESCRIPTION:  An unconditional branch. Its single operand is a 2-byte
-    // signed integer constant. The 2-byte constant is the number of bytes of
-    // the DWARF expression to skip forward or backward from the current
-    // operation, beginning after the 2-byte constant.
     case DW_OP_skip: {
       int16_t skip_offset = static_cast<int16_t>(op->getRawOperand(0));
       lldb::offset_t new_offset = op->getEndOffset() + skip_offset;
@@ -1709,13 +1561,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
           op->getEndOffset(), skip_offset, expr_data.size());
     }
 
-    // OPCODE: DW_OP_bra
-    // OPERANDS: int16_t
-    // DESCRIPTION: A conditional branch. Its single operand is a 2-byte
-    // signed integer constant. This operation pops the top of stack. If the
-    // value popped is not the constant 0, the 2-byte constant operand is the
-    // number of bytes of the DWARF expression to skip forward or backward from
-    // the current operation, beginning after the 2-byte constant.
     case DW_OP_bra: {
       tmp = stack.back();
       stack.pop_back();
@@ -1736,89 +1581,42 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
     } break;
 
-    // OPCODE: DW_OP_eq
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // equals (==) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_eq:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() == tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_ge
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // greater than or equal to (>=) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_ge:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() >= tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_gt
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // greater than (>) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_gt:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() > tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_le
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // less than or equal to (<=) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_le:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() <= tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_lt
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // less than (<) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_lt:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() < tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_ne
-    // OPERANDS: none
-    // DESCRIPTION: pops the top two stack values, compares using the
-    // not equal (!=) operator.
-    // STACK RESULT: push the constant value 1 onto the stack if the result
-    // of the operation is true or the constant value 0 if the result of the
-    // operation is false.
     case DW_OP_ne:
       tmp = stack.back();
       stack.pop_back();
       stack.back().GetScalar() = stack.back().GetScalar() != tmp.GetScalar();
       break;
 
-    // OPCODE: DW_OP_litn
-    // OPERANDS: none
-    // DESCRIPTION: encode the unsigned literal values from 0 through 31.
-    // STACK RESULT: push the unsigned literal constant value onto the top
-    // of the stack.
     case DW_OP_lit0:
     case DW_OP_lit1:
     case DW_OP_lit2:
@@ -1854,9 +1652,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       stack.push_back(to_generic(opcode - DW_OP_lit0));
       break;
 
-    // OPCODE: DW_OP_regN
-    // OPERANDS: none
-    // DESCRIPTION: Push the value in register n on the top of the stack.
     case DW_OP_reg0:
     case DW_OP_reg1:
     case DW_OP_reg2:
@@ -1897,10 +1692,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return err;
       stack.push_back(tmp);
     } break;
-    // OPCODE: DW_OP_regx
-    // OPERANDS:
-    //      ULEB128 literal operand that encodes the register.
-    // DESCRIPTION: Push the value in register on the top of the stack.
     case DW_OP_regx: {
       dwarf4_location_description_kind = Register;
       reg_num = op->getRawOperand(0);
@@ -1911,11 +1702,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       stack.push_back(tmp);
     } break;
 
-    // OPCODE: DW_OP_bregN
-    // OPERANDS:
-    //      SLEB128 offset from register N
-    // DESCRIPTION: Value is in memory at the address specified by register
-    // N plus an offset.
     case DW_OP_breg0:
     case DW_OP_breg1:
     case DW_OP_breg2:
@@ -1959,12 +1745,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       stack.push_back(tmp);
       stack.back().SetValueType(Value::ValueType::LoadAddress);
     } break;
-    // OPCODE: DW_OP_bregx
-    // OPERANDS: 2
-    //      ULEB128 literal operand that encodes the register.
-    //      SLEB128 offset from register N
-    // DESCRIPTION: Value is in memory at the address specified by register
-    // N plus an offset.
     case DW_OP_bregx: {
       reg_num = op->getRawOperand(0);
       if (llvm::Error err =
@@ -1984,26 +1764,9 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return err;
       break;
 
-    // OPCODE: DW_OP_nop
-    // OPERANDS: none
-    // DESCRIPTION: A place holder. It has no effect on the location stack
-    // or any of its values.
     case DW_OP_nop:
       break;
 
-    // OPCODE: DW_OP_piece
-    // OPERANDS: 1
-    //      ULEB128: byte size of the piece
-    // DESCRIPTION: The operand describes the size in bytes of the piece of
-    // the object referenced by the DWARF expression whose result is at the top
-    // of the stack. If the piece is located in a register, but does not occupy
-    // the entire register, the placement of the piece within that register is
-    // defined by the ABI.
-    //
-    // Many compilers store a single variable in sets of registers, or store a
-    // variable partially in memory and partially in registers. DW_OP_piece
-    // provides a way of describing how large a part of a variable a particular
-    // DWARF expression refers to.
     case DW_OP_piece: {
       if (llvm::Error err = Evaluate_DW_OP_piece(
               stack, pieces, op_piece_offset, dwarf4_location_description_kind,
@@ -2052,13 +1815,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
       break;
 
-    // OPCODE: DW_OP_implicit_value
-    // OPERANDS: 2
-    //      ULEB128  size of the value block in bytes
-    //      uint8_t* block bytes encoding value in target's memory
-    //      representation
-    // DESCRIPTION: Value is immediately stored in block in the debug info with
-    // the memory representation of the target.
     case DW_OP_implicit_value: {
       dwarf4_location_description_kind = Implicit;
 
@@ -2085,14 +1841,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
                                      DW_OP_value_to_name(opcode));
     }
 
-    // OPCODE: DW_OP_push_object_address
-    // OPERANDS: none
-    // DESCRIPTION: Pushes the address of the object currently being
-    // evaluated as part of evaluation of a user presented expression. This
-    // object may correspond to an independent variable described by its own
-    // DIE or it may be a component of an array, structure, or class whose
-    // address has been dynamically determined by an earlier step during user
-    // expression evaluation.
     case DW_OP_push_object_address:
       if (object_address_ptr)
         stack.push_back(*object_address_ptr);
@@ -2102,87 +1850,27 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
       break;
 
-    // OPCODE: DW_OP_call2
-    // OPERANDS:
-    //      uint16_t compile unit relative offset of a DIE
-    // DESCRIPTION: Performs subroutine calls during evaluation
-    // of a DWARF expression. The operand is the 2-byte unsigned offset of a
-    // debugging information entry in the current compilation unit.
-    //
-    // Operand interpretation is exactly like that for DW_FORM_ref2.
-    //
-    // This operation transfers control of DWARF expression evaluation to the
-    // DW_AT_location attribute of the referenced DIE. If there is no such
-    // attribute, then there is no effect. Execution of the DWARF expression of
-    // a DW_AT_location attribute may add to and/or remove from values on the
-    // stack. Execution returns to the point following the call when the end of
-    // the attribute is reached. Values on the stack at the time of the call
-    // may be used as parameters by the called expression and values left on
-    // the stack by the called expression may be used as return values by prior
-    // agreement between the calling and called expressions.
     case DW_OP_call2:
       return llvm::createStringError("unimplemented opcode DW_OP_call2");
-    // OPCODE: DW_OP_call4
-    // OPERANDS: 1
-    //      uint32_t compile unit relative offset of a DIE
-    // DESCRIPTION: Performs a subroutine call during evaluation of a DWARF
-    // expression. For DW_OP_call4, the operand is a 4-byte unsigned offset of
-    // a debugging information entry in  the current compilation unit.
-    //
-    // Operand interpretation DW_OP_call4 is exactly like that for
-    // DW_FORM_ref4.
-    //
-    // This operation transfers control of DWARF expression evaluation to the
-    // DW_AT_location attribute of the referenced DIE. If there is no such
-    // attribute, then there is no effect. Execution of the DWARF expression of
-    // a DW_AT_location attribute may add to and/or remove from values on the
-    // stack. Execution returns to the point following the call when the end of
-    // the attribute is reached. Values on the stack at the time of the call
-    // may be used as parameters by the called expression and values left on
-    // the stack by the called expression may be used as return values by prior
-    // agreement between the calling and called expressions.
     case DW_OP_call4:
       return llvm::createStringError("unimplemented opcode DW_OP_call4");
 
-    // OPCODE: DW_OP_stack_value
-    // OPERANDS: None
-    // DESCRIPTION: Specifies that the object does not exist in memory but
-    // rather is a constant value.  The value from the top of the stack is the
-    // value to be used.  This is the actual object value and not the location.
     case DW_OP_stack_value:
       dwarf4_location_description_kind = Implicit;
       stack.back().SetValueType(Value::ValueType::Scalar);
       break;
 
-    // OPCODE: DW_OP_convert
-    // OPERANDS: 1
-    //      A ULEB128 that is either a DIE offset of a
-    //      DW_TAG_base_type or 0 for the generic (pointer-sized) type.
-    //
-    // DESCRIPTION: Pop the top stack element, convert it to a
-    // different type, and push the result.
     case DW_OP_convert:
       if (llvm::Error err = Evaluate_DW_OP_convert(stack, dwarf_cu, module_sp,
                                                    op->getRawOperand(0)))
         return err;
       break;
 
-    // OPCODE: DW_OP_call_frame_cfa
-    // OPERANDS: None
-    // DESCRIPTION: Specifies a DWARF expression that pushes the value of
-    // the canonical frame address consistent with the call frame information
-    // located in .debug_frame (or in the FDEs of the eh_frame section).
     case DW_OP_call_frame_cfa:
       if (llvm::Error err = Evaluate_DW_OP_call_frame_cfa(stack, frame))
         return err;
       break;
 
-    // OPCODE: DW_OP_form_tls_address (or the old pre-DWARFv3 vendor extension
-    // opcode, DW_OP_GNU_push_tls_address)
-    // OPERANDS: none
-    // DESCRIPTION: Pops a TLS offset from the stack, converts it to
-    // an address in the current thread's thread-local storage block, and
-    // pushes it on the stack.
     case DW_OP_form_tls_address:
     case DW_OP_GNU_push_tls_address:
       if (llvm::Error err = Evaluate_DW_OP_form_tls_address(stack, exe_ctx,
@@ -2190,12 +1878,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         return err;
       break;
 
-    // OPCODE: DW_OP_addrx (DW_OP_GNU_addr_index is the legacy name.)
-    // OPERANDS: 1
-    //      ULEB128: index to the .debug_addr section
-    // DESCRIPTION: Pushes an address to the stack from the .debug_addr
-    // section with the base address specified by the DW_AT_addr_base attribute
-    // and the 0 based index is the ULEB128 encoded index.
     case DW_OP_addrx:
     case DW_OP_GNU_addr_index: {
       if (!dwarf_cu)
@@ -2214,13 +1896,6 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       }
     } break;
 
-    // OPCODE: DW_OP_GNU_const_index
-    // OPERANDS: 1
-    //      ULEB128: index to the .debug_addr section
-    // DESCRIPTION: Pushes an constant with the size of a machine address to
-    // the stack from the .debug_addr section with the base address specified
-    // by the DW_AT_addr_base attribute and the 0 based index is the ULEB128
-    // encoded index.
     case DW_OP_GNU_const_index: {
       if (!dwarf_cu) {
         return llvm::createStringError("DW_OP_GNU_const_index found without a "


### PR DESCRIPTION
Most labels in DWARFExpression::Evaluate have a 3-10 line OPCODE/OPERANDS/DESCRIPTION block copied from the DWARF specification. My assumption is that anyone editing this code should be consulting the latest version of the spec, which is the (only) source of truth. This approach doesn't scale, create the opportunity for subtle bugs and makes the code harder to read. 

Anything LLDB specific (i.e. that's not part of the spec) is preserved.