### PR TITLE
[SelectionDAG][NFC] Add function for `peekThroughFreeze`

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1979,11 +1979,19 @@ LLVM_ABI SDValue peekThroughTruncates(SDValue V);
 
 /// Return the non-frozen source operand of \p V if it exists.
 /// If \p V is not a freeze, it is returned as-is.
-LLVM_ABI SDValue peekThroughFreeze(SDValue V);
+inline SDValue peekThroughFreeze(SDValue V) {
+  if (V.getOpcode() == ISD::FREEZE)
+    return V.getOperand(0);
+  return V;
+}
 
 /// Return the non-frozen source operand of \p V if it exists and \p V has
 /// a single use. If \p V is not a single-use freeze, it is returned as-is.
-LLVM_ABI SDValue peekThroughOneUseFreeze(SDValue V);
+inline SDValue peekThroughOneUseFreeze(SDValue V) {
+  if (V.getOpcode() == ISD::FREEZE && V.hasOneUse())
+    return V.getOperand(0);
+  return V;
+}
 
 /// Returns true if \p V is a bitwise not operation. Assumes that an all ones
 /// constant is canonicalized to be operand 1.

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1977,6 +1977,14 @@ LLVM_ABI SDValue peekThroughInsertVectorElt(SDValue V,
 /// If \p V is not a truncation, it is returned as-is.
 LLVM_ABI SDValue peekThroughTruncates(SDValue V);
 
+/// Return the non-frozen source operand of \p V if it exists.
+/// If \p V is not a freeze, it is returned as-is.
+LLVM_ABI SDValue peekThroughFreeze(SDValue V);
+
+/// Return the non-frozen source operand of \p V if it exists and \p V has
+/// a single use. If \p V is not a single-use freeze, it is returned as-is.
+LLVM_ABI SDValue peekThroughOneUseFreeze(SDValue V);
+
 /// Returns true if \p V is a bitwise not operation. Assumes that an all ones
 /// constant is canonicalized to be operand 1.
 LLVM_ABI bool isBitwiseNot(SDValue V, bool AllowUndefs = false);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -7980,7 +7980,7 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
   // fold (and (freeze (load x)), 255) -> (freeze (zextload x, i8))
   // fold (and (freeze (extload x, i16)), 255) -> (freeze (zextload x, i8))
   if (N1C && !VT.isVector()) {
-    SDValue Inner = N0.getOpcode() == ISD::FREEZE ? N0.getOperand(0) : N0;
+    SDValue Inner = peekThroughFreeze(N0);
     if (Inner.getOpcode() == ISD::LOAD)
       if (SDValue Res = reduceLoadWidth(N))
         return Res;

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -13604,18 +13604,6 @@ SDValue llvm::peekThroughTruncates(SDValue V) {
   return V;
 }
 
-SDValue llvm::peekThroughFreeze(SDValue V) {
-  if (V.getOpcode() == ISD::FREEZE)
-    return V.getOperand(0);
-  return V;
-}
-
-SDValue llvm::peekThroughOneUseFreeze(SDValue V) {
-  if (V.getOpcode() == ISD::FREEZE && V.hasOneUse())
-    return V.getOperand(0);
-  return V;
-}
-
 bool llvm::isBitwiseNot(SDValue V, bool AllowUndefs) {
   if (V.getOpcode() != ISD::XOR)
     return false;

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -13604,6 +13604,18 @@ SDValue llvm::peekThroughTruncates(SDValue V) {
   return V;
 }
 
+SDValue llvm::peekThroughFreeze(SDValue V) {
+  if (V.getOpcode() == ISD::FREEZE)
+    return V.getOperand(0);
+  return V;
+}
+
+SDValue llvm::peekThroughOneUseFreeze(SDValue V) {
+  if (V.getOpcode() == ISD::FREEZE && V.hasOneUse())
+    return V.getOperand(0);
+  return V;
+}
+
 bool llvm::isBitwiseNot(SDValue V, bool AllowUndefs) {
   if (V.getOpcode() != ISD::XOR)
     return false;

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -6659,9 +6659,7 @@ static SDValue PerformSETCCCombine(SDNode *N,
 
 static SDValue PerformEXTRACTCombine(SDNode *N,
                                      TargetLowering::DAGCombinerInfo &DCI) {
-  SDValue Vector = N->getOperand(0);
-  if (Vector->getOpcode() == ISD::FREEZE)
-    Vector = Vector->getOperand(0);
+  SDValue Vector = peekThroughFreeze(N->getOperand(0));
   SDLoc DL(N);
   EVT VectorVT = Vector.getValueType();
   if (Vector->getOpcode() == ISD::LOAD && VectorVT.isSimple() &&

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1052,9 +1052,7 @@ bool WebAssemblyTargetLowering::isIntDivCheap(EVT VT,
 
 bool WebAssemblyTargetLowering::isVectorLoadExtDesirable(SDValue ExtVal) const {
   EVT ExtT = ExtVal.getValueType();
-  SDValue N0 = ExtVal->getOperand(0);
-  if (N0.getOpcode() == ISD::FREEZE)
-    N0 = N0.getOperand(0);
+  SDValue N0 = peekThroughFreeze(ExtVal->getOperand(0));
   auto *Load = dyn_cast<LoadSDNode>(N0);
   if (!Load)
     return false;

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -9687,16 +9687,11 @@ LowerBUILD_VECTORAsVariablePermute(SDValue V, const SDLoc &DL,
                                    const X86Subtarget &Subtarget) {
   SDValue SrcVec, IndicesVec;
 
-  auto PeekThroughFreeze = [](SDValue N) {
-    if (N->getOpcode() == ISD::FREEZE && N.hasOneUse())
-      return N->getOperand(0);
-    return N;
-  };
   // Check for a match of the permute source vector and permute index elements.
   // This is done by checking that the i-th build_vector operand is of the form:
   // (extract_elt SrcVec, (extract_elt IndicesVec, i)).
   for (unsigned Idx = 0, E = V.getNumOperands(); Idx != E; ++Idx) {
-    SDValue Op = PeekThroughFreeze(V.getOperand(Idx));
+    SDValue Op = peekThroughOneUseFreeze(V.getOperand(Idx));
     if (Op.getOpcode() != ISD::EXTRACT_VECTOR_ELT)
       return SDValue();
 


### PR DESCRIPTION
There are a few callsites in SelectionDAG and DAGCombiner where it is necessary to look through an `ISD::FREEZE` to unblock some optimization and folds. This patch introduces `peekThroughFreeze` and `peekThroughOneUseFreeze` utility function. 