### PR TITLE
[mlir][core] in -mlir-print-ir-*, dump the pass options as well

### DIFF
--- a/mlir/lib/Pass/IRPrinting.cpp
+++ b/mlir/lib/Pass/IRPrinting.cpp
@@ -47,11 +47,17 @@ private:
 } // namespace
 
 static void printIR(Operation *op, bool printModuleScope, raw_ostream &out,
-                    OpPrintingFlags flags) {
+                    OpPrintingFlags flags, Pass *pass = nullptr) {
   // Otherwise, check to see if we are not printing at module scope.
-  if (!printModuleScope)
-    return op->print(out << " //----- //\n",
-                     op->getBlock() ? flags.useLocalScope() : flags);
+  if (!printModuleScope) {
+    out << " //----- //\n";
+    if (pass) {
+      out << "// Pass options: ";
+      pass->printAsTextualPipeline(out);
+      out << "\n";
+    }
+    return op->print(out, op->getBlock() ? flags.useLocalScope() : flags);
+  }
 
   // Otherwise, we are printing at module scope.
   out << " ('" << op->getName() << "' operation";
@@ -59,6 +65,11 @@ static void printIR(Operation *op, bool printModuleScope, raw_ostream &out,
           op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
     out << ": @" << symbolName.getValue();
   out << ") //----- //\n";
+  if (pass) {
+    out << "// Pass options: ";
+    pass->printAsTextualPipeline(out);
+    out << "\n";
+  }
 
   // Find the top-level operation.
   auto *topLevelOp = op;
@@ -79,7 +90,7 @@ void IRPrinterInstrumentation::runBeforePass(Pass *pass, Operation *op) {
     out << "// -----// IR Dump Before " << pass->getName() << " ("
         << pass->getArgument() << ")";
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags());
+            config->getOpPrintingFlags(), pass);
     out << "\n\n";
   });
 }
@@ -110,7 +121,7 @@ void IRPrinterInstrumentation::runAfterPass(Pass *pass, Operation *op) {
     out << "// -----// IR Dump After " << pass->getName() << " ("
         << pass->getArgument() << ")";
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags());
+            config->getOpPrintingFlags(), pass);
     out << "\n\n";
   });
 }
@@ -125,7 +136,7 @@ void IRPrinterInstrumentation::runAfterPassFailed(Pass *pass, Operation *op) {
     out << formatv("// -----// IR Dump After {0} Failed ({1})", pass->getName(),
                    pass->getArgument());
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags());
+            config->getOpPrintingFlags(), pass);
     out << "\n\n";
   });
 }

--- a/mlir/lib/Pass/IRPrinting.cpp
+++ b/mlir/lib/Pass/IRPrinting.cpp
@@ -47,35 +47,30 @@ private:
 } // namespace
 
 static void printIR(Operation *op, bool printModuleScope, raw_ostream &out,
-                    OpPrintingFlags flags, Pass *pass = nullptr) {
-  // Otherwise, check to see if we are not printing at module scope.
-  if (!printModuleScope) {
-    out << " //----- //\n";
-    if (pass) {
-      out << "// Pass options: ";
-      pass->printAsTextualPipeline(out);
-      out << "\n";
-    }
-    return op->print(out, op->getBlock() ? flags.useLocalScope() : flags);
-  }
-
-  // Otherwise, we are printing at module scope.
-  out << " ('" << op->getName() << "' operation";
-  if (auto symbolName =
-          op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
-    out << ": @" << symbolName.getValue();
-  out << ") //----- //\n";
-  if (pass) {
-    out << "// Pass options: ";
-    pass->printAsTextualPipeline(out);
-    out << "\n";
-  }
-
+                    OpPrintingFlags flags) {
   // Find the top-level operation.
   auto *topLevelOp = op;
   while (auto *parentOp = topLevelOp->getParentOp())
     topLevelOp = parentOp;
   topLevelOp->print(out, flags);
+}
+
+static void printIRHeader(raw_ostream &out, StringRef title, Pass *pass,
+                          Operation *op, bool printModuleScope,
+                          bool failed = false) {
+  out << "// -----// IR Dump " << title << " " << pass->getName();
+  if (failed)
+    out << " Failed";
+  out << ": ";
+  pass->printAsTextualPipeline(out);
+  if (printModuleScope) {
+    out << " ('" << op->getName() << "' operation";
+    if (auto symbolName =
+            op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
+      out << ": @" << symbolName.getValue();
+    out << ")";
+  }
+  out << " //----- //\n";
 }
 
 /// Instrumentation hooks.
@@ -87,10 +82,9 @@ void IRPrinterInstrumentation::runBeforePass(Pass *pass, Operation *op) {
     beforePassFingerPrints.try_emplace(pass, op);
 
   config->printBeforeIfEnabled(pass, op, [&](raw_ostream &out) {
-    out << "// -----// IR Dump Before " << pass->getName() << " ("
-        << pass->getArgument() << ")";
+    printIRHeader(out, "Before", pass, op, config->shouldPrintAtModuleScope());
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags(), pass);
+            config->getOpPrintingFlags());
     out << "\n\n";
   });
 }
