### PR TITLE
[dsymutil] Make --linker explicit in every test

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/accel-imported-declarations.test
+++ b/llvm/test/tools/dsymutil/AArch64/accel-imported-declarations.test
@@ -1,8 +1,10 @@
-RUN: dsymutil -accelerator=Dwarf -oso-prepend-path=%p/../Inputs %p/../Inputs/accel-imported-declaration.macho-arm64 -o %t.dwarf.dSYM
-RUN: dsymutil -accelerator=Apple -oso-prepend-path=%p/../Inputs %p/../Inputs/accel-imported-declaration.macho-arm64 -o %t.apple.dSYM
+RUN: dsymutil --linker classic -accelerator=Dwarf -oso-prepend-path=%p/../Inputs %p/../Inputs/accel-imported-declaration.macho-arm64 -o %t.dwarf.dSYM
+RUN: dsymutil --linker classic -accelerator=Apple -oso-prepend-path=%p/../Inputs %p/../Inputs/accel-imported-declaration.macho-arm64 -o %t.apple.dSYM
 
 RUN: llvm-dwarfdump -v %t.dwarf.dSYM | FileCheck %s -check-prefixes=DWARF,COMMON
 RUN: llvm-dwarfdump -v %t.apple.dSYM | FileCheck %s -check-prefixes=APPLE,COMMON
+
+## FIXME: Support --linker parallel
 
 COMMON: .debug_info contents
 COMMON: {{.*}}DW_TAG_namespace

--- a/llvm/test/tools/dsymutil/AArch64/allow-disallow.test
+++ b/llvm/test/tools/dsymutil/AArch64/allow-disallow.test
@@ -1,64 +1,108 @@
 # Test --allow to include one object file (1.o).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --allow=%p/../Inputs/allow-disallow/one.yaml \
+RUN:   | FileCheck %s --check-prefix=ALLOW-ONE
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --allow=%p/../Inputs/allow-disallow/one.yaml \
 RUN:   | FileCheck %s --check-prefix=ALLOW-ONE
 
 # Test --allow to include two object files (1.o and 3.o).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --allow=%p/../Inputs/allow-disallow/two.yaml \
+RUN:   | FileCheck %s --check-prefix=ALLOW-TWO
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --allow=%p/../Inputs/allow-disallow/two.yaml \
 RUN:   | FileCheck %s --check-prefix=ALLOW-TWO
 
 # Test --allow to include no object files (empty allow list).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --allow=%p/../Inputs/allow-disallow/empty.yaml \
+RUN:   | FileCheck %s --check-prefix=ALLOW-NONE
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --allow=%p/../Inputs/allow-disallow/empty.yaml \
 RUN:   | FileCheck %s --check-prefix=ALLOW-NONE
 
 # Test --disallow to exclude one object file (1.o).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --disallow=%p/../Inputs/allow-disallow/one.yaml \
+RUN:   | FileCheck %s --check-prefix=DISALLOW-ONE
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --disallow=%p/../Inputs/allow-disallow/one.yaml \
 RUN:   | FileCheck %s --check-prefix=DISALLOW-ONE
 
 # Test --disallow to exclude two object files (1.o and 3.o).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --disallow=%p/../Inputs/allow-disallow/two.yaml \
+RUN:   | FileCheck %s --check-prefix=DISALLOW-TWO
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --disallow=%p/../Inputs/allow-disallow/two.yaml \
 RUN:   | FileCheck %s --check-prefix=DISALLOW-TWO
 
 # Test --disallow to exclude no object files (empty allow list).
-RUN: dsymutil --dump-debug-map \
+RUN: dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --oso-prepend-path=%p/../Inputs \
+RUN:   --disallow=%p/../Inputs/allow-disallow/empty.yaml \
+RUN:   | FileCheck %s --check-prefix=DISALLOW-NONE
+RUN: dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --oso-prepend-path=%p/../Inputs \
 RUN:   --disallow=%p/../Inputs/allow-disallow/empty.yaml \
 RUN:   | FileCheck %s --check-prefix=DISALLOW-NONE
 
 # Test error when allow-list file does not exist.
-RUN: not dsymutil --dump-debug-map \
+RUN: not dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --allow=/nonexistent/path 2>&1 \
+RUN:   | FileCheck %s --check-prefix=MISSING-FILE
+RUN: not dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --allow=/nonexistent/path 2>&1 \
 RUN:   | FileCheck %s --check-prefix=MISSING-FILE
 
 # Test error when disallow-list file does not exist.
-RUN: not dsymutil --dump-debug-map \
+RUN: not dsymutil --linker classic --dump-debug-map \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
+RUN:   --disallow=/nonexistent/path 2>&1 \
+RUN:   | FileCheck %s --check-prefix=MISSING-FILE
+RUN: not dsymutil --linker parallel --dump-debug-map \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 \
 RUN:   --disallow=/nonexistent/path 2>&1 \
 RUN:   | FileCheck %s --check-prefix=MISSING-FILE
 
 # Test error when combined with -y.
-RUN: not dsymutil --allow=some.file.yaml \
+RUN: not dsymutil --linker classic --allow=some.file.yaml \
+RUN:   -y %p/../Inputs/remarks/basic.macho.remarks.arm64 2>&1 \
+RUN:   | FileCheck %s --check-prefix=YAML-CONFLICT
+RUN: not dsymutil --linker parallel --allow=some.file.yaml \
 RUN:   -y %p/../Inputs/remarks/basic.macho.remarks.arm64 2>&1 \
 RUN:   | FileCheck %s --check-prefix=YAML-CONFLICT
 
 # Test error when --allow and --disallow are both specified.
-RUN: not dsymutil --allow=some.file.yaml --disallow=some.file.yaml \
+RUN: not dsymutil --linker classic --allow=some.file.yaml --disallow=some.file.yaml \
+RUN:   %p/../Inputs/allow-disallow/a.out.arm64 2>&1 \
+RUN:   | FileCheck %s --check-prefix=ALLOW-DISALLOW-CONFLICT
+RUN: not dsymutil --linker parallel --allow=some.file.yaml --disallow=some.file.yaml \
 RUN:   %p/../Inputs/allow-disallow/a.out.arm64 2>&1 \
 RUN:   | FileCheck %s --check-prefix=ALLOW-DISALLOW-CONFLICT
 

--- a/llvm/test/tools/dsymutil/AArch64/call-pc-reloc.test
+++ b/llvm/test/tools/dsymutil/AArch64/call-pc-reloc.test
@@ -14,7 +14,7 @@ int __attribute__((disable_tail_calls)) main() {
 $ clang -arch arm64 main.cpp -o main.arm64.o -c -g -O2
 $ clang -arch arm64 main.arm64.o -o main.arm64 -g
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_pc/main.arm64 -o %t.dSYM

--- a/llvm/test/tools/dsymutil/AArch64/dwarf5-addr-base.test
+++ b/llvm/test/tools/dsymutil/AArch64/dwarf5-addr-base.test
@@ -46,7 +46,7 @@
 
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
+RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
@@ -64,7 +64,7 @@ RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-LLVM
 
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil --update -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
+RUN: dsymutil --linker classic --update -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s --check-prefix=UPD
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir

--- a/llvm/test/tools/dsymutil/AArch64/dwarf5-addrx-0x0-last.test
+++ b/llvm/test/tools/dsymutil/AArch64/dwarf5-addrx-0x0-last.test
@@ -23,7 +23,7 @@ DEBUGADDR: 0x0000000000000059
 DEBUGADDR: 0x0000000000000000
 DEBUGADDR: ]
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx-0x0-last.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx-0x0-last.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 RUN: llvm-dwarfdump --verbose -debug-info %t.dSYM | FileCheck %s --check-prefix DEBUGINFO
 RUN: llvm-dwarfdump --verbose -debug-line %t.dSYM | FileCheck %s --check-prefix DEBUGLINE

--- a/llvm/test/tools/dsymutil/AArch64/dwarf5-dwarf4-combination-macho.test
+++ b/llvm/test/tools/dsymutil/AArch64/dwarf5-dwarf4-combination-macho.test
@@ -30,7 +30,7 @@
 ; clang -g -c -O1 b.cpp -gdwarf-4 -o 2.o
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-DWARF4-combination -o %t.dir/dwarf5-dwarf4-combination-macho.dSYM
+RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-DWARF4-combination -o %t.dir/dwarf5-dwarf4-combination-macho.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-dwarf4-combination-macho.dSYM -a --verbose | FileCheck %s --check-prefixes=CHECK,WITH-PARENTS
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir

--- a/llvm/test/tools/dsymutil/AArch64/dwarf5-macho.test
+++ b/llvm/test/tools/dsymutil/AArch64/dwarf5-macho.test
@@ -18,7 +18,7 @@
 
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5 -o %t.dir/dwarf5-macho.dSYM
+RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5 -o %t.dir/dwarf5-macho.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-macho.dSYM -a --verbose | FileCheck %s
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir

--- a/llvm/test/tools/dsymutil/AArch64/dwarf5-str-offsets-base-strx.test
+++ b/llvm/test/tools/dsymutil/AArch64/dwarf5-str-offsets-base-strx.test
@@ -50,10 +50,10 @@
 
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
-RUN: dsymutil -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
+RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s --check-prefixes=CHECK,GLOBAL
 
-RUN: dsymutil --update -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
+RUN: dsymutil --linker classic --update -y %p/dummy-debug-map-arm64.map -oso-prepend-path=%p/../Inputs/DWARF5-addr-base-str-off-base -o %t.dir/dwarf5-addr-base.dSYM
 RUN: llvm-dwarfdump %t.dir/dwarf5-addr-base.dSYM -a --verbose | FileCheck %s --check-prefixes=UPD,GLOBALUPD
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir

--- a/llvm/test/tools/dsymutil/AArch64/extern-alias.test
+++ b/llvm/test/tools/dsymutil/AArch64/extern-alias.test
@@ -35,8 +35,8 @@ $ xcrun --sdk iphoneos clang -g private_extern.c -c -o private_extern.o -target 
 $ xcrun --sdk iphoneos clang -g main.c -c -o main.o -target arm64-apple-ios14.0
 $ xcrun --sdk iphoneos clang private_extern.o main.o -target arm64-apple-ios14.0 -o private_extern.out -Xlinker -alias_list -Xlinker alias_list
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/private_extern/private_extern.out -o %t.dSYM --verbose | FileCheck %s
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/extern/extern.out -o %t.dSYM --verbose | FileCheck %s

--- a/llvm/test/tools/dsymutil/AArch64/fat-arch-name.test
+++ b/llvm/test/tools/dsymutil/AArch64/fat-arch-name.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
+# RUN: dsymutil --linker classic -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
 
 # RUN: dsymutil --linker parallel -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null -verbose 2>&1 | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/AArch64/fat-threading.test
