### PR TITLE
[IndVars] Add remarks to help identify missed cases in predicateLoop

### DIFF
--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1864,11 +1864,9 @@ static ExitConditionInfo describeExitingBranch(BasicBlock *ExitingBB, Loop *L,
                                                ScalarEvolution *SE) {
   ExitConditionInfo Info;
 
-  auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
-  if (!BI)
-    return Info;
-
-  // Classify the exit target.
+  // Trap/normal classification is meaningful for any terminator kind
+  // (conditional branch, unconditional branch, switch, invoke, ...), so
+  // do it first before we decide whether to dig out predicate/stride info.
   for (BasicBlock *Succ : successors(ExitingBB)) {
     if (L->contains(Succ))
       continue;
@@ -1877,6 +1875,10 @@ static ExitConditionInfo describeExitingBranch(BasicBlock *ExitingBB, Loop *L,
     else
       Info.IsNormalExit = true;
   }
+
+  auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
+  if (!BI)
+    return Info;
 
   auto *Cmp = dyn_cast_or_null<ICmpInst>(BI->getCondition());
   if (!Cmp)

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1864,7 +1864,7 @@ static ExitConditionInfo describeExitingBranch(BasicBlock *ExitingBB, Loop *L,
                                                ScalarEvolution *SE) {
   ExitConditionInfo Info;
 
-  auto *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+  auto *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
   if (!BI)
     return Info;
 

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/MemorySSA.h"
 #include "llvm/Analysis/MemorySSAUpdater.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
 #include "llvm/Analysis/ScalarEvolutionPatternMatch.h"
@@ -135,6 +136,7 @@ class IndVarSimplify {
   const DataLayout &DL;
   TargetLibraryInfo *TLI;
   const TargetTransformInfo *TTI;
+  OptimizationRemarkEmitter *ORE;
   std::unique_ptr<MemorySSAUpdater> MSSAU;
 
   SmallVector<WeakTrackingVH, 16> DeadInsts;
@@ -167,8 +169,9 @@ class IndVarSimplify {
 public:
   IndVarSimplify(LoopInfo *LI, ScalarEvolution *SE, DominatorTree *DT,
                  const DataLayout &DL, TargetLibraryInfo *TLI,
-                 TargetTransformInfo *TTI, MemorySSA *MSSA, bool WidenIndVars)
-      : LI(LI), SE(SE), DT(DT), DL(DL), TLI(TLI), TTI(TTI),
+                 TargetTransformInfo *TTI, OptimizationRemarkEmitter *ORE,
+                 MemorySSA *MSSA, bool WidenIndVars)
+      : LI(LI), SE(SE), DT(DT), DL(DL), TLI(TLI), TTI(TTI), ORE(ORE),
         WidenIndVars(WidenIndVars) {
     if (MSSA)
       MSSAU = std::make_unique<MemorySSAUpdater>(MSSA);
@@ -1842,6 +1845,134 @@ static bool crashingBBWithoutEffect(const BasicBlock &BB) {
   });
 }
 
+namespace {
+/// Structured description of an exiting branch condition for remarks.
+/// Each field is emitted as a separate ore::NV so tools can consume them.
+struct ExitConditionInfo {
+  StringRef Predicate; // "sgt", "ult", "eq", ... or empty if no ICmp
+  std::string Type;    // "i64", "ptr", ... or empty if unknown
+  std::string Stride;  // "+4", "-1", "varying", "invariant", or "none"
+  bool IsTrapExit = false;
+  bool IsNormalExit = false;
+};
+} // namespace
+
+/// Describe an exiting branch for optimization remarks: predicate kind, the
+/// type being compared, the IV stride if the operand is an AddRec on \p L,
+/// and whether the exit target is an unreachable block or a normal exit.
+static ExitConditionInfo describeExitingBranch(BasicBlock *ExitingBB, Loop *L,
+                                               ScalarEvolution *SE) {
+  ExitConditionInfo Info;
+
+  auto *BI = dyn_cast<BranchInst>(ExitingBB->getTerminator());
+  if (!BI)
+    return Info;
+
+  // Classify the exit target.
+  for (BasicBlock *Succ : successors(ExitingBB)) {
+    if (L->contains(Succ))
+      continue;
+    if (isa<UnreachableInst>(Succ->getTerminator()))
+      Info.IsTrapExit = true;
+    else
+      Info.IsNormalExit = true;
+  }
+
+  auto *Cmp = dyn_cast_or_null<ICmpInst>(BI->getCondition());
+  if (!Cmp)
+    return Info;
+
+  Info.Predicate = CmpInst::getPredicateName(Cmp->getPredicate());
+
+  Type *OpTy = Cmp->getOperand(0)->getType();
+  if (OpTy->isPointerTy()) {
+    Info.Type = "ptr";
+  } else if (OpTy->isIntegerTy()) {
+    std::string Buf;
+    raw_string_ostream OS(Buf);
+    OS << "i" << OpTy->getIntegerBitWidth();
+    Info.Type = std::move(Buf);
+  }
+
+  // Look for an AddRec operand in L to extract the stride.
+  Info.Stride = "none";
+  for (unsigned I = 0; I < 2; ++I) {
+    const SCEV *OpSCEV = SE->getSCEV(Cmp->getOperand(I));
+    auto *AR = dyn_cast<SCEVAddRecExpr>(OpSCEV);
+    if (!AR || AR->getLoop() != L)
+      continue;
+    const SCEV *Step = AR->getStepRecurrence(*SE);
+    if (auto *SC = dyn_cast<SCEVConstant>(Step)) {
+      int64_t V = SC->getAPInt().getSExtValue();
+      std::string Buf;
+      raw_string_ostream OS(Buf);
+      if (V > 0)
+        OS << "+" << V;
+      else
+        OS << V;
+      Info.Stride = std::move(Buf);
+    } else if (SE->isLoopInvariant(Step, L)) {
+      Info.Stride = "invariant";
+    } else {
+      Info.Stride = "varying";
+    }
+    break;
+  }
+
+  return Info;
+}
+
+/// Emit a structured per-exit remark classifying each exiting block as
+/// having a computable or not-computable exit count. Fields are exposed via
+/// ore::NV so YAML consumers (e.g. opt-viewer) can filter by them.
+///
+/// Returns the pair (NumComputable, NumNotComputable).
+static std::pair<unsigned, unsigned>
+emitPerExitCountRemarks(Loop *L, ScalarEvolution *SE, DominatorTree *DT,
+                        OptimizationRemarkEmitter *ORE,
+                        ArrayRef<BasicBlock *> ExitingBlocks) {
+  unsigned NumComputable = 0;
+  unsigned NumNotComputable = 0;
+  const BasicBlock *Latch = L->getLoopLatch();
+
+  for (BasicBlock *ExitBB : ExitingBlocks) {
+    const SCEV *EC = SE->getExitCount(L, ExitBB);
+    Instruction *Term = ExitBB->getTerminator();
+    if (isa<SCEVCouldNotCompute>(EC)) {
+      ++NumNotComputable;
+      ExitConditionInfo Info = describeExitingBranch(ExitBB, L, SE);
+      StringRef Reason = (Latch && !DT->dominates(ExitBB, Latch))
+                             ? "not_dominating_latch"
+                             : "unknown";
+      ORE->emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "ExitCountNotComputable",
+                                        Term)
+               << "Exit count not computable for exit "
+               << ore::NV("Exit", ExitBB->getName())
+               << " (predicate=" << ore::NV("Predicate", Info.Predicate)
+               << ", type=" << ore::NV("Type", Info.Type)
+               << ", stride=" << ore::NV("Stride", Info.Stride)
+               << ", trapExit=" << ore::NV("IsTrapExit", Info.IsTrapExit)
+               << ", normalExit=" << ore::NV("IsNormalExit", Info.IsNormalExit)
+               << ", reason=" << ore::NV("Reason", Reason) << ")";
+      });
+    } else {
+      ++NumComputable;
+      std::string ECStr;
+      raw_string_ostream ECOS(ECStr);
+      EC->print(ECOS);
+      ORE->emit([&]() {
+        return OptimizationRemark(DEBUG_TYPE, "ExitCountComputable", Term)
+               << "Exit count computable for exit "
+               << ore::NV("Exit", ExitBB->getName()) << " ("
+               << ore::NV("ExitCount", ECStr) << ")";
+      });
+    }
+  }
+
+  return {NumComputable, NumNotComputable};
+}
+
 bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
   SmallVector<BasicBlock*, 16> ExitingBlocks;
   L->getExitingBlocks(ExitingBlocks);
