### PR TITLE
[GlobalISel] Cache split LLTs in IRTranslator

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -138,19 +138,19 @@ private:
     }
 
     OffsetListT *insertOffsets(const Value &V) {
-      assert(!TypeToOffsets.contains(V.getType()) && "Type already exists");
-
       auto *OffsetList = new (OffsetAlloc.Allocate()) OffsetListT();
-      TypeToOffsets[V.getType()] = OffsetList;
-      return OffsetList;
+      auto [It, Inserted] = TypeToOffsets.insert({V.getType(), OffsetList});
+      if (!Inserted)
+        llvm_unreachable("Type already exists");
+      return It->second;
     }
 
     SplitTypeListT *insertSplitTys(const Value &V) {
-      assert(!TypeToSplitTys.contains(V.getType()) && "Type already exists");
-
       auto *SplitTyList = new (SplitTyAlloc.Allocate()) SplitTypeListT();
-      TypeToSplitTys[V.getType()] = SplitTyList;
-      return SplitTyList;
+      auto [It, Inserted] = TypeToSplitTys.insert({V.getType(), SplitTyList});
+      if (!Inserted)
+        llvm_unreachable("Type already exists");
+      return It->second;
     }
     SpecificBumpPtrAllocator<VRegListT> VRegAlloc;
     SpecificBumpPtrAllocator<OffsetListT> OffsetAlloc;

--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -78,6 +78,7 @@ private:
 
     using VRegListT = SmallVector<Register, 1>;
     using OffsetListT = SmallVector<uint64_t, 1>;
+    using SplitTypeListT = SmallVector<LLT, 1>;
 
     using const_vreg_iterator =
         DenseMap<const Value *, VRegListT *>::const_iterator;
@@ -102,6 +103,14 @@ private:
       return insertOffsets(V);
     }
 
+    SplitTypeListT *getSplitTys(const Value &V) {
+      auto It = TypeToSplitTys.find(V.getType());
+      if (It != TypeToSplitTys.end())
+        return It->second;
+
+      return insertSplitTys(V);
+    }
+
     const_vreg_iterator findVRegs(const Value &V) const {
       return ValToVRegs.find(&V);
     }
@@ -111,8 +120,10 @@ private:
     void reset() {
       ValToVRegs.clear();
       TypeToOffsets.clear();
+      TypeToSplitTys.clear();
       VRegAlloc.DestroyAll();
       OffsetAlloc.DestroyAll();
+      SplitTyAlloc.DestroyAll();
     }
 
   private:
@@ -133,13 +144,23 @@ private:
       TypeToOffsets[V.getType()] = OffsetList;
       return OffsetList;
     }
+
+    SplitTypeListT *insertSplitTys(const Value &V) {
+      assert(!TypeToSplitTys.contains(V.getType()) && "Type already exists");
+
+      auto *SplitTyList = new (SplitTyAlloc.Allocate()) SplitTypeListT();
+      TypeToSplitTys[V.getType()] = SplitTyList;
+      return SplitTyList;
+    }
     SpecificBumpPtrAllocator<VRegListT> VRegAlloc;
     SpecificBumpPtrAllocator<OffsetListT> OffsetAlloc;
+    SpecificBumpPtrAllocator<SplitTypeListT> SplitTyAlloc;
 
     // We store pointers to vectors here since references may be invalidated
     // while we hold them if we stored the vectors directly.
     DenseMap<const Value *, VRegListT*> ValToVRegs;
     DenseMap<const Type *, OffsetListT*> TypeToOffsets;
+    DenseMap<const Type *, SplitTypeListT *> TypeToSplitTys;
   };
 
   /// Mapping of the values of the current LLVM IR function to the related
@@ -744,6 +765,9 @@ private:
   /// Allocate some vregs and offsets in the VMap. Then populate just the
   /// offsets while leaving the vregs empty.
   ValueToVRegInfo::VRegListT &allocateVRegs(const Value &Val);
+
+  /// Get the cached split LLTs for \p Val.
+  ValueToVRegInfo::SplitTypeListT &getOrCreateSplitTys(const Value &Val);
 
   /// Get the frame index that represents \p Val.
   /// If such VReg does not exist, it is created.

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -193,13 +193,22 @@ IRTranslator::allocateVRegs(const Value &Val) {
   if (VRegsIt != VMap.vregs_end())
     return *VRegsIt->second;
   auto *Regs = VMap.getVRegs(Val);
-  auto *Offsets = VMap.getOffsets(Val);
-  SmallVector<LLT, 4> SplitTys;
-  computeValueLLTs(*DL, *Val.getType(), SplitTys,
-                   Offsets->empty() ? Offsets : nullptr);
+  auto &SplitTys = getOrCreateSplitTys(Val);
   for (unsigned i = 0; i < SplitTys.size(); ++i)
     Regs->push_back(0);
   return *Regs;
+}
+
+IRTranslator::ValueToVRegInfo::SplitTypeListT &
+IRTranslator::getOrCreateSplitTys(const Value &Val) {
+  auto *SplitTys = VMap.getSplitTys(Val);
+  if (!SplitTys->empty())
+    return *SplitTys;
+
+  auto *Offsets = VMap.getOffsets(Val);
+  computeValueLLTs(*DL, *Val.getType(), *SplitTys,
+                   Offsets->empty() ? Offsets : nullptr);
+  return *SplitTys;
 }
 
 ArrayRef<Register> IRTranslator::getOrCreateVRegs(const Value &Val) {
@@ -212,7 +221,6 @@ ArrayRef<Register> IRTranslator::getOrCreateVRegs(const Value &Val) {
 
   // Create entry for this type.
   auto *VRegs = VMap.getVRegs(Val);
-  auto *Offsets = VMap.getOffsets(Val);
 
   if (!Val.getType()->isTokenTy())
     assert(Val.getType()->isSized() &&
@@ -221,6 +229,7 @@ ArrayRef<Register> IRTranslator::getOrCreateVRegs(const Value &Val) {
   // Fast-path values that lower to a single vreg.
   if (!Val.getType()->isAggregateType()) {
     LLT Ty = getLLTForType(*Val.getType(), *DL);
+    auto *Offsets = VMap.getOffsets(Val);
     if (Offsets->empty())
       Offsets->push_back(0);
     VRegs->push_back(MRI->createGenericVirtualRegister(Ty));
@@ -237,9 +246,7 @@ ArrayRef<Register> IRTranslator::getOrCreateVRegs(const Value &Val) {
     return *VRegs;
   }
 
-  SmallVector<LLT, 4> SplitTys;
-  computeValueLLTs(*DL, *Val.getType(), SplitTys,
-                   Offsets->empty() ? Offsets : nullptr);
+  auto &SplitTys = getOrCreateSplitTys(Val);
 
   if (!isa<Constant>(Val)) {
     for (auto Ty : SplitTys)


### PR DESCRIPTION
This is hot and showing up in compile-time profiles on aarch64-O0-g.
Caching is a -0.11% geomean improvement.

https://llvm-compile-time-tracker.com/compare.php?from=a7a2dc59616a8cb1198d933bcdf55ebdbd78894c&to=0cf9d1fe54a3b6fb80af94b5f8fa9ed3830b7582&stat=instructions%3Au

Assisted-by: codex