+++ b/llvm/test/tools/dsymutil/AArch64/fat-threading.test
@@ -1,3 +1,4 @@
 # By default, dsymutil spawns one thread per architecture and this test just
 # ensures that things don't break when processing multiple archs.
-# RUN: dsymutil -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null 2>&1
+# RUN: dsymutil --linker classic -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null 2>&1
+# RUN: dsymutil --linker parallel -no-output %p/../Inputs/fat-test.arm.dylib -o /dev/null 2>&1

--- a/llvm/test/tools/dsymutil/AArch64/firmware.test
+++ b/llvm/test/tools/dsymutil/AArch64/firmware.test
@@ -6,6 +6,8 @@ int main() {
 $ xcrun clang -O0 -target arm64-apple-unknown-macho test.c -c -o test.o
 $ xcrun ld -arch arm64 -o test.out test.o -platform_version firmware 0 0
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/firmware/test.out -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/firmware/test.out -o %t.dSYM
+RUN: llvm-objdump -h %t.dSYM/Contents/Resources/DWARF/test.out | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/firmware/test.out -o %t.dSYM
 RUN: llvm-objdump -h %t.dSYM/Contents/Resources/DWARF/test.out | FileCheck %s
 CHECK: file format mach-o arm64

--- a/llvm/test/tools/dsymutil/AArch64/inline-source.test
+++ b/llvm/test/tools/dsymutil/AArch64/inline-source.test
@@ -1,7 +1,7 @@
 # RUN: rm -rf %t
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj -mtriple arm64-apple-darwin %p/../Inputs/inline.ll -o %t/inline.o
-# RUN: dsymutil -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
+# RUN: dsymutil --linker=classic -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 # RUN: dsymutil --linker=parallel -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 
 # Test inline source files.

--- a/llvm/test/tools/dsymutil/AArch64/missing-object-warning.test
+++ b/llvm/test/tools/dsymutil/AArch64/missing-object-warning.test
@@ -1,4 +1,5 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/missing/foobar.out 2>&1 | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/missing/foobar.out 2>&1 | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/missing/foobar.out 2>&1 | FileCheck %s
 
 CHECK: bar.o unable to open object file
 CHECK-NOT: could not find object file symbol for symbol _bar

--- a/llvm/test/tools/dsymutil/AArch64/missing-symbol-warning.test
+++ b/llvm/test/tools/dsymutil/AArch64/missing-symbol-warning.test
@@ -1,3 +1,4 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/warning/test.out 2>&1 | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/warning/test.out 2>&1 | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs --dump-debug-map %p/../Inputs/private/tmp/warning/test.out 2>&1 | FileCheck %s
 # CHECK: could not find symbol '_foo' in object file '{{.*}}test.o'
 # CHECK: { sym: _main, objAddr: 0x0, binAddr: 0x100003F84, size: 0x1C }

--- a/llvm/test/tools/dsymutil/AArch64/odr-uniquing-DW_AT_name-conflict.test
+++ b/llvm/test/tools/dsymutil/AArch64/odr-uniquing-DW_AT_name-conflict.test
@@ -9,13 +9,13 @@
 #   clang -g -c -o 1.o Inputs/odr-uniquing-DW_AT_name-conflict/lib1.cpp
 #   clang -g -c -o 2.o Inputs/odr-uniquing-DW_AT_name-conflict/lib2.cpp
 
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -o - \
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -o - \
 # RUN:     | llvm-dwarfdump --verify - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -o - \
 # RUN:     | not llvm-dwarfdump --verify - | FileCheck %s --check-prefix=PARALLEL-ODR
 
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -no-odr -o - \
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -no-odr -o - \
 # RUN:     | llvm-dwarfdump --verify - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/odr-uniquing-DW_AT_name-conflict -y %p/dummy-debug-map-arm64.map -no-odr -o - \

--- a/llvm/test/tools/dsymutil/AArch64/preload.test
+++ b/llvm/test/tools/dsymutil/AArch64/preload.test
@@ -4,7 +4,7 @@ void start(void) {}
 $ xcrun clang -c -o foo.o foo.c -g3
 $ xcrun clang -o foo foo.o -g3 -Wl,-preload -nodefaultlibs
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/preload/foo -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/preload/foo -o %t.dSYM
 RUN: llvm-nm %p/../Inputs/private/tmp/preload/foo | FileCheck %s
 RUN: llvm-nm %t.dSYM/Contents/Resources/DWARF/foo | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
@@ -5,7 +5,10 @@
 
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: yaml2obj %s -o %t/main.o
-# RUN: dsymutil %t/main.o -o %t/main.dSYM
+# RUN: dsymutil --linker classic %t/main.o -o %t/main.dSYM
+# RUN: obj2yaml %t/main.dSYM/Contents/Resources/DWARF/main.o -o %t/out.yaml
+# RUN: FileCheck %s < %t/out.yaml
+# RUN: dsymutil --linker parallel %t/main.o -o %t/main.dSYM
 # RUN: obj2yaml %t/main.dSYM/Contents/Resources/DWARF/main.o -o %t/out.yaml
 # RUN: FileCheck %s < %t/out.yaml
 

--- a/llvm/test/tools/dsymutil/AArch64/remarks-linking-bundle-empty.test
+++ b/llvm/test/tools/dsymutil/AArch64/remarks-linking-bundle-empty.test
@@ -2,7 +2,7 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: cat %p/../Inputs/remarks/basic.macho.remarks.empty.arm64 > %t/basic.macho.remarks.empty.arm64
 
-RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.empty.arm64
+RUN: dsymutil --linker classic -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.empty.arm64
 
 Check that the remark file in the bundle does not exist:
 RUN: not cat %t/basic.macho.remarks.empty.arm64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.arm64 2>&1

--- a/llvm/test/tools/dsymutil/AArch64/remarks-linking-bundle.test
+++ b/llvm/test/tools/dsymutil/AArch64/remarks-linking-bundle.test
@@ -5,7 +5,7 @@ RUN: llvm-remarkutil yaml2bitstream %p/../Inputs/private/tmp/remarks/basic1.mach
 RUN: llvm-remarkutil yaml2bitstream %p/../Inputs/private/tmp/remarks/basic2.macho.remarks.arm64.opt.yaml -o %t/private/tmp/remarks/basic2.macho.remarks.arm64.opt.bitstream
 RUN: llvm-remarkutil yaml2bitstream %p/../Inputs/private/tmp/remarks/basic3.macho.remarks.arm64.opt.yaml -o %t/private/tmp/remarks/basic3.macho.remarks.arm64.opt.bitstream
 
-RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/basic.macho.remarks.arm64
+RUN: dsymutil --linker classic -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/basic.macho.remarks.arm64
 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.arm64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.arm64 | FileCheck %s
@@ -16,7 +16,7 @@ Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.arm64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.arm64 | FileCheck %s
 
 Now emit it in a different format: YAML.
-RUN: dsymutil -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/basic.macho.remarks.arm64
+RUN: dsymutil --linker classic -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/basic.macho.remarks.arm64
 RUN: cat %t/basic.macho.remarks.arm64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.arm64 | FileCheck %s --check-prefix=CHECK-YAML
 
 RUN: dsymutil --linker parallel -remarks-output-format=yaml -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/basic.macho.remarks.arm64

--- a/llvm/test/tools/dsymutil/AArch64/static-archive-collision.test
+++ b/llvm/test/tools/dsymutil/AArch64/static-archive-collision.test
@@ -20,7 +20,8 @@ $ clang -g g.c -c -o g/foo.o
 $ libtool -static f/foo.o g/foo.o -o foo.a
 $ clang main.o foo.a -o main.out
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/collision/main.out --dump-debug-map 2>&1 | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/collision/main.out --dump-debug-map 2>&1 | FileCheck %s
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/collision/main.out --dump-debug-map 2>&1 | FileCheck %s
 CHECK: skipping debug map object with duplicate name and timestamp: {{.*}} /private/tmp/collision/foo.a(foo.o)
 CHECK-NOT: could not find symbol '_g'
 CHECK-NOT: could not find symbol '_f'

--- a/llvm/test/tools/dsymutil/AArch64/stmt-seq-macho.test
+++ b/llvm/test/tools/dsymutil/AArch64/stmt-seq-macho.test
@@ -10,7 +10,7 @@
 # RUN: yaml2obj %t/stmt_seq_macho.exe.yaml -o %t/stmt_seq_macho.exe
 # RUN: yaml2obj %t/a.o.yaml -o %t/a.o
 # RUN: yaml2obj %t/b.o.yaml -o %t/b.o
-# RUN: dsymutil --flat --verify-dwarf=none -oso-prepend-path %t %t/stmt_seq_macho.exe -o %t/stmt_seq_macho.dSYM
+# RUN: dsymutil --linker classic --flat --verify-dwarf=none -oso-prepend-path %t %t/stmt_seq_macho.exe -o %t/stmt_seq_macho.dSYM
 # RUN: llvm-dwarfdump --debug-info --debug-line -v %t/stmt_seq_macho.dSYM > %t/stmt_seq_macho.dSYM.txt
 
 ## Verify that all stmt_sequence offsets point to DW_LNE_set_address opcodes
@@ -25,6 +25,8 @@
 ## Ensure no sentinel/invalid offsets (0xffffffff indicates broken patching)
 # RUN: cat %t/stmt_seq_macho.dSYM.txt | FileCheck %s -check-prefix=CHECK_NO_INVALID_OFFSET
 # CHECK_NO_INVALID_OFFSET-NOT: DW_AT_LLVM_stmt_sequence{{.*}}0xfffffff
+
+## FIXME: Support --linker parallel
 
 #--- stmt_seq_macho.cpp
 // This file is split into a.cpp and b.cpp by the gen script.

--- a/llvm/test/tools/dsymutil/AArch64/swiftmodule-include-from-interface.test
+++ b/llvm/test/tools/dsymutil/AArch64/swiftmodule-include-from-interface.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -include-swiftmodules-from-interface -verbose -oso-prepend-path=%p -y -o %t.dSYM  %s | FileCheck %s
+# RUN: dsymutil --linker classic -include-swiftmodules-from-interface -verbose -oso-prepend-path=%p -y -o %t.dSYM  %s | FileCheck %s
 #
 # RUN: dsymutil -include-swiftmodules-from-interface --linker parallel -verbose -oso-prepend-path=%p -y %s -o %t-parallel.dSYM | FileCheck %s
 #

--- a/llvm/test/tools/dsymutil/AArch64/swiftmodule.test
+++ b/llvm/test/tools/dsymutil/AArch64/swiftmodule.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -verbose -oso-prepend-path=%p -y -o %t.dSYM  %s | FileCheck %s
+# RUN: dsymutil --linker classic -verbose -oso-prepend-path=%p -y -o %t.dSYM  %s | FileCheck %s
 #
 # RUN: dsymutil --linker parallel -verbose -oso-prepend-path=%p -y %s -o %t-parallel.dSYM | FileCheck %s
 #

--- a/llvm/test/tools/dsymutil/AArch64/typedefs-with-same-name.test
+++ b/llvm/test/tools/dsymutil/AArch64/typedefs-with-same-name.test
@@ -1,6 +1,8 @@
 #RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o %t.dwarf
 #RUN: llvm-dwarfdump %t.dwarf | FileCheck %s
 
+## FIXME: Support --linker classic
+
 # There should be two typedef DIE named "BarInt" in the resultant .dwarf file.
 # The second should refer to the first, which refer to "Foo<int>".
 # CHECK:      0x[[FIRST_BARINT_ADDR:[0-9a-f]*]]:  DW_TAG_typedef

--- a/llvm/test/tools/dsymutil/ARM/empty-map.test
+++ b/llvm/test/tools/dsymutil/ARM/empty-map.test
@@ -1,7 +1,8 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
-# RUN: dsymutil -q -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s --check-prefix QUIET
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
+# RUN: dsymutil --linker classic -q -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s --check-prefix QUIET
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -q -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s --check-prefix QUIET
 
 ---
 triple:          'thumbv7-apple-darwin'

--- a/llvm/test/tools/dsymutil/ARM/fat-arch-not-found.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-arch-not-found.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 #
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - 2>&1 | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
+++ b/llvm/test/tools/dsymutil/ARM/fat-dylib-update.test
@@ -1,9 +1,9 @@
 # REQUIRES: object-emission,system-darwin
-# RUN: dsymutil -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM
+# RUN: dsymutil --linker classic -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM
 # RUN: llvm-dwarfdump -a -v %t.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
-# RUN: dsymutil -u %t.dSYM
+# RUN: dsymutil --linker classic -u %t.dSYM
 # RUN: llvm-dwarfdump -a -v %t.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
-# RUN: dsymutil -u %t.dSYM -o %t1.dSYM
+# RUN: dsymutil --linker classic -u %t.dSYM -o %t1.dSYM
 # RUN: llvm-dwarfdump -a -v %t1.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s
 #
 # RUN: dsymutil --linker parallel -oso-prepend-path %p/..  %p/../Inputs/fat-test.arm.dylib -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/accelerator.test
+++ b/llvm/test/tools/dsymutil/X86/accelerator.test
@@ -1,6 +1,9 @@
-RUN: dsymutil -accelerator=Dwarf -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.dwarf.dSYM
-RUN: dsymutil -accelerator=Apple -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.apple.dSYM
-RUN: dsymutil -accelerator=None -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.none.dSYM
+RUN: dsymutil --linker classic -accelerator=Dwarf -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.dwarf.dSYM
+RUN: dsymutil --linker parallel -accelerator=Dwarf -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.dwarf.dSYM
+RUN: dsymutil --linker classic -accelerator=Apple -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.apple.dSYM
+RUN: dsymutil --linker parallel -accelerator=Apple -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.apple.dSYM
+RUN: dsymutil --linker classic -accelerator=None -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.none.dSYM
+RUN: dsymutil --linker parallel -accelerator=None -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o %t.none.dSYM
 
 RUN: llvm-dwarfdump -verify %t.dwarf.dSYM
 RUN: llvm-dwarfdump -verify %t.apple.dSYM
@@ -10,9 +13,12 @@ RUN: llvm-dwarfdump -debug-names %t.dwarf.dSYM | FileCheck %s -check-prefixes=NA
 RUN: llvm-dwarfdump -apple-names -apple-namespaces -apple-types %t.apple.dSYM | FileCheck %s -check-prefixes=NAMES,APPLE
 RUN: llvm-dwarfdump -a %t.none.dSYM | FileCheck %s -check-prefixes=NONE
 
-RUN: dsymutil -update -accelerator=Dwarf %t.apple.dSYM
-RUN: dsymutil -update -accelerator=Apple %t.dwarf.dSYM
-RUN: dsymutil -update -accelerator=None %t.none.dSYM
+RUN: dsymutil --linker classic -update -accelerator=Dwarf %t.apple.dSYM
+RUN: dsymutil --linker parallel -update -accelerator=Dwarf %t.apple.dSYM
+RUN: dsymutil --linker classic -update -accelerator=Apple %t.dwarf.dSYM
+RUN: dsymutil --linker parallel -update -accelerator=Apple %t.dwarf.dSYM
+RUN: dsymutil --linker classic -update -accelerator=None %t.none.dSYM
+RUN: dsymutil --linker parallel -update -accelerator=None %t.none.dSYM
 
 RUN: llvm-dwarfdump -verify %t.dwarf.dSYM
 RUN: llvm-dwarfdump -verify %t.apple.dSYM

--- a/llvm/test/tools/dsymutil/X86/alias.test
+++ b/llvm/test/tools/dsymutil/X86/alias.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/alias \
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/alias \
 # RUN: %p/../Inputs/alias/foobar -o - | llvm-dwarfdump - 2>&1 | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/alias \

--- a/llvm/test/tools/dsymutil/X86/assembly-output.test
+++ b/llvm/test/tools/dsymutil/X86/assembly-output.test
@@ -1,3 +1,4 @@
-RUN: dsymutil -S -f -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o - | FileCheck %s
+RUN: dsymutil --linker classic -S -f -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o - | FileCheck %s
+RUN: dsymutil --linker parallel -S -f -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -o - | FileCheck %s
 
 CHECK:  .section __DWARF

--- a/llvm/test/tools/dsymutil/X86/basic-linking-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/basic-linking-bundle.test
@@ -2,7 +2,7 @@ RUN: rm -rf %t
 RUN: mkdir -p %t/dsymdest
 RUN: cp %p/../Inputs/basic.macho.x86_64 %t/basic.macho.x86_64
 
-RUN: dsymutil -accelerator=Pub -oso-prepend-path=%p/.. %t/basic.macho.x86_64
+RUN: dsymutil --linker classic -accelerator=Pub -oso-prepend-path=%p/.. %t/basic.macho.x86_64
 
 Check that the object file in the bundle exists and is sane:
 RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 | FileCheck %S/basic-linking-x86.test
@@ -15,7 +15,7 @@ RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dSYM | FileCheck %S/basic-linking-x
 
 RUN: FileCheck %s --input-file %t/basic.macho.x86_64.dSYM/Contents/Info.plist
 
-RUN: dsymutil -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: llvm-dwarfdump -a %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 | FileCheck %S/basic-linking-x86.test
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist
 

--- a/llvm/test/tools/dsymutil/X86/basic-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-linking-x86.test
@@ -1,20 +1,20 @@
 RUN: cp %p/../Inputs/basic.macho.x86_64 %t1
-RUN: dsymutil -accelerator=Pub -f -oso-prepend-path=%p/.. %t1
+RUN: dsymutil --linker classic -accelerator=Pub -f -oso-prepend-path=%p/.. %t1
 RUN: llvm-dwarfdump -a %t1.dwarf | FileCheck %s
-RUN: dsymutil -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker classic -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic.macho.x86_64
 RUN: llvm-dwarfdump -a %t2 | FileCheck %s
-RUN: dsymutil -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker classic -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | \
 RUN:   FileCheck %s --check-prefixes=CHECK,BASIC,PUB
-RUN: dsymutil -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker classic -accelerator=Pub -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-archive.macho.x86_64 | llvm-dwarfdump -a - \
 RUN:   | FileCheck %s --check-prefixes=CHECK,ARCHIVE,PUB
-RUN: dsymutil -accelerator=Pub -dump-debug-map -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker classic -accelerator=Pub -dump-debug-map -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic.macho.x86_64 | dsymutil -accelerator=Pub -f -y \
 RUN:   -o - - | llvm-dwarfdump -a - | FileCheck %s \
 RUN:   --check-prefixes=CHECK,BASIC,PUB
-RUN: dsymutil -accelerator=Pub -dump-debug-map -oso-prepend-path=%p/.. \
+RUN: dsymutil --linker classic -accelerator=Pub -dump-debug-map -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-archive.macho.x86_64 | dsymutil -accelerator=Pub \
 RUN:   -f -o - -y - | llvm-dwarfdump -a - | FileCheck %s \
 RUN:   --check-prefixes=CHECK,ARCHIVE,PUB

--- a/llvm/test/tools/dsymutil/X86/basic-lto-dw4-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-lto-dw4-linking-x86.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto-dw4.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto-dw4.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-lto-dw4.macho.x86_64 | llvm-dwarfdump -a - \

--- a/llvm/test/tools/dsymutil/X86/basic-lto-linking-x86.test
+++ b/llvm/test/tools/dsymutil/X86/basic-lto-linking-x86.test
@@ -1,5 +1,5 @@
-RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
-RUN: dsymutil -oso-prepend-path=%p/.. -dump-debug-map %p/../Inputs/basic-lto.macho.x86_64 | dsymutil -f -o - -y - | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-lto.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. -dump-debug-map %p/../Inputs/basic-lto.macho.x86_64 | dsymutil -f -o - -y - | llvm-dwarfdump -a - | FileCheck %s
 
 RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-lto.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/basic-with-libfat-test.test
+++ b/llvm/test/tools/dsymutil/X86/basic-with-libfat-test.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-with-libfat-test.macho.x86_64 | llvm-dwarfdump - | FileCheck %s
+RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%p/.. %p/../Inputs/basic-with-libfat-test.macho.x86_64 | llvm-dwarfdump - | FileCheck %s
 
 RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. \
 RUN:   %p/../Inputs/basic-with-libfat-test.macho.x86_64 | llvm-dwarfdump - \

--- a/llvm/test/tools/dsymutil/X86/call-site-entry-linking.test
+++ b/llvm/test/tools/dsymutil/X86/call-site-entry-linking.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/call-site-entry.macho.x86_64 -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/call-site-entry-reloc.test
+++ b/llvm/test/tools/dsymutil/X86/call-site-entry-reloc.test
@@ -19,7 +19,7 @@ The test requires the return PC to match a relocation (in this case the
 DW_AT_high_pc of main). Without this change the value would get relocated
 twice.
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/call_return_pc/call -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/common-sym-multi.test
+++ b/llvm/test/tools/dsymutil/X86/common-sym-multi.test
@@ -1,5 +1,5 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -f -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/common/common.x86_64 -dump-debug-map | FileCheck %s --check-prefix DEBUGMAP

--- a/llvm/test/tools/dsymutil/X86/common-sym.test
+++ b/llvm/test/tools/dsymutil/X86/common-sym.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/common.macho.x86_64 -f -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/custom-line-table.test
+++ b/llvm/test/tools/dsymutil/X86/custom-line-table.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
+# RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
 #
 # RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-line | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/darwin-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/darwin-bundle.test
@@ -5,10 +5,10 @@ RUN: mkdir -p %t/dsymdest
 RUN: cat %p/../Inputs/basic.macho.x86_64 > %t/basic.macho.x86_64
 RUN: cat %p/../Inputs/Info.plist > %t/Info.plist
 
-RUN: dsymutil -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist
 
-RUN: dsymutil -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -toolchain "toolchain&and'some<symbols" -o %t/dsymdest/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -toolchain "toolchain&and'some<symbols" -o %t/dsymdest/basic.macho.x86_64.dSYM
 RUN: FileCheck %s --input-file %t/dsymdest/basic.macho.x86_64.dSYM/Contents/Info.plist --check-prefix=CHECK --check-prefix=TOOLCHAIN
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %t/basic.macho.x86_64 -o %t/dsymdest/basic.macho.x86_64.dSYM

--- a/llvm/test/tools/dsymutil/X86/debug-loc-base-addr.test
+++ b/llvm/test/tools/dsymutil/X86/debug-loc-base-addr.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/baseaddr/loc1.x86_64 -f -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/dsym-companion.test
+++ b/llvm/test/tools/dsymutil/X86/dsym-companion.test
@@ -1,5 +1,5 @@
-RUN: dsymutil -accelerator=Pub -o - %p/../Inputs/basic.macho.i386 -f | llvm-readobj --file-headers -l -S --symbols - | FileCheck %s -check-prefixes=CHECK,CHECK32
-RUN: dsymutil -accelerator=Pub -o - -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -f | llvm-readobj --file-headers -l -S --symbols - | FileCheck %s -check-prefixes=CHECK,CHECK64
+RUN: dsymutil --linker classic -accelerator=Pub -o - %p/../Inputs/basic.macho.i386 -f | llvm-readobj --file-headers -l -S --symbols - | FileCheck %s -check-prefixes=CHECK,CHECK32
+RUN: dsymutil --linker classic -accelerator=Pub -o - -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 -f | llvm-readobj --file-headers -l -S --symbols - | FileCheck %s -check-prefixes=CHECK,CHECK64
 
 This test checks that the dSYM companion binaries generated in 32 and 64 bits
 are correct. The check are pretty strict (we check even the offsets and sizes
@@ -337,3 +337,5 @@ CHECK64:     Value: 0x100001004
 CHECK:     }
 CHECK:   ]
 
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/dwarf4-linetable.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf4-linetable.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-accel.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-accel.test
@@ -12,7 +12,8 @@
 
 ## $ clang -gdwarf-5 dwarf5-accel.cpp -c -o dwarf5-accel.o
 
