### PR TITLE
[flang][cuda][openacc] Add UseDevice attribute to model host_data use_device symbols

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.h
+++ b/flang/include/flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.h
@@ -73,6 +73,9 @@ getDataAttribute(mlir::MLIRContext *mlirContext,
     case Fortran::common::CUDADataAttr::Unified:
       attr = cuf::DataAttribute::Unified;
       break;
+    case Fortran::common::CUDADataAttr::UseDevice:
+      attr = cuf::DataAttribute::Device;
+      break;
     case Fortran::common::CUDADataAttr::Value:
       return {}; // Extension, not a real CUDA Fortran data attribute
     }

--- a/flang/include/flang/Support/Fortran.h
+++ b/flang/include/flang/Support/Fortran.h
@@ -66,7 +66,7 @@ ENUM_CLASS(CUDASubprogramAttrs, Host, Device, HostDevice, Global, Grid_Global)
 
 // CUDA data attributes; mutually exclusive
 ENUM_CLASS(CUDADataAttr, Constant, Device, Managed, Pinned, Shared, Texture,
-    Unified, Value)
+    Unified, UseDevice, Value)
 
 // OpenACC device types
 ENUM_CLASS(

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -124,7 +124,8 @@ static bool IsHostArray(const Symbol &symbol) {
             *details->cudaDataAttr() == common::CUDADataAttr::Constant ||
             *details->cudaDataAttr() == common::CUDADataAttr::Managed ||
             *details->cudaDataAttr() == common::CUDADataAttr::Shared ||
-            *details->cudaDataAttr() == common::CUDADataAttr::Unified)) {
+            *details->cudaDataAttr() == common::CUDADataAttr::Unified ||
+            *details->cudaDataAttr() == common::CUDADataAttr::UseDevice)) {
       return false;
     }
   }
@@ -178,7 +179,8 @@ struct FindHostArray
                   *details->cudaDataAttr() != common::CUDADataAttr::Constant &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Managed &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Shared &&
-                  *details->cudaDataAttr() != common::CUDADataAttr::Unified))) {
+                  *details->cudaDataAttr() != common::CUDADataAttr::Unified &&
+                  *details->cudaDataAttr() != common::CUDADataAttr::UseDevice))) {
         return &symbol;
       }
     }
@@ -833,7 +835,9 @@ void CUDAChecker::Enter(const parser::PrintStmt &x) {
             if (details->cudaDataAttr() &&
                 (*details->cudaDataAttr() == common::CUDADataAttr::Device ||
                     *details->cudaDataAttr() ==
-                        common::CUDADataAttr::Constant)) {
+                        common::CUDADataAttr::Constant ||
+                    *details->cudaDataAttr() ==
+                        common::CUDADataAttr::UseDevice)) {
               context_.Say(parser::FindSourceLocation(*x),
                   "device data not allowed in I/O statements"_err_en_US);
             }

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -180,7 +180,8 @@ struct FindHostArray
                   *details->cudaDataAttr() != common::CUDADataAttr::Managed &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Shared &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Unified &&
-                  *details->cudaDataAttr() != common::CUDADataAttr::UseDevice))) {
+                  *details->cudaDataAttr() !=
+                      common::CUDADataAttr::UseDevice))) {
         return &symbol;
       }
     }

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1240,6 +1240,8 @@ void CheckHelper::CheckObjectEntity(
       messages_.Say(
           "ATTRIBUTES(TEXTURE) is obsolete and no longer supported"_err_en_US);
       break;
+    case common::CUDADataAttr::UseDevice:
+      break;
     }
     if (attr != common::CUDADataAttr::Pinned) {
       if (details.commonBlock()) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2930,9 +2930,15 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
       return 0;
     }
   }
