### PR TITLE
[scudo] Add append overloads for integers and bool

### DIFF
--- a/compiler-rt/lib/scudo/standalone/string_utils.cpp
+++ b/compiler-rt/lib/scudo/standalone/string_utils.cpp
@@ -213,13 +213,7 @@ void ScopedString::vappend(const char *Format, va_list &Args) {
     }
     }
   }
-  String.push_back('\0');
-  if (String.back() != '\0') {
-    // String truncated, make sure the string is terminated properly.
-    // This can happen if there is no more memory when trying to resize
-    // the string.
-    String.back() = '\0';
-  }
+  ensureNullTerminated();
 }
 
 void ScopedString::append(const char *Format, ...) {
@@ -227,6 +221,51 @@ void ScopedString::append(const char *Format, ...) {
   va_start(Args, Format);
   vappend(Format, Args);
   va_end(Args);
+}
+
+void ScopedString::append(const s32 Value) {
+  DCHECK(String.size() > 0);
+  String.resize(String.size() - 1);
+  appendSignedDecimal(static_cast<s64>(Value), 0, false);
+  ensureNullTerminated();
+}
+
+void ScopedString::append(const s64 Value) {
+  DCHECK(String.size() > 0);
+  String.resize(String.size() - 1);
+  appendSignedDecimal(Value, 0, false);
+  ensureNullTerminated();
+}
+
+void ScopedString::append(const u32 Value) {
+  DCHECK(String.size() > 0);
+  String.resize(String.size() - 1);
+  appendUnsigned(static_cast<u64>(Value), 10, 0, false, false);
+  ensureNullTerminated();
+}
+
+void ScopedString::append(const u64 Value) {
+  DCHECK(String.size() > 0);
+  String.resize(String.size() - 1);
+  appendUnsigned(Value, 10, 0, false, false);
+  ensureNullTerminated();
+}
+
+void ScopedString::append(const bool Value) {
+  DCHECK(String.size() > 0);
+  String.resize(String.size() - 1);
+  appendString(0, -1, Value ? "true" : "false");
+  ensureNullTerminated();
+}
+
+void ScopedString::ensureNullTerminated() {
+  String.push_back('\0');
+  if (String.back() != '\0') {
+    // String truncated, make sure the string is terminated properly.
+    // This can happen if there is no more memory when trying to resize
+    // the string.
+    String.back() = '\0';
+  }
 }
 
 void Printf(const char *Format, ...) {

--- a/compiler-rt/lib/scudo/standalone/string_utils.h
+++ b/compiler-rt/lib/scudo/standalone/string_utils.h
@@ -27,6 +27,12 @@ public:
   }
   void vappend(const char *Format, va_list &Args);
   void append(const char *Format, ...) FORMAT(2, 3);
+  void append(const s32);
+  void append(const s64);
+  void append(const u32);
+  void append(const u64);
+  void append(const bool);
+  void ensureNullTerminated();
   void output() const { outputRaw(String.data()); }
   void reserve(size_t Size) { String.reserve(Size + 1); }
   uptr capacity() { return String.capacity() - 1; }

--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -72,6 +72,42 @@ TEST(ScudoStringsTest, Precision) {
   EXPECT_STREQ("12345   ", Str.data());
 }
 
+TEST(ScudoStringTest, AppendSigned32Int) {
+  scudo::ScopedString Str;
+  Str.append(-12345);
+  EXPECT_STREQ("-12345", Str.data());
+}
+
+TEST(ScudoStringTest, AppendSigned64Int) {
+  scudo::ScopedString Str;
+  Str.append(static_cast<scudo::s64>(-3000000000LL));
+  EXPECT_STREQ("-3000000000", Str.data());
+}
+
+TEST(ScudoStringTest, AppendUnsigned32Int) {
+  scudo::ScopedString Str;
+  Str.append(12345u);
+  EXPECT_STREQ("12345", Str.data());
+}
+
+TEST(ScudoStringTest, AppendUnsigned64Int) {
+  scudo::ScopedString Str;
+  Str.append(static_cast<scudo::u64>(5000000000ULL));
+  EXPECT_STREQ("5000000000", Str.data());
+}
+
+TEST(ScudoStringTest, AppendBoolTrue) {
+  scudo::ScopedString Str;
+  Str.append(true);
+  EXPECT_STREQ("true", Str.data());
+}
+
+TEST(ScudoStringTest, AppendBoolFalse) {
+  scudo::ScopedString Str;
+  Str.append(false);
+  EXPECT_STREQ("false", Str.data());
+}
+
 static void fillString(scudo::ScopedString &Str, scudo::uptr Size) {
   for (scudo::uptr I = 0; I < Size; I++)
     Str.append("A");


### PR DESCRIPTION
This patch adds overloads for append to support directly appending s32, s64, u32, u64, and bool values without requiring format strings. This simplifies usage and avoids the overhead of parsing format strings for simple type appends.