-#RUN: dsymutil -accelerator=Dwarf -oso-prepend-path %p/Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic -accelerator=Dwarf -oso-prepend-path %p/Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker parallel -accelerator=Dwarf -oso-prepend-path %p/Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s --check-prefix VERIFY
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-addrbase-broken.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-addrbase-broken.test
@@ -12,7 +12,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker classic -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
@@ -282,3 +282,5 @@ DWARF:
       Entries:
         - Address: 0x10
 ...
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/dwarf5-addrx.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-addrx.test
@@ -42,12 +42,12 @@
 ## $ clang -gdwarf-5 dwarf5-addrx.c -c -o dwarf5-addrx.o
 ## $ clang dwarf5-addrx.o -o dwarf5-addrx.out
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 
 RUN: llvm-dwarfdump --verbose %t.dSYM | FileCheck %s --check-prefix DWARF
 
-RUN: dsymutil --update -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker classic --update -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/dwarf5/dwarf5-addrx.out -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 RUN: llvm-dwarfdump --verify %t.dSYM 2>&1 | FileCheck %s
 
 RUN: llvm-dwarfdump --verbose %t.dSYM | FileCheck %s --check-prefix UPDATE-DWARF

--- a/llvm/test/tools/dsymutil/X86/dwarf5-call-site-entry-reloc.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-call-site-entry-reloc.test
@@ -19,7 +19,7 @@
 ## DW_AT_high_pc of main). Without this change the value would get relocated
 ## twice.
 