-  // UseDevice (OpenACC host_data use_device) has a device address but the
-  // underlying variable is host-resident.  Prefer device dummies, but allow
-  // host dummies with a higher distance.
+  // An actual argument with the UseDevice attribute comes from an OpenACC
+  // host_data use_device clause: the variable itself is host-resident, but
+  // inside the host_data region it is referenced via its device address.
+  // It can therefore match either a host dummy or a device dummy in generic
+  // resolution.  The matching distance disambiguates when both kinds of
+  // specifics exist:
+  //   - device dummy:           0 (best match: actual carries a device address)
+  //   - managed/unified dummy:  2 (acceptable: dummy is reachable from device)
+  //   - host dummy (no attr):   3 (acceptable: underlying variable is host)
   if (actualDataAttr && *actualDataAttr == common::CUDADataAttr::UseDevice) {
     if (!dummyDataAttr)
       return 3;

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2934,7 +2934,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
   // host_data use_device clause: the variable itself is host-resident, but
   // inside the host_data region it is referenced via its device address.
   // It can therefore match either a host dummy or a device dummy in generic
-  // resolution.  The matching distance disambiguates when both kinds of
+  // resolution. The matching distance disambiguates when both kinds of
   // specifics exist:
   //   - device dummy:           0 (best match: actual carries a device address)
   //   - managed/unified dummy:  2 (acceptable: dummy is reachable from device)

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2930,6 +2930,18 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
       return 0;
     }
   }
