### PR TITLE
[libc][sched] Fix generated scheduler prototypes

### DIFF
--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -94,8 +94,6 @@ functions:
     return_type: int
     arguments:
       - type: pid_t
-      - type: int
-      - type: const struct sched_param *
   - name: sched_rr_get_interval
     standards:
       - POSIX
@@ -124,6 +122,8 @@ functions:
     return_type: int
     arguments:
       - type: pid_t
+      - type: int
+      - type: const struct sched_param *
   - name: sched_yield
     standards:
       - POSIX

--- a/libc/test/include/sched_test.cpp
+++ b/libc/test/include/sched_test.cpp
@@ -23,4 +23,12 @@ static_assert(SameType<decltype(CPU_COUNT((cpu_set_t *)0)), int>::value, "");
 static_assert(SameType<decltype(CPU_SET(0, (cpu_set_t *)0)), void>::value, "");
 static_assert(SameType<decltype(CPU_ISSET(0, (cpu_set_t *)0)), int>::value, "");
 
+using SchedGetSchedulerT = int(pid_t) noexcept;
+using SchedSetSchedulerT = int(pid_t, int, const struct sched_param *) noexcept;
+
+static_assert(SameType<decltype(sched_getscheduler), SchedGetSchedulerT>::value,
+              "");
+static_assert(SameType<decltype(sched_setscheduler), SchedSetSchedulerT>::value,
+              "");
+
 extern "C" int main() { return 0; }


### PR DESCRIPTION
Fixes generated <sched.h> prototypes for sched_getscheduler/sched_setscheduler and adds compile-time public-header coverage