### PR TITLE
[clang][NFC] Mark CWG2943 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -184,9 +184,11 @@ template <class T> [[nodiscard]] T g();
 
 void h() {
   f();
-  g<void>();
+  (void)f();
   g<int>();
   // expected-warning@-1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  g<void>();
+  (void)g<void>();
 }
 #endif
 } // namespace cwg2943

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -176,10 +176,8 @@ constexpr U _ = nondeterministic(true);
 
 namespace cwg2943 { // cwg2943: 3.9
 #if __cplusplus >= 201703L
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wignored-attributes"
 [[nodiscard]] void f();
-#pragma clang diagnostic pop
+// expected-warning@-1 {{attribute 'nodiscard' cannot be applied to functions without return value}}
 template <class T> [[nodiscard]] T g();
 
 void h() {

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -174,4 +174,21 @@ constexpr U _ = nondeterministic(true);
 #endif
 } // namespace cwg2922
 
+namespace cwg2943 { // cwg2943: 3.9
+#if __cplusplus >= 201703L
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wignored-attributes"
+[[nodiscard]] void f();
+#pragma clang diagnostic pop
+template <class T> [[nodiscard]] T g();
+
+void h() {
+  f();
+  g<void>();
+  g<int>();
+  // expected-warning@-1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+}
+#endif
+} // namespace cwg2943
+
 // cwg2947 is in cwg2947.cpp

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -20418,7 +20418,7 @@
     <td>[<a href="https://wg21.link/dcl.attr.nodiscard">dcl.attr.nodiscard</a>]</td>
     <td>CD7</td>
     <td>Discarding a void return value</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.9</td>
   </tr>
   <tr id="2944">
     <td><a href="https://cplusplus.github.io/CWG/issues/2944.html">2944</a></td>


### PR DESCRIPTION
[CWG2943](https://wg21.link/cwg2943) says that calling a function that's marked `[[nodiscard]]` but returns `void` should not issue a warning. I've marked it as implemented since Clang 3.9, the first version to support `[[nodiscard]]` at all: https://godbolt.org/z/TYP1oTP1v