### PR TITLE
[libc][unistd] Fix generated at-function prototypes

### DIFF
--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -330,6 +330,7 @@ functions:
       - POSIX
     return_type: ssize_t
     arguments:
+      - type: int
       - type: const char *__restrict
       - type: char *__restrict
       - type: size_t
@@ -365,7 +366,6 @@ functions:
       - POSIX
     return_type: int
     arguments:
-      - type: int
       - type: const char *
       - type: int
       - type: const char *


### PR DESCRIPTION
Fixes generated <unistd.h> prototypes for readlinkat/symlinkat and adds compile-time public-header coverage