### PR TITLE
[NFC][SSAF] Rename PointerFlowReachableAnalysis to UnsafeBufferReachableAnalysis

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.h
@@ -9,16 +9,12 @@
 // Defines
 // - PointerFlowAnalysisResult
 //     - the plain PointerFlow info collected from the whole program.
-// - PointerFlowReachableAnalysisResult
-//     - the set of reachable pointers in the pointer flow graph from a provided
-//       starting set.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_CLANG_SCALABLESTATICANALYSISFRAMEWORK_ANALYSES_POINTERFLOW_POINTERFLOWANALYSIS_H
 #define LLVM_CLANG_SCALABLESTATICANALYSISFRAMEWORK_ANALYSES_POINTERFLOW_POINTERFLOWANALYSIS_H
 
-#include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlow.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisName.h"
@@ -30,8 +26,6 @@ namespace clang::ssaf {
 
 constexpr llvm::StringLiteral PointerFlowAnalysisResultName =
     "PointerFlowAnalysisResult";
-constexpr llvm::StringLiteral UnsafeBufferReachableAnalysisResultName =
-    "UnsafeBufferReachableAnalysisResult";
 
 /// A PointerFlowAnalysisResult is a set of pointer-flow edges, i.e.,
 /// a pointer-flow graph. A directed edge src -> dest corresponds to an
@@ -49,14 +43,6 @@ struct PointerFlowAnalysisResult final : AnalysisResult {
   }
 
   std::map<EntityId, EdgeSet> Edges;
-};
-
-struct UnsafeBufferReachableAnalysisResult final : AnalysisResult {
-  static AnalysisName analysisName() {
-    return AnalysisName(UnsafeBufferReachableAnalysisResultName.str());
-  }
-
-  std::map<EntityId, EntityPointerLevelSet> Reachables;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.h
@@ -6,8 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Defines UnsafeBufferUsageAnalysisResult, the whole-program analysis result
-// type for UnsafeBufferUsageAnalysis.
+// Defines:
+// - UnsafeBufferUsageAnalysisResult
+//     - the whole-program analysis result
+//       type for UnsafeBufferUsageAnalysis. It collects unsafe buffer usages
+//       throughout the whole program.
+//
+// - UnsafeBufferReachableAnalysisResult
+//     - the whole-program analysis result
+//       type for UnsafeBufferReachableAnalysis. It propagates unsafe buffer
+//       usages through the pointer flow graph, starting from the initial set
+//       collected by UnsafeBufferUsageAnalysis.
 //
 //===----------------------------------------------------------------------===//
 
@@ -25,6 +34,8 @@ namespace clang::ssaf {
 
 constexpr llvm::StringLiteral UnsafeBufferUsageAnalysisResultName =
     "UnsafeBufferUsageAnalysisResult";
+constexpr llvm::StringLiteral UnsafeBufferReachableAnalysisResultName =
+    "UnsafeBufferReachableAnalysisResult";
 
 struct UnsafeBufferUsageAnalysisResult final : AnalysisResult {
   static AnalysisName analysisName() {
@@ -36,6 +47,14 @@ struct UnsafeBufferUsageAnalysisResult final : AnalysisResult {
 
   auto begin() const { return UnsafeBuffers.begin(); }
   auto end() const { return UnsafeBuffers.end(); }
+};
+
+struct UnsafeBufferReachableAnalysisResult final : AnalysisResult {
+  static AnalysisName analysisName() {
+    return AnalysisName(UnsafeBufferReachableAnalysisResultName.str());
+  }
+
+  std::map<EntityId, EntityPointerLevelSet> Reachables;
 };
 
 } // namespace clang::ssaf

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.cpp
@@ -8,11 +8,8 @@
 
 #include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.h"
 #include "SSAFAnalysesCommon.h"
-#include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
-#include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevelFormat.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlow.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowFormat.h"
-#include "clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisRegistry.h"
@@ -60,8 +57,9 @@ Expected<std::unique_ptr<AnalysisResult>> deserializePointerFlowAnalysisResult(
                                    PointerFlowAnalysisResultName.data());
 
   if (Content->size() % 2 != 0)
-    return makeSawButExpectedError(
-        *Content, "an even number of elements, got %lu", Content->size());
+    return makeSawButExpectedError(*Content,
+                                   "an even number of elements, got %lu",
+                                   static_cast<size_t>(Content->size()));
 
   std::map<EntityId, EdgeSet> Edges;
 
@@ -115,114 +113,6 @@ public:
 
 AnalysisRegistry::Add<PointerFlowAnalysis>
     RegisterPointerFlowAnalysis("Whole-program pointer flow analysis");
-
-//===----------------------------------------------------------------------===//
-// PointerFlowReachableAnalysis---computes reachable node
-//===----------------------------------------------------------------------===//
-
-json::Object serializePointerFlowReachableAnalysisResult(
-    const UnsafeBufferReachableAnalysisResult &R,
-    JSONFormat::EntityIdToJSONFn IdToJSON) {
-  json::Object Result;
-
-  Result[UnsafeBufferReachableAnalysisResultName] =
-      entityPointerLevelMapToJSON(R.Reachables, IdToJSON);
-  return Result;
-}
-
-Expected<std::unique_ptr<AnalysisResult>>
-deserializePointerFlowReachableAnalysisResult(
-    const json::Object &Obj, JSONFormat::EntityIdFromJSONFn IdFromJSON) {
-  const json::Array *Content =
-      Obj.getArray(UnsafeBufferReachableAnalysisResultName);
-
-  if (!Content)
-    return makeSawButExpectedError(
-        Obj, "an object with a key %s",
-        UnsafeBufferReachableAnalysisResultName.data());
-
-  auto Reachables = entityPointerLevelMapFromJSON(*Content, IdFromJSON);
-
-  if (!Reachables)
-    return Reachables.takeError();
-
-  auto Ret = std::make_unique<UnsafeBufferReachableAnalysisResult>();
-
-  Ret->Reachables = std::move(*Reachables);
-  return Ret;
-}
-
-JSONFormat::AnalysisResultRegistry::Add<UnsafeBufferReachableAnalysisResult>
-    RegisterPointerFlowReachableResultForJSON(
-        serializePointerFlowReachableAnalysisResult,
-        deserializePointerFlowReachableAnalysisResult);
-
-/// Computes all the reachable "nodes" (pointers) in a pointer flow graph from a
-/// provided starter node set.  Specifically, the starter set is the unsafe
-/// pointers found by `UnsafeBufferUsageAnalysis`.
-class UnsafeBufferReachableAnalysis
-    : public DerivedAnalysis<UnsafeBufferReachableAnalysisResult,
-                             PointerFlowAnalysisResult,
-                             UnsafeBufferUsageAnalysisResult> {
-  using GraphT = std::map<EntityId, EdgeSet>;
-  const GraphT *Graph = nullptr;
-
-  // Use pointers for efficiency. Both `Graph` and `Reachables` in the result
-  // are tree-based containers that only grow. So pointers to them are stable.
-  using EPLPtr = const EntityPointerLevel *;
-
-  // Find all outgoing edges from `EPL` in the `Graph`, insert their
-  // destination nodes into `Reachables`, and add newly discovered nodes to
-  // `Worklist`:
-  void updateReachablesWithOutgoings(EPLPtr EPL,
-                                     std::vector<EPLPtr> &WorkList) {
-    for (auto &[Id, SubGraph] : *Graph) {
-      auto I = SubGraph.find(*EPL);
-      EntityPointerLevelSet &ReachablesOfId = getResult().Reachables[Id];
-
-      if (I != SubGraph.end()) {
-        for (const auto &EPL : I->second) {
-          auto [Ignored, Inserted] = ReachablesOfId.insert(EPL);
-          if (Inserted)
-            WorkList.push_back(&EPL);
-        }
-      }
-    }
-  }
-
-public:
-  llvm::Error
-  initialize(const PointerFlowAnalysisResult &Graph,
-             const UnsafeBufferUsageAnalysisResult &Starter) override {
-    this->Graph = &Graph.Edges;
-    assert(getResult().Reachables.empty());
-    getResult().Reachables.insert(Starter.begin(), Starter.end());
-    return llvm::Error::success();
-  }
-
-  llvm::Expected<bool> step() override {
-    auto &Reachables = getResult().Reachables;
-    // Simple DFS:
-    std::vector<EPLPtr> Worklist;
-
-    for (auto &[Id, EPLs] : Reachables)
-      for (auto &EPL : EPLs)
-        Worklist.push_back(&EPL);
-
-    while (!Worklist.empty()) {
-      EPLPtr Node = Worklist.back();
-      Worklist.pop_back();
-
-      updateReachablesWithOutgoings(Node, Worklist);
-    }
-    // This is not an iterative algorithm so stop iteration by retruning false:
-    return false;
-  }
-};
-
-AnalysisRegistry::Add<UnsafeBufferReachableAnalysis>
-    RegisterPointerFlowReachableAnalysis(
-        "Reachable pointers from unsafe buffer usage in pointer flow graph");
 
 } // namespace
 

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
@@ -15,6 +15,7 @@
 #include "SSAFAnalysesCommon.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevelFormat.h"
+#include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowAnalysis.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Serialization/JSONFormat.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/WholeProgramAnalysis/AnalysisRegistry.h"
@@ -81,6 +82,114 @@ public:
 AnalysisRegistry::Add<UnsafeBufferUsageAnalysis>
     RegisterUnsafeBufferUsageAnalysis(
         "Whole-program unsafe buffer usage analysis");
+
+//===----------------------------------------------------------------------===//
+// UnsafeBufferReachableAnalysis---computes reachable unsafe buffer nodes
+//===----------------------------------------------------------------------===//
+
+json::Object serializeUnsafeBufferReachableAnalysisResult(
+    const UnsafeBufferReachableAnalysisResult &R,
+    JSONFormat::EntityIdToJSONFn IdToJSON) {
+  json::Object Result;
+
+  Result[UnsafeBufferReachableAnalysisResultName] =
+      entityPointerLevelMapToJSON(R.Reachables, IdToJSON);
+  return Result;
+}
+
+Expected<std::unique_ptr<AnalysisResult>>
+deserializeUnsafeBufferReachableAnalysisResult(
+    const json::Object &Obj, JSONFormat::EntityIdFromJSONFn IdFromJSON) {
+  const json::Array *Content =
+      Obj.getArray(UnsafeBufferReachableAnalysisResultName);
+
+  if (!Content)
+    return makeSawButExpectedError(
+        Obj, "an object with a key %s",
+        UnsafeBufferReachableAnalysisResultName.data());
+
+  auto Reachables = entityPointerLevelMapFromJSON(*Content, IdFromJSON);
+
+  if (!Reachables)
+    return Reachables.takeError();
+
+  auto Ret = std::make_unique<UnsafeBufferReachableAnalysisResult>();
+
+  Ret->Reachables = std::move(*Reachables);
+  return Ret;
+}
+
+JSONFormat::AnalysisResultRegistry::Add<UnsafeBufferReachableAnalysisResult>
+    RegisterUnsafeBufferReachableResultForJSON(
+        serializeUnsafeBufferReachableAnalysisResult,
+        deserializeUnsafeBufferReachableAnalysisResult);
+
+/// Computes all the reachable "nodes" (pointers) in a pointer flow graph from a
+/// provided starter node set.  Specifically, the starter set is the unsafe
+/// pointers found by `UnsafeBufferUsageAnalysis`.
+class UnsafeBufferReachableAnalysis
+    : public DerivedAnalysis<UnsafeBufferReachableAnalysisResult,
+                             PointerFlowAnalysisResult,
+                             UnsafeBufferUsageAnalysisResult> {
+  using GraphT = std::map<EntityId, EdgeSet>;
+  const GraphT *Graph = nullptr;
+
+  // Use pointers for efficiency. Both `Graph` and `Reachables` in the result
+  // are tree-based containers that only grow. So pointers to them are stable.
+  using EPLPtr = const EntityPointerLevel *;
+
+  // Find all outgoing edges from `EPL` in the `Graph`, insert their
+  // destination nodes into `Reachables`, and add newly discovered nodes to
+  // `Worklist`:
+  void updateReachablesWithOutgoings(EPLPtr EPL,
+                                     std::vector<EPLPtr> &WorkList) {
+    for (auto &[Id, SubGraph] : *Graph) {
+      auto I = SubGraph.find(*EPL);
+      EntityPointerLevelSet &ReachablesOfId = getResult().Reachables[Id];
+
+      if (I != SubGraph.end()) {
+        for (const auto &EPL : I->second) {
+          auto [Ignored, Inserted] = ReachablesOfId.insert(EPL);
+          if (Inserted)
+            WorkList.push_back(&EPL);
+        }
+      }
+    }
+  }
+
+public:
+  llvm::Error
+  initialize(const PointerFlowAnalysisResult &Graph,
+             const UnsafeBufferUsageAnalysisResult &Starter) override {
+    this->Graph = &Graph.Edges;
+    assert(getResult().Reachables.empty());
+    getResult().Reachables.insert(Starter.begin(), Starter.end());
+    return llvm::Error::success();
+  }
+
+  llvm::Expected<bool> step() override {
+    auto &Reachables = getResult().Reachables;
+    // Simple DFS:
+    std::vector<EPLPtr> Worklist;
+
+    for (auto &[Id, EPLs] : Reachables)
+      for (auto &EPL : EPLs)
+        Worklist.push_back(&EPL);
+
+    while (!Worklist.empty()) {
+      EPLPtr Node = Worklist.back();
+      Worklist.pop_back();
+
+      updateReachablesWithOutgoings(Node, Worklist);
+    }
+    // This is not an iterative algorithm so stop iteration by retruning false:
+    return false;
+  }
+};
+
+AnalysisRegistry::Add<UnsafeBufferReachableAnalysis>
+    RegisterUnsafeBufferReachableAnalysis(
+        "Reachable pointers from unsafe buffer usage in pointer flow graph");
 
 } // namespace
 


### PR DESCRIPTION
The previous-named PointerFlowReachableAnalysis is essentially
propagating unsafe buffers on a pointer flow graph.  The pointer flow
analysis is a dependency, instead of the subject.  So do the rename
and move.