### PR TITLE
[AArch64][GlobalISel] Match G_DUP with undef elements

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Combine.td
+++ b/llvm/lib/Target/AArch64/AArch64Combine.td
@@ -258,10 +258,10 @@ def lower_mulv2s64 : GICombineRule<
 >;
 
 def build_vector_to_dup : GICombineRule<
-  (defs root:$root),
+  (defs root:$root, register_matchinfo:$matchinfo),
   (match (wip_match_opcode G_BUILD_VECTOR):$root,
-          [{ return matchBuildVectorToDup(*${root}, MRI); }]),
-  (apply [{ applyBuildVectorToDup(*${root}, MRI, B); }])
+          [{ return matchBuildVectorToDup(*${root}, ${matchinfo}, MRI); }]),
+  (apply [{ applyBuildVectorToDup(*${root}, ${matchinfo}, MRI, B); }])
 >;
 
 def build_vector_to_vector_insert : GICombineRule<

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -846,7 +846,8 @@ void applyScalarizeVectorUnmerge(MachineInstr &MI, MachineRegisterInfo &MRI,
   MI.eraseFromParent();
 }
 
-bool matchBuildVectorToDup(MachineInstr &MI, MachineRegisterInfo &MRI) {
+bool matchBuildVectorToDup(MachineInstr &MI, Register &Src,
+                           MachineRegisterInfo &MRI) {
   assert(MI.getOpcode() == TargetOpcode::G_BUILD_VECTOR);
 
   // Later, during selection, we'll try to match imported patterns using
@@ -855,14 +856,30 @@ bool matchBuildVectorToDup(MachineInstr &MI, MachineRegisterInfo &MRI) {
   if (isBuildVectorAllZeros(MI, MRI) || isBuildVectorAllOnes(MI, MRI))
     return false;
 
-  return getAArch64VectorSplat(MI, MRI).has_value();
+  // Find buildvector which always uses the same register or undef. Return true
+  // so long as at least 2 registers were found (not all-undef or only 1
+  // non-undef entry).
+  Register Reg = 0;
+  unsigned NumNonUndef = 0;
+  for (const MachineOperand &Op : drop_begin(MI.operands())) {
+    if (getOpcodeDef<GImplicitDef>(Op.getReg(), MRI))
+      continue;
+
+    if (!Reg)
+      Reg = Op.getReg();
+    else if (Op.getReg() != Reg)
+      return false;
+    NumNonUndef++;
+  }
+
+  Src = Reg;
+  return Reg && NumNonUndef > 1;
 }
 
-void applyBuildVectorToDup(MachineInstr &MI, MachineRegisterInfo &MRI,
-                           MachineIRBuilder &B) {
+void applyBuildVectorToDup(MachineInstr &MI, Register Src,
+                           MachineRegisterInfo &MRI, MachineIRBuilder &B) {
   B.setInstrAndDebugLoc(MI);
-  B.buildInstr(AArch64::G_DUP, {MI.getOperand(0).getReg()},
-               {MI.getOperand(1).getReg()});
+  B.buildInstr(AArch64::G_DUP, {MI.getOperand(0).getReg()}, {Src});
   MI.eraseFromParent();
 }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-lowering-build-vector-to-dup.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-lowering-build-vector-to-dup.mir
@@ -12,17 +12,16 @@ body:             |
     ; LOWER-LABEL: name: same_reg
     ; LOWER: liveins: $d0
     ; LOWER-NEXT: {{  $}}
-    ; LOWER-NEXT: %r:_(i8) = G_IMPLICIT_DEF
-    ; LOWER-NEXT: %build_vector:_(<8 x i8>) = G_DUP %r(i8)
+    ; LOWER-NEXT: [[DEF:%[0-9]+]]:_(<8 x i8>) = G_IMPLICIT_DEF
+    ; LOWER-NEXT: %build_vector:_(<8 x i8>) = COPY [[DEF]](<8 x i8>)
     ; LOWER-NEXT: $d0 = COPY %build_vector(<8 x i8>)
     ; LOWER-NEXT: RET_ReallyLR implicit $d0
     ;
     ; SELECT-LABEL: name: same_reg
     ; SELECT: liveins: $d0
     ; SELECT-NEXT: {{  $}}
-    ; SELECT-NEXT: %r:gpr32 = IMPLICIT_DEF
-    ; SELECT-NEXT: %build_vector:fpr64 = DUPv8i8gpr %r
-    ; SELECT-NEXT: $d0 = COPY %build_vector
+    ; SELECT-NEXT: [[DEF:%[0-9]+]]:fpr64 = IMPLICIT_DEF
+    ; SELECT-NEXT: $d0 = COPY [[DEF]]
     ; SELECT-NEXT: RET_ReallyLR implicit $d0
     %r:_(i8) = G_IMPLICIT_DEF
     %build_vector:_(<8 x i8>) = G_BUILD_VECTOR %r, %r, %r, %r, %r, %r, %r, %r

--- a/llvm/test/CodeGen/AArch64/arm64-vhadd.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vhadd.ll
@@ -2,9 +2,9 @@
 ; RUN: llc < %s -mtriple=arm64-eabi -aarch64-neon-syntax=apple | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc < %s -mtriple=arm64-eabi -aarch64-neon-syntax=apple -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:	 warning: Instruction selection used fallback path for ext_via_i19
-; CHECK-GI-NEXT: warning: Instruction selection used fallback path for srhadd_v2i32_trunc
-; CHECK-GI-NEXT: warning: Instruction selection used fallback path for urhadd_v2i32_trunc
+; CHECK-GI:       warning: Instruction selection used fallback path for ext_via_i19
+; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for srhadd_v2i32_trunc
+; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for urhadd_v2i32_trunc
 
 define <8 x i8> @shadd8b(ptr nocapture readonly %A, ptr nocapture readonly %B) {
 ; CHECK-LABEL: shadd8b:
@@ -1197,15 +1197,11 @@ define <2 x i16> @hadd8x2_sext_asr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: hadd8x2_sext_asr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    shl.2s v1, v1, #24
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    shl.2s v0, v0, #24
-; CHECK-GI-NEXT:    fmov s2, w8
 ; CHECK-GI-NEXT:    sshr.2s v1, v1, #24
-; CHECK-GI-NEXT:    mov.h v2[1], w8
 ; CHECK-GI-NEXT:    ssra.2s v1, v0, #24
 ; CHECK-GI-NEXT:    uzp1.4h v0, v1, v0
-; CHECK-GI-NEXT:    neg.4h v1, v2
-; CHECK-GI-NEXT:    sshl.4h v0, v0, v1
+; CHECK-GI-NEXT:    sshr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1228,15 +1224,11 @@ define <2 x i16> @hadd8x2_zext_asr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: hadd8x2_zext_asr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    movi d2, #0x0000ff000000ff
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    and.8b v0, v0, v2
 ; CHECK-GI-NEXT:    and.8b v1, v1, v2
-; CHECK-GI-NEXT:    fmov s2, w8
 ; CHECK-GI-NEXT:    add.2s v0, v0, v1
-; CHECK-GI-NEXT:    mov.h v2[1], w8
 ; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
-; CHECK-GI-NEXT:    neg.4h v1, v2
-; CHECK-GI-NEXT:    ushl.4h v0, v0, v1
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1262,15 +1254,11 @@ define <2 x i16> @hadd8x2_sext_lsr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: hadd8x2_sext_lsr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    shl.2s v1, v1, #24
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    shl.2s v0, v0, #24
-; CHECK-GI-NEXT:    fmov s2, w8
 ; CHECK-GI-NEXT:    sshr.2s v1, v1, #24
-; CHECK-GI-NEXT:    mov.h v2[1], w8
 ; CHECK-GI-NEXT:    ssra.2s v1, v0, #24
 ; CHECK-GI-NEXT:    uzp1.4h v0, v1, v0
-; CHECK-GI-NEXT:    neg.4h v1, v2
-; CHECK-GI-NEXT:    ushl.4h v0, v0, v1
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1293,15 +1281,11 @@ define <2 x i16> @hadd8x2_zext_lsr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: hadd8x2_zext_lsr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    movi d2, #0x0000ff000000ff
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    and.8b v0, v0, v2
 ; CHECK-GI-NEXT:    and.8b v1, v1, v2
-; CHECK-GI-NEXT:    fmov s2, w8
 ; CHECK-GI-NEXT:    add.2s v0, v0, v1
-; CHECK-GI-NEXT:    mov.h v2[1], w8
 ; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
-; CHECK-GI-NEXT:    neg.4h v1, v2
-; CHECK-GI-NEXT:    ushl.4h v0, v0, v1
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1436,16 +1420,12 @@ define <2 x i16> @rhadd8x2_sext_asr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    shl.2s v1, v1, #24
 ; CHECK-GI-NEXT:    shl.2s v0, v0, #24
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    movi.2s v2, #1
 ; CHECK-GI-NEXT:    sshr.2s v1, v1, #24
 ; CHECK-GI-NEXT:    ssra.2s v1, v0, #24
-; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov.h v0[1], w8
-; CHECK-GI-NEXT:    add.2s v1, v1, v2
-; CHECK-GI-NEXT:    uzp1.4h v1, v1, v0
-; CHECK-GI-NEXT:    neg.4h v0, v0
-; CHECK-GI-NEXT:    sshl.4h v0, v1, v0
+; CHECK-GI-NEXT:    add.2s v0, v1, v2
+; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
+; CHECK-GI-NEXT:    sshr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1469,17 +1449,13 @@ define <2 x i16> @rhadd8x2_zext_asr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: rhadd8x2_zext_asr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    movi d2, #0x0000ff000000ff
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    and.8b v0, v0, v2
 ; CHECK-GI-NEXT:    and.8b v1, v1, v2
 ; CHECK-GI-NEXT:    movi.2s v2, #1
 ; CHECK-GI-NEXT:    add.2s v0, v0, v1
-; CHECK-GI-NEXT:    fmov s1, w8
 ; CHECK-GI-NEXT:    add.2s v0, v0, v2
-; CHECK-GI-NEXT:    mov.h v1[1], w8
 ; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
-; CHECK-GI-NEXT:    neg.4h v1, v1
-; CHECK-GI-NEXT:    ushl.4h v0, v0, v1
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1509,16 +1485,12 @@ define <2 x i16> @rhadd8x2_sext_lsr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    shl.2s v1, v1, #24
 ; CHECK-GI-NEXT:    shl.2s v0, v0, #24
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    movi.2s v2, #1
 ; CHECK-GI-NEXT:    sshr.2s v1, v1, #24
 ; CHECK-GI-NEXT:    ssra.2s v1, v0, #24
-; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov.h v0[1], w8
-; CHECK-GI-NEXT:    add.2s v1, v1, v2
-; CHECK-GI-NEXT:    uzp1.4h v1, v1, v0
-; CHECK-GI-NEXT:    neg.4h v0, v0
-; CHECK-GI-NEXT:    ushl.4h v0, v1, v0
+; CHECK-GI-NEXT:    add.2s v0, v1, v2
+; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
@@ -1542,17 +1514,13 @@ define <2 x i16> @rhadd8x2_zext_lsr(<2 x i8> %src1, <2 x i8> %src2) {
 ; CHECK-GI-LABEL: rhadd8x2_zext_lsr:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    movi d2, #0x0000ff000000ff
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    and.8b v0, v0, v2
 ; CHECK-GI-NEXT:    and.8b v1, v1, v2
 ; CHECK-GI-NEXT:    movi.2s v2, #1
 ; CHECK-GI-NEXT:    add.2s v0, v0, v1
-; CHECK-GI-NEXT:    fmov s1, w8
 ; CHECK-GI-NEXT:    add.2s v0, v0, v2
-; CHECK-GI-NEXT:    mov.h v1[1], w8
 ; CHECK-GI-NEXT:    uzp1.4h v0, v0, v0
-; CHECK-GI-NEXT:    neg.4h v1, v1
-; CHECK-GI-NEXT:    ushl.4h v0, v0, v1
+; CHECK-GI-NEXT:    ushr.4h v0, v0, #1
 ; CHECK-GI-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/cttz.ll
+++ b/llvm/test/CodeGen/AArch64/cttz.ll
@@ -61,23 +61,20 @@ define void @v3i8(ptr %p1) {
 ;
 ; CHECK-GI-LABEL: v3i8:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w9, [x0]
-; CHECK-GI-NEXT:    mov w8, #65535 // =0xffff
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    fmov s0, w9
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov b1, v0.b[1]
-; CHECK-GI-NEXT:    mov v2.h[2], w8
-; CHECK-GI-NEXT:    add x8, x0, #1
-; CHECK-GI-NEXT:    fmov w9, s1
-; CHECK-GI-NEXT:    mov b1, v0.b[2]
-; CHECK-GI-NEXT:    mov v0.h[1], w9
-; CHECK-GI-NEXT:    fmov w9, s1
-; CHECK-GI-NEXT:    mov v0.h[2], w9
+; CHECK-GI-NEXT:    ldr w8, [x0]
+; CHECK-GI-NEXT:    movi d0, #0xffffffffffffffff
 ; CHECK-GI-NEXT:    add x9, x0, #2
-; CHECK-GI-NEXT:    eor v1.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    add v0.4h, v0.4h, v2.4h
-; CHECK-GI-NEXT:    and v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    fmov s1, w8
+; CHECK-GI-NEXT:    mov b2, v1.b[1]
+; CHECK-GI-NEXT:    fmov w8, s2
+; CHECK-GI-NEXT:    mov b2, v1.b[2]
+; CHECK-GI-NEXT:    mov v1.h[1], w8
+; CHECK-GI-NEXT:    fmov w8, s2
+; CHECK-GI-NEXT:    mov v1.h[2], w8
+; CHECK-GI-NEXT:    add x8, x0, #1
+; CHECK-GI-NEXT:    eor v2.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    add v0.4h, v1.4h, v0.4h
+; CHECK-GI-NEXT:    and v0.8b, v2.8b, v0.8b
 ; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v0.8b
 ; CHECK-GI-NEXT:    cnt v0.8b, v0.8b
 ; CHECK-GI-NEXT:    st1 { v0.b }[0], [x0]
@@ -251,13 +248,10 @@ define void @v3i16(ptr %p1) {
 ;
 ; CHECK-GI-LABEL: v3i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #65535 // =0xffff
+; CHECK-GI-NEXT:    movi d0, #0xffffffffffffffff
 ; CHECK-GI-NEXT:    ldr d1, [x0]
-; CHECK-GI-NEXT:    add x9, x0, #4
-; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov v0.h[1], w8
-; CHECK-GI-NEXT:    mov v0.h[2], w8
 ; CHECK-GI-NEXT:    add x8, x0, #2
+; CHECK-GI-NEXT:    add x9, x0, #4
 ; CHECK-GI-NEXT:    eor v2.8b, v1.8b, v0.8b
 ; CHECK-GI-NEXT:    add v0.4h, v1.4h, v0.4h
 ; CHECK-GI-NEXT:    and v0.8b, v2.8b, v0.8b
@@ -376,10 +370,7 @@ define <3 x i32> @v3i32(<3 x i32> %d) {
 ;
 ; CHECK-GI-LABEL: v3i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    movi v1.2d, #0xffffffffffffffff
 ; CHECK-GI-NEXT:    eor v2.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    add v0.4s, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    and v0.16b, v2.16b, v0.16b

--- a/llvm/test/CodeGen/AArch64/dup.ll
+++ b/llvm/test/CodeGen/AArch64/dup.ll
@@ -2731,3 +2731,12 @@ define <16 x i4> @v8i4_to_v16i8(<8 x i4> %a) {
   %r = shufflevector <8 x i4> %a, <8 x i4> poison, <16 x i32> zeroinitializer
   ret <16 x i4> %r
 }
+
+define <4 x i16> @dup_zero_undef_first() {
+; CHECK-LABEL: dup_zero_undef_first:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
+; CHECK-NEXT:    ret
+    %i = insertelement <4 x i16> zeroinitializer, i16 undef, i32 0
+    ret <4 x i16> %i
+}

--- a/llvm/test/CodeGen/AArch64/fadd-combines.ll
+++ b/llvm/test/CodeGen/AArch64/fadd-combines.ll
@@ -128,9 +128,7 @@ define <4 x float> @fmulnegtwo_vec_undefs(<4 x float> %a, <4 x float> %b) {
 ; CHECK-GI-LABEL: fmulnegtwo_vec_undefs:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    fmov s2, #-2.00000000
-; CHECK-GI-NEXT:    mov v3.s[1], v2.s[0]
-; CHECK-GI-NEXT:    mov v3.s[3], v2.s[0]
-; CHECK-GI-NEXT:    fmul v1.4s, v1.4s, v3.4s
+; CHECK-GI-NEXT:    fmul v1.4s, v1.4s, v2.s[0]
 ; CHECK-GI-NEXT:    fadd v0.4s, v0.4s, v1.4s
 ; CHECK-GI-NEXT:    ret
   %mul = fmul <4 x float> %b, <float undef, float -2.0, float undef, float -2.0>
@@ -148,10 +146,7 @@ define <4 x float> @fmulnegtwo_vec_commute_undefs(<4 x float> %a, <4 x float> %b
 ; CHECK-GI-LABEL: fmulnegtwo_vec_commute_undefs:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    fmov s2, #-2.00000000
-; CHECK-GI-NEXT:    fmov s3, #-2.00000000
-; CHECK-GI-NEXT:    mov v3.s[2], v2.s[0]
-; CHECK-GI-NEXT:    mov v3.s[3], v2.s[0]
-; CHECK-GI-NEXT:    fmul v1.4s, v1.4s, v3.4s
+; CHECK-GI-NEXT:    fmul v1.4s, v1.4s, v2.s[0]
 ; CHECK-GI-NEXT:    fadd v0.4s, v1.4s, v0.4s
 ; CHECK-GI-NEXT:    ret
   %mul = fmul <4 x float> %b, <float -2.0, float undef, float -2.0, float -2.0>

--- a/llvm/test/CodeGen/AArch64/fcmp.ll
+++ b/llvm/test/CodeGen/AArch64/fcmp.ll
@@ -925,26 +925,18 @@ define <3 x i32> @v3f64_i32(<3 x double> %a, <3 x double> %b, <3 x i32> %d, <3 x
 ; CHECK-GI-NEXT:    // kill: def $d3 killed $d3 def $q3
 ; CHECK-GI-NEXT:    // kill: def $d1 killed $d1 def $q1
 ; CHECK-GI-NEXT:    // kill: def $d4 killed $d4 def $q4
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
 ; CHECK-GI-NEXT:    fcmp d2, d5
 ; CHECK-GI-NEXT:    mov v0.d[1], v1.d[0]
 ; CHECK-GI-NEXT:    mov v3.d[1], v4.d[0]
+; CHECK-GI-NEXT:    cset w8, mi
 ; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    cset w9, mi
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    fmov s2, w9
 ; CHECK-GI-NEXT:    fcmgt v0.2d, v3.2d, v0.2d
-; CHECK-GI-NEXT:    mov v1.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #-1 // =0xffffffff
 ; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
-; CHECK-GI-NEXT:    mov v0.d[1], v2.d[0]
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.s[1], w8
-; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    mov v2.s[2], w8
-; CHECK-GI-NEXT:    sshl v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    eor v1.16b, v0.16b, v2.16b
+; CHECK-GI-NEXT:    mov v0.d[1], v1.d[0]
+; CHECK-GI-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
+; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
+; CHECK-GI-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    and v0.16b, v6.16b, v0.16b
 ; CHECK-GI-NEXT:    and v1.16b, v7.16b, v1.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
@@ -998,18 +990,10 @@ define <3 x float> @v3f32_float(<3 x float> %a, <3 x float> %b, <3 x float> %d, 
 ;
 ; CHECK-GI-LABEL: v3f32_float:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
 ; CHECK-GI-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    mov v4.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NEXT:    sshl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
+; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    and v0.16b, v2.16b, v0.16b
 ; CHECK-GI-NEXT:    and v1.16b, v3.16b, v1.16b
@@ -1076,18 +1060,10 @@ define <3 x i32> @v3f32_i32(<3 x float> %a, <3 x float> %b, <3 x i32> %d, <3 x i
 ;
 ; CHECK-GI-LABEL: v3f32_i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
 ; CHECK-GI-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    mov v4.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NEXT:    sshl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
+; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    and v0.16b, v2.16b, v0.16b
 ; CHECK-GI-NEXT:    and v1.16b, v3.16b, v1.16b
@@ -1154,39 +1130,23 @@ define <7 x half> @v7f16_half(<7 x half> %a, <7 x half> %b, <7 x half> %d, <7 x 
 ;
 ; CHECK-GI-NOFP16-LABEL: v7f16_half:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    mov w8, #15 // =0xf
 ; CHECK-GI-NOFP16-NEXT:    mov v4.h[0], v0.h[4]
-; CHECK-GI-NOFP16-NEXT:    mov v6.h[0], v1.h[4]
-; CHECK-GI-NOFP16-NEXT:    fmov s5, w8
-; CHECK-GI-NOFP16-NEXT:    mov w9, #65535 // =0xffff
-; CHECK-GI-NOFP16-NEXT:    fmov s7, w9
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[1], w8
+; CHECK-GI-NOFP16-NEXT:    mov v5.h[0], v1.h[4]
 ; CHECK-GI-NOFP16-NEXT:    mov v4.h[1], v0.h[5]
-; CHECK-GI-NOFP16-NEXT:    mov v6.h[1], v1.h[5]
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[1], w9
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[2], w8
+; CHECK-GI-NOFP16-NEXT:    mov v5.h[1], v1.h[5]
 ; CHECK-GI-NOFP16-NEXT:    mov v4.h[2], v0.h[6]
-; CHECK-GI-NOFP16-NEXT:    mov v6.h[2], v1.h[6]
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[2], w9
+; CHECK-GI-NOFP16-NEXT:    mov v5.h[2], v1.h[6]
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[3], w8
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v4.4s, v4.4h
-; CHECK-GI-NOFP16-NEXT:    fcvtl v6.4s, v6.4h
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[3], w9
+; CHECK-GI-NOFP16-NEXT:    fcvtl v5.4s, v5.4h
 ; CHECK-GI-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[4], w8
-; CHECK-GI-NOFP16-NEXT:    fcmgt v1.4s, v6.4s, v4.4s
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[4], w9
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[5], w8
+; CHECK-GI-NOFP16-NEXT:    fcmgt v1.4s, v5.4s, v4.4s
 ; CHECK-GI-NOFP16-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[5], w9
-; CHECK-GI-NOFP16-NEXT:    mov v5.h[6], w8
-; CHECK-GI-NOFP16-NEXT:    mov v7.h[6], w9
-; CHECK-GI-NOFP16-NEXT:    ushl v0.8h, v0.8h, v5.8h
-; CHECK-GI-NOFP16-NEXT:    neg v1.8h, v5.8h
-; CHECK-GI-NOFP16-NEXT:    sshl v0.8h, v0.8h, v1.8h
-; CHECK-GI-NOFP16-NEXT:    eor v1.16b, v0.16b, v7.16b
+; CHECK-GI-NOFP16-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-NOFP16-NEXT:    shl v0.8h, v0.8h, #15
+; CHECK-GI-NOFP16-NEXT:    cmlt v0.8h, v0.8h, #0
+; CHECK-GI-NOFP16-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-NOFP16-NEXT:    and v0.16b, v2.16b, v0.16b
 ; CHECK-GI-NOFP16-NEXT:    and v1.16b, v3.16b, v1.16b
 ; CHECK-GI-NOFP16-NEXT:    orr v0.16b, v0.16b, v1.16b
@@ -1194,27 +1154,11 @@ define <7 x half> @v7f16_half(<7 x half> %a, <7 x half> %b, <7 x half> %d, <7 x 
 ;
 ; CHECK-GI-FP16-LABEL: v7f16_half:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-FP16-NEXT:    mov w9, #65535 // =0xffff
 ; CHECK-GI-FP16-NEXT:    fcmgt v0.8h, v1.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fmov s4, w8
-; CHECK-GI-FP16-NEXT:    fmov s5, w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[1], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[1], w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[2], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[2], w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[3], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[3], w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[4], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[4], w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[5], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[5], w9
-; CHECK-GI-FP16-NEXT:    mov v4.h[6], w8
-; CHECK-GI-FP16-NEXT:    mov v5.h[6], w9
-; CHECK-GI-FP16-NEXT:    ushl v0.8h, v0.8h, v4.8h
-; CHECK-GI-FP16-NEXT:    neg v1.8h, v4.8h
-; CHECK-GI-FP16-NEXT:    sshl v0.8h, v0.8h, v1.8h
-; CHECK-GI-FP16-NEXT:    eor v1.16b, v0.16b, v5.16b
+; CHECK-GI-FP16-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-FP16-NEXT:    shl v0.8h, v0.8h, #15
+; CHECK-GI-FP16-NEXT:    cmlt v0.8h, v0.8h, #0
+; CHECK-GI-FP16-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-FP16-NEXT:    and v0.16b, v2.16b, v0.16b
 ; CHECK-GI-FP16-NEXT:    and v1.16b, v3.16b, v1.16b
 ; CHECK-GI-FP16-NEXT:    orr v0.16b, v0.16b, v1.16b
@@ -1448,57 +1392,49 @@ define <7 x i32> @v7f16_i32(<7 x half> %a, <7 x half> %b, <7 x i32> %d, <7 x i32
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    mov v2.h[0], v0.h[4]
 ; CHECK-GI-NOFP16-NEXT:    mov v3.h[0], v1.h[4]
-; CHECK-GI-NOFP16-NEXT:    mov w8, #31 // =0x1f
-; CHECK-GI-NOFP16-NEXT:    fmov s4, w8
-; CHECK-GI-NOFP16-NEXT:    fmov s7, w0
-; CHECK-GI-NOFP16-NEXT:    ldr s5, [sp]
-; CHECK-GI-NOFP16-NEXT:    fmov s16, w7
-; CHECK-GI-NOFP16-NEXT:    fmov s18, w4
-; CHECK-GI-NOFP16-NEXT:    ldr s17, [sp, #32]
-; CHECK-GI-NOFP16-NEXT:    ldr s6, [sp, #8]
+; CHECK-GI-NOFP16-NEXT:    ldr s4, [sp]
+; CHECK-GI-NOFP16-NEXT:    fmov s5, w7
+; CHECK-GI-NOFP16-NEXT:    fmov s16, w4
+; CHECK-GI-NOFP16-NEXT:    ldr s6, [sp, #24]
+; CHECK-GI-NOFP16-NEXT:    ldr s7, [sp, #32]
+; CHECK-GI-NOFP16-NEXT:    ldr s17, [sp, #16]
 ; CHECK-GI-NOFP16-NEXT:    mov v2.h[1], v0.h[5]
 ; CHECK-GI-NOFP16-NEXT:    mov v3.h[1], v1.h[5]
-; CHECK-GI-NOFP16-NEXT:    mov v4.s[1], w8
-; CHECK-GI-NOFP16-NEXT:    mov v7.s[1], w1
-; CHECK-GI-NOFP16-NEXT:    mov v16.s[1], v5.s[0]
-; CHECK-GI-NOFP16-NEXT:    ldr s5, [sp, #24]
-; CHECK-GI-NOFP16-NEXT:    mov v18.s[1], w5
-; CHECK-GI-NOFP16-NEXT:    mov v5.s[1], v17.s[0]
+; CHECK-GI-NOFP16-NEXT:    mov v5.s[1], v4.s[0]
+; CHECK-GI-NOFP16-NEXT:    ldr s4, [sp, #8]
+; CHECK-GI-NOFP16-NEXT:    mov v16.s[1], w5
+; CHECK-GI-NOFP16-NEXT:    mov v6.s[1], v7.s[0]
+; CHECK-GI-NOFP16-NEXT:    movi v7.2d, #0xffffffffffffffff
 ; CHECK-GI-NOFP16-NEXT:    mov v2.h[2], v0.h[6]
 ; CHECK-GI-NOFP16-NEXT:    mov v3.h[2], v1.h[6]
-; CHECK-GI-NOFP16-NEXT:    mov v4.s[2], w8
-; CHECK-GI-NOFP16-NEXT:    mov w8, #-1 // =0xffffffff
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-GI-NOFP16-NEXT:    mov v7.s[2], w2
-; CHECK-GI-NOFP16-NEXT:    mov v16.s[2], v6.s[0]
-; CHECK-GI-NOFP16-NEXT:    ldr s6, [sp, #40]
-; CHECK-GI-NOFP16-NEXT:    mov v18.s[2], w6
+; CHECK-GI-NOFP16-NEXT:    mov v5.s[2], v4.s[0]
+; CHECK-GI-NOFP16-NEXT:    ldr s4, [sp, #40]
+; CHECK-GI-NOFP16-NEXT:    mov v16.s[2], w6
+; CHECK-GI-NOFP16-NEXT:    mov v6.s[2], v4.s[0]
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v2.4s, v2.4h
 ; CHECK-GI-NOFP16-NEXT:    fcvtl v3.4s, v3.4h
-; CHECK-GI-NOFP16-NEXT:    mov v5.s[2], v6.s[0]
 ; CHECK-GI-NOFP16-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-GI-NOFP16-NEXT:    mov v7.s[3], w3
+; CHECK-GI-NOFP16-NEXT:    mov v5.s[3], v17.s[0]
 ; CHECK-GI-NOFP16-NEXT:    fcmgt v2.4s, v3.4s, v2.4s
-; CHECK-GI-NOFP16-NEXT:    fmov s3, w8
-; CHECK-GI-NOFP16-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NOFP16-NEXT:    ushl v2.4s, v2.4s, v4.4s
-; CHECK-GI-NOFP16-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NOFP16-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NOFP16-NEXT:    sshl v2.4s, v2.4s, v4.4s
-; CHECK-GI-NOFP16-NEXT:    ldr s4, [sp, #16]
-; CHECK-GI-NOFP16-NEXT:    mov v16.s[3], v4.s[0]
-; CHECK-GI-NOFP16-NEXT:    eor v1.16b, v2.16b, v3.16b
-; CHECK-GI-NOFP16-NEXT:    and v2.16b, v18.16b, v2.16b
-; CHECK-GI-NOFP16-NEXT:    bsl v0.16b, v7.16b, v16.16b
-; CHECK-GI-NOFP16-NEXT:    and v1.16b, v5.16b, v1.16b
+; CHECK-GI-NOFP16-NEXT:    fmov s3, w0
+; CHECK-GI-NOFP16-NEXT:    mov v3.s[1], w1
+; CHECK-GI-NOFP16-NEXT:    shl v2.4s, v2.4s, #31
+; CHECK-GI-NOFP16-NEXT:    mov v3.s[2], w2
+; CHECK-GI-NOFP16-NEXT:    cmlt v2.4s, v2.4s, #0
+; CHECK-GI-NOFP16-NEXT:    eor v1.16b, v2.16b, v7.16b
+; CHECK-GI-NOFP16-NEXT:    and v2.16b, v16.16b, v2.16b
+; CHECK-GI-NOFP16-NEXT:    mov v3.s[3], w3
+; CHECK-GI-NOFP16-NEXT:    and v1.16b, v6.16b, v1.16b
+; CHECK-GI-NOFP16-NEXT:    bsl v0.16b, v3.16b, v5.16b
 ; CHECK-GI-NOFP16-NEXT:    orr v1.16b, v2.16b, v1.16b
 ; CHECK-GI-NOFP16-NEXT:    mov s2, v0.s[1]
 ; CHECK-GI-NOFP16-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-NOFP16-NEXT:    mov s4, v0.s[3]
-; CHECK-GI-NOFP16-NEXT:    fmov w0, s0
 ; CHECK-GI-NOFP16-NEXT:    mov s5, v1.s[1]
 ; CHECK-GI-NOFP16-NEXT:    mov s6, v1.s[2]
+; CHECK-GI-NOFP16-NEXT:    fmov w0, s0
 ; CHECK-GI-NOFP16-NEXT:    fmov w4, s1
 ; CHECK-GI-NOFP16-NEXT:    fmov w1, s2
 ; CHECK-GI-NOFP16-NEXT:    fmov w2, s3
@@ -1510,60 +1446,52 @@ define <7 x i32> @v7f16_i32(<7 x half> %a, <7 x half> %b, <7 x i32> %d, <7 x i32
 ; CHECK-GI-FP16-LABEL: v7f16_i32:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcmgt v0.8h, v1.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    mov w10, #31 // =0x1f
-; CHECK-GI-FP16-NEXT:    fmov s5, w0
-; CHECK-GI-FP16-NEXT:    fmov s2, w10
-; CHECK-GI-FP16-NEXT:    fmov s6, w7
-; CHECK-GI-FP16-NEXT:    ldr s3, [sp]
-; CHECK-GI-FP16-NEXT:    fmov s17, w4
-; CHECK-GI-FP16-NEXT:    ldr s7, [sp, #24]
-; CHECK-GI-FP16-NEXT:    ldr s16, [sp, #32]
-; CHECK-GI-FP16-NEXT:    mov v5.s[1], w1
+; CHECK-GI-FP16-NEXT:    fmov s3, w0
+; CHECK-GI-FP16-NEXT:    ldr s2, [sp]
+; CHECK-GI-FP16-NEXT:    fmov s4, w7
+; CHECK-GI-FP16-NEXT:    fmov s7, w4
+; CHECK-GI-FP16-NEXT:    ldr s5, [sp, #32]
+; CHECK-GI-FP16-NEXT:    ldr s6, [sp, #8]
+; CHECK-GI-FP16-NEXT:    ldr s16, [sp, #16]
+; CHECK-GI-FP16-NEXT:    mov v3.s[1], w1
 ; CHECK-GI-FP16-NEXT:    umov w8, v0.h[4]
 ; CHECK-GI-FP16-NEXT:    umov w9, v0.h[5]
-; CHECK-GI-FP16-NEXT:    mov v2.s[1], w10
-; CHECK-GI-FP16-NEXT:    mov v6.s[1], v3.s[0]
-; CHECK-GI-FP16-NEXT:    ldr s3, [sp, #8]
-; CHECK-GI-FP16-NEXT:    mov v17.s[1], w5
-; CHECK-GI-FP16-NEXT:    mov v7.s[1], v16.s[0]
-; CHECK-GI-FP16-NEXT:    mov v5.s[2], w2
+; CHECK-GI-FP16-NEXT:    mov v4.s[1], v2.s[0]
+; CHECK-GI-FP16-NEXT:    ldr s2, [sp, #24]
+; CHECK-GI-FP16-NEXT:    mov v7.s[1], w5
+; CHECK-GI-FP16-NEXT:    mov v2.s[1], v5.s[0]
+; CHECK-GI-FP16-NEXT:    movi v5.2d, #0xffffffffffffffff
+; CHECK-GI-FP16-NEXT:    mov v3.s[2], w2
 ; CHECK-GI-FP16-NEXT:    fmov s1, w8
 ; CHECK-GI-FP16-NEXT:    umov w8, v0.h[6]
-; CHECK-GI-FP16-NEXT:    mov v2.s[2], w10
 ; CHECK-GI-FP16-NEXT:    ushll v0.4s, v0.4h, #0
-; CHECK-GI-FP16-NEXT:    mov v6.s[2], v3.s[0]
-; CHECK-GI-FP16-NEXT:    ldr s3, [sp, #40]
-; CHECK-GI-FP16-NEXT:    mov v17.s[2], w6
+; CHECK-GI-FP16-NEXT:    mov v4.s[2], v6.s[0]
+; CHECK-GI-FP16-NEXT:    ldr s6, [sp, #40]
+; CHECK-GI-FP16-NEXT:    mov v7.s[2], w6
 ; CHECK-GI-FP16-NEXT:    mov v1.s[1], w9
-; CHECK-GI-FP16-NEXT:    mov v7.s[2], v3.s[0]
-; CHECK-GI-FP16-NEXT:    mov v5.s[3], w3
 ; CHECK-GI-FP16-NEXT:    shl v0.4s, v0.4s, #31
-; CHECK-GI-FP16-NEXT:    mov v1.s[2], w8
-; CHECK-GI-FP16-NEXT:    mov w8, #-1 // =0xffffffff
+; CHECK-GI-FP16-NEXT:    mov v2.s[2], v6.s[0]
+; CHECK-GI-FP16-NEXT:    mov v3.s[3], w3
+; CHECK-GI-FP16-NEXT:    mov v4.s[3], v16.s[0]
 ; CHECK-GI-FP16-NEXT:    cmlt v0.4s, v0.4s, #0
-; CHECK-GI-FP16-NEXT:    fmov s4, w8
-; CHECK-GI-FP16-NEXT:    mov v4.s[1], w8
-; CHECK-GI-FP16-NEXT:    ushl v1.4s, v1.4s, v2.4s
-; CHECK-GI-FP16-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-FP16-NEXT:    sshl v1.4s, v1.4s, v2.4s
-; CHECK-GI-FP16-NEXT:    ldr s2, [sp, #16]
-; CHECK-GI-FP16-NEXT:    mov v4.s[2], w8
-; CHECK-GI-FP16-NEXT:    mov v6.s[3], v2.s[0]
-; CHECK-GI-FP16-NEXT:    eor v3.16b, v1.16b, v4.16b
-; CHECK-GI-FP16-NEXT:    and v1.16b, v17.16b, v1.16b
-; CHECK-GI-FP16-NEXT:    bsl v0.16b, v5.16b, v6.16b
-; CHECK-GI-FP16-NEXT:    and v2.16b, v7.16b, v3.16b
+; CHECK-GI-FP16-NEXT:    mov v1.s[2], w8
+; CHECK-GI-FP16-NEXT:    bsl v0.16b, v3.16b, v4.16b
+; CHECK-GI-FP16-NEXT:    shl v1.4s, v1.4s, #31
 ; CHECK-GI-FP16-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-FP16-NEXT:    mov s4, v0.s[3]
 ; CHECK-GI-FP16-NEXT:    fmov w0, s0
+; CHECK-GI-FP16-NEXT:    cmlt v1.4s, v1.4s, #0
+; CHECK-GI-FP16-NEXT:    eor v5.16b, v1.16b, v5.16b
+; CHECK-GI-FP16-NEXT:    and v1.16b, v7.16b, v1.16b
+; CHECK-GI-FP16-NEXT:    fmov w2, s3
+; CHECK-GI-FP16-NEXT:    fmov w3, s4
+; CHECK-GI-FP16-NEXT:    and v2.16b, v2.16b, v5.16b
 ; CHECK-GI-FP16-NEXT:    orr v1.16b, v1.16b, v2.16b
 ; CHECK-GI-FP16-NEXT:    mov s2, v0.s[1]
 ; CHECK-GI-FP16-NEXT:    mov s5, v1.s[1]
 ; CHECK-GI-FP16-NEXT:    mov s6, v1.s[2]
-; CHECK-GI-FP16-NEXT:    fmov w2, s3
-; CHECK-GI-FP16-NEXT:    fmov w1, s2
-; CHECK-GI-FP16-NEXT:    fmov w3, s4
 ; CHECK-GI-FP16-NEXT:    fmov w4, s1
+; CHECK-GI-FP16-NEXT:    fmov w1, s2
 ; CHECK-GI-FP16-NEXT:    fmov w5, s5
 ; CHECK-GI-FP16-NEXT:    fmov w6, s6
 ; CHECK-GI-FP16-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/fcopysign.ll
+++ b/llvm/test/CodeGen/AArch64/fcopysign.ll
@@ -154,16 +154,10 @@ define <3 x float> @copysign_v3f32(<3 x float> %a, <3 x float> %b) {
 ;
 ; CHECK-GI-LABEL: copysign_v3f32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #-2147483648 // =0x80000000
-; CHECK-GI-NEXT:    mov w9, #2147483647 // =0x7fffffff
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v2.s[1], w9
-; CHECK-GI-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NEXT:    mov v2.s[2], w9
-; CHECK-GI-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-GI-NEXT:    movi v2.4s, #128, lsl #24
+; CHECK-GI-NEXT:    mvni v3.4s, #128, lsl #24
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v3.16b
+; CHECK-GI-NEXT:    and v1.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
 entry:
@@ -203,24 +197,10 @@ define <7 x half> @copysign_v7f16(<7 x half> %a, <7 x half> %b) {
 ;
 ; CHECK-GI-LABEL: copysign_v7f16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #32768 // =0x8000
-; CHECK-GI-NEXT:    mov w9, #32767 // =0x7fff
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[3], w9
-; CHECK-GI-NEXT:    mov v3.h[3], w8
-; CHECK-GI-NEXT:    mov v2.h[4], w9
-; CHECK-GI-NEXT:    mov v3.h[4], w8
-; CHECK-GI-NEXT:    mov v2.h[5], w9
-; CHECK-GI-NEXT:    mov v3.h[5], w8
-; CHECK-GI-NEXT:    mov v2.h[6], w9
-; CHECK-GI-NEXT:    mov v3.h[6], w8
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v3.16b
+; CHECK-GI-NEXT:    movi v2.8h, #128, lsl #8
+; CHECK-GI-NEXT:    mvni v3.8h, #128, lsl #8
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v3.16b
+; CHECK-GI-NEXT:    and v1.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/fcvt_combine.ll
+++ b/llvm/test/CodeGen/AArch64/fcvt_combine.ll
@@ -323,35 +323,10 @@ define <2 x i32> @test14(<2 x float> %f) {
 }
 
 define <3 x i32> @test_illegal_fp_to_int(<3 x float> %in) {
-; CHECK-NO16-SD-LABEL: test_illegal_fp_to_int:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #2
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test_illegal_fp_to_int:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #2
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test_illegal_fp_to_int:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #4.00000000
-; CHECK-NO16-GI-NEXT:    fmov s2, #4.00000000
-; CHECK-NO16-GI-NEXT:    mov v2.s[1], v1.s[0]
-; CHECK-NO16-GI-NEXT:    mov v2.s[2], v1.s[0]
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v2.4s
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_illegal_fp_to_int:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #4.00000000
-; CHECK-FP16-GI-NEXT:    fmov s2, #4.00000000
-; CHECK-FP16-GI-NEXT:    mov v2.s[1], v1.s[0]
-; CHECK-FP16-GI-NEXT:    mov v2.s[2], v1.s[0]
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v2.4s
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test_illegal_fp_to_int:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s, #2
+; CHECK-NEXT:    ret
   %scale = fmul <3 x float> %in, <float 4.0, float 4.0, float 4.0>
   %val = fptosi <3 x float> %scale to <3 x i32>
   ret <3 x i32> %val
@@ -937,35 +912,10 @@ define <2 x i32> @test14_sat(<2 x float> %f) {
 }
 
 define <3 x i32> @test_illegal_fp_to_int_sat_sat(<3 x float> %in) {
-; CHECK-NO16-SD-LABEL: test_illegal_fp_to_int_sat_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #2
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test_illegal_fp_to_int_sat_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #2
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test_illegal_fp_to_int_sat_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #4.00000000
-; CHECK-NO16-GI-NEXT:    fmov s2, #4.00000000
-; CHECK-NO16-GI-NEXT:    mov v2.s[1], v1.s[0]
-; CHECK-NO16-GI-NEXT:    mov v2.s[2], v1.s[0]
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v2.4s
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_illegal_fp_to_int_sat_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #4.00000000
-; CHECK-FP16-GI-NEXT:    fmov s2, #4.00000000
-; CHECK-FP16-GI-NEXT:    mov v2.s[1], v1.s[0]
-; CHECK-FP16-GI-NEXT:    mov v2.s[2], v1.s[0]
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v2.4s
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test_illegal_fp_to_int_sat_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s, #2
+; CHECK-NEXT:    ret
   %mul.i = fmul <3 x float> %in, <float 4.0, float 4.0, float 4.0>
   %vcvt.i = call <3 x i32> @llvm.fptosi.sat.v3i32.v3f32(<3 x float> %mul.i)
   ret <3 x i32> %vcvt.i

--- a/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-vector-interleave.ll
@@ -139,9 +139,7 @@ define <4 x i16> @interleave2_same_const_splat_v4i16() {
 ;
 ; CHECK-GI-LABEL: interleave2_same_const_splat_v4i16:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov v0.h[1], w8
+; CHECK-GI-NEXT:    movi v0.4h, #3
 ; CHECK-GI-NEXT:    zip1 v0.4h, v0.4h, v0.4h
 ; CHECK-GI-NEXT:    ret
   %retval = call <4 x i16> @llvm.vector.interleave2.v4i16(<2 x i16> splat(i16 3), <2 x i16> splat(i16 3))
@@ -158,12 +156,8 @@ define <4 x i16> @interleave2_diff_const_splat_v4i16() {
 ;
 ; CHECK-GI-LABEL: interleave2_diff_const_splat_v4i16:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    mov w9, #4 // =0x4
-; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    fmov s1, w9
-; CHECK-GI-NEXT:    mov v0.h[1], w8
-; CHECK-GI-NEXT:    mov v1.h[1], w9
+; CHECK-GI-NEXT:    movi v0.4h, #3
+; CHECK-GI-NEXT:    movi v1.4h, #4
 ; CHECK-GI-NEXT:    zip1 v0.4h, v0.4h, v1.4h
 ; CHECK-GI-NEXT:    ret
   %retval = call <4 x i16> @llvm.vector.interleave2.v4i16(<2 x i16> splat(i16 3), <2 x i16> splat(i16 4))

--- a/llvm/test/CodeGen/AArch64/fsh.ll
+++ b/llvm/test/CodeGen/AArch64/fsh.ll
@@ -1030,21 +1030,8 @@ define <7 x i16> @rotl_v7i16(<7 x i16> %a, <7 x i16> %c) {
 ;
 ; CHECK-GI-LABEL: rotl_v7i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
-; CHECK-GI-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v2.h[1], wzr
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov v2.h[2], wzr
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[3], wzr
-; CHECK-GI-NEXT:    mov v3.h[3], w8
-; CHECK-GI-NEXT:    mov v2.h[4], wzr
-; CHECK-GI-NEXT:    mov v3.h[4], w8
-; CHECK-GI-NEXT:    mov v2.h[5], wzr
-; CHECK-GI-NEXT:    mov v3.h[5], w8
-; CHECK-GI-NEXT:    mov v2.h[6], wzr
-; CHECK-GI-NEXT:    mov v3.h[6], w8
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-GI-NEXT:    movi v3.8h, #15
 ; CHECK-GI-NEXT:    sub v2.8h, v2.8h, v1.8h
 ; CHECK-GI-NEXT:    and v1.16b, v1.16b, v3.16b
 ; CHECK-GI-NEXT:    and v2.16b, v2.16b, v3.16b
@@ -1073,21 +1060,8 @@ define <7 x i16> @rotr_v7i16(<7 x i16> %a, <7 x i16> %c) {
 ;
 ; CHECK-GI-LABEL: rotr_v7i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
-; CHECK-GI-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v2.h[1], wzr
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov v2.h[2], wzr
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[3], wzr
-; CHECK-GI-NEXT:    mov v3.h[3], w8
-; CHECK-GI-NEXT:    mov v2.h[4], wzr
-; CHECK-GI-NEXT:    mov v3.h[4], w8
-; CHECK-GI-NEXT:    mov v2.h[5], wzr
-; CHECK-GI-NEXT:    mov v3.h[5], w8
-; CHECK-GI-NEXT:    mov v2.h[6], wzr
-; CHECK-GI-NEXT:    mov v3.h[6], w8
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-GI-NEXT:    movi v3.8h, #15
 ; CHECK-GI-NEXT:    sub v2.8h, v2.8h, v1.8h
 ; CHECK-GI-NEXT:    and v1.16b, v1.16b, v3.16b
 ; CHECK-GI-NEXT:    neg v1.8h, v1.8h
@@ -1355,76 +1329,67 @@ define <7 x i32> @rotl_v7i32(<7 x i32> %a, <7 x i32> %c) {
 ; CHECK-GI-LABEL: rotl_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr s0, [sp, #24]
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
-; CHECK-GI-NEXT:    fmov s3, w7
-; CHECK-GI-NEXT:    ldr s2, [sp, #32]
+; CHECK-GI-NEXT:    fmov s2, w7
+; CHECK-GI-NEXT:    ldr s3, [sp, #32]
 ; CHECK-GI-NEXT:    mov x8, sp
-; CHECK-GI-NEXT:    fmov s4, w7
-; CHECK-GI-NEXT:    mov v6.16b, v0.16b
-; CHECK-GI-NEXT:    ldr s7, [sp]
-; CHECK-GI-NEXT:    ldr s5, [sp, #40]
-; CHECK-GI-NEXT:    ld1 { v3.s }[1], [x8]
-; CHECK-GI-NEXT:    add x8, sp, #8
+; CHECK-GI-NEXT:    fmov s1, w7
+; CHECK-GI-NEXT:    ldr s6, [sp]
+; CHECK-GI-NEXT:    mov v5.16b, v0.16b
+; CHECK-GI-NEXT:    ldr s4, [sp, #40]
 ; CHECK-GI-NEXT:    fmov s16, w0
-; CHECK-GI-NEXT:    mov v1.s[1], wzr
-; CHECK-GI-NEXT:    mov v4.s[1], v7.s[0]
-; CHECK-GI-NEXT:    ldr s7, [sp, #8]
-; CHECK-GI-NEXT:    mov v6.s[1], v2.s[0]
+; CHECK-GI-NEXT:    ld1 { v2.s }[1], [x8]
+; CHECK-GI-NEXT:    add x8, sp, #8
 ; CHECK-GI-NEXT:    fmov s17, w0
-; CHECK-GI-NEXT:    add x9, sp, #16
-; CHECK-GI-NEXT:    ld1 { v3.s }[2], [x8]
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
+; CHECK-GI-NEXT:    mov v1.s[1], v6.s[0]
+; CHECK-GI-NEXT:    movi v6.2d, #0000000000000000
+; CHECK-GI-NEXT:    ldr s7, [sp, #8]
+; CHECK-GI-NEXT:    mov v5.s[1], v3.s[0]
 ; CHECK-GI-NEXT:    mov v16.s[1], w1
-; CHECK-GI-NEXT:    fmov s18, w8
-; CHECK-GI-NEXT:    mov v0.s[1], v2.s[0]
-; CHECK-GI-NEXT:    fmov s2, w4
-; CHECK-GI-NEXT:    mov v1.s[2], wzr
-; CHECK-GI-NEXT:    mov v4.s[2], v7.s[0]
-; CHECK-GI-NEXT:    ldr s7, [sp, #16]
-; CHECK-GI-NEXT:    mov v6.s[2], v5.s[0]
-; CHECK-GI-NEXT:    ld1 { v3.s }[3], [x9]
+; CHECK-GI-NEXT:    mov v0.s[1], v3.s[0]
+; CHECK-GI-NEXT:    ld1 { v2.s }[2], [x8]
+; CHECK-GI-NEXT:    add x8, sp, #16
 ; CHECK-GI-NEXT:    mov v17.s[1], w1
-; CHECK-GI-NEXT:    mov v18.s[1], w8
-; CHECK-GI-NEXT:    movi v19.4s, #31
+; CHECK-GI-NEXT:    ldr s18, [sp, #16]
+; CHECK-GI-NEXT:    mov v1.s[2], v7.s[0]
+; CHECK-GI-NEXT:    movi v7.4s, #31
+; CHECK-GI-NEXT:    mov v5.s[2], v4.s[0]
+; CHECK-GI-NEXT:    ld1 { v2.s }[3], [x8]
 ; CHECK-GI-NEXT:    mov v16.s[2], w2
-; CHECK-GI-NEXT:    mov v2.s[1], w5
-; CHECK-GI-NEXT:    mov v0.s[2], v5.s[0]
-; CHECK-GI-NEXT:    mov v4.s[3], v7.s[0]
-; CHECK-GI-NEXT:    fmov s7, w4
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    sub v1.4s, v1.4s, v6.4s
-; CHECK-GI-NEXT:    fmov s6, w8
 ; CHECK-GI-NEXT:    mov v17.s[2], w2
-; CHECK-GI-NEXT:    mov v18.s[2], w8
-; CHECK-GI-NEXT:    mov v16.s[3], w3
-; CHECK-GI-NEXT:    mov v7.s[1], w5
-; CHECK-GI-NEXT:    and v3.16b, v3.16b, v19.16b
-; CHECK-GI-NEXT:    mov v2.s[2], w6
-; CHECK-GI-NEXT:    mov v6.s[1], w8
-; CHECK-GI-NEXT:    and v4.16b, v4.16b, v19.16b
+; CHECK-GI-NEXT:    mov v0.s[2], v4.s[0]
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
+; CHECK-GI-NEXT:    mov v1.s[3], v18.s[0]
+; CHECK-GI-NEXT:    sub v3.4s, v6.4s, v5.4s
+; CHECK-GI-NEXT:    fmov s5, w4
+; CHECK-GI-NEXT:    fmov s6, w4
 ; CHECK-GI-NEXT:    mov v17.s[3], w3
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v18.16b
+; CHECK-GI-NEXT:    mov v16.s[3], w3
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v7.16b
+; CHECK-GI-NEXT:    and v2.16b, v2.16b, v7.16b
+; CHECK-GI-NEXT:    mov v6.s[1], w5
+; CHECK-GI-NEXT:    mov v5.s[1], w5
+; CHECK-GI-NEXT:    and v3.16b, v3.16b, v7.16b
+; CHECK-GI-NEXT:    and v1.16b, v1.16b, v7.16b
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
 ; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    mov v7.s[2], w6
-; CHECK-GI-NEXT:    mov v6.s[2], w8
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v4.4s, v17.4s, v4.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v16.4s, v3.4s
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v6.16b
-; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
-; CHECK-GI-NEXT:    orr v2.16b, v4.16b, v3.16b
-; CHECK-GI-NEXT:    ushl v0.4s, v7.4s, v0.4s
-; CHECK-GI-NEXT:    mov s3, v2.s[2]
-; CHECK-GI-NEXT:    mov s4, v2.s[3]
-; CHECK-GI-NEXT:    fmov w0, s2
-; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
-; CHECK-GI-NEXT:    mov s1, v2.s[1]
-; CHECK-GI-NEXT:    fmov w2, s3
-; CHECK-GI-NEXT:    fmov w3, s4
+; CHECK-GI-NEXT:    mov v6.s[2], w6
+; CHECK-GI-NEXT:    mov v5.s[2], w6
+; CHECK-GI-NEXT:    ushl v1.4s, v17.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v2.4s, v16.4s, v2.4s
+; CHECK-GI-NEXT:    ushl v0.4s, v6.4s, v0.4s
+; CHECK-GI-NEXT:    ushl v3.4s, v5.4s, v3.4s
+; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b
+; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v3.16b
+; CHECK-GI-NEXT:    mov s2, v1.s[1]
+; CHECK-GI-NEXT:    mov s3, v1.s[2]
+; CHECK-GI-NEXT:    mov s4, v1.s[3]
+; CHECK-GI-NEXT:    fmov w0, s1
 ; CHECK-GI-NEXT:    mov s5, v0.s[1]
 ; CHECK-GI-NEXT:    mov s6, v0.s[2]
 ; CHECK-GI-NEXT:    fmov w4, s0
-; CHECK-GI-NEXT:    fmov w1, s1
+; CHECK-GI-NEXT:    fmov w1, s2
+; CHECK-GI-NEXT:    fmov w2, s3
+; CHECK-GI-NEXT:    fmov w3, s4
 ; CHECK-GI-NEXT:    fmov w5, s5
 ; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    ret
@@ -1482,78 +1447,69 @@ define <7 x i32> @rotr_v7i32(<7 x i32> %a, <7 x i32> %c) {
 ; CHECK-GI-LABEL: rotr_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    fmov s1, w7
-; CHECK-GI-NEXT:    ldr s3, [sp]
-; CHECK-GI-NEXT:    fmov s2, w7
+; CHECK-GI-NEXT:    ldr s2, [sp]
+; CHECK-GI-NEXT:    ldr s0, [sp, #24]
+; CHECK-GI-NEXT:    fmov s3, w7
+; CHECK-GI-NEXT:    ldr s4, [sp, #32]
+; CHECK-GI-NEXT:    ldr s5, [sp, #8]
 ; CHECK-GI-NEXT:    mov x8, sp
-; CHECK-GI-NEXT:    ldr s6, [sp, #8]
-; CHECK-GI-NEXT:    movi d0, #0000000000000000
-; CHECK-GI-NEXT:    ldr s7, [sp, #32]
-; CHECK-GI-NEXT:    fmov s16, w0
-; CHECK-GI-NEXT:    fmov s17, w0
-; CHECK-GI-NEXT:    mov v1.s[1], v3.s[0]
-; CHECK-GI-NEXT:    ldr s3, [sp, #24]
-; CHECK-GI-NEXT:    ld1 { v2.s }[1], [x8]
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
+; CHECK-GI-NEXT:    fmov s7, w0
 ; CHECK-GI-NEXT:    add x9, sp, #8
-; CHECK-GI-NEXT:    ldr s5, [sp, #40]
-; CHECK-GI-NEXT:    mov v4.16b, v3.16b
-; CHECK-GI-NEXT:    mov v3.s[1], v7.s[0]
-; CHECK-GI-NEXT:    mov v0.s[1], wzr
-; CHECK-GI-NEXT:    fmov s18, w8
-; CHECK-GI-NEXT:    ld1 { v2.s }[2], [x9]
-; CHECK-GI-NEXT:    mov v17.s[1], w1
-; CHECK-GI-NEXT:    mov v1.s[2], v6.s[0]
-; CHECK-GI-NEXT:    fmov s6, w8
-; CHECK-GI-NEXT:    mov v16.s[1], w1
-; CHECK-GI-NEXT:    mov v4.s[1], v7.s[0]
-; CHECK-GI-NEXT:    ldr s7, [sp, #16]
-; CHECK-GI-NEXT:    fmov s19, w4
-; CHECK-GI-NEXT:    mov v18.s[1], w8
-; CHECK-GI-NEXT:    mov v3.s[2], v5.s[0]
-; CHECK-GI-NEXT:    add x10, sp, #16
-; CHECK-GI-NEXT:    mov v6.s[1], w8
-; CHECK-GI-NEXT:    mov v0.s[2], wzr
-; CHECK-GI-NEXT:    ld1 { v2.s }[3], [x10]
-; CHECK-GI-NEXT:    mov v1.s[3], v7.s[0]
-; CHECK-GI-NEXT:    movi v7.4s, #31
-; CHECK-GI-NEXT:    mov v17.s[2], w2
-; CHECK-GI-NEXT:    mov v4.s[2], v5.s[0]
-; CHECK-GI-NEXT:    fmov s5, w4
-; CHECK-GI-NEXT:    mov v16.s[2], w2
-; CHECK-GI-NEXT:    mov v19.s[1], w5
-; CHECK-GI-NEXT:    mov v18.s[2], w8
-; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    mov v6.s[2], w8
-; CHECK-GI-NEXT:    mov v5.s[1], w5
-; CHECK-GI-NEXT:    and v1.16b, v1.16b, v7.16b
-; CHECK-GI-NEXT:    mov v17.s[3], w3
-; CHECK-GI-NEXT:    sub v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    mov v16.s[3], w3
-; CHECK-GI-NEXT:    and v2.16b, v2.16b, v7.16b
-; CHECK-GI-NEXT:    mov v19.s[2], w6
-; CHECK-GI-NEXT:    and v3.16b, v3.16b, v6.16b
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    mov v5.s[2], w6
-; CHECK-GI-NEXT:    and v0.16b, v0.16b, v18.16b
-; CHECK-GI-NEXT:    ushl v2.4s, v16.4s, v2.4s
+; CHECK-GI-NEXT:    mov v1.s[1], v2.s[0]
+; CHECK-GI-NEXT:    mov v2.16b, v0.16b
+; CHECK-GI-NEXT:    mov v0.s[1], v4.s[0]
+; CHECK-GI-NEXT:    ld1 { v3.s }[1], [x8]
+; CHECK-GI-NEXT:    ldr s6, [sp, #16]
+; CHECK-GI-NEXT:    fmov s17, w4
+; CHECK-GI-NEXT:    mov v7.s[1], w1
+; CHECK-GI-NEXT:    add x8, sp, #16
+; CHECK-GI-NEXT:    movi v16.2d, #0000000000000000
+; CHECK-GI-NEXT:    mov v2.s[1], v4.s[0]
+; CHECK-GI-NEXT:    ldr s4, [sp, #40]
+; CHECK-GI-NEXT:    mov v1.s[2], v5.s[0]
+; CHECK-GI-NEXT:    fmov s5, w0
+; CHECK-GI-NEXT:    ld1 { v3.s }[2], [x9]
+; CHECK-GI-NEXT:    mov v0.s[2], v4.s[0]
+; CHECK-GI-NEXT:    mov v17.s[1], w5
+; CHECK-GI-NEXT:    mov v7.s[2], w2
+; CHECK-GI-NEXT:    mov v5.s[1], w1
+; CHECK-GI-NEXT:    mov v2.s[2], v4.s[0]
+; CHECK-GI-NEXT:    fmov s4, w4
+; CHECK-GI-NEXT:    mov v1.s[3], v6.s[0]
+; CHECK-GI-NEXT:    movi v6.4s, #31
+; CHECK-GI-NEXT:    ld1 { v3.s }[3], [x8]
+; CHECK-GI-NEXT:    mov v17.s[2], w6
+; CHECK-GI-NEXT:    mov v4.s[1], w5
+; CHECK-GI-NEXT:    mov v7.s[3], w3
+; CHECK-GI-NEXT:    mov v5.s[2], w2
 ; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v17.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v0.4s, v5.4s, v0.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v19.4s, v3.4s
-; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b
-; CHECK-GI-NEXT:    orr v0.16b, v3.16b, v0.16b
+; CHECK-GI-NEXT:    sub v2.4s, v16.4s, v2.4s
+; CHECK-GI-NEXT:    and v1.16b, v1.16b, v6.16b
+; CHECK-GI-NEXT:    and v0.16b, v0.16b, v6.16b
+; CHECK-GI-NEXT:    mov v4.s[2], w6
+; CHECK-GI-NEXT:    and v3.16b, v3.16b, v6.16b
+; CHECK-GI-NEXT:    and v2.16b, v2.16b, v6.16b
+; CHECK-GI-NEXT:    mov v5.s[3], w3
+; CHECK-GI-NEXT:    neg v1.4s, v1.4s
+; CHECK-GI-NEXT:    neg v0.4s, v0.4s
+; CHECK-GI-NEXT:    ushl v1.4s, v7.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v0.4s, v17.4s, v0.4s
+; CHECK-GI-NEXT:    ushl v2.4s, v4.4s, v2.4s
+; CHECK-GI-NEXT:    ushl v3.4s, v5.4s, v3.4s
+; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v3.16b
+; CHECK-GI-NEXT:    mov s5, v0.s[1]
+; CHECK-GI-NEXT:    mov s6, v0.s[2]
+; CHECK-GI-NEXT:    fmov w4, s0
 ; CHECK-GI-NEXT:    mov s2, v1.s[1]
 ; CHECK-GI-NEXT:    mov s3, v1.s[2]
 ; CHECK-GI-NEXT:    mov s4, v1.s[3]
 ; CHECK-GI-NEXT:    fmov w0, s1
-; CHECK-GI-NEXT:    mov s5, v0.s[1]
-; CHECK-GI-NEXT:    mov s6, v0.s[2]
-; CHECK-GI-NEXT:    fmov w4, s0
+; CHECK-GI-NEXT:    fmov w5, s5
+; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    fmov w1, s2
 ; CHECK-GI-NEXT:    fmov w2, s3
 ; CHECK-GI-NEXT:    fmov w3, s4
-; CHECK-GI-NEXT:    fmov w5, s5
-; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i32> @llvm.fshr(<7 x i32> %a, <7 x i32> %a, <7 x i32> %c)
@@ -2128,35 +2084,12 @@ define <7 x i16> @fshl_v7i16(<7 x i16> %a, <7 x i16> %b, <7 x i16> %c) {
 ;
 ; CHECK-GI-LABEL: fshl_v7i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #65535 // =0xffff
-; CHECK-GI-NEXT:    mov w9, #15 // =0xf
-; CHECK-GI-NEXT:    mov w10, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    fmov s4, w9
-; CHECK-GI-NEXT:    fmov s5, w10
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov v4.h[1], w9
-; CHECK-GI-NEXT:    mov v5.h[1], w10
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov v4.h[2], w9
-; CHECK-GI-NEXT:    mov v5.h[2], w10
-; CHECK-GI-NEXT:    mov v3.h[3], w8
-; CHECK-GI-NEXT:    mov v4.h[3], w9
-; CHECK-GI-NEXT:    mov v5.h[3], w10
-; CHECK-GI-NEXT:    mov v3.h[4], w8
-; CHECK-GI-NEXT:    mov v4.h[4], w9
-; CHECK-GI-NEXT:    mov v5.h[4], w10
-; CHECK-GI-NEXT:    mov v3.h[5], w8
-; CHECK-GI-NEXT:    mov v4.h[5], w9
-; CHECK-GI-NEXT:    mov v5.h[5], w10
-; CHECK-GI-NEXT:    mov v3.h[6], w8
-; CHECK-GI-NEXT:    mov v4.h[6], w9
-; CHECK-GI-NEXT:    mov v5.h[6], w10
+; CHECK-GI-NEXT:    movi v3.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    movi v4.8h, #15
+; CHECK-GI-NEXT:    ushr v1.8h, v1.8h, #1
 ; CHECK-GI-NEXT:    eor v3.16b, v2.16b, v3.16b
-; CHECK-GI-NEXT:    neg v5.8h, v5.8h
 ; CHECK-GI-NEXT:    and v2.16b, v2.16b, v4.16b
 ; CHECK-GI-NEXT:    and v3.16b, v3.16b, v4.16b
-; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v5.8h
 ; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v2.8h
 ; CHECK-GI-NEXT:    neg v3.8h, v3.8h
 ; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v3.8h
@@ -2182,37 +2115,15 @@ define <7 x i16> @fshr_v7i16(<7 x i16> %a, <7 x i16> %b, <7 x i16> %c) {
 ;
 ; CHECK-GI-LABEL: fshr_v7i16:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-NEXT:    mov w9, #65535 // =0xffff
-; CHECK-GI-NEXT:    mov w10, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    fmov s4, w9
-; CHECK-GI-NEXT:    fmov s5, w10
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov v4.h[1], w9
-; CHECK-GI-NEXT:    mov v5.h[1], w10
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov v4.h[2], w9
-; CHECK-GI-NEXT:    mov v5.h[2], w10
-; CHECK-GI-NEXT:    mov v3.h[3], w8
-; CHECK-GI-NEXT:    mov v4.h[3], w9
-; CHECK-GI-NEXT:    mov v5.h[3], w10
-; CHECK-GI-NEXT:    mov v3.h[4], w8
-; CHECK-GI-NEXT:    mov v4.h[4], w9
-; CHECK-GI-NEXT:    mov v5.h[4], w10
-; CHECK-GI-NEXT:    mov v3.h[5], w8
-; CHECK-GI-NEXT:    mov v4.h[5], w9
-; CHECK-GI-NEXT:    mov v5.h[5], w10
-; CHECK-GI-NEXT:    mov v3.h[6], w8
-; CHECK-GI-NEXT:    mov v4.h[6], w9
-; CHECK-GI-NEXT:    mov v5.h[6], w10
-; CHECK-GI-NEXT:    eor v4.16b, v2.16b, v4.16b
+; CHECK-GI-NEXT:    movi v3.8h, #15
+; CHECK-GI-NEXT:    movi v4.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #1
+; CHECK-GI-NEXT:    and v5.16b, v2.16b, v3.16b
+; CHECK-GI-NEXT:    eor v2.16b, v2.16b, v4.16b
 ; CHECK-GI-NEXT:    and v2.16b, v2.16b, v3.16b
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v5.8h
-; CHECK-GI-NEXT:    and v3.16b, v4.16b, v3.16b
-; CHECK-GI-NEXT:    neg v2.8h, v2.8h
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v3.8h
-; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v2.8h
+; CHECK-GI-NEXT:    neg v3.8h, v5.8h
+; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v2.8h
+; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v3.8h
 ; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
 entry:
@@ -2485,88 +2396,73 @@ define <7 x i32> @fshl_v7i32(<7 x i32> %a, <7 x i32> %b, <7 x i32> %c) {
 ;
 ; CHECK-GI-LABEL: fshl_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr s17, [sp, #48]
+; CHECK-GI-NEXT:    ldr s5, [sp, #80]
+; CHECK-GI-NEXT:    ldr s16, [sp, #88]
+; CHECK-GI-NEXT:    fmov s19, w0
+; CHECK-GI-NEXT:    ldr s1, [sp, #48]
+; CHECK-GI-NEXT:    ldr s7, [sp, #56]
 ; CHECK-GI-NEXT:    add x8, sp, #56
-; CHECK-GI-NEXT:    add x9, sp, #64
-; CHECK-GI-NEXT:    ldr s4, [sp, #48]
-; CHECK-GI-NEXT:    ldr s21, [sp, #56]
-; CHECK-GI-NEXT:    mov w10, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    ld1 { v17.s }[1], [x8]
-; CHECK-GI-NEXT:    ldr s20, [x9]
-; CHECK-GI-NEXT:    add x8, sp, #72
-; CHECK-GI-NEXT:    mov v4.s[1], v21.s[0]
-; CHECK-GI-NEXT:    fmov s21, w7
+; CHECK-GI-NEXT:    mov v5.s[1], v16.s[0]
+; CHECK-GI-NEXT:    fmov s16, w7
 ; CHECK-GI-NEXT:    ldr s6, [sp]
-; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x8]
-; CHECK-GI-NEXT:    ldr s19, [sp, #64]
-; CHECK-GI-NEXT:    ldr s7, [sp, #80]
-; CHECK-GI-NEXT:    ldr s22, [sp, #88]
-; CHECK-GI-NEXT:    mov w9, #31 // =0x1f
-; CHECK-GI-NEXT:    mov w11, #1 // =0x1
-; CHECK-GI-NEXT:    mov v21.s[1], v6.s[0]
-; CHECK-GI-NEXT:    fmov s6, w9
-; CHECK-GI-NEXT:    ldr s18, [sp, #96]
-; CHECK-GI-NEXT:    zip1 v17.2d, v17.2d, v20.2d
-; CHECK-GI-NEXT:    fmov s20, w10
-; CHECK-GI-NEXT:    mov v7.s[1], v22.s[0]
-; CHECK-GI-NEXT:    mov v4.s[2], v19.s[0]
-; CHECK-GI-NEXT:    fmov s19, w11
-; CHECK-GI-NEXT:    fmov s23, w0
-; CHECK-GI-NEXT:    mov v6.s[1], w9
-; CHECK-GI-NEXT:    fmov s24, w9
-; CHECK-GI-NEXT:    ldr s2, [sp, #8]
-; CHECK-GI-NEXT:    mov v20.s[1], w10
+; CHECK-GI-NEXT:    mov v1.s[1], v7.s[0]
+; CHECK-GI-NEXT:    ldr s17, [sp, #64]
+; CHECK-GI-NEXT:    ldr s7, [sp, #48]
+; CHECK-GI-NEXT:    ldr s4, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s0, [sp, #24]
-; CHECK-GI-NEXT:    ldr s5, [sp, #32]
-; CHECK-GI-NEXT:    mov v19.s[1], w11
-; CHECK-GI-NEXT:    mov v7.s[2], v18.s[0]
-; CHECK-GI-NEXT:    ldr s16, [sp, #72]
-; CHECK-GI-NEXT:    mov v23.s[1], w1
-; CHECK-GI-NEXT:    ldr s18, [sp, #80]
-; CHECK-GI-NEXT:    mov v21.s[2], v2.s[0]
-; CHECK-GI-NEXT:    mov v24.s[1], w9
-; CHECK-GI-NEXT:    mov v0.s[1], v5.s[0]
-; CHECK-GI-NEXT:    fmov s5, w4
-; CHECK-GI-NEXT:    mov v20.s[2], w10
-; CHECK-GI-NEXT:    add x8, sp, #88
-; CHECK-GI-NEXT:    movi v22.4s, #31
-; CHECK-GI-NEXT:    mov v4.s[3], v16.s[0]
-; CHECK-GI-NEXT:    mov v6.s[2], w9
-; CHECK-GI-NEXT:    mov v19.s[2], w11
-; CHECK-GI-NEXT:    ldr s1, [sp, #16]
-; CHECK-GI-NEXT:    ldr s3, [sp, #40]
+; CHECK-GI-NEXT:    ldr s3, [sp, #32]
+; CHECK-GI-NEXT:    mov v16.s[1], v6.s[0]
+; CHECK-GI-NEXT:    ldr s6, [sp, #96]
+; CHECK-GI-NEXT:    add x9, sp, #64
+; CHECK-GI-NEXT:    ld1 { v7.s }[1], [x8]
+; CHECK-GI-NEXT:    ldr s18, [x9]
+; CHECK-GI-NEXT:    mov v19.s[1], w1
+; CHECK-GI-NEXT:    mov v5.s[2], v6.s[0]
+; CHECK-GI-NEXT:    movi v6.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    mov v1.s[2], v17.s[0]
+; CHECK-GI-NEXT:    ldr s17, [sp, #72]
+; CHECK-GI-NEXT:    add x8, sp, #72
+; CHECK-GI-NEXT:    ldr s20, [sp, #80]
+; CHECK-GI-NEXT:    mov v16.s[2], v4.s[0]
+; CHECK-GI-NEXT:    mov v0.s[1], v3.s[0]
 ; CHECK-GI-NEXT:    ld1 { v18.s }[1], [x8]
-; CHECK-GI-NEXT:    mov v23.s[2], w2
-; CHECK-GI-NEXT:    mov v5.s[1], w5
+; CHECK-GI-NEXT:    add x8, sp, #88
+; CHECK-GI-NEXT:    movi v4.4s, #31
+; CHECK-GI-NEXT:    ldr s2, [sp, #16]
+; CHECK-GI-NEXT:    eor v5.16b, v5.16b, v6.16b
+; CHECK-GI-NEXT:    fmov s6, w4
+; CHECK-GI-NEXT:    mov v1.s[3], v17.s[0]
+; CHECK-GI-NEXT:    ldr s3, [sp, #40]
+; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x8]
+; CHECK-GI-NEXT:    mov v19.s[2], w2
+; CHECK-GI-NEXT:    zip1 v7.2d, v7.2d, v18.2d
+; CHECK-GI-NEXT:    mov v16.s[3], v2.s[0]
 ; CHECK-GI-NEXT:    add x8, sp, #96
-; CHECK-GI-NEXT:    eor v2.16b, v7.16b, v20.16b
-; CHECK-GI-NEXT:    mov v21.s[3], v1.s[0]
-; CHECK-GI-NEXT:    mov v24.s[2], w9
+; CHECK-GI-NEXT:    mov v6.s[1], w5
 ; CHECK-GI-NEXT:    mov v0.s[2], v3.s[0]
-; CHECK-GI-NEXT:    bic v1.16b, v22.16b, v4.16b
-; CHECK-GI-NEXT:    ld1 { v18.s }[2], [x8]
-; CHECK-GI-NEXT:    neg v3.4s, v19.4s
-; CHECK-GI-NEXT:    and v4.16b, v17.16b, v22.16b
-; CHECK-GI-NEXT:    and v2.16b, v2.16b, v6.16b
-; CHECK-GI-NEXT:    mov v23.s[3], w3
-; CHECK-GI-NEXT:    mov v5.s[2], w6
-; CHECK-GI-NEXT:    ushr v6.4s, v21.4s, #1
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    and v7.16b, v18.16b, v24.16b
-; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v3.4s
+; CHECK-GI-NEXT:    and v2.16b, v5.16b, v4.16b
+; CHECK-GI-NEXT:    bic v1.16b, v4.16b, v1.16b
+; CHECK-GI-NEXT:    ld1 { v20.s }[2], [x8]
+; CHECK-GI-NEXT:    mov v19.s[3], w3
+; CHECK-GI-NEXT:    and v3.16b, v7.16b, v4.16b
+; CHECK-GI-NEXT:    ushr v5.4s, v16.4s, #1
 ; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v23.4s, v4.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v6.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v4.4s, v5.4s, v7.4s
+; CHECK-GI-NEXT:    mov v6.s[2], w6
+; CHECK-GI-NEXT:    neg v1.4s, v1.4s
+; CHECK-GI-NEXT:    and v4.16b, v20.16b, v4.16b
+; CHECK-GI-NEXT:    ushr v0.4s, v0.4s, #1
+; CHECK-GI-NEXT:    ushl v3.4s, v19.4s, v3.4s
+; CHECK-GI-NEXT:    ushl v1.4s, v5.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v4.4s, v6.4s, v4.4s
 ; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    orr v1.16b, v3.16b, v1.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v4.16b, v0.16b
 ; CHECK-GI-NEXT:    mov s2, v1.s[1]
 ; CHECK-GI-NEXT:    mov s3, v1.s[2]
 ; CHECK-GI-NEXT:    mov s4, v1.s[3]
-; CHECK-GI-NEXT:    fmov w0, s1
 ; CHECK-GI-NEXT:    mov s5, v0.s[1]
 ; CHECK-GI-NEXT:    mov s6, v0.s[2]
+; CHECK-GI-NEXT:    fmov w0, s1
 ; CHECK-GI-NEXT:    fmov w4, s0
 ; CHECK-GI-NEXT:    fmov w1, s2
 ; CHECK-GI-NEXT:    fmov w2, s3
@@ -2639,86 +2535,73 @@ define <7 x i32> @fshr_v7i32(<7 x i32> %a, <7 x i32> %b, <7 x i32> %c) {
 ;
 ; CHECK-GI-LABEL: fshr_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr s4, [sp, #48]
+; CHECK-GI-NEXT:    ldr s1, [sp, #48]
+; CHECK-GI-NEXT:    ldr s16, [sp, #56]
 ; CHECK-GI-NEXT:    add x8, sp, #56
-; CHECK-GI-NEXT:    ldr s2, [sp, #48]
-; CHECK-GI-NEXT:    ldr s18, [sp, #56]
-; CHECK-GI-NEXT:    ldr s5, [sp, #80]
-; CHECK-GI-NEXT:    add x9, sp, #72
-; CHECK-GI-NEXT:    ld1 { v4.s }[1], [x8]
-; CHECK-GI-NEXT:    ldr s19, [sp, #88]
-; CHECK-GI-NEXT:    add x8, sp, #64
-; CHECK-GI-NEXT:    mov v2.s[1], v18.s[0]
-; CHECK-GI-NEXT:    ldr s20, [sp, #64]
+; CHECK-GI-NEXT:    ldr s17, [sp, #80]
+; CHECK-GI-NEXT:    ldr s18, [sp, #88]
+; CHECK-GI-NEXT:    add x9, sp, #64
+; CHECK-GI-NEXT:    mov v1.s[1], v16.s[0]
+; CHECK-GI-NEXT:    fmov s16, w0
+; CHECK-GI-NEXT:    ldr s5, [sp, #48]
+; CHECK-GI-NEXT:    mov v17.s[1], v18.s[0]
+; CHECK-GI-NEXT:    fmov s18, w7
+; CHECK-GI-NEXT:    ldr s4, [sp]
+; CHECK-GI-NEXT:    ld1 { v5.s }[1], [x8]
+; CHECK-GI-NEXT:    ldr s6, [x9]
+; CHECK-GI-NEXT:    add x10, sp, #72
+; CHECK-GI-NEXT:    mov v16.s[1], w1
+; CHECK-GI-NEXT:    ldr s20, [sp, #80]
+; CHECK-GI-NEXT:    ldr s7, [sp, #64]
+; CHECK-GI-NEXT:    mov v18.s[1], v4.s[0]
+; CHECK-GI-NEXT:    fmov s4, w4
+; CHECK-GI-NEXT:    add x8, sp, #88
+; CHECK-GI-NEXT:    ld1 { v6.s }[1], [x10]
 ; CHECK-GI-NEXT:    ldr s21, [sp, #96]
-; CHECK-GI-NEXT:    mov v5.s[1], v19.s[0]
-; CHECK-GI-NEXT:    fmov s19, w0
-; CHECK-GI-NEXT:    ldr s7, [sp, #80]
-; CHECK-GI-NEXT:    ld1 { v4.s }[2], [x8]
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
-; CHECK-GI-NEXT:    ldr s16, [sp]
-; CHECK-GI-NEXT:    fmov s22, w8
-; CHECK-GI-NEXT:    add x10, sp, #88
-; CHECK-GI-NEXT:    fmov s23, w8
-; CHECK-GI-NEXT:    mov v2.s[2], v20.s[0]
-; CHECK-GI-NEXT:    ld1 { v7.s }[1], [x10]
-; CHECK-GI-NEXT:    mov v19.s[1], w1
-; CHECK-GI-NEXT:    ld1 { v4.s }[3], [x9]
-; CHECK-GI-NEXT:    mov w9, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    mov v5.s[2], v21.s[0]
-; CHECK-GI-NEXT:    fmov s20, w9
-; CHECK-GI-NEXT:    fmov s21, w7
-; CHECK-GI-NEXT:    mov w10, #1 // =0x1
-; CHECK-GI-NEXT:    mov v22.s[1], w8
-; CHECK-GI-NEXT:    fmov s24, w10
-; CHECK-GI-NEXT:    mov v23.s[1], w8
-; CHECK-GI-NEXT:    mov v19.s[2], w2
-; CHECK-GI-NEXT:    ldr s6, [sp, #8]
+; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x8]
+; CHECK-GI-NEXT:    mov v1.s[2], v7.s[0]
+; CHECK-GI-NEXT:    ldr s3, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s0, [sp, #24]
-; CHECK-GI-NEXT:    mov v20.s[1], w9
-; CHECK-GI-NEXT:    mov v21.s[1], v16.s[0]
-; CHECK-GI-NEXT:    fmov s16, w4
-; CHECK-GI-NEXT:    mov v24.s[1], w10
-; CHECK-GI-NEXT:    ldr s3, [sp, #32]
-; CHECK-GI-NEXT:    movi v18.4s, #31
-; CHECK-GI-NEXT:    add x11, sp, #96
-; CHECK-GI-NEXT:    mov v22.s[2], w8
-; CHECK-GI-NEXT:    ldr s17, [sp, #72]
-; CHECK-GI-NEXT:    mov v16.s[1], w5
-; CHECK-GI-NEXT:    ld1 { v7.s }[2], [x11]
-; CHECK-GI-NEXT:    mov v0.s[1], v3.s[0]
-; CHECK-GI-NEXT:    mov v20.s[2], w9
-; CHECK-GI-NEXT:    mov v21.s[2], v6.s[0]
-; CHECK-GI-NEXT:    mov v2.s[3], v17.s[0]
-; CHECK-GI-NEXT:    mov v19.s[3], w3
-; CHECK-GI-NEXT:    mov v23.s[2], w8
-; CHECK-GI-NEXT:    mov v24.s[2], w10
-; CHECK-GI-NEXT:    ldr s1, [sp, #16]
-; CHECK-GI-NEXT:    and v4.16b, v4.16b, v18.16b
-; CHECK-GI-NEXT:    ldr s3, [sp, #40]
-; CHECK-GI-NEXT:    mov v16.s[2], w6
-; CHECK-GI-NEXT:    and v6.16b, v7.16b, v22.16b
-; CHECK-GI-NEXT:    eor v5.16b, v5.16b, v20.16b
-; CHECK-GI-NEXT:    mov v21.s[3], v1.s[0]
-; CHECK-GI-NEXT:    mov v0.s[2], v3.s[0]
-; CHECK-GI-NEXT:    bic v2.16b, v18.16b, v2.16b
-; CHECK-GI-NEXT:    shl v1.4s, v19.4s, #1
-; CHECK-GI-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NEXT:    neg v6.4s, v6.4s
-; CHECK-GI-NEXT:    and v3.16b, v5.16b, v23.16b
-; CHECK-GI-NEXT:    ushl v5.4s, v16.4s, v24.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    ushl v2.4s, v21.4s, v4.4s
+; CHECK-GI-NEXT:    mov v16.s[2], w2
+; CHECK-GI-NEXT:    mov v4.s[1], w5
+; CHECK-GI-NEXT:    ldr s2, [sp, #32]
+; CHECK-GI-NEXT:    zip1 v5.2d, v5.2d, v6.2d
+; CHECK-GI-NEXT:    movi v6.4s, #31
+; CHECK-GI-NEXT:    add x8, sp, #96
+; CHECK-GI-NEXT:    mov v17.s[2], v21.s[0]
+; CHECK-GI-NEXT:    movi v7.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    ldr s19, [sp, #72]
+; CHECK-GI-NEXT:    ld1 { v20.s }[2], [x8]
+; CHECK-GI-NEXT:    mov v18.s[2], v3.s[0]
+; CHECK-GI-NEXT:    mov v0.s[1], v2.s[0]
+; CHECK-GI-NEXT:    mov v1.s[3], v19.s[0]
+; CHECK-GI-NEXT:    mov v16.s[3], w3
+; CHECK-GI-NEXT:    mov v4.s[2], w6
+; CHECK-GI-NEXT:    ldr s2, [sp, #16]
+; CHECK-GI-NEXT:    and v3.16b, v5.16b, v6.16b
+; CHECK-GI-NEXT:    ldr s5, [sp, #40]
+; CHECK-GI-NEXT:    and v19.16b, v20.16b, v6.16b
+; CHECK-GI-NEXT:    eor v7.16b, v17.16b, v7.16b
+; CHECK-GI-NEXT:    mov v18.s[3], v2.s[0]
+; CHECK-GI-NEXT:    mov v0.s[2], v5.s[0]
+; CHECK-GI-NEXT:    bic v1.16b, v6.16b, v1.16b
+; CHECK-GI-NEXT:    shl v2.4s, v16.4s, #1
+; CHECK-GI-NEXT:    neg v3.4s, v3.4s
+; CHECK-GI-NEXT:    and v5.16b, v7.16b, v6.16b
+; CHECK-GI-NEXT:    shl v4.4s, v4.4s, #1
+; CHECK-GI-NEXT:    neg v6.4s, v19.4s
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v2.4s, v18.4s, v3.4s
+; CHECK-GI-NEXT:    ushl v3.4s, v4.4s, v5.4s
 ; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v6.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v5.4s, v3.4s
 ; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v3.16b, v0.16b
 ; CHECK-GI-NEXT:    mov s2, v1.s[1]
 ; CHECK-GI-NEXT:    mov s3, v1.s[2]
 ; CHECK-GI-NEXT:    mov s4, v1.s[3]
-; CHECK-GI-NEXT:    fmov w0, s1
 ; CHECK-GI-NEXT:    mov s5, v0.s[1]
 ; CHECK-GI-NEXT:    mov s6, v0.s[2]
+; CHECK-GI-NEXT:    fmov w0, s1
 ; CHECK-GI-NEXT:    fmov w4, s0
 ; CHECK-GI-NEXT:    fmov w1, s2
 ; CHECK-GI-NEXT:    fmov w2, s3
@@ -3258,26 +3141,9 @@ define <7 x i16> @rotl_v7i16_c(<7 x i16> %a) {
 ;
 ; CHECK-GI-LABEL: rotl_v7i16_c:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #13 // =0xd
-; CHECK-GI-NEXT:    mov w9, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    mov v1.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    mov v1.h[3], w8
-; CHECK-GI-NEXT:    mov v2.h[3], w9
-; CHECK-GI-NEXT:    mov v1.h[4], w8
-; CHECK-GI-NEXT:    mov v2.h[4], w9
-; CHECK-GI-NEXT:    mov v1.h[5], w8
-; CHECK-GI-NEXT:    mov v2.h[5], w9
-; CHECK-GI-NEXT:    mov v1.h[6], w8
-; CHECK-GI-NEXT:    mov v2.h[6], w9
-; CHECK-GI-NEXT:    neg v1.8h, v1.8h
-; CHECK-GI-NEXT:    ushl v2.8h, v0.8h, v2.8h
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v1.8h
-; CHECK-GI-NEXT:    orr v0.16b, v2.16b, v0.16b
+; CHECK-GI-NEXT:    shl v1.8h, v0.8h, #3
+; CHECK-GI-NEXT:    usra v1.8h, v0.8h, #13
+; CHECK-GI-NEXT:    mov v0.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i16> @llvm.fshl(<7 x i16> %a, <7 x i16> %a, <7 x i16> <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>)
@@ -3298,26 +3164,9 @@ define <7 x i16> @rotr_v7i16_c(<7 x i16> %a) {
 ;
 ; CHECK-GI-LABEL: rotr_v7i16_c:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    mov w9, #13 // =0xd
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    mov v1.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    mov v1.h[3], w8
-; CHECK-GI-NEXT:    mov v2.h[3], w9
-; CHECK-GI-NEXT:    mov v1.h[4], w8
-; CHECK-GI-NEXT:    mov v2.h[4], w9
-; CHECK-GI-NEXT:    mov v1.h[5], w8
-; CHECK-GI-NEXT:    mov v2.h[5], w9
-; CHECK-GI-NEXT:    mov v1.h[6], w8
-; CHECK-GI-NEXT:    mov v2.h[6], w9
-; CHECK-GI-NEXT:    neg v1.8h, v1.8h
-; CHECK-GI-NEXT:    ushl v1.8h, v0.8h, v1.8h
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v2.8h
-; CHECK-GI-NEXT:    orr v0.16b, v1.16b, v0.16b
+; CHECK-GI-NEXT:    shl v1.8h, v0.8h, #13
+; CHECK-GI-NEXT:    usra v1.8h, v0.8h, #3
+; CHECK-GI-NEXT:    mov v0.16b, v1.16b
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i16> @llvm.fshr(<7 x i16> %a, <7 x i16> %a, <7 x i16> <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>)
@@ -3452,45 +3301,35 @@ define <7 x i32> @rotl_v7i32_c(<7 x i32> %a) {
 ; CHECK-GI-LABEL: rotl_v7i32_c:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    fmov s0, w0
-; CHECK-GI-NEXT:    mov w8, #29 // =0x1d
-; CHECK-GI-NEXT:    fmov s2, w0
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov w9, #3 // =0x3
+; CHECK-GI-NEXT:    fmov s1, w0
+; CHECK-GI-NEXT:    fmov s2, w4
 ; CHECK-GI-NEXT:    fmov s3, w4
-; CHECK-GI-NEXT:    fmov s4, w4
-; CHECK-GI-NEXT:    fmov s5, w9
 ; CHECK-GI-NEXT:    mov v0.s[1], w1
-; CHECK-GI-NEXT:    mov v2.s[1], w1
-; CHECK-GI-NEXT:    mov v1.s[1], w8
+; CHECK-GI-NEXT:    mov v1.s[1], w1
+; CHECK-GI-NEXT:    mov v2.s[1], w5
 ; CHECK-GI-NEXT:    mov v3.s[1], w5
-; CHECK-GI-NEXT:    mov v4.s[1], w5
-; CHECK-GI-NEXT:    mov v5.s[1], w9
 ; CHECK-GI-NEXT:    mov v0.s[2], w2
-; CHECK-GI-NEXT:    mov v2.s[2], w2
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    mov v1.s[2], w2
+; CHECK-GI-NEXT:    mov v2.s[2], w6
 ; CHECK-GI-NEXT:    mov v3.s[2], w6
-; CHECK-GI-NEXT:    mov v4.s[2], w6
-; CHECK-GI-NEXT:    mov v5.s[2], w9
 ; CHECK-GI-NEXT:    mov v0.s[3], w3
-; CHECK-GI-NEXT:    mov v2.s[3], w3
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v4.4s, v4.4s, v5.4s
+; CHECK-GI-NEXT:    mov v1.s[3], w3
+; CHECK-GI-NEXT:    shl v2.4s, v2.4s, #3
+; CHECK-GI-NEXT:    usra v2.4s, v3.4s, #29
 ; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #3
-; CHECK-GI-NEXT:    ushl v1.4s, v3.4s, v1.4s
-; CHECK-GI-NEXT:    usra v0.4s, v2.4s, #29
-; CHECK-GI-NEXT:    orr v1.16b, v4.16b, v1.16b
-; CHECK-GI-NEXT:    mov s2, v0.s[1]
+; CHECK-GI-NEXT:    mov s5, v2.s[1]
+; CHECK-GI-NEXT:    mov s6, v2.s[2]
+; CHECK-GI-NEXT:    fmov w4, s2
+; CHECK-GI-NEXT:    usra v0.4s, v1.4s, #29
+; CHECK-GI-NEXT:    mov s1, v0.s[1]
 ; CHECK-GI-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-NEXT:    mov s4, v0.s[3]
-; CHECK-GI-NEXT:    mov s5, v1.s[1]
-; CHECK-GI-NEXT:    mov s6, v1.s[2]
 ; CHECK-GI-NEXT:    fmov w0, s0
-; CHECK-GI-NEXT:    fmov w4, s1
-; CHECK-GI-NEXT:    fmov w1, s2
-; CHECK-GI-NEXT:    fmov w2, s3
-; CHECK-GI-NEXT:    fmov w3, s4
 ; CHECK-GI-NEXT:    fmov w5, s5
 ; CHECK-GI-NEXT:    fmov w6, s6
+; CHECK-GI-NEXT:    fmov w1, s1
+; CHECK-GI-NEXT:    fmov w2, s3
+; CHECK-GI-NEXT:    fmov w3, s4
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i32> @llvm.fshl(<7 x i32> %a, <7 x i32> %a, <7 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>)
@@ -3523,45 +3362,35 @@ define <7 x i32> @rotr_v7i32_c(<7 x i32> %a) {
 ; CHECK-GI-LABEL: rotr_v7i32_c:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    fmov s0, w0
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s2, w0
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov w9, #29 // =0x1d
+; CHECK-GI-NEXT:    fmov s1, w0
+; CHECK-GI-NEXT:    fmov s2, w4
 ; CHECK-GI-NEXT:    fmov s3, w4
-; CHECK-GI-NEXT:    fmov s4, w4
-; CHECK-GI-NEXT:    fmov s5, w9
 ; CHECK-GI-NEXT:    mov v0.s[1], w1
-; CHECK-GI-NEXT:    mov v2.s[1], w1
-; CHECK-GI-NEXT:    mov v1.s[1], w8
+; CHECK-GI-NEXT:    mov v1.s[1], w1
+; CHECK-GI-NEXT:    mov v2.s[1], w5
 ; CHECK-GI-NEXT:    mov v3.s[1], w5
-; CHECK-GI-NEXT:    mov v4.s[1], w5
-; CHECK-GI-NEXT:    mov v5.s[1], w9
 ; CHECK-GI-NEXT:    mov v0.s[2], w2
-; CHECK-GI-NEXT:    mov v2.s[2], w2
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    mov v1.s[2], w2
+; CHECK-GI-NEXT:    mov v2.s[2], w6
 ; CHECK-GI-NEXT:    mov v3.s[2], w6
-; CHECK-GI-NEXT:    mov v4.s[2], w6
-; CHECK-GI-NEXT:    mov v5.s[2], w9
 ; CHECK-GI-NEXT:    mov v0.s[3], w3
-; CHECK-GI-NEXT:    mov v2.s[3], w3
-; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v3.4s, v3.4s, v5.4s
+; CHECK-GI-NEXT:    mov v1.s[3], w3
+; CHECK-GI-NEXT:    shl v2.4s, v2.4s, #29
+; CHECK-GI-NEXT:    usra v2.4s, v3.4s, #3
 ; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #29
-; CHECK-GI-NEXT:    ushl v1.4s, v4.4s, v1.4s
-; CHECK-GI-NEXT:    usra v0.4s, v2.4s, #3
-; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v3.16b
-; CHECK-GI-NEXT:    mov s2, v0.s[1]
+; CHECK-GI-NEXT:    mov s5, v2.s[1]
+; CHECK-GI-NEXT:    mov s6, v2.s[2]
+; CHECK-GI-NEXT:    fmov w4, s2
+; CHECK-GI-NEXT:    usra v0.4s, v1.4s, #3
+; CHECK-GI-NEXT:    mov s1, v0.s[1]
 ; CHECK-GI-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-NEXT:    mov s4, v0.s[3]
-; CHECK-GI-NEXT:    mov s5, v1.s[1]
-; CHECK-GI-NEXT:    mov s6, v1.s[2]
 ; CHECK-GI-NEXT:    fmov w0, s0
-; CHECK-GI-NEXT:    fmov w4, s1
-; CHECK-GI-NEXT:    fmov w1, s2
-; CHECK-GI-NEXT:    fmov w2, s3
-; CHECK-GI-NEXT:    fmov w3, s4
 ; CHECK-GI-NEXT:    fmov w5, s5
 ; CHECK-GI-NEXT:    fmov w6, s6
+; CHECK-GI-NEXT:    fmov w1, s1
+; CHECK-GI-NEXT:    fmov w2, s3
+; CHECK-GI-NEXT:    fmov w3, s4
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i32> @llvm.fshr(<7 x i32> %a, <7 x i32> %a, <7 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>)
@@ -3782,26 +3611,8 @@ define <7 x i16> @fshl_v7i16_c(<7 x i16> %a, <7 x i16> %b) {
 ;
 ; CHECK-GI-LABEL: fshl_v7i16_c:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #13 // =0xd
-; CHECK-GI-NEXT:    mov w9, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    fmov s3, w9
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov v3.h[1], w9
-; CHECK-GI-NEXT:    mov v2.h[2], w8
-; CHECK-GI-NEXT:    mov v3.h[2], w9
-; CHECK-GI-NEXT:    mov v2.h[3], w8
-; CHECK-GI-NEXT:    mov v3.h[3], w9
-; CHECK-GI-NEXT:    mov v2.h[4], w8
-; CHECK-GI-NEXT:    mov v3.h[4], w9
-; CHECK-GI-NEXT:    mov v2.h[5], w8
-; CHECK-GI-NEXT:    mov v3.h[5], w9
-; CHECK-GI-NEXT:    mov v2.h[6], w8
-; CHECK-GI-NEXT:    mov v3.h[6], w9
-; CHECK-GI-NEXT:    neg v2.8h, v2.8h
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v3.8h
-; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v2.8h
-; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #3
+; CHECK-GI-NEXT:    usra v0.8h, v1.8h, #13
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i16> @llvm.fshl(<7 x i16> %a, <7 x i16> %b, <7 x i16> <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>)
@@ -3822,26 +3633,8 @@ define <7 x i16> @fshr_v7i16_c(<7 x i16> %a, <7 x i16> %b) {
 ;
 ; CHECK-GI-LABEL: fshr_v7i16_c:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    mov w9, #13 // =0xd
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    fmov s3, w9
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov v3.h[1], w9
-; CHECK-GI-NEXT:    mov v2.h[2], w8
-; CHECK-GI-NEXT:    mov v3.h[2], w9
-; CHECK-GI-NEXT:    mov v2.h[3], w8
-; CHECK-GI-NEXT:    mov v3.h[3], w9
-; CHECK-GI-NEXT:    mov v2.h[4], w8
-; CHECK-GI-NEXT:    mov v3.h[4], w9
-; CHECK-GI-NEXT:    mov v2.h[5], w8
-; CHECK-GI-NEXT:    mov v3.h[5], w9
-; CHECK-GI-NEXT:    mov v2.h[6], w8
-; CHECK-GI-NEXT:    mov v3.h[6], w9
-; CHECK-GI-NEXT:    neg v2.8h, v2.8h
-; CHECK-GI-NEXT:    ushl v0.8h, v0.8h, v3.8h
-; CHECK-GI-NEXT:    ushl v1.8h, v1.8h, v2.8h
-; CHECK-GI-NEXT:    orr v0.16b, v0.16b, v1.16b
+; CHECK-GI-NEXT:    shl v0.8h, v0.8h, #13
+; CHECK-GI-NEXT:    usra v0.8h, v1.8h, #3
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i16> @llvm.fshr(<7 x i16> %a, <7 x i16> %b, <7 x i16> <i16 3, i16 3, i16 3, i16 3, i16 3, i16 3, i16 3>)
@@ -3994,50 +3787,40 @@ define <7 x i32> @fshl_v7i32_c(<7 x i32> %a, <7 x i32> %b) {
 ; CHECK-GI-LABEL: fshl_v7i32_c:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    fmov s0, w0
-; CHECK-GI-NEXT:    mov w8, #29 // =0x1d
-; CHECK-GI-NEXT:    fmov s5, w7
-; CHECK-GI-NEXT:    fmov s3, w8
+; CHECK-GI-NEXT:    fmov s2, w7
 ; CHECK-GI-NEXT:    ldr s1, [sp]
-; CHECK-GI-NEXT:    mov w9, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s7, w9
+; CHECK-GI-NEXT:    ldr s3, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s4, [sp, #24]
-; CHECK-GI-NEXT:    ldr s6, [sp, #32]
+; CHECK-GI-NEXT:    ldr s5, [sp, #32]
 ; CHECK-GI-NEXT:    mov v0.s[1], w1
-; CHECK-GI-NEXT:    mov v5.s[1], v1.s[0]
+; CHECK-GI-NEXT:    mov v2.s[1], v1.s[0]
 ; CHECK-GI-NEXT:    fmov s1, w4
-; CHECK-GI-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[1], v6.s[0]
-; CHECK-GI-NEXT:    ldr s2, [sp, #8]
-; CHECK-GI-NEXT:    mov v7.s[1], w9
-; CHECK-GI-NEXT:    ldr s6, [sp, #40]
+; CHECK-GI-NEXT:    mov v4.s[1], v5.s[0]
+; CHECK-GI-NEXT:    ldr s5, [sp, #40]
 ; CHECK-GI-NEXT:    mov v1.s[1], w5
 ; CHECK-GI-NEXT:    mov v0.s[2], w2
-; CHECK-GI-NEXT:    mov v5.s[2], v2.s[0]
-; CHECK-GI-NEXT:    ldr s2, [sp, #16]
-; CHECK-GI-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NEXT:    mov v4.s[2], v6.s[0]
-; CHECK-GI-NEXT:    mov v7.s[2], w9
+; CHECK-GI-NEXT:    mov v2.s[2], v3.s[0]
+; CHECK-GI-NEXT:    ldr s3, [sp, #16]
+; CHECK-GI-NEXT:    mov v4.s[2], v5.s[0]
 ; CHECK-GI-NEXT:    mov v1.s[2], w6
 ; CHECK-GI-NEXT:    mov v0.s[3], w3
-; CHECK-GI-NEXT:    mov v5.s[3], v2.s[0]
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v7.4s
+; CHECK-GI-NEXT:    mov v2.s[3], v3.s[0]
+; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #3
 ; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #3
-; CHECK-GI-NEXT:    ushl v2.4s, v4.4s, v3.4s
-; CHECK-GI-NEXT:    usra v0.4s, v5.4s, #29
-; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b
+; CHECK-GI-NEXT:    usra v1.4s, v4.4s, #29
+; CHECK-GI-NEXT:    usra v0.4s, v2.4s, #29
+; CHECK-GI-NEXT:    mov s5, v1.s[1]
+; CHECK-GI-NEXT:    mov s6, v1.s[2]
+; CHECK-GI-NEXT:    fmov w4, s1
 ; CHECK-GI-NEXT:    mov s2, v0.s[1]
 ; CHECK-GI-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-NEXT:    mov s4, v0.s[3]
-; CHECK-GI-NEXT:    mov s5, v1.s[1]
-; CHECK-GI-NEXT:    mov s6, v1.s[2]
 ; CHECK-GI-NEXT:    fmov w0, s0
-; CHECK-GI-NEXT:    fmov w4, s1
+; CHECK-GI-NEXT:    fmov w5, s5
+; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    fmov w1, s2
 ; CHECK-GI-NEXT:    fmov w2, s3
 ; CHECK-GI-NEXT:    fmov w3, s4
-; CHECK-GI-NEXT:    fmov w5, s5
-; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i32> @llvm.fshl(<7 x i32> %a, <7 x i32> %b, <7 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>)
@@ -4082,50 +3865,40 @@ define <7 x i32> @fshr_v7i32_c(<7 x i32> %a, <7 x i32> %b) {
 ; CHECK-GI-LABEL: fshr_v7i32_c:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    fmov s0, w0
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    fmov s5, w7
-; CHECK-GI-NEXT:    fmov s3, w8
+; CHECK-GI-NEXT:    fmov s2, w7
 ; CHECK-GI-NEXT:    ldr s1, [sp]
-; CHECK-GI-NEXT:    mov w9, #29 // =0x1d
-; CHECK-GI-NEXT:    fmov s7, w9
+; CHECK-GI-NEXT:    ldr s3, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s4, [sp, #24]
-; CHECK-GI-NEXT:    ldr s6, [sp, #32]
+; CHECK-GI-NEXT:    ldr s5, [sp, #32]
 ; CHECK-GI-NEXT:    mov v0.s[1], w1
-; CHECK-GI-NEXT:    mov v5.s[1], v1.s[0]
+; CHECK-GI-NEXT:    mov v2.s[1], v1.s[0]
 ; CHECK-GI-NEXT:    fmov s1, w4
-; CHECK-GI-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[1], v6.s[0]
-; CHECK-GI-NEXT:    ldr s2, [sp, #8]
-; CHECK-GI-NEXT:    mov v7.s[1], w9
-; CHECK-GI-NEXT:    ldr s6, [sp, #40]
+; CHECK-GI-NEXT:    mov v4.s[1], v5.s[0]
+; CHECK-GI-NEXT:    ldr s5, [sp, #40]
 ; CHECK-GI-NEXT:    mov v1.s[1], w5
 ; CHECK-GI-NEXT:    mov v0.s[2], w2
-; CHECK-GI-NEXT:    mov v5.s[2], v2.s[0]
-; CHECK-GI-NEXT:    ldr s2, [sp, #16]
-; CHECK-GI-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NEXT:    mov v4.s[2], v6.s[0]
-; CHECK-GI-NEXT:    mov v7.s[2], w9
+; CHECK-GI-NEXT:    mov v2.s[2], v3.s[0]
+; CHECK-GI-NEXT:    ldr s3, [sp, #16]
+; CHECK-GI-NEXT:    mov v4.s[2], v5.s[0]
 ; CHECK-GI-NEXT:    mov v1.s[2], w6
 ; CHECK-GI-NEXT:    mov v0.s[3], w3
-; CHECK-GI-NEXT:    mov v5.s[3], v2.s[0]
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v7.4s
+; CHECK-GI-NEXT:    mov v2.s[3], v3.s[0]
+; CHECK-GI-NEXT:    shl v1.4s, v1.4s, #29
 ; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #29
-; CHECK-GI-NEXT:    ushl v2.4s, v4.4s, v3.4s
-; CHECK-GI-NEXT:    usra v0.4s, v5.4s, #3
-; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b
+; CHECK-GI-NEXT:    usra v1.4s, v4.4s, #3
+; CHECK-GI-NEXT:    usra v0.4s, v2.4s, #3
+; CHECK-GI-NEXT:    mov s5, v1.s[1]
+; CHECK-GI-NEXT:    mov s6, v1.s[2]
+; CHECK-GI-NEXT:    fmov w4, s1
 ; CHECK-GI-NEXT:    mov s2, v0.s[1]
 ; CHECK-GI-NEXT:    mov s3, v0.s[2]
 ; CHECK-GI-NEXT:    mov s4, v0.s[3]
-; CHECK-GI-NEXT:    mov s5, v1.s[1]
-; CHECK-GI-NEXT:    mov s6, v1.s[2]
 ; CHECK-GI-NEXT:    fmov w0, s0
-; CHECK-GI-NEXT:    fmov w4, s1
+; CHECK-GI-NEXT:    fmov w5, s5
+; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    fmov w1, s2
 ; CHECK-GI-NEXT:    fmov w2, s3
 ; CHECK-GI-NEXT:    fmov w3, s4
-; CHECK-GI-NEXT:    fmov w5, s5
-; CHECK-GI-NEXT:    fmov w6, s6
 ; CHECK-GI-NEXT:    ret
 entry:
   %d = call <7 x i32> @llvm.fshr(<7 x i32> %a, <7 x i32> %b, <7 x i32> <i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3>)

--- a/llvm/test/CodeGen/AArch64/hadd-combine.ll
+++ b/llvm/test/CodeGen/AArch64/hadd-combine.ll
@@ -1588,15 +1588,12 @@ define <8 x i8> @dontcrashonnvcasts() {
 ;
 ; CHECK-GI-LABEL: dontcrashonnvcasts:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi d0, #0000000000000000
-; CHECK-GI-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-GI-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-GI-NEXT:    adrp x8, .LCPI91_0
-; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI91_0]
-; CHECK-GI-NEXT:    mov v0.b[2], wzr
-; CHECK-GI-NEXT:    urhadd v1.8b, v2.8b, v1.8b
-; CHECK-GI-NEXT:    mov v0.b[4], wzr
-; CHECK-GI-NEXT:    mov v0.b[6], wzr
-; CHECK-GI-NEXT:    uzp1 v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI91_0]
+; CHECK-GI-NEXT:    urhadd v0.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v2.8b
 ; CHECK-GI-NEXT:    ret
   %vrhadd_v.i = tail call <8 x i8> @llvm.aarch64.neon.urhadd.v8i8(<8 x i8> <i8 0, i8 0, i8 0, i8 -1, i8 0, i8 0, i8 0, i8 0>, <8 x i8> zeroinitializer)
   %shuffle.i = shufflevector <8 x i8> %vrhadd_v.i, <8 x i8> <i8 0, i8 poison, i8 0, i8 poison, i8 0, i8 poison, i8 0, i8 poison>, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>

--- a/llvm/test/CodeGen/AArch64/hoist-and-by-const-from-lshr-in-eqcmp-zero.ll
+++ b/llvm/test/CodeGen/AArch64/hoist-and-by-const-from-lshr-in-eqcmp-zero.ll
@@ -335,11 +335,8 @@ define <4 x i1> @vec_4xi32_nonsplat_undef0_eq(<4 x i32> %x, <4 x i32> %y) nounwi
 ;
 ; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef0_eq:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
+; CHECK-GI-NEXT:    movi v2.4s, #1
 ; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.s[1], w8
-; CHECK-GI-NEXT:    mov v2.s[3], w8
 ; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
 ; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
 ; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, #0
@@ -363,13 +360,11 @@ define <4 x i1> @vec_4xi32_nonsplat_undef1_eq(<4 x i32> %x, <4 x i32> %y) nounwi
 ;
 ; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef1_eq:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
-; CHECK-GI-NEXT:    movi v3.4s, #1
+; CHECK-GI-NEXT:    movi v2.4s, #1
 ; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    mov v2.s[1], wzr
-; CHECK-GI-NEXT:    ushl v1.4s, v3.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
-; CHECK-GI-NEXT:    mov v2.s[3], wzr
 ; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-GI-NEXT:    ret
@@ -391,15 +386,10 @@ define <4 x i1> @vec_4xi32_nonsplat_undef2_eq(<4 x i32> %x, <4 x i32> %y) nounwi
 ;
 ; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef2_eq:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
+; CHECK-GI-NEXT:    movi v2.4s, #1
 ; CHECK-GI-NEXT:    neg v1.4s, v1.4s
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NEXT:    mov v2.s[1], wzr
-; CHECK-GI-NEXT:    mov v3.s[3], w8
-; CHECK-GI-NEXT:    mov v2.s[3], wzr
-; CHECK-GI-NEXT:    ushl v1.4s, v3.4s, v1.4s
+; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
 ; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    xtn v0.4h, v0.4s

--- a/llvm/test/CodeGen/AArch64/hoist-and-by-const-from-shl-in-eqcmp-zero.ll
+++ b/llvm/test/CodeGen/AArch64/hoist-and-by-const-from-shl-in-eqcmp-zero.ll
@@ -325,26 +325,14 @@ define <4 x i1> @vec_4xi32_nonsplat_eq(<4 x i32> %x, <4 x i32> %y) nounwind {
 }
 
 define <4 x i1> @vec_4xi32_nonsplat_undef0_eq(<4 x i32> %x, <4 x i32> %y) nounwind {
-; CHECK-SD-LABEL: vec_4xi32_nonsplat_undef0_eq:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    movi v2.4s, #1
-; CHECK-SD-NEXT:    ushl v1.4s, v2.4s, v1.4s
-; CHECK-SD-NEXT:    and v0.16b, v1.16b, v0.16b
-; CHECK-SD-NEXT:    cmeq v0.4s, v0.4s, #0
-; CHECK-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef0_eq:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.s[1], w8
-; CHECK-GI-NEXT:    mov v2.s[3], w8
-; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
-; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
-; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, #0
-; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: vec_4xi32_nonsplat_undef0_eq:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v2.4s, #1
+; CHECK-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-NEXT:    and v0.16b, v1.16b, v0.16b
+; CHECK-NEXT:    cmeq v0.4s, v0.4s, #0
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %t0 = shl <4 x i32> <i32 1, i32 1, i32 undef, i32 1>, %y
   %t1 = and <4 x i32> %t0, %x
   %res = icmp eq <4 x i32> %t1, <i32 0, i32 0, i32 0, i32 0>
@@ -362,13 +350,11 @@ define <4 x i1> @vec_4xi32_nonsplat_undef1_eq(<4 x i32> %x, <4 x i32> %y) nounwi
 ;
 ; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef1_eq:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi d3, #0000000000000000
 ; CHECK-GI-NEXT:    movi v2.4s, #1
-; CHECK-GI-NEXT:    mov v3.s[1], wzr
 ; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
-; CHECK-GI-NEXT:    mov v3.s[3], wzr
-; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v3.4s
+; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-GI-NEXT:    ret
   %t0 = shl <4 x i32> <i32 1, i32 1, i32 1, i32 1>, %y
@@ -388,16 +374,11 @@ define <4 x i1> @vec_4xi32_nonsplat_undef2_eq(<4 x i32> %x, <4 x i32> %y) nounwi
 ;
 ; CHECK-GI-LABEL: vec_4xi32_nonsplat_undef2_eq:
 ; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    movi d3, #0000000000000000
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.s[1], w8
-; CHECK-GI-NEXT:    mov v3.s[1], wzr
-; CHECK-GI-NEXT:    mov v2.s[3], w8
-; CHECK-GI-NEXT:    mov v3.s[3], wzr
+; CHECK-GI-NEXT:    movi v2.4s, #1
 ; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-GI-NEXT:    and v0.16b, v1.16b, v0.16b
-; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v3.4s
+; CHECK-GI-NEXT:    cmeq v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-GI-NEXT:    ret
   %t0 = shl <4 x i32> <i32 1, i32 1, i32 undef, i32 1>, %y

--- a/llvm/test/CodeGen/AArch64/icmp.ll
+++ b/llvm/test/CodeGen/AArch64/icmp.ll
@@ -1227,18 +1227,10 @@ define <3 x i32> @v3i32_i32(<3 x i32> %a, <3 x i32> %b, <3 x i32> %d, <3 x i32> 
 ;
 ; CHECK-GI-LABEL: v3i32_i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #31 // =0x1f
 ; CHECK-GI-NEXT:    cmgt v0.4s, v1.4s, v0.4s
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    mov v4.s[1], w8
-; CHECK-GI-NEXT:    mov v4.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.s[1], w8
-; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    neg v4.4s, v4.4s
-; CHECK-GI-NEXT:    sshl v0.4s, v0.4s, v4.4s
-; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    shl v0.4s, v0.4s, #31
+; CHECK-GI-NEXT:    cmlt v0.4s, v0.4s, #0
 ; CHECK-GI-NEXT:    eor v1.16b, v0.16b, v1.16b
 ; CHECK-GI-NEXT:    and v0.16b, v2.16b, v0.16b
 ; CHECK-GI-NEXT:    and v1.16b, v3.16b, v1.16b

--- a/llvm/test/CodeGen/AArch64/rem-by-const.ll
+++ b/llvm/test/CodeGen/AArch64/rem-by-const.ll
@@ -680,39 +680,25 @@ define <2 x i8> @sv2i8_7(<2 x i8> %d, <2 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i8_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #65427 // =0xff93
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.h[1], w8
+; CHECK-GI-NEXT:    mvni v1.4h, #108
+; CHECK-GI-NEXT:    shl v2.2s, v0.2s, #24
+; CHECK-GI-NEXT:    movi v3.2s, #7
 ; CHECK-GI-NEXT:    shl v1.4h, v1.4h, #8
+; CHECK-GI-NEXT:    sshr v2.2s, v2.2s, #24
 ; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    smov w8, v1.h[0]
 ; CHECK-GI-NEXT:    smov w9, v1.h[1]
-; CHECK-GI-NEXT:    shl v1.2s, v0.2s, #24
-; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #24
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
-; CHECK-GI-NEXT:    mov v2.s[1], w9
-; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
+; CHECK-GI-NEXT:    fmov s1, w8
+; CHECK-GI-NEXT:    mov v1.s[1], w9
+; CHECK-GI-NEXT:    mul v1.2s, v2.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    sshl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    fmov s2, w8
+; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
-; CHECK-GI-NEXT:    mov v2.b[1], w8
-; CHECK-GI-NEXT:    mov w8, #7 // =0x7
-; CHECK-GI-NEXT:    fmov s3, w8
 ; CHECK-GI-NEXT:    add v1.2s, v1.2s, v0.2s
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    neg v2.8b, v2.8b
-; CHECK-GI-NEXT:    mov w9, v1.s[1]
-; CHECK-GI-NEXT:    mov v1.b[1], w9
-; CHECK-GI-NEXT:    sshl v1.8b, v1.8b, v2.8b
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    movi v3.2s, #7
-; CHECK-GI-NEXT:    ushl v2.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    mov w8, v1.s[1]
+; CHECK-GI-NEXT:    mov v1.b[1], w8
+; CHECK-GI-NEXT:    sshr v1.8b, v1.8b, #2
+; CHECK-GI-NEXT:    ushr v2.8b, v1.8b, #7
 ; CHECK-GI-NEXT:    umov w8, v1.b[0]
 ; CHECK-GI-NEXT:    umov w10, v1.b[1]
 ; CHECK-GI-NEXT:    umov w9, v2.b[0]
@@ -747,36 +733,22 @@ define <2 x i8> @sv2i8_100(<2 x i8> %d, <2 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i8_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #41 // =0x29
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.h[1], w8
+; CHECK-GI-NEXT:    movi v1.4h, #41
+; CHECK-GI-NEXT:    shl v2.2s, v0.2s, #24
+; CHECK-GI-NEXT:    movi v3.2s, #100
+; CHECK-GI-NEXT:    sshr v2.2s, v2.2s, #24
 ; CHECK-GI-NEXT:    shl v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    smov w8, v1.h[0]
 ; CHECK-GI-NEXT:    smov w9, v1.h[1]
-; CHECK-GI-NEXT:    shl v1.2s, v0.2s, #24
-; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #24
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
-; CHECK-GI-NEXT:    mov v2.s[1], w9
-; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #4 // =0x4
+; CHECK-GI-NEXT:    fmov s1, w8
+; CHECK-GI-NEXT:    mov v1.s[1], w9
+; CHECK-GI-NEXT:    mul v1.2s, v2.2s, v1.2s
 ; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    mov w8, #7 // =0x7
-; CHECK-GI-NEXT:    sshl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    neg v3.8b, v3.8b
+; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    mov v2.b[1], w8
-; CHECK-GI-NEXT:    sshl v1.8b, v1.8b, v3.8b
-; CHECK-GI-NEXT:    neg v2.8b, v2.8b
-; CHECK-GI-NEXT:    movi v3.2s, #100
-; CHECK-GI-NEXT:    ushl v2.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    sshr v1.8b, v1.8b, #4
+; CHECK-GI-NEXT:    ushr v2.8b, v1.8b, #7
 ; CHECK-GI-NEXT:    umov w8, v1.b[0]
 ; CHECK-GI-NEXT:    umov w10, v1.b[1]
 ; CHECK-GI-NEXT:    umov w9, v2.b[0]
@@ -915,33 +887,17 @@ define <4 x i8> @sv4i8_7(<4 x i8> %d, <4 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i8_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #147 // =0x93
+; CHECK-GI-NEXT:    movi v1.8b, #147
 ; CHECK-GI-NEXT:    shl v2.4h, v0.4h, #8
-; CHECK-GI-NEXT:    mov w9, #7 // =0x7
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    fmov s4, w9
+; CHECK-GI-NEXT:    movi v3.4h, #7
 ; CHECK-GI-NEXT:    sshr v2.4h, v2.4h, #8
-; CHECK-GI-NEXT:    mov v1.b[1], w8
-; CHECK-GI-NEXT:    mov v4.b[1], w9
-; CHECK-GI-NEXT:    mov v1.b[2], w8
-; CHECK-GI-NEXT:    mov v4.b[2], w9
-; CHECK-GI-NEXT:    mov v1.b[3], w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    mov v4.b[3], w9
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.b[1], w8
 ; CHECK-GI-NEXT:    sshll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    mul v1.4h, v2.4h, v1.4h
 ; CHECK-GI-NEXT:    fmov d2, d0
-; CHECK-GI-NEXT:    mov v3.b[2], w8
 ; CHECK-GI-NEXT:    ssra v2.4h, v1.4h, #8
-; CHECK-GI-NEXT:    mov v3.b[3], w8
 ; CHECK-GI-NEXT:    uzp1 v1.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    movi v3.4h, #7
-; CHECK-GI-NEXT:    sshl v1.8b, v1.8b, v2.8b
-; CHECK-GI-NEXT:    neg v2.8b, v4.8b
-; CHECK-GI-NEXT:    ushl v2.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    sshr v1.8b, v1.8b, #2
+; CHECK-GI-NEXT:    ushr v2.8b, v1.8b, #7
 ; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    ushll v2.8h, v2.8b, #0
 ; CHECK-GI-NEXT:    add v1.4h, v1.4h, v2.4h
@@ -969,32 +925,16 @@ define <4 x i8> @sv4i8_100(<4 x i8> %d, <4 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: sv4i8_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #41 // =0x29
+; CHECK-GI-NEXT:    movi v1.8b, #41
 ; CHECK-GI-NEXT:    shl v2.4h, v0.4h, #8
-; CHECK-GI-NEXT:    mov w9, #7 // =0x7
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    fmov s4, w9
+; CHECK-GI-NEXT:    movi v3.4h, #100
 ; CHECK-GI-NEXT:    sshr v2.4h, v2.4h, #8
-; CHECK-GI-NEXT:    mov v1.b[1], w8
-; CHECK-GI-NEXT:    mov v4.b[1], w9
-; CHECK-GI-NEXT:    mov v1.b[2], w8
-; CHECK-GI-NEXT:    mov v4.b[2], w9
-; CHECK-GI-NEXT:    mov v1.b[3], w8
-; CHECK-GI-NEXT:    mov w8, #4 // =0x4
-; CHECK-GI-NEXT:    mov v4.b[3], w9
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.b[1], w8
 ; CHECK-GI-NEXT:    sshll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    mul v1.4h, v2.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
 ; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #8
-; CHECK-GI-NEXT:    mov v3.b[3], w8
 ; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    movi v3.4h, #100
-; CHECK-GI-NEXT:    sshl v1.8b, v1.8b, v2.8b
-; CHECK-GI-NEXT:    neg v2.8b, v4.8b
-; CHECK-GI-NEXT:    ushl v2.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    sshr v1.8b, v1.8b, #4
+; CHECK-GI-NEXT:    ushr v2.8b, v1.8b, #7
 ; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    ushll v2.8h, v2.8b, #0
 ; CHECK-GI-NEXT:    add v1.4h, v1.4h, v2.4h
@@ -1143,36 +1083,24 @@ define <2 x i8> @uv2i8_7(<2 x i8> %d, <2 x i8> %e) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    movi d1, #0x0000ff000000ff
 ; CHECK-GI-NEXT:    movi v2.2s, #37
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
 ; CHECK-GI-NEXT:    and v1.8b, v0.8b, v1.8b
 ; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    neg v3.8b, v3.8b
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    sub v2.2s, v0.2s, v1.2s
-; CHECK-GI-NEXT:    mov w9, v2.s[1]
-; CHECK-GI-NEXT:    mov v2.b[1], w9
-; CHECK-GI-NEXT:    ushl v2.8b, v2.8b, v3.8b
+; CHECK-GI-NEXT:    mov w8, v2.s[1]
+; CHECK-GI-NEXT:    mov v2.b[1], w8
+; CHECK-GI-NEXT:    ushr v2.8b, v2.8b, #1
 ; CHECK-GI-NEXT:    umov w8, v2.b[0]
 ; CHECK-GI-NEXT:    umov w9, v2.b[1]
 ; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
 ; CHECK-GI-NEXT:    mov v2.s[1], w9
 ; CHECK-GI-NEXT:    add v1.2s, v2.2s, v1.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov w9, v1.s[1]
-; CHECK-GI-NEXT:    mov v2.b[1], w8
-; CHECK-GI-NEXT:    mov v1.b[1], w9
-; CHECK-GI-NEXT:    neg v2.8b, v2.8b
-; CHECK-GI-NEXT:    ushl v1.8b, v1.8b, v2.8b
 ; CHECK-GI-NEXT:    movi v2.2s, #7
+; CHECK-GI-NEXT:    mov w8, v1.s[1]
+; CHECK-GI-NEXT:    mov v1.b[1], w8
+; CHECK-GI-NEXT:    ushr v1.8b, v1.8b, #2
 ; CHECK-GI-NEXT:    umov w8, v1.b[0]
 ; CHECK-GI-NEXT:    umov w9, v1.b[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -1202,21 +1130,13 @@ define <2 x i8> @uv2i8_100(<2 x i8> %d, <2 x i8> %e) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    movi d1, #0x0000ff000000ff
 ; CHECK-GI-NEXT:    movi v2.2s, #41
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
 ; CHECK-GI-NEXT:    and v1.8b, v0.8b, v1.8b
 ; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #4 // =0x4
-; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    ushl v1.8b, v1.8b, v2.8b
 ; CHECK-GI-NEXT:    movi v2.2s, #100
+; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #8
+; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    ushr v1.8b, v1.8b, #4
 ; CHECK-GI-NEXT:    umov w8, v1.b[0]
 ; CHECK-GI-NEXT:    umov w9, v1.b[1]
 ; CHECK-GI-NEXT:    fmov s1, w8
@@ -1253,57 +1173,36 @@ define <3 x i8> @uv3i8_7(<3 x i8> %d, <3 x i8> %e) {
 ; CHECK-GI-LABEL: uv3i8_7:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    and w8, w0, #0xff
-; CHECK-GI-NEXT:    mov w10, #37 // =0x25
 ; CHECK-GI-NEXT:    and w9, w1, #0xff
+; CHECK-GI-NEXT:    movi v2.4h, #37
 ; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
-; CHECK-GI-NEXT:    fmov s2, w10
-; CHECK-GI-NEXT:    fmov s3, w8
+; CHECK-GI-NEXT:    and w8, w2, #0xff
 ; CHECK-GI-NEXT:    fmov s0, w0
 ; CHECK-GI-NEXT:    mov v1.h[1], w9
-; CHECK-GI-NEXT:    mov v2.h[1], w10
-; CHECK-GI-NEXT:    and w9, w2, #0xff
-; CHECK-GI-NEXT:    mov v3.h[1], w8
 ; CHECK-GI-NEXT:    mov v0.h[1], w1
-; CHECK-GI-NEXT:    mov v1.h[2], w9
-; CHECK-GI-NEXT:    mov v2.h[2], w10
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
+; CHECK-GI-NEXT:    mov v1.h[2], w8
 ; CHECK-GI-NEXT:    mov v0.h[2], w2
 ; CHECK-GI-NEXT:    mul v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    neg v2.4h, v3.4h
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
+; CHECK-GI-NEXT:    ushr v2.4h, v1.4h, #8
+; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v2.4h
 ; CHECK-GI-NEXT:    uzp1 v2.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    neg v3.8b, v3.8b
-; CHECK-GI-NEXT:    ushl v2.8b, v2.8b, v3.8b
+; CHECK-GI-NEXT:    ushr v2.8b, v2.8b, #1
 ; CHECK-GI-NEXT:    mov b3, v2.b[1]
 ; CHECK-GI-NEXT:    mov b4, v2.b[2]
 ; CHECK-GI-NEXT:    fmov w8, s3
-; CHECK-GI-NEXT:    fmov w9, s4
 ; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    add v1.4h, v2.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
-; CHECK-GI-NEXT:    mov w8, #7 // =0x7
-; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    ushl v1.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    fmov w8, s4
+; CHECK-GI-NEXT:    mov v2.h[2], w8
+; CHECK-GI-NEXT:    usra v2.4h, v1.4h, #8
+; CHECK-GI-NEXT:    uzp1 v1.8b, v2.8b, v0.8b
+; CHECK-GI-NEXT:    ushr v1.8b, v1.8b, #2
 ; CHECK-GI-NEXT:    mov b2, v1.b[1]
 ; CHECK-GI-NEXT:    mov b3, v1.b[2]
-; CHECK-GI-NEXT:    fmov w9, s2
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v1.h[1], w9
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    fmov w9, s3
-; CHECK-GI-NEXT:    mov v1.h[2], w9
-; CHECK-GI-NEXT:    mov v2.h[2], w8
+; CHECK-GI-NEXT:    fmov w8, s2
+; CHECK-GI-NEXT:    movi v2.4h, #7
+; CHECK-GI-NEXT:    mov v1.h[1], w8
+; CHECK-GI-NEXT:    fmov w8, s3
+; CHECK-GI-NEXT:    mov v1.h[2], w8
 ; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    umov w0, v0.h[0]
 ; CHECK-GI-NEXT:    umov w1, v0.h[1]
@@ -1337,46 +1236,30 @@ define <3 x i8> @uv3i8_100(<3 x i8> %d, <3 x i8> %e) {
 ; CHECK-GI-LABEL: uv3i8_100:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    and w8, w0, #0xff
-; CHECK-GI-NEXT:    mov w10, #41 // =0x29
 ; CHECK-GI-NEXT:    and w9, w1, #0xff
+; CHECK-GI-NEXT:    movi v1.4h, #41
 ; CHECK-GI-NEXT:    fmov s0, w8
-; CHECK-GI-NEXT:    mov w8, #8 // =0x8
-; CHECK-GI-NEXT:    fmov s1, w10
-; CHECK-GI-NEXT:    fmov s2, w8
+; CHECK-GI-NEXT:    and w8, w2, #0xff
 ; CHECK-GI-NEXT:    mov v0.h[1], w9
-; CHECK-GI-NEXT:    mov v1.h[1], w10
-; CHECK-GI-NEXT:    and w9, w2, #0xff
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov v0.h[2], w9
-; CHECK-GI-NEXT:    mov v1.h[2], w10
-; CHECK-GI-NEXT:    mov v2.h[2], w8
-; CHECK-GI-NEXT:    mov w8, #4 // =0x4
-; CHECK-GI-NEXT:    fmov s3, w8
+; CHECK-GI-NEXT:    mov v0.h[2], w8
 ; CHECK-GI-NEXT:    mul v0.4h, v0.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    neg v1.4h, v2.4h
-; CHECK-GI-NEXT:    ushl v0.4h, v0.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
-; CHECK-GI-NEXT:    mov w8, #100 // =0x64
+; CHECK-GI-NEXT:    ushr v0.4h, v0.4h, #8
 ; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v0.8b
-; CHECK-GI-NEXT:    neg v1.8b, v3.8b
-; CHECK-GI-NEXT:    fmov s3, w0
-; CHECK-GI-NEXT:    ushl v0.8b, v0.8b, v1.8b
-; CHECK-GI-NEXT:    mov v3.h[1], w1
+; CHECK-GI-NEXT:    ushr v0.8b, v0.8b, #4
 ; CHECK-GI-NEXT:    mov b1, v0.b[1]
 ; CHECK-GI-NEXT:    mov b2, v0.b[2]
-; CHECK-GI-NEXT:    mov v3.h[2], w2
-; CHECK-GI-NEXT:    fmov w9, s1
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v0.h[1], w9
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    fmov w9, s2
-; CHECK-GI-NEXT:    mov v0.h[2], w9
-; CHECK-GI-NEXT:    mov v1.h[2], w8
-; CHECK-GI-NEXT:    mls v3.4h, v0.4h, v1.4h
-; CHECK-GI-NEXT:    umov w0, v3.h[0]
-; CHECK-GI-NEXT:    umov w1, v3.h[1]
-; CHECK-GI-NEXT:    umov w2, v3.h[2]
+; CHECK-GI-NEXT:    fmov w8, s1
+; CHECK-GI-NEXT:    fmov s1, w0
+; CHECK-GI-NEXT:    mov v0.h[1], w8
+; CHECK-GI-NEXT:    mov v1.h[1], w1
+; CHECK-GI-NEXT:    fmov w8, s2
+; CHECK-GI-NEXT:    movi v2.4h, #100
+; CHECK-GI-NEXT:    mov v0.h[2], w8
+; CHECK-GI-NEXT:    mov v1.h[2], w2
+; CHECK-GI-NEXT:    mls v1.4h, v0.4h, v2.4h
+; CHECK-GI-NEXT:    umov w0, v1.h[0]
+; CHECK-GI-NEXT:    umov w1, v1.h[1]
+; CHECK-GI-NEXT:    umov w2, v1.h[2]
 ; CHECK-GI-NEXT:    ret
 entry:
   %s = urem <3 x i8> %d, <i8 100, i8 100, i8 100>
@@ -1397,36 +1280,20 @@ define <4 x i8> @uv4i8_7(<4 x i8> %d, <4 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i8_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #37 // =0x25
-; CHECK-GI-NEXT:    movi d2, #0xff00ff00ff00ff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.b[1], w8
-; CHECK-GI-NEXT:    and v2.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    mov v1.b[2], w8
-; CHECK-GI-NEXT:    mov v1.b[3], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    mul v1.4h, v2.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
-; CHECK-GI-NEXT:    ushr v2.4h, v1.4h, #8
-; CHECK-GI-NEXT:    mov v3.b[3], w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v2.4h
-; CHECK-GI-NEXT:    neg v3.8b, v3.8b
-; CHECK-GI-NEXT:    mov v4.b[1], w8
-; CHECK-GI-NEXT:    uzp1 v2.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    mov v4.b[2], w8
-; CHECK-GI-NEXT:    ushl v2.8b, v2.8b, v3.8b
+; CHECK-GI-NEXT:    movi d1, #0xff00ff00ff00ff
+; CHECK-GI-NEXT:    movi v2.8b, #37
+; CHECK-GI-NEXT:    and v1.8b, v0.8b, v1.8b
 ; CHECK-GI-NEXT:    ushll v2.8h, v2.8b, #0
-; CHECK-GI-NEXT:    mov v4.b[3], w8
+; CHECK-GI-NEXT:    mul v1.4h, v1.4h, v2.4h
+; CHECK-GI-NEXT:    ushr v2.4h, v1.4h, #8
+; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v2.4h
+; CHECK-GI-NEXT:    uzp1 v2.8b, v2.8b, v0.8b
+; CHECK-GI-NEXT:    ushr v2.8b, v2.8b, #1
+; CHECK-GI-NEXT:    ushll v2.8h, v2.8b, #0
 ; CHECK-GI-NEXT:    usra v2.4h, v1.4h, #8
 ; CHECK-GI-NEXT:    uzp1 v1.8b, v2.8b, v0.8b
-; CHECK-GI-NEXT:    neg v2.8b, v4.8b
-; CHECK-GI-NEXT:    ushl v1.8b, v1.8b, v2.8b
 ; CHECK-GI-NEXT:    movi v2.4h, #7
+; CHECK-GI-NEXT:    ushr v1.8b, v1.8b, #2
 ; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    ret
@@ -1449,25 +1316,15 @@ define <4 x i8> @uv4i8_100(<4 x i8> %d, <4 x i8> %e) {
 ;
 ; CHECK-GI-LABEL: uv4i8_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #41 // =0x29
-; CHECK-GI-NEXT:    movi d2, #0xff00ff00ff00ff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.b[1], w8
-; CHECK-GI-NEXT:    and v2.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    mov v1.b[2], w8
-; CHECK-GI-NEXT:    mov v1.b[3], w8
-; CHECK-GI-NEXT:    mov w8, #4 // =0x4
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.b[1], w8
-; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-GI-NEXT:    mul v1.4h, v2.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.b[2], w8
-; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #8
-; CHECK-GI-NEXT:    mov v3.b[3], w8
-; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    neg v2.8b, v3.8b
-; CHECK-GI-NEXT:    ushl v1.8b, v1.8b, v2.8b
+; CHECK-GI-NEXT:    movi d1, #0xff00ff00ff00ff
+; CHECK-GI-NEXT:    movi v2.8b, #41
+; CHECK-GI-NEXT:    and v1.8b, v0.8b, v1.8b
+; CHECK-GI-NEXT:    ushll v2.8h, v2.8b, #0
+; CHECK-GI-NEXT:    mul v1.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    movi v2.4h, #100
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #8
+; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
+; CHECK-GI-NEXT:    ushr v1.8b, v1.8b, #4
 ; CHECK-GI-NEXT:    ushll v1.8h, v1.8b, #0
 ; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    ret
@@ -1585,26 +1442,17 @@ define <2 x i16> @sv2i16_7(<2 x i16> %d, <2 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #18725 // =0x4925
-; CHECK-GI-NEXT:    shl v2.2s, v0.2s, #16
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    sshr v2.2s, v2.2s, #16
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    sshll v1.4s, v1.4h, #0
-; CHECK-GI-NEXT:    mul v1.2s, v2.2s, v1.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    sshl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    neg v2.4h, v3.4h
+; CHECK-GI-NEXT:    adrp x8, .LCPI40_0
+; CHECK-GI-NEXT:    shl v1.2s, v0.2s, #16
 ; CHECK-GI-NEXT:    movi v3.2s, #7
-; CHECK-GI-NEXT:    ushl v2.4h, v1.4h, v2.4h
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI40_0]
+; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
+; CHECK-GI-NEXT:    sshll v2.4s, v2.4h, #0
+; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
+; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
+; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
+; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #1
+; CHECK-GI-NEXT:    ushr v2.4h, v1.4h, #15
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
 ; CHECK-GI-NEXT:    add v1.2s, v1.2s, v2.2s
@@ -1633,26 +1481,17 @@ define <2 x i16> @sv2i16_100(<2 x i16> %d, <2 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: sv2i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #5243 // =0x147b
-; CHECK-GI-NEXT:    shl v2.2s, v0.2s, #16
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    sshr v2.2s, v2.2s, #16
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #3 // =0x3
-; CHECK-GI-NEXT:    sshll v1.4s, v1.4h, #0
-; CHECK-GI-NEXT:    mul v1.2s, v2.2s, v1.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #15 // =0xf
-; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    sshl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    neg v2.4h, v3.4h
+; CHECK-GI-NEXT:    adrp x8, .LCPI41_0
+; CHECK-GI-NEXT:    shl v1.2s, v0.2s, #16
 ; CHECK-GI-NEXT:    movi v3.2s, #100
-; CHECK-GI-NEXT:    ushl v2.4h, v1.4h, v2.4h
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI41_0]
+; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
+; CHECK-GI-NEXT:    sshll v2.4s, v2.4h, #0
+; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
+; CHECK-GI-NEXT:    sshr v1.2s, v1.2s, #16
+; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
+; CHECK-GI-NEXT:    sshr v1.4h, v1.4h, #3
+; CHECK-GI-NEXT:    ushr v2.4h, v1.4h, #15
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
 ; CHECK-GI-NEXT:    add v1.2s, v1.2s, v2.2s
@@ -1922,30 +1761,21 @@ define <2 x i16> @uv2i16_7(<2 x i16> %d, <2 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv2i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #9363 // =0x2493
-; CHECK-GI-NEXT:    movi d2, #0x00ffff0000ffff
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    and v2.8b, v0.8b, v2.8b
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    mul v1.2s, v2.2s, v1.2s
-; CHECK-GI-NEXT:    neg v3.4h, v3.4h
+; CHECK-GI-NEXT:    movi d1, #0x00ffff0000ffff
+; CHECK-GI-NEXT:    adrp x8, .LCPI48_0
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI48_0]
+; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
+; CHECK-GI-NEXT:    and v1.8b, v0.8b, v1.8b
+; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
 ; CHECK-GI-NEXT:    ushr v2.2s, v1.2s, #16
 ; CHECK-GI-NEXT:    sub v2.2s, v0.2s, v2.2s
 ; CHECK-GI-NEXT:    uzp1 v2.4h, v2.4h, v0.4h
-; CHECK-GI-NEXT:    ushl v2.4h, v2.4h, v3.4h
-; CHECK-GI-NEXT:    fmov s3, w8
+; CHECK-GI-NEXT:    ushr v2.4h, v2.4h, #1
 ; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
-; CHECK-GI-NEXT:    mov v3.h[1], w8
 ; CHECK-GI-NEXT:    usra v2.2s, v1.2s, #16
 ; CHECK-GI-NEXT:    uzp1 v1.4h, v2.4h, v0.4h
-; CHECK-GI-NEXT:    neg v2.4h, v3.4h
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    movi v2.2s, #7
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #2
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    mls v0.2s, v1.2s, v2.2s
 ; CHECK-GI-NEXT:    ret
@@ -1970,26 +1800,17 @@ define <2 x i16> @uv2i16_100(<2 x i16> %d, <2 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv2i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    uzp1 v2.4h, v0.4h, v0.4h
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #5243 // =0x147b
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    neg v1.4h, v1.4h
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    ushl v1.4h, v2.4h, v1.4h
-; CHECK-GI-NEXT:    ushll v2.4s, v3.4h, #0
+; CHECK-GI-NEXT:    uzp1 v1.4h, v0.4h, v0.4h
+; CHECK-GI-NEXT:    adrp x8, .LCPI49_0
+; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI49_0]
+; CHECK-GI-NEXT:    ushll v2.4s, v2.4h, #0
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #2
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    mul v1.2s, v1.2s, v2.2s
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    mov v2.h[1], w8
+; CHECK-GI-NEXT:    movi v2.2s, #100
 ; CHECK-GI-NEXT:    ushr v1.2s, v1.2s, #16
 ; CHECK-GI-NEXT:    uzp1 v1.4h, v1.4h, v0.4h
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    movi v2.2s, #100
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #1
 ; CHECK-GI-NEXT:    ushll v1.4s, v1.4h, #0
 ; CHECK-GI-NEXT:    mls v0.2s, v1.2s, v2.2s
 ; CHECK-GI-NEXT:    ret
@@ -2028,43 +1849,21 @@ define <3 x i16> @uv3i16_7(<3 x i16> %d, <3 x i16> %e) {
 ; CHECK-GI-LABEL: uv3i16_7:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-GI-NEXT:    umov w9, v0.h[0]
-; CHECK-GI-NEXT:    mov w8, #9363 // =0x2493
-; CHECK-GI-NEXT:    umov w10, v0.h[1]
-; CHECK-GI-NEXT:    fmov s2, w8
-; CHECK-GI-NEXT:    umov w11, v0.h[2]
-; CHECK-GI-NEXT:    fmov s1, w9
-; CHECK-GI-NEXT:    mov w9, #16 // =0x10
-; CHECK-GI-NEXT:    mov v2.s[1], w8
-; CHECK-GI-NEXT:    fmov s3, w9
-; CHECK-GI-NEXT:    mov v1.s[1], w10
-; CHECK-GI-NEXT:    mov v3.s[1], w9
-; CHECK-GI-NEXT:    mov v2.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    mov v1.s[2], w11
-; CHECK-GI-NEXT:    mov v3.s[2], w9
-; CHECK-GI-NEXT:    mov w9, #2 // =0x2
+; CHECK-GI-NEXT:    umov w8, v0.h[0]
+; CHECK-GI-NEXT:    umov w9, v0.h[1]
+; CHECK-GI-NEXT:    fmov s1, w8
+; CHECK-GI-NEXT:    umov w8, v0.h[2]
+; CHECK-GI-NEXT:    mov v1.s[1], w9
+; CHECK-GI-NEXT:    mov v1.s[2], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI50_0
+; CHECK-GI-NEXT:    ldr q2, [x8, :lo12:.LCPI50_0]
 ; CHECK-GI-NEXT:    mul v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    neg v2.4s, v3.4s
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v3.h[1], w8
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    xtn v1.4h, v1.4s
-; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    mov v3.h[2], w8
-; CHECK-GI-NEXT:    mov w8, #7 // =0x7
-; CHECK-GI-NEXT:    sub v4.4h, v0.4h, v1.4h
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    neg v3.4h, v3.4h
-; CHECK-GI-NEXT:    ushl v3.4h, v4.4h, v3.4h
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    neg v2.4h, v2.4h
-; CHECK-GI-NEXT:    mov v4.h[1], w8
-; CHECK-GI-NEXT:    add v1.4h, v3.4h, v1.4h
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v2.4h
-; CHECK-GI-NEXT:    mov v4.h[2], w8
-; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v4.4h
+; CHECK-GI-NEXT:    shrn v1.4h, v1.4s, #16
+; CHECK-GI-NEXT:    sub v2.4h, v0.4h, v1.4h
+; CHECK-GI-NEXT:    usra v1.4h, v2.4h, #1
+; CHECK-GI-NEXT:    movi v2.4h, #7
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #2
+; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-GI-NEXT:    ret
 entry:
@@ -2099,40 +1898,19 @@ define <3 x i16> @uv3i16_100(<3 x i16> %d, <3 x i16> %e) {
 ;
 ; CHECK-GI-LABEL: uv3i16_100:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    mov w8, #2 // =0x2
-; CHECK-GI-NEXT:    mov w11, #5243 // =0x147b
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    fmov s2, w11
-; CHECK-GI-NEXT:    mov v1.h[1], w8
-; CHECK-GI-NEXT:    mov v2.s[1], w11
-; CHECK-GI-NEXT:    mov v1.h[2], w8
-; CHECK-GI-NEXT:    mov v2.s[2], w11
-; CHECK-GI-NEXT:    neg v1.4h, v1.4h
-; CHECK-GI-NEXT:    ushl v1.4h, v0.4h, v1.4h
+; CHECK-GI-NEXT:    ushr v1.4h, v0.4h, #2
 ; CHECK-GI-NEXT:    umov w8, v1.h[0]
 ; CHECK-GI-NEXT:    umov w9, v1.h[1]
-; CHECK-GI-NEXT:    umov w10, v1.h[2]
-; CHECK-GI-NEXT:    fmov s1, w8
-; CHECK-GI-NEXT:    mov w8, #16 // =0x10
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    mov v1.s[1], w9
-; CHECK-GI-NEXT:    mov w9, #100 // =0x64
-; CHECK-GI-NEXT:    mov v3.s[1], w8
-; CHECK-GI-NEXT:    mov v1.s[2], w10
-; CHECK-GI-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    mul v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    mov v4.h[1], w8
-; CHECK-GI-NEXT:    neg v2.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    fmov s2, w9
-; CHECK-GI-NEXT:    mov v4.h[2], w8
-; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    xtn v1.4h, v1.4s
-; CHECK-GI-NEXT:    neg v3.4h, v4.4h
-; CHECK-GI-NEXT:    mov v2.h[2], w9
-; CHECK-GI-NEXT:    ushl v1.4h, v1.4h, v3.4h
+; CHECK-GI-NEXT:    fmov s2, w8
+; CHECK-GI-NEXT:    umov w8, v1.h[2]
+; CHECK-GI-NEXT:    mov v2.s[1], w9
+; CHECK-GI-NEXT:    mov v2.s[2], w8
+; CHECK-GI-NEXT:    adrp x8, .LCPI51_0
+; CHECK-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI51_0]
+; CHECK-GI-NEXT:    mul v1.4s, v2.4s, v1.4s
+; CHECK-GI-NEXT:    movi v2.4h, #100
+; CHECK-GI-NEXT:    shrn v1.4h, v1.4s, #16
+; CHECK-GI-NEXT:    ushr v1.4h, v1.4h, #1
 ; CHECK-GI-NEXT:    mls v0.4h, v1.4h, v2.4h
 ; CHECK-GI-NEXT:    ret
 entry:
@@ -2567,36 +2345,22 @@ define <3 x i32> @uv3i32_7(<3 x i32> %d, <3 x i32> %e) {
 ; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI64_0]
 ; CHECK-GI-NEXT:    mov w8, v0.s[2]
 ; CHECK-GI-NEXT:    movk w9, #9362, lsl #16
-; CHECK-GI-NEXT:    mov w10, #1 // =0x1
 ; CHECK-GI-NEXT:    mov v1.s[1], v0.s[1]
 ; CHECK-GI-NEXT:    umull x8, w8, w9
 ; CHECK-GI-NEXT:    umull v1.2d, v1.2s, v2.2s
 ; CHECK-GI-NEXT:    lsr x8, x8, #32
 ; CHECK-GI-NEXT:    ushr v1.2d, v1.2d, #32
 ; CHECK-GI-NEXT:    mov d2, v1.d[1]
-; CHECK-GI-NEXT:    fmov x9, d1
-; CHECK-GI-NEXT:    fmov s1, w9
-; CHECK-GI-NEXT:    mov w9, #2 // =0x2
-; CHECK-GI-NEXT:    fmov x11, d2
-; CHECK-GI-NEXT:    fmov s2, w10
-; CHECK-GI-NEXT:    fmov s3, w9
-; CHECK-GI-NEXT:    mov v1.s[1], w11
-; CHECK-GI-NEXT:    mov v2.s[1], w10
-; CHECK-GI-NEXT:    mov v3.s[1], w9
+; CHECK-GI-NEXT:    fmov x10, d1
+; CHECK-GI-NEXT:    fmov s1, w10
+; CHECK-GI-NEXT:    fmov x9, d2
+; CHECK-GI-NEXT:    mov v1.s[1], w9
 ; CHECK-GI-NEXT:    mov v1.s[2], w8
-; CHECK-GI-NEXT:    mov v2.s[2], w10
-; CHECK-GI-NEXT:    mov w8, #7 // =0x7
-; CHECK-GI-NEXT:    mov v3.s[2], w9
-; CHECK-GI-NEXT:    sub v4.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    ushl v2.4s, v4.4s, v2.4s
-; CHECK-GI-NEXT:    fmov s4, w8
-; CHECK-GI-NEXT:    mov v4.s[1], w8
-; CHECK-GI-NEXT:    add v1.4s, v2.4s, v1.4s
-; CHECK-GI-NEXT:    neg v2.4s, v3.4s
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    mov v4.s[2], w8
-; CHECK-GI-NEXT:    mls v0.4s, v1.4s, v4.4s
+; CHECK-GI-NEXT:    sub v2.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    usra v1.4s, v2.4s, #1
+; CHECK-GI-NEXT:    movi v2.4s, #7
+; CHECK-GI-NEXT:    ushr v1.4s, v1.4s, #2
+; CHECK-GI-NEXT:    mls v0.4s, v1.4s, v2.4s
 ; CHECK-GI-NEXT:    ret
 entry:
   %s = urem <3 x i32> %d, <i32 7, i32 7, i32 7>
@@ -2621,31 +2385,23 @@ define <3 x i32> @uv3i32_100(<3 x i32> %d, <3 x i32> %e) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov v1.s[0], v0.s[0]
 ; CHECK-GI-NEXT:    adrp x8, .LCPI65_0
-; CHECK-GI-NEXT:    mov w9, v0.s[2]
+; CHECK-GI-NEXT:    mov w9, #34079 // =0x851f
 ; CHECK-GI-NEXT:    ldr d2, [x8, :lo12:.LCPI65_0]
-; CHECK-GI-NEXT:    mov w8, #5 // =0x5
-; CHECK-GI-NEXT:    mov w10, #34079 // =0x851f
-; CHECK-GI-NEXT:    fmov s3, w8
-; CHECK-GI-NEXT:    movk w10, #20971, lsl #16
+; CHECK-GI-NEXT:    mov w8, v0.s[2]
+; CHECK-GI-NEXT:    movk w9, #20971, lsl #16
 ; CHECK-GI-NEXT:    mov v1.s[1], v0.s[1]
-; CHECK-GI-NEXT:    umull x9, w9, w10
-; CHECK-GI-NEXT:    mov v3.s[1], w8
+; CHECK-GI-NEXT:    umull x8, w8, w9
 ; CHECK-GI-NEXT:    umull v1.2d, v1.2s, v2.2s
-; CHECK-GI-NEXT:    mov v3.s[2], w8
-; CHECK-GI-NEXT:    lsr x8, x9, #32
+; CHECK-GI-NEXT:    lsr x8, x8, #32
 ; CHECK-GI-NEXT:    ushr v1.2d, v1.2d, #32
-; CHECK-GI-NEXT:    neg v3.4s, v3.4s
 ; CHECK-GI-NEXT:    mov d2, v1.d[1]
-; CHECK-GI-NEXT:    fmov x11, d1
-; CHECK-GI-NEXT:    fmov s1, w11
-; CHECK-GI-NEXT:    fmov x10, d2
-; CHECK-GI-NEXT:    mov v1.s[1], w10
-; CHECK-GI-NEXT:    mov w10, #100 // =0x64
-; CHECK-GI-NEXT:    fmov s2, w10
-; CHECK-GI-NEXT:    mov v2.s[1], w10
+; CHECK-GI-NEXT:    fmov x10, d1
+; CHECK-GI-NEXT:    fmov s1, w10
+; CHECK-GI-NEXT:    fmov x9, d2
+; CHECK-GI-NEXT:    movi v2.4s, #100
+; CHECK-GI-NEXT:    mov v1.s[1], w9
 ; CHECK-GI-NEXT:    mov v1.s[2], w8
-; CHECK-GI-NEXT:    mov v2.s[2], w10
-; CHECK-GI-NEXT:    ushl v1.4s, v1.4s, v3.4s
+; CHECK-GI-NEXT:    ushr v1.4s, v1.4s, #5
 ; CHECK-GI-NEXT:    mls v0.4s, v1.4s, v2.4s
 ; CHECK-GI-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/select_cc.ll
+++ b/llvm/test/CodeGen/AArch64/select_cc.ll
@@ -120,11 +120,8 @@ define <4 x i32> @select_icmp_sgt(<4 x i32> %a, <4 x i8> %b) {
 ;
 ; CHECK-GI-LABEL: select_icmp_sgt:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    movi d2, #0000000000000000
+; CHECK-GI-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-GI-NEXT:    uzp1 v1.8b, v1.8b, v0.8b
-; CHECK-GI-NEXT:    mov v2.b[1], wzr
-; CHECK-GI-NEXT:    mov v2.b[2], wzr
-; CHECK-GI-NEXT:    mov v2.b[3], wzr
 ; CHECK-GI-NEXT:    cmgt v1.8b, v1.8b, v2.8b
 ; CHECK-GI-NEXT:    umov w8, v1.b[0]
 ; CHECK-GI-NEXT:    umov w9, v1.b[1]

--- a/llvm/test/CodeGen/AArch64/shift.ll
+++ b/llvm/test/CodeGen/AArch64/shift.ll
@@ -1044,11 +1044,9 @@ define <2 x i8> @pr168848(<2 x i1> %shift) {
 ; CHECK-GI-LABEL: pr168848:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    movi v1.2s, #1
-; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    and v0.8b, v0.8b, v1.8b
-; CHECK-GI-NEXT:    fmov s1, w8
+; CHECK-GI-NEXT:    movi v1.8b, #1
 ; CHECK-GI-NEXT:    uzp1 v0.4h, v0.4h, v0.4h
-; CHECK-GI-NEXT:    mov v1.b[1], w8
 ; CHECK-GI-NEXT:    uzp1 v0.8b, v0.8b, v0.8b
 ; CHECK-GI-NEXT:    ushl v0.8b, v1.8b, v0.8b
 ; CHECK-GI-NEXT:    umov w8, v0.b[0]

--- a/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
+++ b/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
@@ -619,11 +619,8 @@ define i4 @convert_to_bitmask_4xi8(<4 x i8> %vec) {
 ; CHECK-GI:       ; %bb.0:
 ; CHECK-GI-NEXT:    sub sp, sp, #16
 ; CHECK-GI-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-GI-NEXT:    movi d1, #0000000000000000
+; CHECK-GI-NEXT:    movi.2d v1, #0000000000000000
 ; CHECK-GI-NEXT:    uzp1.8b v0, v0, v0
-; CHECK-GI-NEXT:    mov.b v1[1], wzr
-; CHECK-GI-NEXT:    mov.b v1[2], wzr
-; CHECK-GI-NEXT:    mov.b v1[3], wzr
 ; CHECK-GI-NEXT:    cmeq.8b v0, v0, v1
 ; CHECK-GI-NEXT:    mvn.8b v0, v0
 ; CHECK-GI-NEXT:    umov.b w8, v0[1]
@@ -948,21 +945,20 @@ define i6 @no_combine_illegal_num_elements(<6 x i32> %vec) {
 ; CHECK-GI:       ; %bb.0:
 ; CHECK-GI-NEXT:    sub sp, sp, #16
 ; CHECK-GI-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-GI-NEXT:    fmov s1, w0
-; CHECK-GI-NEXT:    movi d0, #0000000000000000
-; CHECK-GI-NEXT:    fmov s2, w4
-; CHECK-GI-NEXT:    mov.s v1[1], w1
-; CHECK-GI-NEXT:    mov.s v2[1], w5
-; CHECK-GI-NEXT:    mov.s v0[1], wzr
-; CHECK-GI-NEXT:    mov.s v1[2], w2
-; CHECK-GI-NEXT:    cmeq.4s v0, v2, v0
-; CHECK-GI-NEXT:    mov.s v1[3], w3
-; CHECK-GI-NEXT:    mvn.16b v0, v0
-; CHECK-GI-NEXT:    cmtst.4s v1, v1, v1
-; CHECK-GI-NEXT:    mov.s w8, v1[1]
-; CHECK-GI-NEXT:    mov.s w9, v1[2]
-; CHECK-GI-NEXT:    fmov w11, s1
-; CHECK-GI-NEXT:    mov.s w10, v1[3]
+; CHECK-GI-NEXT:    fmov s0, w0
+; CHECK-GI-NEXT:    fmov s1, w4
+; CHECK-GI-NEXT:    movi.2d v2, #0000000000000000
+; CHECK-GI-NEXT:    mov.s v0[1], w1
+; CHECK-GI-NEXT:    mov.s v1[1], w5
+; CHECK-GI-NEXT:    mov.s v0[2], w2
+; CHECK-GI-NEXT:    cmeq.4s v1, v1, v2
+; CHECK-GI-NEXT:    mov.s v0[3], w3
+; CHECK-GI-NEXT:    cmtst.4s v0, v0, v0
+; CHECK-GI-NEXT:    mov.s w8, v0[1]
+; CHECK-GI-NEXT:    mov.s w9, v0[2]
+; CHECK-GI-NEXT:    fmov w11, s0
+; CHECK-GI-NEXT:    mov.s w10, v0[3]
+; CHECK-GI-NEXT:    mvn.16b v0, v1
 ; CHECK-GI-NEXT:    and w8, w8, #0x1
 ; CHECK-GI-NEXT:    bfi w11, w8, #1, #31
 ; CHECK-GI-NEXT:    and w8, w9, #0x1


### PR DESCRIPTION
This helps us match more vector splats that contain undef elements, matching build vectors that contain undef so long as they contain at least 2 duplicate entries.