@@ -1862,23 +1993,56 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
   // through *explicit* control flow.  We have to eliminate the possibility of
   // implicit exits (see below) before we know it's truly exact.
   const SCEV *ExactBTC = SE->getBackedgeTakenCount(L);
-  if (isa<SCEVCouldNotCompute>(ExactBTC) || !Rewriter.isSafeToExpand(ExactBTC))
+
+  // Always emit per-exit diagnostics so YAML consumers can inspect exit-count
+  // state regardless of whether the loop-level ExactBTC is known.
+  unsigned NumComputable = 0, NumNotComputable = 0;
+  std::tie(NumComputable, NumNotComputable) =
+      emitPerExitCountRemarks(L, SE, DT, ORE, ExitingBlocks);
+
+  if (isa<SCEVCouldNotCompute>(ExactBTC) ||
+      !Rewriter.isSafeToExpand(ExactBTC)) {
+    ORE->emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "ExactBTCUnknown",
+                                      L->getHeader()->getTerminator())
+             << "Unable to predicate loop exits: could not compute an "
+                "exact trip count for the loop ("
+             << ore::NV("NumExits", (unsigned)ExitingBlocks.size())
+             << " exits, " << ore::NV("Computable", NumComputable)
+             << " computable, " << ore::NV("NotComputable", NumNotComputable)
+             << " not computable). See per-exit remarks for detail.";
+    });
     return false;
