### PR TITLE
[lldb] Use (_d).pyd as Python extension suffix on Windows

### DIFF
--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -72,7 +72,15 @@ def main():
                     sys.exit(1)
     elif args.variable_name == "LLDB_PYTHON_EXT_SUFFIX":
         if args.stable_abi:
-            print(".abi3%s" % sysconfig.get_config_var("SHLIB_SUFFIX"))
+            shlib_suffix = sysconfig.get_config_var("SHLIB_SUFFIX")
+            if shlib_suffix:
+                print(".abi3%s" % sysconfig.get_config_var("SHLIB_SUFFIX"))
+            else:
+                assert os.name == "nt"
+                if sysconfig.get_config_var("EXT_SUFFIX").startswith("_d"):
+                    print("_d.pyd")
+                else:
+                    print(".pyd")
         else:
             print(sysconfig.get_config_var("EXT_SUFFIX"))
     else:

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -74,7 +74,7 @@ def main():
         if args.stable_abi:
             shlib_suffix = sysconfig.get_config_var("SHLIB_SUFFIX")
             if shlib_suffix:
-                print(".abi3%s" % sysconfig.get_config_var("SHLIB_SUFFIX"))
+                print(".abi3%s" % shlib_suffix)
             else:
                 assert os.name == "nt"
                 if sysconfig.get_config_var("EXT_SUFFIX").startswith("_d"):


### PR DESCRIPTION
The current Windows x86_x64 installer ships a `_lldb.abi3None` in `lib\site-packages\lldb\native`. This will cause errors when trying to import LLDB in Python.

We always use `.abi3{SHLIB_SUFFIX}` as the Python extension suffix in `get-python-config.py`. On Windows(-msvc), this won't result in the correct path. `SHLIB_SUFFIX` is not defined there.

The recognized extensions are:
```console
> python -c "import importlib.machinery;print(importlib.machinery.EXTENSION_SUFFIXES)"
['.cp314-win_amd64.pyd', '.pyd']
> python_d -c "import importlib.machinery;print(importlib.machinery.EXTENSION_SUFFIXES)"
['_d.cp314-win_amd64.pyd', '_d.pyd']
```

The first one is equal to `sysconfig.get_config_var("EXT_SUFFIX")`.

I changed `get-python-config.py` to use `.pyd` if `SHLIB_SUFFIX` is undefined. This is currently hardcoded. It seems like cpython has some contract that the last suffix in `EXTENSION_SUFFIXES` is the untagged one ([from this test](https://github.com/python/cpython/blob/f2c7c0d2b799c927d9a78e87e4a640d3f9b0356c/Lib/test/test_traceback.py#L5225-L5232)). But I haven't found any documentation on that.