-#RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_return_pc
 
 #RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/dwarf5-dw-op-addrx.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-dw-op-addrx.test
@@ -17,11 +17,11 @@
 
 ## $ clang -gdwarf-5 dwarf5-dw-op-addrx.c -c -O2 -o dwarf5-dw-op-addrx.o
 
-#RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-linetable.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-linetable.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o - | llvm-dwarfdump -debug-line -debug-line-str --verbose - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-loclists.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-loclists.test
@@ -16,11 +16,11 @@
 
 ## $ clang -gdwarf-5 dwarf5-loclists.c -c -O2 -o dwarf5-rnglists.o
 
-#RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/dwarf5-many-include-directories.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-many-include-directories.test
@@ -3,7 +3,7 @@
 # RUN: %python %t/all.py > %t/all.ll
 # RUN: sed 's@---TEMPORARY_DIR---@%{/t:regex_replacement}@' %t/debug.map.template > %t/debug.map
 # RUN: %llc_dwarf -mtriple x86_64-apple-macosx10.4.0 -o %t/all.o -filetype=obj %t/all.ll
-# RUN: dsymutil -f -y %t/debug.map -o - | llvm-dwarfdump -debug-line - | FileCheck %s
+# RUN: dsymutil --linker classic -f -y %t/debug.map -o - | llvm-dwarfdump -debug-line - | FileCheck %s
 # RUN: dsymutil --linker parallel -f -y %t/debug.map -o - | llvm-dwarfdump -debug-line - | tee %t/output.txt | FileCheck %s
 
 # CHECK:      include_directories[255] = "/tmp/tmp.0HPkdttdoU/d254"

--- a/llvm/test/tools/dsymutil/X86/dwarf5-rnglists.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-rnglists.test
@@ -29,11 +29,11 @@
 ## $ clang -gdwarf-5 dwarf5-rnglists.c -c -O2 -o dwarf5-rnglists.o
 ## $ clang -gdwarf-5 dwarf5-rnglists.o -o dwarf5-rnglists
 
-#RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix DWARF-CHECK
 
-#RUN: dsymutil --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
+#RUN: dsymutil --linker classic --update -oso-prepend-path %p/../Inputs -y %s -o %t.dSYM
 #RUN: llvm-dwarfdump --verify  %t.dSYM | FileCheck %s
 #RUN: llvm-dwarfdump -a --verbose  %t.dSYM | FileCheck %s --check-prefix UPD-DWARF-CHECK
 

--- a/llvm/test/tools/dsymutil/X86/eh_frame.test
+++ b/llvm/test/tools/dsymutil/X86/eh_frame.test
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
 $ clang eh_frame.cpp -g -c -o eh_frame.o
 $ ld -no_compact_unwind eh_frame.o -o eh_frame.out
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/eh_frame/eh_frame.out -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/eh_frame/eh_frame.out -o %t.dSYM
 RUN: llvm-dwarfdump --verify %t.dSYM
 RUN: llvm-otool -s __TEXT __eh_frame %p/../Inputs/private/tmp/eh_frame/eh_frame.out | FileCheck %s
 RUN: llvm-otool -s __TEXT __eh_frame %t.dSYM/Contents/Resources/DWARF/eh_frame.out | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/empty-CU.test
@@ -1,7 +1,9 @@
 RUN: llvm-mc %p/../Inputs/empty-CU.s -filetype obj -triple x86_64-apple-darwin -o %t.o
-RUN: dsymutil --update -f %t.o -o - | llvm-dwarfdump -v - -debug-info | FileCheck %s
+RUN: dsymutil --linker classic --update -f %t.o -o - | llvm-dwarfdump -v - -debug-info | FileCheck %s
 
 CHECK: .debug_info contents:
 CHECK: 0x00000000: Compile Unit: length = 0x00000008, format = DWARF32, version = 0x0003, abbr_offset = 0x0000, addr_size = 0x04 (next unit at 0x0000000c)
 
 CHECK: 0x0000000b: DW_TAG_compile_unit [1]
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/fat-archive-input-i386.test
+++ b/llvm/test/tools/dsymutil/X86/fat-archive-input-i386.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/fat-object-compatible-triple.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-compatible-triple.test
@@ -2,7 +2,7 @@
 # is no exact string match (e.g. the debug map triple has a version suffix that
 # the object file triple lacks).
 
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64h.test
+++ b/llvm/test/tools/dsymutil/X86/fat-object-input-x86_64h.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs -y %s -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/frame-1.test
+++ b/llvm/test/tools/dsymutil/X86/frame-1.test
@@ -1,7 +1,7 @@
 # RUN: rm -rf %t
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj %p/../Inputs/frame-dw2.ll -o %t/frame-dw2.o
-# RUN: dsymutil -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-frame - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-frame - | FileCheck %s
 
 # This test is meant to verify that identical CIEs will get reused
 # in the same file but also inbetween files. For this to happen, we
@@ -29,3 +29,5 @@ objects:
 # CHECK:  FDE cie=00000000 pc=00003000...00003
 # CHECK-NOT: FDE
 # CHECK: .eh_frame contents:
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/frame-2.test
+++ b/llvm/test/tools/dsymutil/X86/frame-2.test
@@ -2,7 +2,7 @@
 # RUN: mkdir -p %t
 # RUN: llc -filetype=obj %p/../Inputs/frame-dw2.ll -o %t/frame-dw2.o
 # RUN: llc -filetype=obj %p/../Inputs/frame-dw4.ll -o %t/frame-dw4.o
-# RUN: dsymutil -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-frame - | FileCheck %s
+# RUN: dsymutil --linker classic -f -oso-prepend-path=%t -y %s -o - | llvm-dwarfdump -debug-frame - | FileCheck %s
 
 # Check the handling of multiple different CIEs. To have CIEs that
 # appear to be different, use a dwarf2 version of the file along with
@@ -39,3 +39,5 @@ objects:
 # CHECK:  FDE cie=00000000 pc=00004000...00004
 # CHECK-NOT: FDE
 # CHECK: .eh_frame contents:
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/generate-empty-CU.test
+++ b/llvm/test/tools/dsymutil/X86/generate-empty-CU.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
+# RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -o - -oso-prepend-path=%p/.. -y %s | llvm-dwarfdump -v - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/keep-func.test
+++ b/llvm/test/tools/dsymutil/X86/keep-func.test
@@ -20,8 +20,8 @@ int main()
 $ clang++ -O2 -g main.cpp -c -o main.o
 $ clang++ main.o -o main.out
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.omit.dSYM
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.keep.dSYM -keep-function-for-static
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.omit.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.keep.dSYM -keep-function-for-static
 RUN: llvm-dwarfdump %t.omit.dSYM | FileCheck %s --check-prefix OMIT
 RUN: llvm-dwarfdump %t.keep.dSYM | FileCheck %s --check-prefix KEEP
 
