### PR TITLE
[Clang][ItaniumMangle] Preserve field-name closure-prefix for instantiated lambdas

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -62,6 +62,9 @@ ABI Changes in This Version
   types, or ``_Complex float`` types are passed, and may introduce
   incompatibilities with code compiled by earlier versions of Clang that uses
   the ``__regcall`` calling convention on these targets. (#GH62999) (#GH98635)
+- Fixed Itanium mangling for lambdas in instantiated non-static data member
+  initializers by preserving the field-name closure-prefix. This changes the
+  mangled names for affected lambdas. (#GH190555)
 
 AST Dumping Potentially Breaking Changes
 ----------------------------------------

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3873,7 +3873,8 @@ bool Sema::InstantiateInClassInitializer(
   // we don't have a scope.
   ContextRAII SavedContext(*this, Instantiation->getParent());
   EnterExpressionEvaluationContext EvalContext(
-      *this, Sema::ExpressionEvaluationContext::PotentiallyEvaluated);
+      *this, Sema::ExpressionEvaluationContext::PotentiallyEvaluated,
+      Instantiation);
   ExprEvalContexts.back().DelayedDefaultInitializationContext = {
       PointOfInstantiation, Instantiation, CurContext};
 

--- a/clang/test/CodeGenCXX/dtor-local-lambda-mangle.cpp
+++ b/clang/test/CodeGenCXX/dtor-local-lambda-mangle.cpp
@@ -18,7 +18,7 @@ E::E() {
 template<typename T>
 E::E(T t) {
   struct {
-    // CHECK-DAG: _ZTSN1EC1IiEUt_UlvE_E
+    // CHECK-DAG: _ZTSN1EC1IiEUt_12anotherValueMUlvE_E
     int anotherValue = [x = 1] { return x; }();
   } obj;
 }

--- a/clang/test/CodeGenCXX/lambda-expressions-nested-linkage.cpp
+++ b/clang/test/CodeGenCXX/lambda-expressions-nested-linkage.cpp
@@ -43,8 +43,8 @@ L<int> l;
 // CHECK-LABEL: define linkonce_odr noundef i32 @_ZZNK12non_template1L1tMUliE_clEiENKUliE_clEi(ptr
 
 
-// CHECK-LABEL: define linkonce_odr void @_ZNK32lambdas_in_NSDMIs_template_class1LIiEUliE_clEi(ptr
-// CHECK-LABEL: define linkonce_odr noundef i32 @_ZZNK32lambdas_in_NSDMIs_template_class1LIiEUliE_clEiENKUliE_clEi(ptr
+// CHECK-LABEL: define linkonce_odr void @_ZNK32lambdas_in_NSDMIs_template_class1LIiE2t2MUliE_clEi(ptr
+// CHECK-LABEL: define linkonce_odr noundef i32 @_ZZNK32lambdas_in_NSDMIs_template_class1LIiE2t2MUliE_clEiENKUliE_clEi(ptr
 
 // CHECK-LABEL: define linkonce_odr void @_ZZN15inline_function3fooEvENKUliE_clEi
 // CHECK-LABEL: define linkonce_odr noundef signext i8 @_ZZZN15inline_function3fooEvENKUliE_clEiENKUlcE_clEc


### PR DESCRIPTION
Previously, instantiation did not pass `LambdaContextDecl`, so the NSDMI lambda in the class template used the wrong `ContextDecl`.

Fixes: #190555 