### PR TITLE
[libc] Add sys/stat syscall wrappers

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -160,6 +160,14 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  struct_stat
+  HDRS
+    struct_stat.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_stat
+)
+
+add_proxy_header_library(
   ssize_t
   HDRS
     ssize_t.h

--- a/libc/hdr/types/struct_stat.h
+++ b/libc/hdr/types/struct_stat.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy header for struct stat.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_STAT_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_STAT_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_stat.h"
+
+#else // Overlay mode
+
+#include <sys/stat.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_STAT_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -235,3 +235,83 @@ add_header_library(
     libc.hdr.errno_macros
     libc.include.sys_syscall
 )
+
+add_header_library(
+  statx
+  HDRS
+    statx.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  mkdir
+  HDRS
+    mkdir.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.fcntl_macros
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  mkdirat
+  HDRS
+    mkdirat.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  chmod
+  HDRS
+    chmod.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.fcntl_macros
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  fchmod
+  HDRS
+    fchmod.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+)
+
+add_header_library(
+  fchmodat
+  HDRS
+    fchmodat.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.hdr.types.mode_t
+    libc.include.sys_syscall
+)
+

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/chmod.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/chmod.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for chmod.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_CHMOD_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_CHMOD_H
+
+#include "hdr/fcntl_macros.h"
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> chmod(const char *path, mode_t mode) {
+#ifdef SYS_chmod
+  int ret = syscall_impl<int>(SYS_chmod, path, mode);
+#elif defined(SYS_fchmodat)
+  int ret = syscall_impl<int>(SYS_fchmodat, AT_FDCWD, path, mode, 0);
+#elif defined(SYS_fchmodat2)
+  int ret = syscall_impl<int>(SYS_fchmodat2, AT_FDCWD, path, mode, 0,
+                              AT_SYMLINK_NOFOLLOW);
+#else
+#error "chmod, fchmodat and fchmodat2 syscalls not available."
+#endif
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_CHMOD_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/fchmod.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/fchmod.h
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for fchmod.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMOD_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMOD_H
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> fchmod(int fd, mode_t mode) {
+  int ret = syscall_impl<int>(SYS_fchmod, fd, mode);
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMOD_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/fchmodat.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/fchmodat.h
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for fchmodat.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMODAT_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMODAT_H
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> fchmodat(int fd, const char *path, mode_t mode,
+                                  int flags) {
+  int ret = syscall_impl<int>(SYS_fchmodat, fd, path, mode, flags);
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_FCHMODAT_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdir.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdir.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for mkdir.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIR_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIR_H
+
+#include "hdr/fcntl_macros.h"
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> mkdir(const char *path, mode_t mode) {
+#ifdef SYS_mkdir
+  int ret = syscall_impl<int>(SYS_mkdir, path, mode);
+#else
+  int ret = syscall_impl<int>(SYS_mkdirat, AT_FDCWD, path, mode);
+#endif
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIR_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdirat.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdirat.h
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for mkdirat.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIRAT_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIRAT_H
+
+#include "hdr/types/mode_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> mkdirat(int dfd, const char *path, mode_t mode) {
+  int ret = syscall_impl<int>(SYS_mkdirat, dfd, path, mode);
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_MKDIRAT_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/statx.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/statx.h
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ErrorOr-returning syscall wrapper for statx.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_STATX_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_STATX_H
+
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+LIBC_INLINE ErrorOr<int> statx(int dirfd, const char *path, int flags,
+                               unsigned int mask, void *statxbuf) {
+  int ret = syscall_impl<int>(SYS_statx, dirfd, path, flags, mask, statxbuf);
+  if (ret < 0)
+    return Error(-ret);
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_STATX_H

--- a/libc/src/sys/stat/chmod.h
+++ b/libc/src/sys/stat/chmod.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_CHMOD_H
 #define LLVM_LIBC_SRC_SYS_STAT_CHMOD_H
 
+#include "hdr/types/mode_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/fchmod.h
+++ b/libc/src/sys/stat/fchmod.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_FCHMOD_H
 #define LLVM_LIBC_SRC_SYS_STAT_FCHMOD_H
 
+#include "hdr/types/mode_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/fchmodat.h
+++ b/libc/src/sys/stat/fchmodat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_FCHMODAT_H
 #define LLVM_LIBC_SRC_SYS_STAT_FCHMODAT_H
 
+#include "hdr/types/mode_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/fstat.h
+++ b/libc/src/sys/stat/fstat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_FSTAT_H
 #define LLVM_LIBC_SRC_SYS_STAT_FSTAT_H
 
+#include "hdr/types/struct_stat.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/linux/CMakeLists.txt
+++ b/libc/src/sys/stat/linux/CMakeLists.txt
@@ -7,9 +7,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.mode_t
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.chmod
     libc.src.errno.errno
 )
 
@@ -21,9 +19,7 @@ add_entrypoint_object(
     ../fchmod.h
   DEPENDS
     libc.hdr.types.mode_t
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.fchmod
     libc.src.errno.errno
 )
 
@@ -32,11 +28,10 @@ add_entrypoint_object(
   SRCS
     fchmodat.cpp
   HDRS
-    ../fchmod.h
+    ../fchmodat.h
   DEPENDS
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.hdr.types.mode_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.fchmodat
     libc.src.errno.errno
 )
 
@@ -49,9 +44,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.mode_t
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.mkdir
     libc.src.errno.errno
 )
 
@@ -62,9 +55,8 @@ add_entrypoint_object(
   HDRS
     ../mkdirat.h
   DEPENDS
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.hdr.types.mode_t
+    libc.src.__support.OSUtil.linux.syscall_wrappers.mkdirat
     libc.src.errno.errno
 )
 
@@ -74,9 +66,8 @@ add_header_library(
     kernel_statx.h
   DEPENDS
     libc.hdr.stdint_proxy
-    libc.include.sys_stat
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.hdr.types.struct_stat
+    libc.src.__support.OSUtil.linux.syscall_wrappers.statx
     libc.src.__support.common
 )
 
@@ -89,7 +80,7 @@ add_entrypoint_object(
   DEPENDS
     .kernel_statx
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
+    libc.hdr.types.struct_stat
     libc.src.errno.errno
 )
 
@@ -102,7 +93,7 @@ add_entrypoint_object(
   DEPENDS
     .kernel_statx
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
+    libc.hdr.types.struct_stat
     libc.src.errno.errno
 )
 
@@ -115,7 +106,7 @@ add_entrypoint_object(
   DEPENDS
     .kernel_statx
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
+    libc.hdr.types.struct_stat
     libc.src.errno.errno
 )
 

--- a/libc/src/sys/stat/linux/CMakeLists.txt
+++ b/libc/src/sys/stat/linux/CMakeLists.txt
@@ -69,6 +69,7 @@ add_header_library(
     libc.hdr.types.struct_stat
     libc.src.__support.OSUtil.linux.syscall_wrappers.statx
     libc.src.__support.common
+    libc.src.__support.libc_errno
 )
 
 add_entrypoint_object(
@@ -81,7 +82,6 @@ add_entrypoint_object(
     .kernel_statx
     libc.hdr.fcntl_macros
     libc.hdr.types.struct_stat
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -94,7 +94,6 @@ add_entrypoint_object(
     .kernel_statx
     libc.hdr.fcntl_macros
     libc.hdr.types.struct_stat
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -107,7 +106,6 @@ add_entrypoint_object(
     .kernel_statx
     libc.hdr.fcntl_macros
     libc.hdr.types.struct_stat
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/src/sys/stat/linux/chmod.cpp
+++ b/libc/src/sys/stat/linux/chmod.cpp
@@ -8,33 +8,17 @@
 
 #include "src/sys/stat/chmod.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/chmod.h"
 #include "src/__support/common.h"
-
-#include "hdr/fcntl_macros.h"
-#include "hdr/types/mode_t.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, chmod, (const char *path, mode_t mode)) {
-#ifdef SYS_chmod
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_chmod, path, mode);
-#elif defined(SYS_fchmodat)
-  int ret =
-      LIBC_NAMESPACE::syscall_impl<int>(SYS_fchmodat, AT_FDCWD, path, mode, 0);
-#elif defined(SYS_fchmodat2)
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_fchmodat2, AT_FDCWD, path,
-                                              mode, 0, AT_SYMLINK_NOFOLLOW);
-#else
-#error "chmod, fchmodat and fchmodat2 syscalls not available."
-#endif
-
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::chmod(path, mode);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/sys/stat/linux/fchmod.cpp
+++ b/libc/src/sys/stat/linux/fchmod.cpp
@@ -8,21 +8,17 @@
 
 #include "src/sys/stat/fchmod.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/fchmod.h"
 #include "src/__support/common.h"
-
-#include "hdr/types/mode_t.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, fchmod, (int fd, mode_t mode)) {
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_fchmod, fd, mode);
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::fchmod(fd, mode);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/sys/stat/linux/fchmodat.cpp
+++ b/libc/src/sys/stat/linux/fchmodat.cpp
@@ -8,22 +8,18 @@
 
 #include "src/sys/stat/fchmodat.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/fchmodat.h"
 #include "src/__support/common.h"
-
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, fchmodat,
                    (int dirfd, const char *path, mode_t mode, int flags)) {
-  int ret =
-      LIBC_NAMESPACE::syscall_impl<int>(SYS_fchmodat, dirfd, path, mode, flags);
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::fchmodat(dirfd, path, mode, flags);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/sys/stat/linux/fstat.cpp
+++ b/libc/src/sys/stat/linux/fstat.cpp
@@ -14,7 +14,7 @@
 #include "src/__support/common.h"
 
 #include "hdr/fcntl_macros.h"
-#include <sys/stat.h>
+#include "hdr/types/struct_stat.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/linux/fstat.cpp
+++ b/libc/src/sys/stat/linux/fstat.cpp
@@ -8,7 +8,6 @@
 
 #include "src/sys/stat/fstat.h"
 #include "kernel_statx.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 #include "src/__support/common.h"
@@ -19,12 +18,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, fstat, (int fd, struct stat *statbuf)) {
-  int err = statx(fd, "", AT_EMPTY_PATH, statbuf);
-  if (err != 0) {
-    libc_errno = err;
-    return -1;
-  }
-  return 0;
+  return statx(fd, "", AT_EMPTY_PATH, statbuf);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/stat/linux/kernel_statx.h
+++ b/libc/src/sys/stat/linux/kernel_statx.h
@@ -12,6 +12,7 @@
 #include "hdr/stdint_proxy.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/statx.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 #include "hdr/types/struct_stat.h"
@@ -75,8 +76,10 @@ LIBC_INLINE int statx(int dirfd, const char *__restrict path, int flags,
   ::statx_buf xbuf;
   auto result = linux_syscalls::statx(dirfd, path, flags,
                                       ::STATX_BASIC_STATS_MASK, &xbuf);
-  if (!result)
-    return result.error();
+  if (!result) {
+    libc_errno = result.error();
+    return -1;
+  }
 
   statbuf->st_dev = MKDEV(xbuf.stx_dev_major, xbuf.stx_dev_minor);
   statbuf->st_ino = static_cast<decltype(statbuf->st_ino)>(xbuf.stx_ino);

--- a/libc/src/sys/stat/linux/kernel_statx.h
+++ b/libc/src/sys/stat/linux/kernel_statx.h
@@ -10,12 +10,11 @@
 #define LLVM_LIBC_SRC_SYS_STAT_LINUX_KERNEL_STATX_H
 
 #include "hdr/stdint_proxy.h"
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/statx.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
+#include "hdr/types/struct_stat.h"
 
 // It is safe to include this kernel header as it is designed to be
 // included from user programs without causing any name pollution.
@@ -74,10 +73,10 @@ LIBC_INLINE int statx(int dirfd, const char *__restrict path, int flags,
                       struct stat *__restrict statbuf) {
   // We make a statx syscall and copy out the result into the |statbuf|.
   ::statx_buf xbuf;
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_statx, dirfd, path, flags,
-                                              ::STATX_BASIC_STATS_MASK, &xbuf);
-  if (ret < 0)
-    return -ret;
+  auto result = linux_syscalls::statx(dirfd, path, flags,
+                                      ::STATX_BASIC_STATS_MASK, &xbuf);
+  if (!result)
+    return result.error();
 
   statbuf->st_dev = MKDEV(xbuf.stx_dev_major, xbuf.stx_dev_minor);
   statbuf->st_ino = static_cast<decltype(statbuf->st_ino)>(xbuf.stx_ino);

--- a/libc/src/sys/stat/linux/lstat.cpp
+++ b/libc/src/sys/stat/linux/lstat.cpp
@@ -8,10 +8,8 @@
 
 #include "src/sys/stat/lstat.h"
 #include "kernel_statx.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
 #include "hdr/fcntl_macros.h"
@@ -22,12 +20,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, lstat,
                    (const char *__restrict path,
                     struct stat *__restrict statbuf)) {
-  int err = statx(AT_FDCWD, path, AT_SYMLINK_NOFOLLOW, statbuf);
-  if (err != 0) {
-    libc_errno = err;
-    return -1;
-  }
-  return 0;
+  return statx(AT_FDCWD, path, AT_SYMLINK_NOFOLLOW, statbuf);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/stat/linux/lstat.cpp
+++ b/libc/src/sys/stat/linux/lstat.cpp
@@ -15,7 +15,7 @@
 #include "src/__support/common.h"
 
 #include "hdr/fcntl_macros.h"
-#include <sys/stat.h>
+#include "hdr/types/struct_stat.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/linux/mkdir.cpp
+++ b/libc/src/sys/stat/linux/mkdir.cpp
@@ -8,30 +8,17 @@
 
 #include "src/sys/stat/mkdir.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/mkdir.h"
 #include "src/__support/common.h"
-
-#include "hdr/fcntl_macros.h"
-#include "hdr/types/mode_t.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, mkdir, (const char *path, mode_t mode)) {
-#ifdef SYS_mkdir
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_mkdir, path, mode);
-#elif defined(SYS_mkdirat)
-  int ret =
-      LIBC_NAMESPACE::syscall_impl<int>(SYS_mkdirat, AT_FDCWD, path, mode);
-#else
-#error "mkdir and mkdirat syscalls not available."
-#endif
-
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::mkdir(path, mode);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/sys/stat/linux/mkdirat.cpp
+++ b/libc/src/sys/stat/linux/mkdirat.cpp
@@ -8,25 +8,17 @@
 
 #include "src/sys/stat/mkdirat.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/mkdirat.h"
 #include "src/__support/common.h"
-
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, mkdirat, (int dfd, const char *path, mode_t mode)) {
-#ifdef SYS_mkdirat
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_mkdirat, dfd, path, mode);
-#else
-#error "mkdirat syscall not available."
-#endif
-
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::mkdirat(dfd, path, mode);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/sys/stat/linux/stat.cpp
+++ b/libc/src/sys/stat/linux/stat.cpp
@@ -14,7 +14,7 @@
 #include "src/__support/common.h"
 
 #include "hdr/fcntl_macros.h"
-#include <sys/stat.h>
+#include "hdr/types/struct_stat.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/linux/stat.cpp
+++ b/libc/src/sys/stat/linux/stat.cpp
@@ -8,7 +8,6 @@
 
 #include "src/sys/stat/stat.h"
 #include "kernel_statx.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 #include "src/__support/common.h"
@@ -21,12 +20,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, stat,
                    (const char *__restrict path,
                     struct stat *__restrict statbuf)) {
-  int err = statx(AT_FDCWD, path, 0, statbuf);
-  if (err != 0) {
-    libc_errno = err;
-    return -1;
-  }
-  return 0;
+  return statx(AT_FDCWD, path, 0, statbuf);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/stat/lstat.h
+++ b/libc/src/sys/stat/lstat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_LSTAT_H
 #define LLVM_LIBC_SRC_SYS_STAT_LSTAT_H
 
+#include "hdr/types/struct_stat.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/mkdir.h
+++ b/libc/src/sys/stat/mkdir.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_MKDIR_H
 #define LLVM_LIBC_SRC_SYS_STAT_MKDIR_H
 
+#include "hdr/types/mode_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/mkdirat.h
+++ b/libc/src/sys/stat/mkdirat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_MKDIRAT_H
 #define LLVM_LIBC_SRC_SYS_STAT_MKDIRAT_H
 
+#include "hdr/types/mode_t.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sys/stat/stat.h
+++ b/libc/src/sys/stat/stat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_STAT_STAT_H
 #define LLVM_LIBC_SRC_SYS_STAT_STAT_H
 
+#include "hdr/types/struct_stat.h"
 #include "src/__support/macros/config.h"
-#include <sys/stat.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/src/stdio/CMakeLists.txt
+++ b/libc/test/src/stdio/CMakeLists.txt
@@ -465,6 +465,7 @@ if(${LIBC_TARGET_OS} STREQUAL "linux")
     SRCS
       remove_test.cpp
     DEPENDS
+      libc.hdr.sys_stat_macros
       libc.include.unistd
       libc.src.errno.errno
       libc.src.fcntl.open
@@ -482,6 +483,7 @@ if(${LIBC_TARGET_OS} STREQUAL "linux")
     SRCS
       rename_test.cpp
     DEPENDS
+      libc.hdr.sys_stat_macros
       libc.src.errno.errno
       libc.src.fcntl.open
       libc.src.stdio.rename

--- a/libc/test/src/stdio/remove_test.cpp
+++ b/libc/test/src/stdio/remove_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_stat_macros.h"
 #include "src/fcntl/open.h"
 #include "src/stdio/remove.h"
 #include "src/sys/stat/mkdirat.h"

--- a/libc/test/src/stdio/rename_test.cpp
+++ b/libc/test/src/stdio/rename_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "include/llvm-libc-macros/linux/sys-stat-macros.h"
+#include "hdr/sys_stat_macros.h"
 #include "include/llvm-libc-macros/linux/unistd-macros.h"
 #include "src/fcntl/open.h"
 #include "src/stdio/rename.h"

--- a/libc/test/src/sys/stat/CMakeLists.txt
+++ b/libc/test/src/sys/stat/CMakeLists.txt
@@ -64,7 +64,7 @@ add_libc_unittest(
     mkdirat_test.cpp
   DEPENDS
     libc.hdr.fcntl_macros
-    libc.include.sys_stat
+    libc.hdr.sys_stat_macros
     libc.src.errno.errno
     libc.src.sys.stat.mkdirat
     libc.src.unistd.rmdir

--- a/libc/test/src/sys/stat/mkdirat_test.cpp
+++ b/libc/test/src/sys/stat/mkdirat_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_stat_macros.h"
 #include "src/sys/stat/mkdirat.h"
 #include "src/unistd/rmdir.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"

--- a/libc/test/src/sys/statvfs/linux/CMakeLists.txt
+++ b/libc/test/src/sys/statvfs/linux/CMakeLists.txt
@@ -7,6 +7,7 @@ add_libc_unittest(
   SRCS
     statvfs_test.cpp
   DEPENDS
+    libc.hdr.sys_stat_macros
     libc.src.errno.errno
     libc.src.sys.statvfs.statvfs
     libc.src.sys.stat.mkdirat
@@ -22,6 +23,7 @@ add_libc_unittest(
   SRCS
     fstatvfs_test.cpp
   DEPENDS
+    libc.hdr.sys_stat_macros
     libc.src.errno.errno
     libc.src.sys.statvfs.fstatvfs
     libc.src.sys.stat.mkdirat

--- a/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/fcntl/open.h"

--- a/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/sys/stat/mkdirat.h"

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -314,6 +314,7 @@ add_libc_unittest(
     rmdir_test.cpp
   DEPENDS
     libc.hdr.fcntl_macros
+    libc.hdr.sys_stat_macros
     libc.src.errno.errno
     libc.src.sys.stat.mkdir
     libc.src.unistd.rmdir

--- a/libc/test/src/unistd/rmdir_test.cpp
+++ b/libc/test/src/unistd/rmdir_test.cpp
@@ -13,6 +13,7 @@
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/sys_stat_macros.h"
 
 using LlvmLibcRmdirTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 


### PR DESCRIPTION
Added ErrorOr-returning syscall wrappers for chmod, fchmod, fchmodat, mkdir, mkdirat, and statx in src/__support/OSUtil/linux/syscall_wrappers/. Migrated the sys/stat Linux entrypoints to use them.

Added hdr/types/struct_stat.h proxy header. Updated stat, lstat, fstat to use it, and kernel_statx to use the new statx wrapper.

Fixed fchmodat CMakeLists.txt to reference fchmodat.h (was fchmod.h). Updated test dependencies to use hdr/sys_stat_macros.