### PR TITLE
InstCombine: Don't read first argument of llvm.ptrauth.* call argument until checking intrinsic ID.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3314,7 +3314,6 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       if (DS != OtherDS)
         break;
 
-      BasePtr = CI->getArgOperand(0);
       if (CI->getIntrinsicID() == Intrinsic::ptrauth_sign) {
         if (CI->getArgOperand(1) != Key || CI->getArgOperand(2) != Disc)
           break;
@@ -3327,6 +3326,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         AuthDisc = CI->getArgOperand(2);
       } else
         break;
+      BasePtr = CI->getArgOperand(0);
     } else if (const auto *PtrToInt = dyn_cast<PtrToIntOperator>(Ptr)) {
       // ptrauth constants are equivalent to a call to @llvm.ptrauth.sign for
       // our purposes, so check for that too.

--- a/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
@@ -222,6 +222,17 @@ define i64 @test_ptrauth_nop_ds_constant() {
   ret i64 %authed
 }
 
+define i64 @test_ptrauth_auth_call_no_args() {
+; CHECK-LABEL: @test_ptrauth_auth_call_no_args(
+; CHECK-NEXT:    [[CALL:%.*]] = call i64 @foo()
+; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[CALL]], i32 1, i64 1234)
+; CHECK-NEXT:    ret i64 [[AUTHED]]
+;
+  %call = call i64 @foo()
+  %authed = call i64 @llvm.ptrauth.auth(i64 %call, i32 1, i64 1234)
+  ret i64 %authed
+}
+
 declare i64 @llvm.ptrauth.auth(i64, i32, i64)
 declare i64 @llvm.ptrauth.sign(i64, i32, i64)
 declare i64 @llvm.ptrauth.resign(i64, i32, i64, i32, i64)


### PR DESCRIPTION
If llvm.ptrauth.auth or llvm.ptrauth.resign is called on the result of
a call with no arguments InstCombine will hit an assertion failure due
to reading the non-existent first argument. Fix it.

Assisted-by: gemini (wrote test)
