### PR TITLE
[compiler-rt] Improve lit test discovery speed on Darwin

### DIFF
--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import shlex
+import subprocess
 
 import lit.formats
 
@@ -334,3 +335,22 @@ if not config.parallelism_group:
 
 if config.target_os == "NetBSD":
     config.substitutions.insert(0, ("%run", config.netbsd_noaslr_prefix))
+
+if config.target_os == "Darwin":
+    if lit.util.which("log"):
+        # Querying the log can only done by a privileged user so
+        # so check if we can query the log.
+        exit_code = -1
+        with open("/dev/null", "r") as f:
+            # Run a `log show` command the should finish fairly quickly and produce very little output.
+            exit_code = subprocess.call(
+                ["log", "show", "--last", "1m", "--predicate", "1 == 0"],
+                stdout=f,
+                stderr=f,
+            )
+        if exit_code == 0:
+            config.available_features.add("darwin_log_cmd")
+        else:
+            lit_config.warning("log command found but cannot queried")
+    else:
+        lit_config.warning("log command not found. Some tests will be skipped.")

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -13,14 +13,23 @@ import json
 import lit.formats
 import lit.util
 
-
 def get_path_from_clang(args, allow_failure):
+    clang_path_cache = getattr(lit_config, "_clang_path_cache", None)
+
+    if clang_path_cache is None:
+        clang_path_cache = {}
+        setattr(lit_config, "_clang_path_cache", clang_path_cache)
+
     clang_cmd = [
         config.clang.strip(),
         f"--target={config.target_triple}",
         *args,
     ]
-    path = None
+
+    path = clang_path_cache.get(tuple(clang_cmd))
+    if path is not None:
+        return path, clang_cmd
+
     try:
         result = subprocess.run(
             clang_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
@@ -32,6 +41,8 @@ def get_path_from_clang(args, allow_failure):
             lit_config.warning(msg)
         else:
             lit_config.fatal(msg)
+
+    clang_path_cache[tuple(clang_cmd)] = path
     return path, clang_cmd
 
 
@@ -952,23 +963,6 @@ if config.target_os == "Darwin":
     # much slower. Let's override this and run lit tests with 'abort_on_error=0'.
     config.default_sanitizer_opts += ["abort_on_error=0"]
     config.default_sanitizer_opts += ["log_to_syslog=0"]
-    if lit.util.which("log"):
-        # Querying the log can only done by a privileged user so
-        # so check if we can query the log.
-        exit_code = -1
-        with open("/dev/null", "r") as f:
-            # Run a `log show` command the should finish fairly quickly and produce very little output.
-            exit_code = subprocess.call(
-                ["log", "show", "--last", "1m", "--predicate", "1 == 0"],
-                stdout=f,
-                stderr=f,
-            )
-        if exit_code == 0:
-            config.available_features.add("darwin_log_cmd")
-        else:
-            lit_config.warning("log command found but cannot queried")
-    else:
-        lit_config.warning("log command not found. Some tests will be skipped.")
 elif config.android:
     config.default_sanitizer_opts += ["abort_on_error=0"]
 


### PR DESCRIPTION
compiler-rt lit test discovery takes quite a while on Darwin (i.e. the time from when you launch llvm-lit to when the first test runs can be *minutes* for `check-compiler-rt`). This improves a couple of operations that take up the most time:

- We are asking clang for its resource directory many times. Adds a cache (global to each invocation of `llvm-lit` for `get_path_from_clang`.
- `log show` can be quite slow. Let's only check it for ASAN, because that's the only suite that needs to know if it works.

rdar://175893448