### PR TITLE
[ARM] AnyExtend should return true for isSignExtended

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -9203,25 +9203,20 @@ static bool isExtendedBUILD_VECTOR(SDNode *N, SelectionDAG &DAG,
   return true;
 }
 
-/// isSignExtended - Check if a node is a vector value that is sign-extended
-/// or a constant BUILD_VECTOR with sign-extended elements.
+/// isSignExtended - Check if a node is a vector value that is sign-extended (or
+/// any-extended) or a constant BUILD_VECTOR with sign-extended elements.
 static bool isSignExtended(SDNode *N, SelectionDAG &DAG) {
-  if (N->getOpcode() == ISD::SIGN_EXTEND || ISD::isSEXTLoad(N))
-    return true;
-  if (isExtendedBUILD_VECTOR(N, DAG, true))
-    return true;
-  return false;
+  return N->getOpcode() == ISD::SIGN_EXTEND ||
+         N->getOpcode() == ISD::ANY_EXTEND || ISD::isSEXTLoad(N) ||
+         isExtendedBUILD_VECTOR(N, DAG, true);
 }
 
 /// isZeroExtended - Check if a node is a vector value that is zero-extended (or
 /// any-extended) or a constant BUILD_VECTOR with zero-extended elements.
 static bool isZeroExtended(SDNode *N, SelectionDAG &DAG) {
-  if (N->getOpcode() == ISD::ZERO_EXTEND || N->getOpcode() == ISD::ANY_EXTEND ||
-      ISD::isZEXTLoad(N))
-    return true;
-  if (isExtendedBUILD_VECTOR(N, DAG, false))
-    return true;
-  return false;
+  return N->getOpcode() == ISD::ZERO_EXTEND ||
+         N->getOpcode() == ISD::ANY_EXTEND || ISD::isZEXTLoad(N) ||
+         isExtendedBUILD_VECTOR(N, DAG, false);
 }
 
 static EVT getExtensionTo64Bits(const EVT &OrigVT) {

--- a/llvm/test/CodeGen/ARM/lowerMUL-newload.ll
+++ b/llvm/test/CodeGen/ARM/lowerMUL-newload.ll
@@ -4,7 +4,7 @@
 define arm_aapcs_vfpcc <4 x i16> @mla_args(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2) {
 ; CHECK-LABEL: mla_args:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmull.u16 q8, d1, d0
+; CHECK-NEXT:    vmull.s16 q8, d1, d0
 ; CHECK-NEXT:    vaddw.u16 q8, q8, d2
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
@@ -50,8 +50,8 @@ entry:
 define arm_aapcs_vfpcc <4 x i16> @addmul_args(<4 x i16> %vec0, <4 x i16> %vec1, <4 x i16> %vec2) {
 ; CHECK-LABEL: addmul_args:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmull.u16 q8, d1, d2
-; CHECK-NEXT:    vmlal.u16 q8, d0, d2
+; CHECK-NEXT:    vmull.s16 q8, d1, d2
+; CHECK-NEXT:    vmlal.s16 q8, d0, d2
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
 entry:

--- a/llvm/test/CodeGen/ARM/vmla.ll
+++ b/llvm/test/CodeGen/ARM/vmla.ll
@@ -156,7 +156,7 @@ define <2 x i64> @vmlalu32(<2 x i64> %A, <2 x i32> %B, <2 x i32> %C) nounwind {
 define <8 x i16> @vmlala8(<8 x i16> %A, <8 x i8> %B, <8 x i8> %C) nounwind {
 ; CHECK-LABEL: vmlala8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlal.u8 q0, d2, d3
+; CHECK-NEXT:    vmlal.s8 q0, d2, d3
 ; CHECK-NEXT:    vbic.i16 q0, #0xff00
 ; CHECK-NEXT:    bx lr
   %tmp4 = zext <8 x i8> %B to <8 x i16>
@@ -170,7 +170,7 @@ define <8 x i16> @vmlala8(<8 x i16> %A, <8 x i8> %B, <8 x i8> %C) nounwind {
 define <4 x i32> @vmlala16(<4 x i32> %A, <4 x i16> %B, <4 x i16> %C) nounwind {
 ; CHECK-LABEL: vmlala16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlal.u16 q0, d2, d3
+; CHECK-NEXT:    vmlal.s16 q0, d2, d3
 ; CHECK-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -185,7 +185,7 @@ define <4 x i32> @vmlala16(<4 x i32> %A, <4 x i16> %B, <4 x i16> %C) nounwind {
 define <2 x i64> @vmlala32(<2 x i64> %A, <2 x i32> %B, <2 x i32> %C) nounwind {
 ; CHECK-LABEL: vmlala32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlal.u32 q0, d2, d3
+; CHECK-NEXT:    vmlal.s32 q0, d2, d3
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -256,7 +256,7 @@ entry:
 define arm_aapcs_vfpcc <4 x i32> @test_vmlal_lanea16(<4 x i32> %arg0_uint32x4_t, <4 x i16> %arg1_uint16x4_t, <4 x i16> %arg2_uint16x4_t) nounwind readnone {
 ; CHECK-LABEL: test_vmlal_lanea16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmlal.u16 q0, d2, d3[1]
+; CHECK-NEXT:    vmlal.s16 q0, d2, d3[1]
 ; CHECK-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -273,7 +273,7 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @test_vmlal_lanea32(<2 x i64> %arg0_uint64x2_t, <2 x i32> %arg1_uint32x2_t, <2 x i32> %arg2_uint32x2_t) nounwind readnone {
 ; CHECK-LABEL: test_vmlal_lanea32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmlal.u32 q0, d2, d3[1]
+; CHECK-NEXT:    vmlal.s32 q0, d2, d3[1]
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr

--- a/llvm/test/CodeGen/ARM/vmls.ll
+++ b/llvm/test/CodeGen/ARM/vmls.ll
@@ -156,7 +156,7 @@ define <2 x i64> @vmlslu32(<2 x i64> %A, <2 x i32> %B, <2 x i32> %C) nounwind {
 define <8 x i16> @vmlsla8(<8 x i16> %A, <8 x i8> %B, <8 x i8> %C) nounwind {
 ; CHECK-LABEL: vmlsla8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlsl.u8 q0, d2, d3
+; CHECK-NEXT:    vmlsl.s8 q0, d2, d3
 ; CHECK-NEXT:    vbic.i16 q0, #0xff00
 ; CHECK-NEXT:    bx lr
   %tmp4 = zext <8 x i8> %B to <8 x i16>
@@ -170,7 +170,7 @@ define <8 x i16> @vmlsla8(<8 x i16> %A, <8 x i8> %B, <8 x i8> %C) nounwind {
 define <4 x i32> @vmlsla16(<4 x i32> %A, <4 x i16> %B, <4 x i16> %C) nounwind {
 ; CHECK-LABEL: vmlsla16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlsl.u16 q0, d2, d3
+; CHECK-NEXT:    vmlsl.s16 q0, d2, d3
 ; CHECK-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -185,7 +185,7 @@ define <4 x i32> @vmlsla16(<4 x i32> %A, <4 x i16> %B, <4 x i16> %C) nounwind {
 define <2 x i64> @vmlsla32(<2 x i64> %A, <2 x i32> %B, <2 x i32> %C) nounwind {
 ; CHECK-LABEL: vmlsla32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmlsl.u32 q0, d2, d3
+; CHECK-NEXT:    vmlsl.s32 q0, d2, d3
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -256,7 +256,7 @@ entry:
 define arm_aapcs_vfpcc <4 x i32> @test_vmlsl_lanea16(<4 x i32> %arg0_uint32x4_t, <4 x i16> %arg1_uint16x4_t, <4 x i16> %arg2_uint16x4_t) nounwind readnone {
 ; CHECK-LABEL: test_vmlsl_lanea16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmlsl.u16 q0, d2, d3[1]
+; CHECK-NEXT:    vmlsl.s16 q0, d2, d3[1]
 ; CHECK-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr
@@ -273,7 +273,7 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @test_vmlsl_lanea32(<2 x i64> %arg0_uint64x2_t, <2 x i32> %arg1_uint32x2_t, <2 x i32> %arg2_uint32x2_t) nounwind readnone {
 ; CHECK-LABEL: test_vmlsl_lanea32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmlsl.u32 q0, d2, d3[1]
+; CHECK-NEXT:    vmlsl.s32 q0, d2, d3[1]
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
 ; CHECK-NEXT:    vand q0, q0, q8
 ; CHECK-NEXT:    bx lr

--- a/llvm/test/CodeGen/ARM/vmul.ll
+++ b/llvm/test/CodeGen/ARM/vmul.ll
@@ -283,7 +283,7 @@ define <2 x i64> @vmullu32_int(<2 x i32> %A, <2 x i32> %B) nounwind {
 define <8 x i16> @vmulla8(<8 x i8> %A, <8 x i8> %B) nounwind {
 ; CHECK-LABEL: vmulla8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmull.u8 q0, d0, d1
+; CHECK-NEXT:    vmull.s8 q0, d0, d1
 ; CHECK-NEXT:    vbic.i16 q0, #0xff00
 ; CHECK-NEXT:    bx lr
 	%tmp3 = zext <8 x i8> %A to <8 x i16>
@@ -296,7 +296,7 @@ define <8 x i16> @vmulla8(<8 x i8> %A, <8 x i8> %B) nounwind {
 define <4 x i32> @vmulla16(<4 x i16> %A, <4 x i16> %B) nounwind {
 ; CHECK-LABEL: vmulla16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmull.u16 q8, d0, d1
+; CHECK-NEXT:    vmull.s16 q8, d0, d1
 ; CHECK-NEXT:    vmov.i32 q9, #0xffff
 ; CHECK-NEXT:    vand q0, q8, q9
 ; CHECK-NEXT:    bx lr
@@ -310,7 +310,7 @@ define <4 x i32> @vmulla16(<4 x i16> %A, <4 x i16> %B) nounwind {
 define <2 x i64> @vmulla32(<2 x i32> %A, <2 x i32> %B) nounwind {
 ; CHECK-LABEL: vmulla32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmull.u32 q8, d0, d1
+; CHECK-NEXT:    vmull.s32 q8, d0, d1
 ; CHECK-NEXT:    vmov.i64 q9, #0xffffffff
 ; CHECK-NEXT:    vand q0, q8, q9
 ; CHECK-NEXT:    bx lr
@@ -429,7 +429,7 @@ entry:
 define arm_aapcs_vfpcc <4 x i32> @test_vmull_lanea16(<4 x i16> %arg0_uint16x4_t, <4 x i16> %arg1_uint16x4_t) nounwind readnone {
 ; CHECK-LABEL: test_vmull_lanea16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmull.u16 q8, d0, d1[1]
+; CHECK-NEXT:    vmull.s16 q8, d0, d1[1]
 ; CHECK-NEXT:    vmov.i32 q9, #0xffff
 ; CHECK-NEXT:    vand q0, q8, q9
 ; CHECK-NEXT:    bx lr
@@ -445,7 +445,7 @@ entry:
 define arm_aapcs_vfpcc <2 x i64> @test_vmull_lanea32(<2 x i32> %arg0_uint32x2_t, <2 x i32> %arg1_uint32x2_t) nounwind readnone {
 ; CHECK-LABEL: test_vmull_lanea32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmull.u32 q8, d0, d1[1]
+; CHECK-NEXT:    vmull.s32 q8, d0, d1[1]
 ; CHECK-NEXT:    vmov.i64 q9, #0xffffffff
 ; CHECK-NEXT:    vand q0, q8, q9
 ; CHECK-NEXT:    bx lr


### PR DESCRIPTION
There is no inherent benefit to return true for isZeroExtended but not isSignExtended.