### PR TITLE
[libc][NFC] Remove <sys/mman.h> from mmap.h and fix tests

### DIFF
--- a/libc/src/sys/mman/mmap.h
+++ b/libc/src/sys/mman/mmap.h
@@ -9,8 +9,9 @@
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_MMAP_H
 #define LLVM_LIBC_SRC_SYS_MMAN_MMAP_H
 
+#include "hdr/types/off_t.h"
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/mman.h> // For size_t and off_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/integration/src/pthread/CMakeLists.txt
+++ b/libc/test/integration/src/pthread/CMakeLists.txt
@@ -50,6 +50,7 @@ add_integration_test(
   DEPENDS
     libc.hdr.time_macros
     libc.hdr.errno_macros
+    libc.hdr.sys_mman_macros
     libc.include.pthread
     libc.src.pthread.pthread_rwlock_destroy
     libc.src.pthread.pthread_rwlock_init
@@ -262,6 +263,7 @@ add_integration_test(
   SRCS
     pthread_create_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.pthread
     libc.src.errno.errno
     libc.src.pthread.pthread_create

--- a/libc/test/integration/src/pthread/pthread_create_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_create_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/pthread/pthread_attr_destroy.h"
 #include "src/pthread/pthread_attr_getdetachstate.h"
 #include "src/pthread/pthread_attr_getguardsize.h"

--- a/libc/test/integration/src/pthread/pthread_rwlock_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_rwlock_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/errno_macros.h"
+#include "hdr/sys_mman_macros.h"
 #include "hdr/time_macros.h"
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/CPP/new.h"

--- a/libc/test/integration/startup/linux/CMakeLists.txt
+++ b/libc/test/integration/startup/linux/CMakeLists.txt
@@ -38,6 +38,7 @@ add_integration_test(
   SRCS
     tls_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.src.errno.errno
     libc.src.sys.mman.mmap

--- a/libc/test/integration/startup/linux/tls_test.cpp
+++ b/libc/test/integration/startup/linux/tls_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "test/IntegrationTest/test.h"
 

--- a/libc/test/src/__support/threads/linux/CMakeLists.txt
+++ b/libc/test/src/__support/threads/linux/CMakeLists.txt
@@ -10,6 +10,7 @@ add_libc_test(
     libc.src.sys.mman.munmap
     libc.src.stdlib.exit
     libc.hdr.signal_macros
+    libc.hdr.sys_mman_macros
 )
 
 add_libc_test(

--- a/libc/test/src/__support/threads/linux/raw_mutex_test.cpp
+++ b/libc/test/src/__support/threads/linux/raw_mutex_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/signal_macros.h"
+#include "hdr/sys_mman_macros.h"
 #include "include/llvm-libc-macros/linux/time-macros.h"
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/OSUtil/syscall.h"

--- a/libc/test/src/strings/CMakeLists.txt
+++ b/libc/test/src/strings/CMakeLists.txt
@@ -117,6 +117,7 @@ add_libc_test(
   SRCS
     wide_read_memory_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.src.string.string_utils
     libc.src.sys.mman.mmap
     libc.src.sys.mman.mprotect

--- a/libc/test/src/strings/wide_read_memory_test.cpp
+++ b/libc/test/src/strings/wide_read_memory_test.cpp
@@ -21,6 +21,7 @@
 // unreadable, the middle usable normally. By placing test data at the edges
 // between the middle page and the others, we can test for bad accesses.
 
+#include "hdr/sys_mman_macros.h"
 #include "src/__support/CPP/array.h"
 #include "src/string/memory_utils/inline_memset.h"
 #include "src/string/string_utils.h"

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -7,6 +7,7 @@ add_libc_unittest(
   SRCS
     mmap_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.src.errno.errno
     libc.src.sys.mman.mmap
@@ -22,6 +23,7 @@ add_libc_unittest(
   SRCS
     mremap_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.src.errno.errno
     libc.src.sys.mman.mmap
@@ -39,6 +41,7 @@ if (NOT LLVM_USE_SANITIZER)
     SRCS
       mprotect_test.cpp
     DEPENDS
+      libc.hdr.sys_mman_macros
       libc.include.sys_mman
       libc.include.signal
       libc.src.errno.errno
@@ -57,6 +60,7 @@ add_libc_unittest(
   SRCS
   madvise_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.src.errno.errno
     libc.src.sys.mman.mmap
@@ -79,6 +83,7 @@ if (NOT LLVM_USE_SANITIZER)
     DEPENDS
       libc.hdr.errno_macros
       libc.hdr.signal_macros
+      libc.hdr.sys_mman_macros
       libc.hdr.types.size_t
       libc.src.sys.mman.mmap
       libc.src.sys.mman.munmap
@@ -99,6 +104,7 @@ add_libc_unittest(
   SRCS
   posix_madvise_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.src.errno.errno
     libc.src.sys.mman.mmap
@@ -115,6 +121,7 @@ add_libc_unittest(
   SRCS
     mincore_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.include.unistd
     libc.src.errno.errno
@@ -136,6 +143,7 @@ add_libc_unittest(
   SRCS
     mlock_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.include.unistd
     libc.src.errno.errno
@@ -162,6 +170,7 @@ add_libc_unittest(
   SRCS
     msync_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.include.unistd
     libc.src.errno.errno
@@ -183,6 +192,7 @@ add_libc_unittest(
   SRCS
     remap_file_pages_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.include.sys_stat
     libc.test.UnitTest.ErrnoCheckingTest
@@ -203,6 +213,7 @@ add_libc_unittest(
   SRCS
     shm_test.cpp
   DEPENDS
+    libc.hdr.sys_mman_macros
     libc.include.sys_mman
     libc.include.sys_syscall
     libc.src.errno.errno

--- a/libc/test/src/sys/mman/linux/madvise_test.cpp
+++ b/libc/test/src/sys/mman/linux/madvise_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/madvise.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/madvise.h"
 #include "src/sys/mman/mincore.h"
 #include "src/sys/mman/mlock.h"

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -10,6 +10,7 @@
 // munlock, and munlockall should have separate test files which only need to
 // check our code paths (succeeds and errors).
 
+#include "hdr/sys_mman_macros.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/libc_errno.h"
 #include "src/sys/mman/madvise.h"

--- a/libc/test/src/sys/mman/linux/mmap_test.cpp
+++ b/libc/test/src/sys/mman/linux/mmap_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"

--- a/libc/test/src/sys/mman/linux/mprotect_test.cpp
+++ b/libc/test/src/sys/mman/linux/mprotect_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/mprotect.h"
 #include "src/sys/mman/munmap.h"

--- a/libc/test/src/sys/mman/linux/mremap_test.cpp
+++ b/libc/test/src/sys/mman/linux/mremap_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/mremap.h"
 #include "src/sys/mman/munmap.h"

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mlock.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/msync.h"

--- a/libc/test/src/sys/mman/linux/pkey_test.cpp
+++ b/libc/test/src/sys/mman/linux/pkey_test.cpp
@@ -8,6 +8,7 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/signal_macros.h"
+#include "hdr/sys_mman_macros.h"
 #include "hdr/types/size_t.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"

--- a/libc/test/src/sys/mman/linux/posix_madvise_test.cpp
+++ b/libc/test/src/sys/mman/linux/posix_madvise_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
 #include "src/sys/mman/posix_madvise.h"

--- a/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
+++ b/libc/test/src/sys/mman/linux/remap_file_pages_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_mman_macros.h"
 #include "src/fcntl/open.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"

--- a/libc/test/src/sys/mman/linux/shm_test.cpp
+++ b/libc/test/src/sys/mman/linux/shm_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/sys_mman_macros.h"
 #include "src/fcntl/fcntl.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"


### PR DESCRIPTION
Removed the last direct <sys/mman.h> include from mmap.h, replacing it with hdr/types/size_t.h and hdr/types/off_t.h.

Added hdr/sys_mman_macros.h to test files that relied on transitive includes for PROT_READ, MAP_ANONYMOUS, and similar macros.