### PR TITLE
[DAG] expandVecReduce - ensure widening to a wider vector type

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12272,6 +12272,7 @@ SDValue TargetLowering::expandVecReduce(SDNode *Node, SelectionDAG &DAG) const {
           EVT WideVT = getTypeToTransformTo(*DAG.getContext(), HalfVT);
           if (WideVT.isVector() &&
               WideVT.getScalarType() == HalfVT.getScalarType() &&
+              WideVT.getVectorNumElements() >= HalfVT.getVectorNumElements() &&
               isOperationLegalOrCustom(BaseOpcode, WideVT)) {
             SDValue Lo, Hi;
             std::tie(Lo, Hi) = DAG.SplitVector(Op, dl);


### PR DESCRIPTION
Add missing check in #194672 that the getTypeToTransformTo is actually WIDER than the half type

Test coverage will follow shortly in an upcoming x86 patch