### PR TITLE
[lldb-dap] Add more logs when running in server mode

### DIFF
--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -583,8 +583,7 @@ static llvm::Error serveConnection(
     std::thread client([=, &log]() {
       llvm::set_thread_name(client_name + ".runloop");
 
-      const std::string client_prefix = llvm::formatv("({})", client_name);
-      Log client_log = log.WithPrefix(client_prefix);
+      Log client_log = log.WithPrefix("(" + client_name + ")");
       DAP_LOG(client_log, "client connected");
 
       MainLoop loop;
@@ -593,8 +592,8 @@ static llvm::Error serveConnection(
               client_name, transport, loop);
 
       if (auto Err = dap.ConfigureIO()) {
-        DAP_LOG(log, "{} error: Failed to configure stdout redirect: {}",
-                client_prefix, llvm::toStringWithoutConsuming(Err));
+        DAP_LOG(client_log, "error: Failed to configure stdout redirect: {}",
+                llvm::toStringWithoutConsuming(Err));
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                     "Failed to configure stdout redirect: ");
         return;
@@ -604,8 +603,7 @@ static llvm::Error serveConnection(
       DAPSessionManager::GetInstance().RegisterSession(&loop, &dap);
 
       if (auto Err = dap.Loop()) {
-        DAP_LOG(log, "{} error: {}", client_prefix,
-                llvm::toStringWithoutConsuming(Err));
+        DAP_LOG(client_log, "error: {}", llvm::toStringWithoutConsuming(Err));
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                     "DAP session (" + client_name +
                                         ") error: ");

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -583,7 +583,8 @@ static llvm::Error serveConnection(
     std::thread client([=, &log]() {
       llvm::set_thread_name(client_name + ".runloop");
 
-      Log client_log = log.WithPrefix("(" + client_name + ")");
+      const std::string client_prefix = llvm::formatv("({})", client_name);
+      Log client_log = log.WithPrefix(client_prefix);
       DAP_LOG(client_log, "client connected");
 
       MainLoop loop;
@@ -592,6 +593,8 @@ static llvm::Error serveConnection(
               client_name, transport, loop);
 
       if (auto Err = dap.ConfigureIO()) {
+        DAP_LOG(log, "{} error: Failed to configure stdout redirect: {}",
+                client_prefix, llvm::toStringWithoutConsuming(Err));
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                     "Failed to configure stdout redirect: ");
         return;
@@ -601,6 +604,8 @@ static llvm::Error serveConnection(
       DAPSessionManager::GetInstance().RegisterSession(&loop, &dap);
 
       if (auto Err = dap.Loop()) {
+        DAP_LOG(log, "{} error: {}", client_prefix,
+                llvm::toStringWithoutConsuming(Err));
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                     "DAP session (" + client_name +
                                         ") error: ");
@@ -842,6 +847,8 @@ int main(int argc, char *argv[]) {
   if (!connection.empty()) {
     auto maybeProtoclAndName = validateConnection(connection);
     if (auto Err = maybeProtoclAndName.takeError()) {
+      DAP_LOG(log, "Connection Failed: {}",
+              llvm::toStringWithoutConsuming(Err));
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                   "Invalid connection: ");
       return EXIT_FAILURE;


### PR DESCRIPTION
Had a recent failure in server mode but could not find the reason for the failure.

```
[09:26:05.247] lldb-dap.cpp:552 started with connection listeners connection://[127.0.0.1]:34035
[09:26:05.258] lldb-dap.cpp:587 (conn0) client connected
[09:26:05.263] lldb-dap.cpp:630 server shutting down, disconnecting remaining clients
[09:26:05.263] (conn0) <-- {"event":"terminated","seq":1,"type":"event"}
[09:26:05.263] DAP.cpp:1005 (conn0) transport closed
[09:26:05.272] lldb-dap.cpp:609 (conn0) client disconnected
```