### PR TITLE
[llubi][NFC] Fix build with old GCC

### DIFF
--- a/llvm/tools/llubi/lib/Interpreter.cpp
+++ b/llvm/tools/llubi/lib/Interpreter.cpp
@@ -786,7 +786,7 @@ public:
       const uint64_t Offset = Chunk * EVL;
       if (Offset > Vec.size() || EVL > Vec.size() - Offset)
         return AnyValue::poison();
-      return std::vector(Vec.begin() + Offset, Vec.begin() + Offset + EVL);
+      return std::vector<AnyValue>(Vec.begin() + Offset, Vec.begin() + Offset + EVL);
     }
     case Intrinsic::vector_reverse: {
       auto Vec = Args[0].asAggregate();

--- a/llvm/tools/llubi/lib/Interpreter.cpp
+++ b/llvm/tools/llubi/lib/Interpreter.cpp
@@ -786,7 +786,8 @@ public:
       const uint64_t Offset = Chunk * EVL;
       if (Offset > Vec.size() || EVL > Vec.size() - Offset)
         return AnyValue::poison();
-      return std::vector<AnyValue>(Vec.begin() + Offset, Vec.begin() + Offset + EVL);
+      return std::vector<AnyValue>(Vec.begin() + Offset,
+                                   Vec.begin() + Offset + EVL);
     }
     case Intrinsic::vector_reverse: {
       auto Vec = Args[0].asAggregate();


### PR DESCRIPTION
Using old GCC (7.5 in this case), we get a compile error about not being able to deduce the template paramerter:


```
/llvm/llvm/tools/llubi/lib/Interpreter.cpp:770:14: error: no viable constructor or deduction guide for deduction of template arguments of 'std::vector'
  770 |       return std::vector(Vec.begin() + Offset, Vec.begin() + Offset + DstSize);
```

The error was introduced in https://github.com/llvm/llvm-project/pull/194345.

Just specify the element type.