@@ -34,3 +34,5 @@ OMIT-NOT: DW_AT_name	("MyDummyVar")
 OMIT-NOT: DW_AT_name	("FOO_VAR_TYPE")
 OMIT-NOT: DW_AT_name	("x1")
 OMIT-NOT: DW_AT_name	("x2")
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/label.test
+++ b/llvm/test/tools/dsymutil/X86/label.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
+# RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
 
 # RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs -y %s -f -o - | llvm-dwarfdump - --debug-info | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/label2.test
+++ b/llvm/test/tools/dsymutil/X86/label2.test
@@ -11,7 +11,7 @@ foobar:
 $ clang -g label.c -c -o label.o
 $ clang label.o -o label.out
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/label/label.out -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/lc_build_version.test
+++ b/llvm/test/tools/dsymutil/X86/lc_build_version.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f %p/../Inputs/lc_build_version.x86_64 -o - \
+# RUN: dsymutil --linker classic -f %p/../Inputs/lc_build_version.x86_64 -o - \
 # RUN:   -oso-prepend-path=%p/.. | obj2yaml | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f %p/../Inputs/lc_build_version.x86_64 -o - \

--- a/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
+++ b/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
@@ -48,6 +48,8 @@ Note that the link order in the last command matters for this test.
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
 RUN: llvm-dwarfdump --debug-info %t.dSYM | FileCheck %s
 
+## FIXME: Support --linker classic
+
 CHECK:       DW_TAG_compile_unit
 CHECK-NEXT:    DW_AT_producer    ("llvm DWARFLinkerParallel library
 CHECK-NEXT:    DW_AT_language    (DW_LANG_C_plus_plus_14)

--- a/llvm/test/tools/dsymutil/X86/location-expression.test
+++ b/llvm/test/tools/dsymutil/X86/location-expression.test
@@ -10,7 +10,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
+# RUN: dsymutil --linker classic -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
 # RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a --verbose - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64

--- a/llvm/test/tools/dsymutil/X86/module-warnings.test
+++ b/llvm/test/tools/dsymutil/X86/module-warnings.test
@@ -23,7 +23,7 @@
 # RUN: cp %p/../Inputs/module-warnings/1.o %t.dir
 # RUN: cp %p/../Inputs/module-warnings/Foo.pcm %t.dir/ModuleCache
 #
-# RUN: dsymutil -verify -f -oso-prepend-path=%t.dir -y \
+# RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y \
 # RUN:   %p/dummy-debug-map.map -o %t 2>&1 | FileCheck %s
 #
 # Module-not-found should be reported only once.
@@ -32,12 +32,12 @@
 # CHECK-NOT: warning: {{.*}}Bar.pcm:
 #
 # RUN: cp %p/../Inputs/module-warnings/libstatic.a %t.dir
-# RUN: dsymutil -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 | FileCheck %s
+# RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 | FileCheck %s
 # CHECK: rebuild the module cache
 # CHECK-NOT: static libraries
 #
 # RUN: rm -rf %t.dir/ModuleCache
-# RUN: dsymutil -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 \
+# RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=STATIC
 # STATIC: warning: {{.*}}Bar.pcm:
 # STATIC: note: Linking a static library
@@ -52,3 +52,5 @@ objects:
     symbols:
       - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
 ...
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/multiple-inputs.test
+++ b/llvm/test/tools/dsymutil/X86/multiple-inputs.test
@@ -7,7 +7,7 @@ RUN: cp %p/../Inputs/basic-lto.macho.x86_64 %t/basic-lto.macho.x86_64
 RUN: cp %p/../Inputs/basic-lto-dw4.macho.x86_64 %t/basic-lto-dw4.macho.x86_64
 
 # Multiple inputs in flat mode
-RUN: dsymutil -f -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64
+RUN: dsymutil --linker classic -f -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64
 RUN: llvm-dwarfdump -a %t/basic.macho.x86_64.dwarf \
 RUN:   | FileCheck %S/basic-linking-x86.test --check-prefixes=CHECK,BASIC
 RUN: llvm-dwarfdump -a %t/basic-archive.macho.x86_64.dwarf \
@@ -16,7 +16,7 @@ RUN: llvm-dwarfdump -a %t/basic-lto.macho.x86_64.dwarf | FileCheck %S/basic-lto-
 RUN: llvm-dwarfdump -a %t/basic-lto-dw4.macho.x86_64.dwarf | FileCheck %S/basic-lto-dw4-linking-x86.test
 
 # Multiple inputs that end up in the same named bundle
-RUN: dsymutil -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic.macho.x86_64 \
 RUN:   | FileCheck %S/basic-linking-x86.test --check-prefixes=CHECK,BASIC
 RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-archive.macho.x86_64 \
@@ -25,7 +25,7 @@ RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-lto.macho.x86_64 |
 RUN: llvm-dwarfdump -a %t.dSYM/Contents/Resources/DWARF/basic-lto-dw4.macho.x86_64 | FileCheck %S/basic-lto-dw4-linking-x86.test
 
 # Multiple inputs in a named bundle in flat mode... impossible.
-RUN: not dsymutil -f -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
+RUN: not dsymutil --linker classic -f -oso-prepend-path=%p/.. %t/basic.macho.x86_64 %t/basic-archive.macho.x86_64 %t/basic-lto.macho.x86_64 %t/basic-lto-dw4.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s
 
 ## ---------------------------------------
 ## Repeat the same steps for --linker parallel

--- a/llvm/test/tools/dsymutil/X86/objc.test
+++ b/llvm/test/tools/dsymutil/X86/objc.test
@@ -1,8 +1,8 @@
-RUN: dsymutil --verify-dwarf=output -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d4
+RUN: dsymutil --linker classic --verify-dwarf=output -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d4
 RUN: llvm-dwarfdump -apple-types -apple-objc %t.d4 | FileCheck %s
 
 ; Test DWARF 5 tables
-RUN: dsymutil --verify-dwarf=output --accelerator='Dwarf' -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d5
+RUN: dsymutil --linker classic --verify-dwarf=output --accelerator='Dwarf' -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d5
 RUN: llvm-dwarfdump -debug-names %t.d5 | FileCheck %s --check-prefix=D5
 
 D5: String: {{.*}} "method1:"
@@ -62,3 +62,5 @@ CHECK-NEXT:       ]
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 CHECK-NEXT: ]
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/object-prefix-path.test
+++ b/llvm/test/tools/dsymutil/X86/object-prefix-path.test
@@ -2,7 +2,7 @@ RUN: rm -rf %t.dir && mkdir %t.dir && mkdir %t.dir/ModuleCacheRenamed
 RUN: cp %p/../Inputs/module-warnings/1.o %t.dir
 RUN: cp %p/../Inputs/module-warnings/Foo.pcm %t.dir/ModuleCacheRenamed
 
-RUN: dsymutil -verify -f -oso-prepend-path=%t.dir -y \
+RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y \
 RUN:   %p/dummy-debug-map.map -o %t \
 RUN:   -object-prefix-map=/ModuleCache=/ModuleCacheRenamed \
 RUN:   2>&1 | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/odr-simple-template-names-mixed.test
+++ b/llvm/test/tools/dsymutil/X86/odr-simple-template-names-mixed.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 # RUN: dsymutil --linker parallel -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck --check-prefix=PARALLEL %s
 
 ## Test that dsymutil correctly resolves simple template names to types that use

--- a/llvm/test/tools/dsymutil/X86/odr-simple-template-names.test
+++ b/llvm/test/tools/dsymutil/X86/odr-simple-template-names.test
@@ -6,7 +6,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck %s
 # RUN: dsymutil --linker parallel -f -y %t2.map -o - | llvm-dwarfdump --debug-info - | FileCheck --check-prefix=PARALLEL %s
 
 ## Test that dsymutil correctly handles -gsimple-template-names, where

--- a/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
@@ -11,7 +11,7 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker classic -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
@@ -198,3 +198,5 @@ DWARF:
             - Value:  0x0000001a
         - AbbrCode: 0
 ...
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/op-convert-offset.test
+++ b/llvm/test/tools/dsymutil/X86/op-convert-offset.test
@@ -20,7 +20,7 @@
 # $ xcrun clang -c op-convert-offset.ll -O0 -arch x86_64
 # $ xcrun clang -g op-convert-offset.o -O0 -arch x86_64 -o op-convert-offset
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/op-convert-offset/op-convert-offset -o %t.dSYM 2>&1
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/op-convert-offset/op-convert-offset -o %t.dSYM 2>&1
 RUN: llvm-dwarfdump %p/../Inputs/private/tmp/op-convert-offset/op-convert-offset.o 2>&1 | FileCheck %s --check-prefix OBJ
 RUN: llvm-dwarfdump %t.dSYM 2>&1 | FileCheck %s --check-prefix DSYM
 

--- a/llvm/test/tools/dsymutil/X86/op-convert.test
+++ b/llvm/test/tools/dsymutil/X86/op-convert.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s
+# RUN: dsymutil --linker classic -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s
 # RUN: llvm-dwarfdump %t | FileCheck %s
 
 # RUN: dsymutil --linker parallel -f -o %t --verify -oso-prepend-path=%p/../Inputs -y %s

--- a/llvm/test/tools/dsymutil/X86/reflection-dump.test
+++ b/llvm/test/tools/dsymutil/X86/reflection-dump.test
@@ -6,7 +6,7 @@ RUN: yaml2obj %p/../Inputs/main.yaml -o %t.dir/main
 RUN: yaml2obj %p/../Inputs/test.yaml -o %t.dir/tmp/test-1.o
 RUN: yaml2obj %p/../Inputs/reflection_metadata.yaml -o %t.dir/tmp/reflection_metadata-1.o
 
-RUN: dsymutil -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM
 RUN: llvm-objdump -s %t.dir/main.dSYM/Contents/Resources/DWARF/main | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%t.dir %t.dir/main -o %t.dir/main.dSYM

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-fat-bundle.test
@@ -6,7 +6,7 @@ RUN: cat %p/../Inputs/remarks/fat.macho.remarks.x86 > %t/fat.macho.remarks.x86
 RUN: llvm-remarkutil yaml2bitstream %p/../Inputs/private/tmp/remarks/fat.macho.remarks.x86_64.opt.yaml -o %t/private/tmp/remarks/fat.macho.remarks.x86_64.opt.bitstream
 RUN: llvm-remarkutil yaml2bitstream %p/../Inputs/private/tmp/remarks/fat.macho.remarks.x86_64h.opt.yaml -o %t/private/tmp/remarks/fat.macho.remarks.x86_64h.opt.bitstream
 
-RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/fat.macho.remarks.x86
+RUN: dsymutil --linker classic -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%t %t/fat.macho.remarks.x86
 
 Check that the remark files in the bundle exist and are all sane:
 RUN: llvm-bcanalyzer -dump %t/fat.macho.remarks.x86.dSYM/Contents/Resources/Remarks/fat.macho.remarks.x86-x86_64h | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -11,7 +11,7 @@ RUN: cp %p/../Inputs/basic2.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
 
 # Verify all the files are present.
-RUN: dsymutil -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 # Make sure we don't crash with an empty TMPDIR.
 RUN: env TMPDIR="" dsymutil -o -f -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1
@@ -31,16 +31,16 @@ RUN: ls %t.diags | grep 'dsymutil-' | count 1
 
 # Remove the input files and verify that was successful.
 RUN: rm -rf %t
-RUN: not dsymutil -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
+RUN: not dsymutil --linker classic -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
 
 RUN: not dsymutil --linker parallel -f -o %t.error -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefix=ERROR
 
 # Use the reproducer.
-RUN: dsymutil -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 RUN: dsymutil --linker parallel -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 # Using a reproducer takes precedence.
-RUN: dsymutil -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
+RUN: dsymutil --linker classic -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 RUN: dsymutil --linker parallel -gen-reproducer -use-reproducer %t.repro -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/statistics.test
+++ b/llvm/test/tools/dsymutil/X86/statistics.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
+# RUN: dsymutil --linker classic -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
 # RUN: dsymutil --linker parallel -statistics -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s
 #
 # CHECK: -------------------------------------------------------------------------------

--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -1,6 +1,6 @@
 RUN: rm -rf %t && mkdir %t
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker classic -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker classic -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
 RUN: llvm-readobj --sections --section-data %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
 RUN: llvm-dwarfdump --show-section-sizes %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
@@ -28,5 +28,5 @@ READOBJ-NEXT: |.|
 
 DWARFDUMP: __swift_ast
 
-RUN: dsymutil -s %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
+RUN: dsymutil --linker classic -s %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
 NAST-NOT: N_AST

--- a/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
+++ b/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/swift-dwarf-loc.macho.x86_64 -no-output -verbose | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/X86/swift-interface.test
+++ b/llvm/test/tools/dsymutil/X86/swift-interface.test
@@ -3,11 +3,11 @@
 # RUN: mkdir -p %t.dir/Foo/x86_64
 # RUN: llvm-mc -triple x86_64-apple-macos -filetype=obj -o %t.dir/obj/1.o \
 # RUN:    %p/../Inputs/swift-interface.s
-# RUN: dsymutil -oso-prepend-path %t.dir -y %s \
+# RUN: dsymutil --linker classic -oso-prepend-path %t.dir -y %s \
 # RUN:    -o %t.dir/swift-interface.dSYM 2>&1 \
 # RUN:    | FileCheck %s --check-prefix=WARNINGS
 # RUN: echo "// module Foo" >%t.dir/Foo/x86_64.swiftinterface
-# RUN: dsymutil -oso-prepend-path %t.dir -y %s \
+# RUN: dsymutil --linker classic -oso-prepend-path %t.dir -y %s \
 # RUN:    -o %t.dir/swift-interface.dSYM
 # RUN: cat %t.dir/swift-interface.dSYM/Contents/Resources/Swift/x86_64/Foo.swiftinterface \
 # RUN:   | FileCheck %s --check-prefix=INTERFACE
@@ -24,3 +24,5 @@ objects:
     symbols:
       - { sym: _main, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
 ...
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/tail-call-linking.test
+++ b/llvm/test/tools/dsymutil/X86/tail-call-linking.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s -implicit-check-not=DW_AT_call_pc
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/tail-call.macho.x86_64 -o %t.dSYM

--- a/llvm/test/tools/dsymutil/X86/template_operators.test
+++ b/llvm/test/tools/dsymutil/X86/template_operators.test
@@ -1,4 +1,5 @@
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/templated_operators/template_operators -o %t.apple.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/templated_operators/template_operators -o %t.apple.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/templated_operators/template_operators -o %t.apple.dSYM
 
 RUN: llvm-dwarfdump -apple-names %t.apple.dSYM | FileCheck %s -check-prefix=NAMES
 

--- a/llvm/test/tools/dsymutil/X86/thinlto.test
+++ b/llvm/test/tools/dsymutil/X86/thinlto.test
@@ -19,7 +19,7 @@ void function1()
 $ xcrun clang++ -g -flto=thin -O2 foo.cpp bar.cpp -c
 $ xcrun clang++ -flto=thin foo.o bar.o -Xlinker -object_path_lto -Xlinker lto -shared -o foobar.dylib
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/thinlto/foobar.dylib -o %t.dSYM 2>&1 | FileCheck %s --allow-empty
 

--- a/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
+++ b/llvm/test/tools/dsymutil/X86/timestamp-mismatch.test
@@ -3,8 +3,8 @@ RUN: cp %p/../Inputs/basic.macho.x86_64 %t/Inputs
 RUN: cp %p/../Inputs/basic1.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic2.macho.x86_64.o %t/Inputs
 RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
-RUN: dsymutil -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --check-prefix=WARN
-RUN: dsymutil -no-object-timestamp -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --allow-empty --check-prefix=NOWARN
+RUN: dsymutil --linker classic -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --check-prefix=WARN
+RUN: dsymutil --linker classic -no-object-timestamp -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --allow-empty --check-prefix=NOWARN
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --check-prefix=WARN
 RUN: dsymutil --linker parallel -no-object-timestamp -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 -o %t.dSYM 2>&1 | FileCheck %s --allow-empty --check-prefix=NOWARN

--- a/llvm/test/tools/dsymutil/X86/tls-variable.test
+++ b/llvm/test/tools/dsymutil/X86/tls-variable.test
@@ -9,12 +9,12 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker classic -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
 # RUN: dsymutil --linker parallel -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
 #
 ## In update mode, markEverythingAsKept must also handle DW_OP_GNU_push_tls_address.
-# RUN: dsymutil -y %t2.map --keep-function-for-static -f -o %t.dSYM
-# RUN: dsymutil -u %t.dSYM -f -o - | llvm-dwarfdump -a - | FileCheck %s --check-prefix=UPDATE
+# RUN: dsymutil --linker classic -y %t2.map --keep-function-for-static -f -o %t.dSYM
+# RUN: dsymutil --linker classic -u %t.dSYM -f -o - | llvm-dwarfdump -a - | FileCheck %s --check-prefix=UPDATE
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/X86/union-fwd-decl.test
+++ b/llvm/test/tools/dsymutil/X86/union-fwd-decl.test
@@ -45,7 +45,7 @@ $ clang++ use.o container.o -o a.out
 
 Note that the link order in the last command matters for this test.
 
-RUN: dsymutil -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
 RUN: llvm-dwarfdump %t.dSYM | FileCheck %s
 
 CHECK: DW_TAG_compile_unit
@@ -59,3 +59,5 @@ CHECK:          DW_AT_name      ("Container_ivars")
 CHECK-NEXT:     DW_AT_byte_size (0x01)
 CHECK-NEXT:     DW_AT_decl_file ("{{.*}}container.cpp")
 CHECK-NEXT:     DW_AT_decl_line (4)
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/update-one-CU.test
+++ b/llvm/test/tools/dsymutil/X86/update-one-CU.test
@@ -1,5 +1,5 @@
-RUN: dsymutil -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.dSYM
-RUN: dsymutil -update %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker classic -update %t.dSYM
 RUN: llvm-dwarfdump -apple-types -apple-objc %t.dSYM | FileCheck %s
 
 CHECK: .apple_types contents:
@@ -33,3 +33,5 @@ CHECK-NEXT:   Data 0 [
 CHECK-NEXT:     Atom[0]: 0x0000007a
 CHECK-NEXT:   ]
 CHECK-NEXT: }
+
+## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/update.test
+++ b/llvm/test/tools/dsymutil/X86/update.test
@@ -1,15 +1,21 @@
 RUN: rm -rf %t.dir
 RUN: mkdir -p %t.dir
 RUN: cat %p/../Inputs/basic.macho.x86_64 > %t.dir/basic
-RUN: dsymutil -accelerator=Pub -oso-prepend-path=%p/.. %t.dir/basic
+RUN: dsymutil --linker classic -accelerator=Pub -oso-prepend-path=%p/.. %t.dir/basic
+RUN: dsymutil --linker parallel -accelerator=Pub -oso-prepend-path=%p/.. %t.dir/basic
 RUN: llvm-dwarfdump -a %t.dir/basic.dSYM | FileCheck %S/basic-linking-x86.test
-RUN: dsymutil -accelerator=Pub --update %t.dir/basic.dSYM
+RUN: dsymutil --linker classic -accelerator=Pub --update %t.dir/basic.dSYM
+RUN: dsymutil --linker parallel -accelerator=Pub --update %t.dir/basic.dSYM
 RUN: llvm-dwarfdump -a %t.dir/basic.dSYM | FileCheck %S/basic-linking-x86.test
-RUN: dsymutil -accelerator=Pub -u %t.dir/basic.dSYM
+RUN: dsymutil --linker classic -accelerator=Pub -u %t.dir/basic.dSYM
+RUN: dsymutil --linker parallel -accelerator=Pub -u %t.dir/basic.dSYM
 RUN: llvm-dwarfdump -a %t.dir/basic.dSYM | FileCheck %S/basic-linking-x86.test
-RUN: dsymutil -accelerator=Pub --update %t.dir/basic.dSYM -o %t.dir/updated.dSYM
+RUN: dsymutil --linker classic -accelerator=Pub --update %t.dir/basic.dSYM -o %t.dir/updated.dSYM
+RUN: dsymutil --linker parallel -accelerator=Pub --update %t.dir/basic.dSYM -o %t.dir/updated.dSYM
 RUN: llvm-dwarfdump -a %t.dir/updated.dSYM | FileCheck %S/basic-linking-x86.test
 
-RUN: dsymutil -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64
-RUN: dsymutil -accelerator=Pub -f -u %t2 -o %t3
+RUN: dsymutil --linker classic -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64
+RUN: dsymutil --linker parallel -accelerator=Pub -f -o %t2 -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64
+RUN: dsymutil --linker classic -accelerator=Pub -f -u %t2 -o %t3
+RUN: dsymutil --linker parallel -accelerator=Pub -f -u %t2 -o %t3
 RUN: llvm-dwarfdump -a %t3 | FileCheck %S/basic-linking-x86.test

