### PR TITLE
[lldb] Adjust TestDataFormatterCpp.py for arm64e

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -318,14 +318,14 @@ class CppDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable member_func_ptr",
             patterns=["member_func_ptr = 0x[0-9a-z]+"],
-            substrs=["(a.out`IUseCharStar::member_func(int) at main.cpp:61)"],
+            substrs=["a.out`IUseCharStar::member_func(int) at main.cpp:61)"],
         )
         self.expect(
             "frame variable ref_to_member_func_ptr",
             patterns=["ref_to_member_func_ptr = 0x[0-9a-z]+"],
-            substrs=["(a.out`IUseCharStar::member_func(int) at main.cpp:61)"],
+            substrs=["a.out`IUseCharStar::member_func(int) at main.cpp:61)"],
         )
         self.expect(
             "frame variable virt_member_func_ptr",
-            patterns=["virt_member_func_ptr = 0x[0-9a-z]+$"],
+            patterns=["virt_member_func_ptr = 0x[0-9a-z]+"],
         )


### PR DESCRIPTION
For two of these cases, the initial open parenthesis comes much earlier. Compare:

```
arm64e:
(actual=0x00000001000006c4 a.out`IUseCharStar::member_func(int) ...
arm64:
(a.out`IUseCharStar::member_func(int) ...
```

For the third case, the address was not the last part of the output string. It looks more like this:
```
virt_member_func_ptr = 0x00000000000000005b3f0001047c46e0
(actual=0x00000001047c46e0 ...
```