### PR TITLE
[mlir][spirv] Support OpenCL.std clz in the SPIR-V dialect

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
@@ -783,6 +783,29 @@ def SPIRV_CLSAbsOp : SPIRV_CLUnaryArithmeticOp<"s_abs", 141, SPIRV_Integer> {
 
 // -----
 
+def SPIRV_CLClzOp : SPIRV_CLUnaryArithmeticOp<"clz", 151, SPIRV_Integer> {
+  let summary = "Count leading zeros in operand";
+
+  let description = [{
+    Returns the number of most-significant 0-bits in x.
+
+    Result Type and x must be integer or vector(2,3,4,8,16) of
+    integer values.
+
+    All of the operands, including the Result Type operand, must be of the
+    same type.
+
+    #### Example:
+
+    ```mlir
+    %2 = spirv.CL.clz %0 : i32
+    %3 = spirv.CL.clz %1 : vector<3xi16>
+    ```
+  }];
+}
+
+// -----
+
 def SPIRV_CLSMaxOp : SPIRV_CLBinaryArithmeticOp<"s_max", 156, SPIRV_Integer> {
   let summary = "Return maximum of two signed integer operands";
 

--- a/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/ocl-ops.mlir
@@ -169,6 +169,56 @@ func.func @sabs(%arg0 : i32) -> () {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spirv.CL.clz
+//===----------------------------------------------------------------------===//
+
+func.func @clz(%arg0 : i32) -> () {
+  // CHECK: spirv.CL.clz {{%.*}} : i32
+  %2 = spirv.CL.clz %arg0 : i32
+  return
+}
+
+func.func @clzvec(%arg0 : vector<3xi16>) -> () {
+  // CHECK: spirv.CL.clz {{%.*}} : vector<3xi16>
+  %2 = spirv.CL.clz %arg0 : vector<3xi16>
+  return
+}
+
+// -----
+
+func.func @clz(%arg0 : f32) -> () {
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or fixed-length vector of 8/16/32/64-bit integer values}}
+  %2 = spirv.CL.clz %arg0 : f32
+  return
+}
+
+// -----
+
+func.func @clz(%arg0 : vector<5xi32>) -> () {
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or fixed-length vector of 8/16/32/64-bit integer values of length 2/3/4}}
+  %2 = spirv.CL.clz %arg0 : vector<5xi32>
+  return
+}
+
+// -----
+
+func.func @clz(%arg0 : i32, %arg1 : i32) -> () {
+  // expected-error @+1 {{expected ':'}}
+  %2 = spirv.CL.clz %arg0, %arg1 : i32
+  return
+}
+
+// -----
+
+func.func @clz(%arg0 : i32) -> () {
+  // expected-error @+1 {{expected non-function type}}
+  %2 = spirv.CL.clz %arg0 :
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spirv.CL.fma
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Target/SPIRV/ocl-ops.mlir
+++ b/mlir/test/Target/SPIRV/ocl-ops.mlir
@@ -35,6 +35,8 @@ spirv.module Physical64 OpenCL requires #spirv.vce<v1.0, [Kernel, Addresses, Vec
   spirv.func @integer_insts(%arg0 : i32) "None" {
     // CHECK: {{%.*}} = spirv.CL.s_abs {{%.*}} : i32
     %0 = spirv.CL.s_abs %arg0 : i32
+    // CHECK: {{%.*}} = spirv.CL.clz {{%.*}} : i32
+    %1 = spirv.CL.clz %arg0 : i32
     spirv.Return
   }
 


### PR DESCRIPTION
Add support for the OpenCL.std clz extended instruction in the MLIR SPIR-V dialect.
From Spriv Specs - Op Name: "clz", Op Code: "151"