### PR TITLE
[libc][NFC] Replace <sys/mman.h> with proxy headers in mman

### DIFF
--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -39,7 +39,8 @@ add_entrypoint_object(
   HDRS
     ../mremap.h
   DEPENDS
-    libc.include.sys_mman
+    libc.hdr.sys_mman_macros
+    libc.hdr.types.size_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -76,7 +77,8 @@ add_entrypoint_object(
   HDRS
     ../posix_madvise.h
   DEPENDS
-    libc.include.sys_mman
+    libc.hdr.sys_mman_macros
+    libc.hdr.types.size_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
 )

--- a/libc/src/sys/mman/linux/mremap.cpp
+++ b/libc/src/sys/mman/linux/mremap.cpp
@@ -17,6 +17,8 @@
 #include <stdarg.h>
 #include <sys/syscall.h> // For syscall numbers.
 
+#include "hdr/sys_mman_macros.h" // For MREMAP_FIXED, MAP_FAILED.
+
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(void *, mremap,

--- a/libc/src/sys/mman/linux/posix_madvise.cpp
+++ b/libc/src/sys/mman/linux/posix_madvise.cpp
@@ -14,6 +14,8 @@
 
 #include <sys/syscall.h> // For syscall numbers.
 
+#include "hdr/sys_mman_macros.h" // For POSIX_MADV_DONTNEED.
+
 namespace LIBC_NAMESPACE_DECL {
 
 // This function is currently linux only. It has to be refactored suitably if

--- a/libc/src/sys/mman/madvise.h
+++ b/libc/src/sys/mman/madvise.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MADVISE_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MADVISE_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t and off_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/mincore.h
+++ b/libc/src/sys/mman/mincore.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MINCORE_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MINCORE_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/mlock.h
+++ b/libc/src/sys/mman/mlock.h
@@ -9,9 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MLOCK_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MLOCK_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/mlock2.h
+++ b/libc/src/sys/mman/mlock2.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MLOCK2_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MLOCK2_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
+
 #include <sys/syscall.h>
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sys/mman/mlockall.h
+++ b/libc/src/sys/mman/mlockall.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_SYS_MMAN_MLOCKALL_H
 
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/mprotect.h
+++ b/libc/src/sys/mman/mprotect.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MPROTECT_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MPROTECT_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t and off_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/mremap.h
+++ b/libc/src/sys/mman/mremap.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MREMAP_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MREMAP_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t and off_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/msync.h
+++ b/libc/src/sys/mman/msync.h
@@ -9,9 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MSYNC_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MSYNC_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/munlock.h
+++ b/libc/src/sys/mman/munlock.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MUNLOCK_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MUNLOCK_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/munlockall.h
+++ b/libc/src/sys/mman/munlockall.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_SYS_MMAN_MUNLOCKALL_H
 
 #include "src/__support/macros/config.h"
-#include <sys/mman.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/munmap.h
+++ b/libc/src/sys/mman/munmap.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MUNMAP_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MUNMAP_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t.
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/mman/posix_madvise.h
+++ b/libc/src/sys/mman/posix_madvise.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_POSIX_MADVISE_H
 #define LLVM_LIBC_SRC_SYS_MMAN_POSIX_MADVISE_H
 
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t and off_t
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
Replaced direct <sys/mman.h> includes in sys/mman entrypoint headers with granular proxy headers (hdr/types/size_t.h). The mmap.h entrypoint header retains its transitive sys/mman.h include, keeping tests working.

Updated mremap.cpp and posix_madvise.cpp to include hdr/sys_mman_macros.h for mman macros used directly.