+  // UseDevice (OpenACC host_data use_device) has a device address but the
+  // underlying variable is host-resident.  Prefer device dummies, but allow
+  // host dummies with a higher distance.
+  if (actualDataAttr && *actualDataAttr == common::CUDADataAttr::UseDevice) {
+    if (!dummyDataAttr)
+      return 3;
+    if (*dummyDataAttr == common::CUDADataAttr::Device)
+      return 0;
+    if (*dummyDataAttr == common::CUDADataAttr::Managed ||
+        *dummyDataAttr == common::CUDADataAttr::Unified)
+      return 2;
+  }
   return cudaInfMatchingValue;
 }
 

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1616,12 +1616,14 @@ bool AccVisitor::Pre(const parser::OpenACCBlockConstruct &x) {
 
 void AccVisitor::CopySymbolWithDevice(const parser::Name *name) {
   // New symbols are created for those appearing in the use_device clause.
-  // These new symbols get the CUDA device attribute.
+  // These new symbols get the CUDA UseDevice attribute so that generic
+  // resolution can distinguish them from true DEVICE variables: UseDevice
+  // actuals are compatible with both host and device dummy arguments.
   if (name && name->symbol) {
     Symbol *copy{CopyUseDeviceSymbol(*name->symbol)};
     if (copy) {
       if (auto *object{copy->detailsIf<ObjectEntityDetails>()}) {
-        object->set_cudaDataAttr(common::CUDADataAttr::Device);
+        object->set_cudaDataAttr(common::CUDADataAttr::UseDevice);
       }
       name->symbol = copy;
     }

--- a/flang/lib/Semantics/type.cpp
+++ b/flang/lib/Semantics/type.cpp
@@ -736,7 +736,7 @@ static const DeclTypeSpec *CloneDerivedTypeForUseDeviceImpl(
   if (path.size() == 1) {
     if (Symbol * comp{newScope.FindComponent(path[0])}) {
       if (auto *details{comp->detailsIf<ObjectEntityDetails>()}) {
-        details->set_cudaDataAttr(common::CUDADataAttr::Device);
+        details->set_cudaDataAttr(common::CUDADataAttr::UseDevice);
       }
     }
   }

--- a/flang/lib/Support/Fortran.cpp
+++ b/flang/lib/Support/Fortran.cpp
@@ -117,8 +117,7 @@ bool AreCompatibleCUDADataAttrs(std::optional<CUDADataAttr> x,
   if (ignoreTKR.test(common::IgnoreTKR::Device)) {
     return true;
   }
-  // UseDevice (from OpenACC host_data use_device) is compatible with any dummy:
-  // it has a device address but the underlying variable may be host-resident.
+  // A use_device(...) actual is compatible with any dummy.
   if (y && *y == CUDADataAttr::UseDevice)
     return true;
   if (!y && isHostDeviceProcedure) {

--- a/flang/lib/Support/Fortran.cpp
+++ b/flang/lib/Support/Fortran.cpp
@@ -117,6 +117,10 @@ bool AreCompatibleCUDADataAttrs(std::optional<CUDADataAttr> x,
   if (ignoreTKR.test(common::IgnoreTKR::Device)) {
     return true;
   }
+  // UseDevice (from OpenACC host_data use_device) is compatible with any dummy:
+  // it has a device address but the underlying variable may be host-resident.
+  if (y && *y == CUDADataAttr::UseDevice)
+    return true;
   if (!y && isHostDeviceProcedure) {
     return true;
   }

--- a/flang/test/Semantics/cuf27.cuf
+++ b/flang/test/Semantics/cuf27.cuf
@@ -1,0 +1,85 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -fopenacc
+
+! Test that OpenACC host_data use_device variables (UseDevice attribute)
+! are compatible with both host and device dummy arguments in generic
+! resolution.
+
+module m
+  interface overl
+    module procedure overl_host
+  end interface
+contains
+  subroutine overl_host(x)
+    integer :: x(:)
+  end subroutine
+end module m
+
+module m2
+  interface dforce
+    module procedure dforce_host
+    module procedure dforce_device
+  end interface
+contains
+  subroutine dforce_host(x, y)
+    integer :: x(:), y(:)
+  end subroutine
+  subroutine dforce_device(x, y)
+    integer, device :: x(:), y(:)
+  end subroutine
+end module m2
+
+subroutine test_use_device_host_only()
+  use m
+  integer, allocatable :: fx(:)
+  allocate(fx(100))
+  !$acc data copy(fx)
+  !$acc host_data use_device(fx)
+  call overl(fx)
+  !$acc end host_data
+  !$acc end data
+  deallocate(fx)
+end
+
+subroutine test_use_device_with_device_specific()
+  use m2
+  integer, allocatable :: fx(:)
+  integer, device, allocatable :: fy(:)
+  allocate(fx(100), fy(100))
+  !$acc data copy(fx)
+  !$acc host_data use_device(fx)
+  call dforce(fx, fy)
+  !$acc end host_data
+  !$acc end data
+  deallocate(fx, fy)
+end
+
+module m3
+  integer, parameter :: dp = selected_real_kind(14,200)
+  complex(dp), allocatable, target, pinned :: vkb(:,:)
+  interface dforce2
+    module procedure dforce2_host
+    module procedure dforce2_gpu
+  end interface
+contains
+  subroutine dforce2_host(vkb, c, v)
+    complex(dp) :: vkb(:,:), c(:,:)
+    real(dp) :: v(:,:)
+  end subroutine
+  subroutine dforce2_gpu(vkb, c, v)
+    complex(dp), device :: vkb(:,:), c(:,:)
+    real(dp), device :: v(:,:)
+  end subroutine
+end module m3
+
+subroutine test_use_device_pinned_use_assoc()
+  use m3
+  complex(dp), device, allocatable :: c_d(:,:)
+  real(dp), device, allocatable :: v_d(:,:)
+  allocate(vkb(64,64), c_d(64,64), v_d(64,64))
+  !$acc enter data copyin(vkb)
+  !$acc host_data use_device(vkb)
+  call dforce2(vkb, c_d, v_d)
+  !$acc end host_data
+  !$acc exit data delete(vkb)
+  deallocate(vkb, c_d, v_d)
+end


### PR DESCRIPTION
Symbols appearing in `!$acc host_data use_device(...)` were previously marked with `CUDADataAttr::Device`, which caused generic resolution to fail.

Introduce a new CUDADataAttr::UseDevice enumerator and use it in `CopySymbolWithDevice` / `CloneDerivedTypeForUseDeviceImpl` instead of Device. The new attribute is:

1. Compatible with any dummy in AreCompatibleCUDADataAttrs.
2. Ranked in the matching distance table (GetMatchingDistance): prefers Device dummies (0), accepts Managed/Unified (2), and allows host dummies (3).
3. Not user-spellable — only set internally during OpenACC name resolution, never parsed from source or written to module files.
4. Treated like Device for non-host-array checks, I/O restrictions, and MLIR lowering (mapped to `cuf::DataAttribute::Device`).