+  }
 
   assert(SE->isLoopInvariant(ExactBTC, L) && "BTC must be loop invariant");
   assert(ExactBTC->getType()->isIntegerTy() && "BTC must be integer");
 
   auto BadExit = [&](BasicBlock *ExitingBB) {
-    // If our exiting block exits multiple loops, we can only rewrite the
-    // innermost one.  Otherwise, we're changing how many times the innermost
-    // loop runs before it exits.
-    if (LI->getLoopFor(ExitingBB) != L)
+    Instruction *Term = ExitingBB->getTerminator();
+    // The exiting block belongs to a loop other than L (an inner, nested
+    // loop).  We can only rewrite the innermost loop; otherwise we'd be
+    // changing how many times that inner loop runs before it exits.
+    if (LI->getLoopFor(ExitingBB) != L) {
+      ORE->emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "ExitNotInCurrentLoop",
+                                        Term)
+               << "Unable to predicate loop exit: exiting block belongs to "
+                  "a different (inner) loop than the one being processed.";
+      });
       return true;
+    }
 
     // Can't rewrite non-branch yet.
-    CondBrInst *BI = dyn_cast<CondBrInst>(ExitingBB->getTerminator());
-    if (!BI)
+    CondBrInst *BI = dyn_cast<CondBrInst>(Term);
+    if (!BI) {
+      ORE->emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "NonBranchExit", Term)
+               << "Unable to predicate loop exit: exit is not a conditional "
+                  "branch (e.g. switch or invoke).";
+      });
       return true;
+    }
 
     // If already constant, nothing to do.
     if (isa<Constant>(BI->getCondition()))
@@ -1889,12 +2053,19 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
     // have already been removed; TODO: generalize
     BasicBlock *ExitBlock =
     BI->getSuccessor(L->contains(BI->getSuccessor(0)) ? 1 : 0);
-    if (!ExitBlock->phis().empty())
+    if (!ExitBlock->phis().empty()) {
+      ORE->emit([&]() {
+        return OptimizationRemarkMissed(DEBUG_TYPE, "ExitBlockHasPhis", Term)
+               << "Unable to predicate loop exit: values computed inside "
+                  "the loop are used after the exit.";
+      });
       return true;
+    }
 
     const SCEV *ExitCount = SE->getExitCount(L, ExitingBB);
     if (isa<SCEVCouldNotCompute>(ExitCount) ||
         !Rewriter.isSafeToExpand(ExitCount))
+      // Already diagnosed by emitPerExitCountRemarks above.
       return true;
 
     assert(SE->isLoopInvariant(ExitCount, L) &&
@@ -1905,6 +2076,14 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
 
   // Make sure all exits dominate the latch. This means there is a linear chain
   // of exits. We check this before sorting so we have a total order.
+  //
+  // Note: SCEV's computeExitLimit already bails to CouldNotCompute for any
+  // exit that does not dominate the latch, so in practice we will have
+  // returned above via the ExactBTCUnknown path before reaching this check
+  // whenever a non-dominating exit is present. The per-exit remark emitted by
+  // emitPerExitCountRemarks attaches Reason=not_dominating_latch in that case
+  // so tools can tell this apart from other not-computable reasons. The check
+  // below is retained as a defensive guard.
   BasicBlock *Latch = L->getLoopLatch();
   for (BasicBlock *ExitingBB : ExitingBlocks)
     if (!DT->dominates(ExitingBB, Latch))
@@ -1943,8 +2122,15 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
       break;
     }
 
