### PR TITLE
[CodeGen][NFC] Remove contractions in error messages

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -10390,7 +10390,7 @@ static bool prepareDAGLevelOperands(ConstraintDecisionInfo &Info,
         // C_RegisterClass, and a target-defined fashion for
         // C_Immediate/C_Other). Find a register that we can use.
         if (OpInfo.AssignedRegs.Regs.empty()) {
-          Info.ErrorMsg << "couldn't allocate output register for "
+          Info.ErrorMsg << "could not allocate output register for "
                         << "constraint '" << OpInfo.ConstraintCode << "'";
           return true;
         }
@@ -10420,8 +10420,8 @@ static bool prepareDAGLevelOperands(ConstraintDecisionInfo &Info,
         if (Flag.isRegDefKind() || Flag.isRegDefEarlyClobberKind()) {
           if (OpInfo.isIndirect) {
             // This happens on gcc/testsuite/gcc.dg/pr8788-1.c
-            Info.ErrorMsg << "inline asm not supported yet: don't know how "
-                          << "to handle tied indirect register inputs";
+            Info.ErrorMsg << "inline asm not supported yet: cannot handle "
+                          << "tied indirect register inputs";
             return true;
           }
 
@@ -10552,14 +10552,14 @@ static bool prepareDAGLevelOperands(ConstraintDecisionInfo &Info,
 
       // TODO: Support this.
       if (OpInfo.isIndirect) {
-        Info.ErrorMsg << "Don't know how to handle indirect register inputs "
-                      << "yet for constraint '" << OpInfo.ConstraintCode << "'";
+        Info.ErrorMsg << "cannot handle indirect register inputs yet for "
+                      << "constraint '" << OpInfo.ConstraintCode << "'";
         return true;
       }
 
       // Copy the input into the appropriate registers.
       if (OpInfo.AssignedRegs.Regs.empty()) {
-        Info.ErrorMsg << "couldn't allocate input reg for constraint '"
+        Info.ErrorMsg << "could not allocate input reg for constraint '"
                       << OpInfo.ConstraintCode << "'";
         return true;
       }

--- a/llvm/test/CodeGen/AArch64/aarch64-sve-asm-negative.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-sve-asm-negative.ll
@@ -5,7 +5,7 @@
 ; constraint be used with a Neon register.
 
 ; Function Attrs: nounwind readnone
-; CHECK: error: couldn't allocate input reg for constraint 'y'
+; CHECK: error: could not allocate input reg for constraint 'y'
 define <4 x i32> @test_neon(<4 x i32> %in1, <4 x i32> %in2) {
   %1 = tail call <4 x i32> asm "add $0.4s, $1.4s, $2.4s", "=w,w,y"(<4 x i32> %in1, <4 x i32> %in2)
   ret <4 x i32> %1

--- a/llvm/test/CodeGen/AArch64/asm-ld1-wrong-constraint.ll
+++ b/llvm/test/CodeGen/AArch64/asm-ld1-wrong-constraint.ll
@@ -11,7 +11,7 @@ define i64 @rdar130887714(ptr noundef %0) {
   store ptr %0, ptr %2, align 8
   %4 = load ptr, ptr %2, align 8
   call void asm sideeffect "ld1 { $0.2d, ${0:T}.2d, ${0:U}.2d, ${0:V}.2d} , [$1]", "*w,r"(ptr elementtype(%struct.uint64x2x4_t) %3, ptr %4) #0, !srcloc !0
-; CHECK: error: Don't know how to handle indirect register inputs yet for constraint 'w' at line 250
+; CHECK: error: cannot handle indirect register inputs yet for constraint 'w' at line 250
 
   %5 = getelementptr inbounds %struct.uint64x2x4_t, ptr %3, i32 0, i32 0
   %6 = getelementptr inbounds [4 x <2 x i64>], ptr %5, i64 0, i64 0

--- a/llvm/test/CodeGen/AArch64/inline-asm-constraints-bad-sve.ll
+++ b/llvm/test/CodeGen/AArch64/inline-asm-constraints-bad-sve.ll
@@ -3,9 +3,9 @@
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 target triple = "aarch64-unknown-linux-gnu"
 
-; CHECK: error: couldn't allocate input reg for constraint 'Upa'
-; CHECK: error: couldn't allocate input reg for constraint 'r'
-; CHECK: error: couldn't allocate output register for constraint 'w'
+; CHECK: error: could not allocate input reg for constraint 'Upa'
+; CHECK: error: could not allocate input reg for constraint 'r'
+; CHECK: error: could not allocate output register for constraint 'w'
 ; CHECK: error: unknown token in expression
 
 define <vscale x 16 x i1> @foo1(ptr %in) {

--- a/llvm/test/CodeGen/AArch64/inlineasm-illegal-type.ll
+++ b/llvm/test/CodeGen/AArch64/inlineasm-illegal-type.ll
@@ -1,9 +1,9 @@
 ;RUN:  not llc -mtriple=aarch64-linux-gnu -mattr=-fp-armv8 < %s 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate output register for constraint '{d0}'
-; CHECK: error: couldn't allocate output register for constraint 'w'
-; CHECK: error: couldn't allocate input reg for constraint 'w'
-; CHECK: error: couldn't allocate input reg for constraint 'w'
+; CHECK: error: could not allocate output register for constraint '{d0}'
+; CHECK: error: could not allocate output register for constraint 'w'
+; CHECK: error: could not allocate input reg for constraint 'w'
+; CHECK: error: could not allocate input reg for constraint 'w'
 
 define hidden double @test1(double %xx) local_unnamed_addr #0 {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/inline-asm-av-constraint-err.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm-av-constraint-err.ll
@@ -2,25 +2,25 @@
 
 ; Make sure illegal type uses are correctly diagnosed
 
-; CHECK: error: couldn't allocate input reg for constraint 'VA'
+; CHECK: error: could not allocate input reg for constraint 'VA'
 define void @use_A_i8(i8 %x) {
   call void asm sideeffect "; use $0", "^VA"(i8 %x)
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'VA'
+; CHECK: error: could not allocate output register for constraint 'VA'
 define i8 @def_A_i8() {
   %ret = call i8 asm sideeffect "; def $0", "=^VA"()
   ret i8 %ret
 }
 
-; CHECK: error: couldn't allocate input reg for constraint 'VA'
+; CHECK: error: could not allocate input reg for constraint 'VA'
 define void @use_A_i1(i1 %x) {
   call void asm sideeffect "; use $0", "^VA"(i1 %x)
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'VA'
+; CHECK: error: could not allocate output register for constraint 'VA'
 define i1 @def_A_i1() {
   %ret = call i1 asm sideeffect "; def $0", "=^VA"()
   ret i1 %ret

--- a/llvm/test/CodeGen/AMDGPU/inline-asm-av-constraint.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm-av-constraint.ll
@@ -3,7 +3,7 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx90a < %s | FileCheck %s
 
 ; FIXME: Shouldn't emit and
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_i16(i16 %x) {
 ; CHECK-LABEL: use_A_i16:
 ; CHECK:       ; %bb.0:
@@ -17,7 +17,7 @@ define void @use_A_i16(i16 %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_f16(half %x) {
 ; CHECK-LABEL: use_A_f16:
 ; CHECK:       ; %bb.0:
@@ -30,7 +30,7 @@ define void @use_A_f16(half %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_bf16(bfloat %x) {
 ; CHECK-LABEL: use_A_bf16:
 ; CHECK:       ; %bb.0:
@@ -43,7 +43,7 @@ define void @use_A_bf16(bfloat %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_v2i16(<2 x i16> %x) {
 ; CHECK-LABEL: use_A_v2i16:
 ; CHECK:       ; %bb.0:
@@ -56,7 +56,7 @@ define void @use_A_v2i16(<2 x i16> %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_v2f16(<2 x half> %x) {
 ; CHECK-LABEL: use_A_v2f16:
 ; CHECK:       ; %bb.0:
@@ -69,7 +69,7 @@ define void @use_A_v2f16(<2 x half> %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_v2bf16(<2 x bfloat> %x) {
 ; CHECK-LABEL: use_A_v2bf16:
 ; CHECK:       ; %bb.0:
@@ -82,7 +82,7 @@ define void @use_A_v2bf16(<2 x bfloat> %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_i32(i32 %x) {
 ; CHECK-LABEL: use_A_i32:
 ; CHECK:       ; %bb.0:
@@ -95,7 +95,7 @@ define void @use_A_i32(i32 %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_f32(float %x) {
 ; CHECK-LABEL: use_A_f32:
 ; CHECK:       ; %bb.0:
@@ -108,7 +108,7 @@ define void @use_A_f32(float %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_i64(i64 %x) {
 ; CHECK-LABEL: use_A_i64:
 ; CHECK:       ; %bb.0:
@@ -121,7 +121,7 @@ define void @use_A_i64(i64 %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_f64(double %x) {
 ; CHECK-LABEL: use_A_f64:
 ; CHECK:       ; %bb.0:
@@ -134,7 +134,7 @@ define void @use_A_f64(double %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_p1(ptr addrspace(1) %x) {
 ; CHECK-LABEL: use_A_p1:
 ; CHECK:       ; %bb.0:
@@ -147,7 +147,7 @@ define void @use_A_p1(ptr addrspace(1) %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_v32i32(<32 x i32> %x) {
 ; CHECK-LABEL: use_A_v32i32:
 ; CHECK:       ; %bb.0:
@@ -162,7 +162,7 @@ define void @use_A_v32i32(<32 x i32> %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'VA'
+; ERR: error: could not allocate input reg for constraint 'VA'
 define void @use_A_v32f32(<32 x float> %x) {
 ; CHECK-LABEL: use_A_v32f32:
 ; CHECK:       ; %bb.0:
@@ -177,7 +177,7 @@ define void @use_A_v32f32(<32 x float> %x) {
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint 'VA'
+; ERR: error: could not allocate output register for constraint 'VA'
 define i16 @def_A_i16() {
 ; CHECK-LABEL: def_A_i16:
 ; CHECK:       ; %bb.0:
@@ -190,7 +190,7 @@ define i16 @def_A_i16() {
   ret i16 %ret
 }
 
-; ERR: error: couldn't allocate output register for constraint 'VA'
+; ERR: error: could not allocate output register for constraint 'VA'
 define i32 @def_A_i32() {
 ; CHECK-LABEL: def_A_i32:
 ; CHECK:       ; %bb.0:
@@ -203,7 +203,7 @@ define i32 @def_A_i32() {
   ret i32 %ret
 }
 
-; ERR: error: couldn't allocate output register for constraint 'VA'
+; ERR: error: could not allocate output register for constraint 'VA'
 define ptr addrspace(1) @def_A_p1() {
 ; CHECK-LABEL: def_A_p1:
 ; CHECK:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/inline-asm-out-of-bounds-register.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm-out-of-bounds-register.ll
@@ -1,97 +1,97 @@
 ; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=bonaire -filetype=null %s 2>&1 | FileCheck -implicit-check-not=error %s
 ; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -filetype=null %s 2>&1 | FileCheck -implicit-check-not=error %s
 
-; CHECK: error: couldn't allocate output register for constraint '{v256}'
+; CHECK: error: could not allocate output register for constraint '{v256}'
 define void @out_of_bounds_vgpr32_def() {
   %v = tail call i32 asm sideeffect "v_mov_b32 $0, -1", "={v256}"()
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{v[255:256]}'
+; CHECK: error: could not allocate output register for constraint '{v[255:256]}'
 define void @out_of_bounds_vgpr64_def_high_tuple() {
   %v = tail call i32 asm sideeffect "v_mov_b32 $0, -1", "={v[255:256]}"()
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{v[256:257]}'
+; CHECK: error: could not allocate output register for constraint '{v[256:257]}'
 define void @out_of_bounds_vgpr64_def_low_tuple() {
   %v = tail call i32 asm sideeffect "v_mov_b32 $0, -1", "={v[256:257]}"()
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v256}'
+; CHECK: error: could not allocate input reg for constraint '{v256}'
 define void @out_of_bounds_vgpr32_use() {
   %v = tail call i32 asm sideeffect "v_mov_b32 %0, %1", "=v,{v256}"(i32 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[255:256]}'
+; CHECK: error: could not allocate input reg for constraint '{v[255:256]}'
 define void @out_of_bounds_vgpr64_high_tuple() {
   tail call void asm sideeffect "; use %0", "{v[255:256]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[256:257]}'
+; CHECK: error: could not allocate input reg for constraint '{v[256:257]}'
 define void @out_of_bounds_vgpr64_low_tuple() {
   tail call void asm sideeffect "; use %0", "{v[256:257]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[1:0]}'
+; CHECK: error: could not allocate input reg for constraint '{v[1:0]}'
 define void @vgpr_tuple_swapped() {
   tail call void asm sideeffect "; use %0", "{v[1:0]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v4294967295}'
+; CHECK: error: could not allocate input reg for constraint '{v4294967295}'
 define void @vgpr_uintmax() {
   tail call void asm sideeffect "; use %0", "{v4294967295}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v4294967296}'
+; CHECK: error: could not allocate input reg for constraint '{v4294967296}'
 define void @vgpr_uintmax_p1() {
   tail call void asm sideeffect "; use %0", "{v4294967296}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[4294967295:4294967296]}'
+; CHECK: error: could not allocate input reg for constraint '{v[4294967295:4294967296]}'
 define void @vgpr_tuple_uintmax() {
   tail call void asm sideeffect "; use %0", "{v[4294967295:4294967296]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[0:4294967295]}'
+; CHECK: error: could not allocate input reg for constraint '{v[0:4294967295]}'
 define void @vgpr_tuple_0_uintmax() {
   tail call void asm sideeffect "; use %0", "{v[0:4294967295]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[0:4294967296]}'
+; CHECK: error: could not allocate input reg for constraint '{v[0:4294967296]}'
 define void @vgpr_tuple_0_uintmax_p1() {
   tail call void asm sideeffect "; use %0", "{v[0:4294967296]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[4294967264:4294967295]}'
+; CHECK: error: could not allocate input reg for constraint '{v[4294967264:4294967295]}'
 define void @vgpr32_last_is_uintmax() {
   tail call void asm sideeffect "; use %0", "{v[4294967264:4294967295]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[4294967265:4294967296]}'
+; CHECK: error: could not allocate input reg for constraint '{v[4294967265:4294967296]}'
 define void @vgpr32_last_is_uintmax_p1() {
   tail call void asm sideeffect "; use %0", "{v[4294967265:4294967296]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[2:2147483651]}'
+; CHECK: error: could not allocate input reg for constraint '{v[2:2147483651]}'
 define void @overflow_bitwidth_0() {
   tail call void asm sideeffect "; use %0", "{v[2:2147483651]}"(i64 123)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint '{v[2147483635:2147483651]}'
+; CHECK: error: could not allocate input reg for constraint '{v[2147483635:2147483651]}'
 define void @overflow_bitwidth_1() {
   tail call void asm sideeffect "; use %0", "{v[2147483635:2147483651]}"(i64 123)
   ret void

--- a/llvm/test/CodeGen/AMDGPU/inline-asm-vgpr-range-unsupported-width.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm-vgpr-range-unsupported-width.ll
@@ -3,7 +3,7 @@
 ; This is a negative test: the VGPR physical register range below requires
 ; a 13-register (416-bit) VGPR, which doesn't exist.
 
-; CHECK: error: couldn't allocate output register for constraint '{v[0:12]}'
+; CHECK: error: could not allocate output register for constraint '{v[0:12]}'
 
 define amdgpu_kernel void @k() {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/inlineasm-illegal-type.ll
+++ b/llvm/test/CodeGen/AMDGPU/inlineasm-illegal-type.ll
@@ -2,30 +2,30 @@
 ; RUN: not llc -mtriple=amdgcn -mcpu=tonga < %s 2>&1 | FileCheck -check-prefix=GCN %s
 ; RUN: not llc -mtriple=amdgcn -mcpu=tahiti < %s 2>&1 | FileCheck -check-prefix=GCN -check-prefix=SICI %s
 
-; GCN: error: couldn't allocate output register for constraint 's'
-; GCN: error: couldn't allocate input reg for constraint 's'
+; GCN: error: could not allocate output register for constraint 's'
+; GCN: error: could not allocate input reg for constraint 's'
 define amdgpu_kernel void @s_input_output_i8() {
   %v = tail call i8 asm sideeffect "s_mov_b32 $0, -1", "=s"()
   tail call void asm sideeffect "; use $0", "s"(i8 %v)
   ret void
 }
 
-; GCN: error: couldn't allocate output register for constraint 'v'
-; GCN: error: couldn't allocate input reg for constraint 'v'
+; GCN: error: could not allocate output register for constraint 'v'
+; GCN: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_i8() {
   %v = tail call i8 asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(i8 %v)
   ret void
 }
 
-; GCN: error: couldn't allocate input reg for constraint 'v'
+; GCN: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_empty_struct() {
   call void asm "", "v"({} poison)
   ret void
 }
 
-; SICI: error: couldn't allocate output register for constraint 's'
-; SICI: error: couldn't allocate input reg for constraint 's'
+; SICI: error: could not allocate output register for constraint 's'
+; SICI: error: could not allocate input reg for constraint 's'
 ; VI-NOT: error
 define amdgpu_kernel void @s_input_output_v2f16() {
   %v = tail call <2 x half> asm sideeffect "s_mov_b32 $0, -1", "=s"()
@@ -33,8 +33,8 @@ define amdgpu_kernel void @s_input_output_v2f16() {
   ret void
 }
 
-; SICI: error: couldn't allocate output register for constraint 'v'
-; SICI: error: couldn't allocate input reg for constraint 'v'
+; SICI: error: could not allocate output register for constraint 'v'
+; SICI: error: could not allocate input reg for constraint 'v'
 ; VI-NOT: error
 define amdgpu_kernel void @v_input_output_v2f16() {
   %v = tail call <2 x half> asm sideeffect "v_mov_b32 $0, -1", "=v"()
@@ -42,8 +42,8 @@ define amdgpu_kernel void @v_input_output_v2f16() {
   ret void
 }
 
-; SICI: error: couldn't allocate output register for constraint 's'
-; SICI: error: couldn't allocate input reg for constraint 's'
+; SICI: error: could not allocate output register for constraint 's'
+; SICI: error: could not allocate input reg for constraint 's'
 ; VI-NOT: error
 define amdgpu_kernel void @s_input_output_v2i16() {
   %v = tail call <2 x i16> asm sideeffect "s_mov_b32 $0, -1", "=s"()

--- a/llvm/test/CodeGen/AMDGPU/inlineasm-mismatched-size-error.ll
+++ b/llvm/test/CodeGen/AMDGPU/inlineasm-mismatched-size-error.ll
@@ -2,19 +2,19 @@
 
 ; Diagnose register constraints that are not wide enough.
 
-; ERR: error: couldn't allocate output register for constraint '{v[8:15]}'
+; ERR: error: could not allocate output register for constraint '{v[8:15]}'
 define <9 x i32> @inline_asm_9xi32_in_8v_def() {
   %asm = call <9 x i32> asm sideeffect "; def $0", "={v[8:15]}"()
   ret <9 x i32> %asm
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{v[8:15]}'
+; ERR: error: could not allocate input reg for constraint '{v[8:15]}'
 define void @inline_asm_9xi32_in_8v_use(<9 x i32> %val) {
   call void asm sideeffect "; use $0", "{v[8:15]}"(<9 x i32> %val)
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[8:15]}'
+; ERR: error: could not allocate output register for constraint '{s[8:15]}'
 define <9 x i32> @inline_asm_9xi32_in_8s_def() {
   %asm = call <9 x i32> asm sideeffect "; def $0", "={s[8:15]}"()
   ret <9 x i32> %asm
@@ -23,19 +23,19 @@ define <9 x i32> @inline_asm_9xi32_in_8s_def() {
 
 ; Diagnose register constraints that are too wide.
 
-; ERR: error: couldn't allocate output register for constraint '{v[8:16]}'
+; ERR: error: could not allocate output register for constraint '{v[8:16]}'
 define <8 x i32> @inline_asm_8xi32_in_9v_def() {
   %asm = call <8 x i32> asm sideeffect "; def $0", "={v[8:16]}"()
   ret <8 x i32> %asm
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{v[8:16]}'
+; ERR: error: could not allocate input reg for constraint '{v[8:16]}'
 define void @inline_asm_8xi32_in_9v_use(<8 x i32> %val) {
   call void asm sideeffect "; use $0", "{v[8:16]}"(<8 x i32> %val)
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[8:16]}'
+; ERR: error: could not allocate output register for constraint '{s[8:16]}'
 define <8 x i32> @inline_asm_8xi32_in_9s_def() {
   %asm = call <8 x i32> asm sideeffect "; def $0", "={s[8:16]}"()
   ret <8 x i32> %asm
@@ -44,13 +44,13 @@ define <8 x i32> @inline_asm_8xi32_in_9s_def() {
 
 ; Diagnose mismatched scalars with register ranges
 
-; ERR: error: couldn't allocate output register for constraint '{s[4:5]}'
+; ERR: error: could not allocate output register for constraint '{s[4:5]}'
 define void @inline_asm_scalar_read_too_wide() {
   %asm = call i32 asm sideeffect "; def $0 ", "={s[4:5]}"()
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[4:4]}'
+; ERR: error: could not allocate output register for constraint '{s[4:4]}'
 define void @inline_asm_scalar_read_too_narrow() {
   %asm = call i64 asm sideeffect "; def $0 ", "={s[4:4]}"()
   ret void
@@ -59,34 +59,34 @@ define void @inline_asm_scalar_read_too_narrow() {
 ; Single registers for vector types that are too wide or too narrow should be
 ; diagnosed.
 
-; ERR: error: couldn't allocate input reg for constraint '{v8}'
+; ERR: error: could not allocate input reg for constraint '{v8}'
 define void @inline_asm_4xi32_in_v_use(<4 x i32> %val) {
   call void asm sideeffect "; use $0", "{v8}"(<4 x i32> %val)
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{v8}'
+; ERR: error: could not allocate output register for constraint '{v8}'
 define <4 x i32> @inline_asm_4xi32_in_v_def() {
   %asm = call <4 x i32> asm sideeffect "; def $0", "={v8}"()
   ret <4 x i32> %asm
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s8}'
+; ERR: error: could not allocate output register for constraint '{s8}'
 define <4 x i32> @inline_asm_4xi32_in_s_def() {
   %asm = call <4 x i32> asm sideeffect "; def $0", "={s8}"()
   ret <4 x i32> %asm
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{v8}'
-; ERR: error: couldn't allocate input reg for constraint 'v'
+; ERR: error: could not allocate input reg for constraint '{v8}'
+; ERR: error: could not allocate input reg for constraint 'v'
 define void @inline_asm_2xi8_in_v_use(<2 x i8> %val) {
   call void asm sideeffect "; use $0", "{v8}"(<2 x i8> %val)
   call void asm sideeffect "; use $0", "v"(<2 x i8> %val)
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{v8}'
-; ERR: error: couldn't allocate output register for constraint 'v'
+; ERR: error: could not allocate output register for constraint '{v8}'
+; ERR: error: could not allocate output register for constraint 'v'
 define <2 x i8> @inline_asm_2xi8_in_v_def() {
   %phys = call <2 x i8> asm sideeffect "; def $0", "={v8}"()
   %virt = call <2 x i8> asm sideeffect "; def $0", "=v"()
@@ -94,8 +94,8 @@ define <2 x i8> @inline_asm_2xi8_in_v_def() {
   ret <2 x i8> %r
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s8}'
-; ERR: error: couldn't allocate output register for constraint 's'
+; ERR: error: could not allocate output register for constraint '{s8}'
+; ERR: error: could not allocate output register for constraint 's'
 define <2 x i8> @inline_asm_2xi8_in_s_def() {
   %phys = call <2 x i8> asm sideeffect "; def $0", "={s8}"()
   %virt = call <2 x i8> asm sideeffect "; def $0", "=s"()
@@ -106,73 +106,73 @@ define <2 x i8> @inline_asm_2xi8_in_s_def() {
 
 ; The register is wide enough, but it does not satisfy alignment constraints:
 
-; ERR: error: couldn't allocate input reg for constraint '{s[1:2]}'
+; ERR: error: could not allocate input reg for constraint '{s[1:2]}'
 define void @misaligned_sgpr_2xi32_in(<2 x i32> inreg %arg0) {
   call void asm sideeffect "; use $0", "{s[1:2]}"(<2 x i32> %arg0)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{s[23:24]}'
+; ERR: error: could not allocate input reg for constraint '{s[23:24]}'
 define void @misaligned_sgpr_2xi32_in_23(<2 x i32> inreg %arg0) {
   call void asm sideeffect "; use $0", "{s[23:24]}"(<2 x i32> %arg0)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{s[1:4]}'
+; ERR: error: could not allocate input reg for constraint '{s[1:4]}'
 define void @misaligned_sgpr_4xi32_in(<4 x i32> inreg %arg0) {
   call void asm sideeffect "; use $0", "{s[1:4]}"(<4 x i32> %arg0)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint '{s[2:5]}'
+; ERR: error: could not allocate input reg for constraint '{s[2:5]}'
 define void @misaligned_sgpr_4xi32_in_2(<4 x i32> inreg %arg0) {
   call void asm sideeffect "; use $0", "{s[2:5]}"(<4 x i32> %arg0)
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[1:2]}'
+; ERR: error: could not allocate output register for constraint '{s[1:2]}'
 define <2 x i32> @misaligned_sgpr_2xi32_out() {
   %asm = call <2 x i32> asm sideeffect "; def $0", "={s[1:2]}"()
   ret <2 x i32> %asm
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[23:24]}'
+; ERR: error: could not allocate output register for constraint '{s[23:24]}'
 define <2 x i32> @misaligned_sgpr_2xi32_out_23() {
   %asm = call <2 x i32> asm sideeffect "; def $0", "={s[23:24]}"()
   ret <2 x i32> %asm
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[1:4]}'
+; ERR: error: could not allocate output register for constraint '{s[1:4]}'
 define <4 x i32> @misaligned_sgpr_4xi32_out() {
   %asm = call <4 x i32> asm sideeffect "; def $0", "={s[1:4]}"()
   ret <4 x i32> %asm
 }
 
-; ERR: error: couldn't allocate output register for constraint '{s[2:5]}'
+; ERR: error: could not allocate output register for constraint '{s[2:5]}'
 define <4 x i32> @misaligned_sgpr_4xi32_out_2() {
   %asm = call <4 x i32> asm sideeffect "; def $0", "={s[2:5]}"()
   ret <4 x i32> %asm
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'v'
+; ERR: error: could not allocate input reg for constraint 'v'
 define void @i1_used_as_vgpr_operand(ptr %p, i1 %b) {
   tail call void asm sideeffect "global_store_byte $0, $1, off glc slc", "v,v"(ptr %p, i1 %b)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'a'
+; ERR: error: could not allocate input reg for constraint 'a'
 define void @i1_used_as_agpr_operand(ptr %p, i1 %b) {
   tail call void asm sideeffect "global_store_byte $0, $1, off glc slc", "v,a"(ptr %p, i1 %b)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 's'
+; ERR: error: could not allocate input reg for constraint 's'
 define void @i1_used_as_sgpr_operand_s(ptr %p, i1 %b) {
   tail call void asm sideeffect "global_store_byte $0, $1, off glc slc", "v,s"(ptr %p, i1 %b)
   ret void
 }
 
-; ERR: error: couldn't allocate input reg for constraint 'r'
+; ERR: error: could not allocate input reg for constraint 'r'
 define void @i1_used_as_sgpr_operand_r(ptr %p, i1 %b) {
   tail call void asm sideeffect "global_store_byte $0, $1, off glc slc", "v,r"(ptr %p, i1 %b)
   ret void

--- a/llvm/test/CodeGen/AMDGPU/inlineasm-v16.ll
+++ b/llvm/test/CodeGen/AMDGPU/inlineasm-v16.ll
@@ -5,8 +5,8 @@
 ; GCN-LABEL: {{^}}s_input_output_v8f16
 ; GCN: s_mov_b32 s[0:3], -1
 ; GCN: ; use s[0:3]
-; INVALID: error: couldn't allocate output register for constraint 's'
-; INVALID: error: couldn't allocate input reg for constraint 's'
+; INVALID: error: could not allocate output register for constraint 's'
+; INVALID: error: could not allocate input reg for constraint 's'
 define amdgpu_kernel void @s_input_output_v8f16() {
   %v = tail call <8 x half> asm sideeffect "s_mov_b32 $0, -1", "=s"()
   tail call void asm sideeffect "; use $0", "s"(<8 x half> %v)
@@ -16,8 +16,8 @@ define amdgpu_kernel void @s_input_output_v8f16() {
 ; GCN-LABEL: {{^}}s_input_output_v8i16
 ; GCN: s_mov_b32 s[0:3], -1
 ; GCN: ; use s[0:3]
-; INVALID: error: couldn't allocate output register for constraint 's'
-; INVALID: error: couldn't allocate input reg for constraint 's'
+; INVALID: error: could not allocate output register for constraint 's'
+; INVALID: error: could not allocate input reg for constraint 's'
 define amdgpu_kernel void @s_input_output_v8i16() {
   %v = tail call <8 x i16> asm sideeffect "s_mov_b32 $0, -1", "=s"()
   tail call void asm sideeffect "; use $0", "s"(<8 x i16> %v)
@@ -27,8 +27,8 @@ define amdgpu_kernel void @s_input_output_v8i16() {
 ; GCN-LABEL: {{^}}v_input_output_v8f16
 ; GCN: v_mov_b32 v[0:3], -1
 ; GCN: ; use v[0:3]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v8f16() {
   %v = tail call <8 x half> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<8 x half> %v)
@@ -38,8 +38,8 @@ define amdgpu_kernel void @v_input_output_v8f16() {
 ; GCN-LABEL: {{^}}v_input_output_v8i16
 ; GCN: v_mov_b32 v[0:3], -1
 ; GCN: ; use v[0:3]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v8i16() {
   %v = tail call <8 x i16> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<8 x i16> %v)
@@ -49,8 +49,8 @@ define amdgpu_kernel void @v_input_output_v8i16() {
 ; GCN-LABEL: {{^}}s_input_output_v16f16
 ; GCN: s_mov_b32 s[0:7], -1
 ; GCN: ; use s[0:7]
-; INVALID: error: couldn't allocate output register for constraint 's'
-; INVALID: error: couldn't allocate input reg for constraint 's'
+; INVALID: error: could not allocate output register for constraint 's'
+; INVALID: error: could not allocate input reg for constraint 's'
 define amdgpu_kernel void @s_input_output_v16f16() {
   %v = tail call <16 x half> asm sideeffect "s_mov_b32 $0, -1", "=s"()
   tail call void asm sideeffect "; use $0", "s"(<16 x half> %v)
@@ -60,8 +60,8 @@ define amdgpu_kernel void @s_input_output_v16f16() {
 ; GCN-LABEL: {{^}}s_input_output_v16i16
 ; GCN: s_mov_b32 s[0:7], -1
 ; GCN: ; use s[0:7]
-; INVALID: error: couldn't allocate output register for constraint 's'
-; INVALID: error: couldn't allocate input reg for constraint 's'
+; INVALID: error: could not allocate output register for constraint 's'
+; INVALID: error: could not allocate input reg for constraint 's'
 define amdgpu_kernel void @s_input_output_v16i16() {
   %v = tail call <16 x i16> asm sideeffect "s_mov_b32 $0, -1", "=s"()
   tail call void asm sideeffect "; use $0", "s"(<16 x i16> %v)
@@ -71,8 +71,8 @@ define amdgpu_kernel void @s_input_output_v16i16() {
 ; GCN-LABEL: {{^}}v_input_output_v16f16
 ; GCN: v_mov_b32 v[0:7], -1
 ; GCN: ; use v[0:7]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v16f16() {
   %v = tail call <16 x half> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<16 x half> %v)
@@ -82,8 +82,8 @@ define amdgpu_kernel void @v_input_output_v16f16() {
 ; GCN-LABEL: {{^}}v_input_output_v16i16
 ; GCN: v_mov_b32 v[0:7], -1
 ; GCN: ; use v[0:7]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v16i16() {
   %v = tail call <16 x i16> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<16 x i16> %v)
@@ -93,8 +93,8 @@ define amdgpu_kernel void @v_input_output_v16i16() {
 ; GCN-LABEL: {{^}}v_input_output_v32f16
 ; GCN: v_mov_b32 v[0:15], -1
 ; GCN: ; use v[0:15]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v32f16() {
   %v = tail call <32 x half> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<32 x half> %v)
@@ -104,8 +104,8 @@ define amdgpu_kernel void @v_input_output_v32f16() {
 ; GCN-LABEL: {{^}}v_input_output_v32i16
 ; GCN: v_mov_b32 v[0:15], -1
 ; GCN: ; use v[0:15]
-; INVALID: error: couldn't allocate output register for constraint 'v'
-; INVALID: error: couldn't allocate input reg for constraint 'v'
+; INVALID: error: could not allocate output register for constraint 'v'
+; INVALID: error: could not allocate input reg for constraint 'v'
 define amdgpu_kernel void @v_input_output_v32i16() {
   %v = tail call <32 x i16> asm sideeffect "v_mov_b32 $0, -1", "=v"()
   tail call void asm sideeffect "; use $0", "v"(<32 x i16> %v)

--- a/llvm/test/CodeGen/AMDGPU/invalid-inline-asm-constraint-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/invalid-inline-asm-constraint-crash.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=amdgcn < %s 2>&1 | FileCheck -check-prefix=ERR %s
 
-; ERR: error: couldn't allocate output register for constraint 'q'
+; ERR: error: could not allocate output register for constraint 'q'
 define void @crash_use_invalid_output_constraint_block(ptr addrspace(1) %arg) {
 bb:
   %v = call i32 asm sideeffect "", "=q"()
@@ -29,7 +29,7 @@ define void @invalid_input_constraint_multi_valid() {
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint 'q'
+; ERR: error: could not allocate output register for constraint 'q'
 define void @crash_use_invalid_output_constraint_block_multi(ptr addrspace(1) %arg) {
 bb:
   %v = call { i32, i32 } asm sideeffect "", "=q,=q"()
@@ -40,7 +40,7 @@ use:
   ret void
 }
 
-; ERR: error: couldn't allocate output register for constraint 'q'
+; ERR: error: could not allocate output register for constraint 'q'
 define void @crash_use_invalid_output_constraint_block_multi_valid(ptr addrspace(1) %arg) {
 bb:
   %v = call { i32, i32 } asm sideeffect "", "=q,=v"()

--- a/llvm/test/CodeGen/AMDGPU/reject-agpr-usage-before-gfx908.ll
+++ b/llvm/test/CodeGen/AMDGPU/reject-agpr-usage-before-gfx908.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc -mtriple=amdgcn -mcpu=gfx900 < %s 2>&1 | FileCheck -check-prefixes=GCN %s
 ; RUN: not llc -mtriple=amdgcn -mcpu=gfx906 < %s 2>&1 | FileCheck -check-prefixes=GCN %s
 
-; GCN:     couldn't allocate input reg for constraint 'a'
+; GCN:     could not allocate input reg for constraint 'a'
 
 define amdgpu_kernel void @used_1a() {
   call void asm sideeffect "", "a"(i32 1)

--- a/llvm/test/CodeGen/ARM/2013-11-08-inline-asm-neon-array.ll
+++ b/llvm/test/CodeGen/ARM/2013-11-08-inline-asm-neon-array.ll
@@ -13,4 +13,4 @@ define void @foo() #0 {
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'w'
+; CHECK: error: could not allocate output register for constraint 'w'

--- a/llvm/test/CodeGen/ARM/bad-constraint.ll
+++ b/llvm/test/CodeGen/ARM/bad-constraint.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc -filetype=obj %s -o /dev/null 2>&1 | FileCheck %s
-; CHECK:      error: couldn't allocate input reg for constraint '{d2}'
-; CHECK-NEXT: error: couldn't allocate input reg for constraint '{s2}'
-; CHECK-NEXT: error: couldn't allocate input reg for constraint '{d3}'
+; CHECK:      error: could not allocate input reg for constraint '{d2}'
+; CHECK-NEXT: error: could not allocate input reg for constraint '{s2}'
+; CHECK-NEXT: error: could not allocate input reg for constraint '{d3}'
 
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv8a-unknown-linux-gnueabihf"

--- a/llvm/test/CodeGen/ARM/indirect-reg-input.ll
+++ b/llvm/test/CodeGen/ARM/indirect-reg-input.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc -mtriple=arm-eabi -mcpu=cortex-a8 %s -o - 2>&1 | FileCheck %s
 
 ; Check for error message:
-; CHECK: error: inline asm not supported yet: don't know how to handle tied indirect register inputs
+; CHECK: error: inline asm not supported yet: cannot handle tied indirect register inputs
 
 %struct.my_stack = type { %struct.myjmp_buf }
 %struct.myjmp_buf = type { [6 x i32] }

--- a/llvm/test/CodeGen/ARM/inline-diagnostics.ll
+++ b/llvm/test/CodeGen/ARM/inline-diagnostics.ll
@@ -2,7 +2,7 @@
 
 %struct.float4 = type { float, float, float, float }
 
-; CHECK: error: Don't know how to handle indirect register inputs yet for constraint 'w'
+; CHECK: error: cannot handle indirect register inputs yet for constraint 'w'
 define float @inline_func(float %f1, float %f2) #0 {
   %c1 = alloca %struct.float4, align 4
   %c2 = alloca %struct.float4, align 4

--- a/llvm/test/CodeGen/Hexagon/inline-asm-bad-constraint.ll
+++ b/llvm/test/CodeGen/Hexagon/inline-asm-bad-constraint.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=hexagon < %s 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate output register for constraint 'r'
+; CHECK: error: could not allocate output register for constraint 'r'
 
 target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
 target triple = "hexagon"

--- a/llvm/test/CodeGen/Hexagon/inline-asm-error.ll
+++ b/llvm/test/CodeGen/Hexagon/inline-asm-error.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=hexagon < %s 2>&1 | FileCheck %s
 
-; CHECK: error: Don't know how to handle indirect register inputs yet for constraint 'r'
+; CHECK: error: cannot handle indirect register inputs yet for constraint 'r'
 
 %s.0 = type { ptr, i32, %s.1 }
 %s.1 = type { %s.2 }

--- a/llvm/test/CodeGen/LoongArch/inline-asm-constraint-error.ll
+++ b/llvm/test/CodeGen/LoongArch/inline-asm-constraint-error.ll
@@ -32,15 +32,15 @@ define void @constraint_K() {
 }
 
 define void @constraint_f() nounwind {
-; LA32: error: couldn't allocate input reg for constraint 'f'
+; LA32: error: could not allocate input reg for constraint 'f'
   tail call void asm "fadd.s $$fa0, $$fa0, $0", "f"(float 0.0)
-; LA32: error: couldn't allocate input reg for constraint 'f'
+; LA32: error: could not allocate input reg for constraint 'f'
   tail call void asm "fadd.s $$fa0, $$fa0, $0", "f"(double 0.0)
   ret void
 }
 
 define void @constraint_r_vec() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'r'
+; CHECK: error: could not allocate input reg for constraint 'r'
   tail call void asm "add.w $$a0, $$a0, $0", "r"(<4 x i32> zeroinitializer)
   ret void
 }

--- a/llvm/test/CodeGen/LoongArch/inline-asm-reg-names-error.ll
+++ b/llvm/test/CodeGen/LoongArch/inline-asm-reg-names-error.ll
@@ -2,13 +2,13 @@
 ; RUN: not llc --mtriple=loongarch64 -mattr=+d 2>&1 < %s | FileCheck %s
 
 define i32 @non_exit_r32(i32 %a) nounwind {
-; CHECK: error: couldn't allocate input reg for constraint '{$r32}'
+; CHECK: error: could not allocate input reg for constraint '{$r32}'
   %1 = tail call i32 asm "addi.w $0, $1, 1", "=r,{$r32}"(i32 %a)
   ret i32 %1
 }
 
 define i32 @non_exit_foo(i32 %a) nounwind {
-; CHECK: error: couldn't allocate input reg for constraint '{$foo}'
+; CHECK: error: could not allocate input reg for constraint '{$foo}'
   %1 = tail call i32 asm "addi.w $0, $1, 1", "=r,{$foo}"(i32 %a)
   ret i32 %1
 }

--- a/llvm/test/CodeGen/LoongArch/inline-asm-reg-names-f-error.ll
+++ b/llvm/test/CodeGen/LoongArch/inline-asm-reg-names-f-error.ll
@@ -2,13 +2,13 @@
 ; RUN: not llc --mtriple=loongarch64 --mattr=+f,+d 2>&1 < %s | FileCheck %s
 
 define double @non_exit_f32(double %a) nounwind {
-; CHECK: error: couldn't allocate input reg for constraint '{$f32}'
+; CHECK: error: could not allocate input reg for constraint '{$f32}'
   %1 = tail call double asm "fabs.d $0, $1", "=f,{$f32}"(double %a)
   ret double %1
 }
 
 define double @non_exit_foo(double %a) nounwind {
-; CHECK: error: couldn't allocate input reg for constraint '{$foo}'
+; CHECK: error: could not allocate input reg for constraint '{$foo}'
   %1 = tail call double asm "fabs.d $0, $1", "=f,{$foo}"(double %a)
   ret double %1
 }

--- a/llvm/test/CodeGen/Mips/constraint-c-err.ll
+++ b/llvm/test/CodeGen/Mips/constraint-c-err.ll
@@ -8,7 +8,7 @@ entry:
   %0 = load float, ptr %jmp, align 4
   call void asm sideeffect "jr $0", "c,~{$1}"(float %0) #1
 
-; CHECK: error: couldn't allocate input reg for constraint 'c'
+; CHECK: error: could not allocate input reg for constraint 'c'
 
   ret i32 0
 }

--- a/llvm/test/CodeGen/PowerPC/crbit-asm-disabled.ll
+++ b/llvm/test/CodeGen/PowerPC/crbit-asm-disabled.ll
@@ -9,7 +9,7 @@ entry:
   %tobool3 = icmp ne i8 %1, 0
   ret i1 %tobool3
 
-; CHECK: error: couldn't allocate output register for constraint 'wc'
+; CHECK: error: could not allocate output register for constraint 'wc'
 }
 
 attributes #0 = { nounwind "target-features"="-crbits" }

--- a/llvm/test/CodeGen/PowerPC/vec-asm-disabled.ll
+++ b/llvm/test/CodeGen/PowerPC/vec-asm-disabled.ll
@@ -7,7 +7,7 @@ entry:
   %0 = call <4 x i32> asm "xxland $0, $1, $2", "=^wd,^wd,^wd"(<4 x i32> %b1, <4 x i32> %b2) #0
   ret <4 x i32> %0
 
-; CHECK: error: couldn't allocate output register for constraint 'wd'
+; CHECK: error: could not allocate output register for constraint 'wd'
 }
 
 define signext i32 @testi2(<4 x float> %__A) #0 {
@@ -16,19 +16,19 @@ entry:
   %asmresult = extractvalue { i32, <4 x float> } %0, 0
   ret i32 %asmresult
 
-; CHECK: error: couldn't allocate output register for constraint 'wi'
+; CHECK: error: could not allocate output register for constraint 'wi'
 }
 
 define float @test_ww(float %x, float %y) #0 {
   %1 = tail call float asm "xsmaxdp ${0:x},${1:x},${2:x}", "=^ww,^ww,^ww"(float %x, float %y) #0
   ret float %1
-; CHECK: error: couldn't allocate output register for constraint 'ww'
+; CHECK: error: could not allocate output register for constraint 'ww'
 }
 
 define double @test_ws(double %x, double %y) #0 {
   %1 = tail call double asm "xsmaxdp ${0:x},${1:x},${2:x}", "=^ws,^ws,^ws"(double %x, double %y) #0
   ret double %1
-; CHECK: error: couldn't allocate output register for constraint 'ws'
+; CHECK: error: could not allocate output register for constraint 'ws'
 }
 
 attributes #0 = { nounwind "target-features"="-vsx" }

--- a/llvm/test/CodeGen/RISCV/inline-asm-invalid.ll
+++ b/llvm/test/CodeGen/RISCV/inline-asm-invalid.ll
@@ -24,89 +24,89 @@ define void @constraint_K() {
 }
 
 define void @constraint_f() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'f'
+; CHECK: error: could not allocate input reg for constraint 'f'
   tail call void asm "fadd.s fa0, fa0, $0", "f"(float 0.0)
-; CHECK: error: couldn't allocate input reg for constraint 'f'
+; CHECK: error: could not allocate input reg for constraint 'f'
   tail call void asm "fadd.d fa0, fa0, $0", "f"(double 0.0)
   ret void
 }
 
 define void @constraint_cf() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'cf'
+; CHECK: error: could not allocate input reg for constraint 'cf'
   tail call void asm "fadd.s fa0, fa0, $0", "^cf"(float 0.0)
-; CHECK: error: couldn't allocate input reg for constraint 'cf'
+; CHECK: error: could not allocate input reg for constraint 'cf'
   tail call void asm "fadd.d fa0, fa0, $0", "^cf"(double 0.0)
   ret void
 }
 
 define void @constraint_r_fixed_vec() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'r'
+; CHECK: error: could not allocate input reg for constraint 'r'
   tail call void asm "add a0, a0, $0", "r"(<4 x i32> zeroinitializer)
   ret void
 }
 
 define void @constraint_r_scalable_vec() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'r'
+; CHECK: error: could not allocate input reg for constraint 'r'
   tail call void asm "add a0, a0, $0", "r"(<vscale x 4 x i32> zeroinitializer)
   ret void
 }
 
 define void @constraint_cr_fixed_vec() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'cr'
+; CHECK: error: could not allocate input reg for constraint 'cr'
   tail call void asm "add a0, a0, $0", "^cr"(<4 x i32> zeroinitializer)
   ret void
 }
 
 define void @constraint_cr_scalable_vec() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'cr'
+; CHECK: error: could not allocate input reg for constraint 'cr'
   tail call void asm "add a0, a0, $0", "^cr"(<vscale x 4 x i32> zeroinitializer)
   ret void
 }
 
 define void @constraint_R_i32() nounwind {
-; CHECK32: error: couldn't allocate input reg for constraint 'R'
+; CHECK32: error: could not allocate input reg for constraint 'R'
   tail call void asm "add a0, a0, $0", "R"(i32 zeroinitializer)
   ret void
 }
 
 define void @constraint_R_i64() nounwind {
-; CHECK64: error: couldn't allocate input reg for constraint 'R'
+; CHECK64: error: could not allocate input reg for constraint 'R'
   tail call void asm "add a0, a0, $0", "R"(i64 zeroinitializer)
   ret void
 }
 
 define void @constraint_R_i128() nounwind {
-; CHECK32: error: couldn't allocate input reg for constraint 'R'
+; CHECK32: error: could not allocate input reg for constraint 'R'
   tail call void asm "add a0, a0, $0", "R"(i128 zeroinitializer)
   ret void
 }
 
 define void @constraint_R_i256() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'R'
+; CHECK: error: could not allocate input reg for constraint 'R'
   tail call void asm "add a0, a0, $0", "R"(i256 zeroinitializer)
   ret void
 }
 
 define void @constraint_cR_i32() nounwind {
-; CHECK32: error: couldn't allocate input reg for constraint 'cR'
+; CHECK32: error: could not allocate input reg for constraint 'cR'
   tail call void asm "add a0, a0, $0", "^cR"(i32 zeroinitializer)
   ret void
 }
 
 define void @constraint_cR_i64() nounwind {
-; CHECK64: error: couldn't allocate input reg for constraint 'cR'
+; CHECK64: error: could not allocate input reg for constraint 'cR'
   tail call void asm "add a0, a0, $0", "^cR"(i64 zeroinitializer)
   ret void
 }
 
 define void @constraint_cR_i128() nounwind {
-; CHECK32: error: couldn't allocate input reg for constraint 'cR'
+; CHECK32: error: could not allocate input reg for constraint 'cR'
   tail call void asm "add a0, a0, $0", "^cR"(i128 zeroinitializer)
   ret void
 }
 
 define void @constraint_cR_i256() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'cR'
+; CHECK: error: could not allocate input reg for constraint 'cR'
   tail call void asm "add a0, a0, $0", "^cR"(i256 zeroinitializer)
   ret void
 }

--- a/llvm/test/CodeGen/SPARC/inlineasm-bad.ll
+++ b/llvm/test/CodeGen/SPARC/inlineasm-bad.ll
@@ -1,9 +1,9 @@
 ; RUN: not llc -mtriple=sparc <%s 2>&1 | FileCheck %s
 ; RUN: not llc -mtriple=sparcv9 <%s 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate input reg for constraint '{f32}'
-; CHECK: error: couldn't allocate input reg for constraint '{f21}'
-; CHECK: error: couldn't allocate input reg for constraint '{f38}'
+; CHECK: error: could not allocate input reg for constraint '{f32}'
+; CHECK: error: could not allocate input reg for constraint '{f21}'
+; CHECK: error: could not allocate input reg for constraint '{f38}'
 define void @test_constraint_float_reg() {
 entry:
   tail call void asm sideeffect "fadds $0,$1,$2", "{f32},{f0},{f0}"(float 6.0, float 7.0, float 8.0)

--- a/llvm/test/CodeGen/SystemZ/inline-asm-f-constraint-softfloat.ll
+++ b/llvm/test/CodeGen/SystemZ/inline-asm-f-constraint-softfloat.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=s390x-linux-gnu -mcpu=z15 -mattr=soft-float < %s 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate output register for constraint 'f'
+; CHECK: error: could not allocate output register for constraint 'f'
 
 define signext i32 @int_and_f(i32 signext %cc_dep1) {
 entry:

--- a/llvm/test/CodeGen/SystemZ/inline-asm-v-constraint-novecfacility.ll
+++ b/llvm/test/CodeGen/SystemZ/inline-asm-v-constraint-novecfacility.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc < %s -mtriple=s390x-linux-gnu -mcpu=zEC12 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate output register for constraint 'v'
+; CHECK: error: could not allocate output register for constraint 'v'
 
 define signext i32 @int_and_v(i32 signext %cc_dep1) {
 entry:

--- a/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-01.ll
+++ b/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-01.ll
@@ -7,4 +7,4 @@ define float @f1() {
   ret float %ret
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'f'
+; CHECK: error: could not allocate output register for constraint 'f'

--- a/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-02.ll
+++ b/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-02.ll
@@ -7,4 +7,4 @@ define float @f1() {
   ret float %ret
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{f0}'
+; CHECK: error: could not allocate output register for constraint '{f0}'

--- a/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-03.ll
+++ b/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-03.ll
@@ -7,4 +7,4 @@ define <2 x i64> @f1() {
   ret <2 x i64> %ret
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'v'
+; CHECK: error: could not allocate output register for constraint 'v'

--- a/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-04.ll
+++ b/llvm/test/CodeGen/SystemZ/soft-float-inline-asm-04.ll
@@ -7,4 +7,4 @@ define <2 x i64> @f1() {
   ret <2 x i64> %ret
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{v0}'
+; CHECK: error: could not allocate output register for constraint '{v0}'

--- a/llvm/test/CodeGen/X86/asm-reject-reg-type-mismatch.ll
+++ b/llvm/test/CodeGen/X86/asm-reject-reg-type-mismatch.ll
@@ -1,26 +1,26 @@
 ; RUN: not llc -o /dev/null %s 2>&1 | FileCheck %s
 target triple = "x86_64--"
 
-; CHECK: error: couldn't allocate output register for constraint '{ax}'
+; CHECK: error: could not allocate output register for constraint '{ax}'
 define i128 @blup() {
   %v = tail call i128 asm "", "={ax},0"(i128 0)
   ret i128 %v
 }
 
-; CHECK: error: couldn't allocate input reg for constraint 'r'
+; CHECK: error: could not allocate input reg for constraint 'r'
 define void @fp80(x86_fp80) {
   tail call void asm sideeffect "", "r"(x86_fp80 %0)
   ret void
 }
 
-; CHECK: error: couldn't allocate input reg for constraint 'f'
+; CHECK: error: could not allocate input reg for constraint 'f'
 define void @f_constraint_i128(ptr %0) {
   %2 = load i128, ptr %0, align 16
   tail call void asm sideeffect "", "f"(i128 %2)
   ret void
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'r'
+; CHECK: error: could not allocate output register for constraint 'r'
 define void @r_constraint_v4i128(ptr %0) {
   %2 = alloca <4 x i128>, align 64
   %3 = tail call <4 x i128> asm sideeffect "", "=r"()

--- a/llvm/test/CodeGen/X86/asm-reject-rex.ll
+++ b/llvm/test/CodeGen/X86/asm-reject-rex.ll
@@ -2,19 +2,19 @@
 ; Make sure X32 still works.
 ; RUN: llc -o /dev/null %s -mtriple=x86_64-linux-gnux32
 
-; CHECK: error: couldn't allocate output register for constraint '{xmm8}'
+; CHECK: error: could not allocate output register for constraint '{xmm8}'
 define i64 @blup() {
   %v = tail call i64 asm "", "={xmm8},0"(i64 0)
   ret i64 %v
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{r8d}'
+; CHECK: error: could not allocate output register for constraint '{r8d}'
 define i32 @foo() {
   %v = tail call i32 asm "", "={r8d},0"(i32 0)
   ret i32 %v
 }
 
-; CHECK: error: couldn't allocate output register for constraint '{rax}'
+; CHECK: error: could not allocate output register for constraint '{rax}'
 define i64 @bar() {
   %v = tail call i64 asm "", "={rax},0"(i64 0)
   ret i64 %v

--- a/llvm/test/CodeGen/X86/asm-reject-vk32-vk64.ll
+++ b/llvm/test/CodeGen/X86/asm-reject-vk32-vk64.ll
@@ -1,28 +1,28 @@
 ; RUN: not llc -o /dev/null %s -mtriple=x86_64-unknown-unknown -mattr=avx512f 2>&1 | FileCheck %s
 ; RUN: not llc -o /dev/null %s -mtriple=i386-unknown-unknown -mattr=avx512f 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate input reg for constraint 'Yk'
+; CHECK: error: could not allocate input reg for constraint 'Yk'
 define <8 x i64> @mask_Yk_i32(i32 %msk, <8 x i64> %x, <8 x i64> %y) {
 entry:
   %0 = tail call <8 x i64> asm "vpaddw\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i32 %msk, <8 x i64> %x, <8 x i64> %y)
   ret <8 x i64> %0
 }
 
-; CHECK: error: couldn't allocate input reg for constraint 'Yk'
+; CHECK: error: could not allocate input reg for constraint 'Yk'
 define <8 x i64> @mask_Yk_i64(i64 %msk, <8 x i64> %x, <8 x i64> %y) {
 entry:
   %0 = tail call <8 x i64> asm "vpaddb\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i64 %msk, <8 x i64> %x, <8 x i64> %y)
   ret <8 x i64> %0
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'k'
+; CHECK: error: could not allocate output register for constraint 'k'
 define i32 @k_wise_op_i32(i32 %msk_src1, i32 %msk_src2) {
 entry:
   %0 = tail call i32 asm "kandd\09$2, $1, $0", "=k,k,k,~{dirflag},~{fpsr},~{flags}"(i32 %msk_src1, i32 %msk_src2)
   ret i32 %0
 }
 
-; CHECK: error: couldn't allocate output register for constraint 'k'
+; CHECK: error: could not allocate output register for constraint 'k'
 define i64 @k_wise_op_i64(i64 %msk_src1, i64 %msk_src2) {
 entry:
   %0 = tail call i64 asm "kandq\09$2, $1, $0", "=k,k,k,~{dirflag},~{fpsr},~{flags}"(i64 %msk_src1, i64 %msk_src2)

--- a/llvm/test/CodeGen/X86/asm-reject-x87-int.ll
+++ b/llvm/test/CodeGen/X86/asm-reject-x87-int.ll
@@ -22,7 +22,7 @@
 
 %struct.float4 = type { float }
 
-; CHECK: error: couldn't allocate output register for constraint '{st}'
+; CHECK: error: could not allocate output register for constraint '{st}'
 define dso_local i32 @foo() {
 entry:
   %retval = alloca i32, align 4

--- a/llvm/test/CodeGen/X86/asm-reject-xmm16.ll
+++ b/llvm/test/CodeGen/X86/asm-reject-xmm16.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc -o /dev/null %s -mtriple=x86_64-unknown-unknown 2>&1 | FileCheck %s
 ; RUN: not llc -o /dev/null %s -mtriple=i386-unknown-unknown -mattr=avx512vl 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate output register for constraint '{xmm16}'
+; CHECK: error: could not allocate output register for constraint '{xmm16}'
 define i64 @blup() {
   %v = tail call i64 asm "", "={xmm16},0"(i64 0)
   ret i64 %v

--- a/llvm/test/CodeGen/X86/inline-asm-avx512f-x-constraint.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-avx512f-x-constraint.ll
@@ -18,7 +18,7 @@ entry:
 ; FP16: %[[REG1:.*]]:vr512_0_15 = COPY %1
 ; FP16: %[[REG2:.*]]:vr512_0_15 = COPY %2
 ; FP16: INLINEASM &"vaddph\09$3, $2, $0 {$1}", attdialect, {{.*}}, def %{{.*}}, {{.*}}, %{{.*}}, {{.*}}, %[[REG1]], {{.*}}, %[[REG2]], clobber, implicit-def early-clobber $df, clobber, implicit-def early-clobber $fpsw, clobber, implicit-def early-clobber $eflags
-; CHECK-STDERR: couldn't allocate output register for constraint 'x'
+; CHECK-STDERR: could not allocate output register for constraint 'x'
 define <32 x half> @mask_Yk_f16(i8 signext %msk, <32 x half> %x, <32 x half> %y) {
 entry:
   %0 = tail call <32 x half> asm "vaddph\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i8 %msk, <32 x half> %x, <32 x half> %y)
@@ -29,7 +29,7 @@ entry:
 ; FP16: %[[REG1:.*]]:vr512_0_15 = COPY %1
 ; FP16: %[[REG2:.*]]:vr512_0_15 = COPY %2
 ; FP16: INLINEASM &"vaddph\09$3, $2, $0 {$1}", attdialect, {{.*}}, def %{{.*}}, {{.*}}, %{{.*}}, {{.*}}, %[[REG1]], {{.*}}, %[[REG2]], clobber, implicit-def early-clobber $df, clobber, implicit-def early-clobber $fpsw, clobber, implicit-def early-clobber $eflags
-; CHECK-STDERR: couldn't allocate output register for constraint 'x'
+; CHECK-STDERR: could not allocate output register for constraint 'x'
 define <32 x bfloat> @mask_Yk_bf16(i8 signext %msk, <32 x bfloat> %x, <32 x bfloat> %y) {
 entry:
   %0 = tail call <32 x bfloat> asm "vaddph\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i8 %msk, <32 x bfloat> %x, <32 x bfloat> %y)

--- a/llvm/test/CodeGen/X86/inline-asm-x-i128.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-x-i128.ll
@@ -4,7 +4,7 @@
 ; RUN: not llc < %s -mtriple=i386-unknown-linux-gnu 2>&1 | FileCheck %s --check-prefix=ERROR
 
 ; For 32-bit we still error since __int128 isn't supported in the frontend.
-; ERROR: error: couldn't allocate output register for constraint 'x'
+; ERROR: error: could not allocate output register for constraint 'x'
 
 define { i64, i64 } @foo(i64 %0, i64 %1) {
 ; CHECK-LABEL: foo:

--- a/llvm/test/CodeGen/X86/physreg-pairs-error.ll
+++ b/llvm/test/CodeGen/X86/physreg-pairs-error.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=i386-unknown-linux-gnu -o - %s 2>&1 | FileCheck %s
 
-; CHECK: error: couldn't allocate input reg for constraint '{esp}'
+; CHECK: error: could not allocate input reg for constraint '{esp}'
 define dso_local i64 @test_esp(i64 %in) local_unnamed_addr nounwind {
 entry:
   %0 = tail call i64 asm sideeffect "mov $1, $0", "=r,{esp},~{dirflag},~{fpsr},~{flags}"(i64 81985529216486895)

--- a/llvm/test/CodeGen/X86/pr37359.ll
+++ b/llvm/test/CodeGen/X86/pr37359.ll
@@ -3,7 +3,7 @@ target triple = "x86_64--"
 
 @a = global i32 0, align 4
 
-; CHECK: error: couldn't allocate input reg for constraint 'x'
+; CHECK: error: could not allocate input reg for constraint 'x'
 define i32 @main() {
 entry:
   %0 = load i32, ptr @a, align 4

--- a/llvm/test/CodeGen/X86/pr43157.ll
+++ b/llvm/test/CodeGen/X86/pr43157.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc < %s -mtriple=i686-pc-linux -o - -mattr=+sse2 2>&1 | FileCheck %s --check-prefix=ERR
 ; RUN: llc < %s -mtriple=x86_64-pc-linux -o - -mattr=+mmx | FileCheck %s
 
-; ERR: error: couldn't allocate input reg for constraint 'x'
+; ERR: error: could not allocate input reg for constraint 'x'
 define void @foo(fp128 %x) {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0: # %entry

--- a/llvm/test/CodeGen/X86/pr50907.ll
+++ b/llvm/test/CodeGen/X86/pr50907.ll
@@ -2,7 +2,7 @@
 ; RUN: not llc -o /dev/null %s 2>&1 | FileCheck %s
 target triple = "x86_64-unknown-linux-gnu"
 
-; CHECK: error: couldn't allocate input reg for constraint 'r'
+; CHECK: error: could not allocate input reg for constraint 'r'
 define i32 @f2() #0 {
 entry:
   %retval = alloca i32, align 4


### PR DESCRIPTION
We shouldn't use c'tract'ns so m'ch.