### PR TITLE
[TEST-ONLY] Make sure clang-extdef-mapping don't infer database

### DIFF
--- a/clang/test/Analysis/analyzeOneFunction.cpp
+++ b/clang/test/Analysis/analyzeOneFunction.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s \
 // RUN:   -analyze-function="c:@S@Window@F@overloaded#I#"
 
-// RUN: %clang_extdef_map %s | FileCheck %s
+// RUN: %clang_extdef_map %s -- | FileCheck %s
 // CHECK-DAG: 27:c:@S@Window@F@overloaded#I#
 // CHECK-DAG: 27:c:@S@Window@F@overloaded#C#
 // CHECK-DAG: 27:c:@S@Window@F@overloaded#d#

--- a/clang/test/Analysis/ctu/on-demand-parsing.c
+++ b/clang/test/Analysis/ctu/on-demand-parsing.c
@@ -9,7 +9,7 @@
 //
 // RUN: echo '"%t/other.c": ["gcc", "-std=c89", "-Wno-visibility", "other.c"]' | sed -e 's/\\/\\\\/g' > %t/invocations.yaml
 //
-// RUN: cd "%t" && %clang_extdef_map "%t/other.c" > externalDefMap.txt
+// RUN: cd "%t" && %clang_extdef_map "%t/other.c" -- > externalDefMap.txt
 //
 // RUN: cd "%t" && %clang_analyze_cc1 -std=c89 \
 // RUN:   -analyzer-checker=core,debug.ExprInspection \

--- a/clang/test/Analysis/ctu/on-demand-parsing.cpp
+++ b/clang/test/Analysis/ctu/on-demand-parsing.cpp
@@ -11,7 +11,7 @@
 //
 // RUN: echo '{"%t/Inputs/chain.cpp": ["g++", "%t/Inputs/chain.cpp"], "%t/Inputs/other.cpp": ["g++", "%t/Inputs/other.cpp"]}' | sed -e 's/\\/\\\\/g' > %t/invocations.yaml
 //
-// RUN: cd "%t" && %clang_extdef_map Inputs/chain.cpp Inputs/other.cpp > externalDefMap.txt
+// RUN: cd "%t" && %clang_extdef_map Inputs/chain.cpp Inputs/other.cpp -- > externalDefMap.txt
 //
 // RUN: cd "%t" && %clang_analyze_cc1 \
 // RUN:   -analyzer-checker=core,debug.ExprInspection \

--- a/clang/test/Tooling/clang-extdef-mapping.cpp
+++ b/clang/test/Tooling/clang-extdef-mapping.cpp
@@ -1,4 +1,4 @@
-// RUN: clang-extdef-mapping "%s" 2>&1 | FileCheck %s
+// RUN: clang-extdef-mapping "%s" -- 2>&1 | FileCheck %s
 
 // CHECK: 8:c:@F@foo {{.*}}clang-extdef-mapping.cpp
 extern "C" int foo() { return 0; }


### PR DESCRIPTION
Make sure when running clang-extdef-mapping in the lit test, it should
not try to infer compilation database from source location. Such
behavior can run into issue when user has a `compile_commands.json` in
the source directory for LSP server, and tests will run with unexpected
configuration.

This becomes worse then PCH is enabled by default. Since host compiler
often on a different version from built version, the test will flat out
fail trying to import PCH built by host compiler.

Tests that accidentally tries to infer compilation database actually just
needs to be updated with an empty list of arguments.