-  if (ExitingBlocks.empty())
+  if (ExitingBlocks.empty()) {
+    ORE->emit([&]() {
+      return OptimizationRemarkMissed(DEBUG_TYPE, "NoPredicatableExits",
+                                      L->getHeader()->getTerminator())
+             << "Unable to predicate loop exits: no predicatable exit "
+                "remaining after filtering (see per-exit remarks).";
+    });
     return false;
+  }
 
   // At this point, ExitingBlocks consists of only those blocks which are
   // predicatable.  Given that, we know we have at least one exit we can
@@ -1959,17 +2145,37 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
     for (auto &I : *BB) {
       // TODO:isGuaranteedToTransfer
       if (I.mayHaveSideEffects()) {
-        if (!LoopPredicationTraps)
+        if (!LoopPredicationTraps) {
+          ORE->emit([&]() {
+            return OptimizationRemarkMissed(DEBUG_TYPE, "LoopSideEffects",
+                                            L->getHeader()->getTerminator())
+                   << "Unable to predicate loop exits: loop body has "
+                      "side effects and LoopPredicationTraps is disabled.";
+          });
           return false;
+        }
         HasThreadLocalSideEffects = true;
         if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
           // Simple stores cannot be observed by other threads.
           // If HasThreadLocalSideEffects is set, we check
           // crashingBBWithoutEffect to make sure that the crashing BB cannot
           // observe them either.
-          if (!SI->isSimple())
+          if (!SI->isSimple()) {
+            ORE->emit([&]() {
+              return OptimizationRemarkMissed(DEBUG_TYPE, "AtomicStoreInLoop",
+                                              L->getHeader()->getTerminator())
+                     << "Unable to predicate loop exits: loop contains "
+                        "an atomic or volatile store.";
+            });
             return false;
+          }
         } else {
+          ORE->emit([&]() {
+            return OptimizationRemarkMissed(DEBUG_TYPE, "LoopSideEffects",
+                                            L->getHeader()->getTerminator())
+                   << "Unable to predicate loop exits: loop body has "
+                      "side effects (e.g. call or fence).";
+          });
           return false;
         }
       }
@@ -2014,8 +2220,16 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
       // a trap can still be optimized, because local side effects cannot
       // be observed in the exit case (the trap). We could be smarter about
       // this, but for now lets pattern match common cases that directly trap.
-      if (Unreachable == nullptr || !crashingBBWithoutEffect(*Unreachable))
+      if (Unreachable == nullptr || !crashingBBWithoutEffect(*Unreachable)) {
+        ORE->emit([&]() {
+          return OptimizationRemarkMissed(DEBUG_TYPE,
+                                          "TrapBlockObservesSideEffects",
+                                          ExitingBB->getTerminator())
+                 << "Unable to predicate loop exit: trap block may observe "
+                    "side effects from the loop body.";
+        });
         return Changed;
+      }
     }
     Value *NewCond;
     if (ExitCount == ExactBTC) {
@@ -2039,6 +2253,11 @@ bool IndVarSimplify::predicateLoopExits(Loop *L, SCEVExpander &Rewriter) {
     BI->setCondition(NewCond);
     if (OldCond->use_empty())
       DeadInsts.emplace_back(OldCond);
+    ORE->emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "PredicatedExit",
+                                ExitingBB->getTerminator())
+             << "Loop exit predicated and hoisted to preheader.";
+    });
     Changed = true;
     RunUnswitching = true;
   }
