### PR TITLE
[bazel] Fix testonly declarations in mlir

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -538,7 +538,6 @@ def gentbl_sharded_ops(
         gentbl_shard_rule(
             index = i,
             name = name + "__src_shard" + str(i),
-            testonly = test,
             out = out_file,
             sharder = sharder,
             src_file = src_file,


### PR DESCRIPTION
Some recent Bazel change (unsure what) caused these to start failing because they weren't properly declared. Some of these test targets are used in 'real' binaries, so it doesn't make sense to propagate `testonly`, so just remove it.