### PR TITLE
[Loads] Fix crash on mixed-address-space pointers in no-AA store check

### DIFF
--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -580,6 +580,8 @@ static bool areNonOverlapSameBaseLoadAndStore(const Value *LoadPtr,
       DL, StoreOffset, /* AllowNonInbounds */ false);
   if (LoadBase != StoreBase)
     return false;
+  if (LoadOffset.getBitWidth() != StoreOffset.getBitWidth())
+    return false;
   auto LoadAccessSize = LocationSize::precise(DL.getTypeStoreSize(LoadTy));
   auto StoreAccessSize = LocationSize::precise(DL.getTypeStoreSize(StoreTy));
   ConstantRange LoadRange(LoadOffset,

--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -574,13 +574,13 @@ static bool areNonOverlapSameBaseLoadAndStore(const Value *LoadPtr,
                                               const DataLayout &DL) {
   APInt LoadOffset(DL.getIndexTypeSizeInBits(LoadPtr->getType()), 0);
   APInt StoreOffset(DL.getIndexTypeSizeInBits(StorePtr->getType()), 0);
+  if (LoadOffset.getBitWidth() != StoreOffset.getBitWidth())
+    return false;
   const Value *LoadBase = LoadPtr->stripAndAccumulateConstantOffsets(
       DL, LoadOffset, /* AllowNonInbounds */ false);
   const Value *StoreBase = StorePtr->stripAndAccumulateConstantOffsets(
       DL, StoreOffset, /* AllowNonInbounds */ false);
   if (LoadBase != StoreBase)
-    return false;
-  if (LoadOffset.getBitWidth() != StoreOffset.getBitWidth())
     return false;
   auto LoadAccessSize = LocationSize::precise(DL.getTypeStoreSize(LoadTy));
   auto StoreAccessSize = LocationSize::precise(DL.getTypeStoreSize(StoreTy));

--- a/llvm/unittests/Analysis/LoadsTest.cpp
+++ b/llvm/unittests/Analysis/LoadsTest.cpp
@@ -67,9 +67,9 @@ entry:
   ASSERT_TRUE(CI->equalsInt(42));
 }
 
-// Test the load and store pointers reach the same base value through different address spaces
-// with different index widths (here AS=0 has 64-bit pointers and AS=5 has
-// 32-bit pointers)
+// Test the load and store pointers reach the same base value through different
+// address spaces with different index widths (here AS=0 has 64-bit pointers and
+// AS=5 has 32-bit pointers)
 TEST(LoadsTest, FindAvailableLoadedValueMixedAddrSpaceNullAA) {
   LLVMContext C;
   std::unique_ptr<Module> M = parseIR(C, R"IR(

--- a/llvm/unittests/Analysis/LoadsTest.cpp
+++ b/llvm/unittests/Analysis/LoadsTest.cpp
@@ -67,6 +67,35 @@ entry:
   ASSERT_TRUE(CI->equalsInt(42));
 }
 
+// Test the load and store pointers reach the same base value through different address spaces
+// with different index widths (here AS=0 has 64-bit pointers and AS=5 has
+// 32-bit pointers)
+TEST(LoadsTest, FindAvailableLoadedValueMixedAddrSpaceNullAA) {
+  LLVMContext C;
+  std::unique_ptr<Module> M = parseIR(C, R"IR(
+target datalayout = "e-p:64:64-p5:32:32-i64:64-n32:64-S32-A5"
+
+define ptr @f() {
+entry:
+  %a = alloca [16 x i8], align 8, addrspace(5)
+  %ac = addrspacecast ptr addrspace(5) %a to ptr
+  store ptr null, ptr %ac, align 8
+  %q = getelementptr inbounds i8, ptr addrspace(5) %a, i32 8
+  store i64 42, ptr addrspace(5) %q, align 8
+  %v = load ptr, ptr %ac, align 8
+  ret ptr %v
+}
+)IR");
+  auto *F = cast<Function>(M->getNamedValue("f"));
+  ASSERT_TRUE(F);
+  auto *LI = cast<LoadInst>(&*++F->front().rbegin());
+  ASSERT_TRUE(LI);
+  BasicBlock::iterator BBI(LI);
+  Value *Loaded =
+      FindAvailableLoadedValue(LI, LI->getParent(), BBI, 0, nullptr, nullptr);
+  EXPECT_EQ(Loaded, nullptr);
+}
+
 TEST(LoadsTest, CanReplacePointersIfEqual) {
   LLVMContext C;
   std::unique_ptr<Module> M = parseIR(C,


### PR DESCRIPTION
Fix crash on mixed-address-space pointers in no-AA store check. `areNonOverlapSameBaseLoadAndStore` built `ConstantRanges` from `APInts` sized by the load and store pointer index widths. When those widths differ (AMDGPU's AS=0 vs AS=5), `ConstantRange::intersectWith` asserts. Adds early return mirroring `BasicAA` path.

This can happen when `FindAvailableLoadedValue` is called without `BatchAAResults`. The path with `BatchAAResults` already handles it.

This crash was observed in #190607, so it was reverted in #195135