### PR TITLE
[LV] Introduce isLegalMaskedLoadOrStore (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.cpp
@@ -59,8 +59,8 @@ static cl::opt<bool> ForceTargetSupportsMaskedMemoryOps(
     cl::desc("Assume the target supports masked memory operations (used for "
              "testing)."));
 
-bool VFSelectionContext::isLegalMaskedLoadOrStore(
-    Instruction *I, ElementCount VF) const {
+bool VFSelectionContext::isLegalMaskedLoadOrStore(Instruction *I,
+                                                  ElementCount VF) const {
   assert(isa<LoadInst>(I) || isa<StoreInst>(I));
   auto *Ptr = getLoadStorePointerOperand(I);
   auto *Ty = getLoadStoreType(I);

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.cpp
@@ -59,20 +59,20 @@ static cl::opt<bool> ForceTargetSupportsMaskedMemoryOps(
     cl::desc("Assume the target supports masked memory operations (used for "
              "testing)."));
 
-bool VFSelectionContext::isLegalMaskedStore(Type *DataType, Value *Ptr,
-                                            Align Alignment,
-                                            unsigned AddressSpace) const {
-  return Legal->isConsecutivePtr(DataType, Ptr) &&
-         (ForceTargetSupportsMaskedMemoryOps ||
-          TTI.isLegalMaskedStore(DataType, Alignment, AddressSpace));
-}
+bool VFSelectionContext::isLegalMaskedLoadOrStore(
+    Instruction *I, ElementCount VF) const {
+  assert(isa<LoadInst>(I) || isa<StoreInst>(I));
+  auto *Ptr = getLoadStorePointerOperand(I);
+  auto *Ty = getLoadStoreType(I);
+  const unsigned AS = getLoadStoreAddressSpace(I);
+  const Align Alignment = getLoadStoreAlignment(I);
 
-bool VFSelectionContext::isLegalMaskedLoad(Type *DataType, Value *Ptr,
-                                           Align Alignment,
-                                           unsigned AddressSpace) const {
-  return Legal->isConsecutivePtr(DataType, Ptr) &&
-         (ForceTargetSupportsMaskedMemoryOps ||
-          TTI.isLegalMaskedLoad(DataType, Alignment, AddressSpace));
+  if (!Legal->isConsecutivePtr(Ty, Ptr))
+    return false;
+
+  return ForceTargetSupportsMaskedMemoryOps ||
+         (isa<LoadInst>(I) ? TTI.isLegalMaskedLoad(Ty, Alignment, AS)
+                           : TTI.isLegalMaskedStore(Ty, Alignment, AS));
 }
 
 bool VFSelectionContext::isLegalGatherOrScatter(Value *V,

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -650,15 +650,9 @@ public:
   /// of FP operations.
   bool useOrderedReductions(const RecurrenceDescriptor &RdxDesc) const;
 
-  /// Returns true if the target machine supports masked store operation
-  /// for the given \p DataType and kind of access to \p Ptr.
-  bool isLegalMaskedStore(Type *DataType, Value *Ptr, Align Alignment,
-                          unsigned AddressSpace) const;
-
-  /// Returns true if the target machine supports masked load operation
-  /// for the given \p DataType and kind of access to \p Ptr.
-  bool isLegalMaskedLoad(Type *DataType, Value *Ptr, Align Alignment,
-                         unsigned AddressSpace) const;
+  /// Returns true if the target machine can represent \p I as a masked load
+  /// or store.
+  bool isLegalMaskedLoadOrStore(Instruction *I, ElementCount VF) const;
 
   /// Returns true if the target machine can represent \p V as a masked gather
   /// or scatter operation.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -650,8 +650,8 @@ public:
   /// of FP operations.
   bool useOrderedReductions(const RecurrenceDescriptor &RdxDesc) const;
 
-  /// Returns true if the target machine can represent \p I as a masked load
-  /// or store.
+  /// Returns true if the target machine supports masked loads or stores
+  /// for \p I's data type and alignment.
   bool isLegalMaskedLoadOrStore(Instruction *I, ElementCount VF) const;
 
   /// Returns true if the target machine can represent \p V as a masked gather

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2465,18 +2465,8 @@ bool LoopVectorizationCostModel::isScalarWithPredication(Instruction *I,
     return getCallWideningDecision(cast<CallInst>(I), VF).Kind == CM_Scalarize;
   case Instruction::Load:
   case Instruction::Store: {
-    auto *Ptr = getLoadStorePointerOperand(I);
-    auto *Ty = getLoadStoreType(I);
-    unsigned AS = getLoadStoreAddressSpace(I);
-    Type *VTy = Ty;
-    if (VF.isVector())
-      VTy = VectorType::get(Ty, VF);
-    const Align Alignment = getLoadStoreAlignment(I);
-    return isa<LoadInst>(I)
-               ? !(Config.isLegalMaskedLoad(Ty, Ptr, Alignment, AS) ||
-                   TTI.isLegalMaskedGather(VTy, Alignment))
-               : !(Config.isLegalMaskedStore(Ty, Ptr, Alignment, AS) ||
-                   TTI.isLegalMaskedScatter(VTy, Alignment));
+    return !Config.isLegalMaskedLoadOrStore(I, VF) &&
+           !Config.isLegalGatherOrScatter(I, VF);
   }
   case Instruction::UDiv:
   case Instruction::SDiv:


### PR DESCRIPTION
This simplifies legality checks, and eventually will become the single point querying TTI hooks for masked ld/st. Currently, legality checks for interleaved accesses still query TTI directly.

This is a stacked PR
- https://github.com/llvm/llvm-project/pull/195242 (this)
- https://github.com/llvm/llvm-project/pull/195243
- https://github.com/llvm/llvm-project/pull/195042
- https://github.com/llvm/llvm-project/pull/194579