### PR TITLE
[mlir][linalg] Fix crash in FoldAddIntoDest on block-arg operands

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/FoldAddIntoDest.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/FoldAddIntoDest.cpp
@@ -24,10 +24,13 @@ static bool isDefinedAsZero(Value val) {
   if (isZeroIntegerOrFloat(val))
     return true;
 
-  return TypeSwitch<Operation *, bool>(val.getDefiningOp())
+  auto *defOp = val.getDefiningOp();
+  if (!defOp)
+    return false;
+
+  return TypeSwitch<Operation *, bool>(defOp)
       .Case<linalg::FillOp, linalg::CopyOp>([&](auto op) {
-        return op && op.getInputs().size() == 1 &&
-               isDefinedAsZero(op.getInputs()[0]);
+        return op.getInputs().size() == 1 && isDefinedAsZero(op.getInputs()[0]);
       })
       .Default([&](auto) { return false; });
 }

--- a/mlir/test/Dialect/Linalg/fold-add-into-dest.mlir
+++ b/mlir/test/Dialect/Linalg/fold-add-into-dest.mlir
@@ -297,3 +297,30 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_no_fold_when_dominated_dest_is_block_arg(
+    %lhs: !type, %rhs: !type, %dest: !type, %other: !type) -> !type {
+  %0 = linalg.matmul ins(%lhs, %rhs : !type, !type) outs(%dest : !type) -> !type
+  %1 = tensor.empty() : !type
+  %2 = linalg.add ins(%0, %other : !type, !type) outs(%1 : !type) -> !type
+  return %2 : !type
+}
+
+// CHECK-LABEL: func.func @expect_no_fold_when_dominated_dest_is_block_arg
+// CHECK: linalg.matmul
+// CHECK-NEXT: tensor.empty
+// CHECK-NEXT: linalg.add
+// CHECK-NEXT: return
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.linalg.fold_add_into_dest
+    } : !transform.any_op
+    transform.yield
+  }
+}


### PR DESCRIPTION
`isDefinedAsZero` was vulnerable to a classic "passing an unchecked `Operation *` to `TypeSwitch`".