### PR TITLE
Add the ability to pass a parent to ValueObjectMemory::Create.

### DIFF
--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -1011,9 +1011,9 @@ protected:
     ChildrenMap m_children;
     size_t m_children_count = 0;
   };
-  
+
   using ValueObjectManagerSP = std::shared_ptr<ValueObjectManager>;
-  
+
   /// The following two functions are helpers for Create methods
   /// for ValueObject subclasses that need to optionally receive
   /// a parent or external manager.
@@ -1027,11 +1027,12 @@ protected:
       manager_sp = ValueObjectManager::Create();
     return manager_sp;
   }
-  
+
   /// If manager is null, makes a new ValueObjectManager and sets
   /// manager to the new ValueObjectManager.  It also returns the
   /// shared pointer which is necessary to keep the new manager alive.
-  static ValueObjectManagerSP CreateManagerIfEmpty(ValueObjectManager *&manager) {
+  static ValueObjectManagerSP
+  CreateManagerIfEmpty(ValueObjectManager *&manager) {
     std::shared_ptr<ValueObjectManager> manager_sp;
     if (!manager) {
       manager_sp = ValueObjectManager::Create();
@@ -1039,7 +1040,6 @@ protected:
     }
     return manager_sp;
   }
-
 
   // Classes that inherit from ValueObject can see and modify these
 
@@ -1212,8 +1212,6 @@ protected:
 
 protected:
   virtual void DoUpdateChildrenAddressType(ValueObject &valobj) {};
-  
-  
 
 private:
   void UpdateChildrenAddressType() {

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -1011,6 +1011,35 @@ protected:
     ChildrenMap m_children;
     size_t m_children_count = 0;
   };
+  
+  using ValueObjectManagerSP = std::shared_ptr<ValueObjectManager>;
+  
+  /// The following two functions are helpers for Create methods
+  /// for ValueObject subclasses that need to optionally receive
+  /// a parent or external manager.
+  /// This returns a ValueObjectManagerSP that is either the SP of the
+  /// parent - if it is non-null, or a new manager if null.
+  static ValueObjectManagerSP ReuseManagerIfParent(ValueObject *parent) {
+    std::shared_ptr<ValueObjectManager> manager_sp;
+    if (parent)
+      manager_sp = parent->GetManager()->shared_from_this();
+    else
+      manager_sp = ValueObjectManager::Create();
+    return manager_sp;
+  }
+  
+  /// If manager is null, makes a new ValueObjectManager and sets
+  /// manager to the new ValueObjectManager.  It also returns the
+  /// shared pointer which is necessary to keep the new manager alive.
+  static ValueObjectManagerSP CreateManagerIfEmpty(ValueObjectManager *&manager) {
+    std::shared_ptr<ValueObjectManager> manager_sp;
+    if (!manager) {
+      manager_sp = ValueObjectManager::Create();
+      manager = manager_sp.get();
+    }
+    return manager_sp;
+  }
+
 
   // Classes that inherit from ValueObject can see and modify these
 
@@ -1183,6 +1212,8 @@ protected:
 
 protected:
   virtual void DoUpdateChildrenAddressType(ValueObject &valobj) {};
+  
+  
 
 private:
   void UpdateChildrenAddressType() {

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -1020,7 +1020,7 @@ protected:
   /// This returns a ValueObjectManagerSP that is either the SP of the
   /// parent - if it is non-null, or a new manager if null.
   static ValueObjectManagerSP ReuseManagerIfParent(ValueObject *parent) {
-    std::shared_ptr<ValueObjectManager> manager_sp;
+    ValueObjectManagerSP manager_sp;
     if (parent)
       manager_sp = parent->GetManager()->shared_from_this();
     else
@@ -1033,7 +1033,7 @@ protected:
   /// shared pointer which is necessary to keep the new manager alive.
   static ValueObjectManagerSP
   CreateManagerIfEmpty(ValueObjectManager *&manager) {
-    std::shared_ptr<ValueObjectManager> manager_sp;
+    ValueObjectManagerSP manager_sp;
     if (!manager) {
       manager_sp = ValueObjectManager::Create();
       manager = manager_sp.get();

--- a/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
@@ -174,16 +174,6 @@ private:
   ValueObjectConstResult(ExecutionContextScope *exe_scope,
                          ValueObjectManager &manager, Status &&error);
 
-  static std::shared_ptr<ValueObjectManager>
-  CreateManagerIfEmpty(ValueObjectManager *&manager) {
-    std::shared_ptr<ValueObjectManager> manager_sp;
-    if (!manager) {
-      manager_sp = ValueObjectManager::Create();
-      manager = manager_sp.get();
-    }
-    return manager_sp;
-  }
-
   ValueObject *CreateChildAtIndex(size_t idx) override {
     return m_impl.CreateChildAtIndex(idx);
   }

--- a/lldb/include/lldb/ValueObject/ValueObjectMemory.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectMemory.h
@@ -34,12 +34,14 @@ public:
   static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
                                     llvm::StringRef name,
                                     const Address &address,
-                                    lldb::TypeSP &type_sp);
+                                    lldb::TypeSP &type_sp,
+                                    ValueObject *parent = nullptr);
 
   static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
                                     llvm::StringRef name,
                                     const Address &address,
-                                    const CompilerType &ast_type);
+                                    const CompilerType &ast_type,
+                                    ValueObject *parent = nullptr);
 
   llvm::Expected<uint64_t> GetByteSize() override;
 

--- a/lldb/source/ValueObject/ValueObjectConstResult.cpp
+++ b/lldb/source/ValueObject/ValueObjectConstResult.cpp
@@ -31,7 +31,7 @@ ValueObjectSP ValueObjectConstResult::Create(ExecutionContextScope *exe_scope,
                                              uint32_t addr_byte_size,
                                              lldb::addr_t address,
                                              ValueObjectManager *manager) {
-  std::shared_ptr<ValueObjectManager> manager_sp =
+  ValueObjectManagerSP manager_sp =
       CreateManagerIfEmpty(manager);
 
   return (new ValueObjectConstResult(exe_scope, *manager, byte_order,

--- a/lldb/source/ValueObject/ValueObjectConstResult.cpp
+++ b/lldb/source/ValueObject/ValueObjectConstResult.cpp
@@ -31,8 +31,7 @@ ValueObjectSP ValueObjectConstResult::Create(ExecutionContextScope *exe_scope,
                                              uint32_t addr_byte_size,
                                              lldb::addr_t address,
                                              ValueObjectManager *manager) {
-  ValueObjectManagerSP manager_sp =
-      CreateManagerIfEmpty(manager);
+  ValueObjectManagerSP manager_sp = CreateManagerIfEmpty(manager);
 
   return (new ValueObjectConstResult(exe_scope, *manager, byte_order,
                                      addr_byte_size, address))

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -32,8 +32,11 @@ using namespace lldb_private;
 ValueObjectSP ValueObjectMemory::Create(ExecutionContextScope *exe_scope,
                                         llvm::StringRef name,
                                         const Address &address,
-                                        lldb::TypeSP &type_sp) {
-  auto manager_sp = ValueObjectManager::Create();
+                                        lldb::TypeSP &type_sp,
+                                        ValueObject *parent) {
+  
+  std::shared_ptr<ValueObjectManager> manager_sp = 
+      ValueObject::ReuseManagerIfParent(parent);
   return (new ValueObjectMemory(exe_scope, *manager_sp, name, address, type_sp))
       ->GetSP();
 }
@@ -41,8 +44,10 @@ ValueObjectSP ValueObjectMemory::Create(ExecutionContextScope *exe_scope,
 ValueObjectSP ValueObjectMemory::Create(ExecutionContextScope *exe_scope,
                                         llvm::StringRef name,
                                         const Address &address,
-                                        const CompilerType &ast_type) {
-  auto manager_sp = ValueObjectManager::Create();
+                                        const CompilerType &ast_type,
+                                        ValueObject *parent) {
+  std::shared_ptr<ValueObjectManager> manager_sp = 
+      ValueObject::ReuseManagerIfParent(parent);
   return (new ValueObjectMemory(exe_scope, *manager_sp, name, address,
                                 ast_type))
       ->GetSP();

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -34,8 +34,8 @@ ValueObjectSP ValueObjectMemory::Create(ExecutionContextScope *exe_scope,
                                         const Address &address,
                                         lldb::TypeSP &type_sp,
                                         ValueObject *parent) {
-  
-  std::shared_ptr<ValueObjectManager> manager_sp = 
+
+  std::shared_ptr<ValueObjectManager> manager_sp =
       ValueObject::ReuseManagerIfParent(parent);
   return (new ValueObjectMemory(exe_scope, *manager_sp, name, address, type_sp))
       ->GetSP();
@@ -46,7 +46,7 @@ ValueObjectSP ValueObjectMemory::Create(ExecutionContextScope *exe_scope,
                                         const Address &address,
                                         const CompilerType &ast_type,
                                         ValueObject *parent) {
-  std::shared_ptr<ValueObjectManager> manager_sp = 
+  std::shared_ptr<ValueObjectManager> manager_sp =
       ValueObject::ReuseManagerIfParent(parent);
   return (new ValueObjectMemory(exe_scope, *manager_sp, name, address,
                                 ast_type))


### PR DESCRIPTION
Also move the equivalent helper function from ValueObjectConstResult to ValueObject.h where it more properly belongs.

This patch is necessary if one were to use ValueObjectMemory for a synthetic child.  There aren't any current uses of this sort in lldb, though there are on the swift fork.