--- a/llvm/test/tools/dsymutil/X86/verify.test
+++ b/llvm/test/tools/dsymutil/X86/verify.test
@@ -1,23 +1,23 @@
 # Positive tests in regular and verbose mode.
-# RUN: dsymutil -verify -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --allow-empty --check-prefix=QUIET-SUCCESS
-# RUN: dsymutil -verify -verbose -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS,VERBOSE
+# RUN: dsymutil --linker classic -verify -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --allow-empty --check-prefix=QUIET-SUCCESS
+# RUN: dsymutil --linker classic -verify -verbose -oso-prepend-path=%p/.. %p/../Inputs/basic.macho.x86_64 %p/../Inputs/basic-archive.macho.x86_64 %p/../Inputs/basic-lto.macho.x86_64 %p/../Inputs/basic-lto-dw4.macho.x86_64 -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS,VERBOSE
 
 # VERBOSE: Verifying DWARF for architecture: x86_64
 # QUIET-SUCCESS-NOT: error: output verification failed
 
 # Negative output tests in regular and verbose mode.
 # (Invalid object generated from ../Inputs/invalid.s by modified the low PC.)
-# RUN: not dsymutil -verify -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
-# RUN: not dsymutil -verify-dwarf=output -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
-# RUN: not dsymutil -verify -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,VERBOSE
+# RUN: not dsymutil --linker classic -verify -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
+# RUN: not dsymutil --linker classic -verify-dwarf=output -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-OUTPUT-FAIL
+# RUN: not dsymutil --linker classic -verify -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,VERBOSE
 
 # Negative input & output tests in regular and verbose mode. Only output failures result in a non-zero exit code.
-# RUN: dsymutil -verify-dwarf=input -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
-# RUN: dsymutil -verify-dwarf=input -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
-# RUN: dsymutil -verify-dwarf=none -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS
-# RUN: not dsymutil -verify-dwarf=bogus -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=BOGUS
-# RUN: not dsymutil -verify-dwarf=all -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,QUIET-INPUT-FAIL
-# RUN: not dsymutil -verify-dwarf=all -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=VERBOSE-INPUT-FAIL
+# RUN: dsymutil --linker classic -verify-dwarf=input -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
+# RUN: dsymutil --linker classic -verify-dwarf=input -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefix=QUIET-INPUT-FAIL
+# RUN: dsymutil --linker classic -verify-dwarf=none -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-SUCCESS
+# RUN: not dsymutil --linker classic -verify-dwarf=bogus -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=BOGUS
+# RUN: not dsymutil --linker classic -verify-dwarf=all -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=QUIET-OUTPUT-FAIL,QUIET-INPUT-FAIL
+# RUN: not dsymutil --linker classic -verify-dwarf=all -verbose -oso-prepend-path=%p/../Inputs -y %s -o %t 2>&1 | FileCheck %s --check-prefixes=VERBOSE-INPUT-FAIL
 
 # VERBOSE-INPUT-FAIL-DAG: error: Abbreviation declaration contains multiple DW_AT_language attributes.
 # QUIET-INPUT-FAIL-DAG: warning: input verification failed

--- a/llvm/test/tools/dsymutil/absolute_symbol.test
+++ b/llvm/test/tools/dsymutil/absolute_symbol.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -dump-debug-map -oso-prepend-path %p %p/Inputs/absolute_sym.macho.i386 | FileCheck %s
+RUN: dsymutil --linker classic -dump-debug-map -oso-prepend-path %p %p/Inputs/absolute_sym.macho.i386 | FileCheck %s
 
 RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path %p %p/Inputs/absolute_sym.macho.i386 | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/arch-option.test
+++ b/llvm/test/tools/dsymutil/arch-option.test
@@ -1,15 +1,15 @@
 Processing of the -arch option happens at debug map parsing time, thus just
 looking at the dumped debug maps is enough to validate their effects.
 
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch all | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch='*' | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 | FileCheck %s -check-prefixes=ARM64,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm | FileCheck %s -check-prefixes=ARMV7S,ARMV7,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch armv7 | FileCheck %s -check-prefixes=ARMV7,CHECK
-RUN: dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 -arch armv7s | FileCheck %s -check-prefixes=ARM64,ARMV7S,CHECK
-RUN: not dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm42 2>&1 | FileCheck %s -check-prefix=BADARCH
-RUN: not dsymutil -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch i386 2>&1 | FileCheck %s -check-prefix=EMPTY
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch all | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch='*' | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 | FileCheck %s -check-prefixes=ARM64,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm | FileCheck %s -check-prefixes=ARMV7S,ARMV7,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch armv7 | FileCheck %s -check-prefixes=ARMV7,CHECK
+RUN: dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm64 -arch armv7s | FileCheck %s -check-prefixes=ARM64,ARMV7S,CHECK
+RUN: not dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch arm42 2>&1 | FileCheck %s -check-prefix=BADARCH
+RUN: not dsymutil --linker classic -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch i386 2>&1 | FileCheck %s -check-prefix=EMPTY
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK
 RUN: dsymutil --linker parallel -oso-prepend-path %p -dump-debug-map %p/Inputs/fat-test.arm.dylib -arch all | FileCheck %s -check-prefixes=ARM64,ARMV7S,ARMV7,CHECK

--- a/llvm/test/tools/dsymutil/archive-timestamp.test
+++ b/llvm/test/tools/dsymutil/archive-timestamp.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -no-output -oso-prepend-path=%p -y %s 2>&1 | FileCheck -DMSG=%errc_ENOENT %s
+# RUN: dsymutil --linker classic -no-output -oso-prepend-path=%p -y %s 2>&1 | FileCheck -DMSG=%errc_ENOENT %s
 
 # RUN: dsymutil --linker parallel -no-output -oso-prepend-path=%p -y %s 2>&1 | FileCheck -DMSG=%errc_ENOENT %s
 

--- a/llvm/test/tools/dsymutil/asm-line-tables.test
+++ b/llvm/test/tools/dsymutil/asm-line-tables.test
@@ -5,8 +5,10 @@ $ clang -target arm64-apple-macos26 asm-line-tables.s -o asm-line-tables.o -c -g
 $ clang -target arm64-apple-macos26 -o asm-line-tables.arm64 asm-line-tables.o -nodefaultlibs -nostdlib -static -Wl,-oso_prefix,$PWD
 
 REQUIRES: aarch64-registered-target
-RUN: dsymutil -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
 RUN: llvm-dwarfdump --debug-line %t.dSYM | FileCheck %s
+
+## FIXME: Support --linker parallel
 
 CHECK:      0x00000001000002e8      5      0      0   0             0       0  is_stmt
 CHECK-NEXT: 0x00000001000002ec      9      0      0   0             0       0  is_stmt

--- a/llvm/test/tools/dsymutil/basic-linking.test
+++ b/llvm/test/tools/dsymutil/basic-linking.test
@@ -1,15 +1,18 @@
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefix=CHECK-ARCHIVE
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 %p/Inputs/basic-lto.macho.x86_64 %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefixes=CHECK,CHECK-LTO,CHECK-ARCHIVE
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/basic-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/two-level-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-TWO
-RUN: dsymutil -no-output -verbose -oso-prepend-path=%p -build-variant-suffix=_debug -D WrongPath -D %p/Inputs %p/Inputs/variant-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-VARIANT
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefix=CHECK-ARCHIVE
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 %p/Inputs/basic-lto.macho.x86_64 %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefixes=CHECK,CHECK-LTO,CHECK-ARCHIVE
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/basic-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/two-level-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-TWO
+RUN: dsymutil --linker classic -no-output -verbose -oso-prepend-path=%p -build-variant-suffix=_debug -D WrongPath -D %p/Inputs %p/Inputs/variant-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-VARIANT
 
 RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
 RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
 RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefix=CHECK-ARCHIVE
 RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 %p/Inputs/basic-lto.macho.x86_64 %p/Inputs/basic-archive.macho.x86_64 | FileCheck %s --check-prefixes=CHECK,CHECK-LTO,CHECK-ARCHIVE
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/basic-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p -D %p/Inputs %p/Inputs/two-level-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-TWO
+RUN: dsymutil --linker parallel -no-output -verbose -oso-prepend-path=%p -build-variant-suffix=_debug -D WrongPath -D %p/Inputs %p/Inputs/variant-relink.macho.arm64.dylib | FileCheck %s --check-prefix=CHECK-RELINK-VARIANT
 
 This test check the basic Dwarf linking process through the debug dumps.
 

--- a/llvm/test/tools/dsymutil/codesign.test
+++ b/llvm/test/tools/dsymutil/codesign.test
@@ -1,15 +1,21 @@
 REQUIRES: system-darwin, x86-registered-target
 
 ## Verify --codesign signs the dSYM bundle.
-RUN: dsymutil -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.dSYM --codesign=-
+RUN: dsymutil --linker classic -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.dSYM --codesign=-
+RUN: codesign -v %t.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.dSYM --codesign=-
 RUN: codesign -v %t.dSYM
 
 ## Verify --codesign is incompatible with --flat.
-RUN: not dsymutil -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.flat --flat --codesign=- 2>&1 \
+RUN: not dsymutil --linker classic -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.flat --flat --codesign=- 2>&1 \
+RUN:   | FileCheck %s --check-prefix=FLAT
+RUN: not dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 -o %t.flat --flat --codesign=- 2>&1 \
 RUN:   | FileCheck %s --check-prefix=FLAT
 FLAT: error: --codesign is not supported with --flat: no bundle to sign
 
 ## Verify --codesign is incompatible with --no-output.
-RUN: not dsymutil -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 --no-output --codesign=- 2>&1 \
+RUN: not dsymutil --linker classic -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 --no-output --codesign=- 2>&1 \
+RUN:   | FileCheck %s --check-prefix=NOOUT
+RUN: not dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/basic.macho.x86_64 --no-output --codesign=- 2>&1 \
 RUN:   | FileCheck %s --check-prefix=NOOUT
 NOOUT: error: --codesign is not supported with --no-output: nothing to sign