@@ -118,10 +112,9 @@ void IRPrinterInstrumentation::runAfterPass(Pass *pass, Operation *op) {
   }
 
   config->printAfterIfEnabled(pass, op, [&](raw_ostream &out) {
-    out << "// -----// IR Dump After " << pass->getName() << " ("
-        << pass->getArgument() << ")";
+    printIRHeader(out, "After", pass, op, config->shouldPrintAtModuleScope());
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags(), pass);
+            config->getOpPrintingFlags());
     out << "\n\n";
   });
 }
@@ -133,10 +126,10 @@ void IRPrinterInstrumentation::runAfterPassFailed(Pass *pass, Operation *op) {
     beforePassFingerPrints.erase(pass);
 
   config->printAfterIfEnabled(pass, op, [&](raw_ostream &out) {
-    out << formatv("// -----// IR Dump After {0} Failed ({1})", pass->getName(),
-                   pass->getArgument());
+    printIRHeader(out, "After", pass, op, config->shouldPrintAtModuleScope(),
+                  /*failed=*/true);
     printIR(op, config->shouldPrintAtModuleScope(), out,
-            config->getOpPrintingFlags(), pass);
+            config->getOpPrintingFlags());
     out << "\n\n";
   });
 }

--- a/mlir/lib/Pass/IRPrinting.cpp
+++ b/mlir/lib/Pass/IRPrinting.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include <mutex>
 
 using namespace mlir;
 using namespace mlir::detail;
@@ -260,16 +261,13 @@ static LogicalResult createDirectoryOrPrintErr(llvm::StringRef dirPath) {
 
 /// Creates  directories (if required) and opens an output file for the
 /// FileTreeIRPrinterConfig.
-static std::unique_ptr<llvm::ToolOutputFile>
-createTreePrinterOutputPath(Operation *op, llvm::StringRef passArgument,
-                            llvm::StringRef rootDir,
-                            llvm::DenseMap<Operation *, unsigned> &counters) {
+static std::unique_ptr<llvm::ToolOutputFile> createTreePrinterOutputPath(
+    ArrayRef<std::pair<std::string, std::string>> opAndSymbolNames,
+    llvm::StringRef fileName, llvm::StringRef rootDir) {
   // Create the path. We will create a tree rooted at the given 'rootDir'
   // directory. The root directory will contain folders with the names of
   // modules. Sub-directories within those folders mirror the nesting
   // structure of the pass manager, using symbol names for directory names.
-  auto [opAndSymbolNames, fileName] =
-      getOpAndSymbolNames(op, passArgument, counters);
 
   // Create all the directories, starting at the root. Abort early if we fail to
   // create any directory.
@@ -319,8 +317,19 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
                             PrintCallbackFn printCallback) final {
     if (!shouldPrintBeforePass || !shouldPrintBeforePass(pass, operation))
       return;
-    std::unique_ptr<llvm::ToolOutputFile> file = createTreePrinterOutputPath(
-        operation, pass->getArgument(), treeDir, counters);
+
+    SmallVector<std::pair<std::string, std::string>> opAndSymbolNames;
+    std::string fileName;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      auto result =
+          getOpAndSymbolNames(operation, pass->getArgument(), counters);
+      opAndSymbolNames = std::move(result.first);
+      fileName = std::move(result.second);
+    }
+
+    std::unique_ptr<llvm::ToolOutputFile> file =
+        createTreePrinterOutputPath(opAndSymbolNames, fileName, treeDir);
     if (!file)
       return;
     printCallback(file->os());
@@ -331,8 +340,19 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
                            PrintCallbackFn printCallback) final {
     if (!shouldPrintAfterPass || !shouldPrintAfterPass(pass, operation))
       return;
-    std::unique_ptr<llvm::ToolOutputFile> file = createTreePrinterOutputPath(
-        operation, pass->getArgument(), treeDir, counters);
+
+    SmallVector<std::pair<std::string, std::string>> opAndSymbolNames;
+    std::string fileName;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      auto result =
+          getOpAndSymbolNames(operation, pass->getArgument(), counters);
+      opAndSymbolNames = std::move(result.first);
+      fileName = std::move(result.second);
+    }
+
+    std::unique_ptr<llvm::ToolOutputFile> file =
+        createTreePrinterOutputPath(opAndSymbolNames, fileName, treeDir);
     if (!file)
       return;
     printCallback(file->os());
@@ -349,6 +369,9 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
   /// Counters used for labeling the prefix. Every op which could be targeted by
   /// a pass gets its own counter.
   llvm::DenseMap<Operation *, unsigned> counters;
+
+  /// Mutex to protect `counters` map.
+  std::mutex mutex;
 };
 
 } // namespace