@@ -2219,8 +2438,12 @@ PreservedAnalyses IndVarSimplifyPass::run(Loop &L, LoopAnalysisManager &AM,
   Function *F = L.getHeader()->getParent();
   const DataLayout &DL = F->getDataLayout();
 
-  IndVarSimplify IVS(&AR.LI, &AR.SE, &AR.DT, DL, &AR.TLI, &AR.TTI, AR.MSSA,
-                     WidenIndVars && AllowIVWidening);
+  // For the old PM, we can't use OptimizationRemarkEmitter as an analysis
+  // pass. Function analyses need to be preserved across loop transformations
+  // but ORE cannot be preserved. See the same pattern in LICM.
+  OptimizationRemarkEmitter ORE(F);
+  IndVarSimplify IVS(&AR.LI, &AR.SE, &AR.DT, DL, &AR.TLI, &AR.TTI, &ORE,
+                     AR.MSSA, WidenIndVars && AllowIVWidening);
   if (!IVS.run(&L))
     return PreservedAnalyses::all();
 

--- a/llvm/test/Transforms/IndVarSimplify/predicate-exits-remarks.ll
+++ b/llvm/test/Transforms/IndVarSimplify/predicate-exits-remarks.ll
@@ -1,0 +1,273 @@
+; Check that IndVarSimplify::predicateLoopExits emits optimization remarks
+; with structured ore::NV fields for tool consumption.
+;
+; Textual remark stream:
+; RUN: opt -passes=indvars -pass-remarks=indvars -pass-remarks-missed=indvars \
+; RUN:     -disable-output %s 2>&1 | FileCheck %s
+;
+; YAML remark stream (structured fields):
+; RUN: opt -passes=indvars -pass-remarks-output=%t.yaml -disable-output %s
+; RUN: FileCheck --check-prefix=YAML %s < %t.yaml
+
+; CHECK: remark: {{.*}}: Exit count computable for exit
+; CHECK: remark: {{.*}}: Loop exit predicated and hoisted to preheader
+; CHECK: remark: {{.*}}: Exit count not computable for exit {{.*}} trapExit=true{{.*}} normalExit=false{{.*}} reason=unknown
+; CHECK: remark: {{.*}}: Exit count not computable for exit {{.*}} trapExit=false{{.*}} normalExit=true{{.*}} reason=unknown
+; CHECK: remark: {{.*}}: Unable to predicate loop exits: could not compute an exact trip count
+; CHECK: remark: {{.*}}: Exit count not computable for exit {{.*}} reason=not_dominating_latch
+; CHECK: remark: {{.*}}: Unable to predicate loop exits: could not compute an exact trip count
+; CHECK: remark: {{.*}}: Unable to predicate loop exit: exit is not a conditional branch
+; CHECK: remark: {{.*}}: Unable to predicate loop exits: no predicatable exit remaining
+; CHECK: remark: {{.*}}: Unable to predicate loop exit: exiting block belongs to a different (inner) loop
+; CHECK: remark: {{.*}}: Unable to predicate loop exit: values computed inside the loop are used after the exit
+; CHECK: remark: {{.*}}: Unable to predicate loop exit: trap block may observe side effects
+; CHECK: remark: {{.*}}: Unable to predicate loop exits: loop contains an atomic or volatile store
+; CHECK: remark: {{.*}}: Unable to predicate loop exits: loop body has side effects
+; CHECK: remark: {{.*}}: Exit count computable for exit
+; CHECK: remark: {{.*}}: Loop exit predicated and hoisted to preheader
+
+; CHECK-NOT: loop_with_annotated_call{{.*}}Unable to predicate loop exits: loop body has side effects
+
+; YAML-DAG: Name:            ExitCountComputable
+; YAML-DAG: Name:            PredicatedExit
+; YAML-DAG: Name:            ExitCountNotComputable
+; YAML-DAG: Name:            ExactBTCUnknown
+; YAML-DAG: Name:            NonBranchExit
+; YAML-DAG: Name:            NoPredicatableExits
+; YAML-DAG: Name:            ExitNotInCurrentLoop
+; YAML-DAG: Name:            ExitBlockHasPhis
+; YAML-DAG: Name:            TrapBlockObservesSideEffects
+; YAML-DAG: Name:            AtomicStoreInLoop
+; YAML-DAG: Name:            LoopSideEffects
+; YAML-DAG:   - IsTrapExit:      'true'
+; YAML-DAG:   - Predicate:       ugt
+; YAML-DAG:   - Stride:          '+4'
+; YAML-DAG:   - Reason:          not_dominating_latch
+; YAML-DAG:   - Reason:          unknown
+
+;----------------------------------------------------------------------------
+; Trivially predicatable single-exit loop -> ExitCountComputable + PredicatedExit.
+;----------------------------------------------------------------------------
+define void @predicatable(i32 %n) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cmp = icmp ult i32 %iv.next, %n
+  br i1 %cmp, label %loop, label %exit
+exit:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; Multi-exit with a trap exit. The trap-exit's count is not computable (no
+; wrap flags on the address AddRec), so we expect ExactBTCUnknown on the
+; header and an ExitCountNotComputable with IsTrapExit=true.
+;----------------------------------------------------------------------------
+define void @multi_exit_with_trap(i64 %start, i64 %end, i64 %limit) mustprogress {
+entry:
+  %cmp.entry = icmp ule i64 %start, %end
+  br i1 %cmp.entry, label %loop, label %exit
+loop:
+  %iv = phi i64 [ %start, %entry ], [ %iv.next, %latch ]
+  %trap.cmp = icmp ugt i64 %iv, %limit
+  br i1 %trap.cmp, label %trap, label %latch
+latch:
+  %iv.next = add i64 %iv, 4
+  %cond = icmp ne i64 %iv.next, %end
+  br i1 %cond, label %loop, label %exit
+trap:
+  call void @llvm.trap()
+  unreachable
+exit:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; Two exiting blocks; `inner` does not dominate the latch because its
+; successor `merge` is also reachable via `other_side`. SCEV cannot compute
+; an exit count for a non-dominating exit (see
+; ScalarEvolution::computeExitLimit's dominance guard), so this gets a
+; not-computable remark with Reason=not_dominating_latch. The overall bail
+; is ExactBTCUnknown (one exit missing makes the BTC unknown).
+;----------------------------------------------------------------------------
+define void @exit_not_dominating_latch(i32 %n) {
+entry:
+  br label %header
+header:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %cond1 = icmp ult i32 %iv, 100
+  br i1 %cond1, label %split, label %exit1
+split:
+  %pick = icmp ult i32 %iv, %n
+  br i1 %pick, label %inner, label %other_side
+inner:
+  %cond_exit = icmp eq i32 %iv, 5
+  br i1 %cond_exit, label %exit2, label %merge
+other_side:
+  br label %merge
+merge:
+  br label %latch
+latch:
+  %iv.next = add nuw nsw i32 %iv, 1
+  br label %header
+exit1:
+  ret void
+exit2:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; Sole exit is a `switch` -> BadExit filters it (NonBranchExit), leaving
+; ExitingBlocks empty -> NoPredicatableExits fires. SCEV handles the
+; single-exit switch via computeExitLimitFromSingleExitSwitch, so ExactBTC
+; is known (10) and we actually reach the filter phase.
+;----------------------------------------------------------------------------
+define void @all_exits_filtered_via_switch() {
+entry:
+  br label %header
+header:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %header ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  switch i32 %iv, label %header [ i32 10, label %exit ]
+exit:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; Nested loops; when processing the OUTER loop, inner.header is an exiting
+; block of outer (branches to exit_outer) but LI->getLoopFor(inner.header)
+; returns the INNER loop != outer -> BadExit fires ExitNotInCurrentLoop.
+; Both outer exits have SCEV-computable counts (so ExactBTC is known).
+;----------------------------------------------------------------------------
+define void @nested_exit_from_inner() mustprogress {
+entry:
+  br label %outer.header
+outer.header:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %outer.latch ]
+  br label %inner.header
+inner.header:
+  %j = phi i32 [ 0, %outer.header ], [ %j.next, %inner.latch ]
+  %early = icmp eq i32 %j, 5
+  br i1 %early, label %exit_outer, label %inner.latch
+inner.latch:
+  %j.next = add nuw nsw i32 %j, 1
+  %inner_cond = icmp ult i32 %j.next, 10
+  br i1 %inner_cond, label %inner.header, label %outer.latch
+outer.latch:
+  %i.next = add nuw nsw i32 %i, 1
+  %outer_cond = icmp ult i32 %i.next, 100
+  br i1 %outer_cond, label %outer.header, label %exit_outer
+exit_outer:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; One exit block holds an LCSSA phi consuming an in-loop value that's used
+; by the caller. BadExit filters that exiting block -> ExitBlockHasPhis.
+; The other exit is clean so the filter path fires cleanly.
+;----------------------------------------------------------------------------
+define i32 @exit_block_has_lcssa_phi(i32 %n, ptr %p) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop.body ]
+  %acc = phi i32 [ 0, %entry ], [ %acc.next, %loop.body ]
+  %cmp.early = icmp ult i32 %iv, %n
+  br i1 %cmp.early, label %loop.body, label %exit.phi
+loop.body:
+  %ld = load i32, ptr %p, align 4
+  %acc.next = add i32 %acc, %ld
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cmp.latch = icmp ult i32 %iv.next, 100
+  br i1 %cmp.latch, label %loop, label %exit.clean
+exit.phi:
+  %lcssa = phi i32 [ %acc, %loop ]
+  %use = mul i32 %lcssa, 7
+  ret i32 %use
+exit.clean:
+  ret i32 0
+}
+
+;----------------------------------------------------------------------------
+; Loop has a simple store (HasThreadLocalSideEffects=true). Its exit targets
+; a block ending in unreachable that also contains an extra store, so
+; crashingBBWithoutEffect rejects it -> TrapBlockObservesSideEffects fires.
+;----------------------------------------------------------------------------
+define void @trap_block_observes_side_effects(ptr %p, ptr %q) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  store i32 %iv, ptr %p, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cond = icmp ult i32 %iv.next, 100
+  br i1 %cond, label %loop, label %trap
+trap:
+  store i32 0, ptr %q, align 4
+  unreachable
+}
+
+;----------------------------------------------------------------------------
+; Loop containing an atomic store -> AtomicStoreInLoop missed remark.
+;----------------------------------------------------------------------------
+define void @loop_with_atomic_store(ptr %p, i32 %n) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  store atomic i32 %iv, ptr %p seq_cst, align 4
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cmp = icmp ult i32 %iv.next, %n
+  br i1 %cmp, label %loop, label %exit
+exit:
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; Loop containing a call with side effects -> LoopSideEffects missed remark.
+;----------------------------------------------------------------------------
+declare void @side_effect()
+
+define void @loop_with_side_effect_call(i32 %n) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  call void @side_effect()
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cmp = icmp ult i32 %iv.next, %n
+  br i1 %cmp, label %loop, label %exit
+exit:
+  ret void
+}
+
+declare void @llvm.trap()
+
+;----------------------------------------------------------------------------
+; Contrast: a call whose declaration carries memory(none)+nounwind+willreturn
+; has mayHaveSideEffects()==false, so predicateLoopExits does NOT bail at the
+; side-effects check. The loop should be predicated just like @predicatable.
+;
+; In C source, these attributes come from:
+;   __attribute__((const))    -> memory(none) nounwind willreturn
+;   __attribute__((pure))     -> memory(read) nounwind willreturn   (also OK)
+; Either GCC/Clang attribute makes the callee appear side-effect-free to LLVM
+; (see Instruction::mayHaveSideEffects = mayWriteToMemory || mayThrow ||
+;  !willReturn), which in turn lets IndVarSimplify predicate the exit.
+;----------------------------------------------------------------------------
+declare void @no_side_effect_call() memory(none) nounwind willreturn
+
+define void @loop_with_annotated_call(i32 %n) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  call void @no_side_effect_call()
+  %iv.next = add nuw nsw i32 %iv, 1
+  %cmp = icmp ult i32 %iv.next, %n
+  br i1 %cmp, label %loop, label %exit
+exit:
+  ret void
+}


### PR DESCRIPTION
predicateLoopExits has many early-return paths where the pass bails out
  without any diagnostic, which makes it hard to explain why a given loop
  was not predicated.

Since this phase is quite critical for optimizing traps (C++ hardening,
 or bounds-safety), we want to make it easy to identify reason.

Added an OptimizationRemarkEmitter to emit structured remarks.

Missed remarks on each early return:
      ExactBTCUnknown, ExitNotInCurrentLoop, NonBranchExit,
      ExitBlockHasPhis, NoPredicatableExits, AtomicStoreInLoop,
      TrapBlockObservesSideEffects,LoopSideEffects

Per-exit diagnostics (one remark per exiting block):
      ExitCountComputable    -- ore::NV Exit, ExitCount
      ExitCountNotComputable -- ore::NV Exit, Predicate, Type, Stride,
                                IsTrapExit, IsNormalExit, Reason
      eg. Reason is "not_dominating_latch" the exiting block does
      not dominate the latch.

Added a Success remark:
      PredicatedExit -- emitted when an exit is hoisted to the preheader.