### PR TITLE
[Clang] Don't trigger `-Wweak-vtables` on an explicit instantiation declaration

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19290,6 +19290,7 @@ bool Sema::DefineUsedVTables() {
         !(Class->getOwningModule() &&
           Class->getOwningModule()->isInterfaceOrPartition()) &&
         ClassTSK != TSK_ImplicitInstantiation &&
+        ClassTSK != TSK_ExplicitInstantiationDeclaration &&
         ClassTSK != TSK_ExplicitInstantiationDefinition) {
       const FunctionDecl *KeyFunctionDef = nullptr;
       if (!KeyFunction || (KeyFunction->hasBody(KeyFunctionDef) &&

--- a/clang/test/SemaCXX/warn-weak-vtables.cpp
+++ b/clang/test/SemaCXX/warn-weak-vtables.cpp
@@ -89,7 +89,7 @@ void uses_templ() {
   TemplVirt<long> l;
 }
 
-namespace pr195110 {
+namespace GH195110 {
 // Check that no warning is emitted on a template instantiation.
 template <class> struct basic_streambuf {
   __attribute__((__exclude_from_explicit_instantiation__)) virtual void

--- a/clang/test/SemaCXX/warn-weak-vtables.cpp
+++ b/clang/test/SemaCXX/warn-weak-vtables.cpp
@@ -89,6 +89,19 @@ void uses_templ() {
   TemplVirt<long> l;
 }
 
+namespace pr195110 {
+// Check that no warning is emitted on a template instantiation.
+template <class> struct basic_streambuf {
+  __attribute__((__exclude_from_explicit_instantiation__)) virtual void
+  overflow();
+
+  virtual ~basic_streambuf() {}
+};
+extern template class basic_streambuf<char>;
+
+basic_streambuf<char> b;
+}
+
 //--- module-weak-vtable.cpp
 // expected-no-diagnostics
 export module m;


### PR DESCRIPTION
fixes #195110