--- a/mlir/lib/Pass/IRPrinting.cpp
+++ b/mlir/lib/Pass/IRPrinting.cpp
@@ -16,7 +16,6 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ToolOutputFile.h"
-#include <mutex>
 
 using namespace mlir;
 using namespace mlir::detail;
@@ -261,13 +260,16 @@ static LogicalResult createDirectoryOrPrintErr(llvm::StringRef dirPath) {
 
 /// Creates  directories (if required) and opens an output file for the
 /// FileTreeIRPrinterConfig.
-static std::unique_ptr<llvm::ToolOutputFile> createTreePrinterOutputPath(
-    ArrayRef<std::pair<std::string, std::string>> opAndSymbolNames,
-    llvm::StringRef fileName, llvm::StringRef rootDir) {
+static std::unique_ptr<llvm::ToolOutputFile>
+createTreePrinterOutputPath(Operation *op, llvm::StringRef passArgument,
+                            llvm::StringRef rootDir,
+                            llvm::DenseMap<Operation *, unsigned> &counters) {
   // Create the path. We will create a tree rooted at the given 'rootDir'
   // directory. The root directory will contain folders with the names of
   // modules. Sub-directories within those folders mirror the nesting
   // structure of the pass manager, using symbol names for directory names.
+  auto [opAndSymbolNames, fileName] =
+      getOpAndSymbolNames(op, passArgument, counters);
 
   // Create all the directories, starting at the root. Abort early if we fail to
   // create any directory.
@@ -317,19 +319,8 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
                             PrintCallbackFn printCallback) final {
     if (!shouldPrintBeforePass || !shouldPrintBeforePass(pass, operation))
       return;
-
-    SmallVector<std::pair<std::string, std::string>> opAndSymbolNames;
-    std::string fileName;
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      auto result =
-          getOpAndSymbolNames(operation, pass->getArgument(), counters);
-      opAndSymbolNames = std::move(result.first);
-      fileName = std::move(result.second);
-    }
-
-    std::unique_ptr<llvm::ToolOutputFile> file =
-        createTreePrinterOutputPath(opAndSymbolNames, fileName, treeDir);
+    std::unique_ptr<llvm::ToolOutputFile> file = createTreePrinterOutputPath(
+        operation, pass->getArgument(), treeDir, counters);
     if (!file)
       return;
     printCallback(file->os());
@@ -340,19 +331,8 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
                            PrintCallbackFn printCallback) final {
     if (!shouldPrintAfterPass || !shouldPrintAfterPass(pass, operation))
       return;
-
-    SmallVector<std::pair<std::string, std::string>> opAndSymbolNames;
-    std::string fileName;
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      auto result =
-          getOpAndSymbolNames(operation, pass->getArgument(), counters);
-      opAndSymbolNames = std::move(result.first);
-      fileName = std::move(result.second);
-    }
-
-    std::unique_ptr<llvm::ToolOutputFile> file =
-        createTreePrinterOutputPath(opAndSymbolNames, fileName, treeDir);
+    std::unique_ptr<llvm::ToolOutputFile> file = createTreePrinterOutputPath(
+        operation, pass->getArgument(), treeDir, counters);
     if (!file)
       return;
     printCallback(file->os());
@@ -369,9 +349,6 @@ struct FileTreeIRPrinterConfig : public PassManager::IRPrinterConfig {
   /// Counters used for labeling the prefix. Every op which could be targeted by
   /// a pass gets its own counter.
   llvm::DenseMap<Operation *, unsigned> counters;
-
-  /// Mutex to protect `counters` map.
-  std::mutex mutex;
 };
 
 } // namespace

