### PR TITLE
[LSan] Use exit caller SP for exit-triggerring leak checks

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -873,6 +873,19 @@ INTERCEPTOR(int, atexit, void (*func)()) {
 }
 #  endif
 
+#  if CAN_SANITIZE_LEAKS
+// TODO: Intercept more program-killing functions that behave like exit().
+INTERCEPTOR(void, exit, int status) {
+  if (AsanInited() && common_flags()->detect_leaks &&
+      common_flags()->leak_check_at_exit) {
+    // Capture the boundary before libc runs atexit handlers.
+    __lsan::RecordExitCallerSP(GET_CURRENT_FRAME());
+  }
+  REAL(exit)(status);
+}
+
+#  endif
+
 #  if ASAN_INTERCEPT_PTHREAD_ATFORK
 extern "C" {
 extern int _pthread_atfork(void (*prepare)(), void (*parent)(),
@@ -1001,6 +1014,10 @@ void InitializeAsanInterceptors() {
 
 #  if ASAN_INTERCEPT_ATEXIT
   ASAN_INTERCEPT_FUNC(atexit);
+#  endif
+
+#  if CAN_SANITIZE_LEAKS
+  ASAN_INTERCEPT_FUNC(exit);
 #  endif
 
 #  if ASAN_INTERCEPT_PTHREAD_ATFORK

--- a/compiler-rt/lib/hwasan/hwasan_interceptors.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_interceptors.cpp
@@ -24,6 +24,7 @@
 #include "hwasan_thread.h"
 #include "hwasan_thread_list.h"
 #include "interception/interception.h"
+#include "lsan/lsan_common.h"
 #include "sanitizer_common/sanitizer_errno.h"
 #include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_stackdepot.h"
@@ -313,6 +314,19 @@ INTERCEPTOR(void, pthread_exit, void *retval) {
   REAL(pthread_exit)(retval);
 }
 
+#    if CAN_SANITIZE_LEAKS
+// TODO: Intercept more program-killing functions that behave like exit().
+INTERCEPTOR(void, exit, int status) {
+  if (hwasan_inited && common_flags()->detect_leaks &&
+      common_flags()->leak_check_at_exit) {
+    // Capture the boundary before libc runs atexit handlers.
+    __lsan::RecordExitCallerSP(GET_CURRENT_FRAME());
+  }
+  REAL(exit)(status);
+}
+
+#    endif
+
 #    if SANITIZER_GLIBC
 INTERCEPTOR(int, pthread_tryjoin_np, void *thread, void **ret) {
   int result;
@@ -536,6 +550,9 @@ void InitializeInterceptors() {
   INTERCEPT_FUNCTION(pthread_join);
   INTERCEPT_FUNCTION(pthread_detach);
   INTERCEPT_FUNCTION(pthread_exit);
+#    if CAN_SANITIZE_LEAKS
+  INTERCEPT_FUNCTION(exit);
+#    endif
 #    if SANITIZER_GLIBC
   INTERCEPT_FUNCTION(pthread_tryjoin_np);
   INTERCEPT_FUNCTION(pthread_timedjoin_np);

--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -13,6 +13,7 @@
 
 #include "lsan_common.h"
 
+#include "sanitizer_common/sanitizer_atomic.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_flag_parser.h"
 #include "sanitizer_common/sanitizer_flags.h"
@@ -41,9 +42,18 @@ namespace __lsan {
 // This mutex is used to prevent races between DoLeakCheck and IgnoreObject, and
 // also to protect the global list of root regions.
 static Mutex global_mutex;
+static atomic_uintptr_t exit_caller_sp;
 
 void LockGlobal() SANITIZER_ACQUIRE(global_mutex) { global_mutex.Lock(); }
 void UnlockGlobal() SANITIZER_RELEASE(global_mutex) { global_mutex.Unlock(); }
+
+void RecordExitCallerSP(uptr sp) {
+  atomic_store(&exit_caller_sp, sp, memory_order_relaxed);
+}
+
+static uptr GetExitCallerSP() {
+  return atomic_load(&exit_caller_sp, memory_order_relaxed);
+}
 
 Flags lsan_flags;
 
@@ -881,6 +891,11 @@ static bool CheckForLeaksOnce() {
     // threads are suspended and stack pointers captured.
     param.caller_tid = GetTid();
     param.caller_sp = reinterpret_cast<uptr>(__builtin_frame_address(0));
+    // If exit() has started, leak checking runs from the termination/atexit
+    // path. Use the stack boundary captured at exit() entry so frames created
+    // by libc exit handlers and LSan itself do not expand the live stack root.
+    if (uptr exit_sp = GetExitCallerSP())
+      param.caller_sp = exit_sp;
     LockStuffAndStopTheWorld(CheckForLeaksCallback, &param);
     if (!param.success) {
       Report("LeakSanitizer has encountered a fatal error.\n");

--- a/compiler-rt/lib/lsan/lsan_common.h
+++ b/compiler-rt/lib/lsan/lsan_common.h
@@ -274,6 +274,7 @@ void ScanExtraStackRanges(const InternalMmapVector<Range> &ranges,
 // Functions called from the parent tool.
 const char *MaybeCallLsanDefaultOptions();
 void InitCommonLsan();
+void RecordExitCallerSP(uptr sp);
 void DoLeakCheck();
 void DoRecoverableLeakCheckVoid();
 void DisableCounterUnderflow();

--- a/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -563,6 +563,16 @@ INTERCEPTOR(void, _exit, int status) {
   REAL(_exit)(status);
 }
 
+// TODO: Intercept more program-killing functions that behave like exit().
+INTERCEPTOR(void, exit, int status) {
+  if (lsan_inited && common_flags()->detect_leaks &&
+      common_flags()->leak_check_at_exit) {
+    // Capture the boundary before libc runs atexit handlers.
+    RecordExitCallerSP(GET_CURRENT_FRAME());
+  }
+  REAL(exit)(status);
+}
+
 #define COMMON_INTERCEPT_FUNCTION(name) INTERCEPT_FUNCTION(name)
 #define SIGNAL_INTERCEPTOR_ENTER() ENSURE_LSAN_INITED
 #include "sanitizer_common/sanitizer_signal_interceptors.inc"
@@ -600,6 +610,7 @@ void InitializeInterceptors() {
   LSAN_MAYBE_INTERCEPT_TIMEDJOIN;
   LSAN_MAYBE_INTERCEPT_TRYJOIN;
   INTERCEPT_FUNCTION(_exit);
+  INTERCEPT_FUNCTION(exit);
 
   LSAN_MAYBE_INTERCEPT__LWP_EXIT;
   LSAN_MAYBE_INTERCEPT_THR_EXIT;

--- a/compiler-rt/test/lsan/TestCases/Linux/exit_atexit_stale_stack.cpp
+++ b/compiler-rt/test/lsan/TestCases/Linux/exit_atexit_stale_stack.cpp
@@ -10,9 +10,6 @@
 // RUN: %clangxx_lsan -O0 -fno-omit-frame-pointer -DEXPLICIT_EXIT %s -o %t
 // RUN: %env_lsan_opts="use_registers=0:use_stacks=1" not %run %t 2>&1 | FileCheck %s
 //
-// RUN: %clangxx_lsan -O0 -fno-omit-frame-pointer %s -o %t
-// RUN: %env_lsan_opts="use_registers=0:use_stacks=1" not %run %t 2>&1 | FileCheck %s
-//
 // REQUIRES: x86_64-target-arch, glibc
 // UNSUPPORTED: hwasan
 

--- a/compiler-rt/test/lsan/TestCases/Linux/exit_atexit_stale_stack.cpp
+++ b/compiler-rt/test/lsan/TestCases/Linux/exit_atexit_stale_stack.cpp
@@ -1,0 +1,66 @@
+// Test that LSan's atexit leak check does not scan stale pointers left in a
+// dead user stack frame after exit() has been called.
+//
+// This is intentionally x86_64/glibc-specific. The inline assembly writes the
+// leaked pointer into a known stack slot in a noinline helper frame. That frame
+// is dead before main calls exit(0). Without the exit-entry stack boundary, the
+// later DoLeakCheck stack pointer can make LSan scan the stale helper frame and
+// incorrectly mark the allocation reachable.
+//
+// RUN: %clangxx_lsan -O0 -fno-omit-frame-pointer -DEXPLICIT_EXIT %s -o %t
+// RUN: %env_lsan_opts="use_registers=0:use_stacks=1" not %run %t 2>&1 | FileCheck %s
+//
+// RUN: %clangxx_lsan -O0 -fno-omit-frame-pointer %s -o %t
+// RUN: %env_lsan_opts="use_registers=0:use_stacks=1" not %run %t 2>&1 | FileCheck %s
+//
+// REQUIRES: x86_64-target-arch, glibc
+// UNSUPPORTED: hwasan
+
+#include <stdlib.h>
+
+// This test detects a false negative caused by stale stack roots after exit().
+// OFF must point to a stack-frame hole that survives until LSan's atexit leak
+// check. The exact holes depend on the libc version and generated exit-handler
+// stack layout. On glibc 2.39 (Ubuntu 24.04), known working values include 64,
+// 80, 88, 160, 384, 400, 408, and 416.
+#ifndef OFF
+#  define OFF 64
+#endif
+
+#ifdef EXPLICIT_EXIT
+__attribute__((noinline)) void leak_to_dead_frame(void) {
+  __asm__ __volatile__("movl $100, %%edi\n\t"
+                       "callq malloc@PLT\n\t"
+                       "movq %%rax, -%c0(%%rbp)\n\t"
+                       "xorq %%rax, %%rax\n\t"
+                       :
+                       : "i"(OFF)
+                       : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10",
+                         "r11", "memory");
+}
+
+int main(void) {
+  leak_to_dead_frame();
+  // Explicit exit called by user code.
+  exit(0);
+}
+
+#else
+
+int main(void) {
+  __asm__ __volatile__("movl $100, %%edi\n\t"
+                       "callq malloc@PLT\n\t"
+                       "movq %%rax, -%c0(%%rbp)\n\t"
+                       "xorq %%rax, %%rax\n\t"
+                       :
+                       : "i"(OFF)
+                       : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10",
+                         "r11", "memory");
+  // Implicit exit called by libc after main returns.
+  return 0;
+}
+#endif
+
+// CHECK: LeakSanitizer: detected memory leaks
+// CHECK: Direct leak of 100 byte(s) in 1 object(s)
+// CHECK: SUMMARY: {{.*}}Sanitizer: 100 byte(s) leaked in 1 allocation(s)


### PR DESCRIPTION
This patch reduces a LSan FN in `exit()` paths.

LSan scans stacks conservatively. When the leak check is reached through the process termination path (e.g., `exit`), stack frames created by libc exit handling and LSan itself can expose legacy user stack bytes as live roots. If those bytes still
contain a leaked heap pointer, the chunk can be marked reachable and the leak is not reported.

This patch continues the strategy from 39db491957dc, which captured `caller_sp` early in `CheckForLeaks()` to avoid later LSan stack growth affecting the root set. This patch captures the boundary earlier, at `exit()` interceptor entry.

Related issue: https://github.com/llvm/llvm-project/issues/42932

Consider the following case:

```c++
__attribute__((noinline)) void leak_to_dead_frame() {
  void *p = malloc(100);
  char buf[xxxx];
  // storing p into specific slots of buf would lead to FN of LSan.
  // The slot index is determined by the glibc exit implementation.
  buf[_] = p; 
}

int main() {
  leak_to_dead_frame();
  exit(0);
}
```

Without an exit-entry boundary, the later atexit leak check can scan the frames of  `exit` and its callees as live roots. 

With this patch, LSan uses the stack boundary captured at `exit()` entry and reports the leak.

