### PR TITLE
[llubi] Fix evaluation order of logic operators

### DIFF
--- a/llvm/tools/llubi/lib/Library.cpp
+++ b/llvm/tools/llubi/lib/Library.cpp
@@ -67,9 +67,9 @@ std::optional<std::string> Library::readStringFromMemory(const Pointer &Ptr) {
 AnyValue Library::executeMalloc(StringRef Name, Type *Type,
                                 ArrayRef<AnyValue> Args,
                                 MemAllocKind AllocKind) {
-  assert(AllocKind == MemAllocKind::Malloc || AllocKind == MemAllocKind::New ||
-         AllocKind == MemAllocKind::NewArray &&
-             "Unexpected MemAllocKind for malloc()/new/new[]");
+  assert((AllocKind == MemAllocKind::Malloc || AllocKind == MemAllocKind::New ||
+          AllocKind == MemAllocKind::NewArray) &&
+         "Unexpected MemAllocKind for malloc()/new/new[]");
 
   const auto &SizeVal = Args[0];
 


### PR DESCRIPTION
`&&` is evaluated first, though it doesn't affect the result.
