### PR TITLE
[lldb] Add completion support for direct ivars

### DIFF
--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -483,7 +483,9 @@ static CompilerType GetInstanceVariableType(StackFrame &frame,
   auto *lang = Language::FindPlugin(frame.GetLanguage().AsLanguageType());
   if (!lang)
     return {};
-  llvm::StringRef instance_name = lang->GetInstanceVariableName();
+  SymbolContext sc = frame.GetSymbolContext(eSymbolContextFunction |
+                                            eSymbolContextBlock);
+  llvm::StringRef instance_name = sc.GetInstanceVariableName();
   if (instance_name.empty())
     return {};
   VariableSP var_sp = variable_list.FindVariable(ConstString(instance_name));

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -476,10 +476,11 @@ static void PrivateAutoComplete(
         &prefix_path, // Anything that has been resolved already will be in here
     const CompilerType &compiler_type, CompletionRequest &request);
 
-/// Get the CompilerType of the instance variable (this/self) for direct ivar
-/// completion. Returns an invalid CompilerType if not in a method context.
-static CompilerType GetInstanceVariableType(StackFrame &frame,
-                                            VariableList &variable_list) {
+/// Get the CompilerType of the current instance (this/self) for direct ivar
+/// completion. Returns an invalid CompilerType if the frame is not for an
+/// instance method.
+static CompilerType GetInstanceType(StackFrame &frame,
+                                    VariableList &variable_list) {
   SymbolContext sc =
       frame.GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
   llvm::StringRef instance_name = sc.GetInstanceVariableName();
@@ -623,8 +624,7 @@ static void PrivateAutoComplete(
 
           // Offer members of this/self so that direct ivar access can be
           // completed (eg "frame variable member" for "this->member").
-          CompilerType instance_type =
-              GetInstanceVariableType(*frame, *variable_list);
+          CompilerType instance_type = GetInstanceType(*frame, *variable_list);
           if (instance_type.IsValid())
             PrivateAutoCompleteMembers(frame, "", "", "", instance_type,
                                        request);
@@ -753,8 +753,7 @@ static void PrivateAutoComplete(
 
           // Try also completing the token as a member of this/self (direct ivar
           // access).
-          CompilerType instance_type =
-              GetInstanceVariableType(*frame, *variable_list);
+          CompilerType instance_type = GetInstanceType(*frame, *variable_list);
           if (instance_type.IsValid())
             PrivateAutoCompleteMembers(frame, token, remaining_partial_path,
                                        prefix_path, instance_type, request);

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -626,7 +626,7 @@ static void PrivateAutoComplete(
           // completed (eg "frame variable member" for "this->member").
           CompilerType instance_type =
               GetInstanceVariableType(*frame, *variable_list);
-          if (instance_type)
+          if (instance_type.IsValid())
             PrivateAutoCompleteMembers(frame, "", "", "", instance_type,
                                        request);
         }

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -476,8 +476,8 @@ static void PrivateAutoComplete(
         &prefix_path, // Anything that has been resolved already will be in here
     const CompilerType &compiler_type, CompletionRequest &request);
 
-// Get the CompilerType of the instance variable (this/self) for direct ivar
-// completion. Returns an invalid CompilerType if not in a method context.
+/// Get the CompilerType of the instance variable (this/self) for direct ivar
+/// completion. Returns an invalid CompilerType if not in a method context.
 static CompilerType GetInstanceVariableType(StackFrame &frame,
                                             VariableList &variable_list) {
   auto *lang = Language::FindPlugin(frame.GetLanguage().AsLanguageType());

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -480,8 +480,8 @@ static void PrivateAutoComplete(
 /// completion. Returns an invalid CompilerType if not in a method context.
 static CompilerType GetInstanceVariableType(StackFrame &frame,
                                             VariableList &variable_list) {
-  SymbolContext sc = frame.GetSymbolContext(eSymbolContextFunction |
-                                            eSymbolContextBlock);
+  SymbolContext sc =
+      frame.GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
   llvm::StringRef instance_name = sc.GetInstanceVariableName();
   if (instance_name.empty())
     return {};

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ABI.h"
+#include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StackFrame.h"
@@ -475,6 +476,28 @@ static void PrivateAutoComplete(
         &prefix_path, // Anything that has been resolved already will be in here
     const CompilerType &compiler_type, CompletionRequest &request);
 
+// Get the CompilerType of the instance variable (this/self) for direct ivar
+// completion. Returns an invalid CompilerType if not in a method context.
+static CompilerType GetInstanceVariableType(StackFrame &frame,
+                                            VariableList &variable_list) {
+  auto *lang = Language::FindPlugin(frame.GetLanguage().AsLanguageType());
+  if (!lang)
+    return {};
+  llvm::StringRef instance_name = lang->GetInstanceVariableName();
+  if (instance_name.empty())
+    return {};
+  VariableSP var_sp = variable_list.FindVariable(ConstString(instance_name));
+  if (!var_sp)
+    return {};
+  Type *var_type = var_sp->GetType();
+  if (!var_type)
+    return {};
+  CompilerType compiler_type = var_type->GetForwardCompilerType();
+  if (compiler_type.IsPointerType())
+    compiler_type = compiler_type.GetPointeeType();
+  return compiler_type.GetCanonicalType();
+}
+
 static void PrivateAutoCompleteMembers(
     StackFrame *frame, const std::string &partial_member_name,
     llvm::StringRef partial_path,
@@ -598,6 +621,14 @@ static void PrivateAutoComplete(
         if (variable_list) {
           for (const VariableSP &var_sp : *variable_list)
             request.AddCompletion(var_sp->GetName());
+
+          // Offer members of this/self so that direct ivar access can be
+          // completed (eg "frame variable member" for "this->member").
+          CompilerType instance_type =
+              GetInstanceVariableType(*frame, *variable_list);
+          if (instance_type)
+            PrivateAutoCompleteMembers(frame, "", "", "", instance_type,
+                                       request);
         }
       }
     }
@@ -720,6 +751,14 @@ static void PrivateAutoComplete(
               }
             }
           }
+
+          // Try also completing the token as a member of this/self (direct ivar
+          // access).
+          CompilerType instance_type =
+              GetInstanceVariableType(*frame, *variable_list);
+          if (instance_type)
+            PrivateAutoCompleteMembers(frame, token, remaining_partial_path,
+                                       prefix_path, instance_type, request);
         }
       }
       break;

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -480,9 +480,6 @@ static void PrivateAutoComplete(
 /// completion. Returns an invalid CompilerType if not in a method context.
 static CompilerType GetInstanceVariableType(StackFrame &frame,
                                             VariableList &variable_list) {
-  auto *lang = Language::FindPlugin(frame.GetLanguage().AsLanguageType());
-  if (!lang)
-    return {};
   SymbolContext sc = frame.GetSymbolContext(eSymbolContextFunction |
                                             eSymbolContextBlock);
   llvm::StringRef instance_name = sc.GetInstanceVariableName();
@@ -758,7 +755,7 @@ static void PrivateAutoComplete(
           // access).
           CompilerType instance_type =
               GetInstanceVariableType(*frame, *variable_list);
-          if (instance_type)
+          if (instance_type.IsValid())
             PrivateAutoCompleteMembers(frame, token, remaining_partial_path,
                                        prefix_path, instance_type, request);
         }

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -483,7 +483,7 @@ static CompilerType GetInstanceType(StackFrame &frame,
                                     VariableList &variable_list) {
   SymbolContext sc =
       frame.GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
-  llvm::StringRef instance_name = sc.GetInstanceVariableName();
+  llvm::StringRef instance_name = sc.GetInstanceName();
   if (instance_name.empty())
     return {};
   VariableSP var_sp = variable_list.FindVariable(ConstString(instance_name));

--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -82,6 +82,14 @@ class CommandLineCompletionTestCase(TestBase):
             f"{command} ptr_container->Mem", f"{command} ptr_container->MemberVar"
         )
 
+    def test_frame_variable_direct_ivar(self):
+        """Test that 'frame variable' completes members of 'this' directly."""
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, "Bar")
+        self.completions_contain("frame variable ", ["t", "temp"])
+        self.complete_from_to("frame variable te", "frame variable temp")
+        self.complete_from_to("frame variable t.", "frame variable t.x")
+
     def test_process_attach_dash_dash_con(self):
         """Test that 'process attach --con' completes to 'process attach --continue '."""
         self.complete_from_to("process attach --con", "process attach --continue ")


### PR DESCRIPTION
Fixes the current shortcoming where `v m_na<TAB>` will not complete the member `m_name` on `this`. This implements tab completion to complement direct ivar access support in `frame variable`.

Assisted-by: claude