### PR TITLE
[libcxx][lit] Fix dsl.sh.py test failure on Windows

### DIFF
--- a/libcxx/test/selftest/dsl/dsl.sh.py
+++ b/libcxx/test/selftest/dsl/dsl.sh.py
@@ -143,6 +143,12 @@ class TestSourceBuilds(SetupConfigs):
         self.assertFalse(dsl.sourceBuilds(self.config, source))
 
 
+def line_breaks_conversion(origin):
+    if os.linesep == "\r\n":
+        return origin.replace("\r\n", "\n")
+    return origin
+
+
 class TestProgramOutput(SetupConfigs):
     """
     Tests for libcxx.test.dsl.programOutput
@@ -161,7 +167,8 @@ class TestProgramOutput(SetupConfigs):
         int main(int, char**) { std::printf("FOOBAR\\n"); return 0; }
         """
         self.assertEqual(
-            dsl.programOutput(self.config, source), "FOOBAR%s" % os.linesep
+            line_breaks_conversion(dsl.programOutput(self.config, source)),
+            "FOOBAR\n",
         )
 
     def test_valid_program_returns_no_output(self):
@@ -225,15 +232,15 @@ class TestProgramOutput(SetupConfigs):
             "%{compile_flags}",
             compileFlags + " -DMACRO=1",
         )
-        output1 = dsl.programOutput(self.config, source)
-        self.assertEqual(output1, "MACRO=1%s" % os.linesep)
+        output1 = line_breaks_conversion(dsl.programOutput(self.config, source))
+        self.assertEqual(output1, "MACRO=1\n")
 
         self.config.substitutions[compileFlagsIndex] = (
             "%{compile_flags}",
             compileFlags + " -DMACRO=2",
         )
-        output2 = dsl.programOutput(self.config, source)
-        self.assertEqual(output2, "MACRO=2%s" % os.linesep)
+        output2 = line_breaks_conversion(dsl.programOutput(self.config, source))
+        self.assertEqual(output2, "MACRO=2\n")
 
     def test_program_stderr_is_not_conflated_with_stdout(self):
         # Run a program that produces stdout output and stderr output too, making


### PR DESCRIPTION
We are seeing linux runtimes test failures on Windows host after PR #194752 was merged. The runtimes unit test is producing Unix style line break symbol on Windows, causing dsl.sh.py to fail. This patch mitigate this issue by converting Windows style line breaks to Unix style ones to mitigate this issue.