### PR TITLE
clang: Fix broken --offload-arch arguments in tests

### DIFF
--- a/clang/test/Driver/hip-launch-api.hip
+++ b/clang/test/Driver/hip-launch-api.hip
@@ -1,13 +1,13 @@
 // By default FE assumes -fhip-new-launch-api.
 
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -offload-arch=gfx906 \ 
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx906 \
 // RUN:   -nogpulib -nogpuinc %s 2>&1 | FileCheck -check-prefixes=NEW %s
 // NEW: "-fhip-new-launch-api"
 
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -offload-arch=gfx906 %s \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx906 %s \
 // RUN:   -nogpulib -nogpuinc -fhip-new-launch-api 2>&1 | FileCheck -check-prefixes=NEW %s
 // NEW: "-fhip-new-launch-api"
 
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -offload-arch=gfx906 %s \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx906 %s \
 // RUN:   -nogpulib -nogpuinc -fno-hip-new-launch-api 2>&1 | FileCheck -check-prefixes=OLD %s
 // OLD-NOT: "-fhip-new-launch-api"

--- a/clang/test/Driver/hip-std.hip
+++ b/clang/test/Driver/hip-std.hip
@@ -1,23 +1,23 @@
-// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-unknown-linux-gnu -offload-arch=gfx906 %s \
+// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-unknown-linux-gnu --offload-arch=gfx906 %s \
 // RUN:   2>&1 | FileCheck -check-prefixes=DEFAULT %s
 // DEFAULT: "-cc1"{{.*}}"-fcuda-is-device"{{.*}}
 // DEFAULT-NOT: "-std="{{.*}}
 // DEFAULT: "-cc1"{{.*}}
 // DEFAULT-NOT: "-std="{{.*}}
 
-// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-unknown-linux-gnu -offload-arch=gfx906 %s \
+// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-unknown-linux-gnu --offload-arch=gfx906 %s \
 // RUN:   -std=c++17 %s 2>&1 | FileCheck -check-prefixes=SPECIFIED %s
 // SPECIFIED: "-cc1"{{.*}}"-fcuda-is-device"{{.*}}"-std=c++17"
 // SPECIFIED: "-cc1"{{.*}}"-std=c++17"
 
-// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-pc-windows-msvc -offload-arch=gfx906 %s \
+// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-pc-windows-msvc --offload-arch=gfx906 %s \
 // RUN:   2>&1 | FileCheck -check-prefixes=MSVC-DEF %s
 // MSVC-DEF: "-cc1"{{.*}}"-fcuda-is-device"{{.*}}
 // MSVC-DEF-NOT: "-std="{{.*}}
 // MSVC-DEF: "-cc1"{{.*}}
 // MSVC-DEF-NOT: "-std="{{.*}}
 
-// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-pc-windows-msvc -offload-arch=gfx906 %s \
+// RUN: %clang -### -nogpulib -nogpuinc --target=x86_64-pc-windows-msvc --offload-arch=gfx906 %s \
 // RUN:   -std=c++17 %s 2>&1 | FileCheck -check-prefixes=MSVC-SPEC %s
 // MSVC-SPEC: "-cc1"{{.*}}"-fcuda-is-device"{{.*}}"-std=c++17"
 // MSVC-SPEC: "-cc1"{{.*}}"-std=c++17"


### PR DESCRIPTION
These need to use 2 dashes. A single dash is interpreted as -o. Fix
this in all tests using the single dash, except one which appears
to be testing the behavior of warning on the misspelled argument.