### PR TITLE
[VPlan] Fix scalarizeInstruction for ExtractValue

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3337,8 +3337,22 @@ void VPReplicateRecipe::execute(VPTransformState &State) {
 
   // Replace the operands of the cloned instructions with their scalar
   // equivalents in the new loop.
-  for (const auto &[Idx, V] : enumerate(operands()))
-    Cloned->setOperand(Idx, State.get(V, true));
+  auto *EVI = dyn_cast<ExtractValueInst>(Instr);
+  for (const auto &[Idx, V] : enumerate(operands())) {
+    if (EVI && Idx > 0) {
+      // tryToWiden() stores ExtractValueInst->getIndices() as the second
+      // operand.
+
+      // Invariants from tryToWiden()
+      assert(Idx == 1);
+      assert(EVI->getNumIndices() == 1 && "Expected one extractvalue index");
+
+      Value *NewOp = State.get(V, true);
+      assert(cast<ConstantInt>(NewOp)->getZExtValue() == EVI->getIndices()[0]);
+    } else {
+      Cloned->setOperand(Idx, State.get(V, true));
+    }
+  }
 
   // Place the cloned scalar in the new loop.
   State.Builder.Insert(Cloned);

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3337,12 +3337,11 @@ void VPReplicateRecipe::execute(VPTransformState &State) {
 
   // Replace the operands of the cloned instructions with their scalar
   // equivalents in the new loop.
-  auto *EVI = dyn_cast<ExtractValueInst>(Instr);
+  auto *EVI = dyn_cast<ExtractValueInst>(Cloned);
   for (const auto &[Idx, V] : enumerate(operands())) {
+    // tryToWiden() stores ExtractValueInst->getIndices() as the second
+    // operand. It's not valid to pass it to setOperand().
     if (EVI && Idx > 0) {
-      // tryToWiden() stores ExtractValueInst->getIndices() as the second
-      // operand.
-
       // Invariants from tryToWiden()
       assert(Idx == 1);
       assert(EVI->getNumIndices() == 1 && "Expected one extractvalue index");


### PR DESCRIPTION
Previously, loop-vectorize crashed when trying to scalarize extractvalue (https://github.com/llvm/llvm-project/issues/193275), which has been worked around by not scalarizing ExtractValue
(https://github.com/llvm/llvm-project/pull/193404).

This patch fixes scalarizeInstruction for ExtractValue by correctly handling/ignoring the second operand of the recipe (which for ExtractValue, are actually the "indices", not a true operand), instead of passing it to setOperand.

N.B. this patch does not yet re-enable scalarizing ExtractValue. There is a separate fix that is also required
(scalarizing vectorized structs in VPTransformState::get(): https://github.com/llvm/llvm-project/pull/194113).