--- a/llvm/test/tools/dsymutil/debug-map-parsing.test
+++ b/llvm/test/tools/dsymutil/debug-map-parsing.test
@@ -1,8 +1,8 @@
-RUN: dsymutil -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
-RUN: dsymutil -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
-RUN: dsymutil -verbose -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-ARCHIVE
-RUN: dsymutil -dump-debug-map %p/Inputs/basic.macho.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NOT-FOUND
-RUN: not dsymutil -dump-debug-map %p/Inputs/inexistant 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NO-EXECUTABLE
+RUN: dsymutil --linker classic -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
+RUN: dsymutil --linker classic -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO
+RUN: dsymutil --linker classic -verbose -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-archive.macho.x86_64 2>&1 | FileCheck %s --check-prefix=CHECK-ARCHIVE
+RUN: dsymutil --linker classic -dump-debug-map %p/Inputs/basic.macho.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NOT-FOUND
+RUN: not dsymutil --linker classic -dump-debug-map %p/Inputs/inexistant 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=NO-EXECUTABLE
 
 RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 | FileCheck %s
 RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p %p/Inputs/basic-lto.macho.x86_64 | FileCheck %s --check-prefix=CHECK-LTO

--- a/llvm/test/tools/dsymutil/dump-symtab.test
+++ b/llvm/test/tools/dsymutil/dump-symtab.test
@@ -1,5 +1,5 @@
-RUN: dsymutil -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=ALL,I386 %s
-RUN: dsymutil -arch i386 -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=I386,ONE %s
+RUN: dsymutil --linker classic -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=ALL,I386 %s
+RUN: dsymutil --linker classic -arch i386 -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=I386,ONE %s
 
 RUN: dsymutil --linker parallel -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=ALL,I386 %s
 RUN: dsymutil --linker parallel -arch i386 -s %p/Inputs/fat-test.dylib | FileCheck -check-prefixes=I386,ONE %s

--- a/llvm/test/tools/dsymutil/embed-resource.test
+++ b/llvm/test/tools/dsymutil/embed-resource.test
@@ -6,7 +6,12 @@ Create a temp resource file and embed it into the dSYM bundle.
 
 RUN: rm -rf %t.dir && mkdir -p %t.dir
 RUN: echo "# test resource" > %t.dir/test.py
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN:   --embed-resource %t.dir/test.py=Python/test.py \
+RUN:   -o %t.dir/basic.macho.x86_64.dSYM
+RUN: diff %t.dir/test.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/test.py
+RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
 RUN:   --embed-resource %t.dir/test.py=Python/test.py \
 RUN:   -o %t.dir/basic.macho.x86_64.dSYM
 RUN: diff %t.dir/test.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/test.py
@@ -15,7 +20,14 @@ Verify multiple --embed-resource options.
 
 RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
 RUN: echo "second" > %t.dir/second.txt
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN:   --embed-resource %t.dir/test.py=Python/test.py \
+RUN:   --embed-resource %t.dir/second.txt=Scripts/second.txt \
+RUN:   -o %t.dir/basic.macho.x86_64.dSYM
+RUN: diff %t.dir/test.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/test.py
+RUN: diff %t.dir/second.txt %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Scripts/second.txt
+RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
 RUN:   --embed-resource %t.dir/test.py=Python/test.py \
 RUN:   --embed-resource %t.dir/second.txt=Scripts/second.txt \
 RUN:   -o %t.dir/basic.macho.x86_64.dSYM
@@ -25,7 +37,12 @@ RUN: diff %t.dir/second.txt %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Sc
 Verify verbose output.
 
 RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN:   --embed-resource %t.dir/test.py=Python/test.py \
+RUN:   --verbose -o %t.dir/basic.macho.x86_64.dSYM 2>&1 \
+RUN:   | FileCheck --check-prefix=VERBOSE %s
+RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
 RUN:   --embed-resource %t.dir/test.py=Python/test.py \
 RUN:   --verbose -o %t.dir/basic.macho.x86_64.dSYM 2>&1 \
 RUN:   | FileCheck --check-prefix=VERBOSE %s
@@ -34,7 +51,11 @@ VERBOSE: embed resource {{.*}}test.py -> {{.*}}Resources{{.}}Python{{.}}test.py
 
 Verify error on missing source file.
 
-RUN: not dsymutil -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN: not dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN:   --embed-resource %t.dir/nonexistent.py=Python/foo.py \
+RUN:   -o %t.dir/basic.macho.x86_64.dSYM 2>&1 \
+RUN:   | FileCheck --check-prefix=MISSING %s
+RUN: not dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
 RUN:   --embed-resource %t.dir/nonexistent.py=Python/foo.py \
 RUN:   -o %t.dir/basic.macho.x86_64.dSYM 2>&1 \
 RUN:   | FileCheck --check-prefix=MISSING %s
@@ -48,7 +69,14 @@ RUN: mkdir -p %t.dir/pydir/sub
 RUN: echo "file_a" > %t.dir/pydir/a.py
 RUN: echo "file_b" > %t.dir/pydir/b.py
 RUN: echo "file_sub" > %t.dir/pydir/sub/c.py
-RUN: dsymutil -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN: dsymutil --linker classic -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
+RUN:   --embed-resource %t.dir/pydir=Python \
+RUN:   -o %t.dir/basic.macho.x86_64.dSYM
+RUN: diff %t.dir/pydir/a.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/a.py
+RUN: diff %t.dir/pydir/b.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/b.py
+RUN: diff %t.dir/pydir/sub/c.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/sub/c.py
+RUN: rm -rf %t.dir/basic.macho.x86_64.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path=%p %p/Inputs/basic.macho.x86_64 \
 RUN:   --embed-resource %t.dir/pydir=Python \
 RUN:   -o %t.dir/basic.macho.x86_64.dSYM
 RUN: diff %t.dir/pydir/a.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resources/Python/a.py
@@ -57,11 +85,14 @@ RUN: diff %t.dir/pydir/sub/c.py %t.dir/basic.macho.x86_64.dSYM/Contents/Resource
 
 Verify error cases.
 
-RUN: not dsymutil --embed-resource noequals file1 2>&1 | FileCheck --check-prefix=BADEMBED %s
+RUN: not dsymutil --linker classic --embed-resource noequals file1 2>&1 | FileCheck --check-prefix=BADEMBED %s
+RUN: not dsymutil --linker parallel --embed-resource noequals file1 2>&1 | FileCheck --check-prefix=BADEMBED %s
 BADEMBED: error: invalid --embed-resource argument 'noequals': expected <src-path>=<dst-path>
 
-RUN: not dsymutil --embed-resource /tmp/a.py=../../etc/passwd file1 2>&1 | FileCheck --check-prefix=ESCAPE %s
+RUN: not dsymutil --linker classic --embed-resource /tmp/a.py=../../etc/passwd file1 2>&1 | FileCheck --check-prefix=ESCAPE %s
+RUN: not dsymutil --linker parallel --embed-resource /tmp/a.py=../../etc/passwd file1 2>&1 | FileCheck --check-prefix=ESCAPE %s
 ESCAPE: error: invalid --embed-resource destination '../../etc/passwd': must be a relative path within the bundle
 
-RUN: not dsymutil --embed-resource /tmp/a.py=%/t/absolute file1 2>&1 | FileCheck --check-prefix=ABSOLUTE %s
+RUN: not dsymutil --linker classic --embed-resource /tmp/a.py=%/t/absolute file1 2>&1 | FileCheck --check-prefix=ABSOLUTE %s
+RUN: not dsymutil --linker parallel --embed-resource /tmp/a.py=%/t/absolute file1 2>&1 | FileCheck --check-prefix=ABSOLUTE %s
 ABSOLUTE: error: invalid --embed-resource destination '{{.*}}absolute': must be a relative path within the bundle

--- a/llvm/test/tools/dsymutil/fat-binary-output.test
+++ b/llvm/test/tools/dsymutil/fat-binary-output.test
@@ -1,4 +1,4 @@
-RUN: dsymutil -f -verbose -no-output %p/Inputs/fat-test.dylib -oso-prepend-path %p | FileCheck %s
+RUN: dsymutil --linker classic -f -verbose -no-output %p/Inputs/fat-test.dylib -oso-prepend-path %p | FileCheck %s
 
 RUN: dsymutil --linker parallel -f -verbose -no-output %p/Inputs/fat-test.dylib -oso-prepend-path %p | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/fat-header.test
+++ b/llvm/test/tools/dsymutil/fat-header.test
@@ -1,12 +1,12 @@
 REQUIRES: system-darwin,arm-registered-target,aarch64-registered-target
 
-RUN: dsymutil -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat32.dSYM
+RUN: dsymutil --linker classic -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat32.dSYM
 RUN: llvm-objdump -m --universal-headers %t.fat32.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT32
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat32.dSYM
 RUN: llvm-objdump -m --universal-headers %t.fat32.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT32
 
-RUN: dsymutil -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat64.dSYM -fat64
+RUN: dsymutil --linker classic -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat64.dSYM -fat64
 RUN: llvm-objdump -m --universal-headers %t.fat64.dSYM/Contents/Resources/DWARF/fat-test.arm.dylib | FileCheck %s -check-prefixes=FAT64
 
 RUN: dsymutil --linker parallel -oso-prepend-path %p %p/Inputs/fat-test.arm.dylib -o %t.fat64.dSYM -fat64

--- a/llvm/test/tools/dsymutil/null-die.test
+++ b/llvm/test/tools/dsymutil/null-die.test
@@ -1,5 +1,7 @@
-#RUN: dsymutil -f -oso-prepend-path=%p/Inputs/ -y %s -no-output 2>&1 \
+#RUN: dsymutil --linker classic -f -oso-prepend-path=%p/Inputs/ -y %s -no-output 2>&1 \
 #RUN:   |  FileCheck %s
+
+## FIXME: Support --linker parallel
 
 # CHECK: warning: could not find referenced DIE
 

--- a/llvm/test/tools/dsymutil/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/odr-two-units-in-single-file.test
@@ -8,7 +8,9 @@
 # RUN: echo '    symbols:' >> %t2.map
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
-# RUN: dsymutil -y -j 16 %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker classic -y -j 16 %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+
+## FIXME: Support --linker parallel
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:

--- a/llvm/test/tools/dsymutil/yaml-object-address-rewrite.test
+++ b/llvm/test/tools/dsymutil/yaml-object-address-rewrite.test
@@ -1,4 +1,4 @@
-# RUN: dsymutil -dump-debug-map -oso-prepend-path=%p -y %s | FileCheck %s
+# RUN: dsymutil --linker classic -dump-debug-map -oso-prepend-path=%p -y %s | FileCheck %s
 #
 # RUN: dsymutil --linker parallel -dump-debug-map -oso-prepend-path=%p -y %s | FileCheck %s
 #


### PR DESCRIPTION
Pass `--linker classic` or `--linker parallel` on every `dsymutil` invocation instead of relying on the implicit default. This preserves the existing coverage in preparation for toggling the default in the future.

Tests previously exercising only one linker now mirror the RUN block for the other, sharing FileCheck prefixes. Not all tests are compatible, and I've added a FIXME to make them easy to spot.