### PR TITLE
[RFC][NVPTX] Update data layout string to include null pointer value spec

### DIFF
--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -144,11 +144,11 @@
 
 // RUN: %clang_cc1 -triple nvptx-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=NVPTX
-// NVPTX: target datalayout = "e-p:32:32-p6:32:32-p7:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
+// NVPTX: target datalayout = "e-p:32:32-po3:32:32-po5:32:32-p6:32:32-po7:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
 
 // RUN: %clang_cc1 -triple nvptx64-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=NVPTX64
-// NVPTX64: target datalayout = "e-p6:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
+// NVPTX64: target datalayout = "e-po3:64:64-po5:64:64-p6:32:32-po7:64:64-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
 
 // RUN: %clang_cc1 -triple r600-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=R600

--- a/llvm/lib/TargetParser/TargetDataLayout.cpp
+++ b/llvm/lib/TargetParser/TargetDataLayout.cpp
@@ -463,11 +463,11 @@ static std::string computeNVPTXDataLayout(const Triple &T, StringRef ABIName) {
   // Distributed Shared Memory (addrspace:7) follows shared memory
   // (addrspace:3).
   if (!Is64Bit)
-    Ret += "-p:32:32-p6:32:32-p7:32:32";
+    Ret += "-p:32:32-po3:32:32-po5:32:32-p6:32:32-po7:32:32";
   else if (ABIName == "shortptr")
-    Ret += "-p3:32:32-p4:32:32-p5:32:32-p6:32:32-p7:32:32";
+    Ret += "-po3:32:32-p4:32:32-po5:32:32-p6:32:32-po7:32:32";
   else
-    Ret += "-p6:32:32";
+    Ret += "-po3:64:64-po5:64:64-p6:32:32-po7:64:64";
 
   Ret += "-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64";
 


### PR DESCRIPTION
PR #183207 introduced support in the data layout for targets to specify the
actual nullptr value per address space. If not specified, it defaults to zero.
This PR updates the NVPTX data layout string accordingly.
