### PR TITLE
[AMDGPU][NFC] Update join/signal ordering in named barrier tests

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync-and-module-lds.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync-and-module-lds.ll
@@ -22,13 +22,13 @@
 define void @func1() #0 {
 ; CHECK-LABEL: define void @func1(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   ret void
 }
@@ -36,14 +36,14 @@ define void @func1() #0 {
 define void @func2() #0 {
 ; CHECK-LABEL: define void @func2(
 ; CHECK-SAME: ) #[[ATTR0]] {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    store i8 7, ptr addrspace(3) @llvm.amdgcn.module.lds, align 4
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   store i8 7, ptr addrspace(3) @lds1, align 4
   ret void
@@ -53,8 +53,8 @@ define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-LABEL: define amdgpu_kernel void @kernel1(
 ; CHECK-SAME: ) #[[ATTR1:[0-9]+]] {
 ; CHECK-NEXT:    call void @llvm.donothing() [ "ExplicitUse"(ptr addrspace(3) @llvm.amdgcn.module.lds) ]
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1.kernel1)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    [[STATE:%.*]] = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) @bar1.kernel1)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier()
@@ -63,8 +63,8 @@ define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-NEXT:    store i8 9, ptr addrspace(3) @llvm.amdgcn.module.lds, align 4
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   %state = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) @bar1)
   call void @llvm.amdgcn.s.barrier()
@@ -78,15 +78,15 @@ define amdgpu_kernel void @kernel2() #0 {
 ; CHECK-LABEL: define amdgpu_kernel void @kernel2(
 ; CHECK-SAME: ) #[[ATTR1]] {
 ; CHECK-NEXT:    call void @llvm.donothing() [ "ExplicitUse"(ptr addrspace(3) @llvm.amdgcn.module.lds) ]
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    call void @func2()
 ; CHECK-NEXT:    store i8 10, ptr addrspace(3) @llvm.amdgcn.module.lds, align 4
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   call void @func2()
   store i8 10, ptr addrspace(3) @lds1, align 4

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync-and-sw-lds.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync-and-sw-lds.ll
@@ -15,13 +15,13 @@
 define void @bar() #0 {
 ; CHECK-LABEL: define void @bar(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
-; CHECK:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+; CHECK:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK:    store i8 7, ptr addrspace(1) {{.*}}, align 4
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   store i8 7, ptr addrspace(3) @lds1, align 4
   ret void
@@ -32,15 +32,15 @@ define amdgpu_kernel void @barkernel() #0 {
 ; CHECK-SAME: ) #[[ATTR1:[0-9]+]] !llvm.amdgcn.lds.kernel.id [[META4:![0-9]+]] {
 ; CHECK:    {{.*}} = call i64 @__asan_malloc_impl(i64 {{.*}}, i64 {{.*}})
 ; CHECK:    call void @llvm.amdgcn.s.barrier()
-; CHECK:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+; CHECK:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK:    call void @bar()
 ; CHECK:    store i8 10, ptr addrspace(1) {{.*}}, align 4
 ; CHECK:    call void @__asan_free_impl(i64 {{.*}}, i64 {{.*}})
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   call void @bar()
   store i8 10, ptr addrspace(3) @lds1, align 4

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-lower-exec-sync.ll
@@ -16,26 +16,26 @@
 ;.
 define void @func1() {
 ; CHECK-LABEL: define void @func1() {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   ret void
 }
 
 define void @func2() {
 ; CHECK-LABEL: define void @func2() {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   ret void
 }
@@ -43,8 +43,8 @@ define void @func2() {
 define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-LABEL: define amdgpu_kernel void @kernel1(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1.kernel1)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    [[STATE:%.*]] = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) @bar1.kernel1)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier()
@@ -52,8 +52,8 @@ define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-NEXT:    call void @func2()
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   %state = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) @bar1)
   call void @llvm.amdgcn.s.barrier()
@@ -65,14 +65,14 @@ define amdgpu_kernel void @kernel1() #0 {
 define amdgpu_kernel void @kernel2() #0 {
 ; CHECK-LABEL: define amdgpu_kernel void @kernel2(
 ; CHECK-SAME: ) #[[ATTR0]] {
-; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
 ; CHECK-NEXT:    call void @llvm.amdgcn.s.barrier.wait(i16 1)
 ; CHECK-NEXT:    call void @func2()
 ; CHECK-NEXT:    ret void
 ;
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
 
   call void @func2()

--- a/llvm/test/CodeGen/AMDGPU/lds-link-time-codegen-named-barrier.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-link-time-codegen-named-barrier.ll
@@ -9,8 +9,8 @@
 
 ; CHECK-LABEL: kernel:
 ; CHECK: s_lshr_b32 s{{[0-9]+}}, __amdgpu_named_barrier.bar{{[^ @]*}}@abs32@lo, 4
-; CHECK: s_barrier_signal m0
 ; CHECK: s_barrier_join m0
+; CHECK: s_barrier_signal m0
 ; CHECK: s_barrier_wait 1
 
 ; KD: group_segment_fixed_size = 0 (linker will patch).
@@ -20,16 +20,16 @@
 ; CHECK:      .amdgpu_lds __amdgpu_named_barrier.bar{{[^ ,]*}}, 32, 4
 
 define amdgpu_kernel void @kernel() {
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar, i32 3)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar, i32 3)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   call void @helper()
   ret void
 }
 
 declare void @helper()
-declare void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3), i32) #0
 declare void @llvm.amdgcn.s.barrier.join(ptr addrspace(3)) #0
+declare void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3), i32) #0
 declare void @llvm.amdgcn.s.barrier.wait(i16) #0
 
 attributes #0 = { convergent nounwind }

--- a/llvm/test/CodeGen/AMDGPU/lds-link-time-named-barrier.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-link-time-named-barrier.ll
@@ -17,10 +17,10 @@
 
 define amdgpu_kernel void @kernel(i32 %idx) {
 ; CHECK-LABEL: define amdgpu_kernel void @kernel(
-; CHECK:         call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @[[BAR]], i32 3)
 ; CHECK:         call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @[[BAR]])
-  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar, i32 3)
+; CHECK:         call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @[[BAR]], i32 3)
   call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar)
+  call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar, i32 3)
   call void @llvm.amdgcn.s.barrier.wait(i16 1)
   %gep = getelementptr [4 x i32], ptr addrspace(3) @lds, i32 0, i32 %idx
   store i32 42, ptr addrspace(3) %gep, align 4

--- a/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-barrier-lowering.ll
@@ -14,16 +14,16 @@
 
 ; SOUT:        .set .Lfunc1.num_named_barrier, 7
 define void @func1() {
-    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar3)
+    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar3, i32 7)
     call void @llvm.amdgcn.s.barrier.wait(i16 1)
     ret void
 }
 
 ; SOUT:        .set .Lfunc2.num_named_barrier, 2
 define void @func2() {
-    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar2)
+    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar2, i32 7)
     call void @llvm.amdgcn.s.barrier.wait(i16 1)
     ret void
 }
@@ -32,8 +32,8 @@ define void @func2() {
 ; SOUT:        .set .Lkernel1.num_named_barrier, max(6, .Lfunc1.num_named_barrier, .Lfunc2.num_named_barrier)
 define amdgpu_kernel void @kernel1() #0 {
 ; CHECK-DAG: call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1.kernel1, i32 11)
-    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 11)
     call void @llvm.amdgcn.s.barrier.wait(i16 1)
     %state = call i32 @llvm.amdgcn.s.get.named.barrier.state(ptr addrspace(3) @bar1)
     call void @llvm.amdgcn.s.barrier()
@@ -46,8 +46,8 @@ define amdgpu_kernel void @kernel1() #0 {
 ; SOUT:        .set .Lkernel2.num_named_barrier, max(6, .Lfunc2.num_named_barrier)
 define amdgpu_kernel void @kernel2() #0 {
 ; CHECK-DAG: call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
-    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
     call void @llvm.amdgcn.s.barrier.join(ptr addrspace(3) @bar1)
+    call void @llvm.amdgcn.s.barrier.signal.var(ptr addrspace(3) @bar1, i32 9)
     call void @llvm.amdgcn.s.barrier.wait(i16 1)
 
     call void @func2()


### PR DESCRIPTION
The ISA requires that you join a barrier before signaling it if you're planning to wait on that barrier. Some IR-level tests have the join and signal in the wrong order, confusing people.

This PR reorders join and signal.var in order to make correct usage more obvious going forward.

AI: none