### PR TITLE
[Fuchsia] Enable OpenCSD by default for Fuchsia

### DIFF
--- a/clang/cmake/caches/Fuchsia.cmake
+++ b/clang/cmake/caches/Fuchsia.cmake
@@ -36,6 +36,8 @@ set(_FUCHSIA_BOOTSTRAP_PASSTHROUGH
   CURL_ROOT
   OpenSSL_ROOT
   httplib_ROOT
+  LLVM_ENABLE_OPENCSD
+  OPENCSD_ROOT
 
   # Deprecated
   CursesAndPanel_ROOT


### PR DESCRIPTION
Pass LLVM_ENABLE_OPENCSD and OPENCSD_ROOT through the Fuchsia stage 1 cache.