--- a/mlir/test/Pass/dynamic-pipeline-nested.mlir
+++ b/mlir/test/Pass/dynamic-pipeline-nested.mlir
@@ -10,7 +10,7 @@ func.func @f() {
 
 // CHECK: IR Dump Before
 // CHECK-SAME: TestDynamicPipelinePass
-// CHECK-NEXT: module @inner_mod1
+// CHECK: module @inner_mod1
 module @inner_mod1 {
 // We use the mlir-print-ir-after-all dumps to check the granularity of the
 // scheduling: if we are nesting we expect to see to individual "Dump Before
@@ -18,11 +18,11 @@ module @inner_mod1 {
 // the CSE pass to run on the `inner_mod1` module directly.
 
 // CHECK: Dump Before CSE
-// NOTNESTED-NEXT: @inner_mod1
-// NESTED-NEXT: @foo
+// NOTNESTED: @inner_mod1
+// NESTED: @foo
   module @foo {}
 // Only in the nested case we have a second run of the pass here.
 // NESTED: Dump Before CSE
-// NESTED-NEXT: @baz
+// NESTED: @baz
   module @baz {}
 }

--- a/mlir/test/Pass/dynamic-pipeline.mlir
+++ b/mlir/test/Pass/dynamic-pipeline.mlir
@@ -10,20 +10,20 @@ func.func @f() {
 
 // CHECK: IR Dump Before
 // CHECK-SAME: TestDynamicPipelinePass
-// CHECK-NEXT: module @inner_mod1
+// CHECK: module @inner_mod1
 // MOD2-ONLY: dynamic-pipeline skip op name: inner_mod1
 module @inner_mod1 {
 // MOD1: Dump Before CSE
-// MOD1-NEXT: @foo
+// MOD1: @foo
 // MOD1: Dump Before Canonicalizer
-// MOD1-NEXT: @foo
+// MOD1: @foo
   func.func @foo() {
     return
   }
 // MOD1: Dump Before CSE
-// MOD1-NEXT: @baz
+// MOD1: @baz
 // MOD1: Dump Before Canonicalizer
-// MOD1-NEXT: @baz
+// MOD1: @baz
   func.func @baz() {
     return
   }
@@ -31,13 +31,13 @@ module @inner_mod1 {
 
 // CHECK: IR Dump Before
 // CHECK-SAME: TestDynamicPipelinePass
-// CHECK-NEXT: module @inner_mod2
+// CHECK: module @inner_mod2
 // MOD1-ONLY: dynamic-pipeline skip op name: inner_mod2
 module @inner_mod2 {
 // MOD2: Dump Before CSE
-// MOD2-NEXT: @foo
+// MOD2: @foo
 // MOD2: Dump Before Canonicalizer
-// MOD2-NEXT: @foo
+// MOD2: @foo
   func.func @foo() {
     return
   }

--- a/mlir/test/Pass/ir-printing.mlir
+++ b/mlir/test/Pass/ir-printing.mlir
@@ -5,6 +5,7 @@
 // RUN: mlir-opt %s -mlir-disable-threading=true -pass-pipeline='builtin.module(func.func(cse,canonicalize))' -mlir-print-ir-before=cse -mlir-print-ir-module-scope -o /dev/null 2>&1 | FileCheck -check-prefix=BEFORE_MODULE %s
 // RUN: mlir-opt %s -mlir-disable-threading=true -pass-pipeline='builtin.module(func.func(cse,cse))' -mlir-print-ir-after-all -mlir-print-ir-after-change -o /dev/null 2>&1 | FileCheck -check-prefix=AFTER_ALL_CHANGE %s
 // RUN: not mlir-opt %s -mlir-disable-threading=true -pass-pipeline='builtin.module(func.func(cse,test-pass-failure))' -mlir-print-ir-after-failure -o /dev/null 2>&1 | FileCheck -check-prefix=AFTER_FAILURE %s
+// RUN: mlir-opt %s -mlir-disable-threading=true -pass-pipeline='builtin.module(func.func(canonicalize{max-iterations=5}))' -mlir-print-ir-before=canonicalize -o /dev/null 2>&1 | FileCheck -check-prefix=OPTIONS %s
 
 func.func @foo() {
   %0 = arith.constant 0 : i32
@@ -65,3 +66,6 @@ func.func @bar() {
 // AFTER_FAILURE-NOT: // -----// IR Dump After{{.*}}CSE
 // AFTER_FAILURE: // -----// IR Dump After{{.*}}TestFailurePass Failed (test-pass-failure) //----- //
 // AFTER_FAILURE: func @foo()
+
+// OPTIONS: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
+// OPTIONS-NEXT: // Pass options: canonicalize{cse-between-iterations=false{{[[:space:]]*}}max-iterations=5 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}

--- a/mlir/test/Pass/ir-printing.mlir
+++ b/mlir/test/Pass/ir-printing.mlir
@@ -16,56 +16,55 @@ func.func @bar() {
   return
 }
 
-// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE: func @foo()
-// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE: func @bar()
-// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
+// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass: canonicalize //----- //
 // BEFORE-NOT: // -----// IR Dump After
 
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE_ALL: func @foo()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass: canonicalize{{.*}} //----- //
 // BEFORE_ALL: func @foo()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE_ALL: func @bar()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass: canonicalize{{.*}} //----- //
 // BEFORE_ALL: func @bar()
 // BEFORE_ALL-NOT: // -----// IR Dump After
 
 // AFTER-NOT: // -----// IR Dump Before
-// AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // AFTER: func @foo()
-// AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // AFTER: func @bar()
-// AFTER-NOT: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
+// AFTER-NOT: // -----// IR Dump After{{.*}}CanonicalizerPass: canonicalize{{.*}} //----- //
 
 // AFTER_ALL-NOT: // -----// IR Dump Before
-// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // AFTER_ALL: func @foo()
-// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass: canonicalize{{.*}} //----- //
 // AFTER_ALL: func @foo()
-// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // AFTER_ALL: func @bar()
-// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass: canonicalize{{.*}} //----- //
 // AFTER_ALL: func @bar()
 
-// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass (cse) ('func.func' operation: @foo) //----- //
+// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass: cse ('func.func' operation: @foo) //----- //
 // BEFORE_MODULE: func @foo()
 // BEFORE_MODULE: func @bar()
-// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass (cse) ('func.func' operation: @bar) //----- //
+// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass: cse ('func.func' operation: @bar) //----- //
 // BEFORE_MODULE: func @foo()
 // BEFORE_MODULE: func @bar()
 
-// AFTER_ALL_CHANGE: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER_ALL_CHANGE: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // AFTER_ALL_CHANGE: func @foo()
-// AFTER_ALL_CHANGE-NOT: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
+// AFTER_ALL_CHANGE-NOT: // -----// IR Dump After{{.*}}CSEPass: cse //----- //
 // We expect that only 'foo' changed during CSE, and the second run of CSE did
 // nothing.
 
 // AFTER_FAILURE-NOT: // -----// IR Dump After{{.*}}CSE
-// AFTER_FAILURE: // -----// IR Dump After{{.*}}TestFailurePass Failed (test-pass-failure) //----- //
+// AFTER_FAILURE: // -----// IR Dump After{{.*}}TestFailurePass Failed: test-pass-failure{{.*}} //----- //
 // AFTER_FAILURE: func @foo()
 
-// OPTIONS: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
-// OPTIONS-NEXT: // Pass options: canonicalize{cse-between-iterations=false{{[[:space:]]*}}max-iterations=5 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}
+// OPTIONS: // -----// IR Dump Before{{.*}}CanonicalizerPass: canonicalize{cse-between-iterations=false{{[[:space:]]*}}max-iterations=5 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true} //----- //

--- a/mlir/test/Pass/ir-printing.mlir
+++ b/mlir/test/Pass/ir-printing.mlir
@@ -17,38 +17,38 @@ func.func @bar() {
 }
 
 // BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE-NEXT: func @foo()
+// BEFORE: func @foo()
 // BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE-NEXT: func @bar()
+// BEFORE: func @bar()
 // BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE-NOT: // -----// IR Dump After
 
 // BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE_ALL-NEXT: func @foo()
+// BEFORE_ALL: func @foo()
 // BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
-// BEFORE_ALL-NEXT: func @foo()
+// BEFORE_ALL: func @foo()
 // BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE_ALL-NEXT: func @bar()
+// BEFORE_ALL: func @bar()
 // BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
-// BEFORE_ALL-NEXT: func @bar()
+// BEFORE_ALL: func @bar()
 // BEFORE_ALL-NOT: // -----// IR Dump After
 
 // AFTER-NOT: // -----// IR Dump Before
 // AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
-// AFTER-NEXT: func @foo()
+// AFTER: func @foo()
 // AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
-// AFTER-NEXT: func @bar()
+// AFTER: func @bar()
 // AFTER-NOT: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
 
 // AFTER_ALL-NOT: // -----// IR Dump Before
 // AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
-// AFTER_ALL-NEXT: func @foo()
+// AFTER_ALL: func @foo()
 // AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
-// AFTER_ALL-NEXT: func @foo()
+// AFTER_ALL: func @foo()
 // AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
-// AFTER_ALL-NEXT: func @bar()
+// AFTER_ALL: func @bar()
 // AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
-// AFTER_ALL-NEXT: func @bar()
+// AFTER_ALL: func @bar()
 
 // BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass (cse) ('func.func' operation: @foo) //----- //
 // BEFORE_MODULE: func @foo()
@@ -58,7 +58,7 @@ func.func @bar() {
 // BEFORE_MODULE: func @bar()
 
 // AFTER_ALL_CHANGE: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
-// AFTER_ALL_CHANGE-NEXT: func @foo()
+// AFTER_ALL_CHANGE: func @foo()
 // AFTER_ALL_CHANGE-NOT: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // We expect that only 'foo' changed during CSE, and the second run of CSE did
 // nothing.

--- a/mlir/test/Pass/run-reproducer.mlir
+++ b/mlir/test/Pass/run-reproducer.mlir
@@ -27,8 +27,8 @@ func.func @bar() {
 #-}
 
 // BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE-NEXT: func @foo()
+// BEFORE: func @foo()
 // BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
-// BEFORE-NEXT: func @bar()
+// BEFORE: func @bar()
 // BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE-NOT: // -----// IR Dump After

--- a/mlir/test/Pass/run-reproducer.mlir
+++ b/mlir/test/Pass/run-reproducer.mlir
@@ -26,9 +26,9 @@ func.func @bar() {
   }
 #-}
 
-// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE: func @foo()
-// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass: cse //----- //
 // BEFORE: func @bar()
-// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
+// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass: canonicalize //----- //
 // BEFORE-NOT: // -----// IR Dump After

--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -275,7 +275,7 @@ def testPrintIrAfterAll():
         pm = PassManager.parse("builtin.module(canonicalize)")
         ctx.enable_multithreading(False)
         pm.enable_ir_printing()
-        # CHECK: // -----// IR Dump After CanonicalizerPass (canonicalize) //----- //
+        # CHECK: // -----// IR Dump After CanonicalizerPass: canonicalize{{.*}} //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     return
@@ -301,14 +301,14 @@ def testPrintIrBeforeAndAfterAll():
         pm = PassManager.parse("builtin.module(canonicalize)")
         ctx.enable_multithreading(False)
         pm.enable_ir_printing(print_before_all=True, print_after_all=True)
-        # CHECK: // -----// IR Dump Before CanonicalizerPass (canonicalize) //----- //
+        # CHECK: // -----// IR Dump Before CanonicalizerPass: canonicalize{{.*}} //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     %[[C10:.*]] = arith.constant 10 : i64
         # CHECK:     return
         # CHECK:   }
         # CHECK: }
-        # CHECK: // -----// IR Dump After CanonicalizerPass (canonicalize) //----- //
+        # CHECK: // -----// IR Dump After CanonicalizerPass: canonicalize{{.*}} //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     return


### PR DESCRIPTION
This change modifies the header comment to IR dumped by `-mlir-print-ir-*` flags. The new comment contains the exact pass pipeline run for the pass in question. This is useful when using `mlir-print-ir-tree-dir`, as it provides the exact reproducing pass pipeline that can be used on the dumped IR.

For example, when using --mlir-print-ir-before-all when triaging a stack trace, the last dumped IR (along with this new comment) can be used to reproduce the failure with a single pass.

Before:

```
// -----// IR Dump Before CanonicalizerPass (canonicalize) //----- //
```

After:

```
// -----// IR Dump Before CanonicalizerPass: canonicalize{cse-between-iterations=false    max-iterations=5 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true} //----- //
```