### PR TITLE
[clang] Implement CWG2413 (implicit `typename` in conversion operators)

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -34,7 +34,8 @@ void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
                     cxxMethodDecl(), hasParent(friendDecl()),
                     functionDecl(has(nestedNameSpecifier())),
                     cxxDeductionGuideDecl(hasDeclContext(recordDecl())))))))),
-                // Match return types.
+                // Match return types. FIXME: CWG2413 made conversion operators
+                // an implicit typename context.
                 functionDecl(unless(cxxConversionDecl()))))),
             hasParent(expr(anyOf(cxxNamedCastExpr(), cxxNewExpr()))));
   Finder->addMatcher(

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -155,6 +155,9 @@ C++17 Feature Support
 Resolutions to C++ Defect Reports
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Clang now allows omitting ``typename`` before a template name in a
+  conversion operator, implementing `CWG2413 <https://wg21.link/cwg2413>`_.
+
 C Language Changes
 ------------------
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1685,13 +1685,13 @@ private:
     case DeclSpecContext::DSC_alias_declaration:
     case DeclSpecContext::DSC_template_param:
     case DeclSpecContext::DSC_new:
+    case DeclSpecContext::DSC_conv_operator:
       return ImplicitTypenameContext::Yes;
 
     case DeclSpecContext::DSC_normal:
     case DeclSpecContext::DSC_objc_method_result:
     case DeclSpecContext::DSC_condition:
     case DeclSpecContext::DSC_template_arg:
-    case DeclSpecContext::DSC_conv_operator:
     case DeclSpecContext::DSC_association:
       return ImplicitTypenameContext::No;
     }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3364,11 +3364,8 @@ void Parser::ParseDeclarationSpecifiers(
 
   // If we are in a operator context, convert it back into a type specifier
   // context for better error handling later on.
-  if (DSContext == DeclSpecContext::DSC_conv_operator) {
-    // No implicit typename here.
-    AllowImplicitTypename = ImplicitTypenameContext::No;
+  if (DSContext == DeclSpecContext::DSC_conv_operator)
     DSContext = DeclSpecContext::DSC_type_specifier;
-  }
 
   bool EnteringContext = (DSContext == DeclSpecContext::DSC_class ||
                           DSContext == DeclSpecContext::DSC_top_level);

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -1,21 +1,21 @@
-// RUN: %clang_cc1 -std=c++98 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14
-// RUN: %clang_cc1 -std=c++11 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14
-// RUN: %clang_cc1 -std=c++14 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14
-// RUN: %clang_cc1 -std=c++17 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx17
-// RUN: %clang_cc1 -std=c++20 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
-// RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
-// RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++98 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++11 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++14 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++17 -pedantic-errors %s -verify=expected,since-cxx17,cxx98-17
+// RUN: %clang_cc1 -std=c++20 -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++23 -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++2c -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
 
 // cwg2406 is in cwg2406.cpp
 
 namespace cwg2413 { // cwg2413: 23
-#if __cplusplus >= 202002L
 template <typename T>
 struct S {
   operator T::R();
+  // cxx98-17-error@-1 {{missing 'typename' prior to dependent type name 'T::R' is a C++20 extension}}
   void f() { operator T::R(); }
+  // cxx98-17-error@-1 {{missing 'typename' prior to dependent type name 'T::R' is a C++20 extension}}
 };
-#endif
 } // namespace cwg2413
 
 namespace cwg2428 { // cwg2428: 19

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -std=c++98 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
-// RUN: %clang_cc1 -std=c++11 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
-// RUN: %clang_cc1 -std=c++14 -pedantic-errors %s -verify=expected,cxx98-14,cxx98-17
-// RUN: %clang_cc1 -std=c++17 -pedantic-errors %s -verify=expected,since-cxx17,cxx98-17
-// RUN: %clang_cc1 -std=c++20 -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
-// RUN: %clang_cc1 -std=c++23 -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
-// RUN: %clang_cc1 -std=c++2c -pedantic-errors %s -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++98 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++11 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++14 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,cxx98-14,cxx98-17
+// RUN: %clang_cc1 -std=c++17 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx17,cxx98-17
+// RUN: %clang_cc1 -std=c++20 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++23 -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
+// RUN: %clang_cc1 -std=c++2c -fexceptions -fcxx-exceptions -pedantic-errors %s -verify-directives -verify=expected,since-cxx20,since-cxx17
 
 // cwg2406 is in cwg2406.cpp
 

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -8,6 +8,16 @@
 
 // cwg2406 is in cwg2406.cpp
 
+namespace cwg2413 { // cwg2413: 23
+#if __cplusplus >= 202002L
+template <typename T>
+struct S {
+  operator T::R();
+  void f() { operator T::R(); }
+};
+#endif
+} // namespace cwg2413
+
 namespace cwg2428 { // cwg2428: 19
 #if __cplusplus >= 202002L
 template <typename>

--- a/clang/test/CXX/temp/temp.res/p4.cpp
+++ b/clang/test/CXX/temp/temp.res/p4.cpp
@@ -157,8 +157,8 @@ template int Test<X>;
 
 template<typename T> struct A {
   enum E : T::type {}; // expected-error{{missing 'typename'}}
-  operator T::type() {} // expected-error{{missing 'typename'}}
-  void f() { this->operator T::type(); } // expected-error{{missing 'typename'}}
+  operator T::type() {}
+  void f() { this->operator T::type(); }
 };
 
 template<typename T>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -16684,7 +16684,7 @@
     <td>[<a href="https://wg21.link/temp.res">temp.res</a>]</td>
     <td>CD6</td>
     <td><TT>typename</TT> in <I>conversion-function-id</I>s</td>
-    <td class="full" align="center">Clang 23</td>
+    <td class="unreleased" align="center">Clang 23</td>
   </tr>
   <tr id="2414">
     <td><a href="https://cplusplus.github.io/CWG/issues/2414.html">2414</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -16684,7 +16684,7 @@
     <td>[<a href="https://wg21.link/temp.res">temp.res</a>]</td>
     <td>CD6</td>
     <td><TT>typename</TT> in <I>conversion-function-id</I>s</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 23</td>
   </tr>
   <tr id="2414">
     <td><a href="https://cplusplus.github.io/CWG/issues/2414.html">2414</a></td>


### PR DESCRIPTION
Link: [CWG2413](https://wg21.link/cwg2413). This DR was resolved by [P1787R6](https://wg21.link/P1787R6) by adding the following wording to [[temp.res.general]/4](https://eel.is/c++draft/temp.res.general#4):

> A [type-only context](https://eel.is/c++draft/temp.res.general#def:context,type-only) is defined as follows: A qualified or unqualified name is said to be in a type-only context if it is the terminal name of
> - ...
> - a [type-specifier](https://eel.is/c++draft/dcl.type.general#nt:type-specifier) of a
>   - ...
>   -  [conversion-type-id](https://eel.is/c++draft/class.conv.fct#nt:conversion-type-id),

Towards #54150.