### PR TITLE
[llvm-dwarfdump][LineCov 3/3] Add IR analysis for variable coverage

### DIFF
--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -205,8 +205,9 @@ OPTIONS
 
 .. option:: --variable-coverage-bitcode-file
 
-            File containing bitcode used for calculating variable definedness
-            in coverage statistics (implies :option:`--show-variable-coverage`)
+            File containing LLVM IR (bitcode or textual) used for calculating
+            variable definedness in coverage statistics (implies
+            :option:`--show-variable-coverage`)
 
 .. option:: --combine-inline-variable-instances
 

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -203,6 +203,11 @@ OPTIONS
             File to use as the baseline for variable coverage statistics
             (implies :option:`--show-variable-coverage`)
 
+.. option:: --variable-coverage-bitcode-file
+
+            File containing bitcode used for calculating variable definedness
+            in coverage statistics (implies :option:`--show-variable-coverage`)
+
 .. option:: --combine-inline-variable-instances
 
             Use with :option:`--show-variable-coverage` to average variable

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -36,3 +36,27 @@ BASELINE-NEXT: fn1 u test.c:4 1 14 0.0714 7 0.5
 BASELINE-NEXT: fn1 v test.c:13 0 14 0 7 0.5
 BASELINE-NEXT: fn1 x test.c:3 7 14 0.5 7 0.5
 BASELINE-NEXT: fn1 y test.c:3 7 14 0.5 7 0.5
+
+RUN: llvm-dwarfdump --show-variable-coverage --variable-coverage-bitcode-file=%S/Inputs/coverage.ll %t.o | FileCheck %s --check-prefix=BITCODE
+
+BITCODE:      Variable coverage statistics:
+BITCODE-NEXT: Function InlChain Variable Decl LinesCovered
+BITCODE-NEXT: f k test.c:20 2
+BITCODE-NEXT: f l test.c:20 3
+BITCODE-NEXT: fn1 a test.c:11 6
+BITCODE-NEXT: fn1 u test.c:4 12
+BITCODE-NEXT: fn1 v test.c:13 4
+BITCODE-NEXT: fn1 x test.c:3 13
+BITCODE-NEXT: fn1 y test.c:3 13
+
+RUN: llvm-dwarfdump --show-variable-coverage --variable-coverage-bitcode-file=%S/Inputs/coverage.ll --coverage-baseline %t.o %t-opt.o | FileCheck %s --check-prefix=BASELINE-BITCODE
+
+BASELINE-BITCODE:      Variable coverage statistics:
+BASELINE-BITCODE-NEXT: Function InlChain Variable Decl LinesCovered Baseline CoveredRatio LinesPresent LinesPresentRatio
+BASELINE-BITCODE-NEXT: f k test.c:20 2 2 1 2 1
+BASELINE-BITCODE-NEXT: f l test.c:20 3 3 1 3 1
+BASELINE-BITCODE-NEXT: fn1 a test.c:11 3 6 0.5 3 0.5
+BASELINE-BITCODE-NEXT: fn1 u test.c:4 1 12 0.0833 5 0.417
+BASELINE-BITCODE-NEXT: fn1 v test.c:13 0 4 0 2 0.5
+BASELINE-BITCODE-NEXT: fn1 x test.c:3 6 13 0.462 6 0.462
+BASELINE-BITCODE-NEXT: fn1 y test.c:3 6 13 0.462 6 0.462

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -14,6 +14,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/IR/CFG.h"
+#include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DebugProgramInstruction.h"
 #include "llvm/IR/Instructions.h"
@@ -27,12 +28,15 @@ using namespace llvm;
 using namespace llvm::dwarf;
 using namespace llvm::object;
 
-typedef std::pair<std::string, std::string> StringPair;
 /// Pair of file index and line number representing a source location.
 typedef std::pair<uint16_t, size_t> SourceLocation;
-typedef std::map<StringPair,
-                 std::optional<DenseSet<std::pair<StringRef, uint32_t>>>>
-    LineMap;
+/// Pair of subroutine name and variable name representing a local variable.
+typedef std::pair<std::string, std::string> BitcodeVarKey;
+/// Pair of file name and line number representing a source location.
+typedef std::pair<StringRef, uint32_t> BitcodeSourceLocation;
+/// Maps local variables found in the bitcode to a set of source locations.
+typedef std::map<BitcodeVarKey, std::optional<DenseSet<BitcodeSourceLocation>>>
+    BitcodeLineMap;
 
 /// Adds source locations to the line set that correspond to an address range.
 static void addLines(const DWARFDebugLine::LineTable *LineTable,
@@ -93,10 +97,12 @@ convertFileIndices(DenseSet<SourceLocation> Lines,
 /// Returns the set of source lines covered by a variable's debug information,
 /// computed by intersecting the variable's location ranges and the containing
 /// scope's address ranges.
-static DenseSet<SourceLocation> computeVariableCoverage(
-    DWARFDie VariableDIE, const DWARFDebugLine::LineTable *const LineTable,
-    DenseMap<uint16_t, uint16_t> &FileIndexMap,
-    StringMap<uint16_t> &FileNameMap, LineMap::value_type *DefinedLines) {
+static DenseSet<SourceLocation>
+computeVariableCoverage(DWARFDie VariableDIE,
+                        const DWARFDebugLine::LineTable *const LineTable,
+                        DenseMap<uint16_t, uint16_t> &FileIndexMap,
+                        StringMap<uint16_t> &FileNameMap,
+                        BitcodeLineMap::value_type *DefinedLines) {
   // The optionals below will be empty if no address ranges were found, and
   // present (but containing an empty set) if ranges were found but contained no
   // source locations, in order to distinguish the two cases.
@@ -150,7 +156,7 @@ static DenseSet<SourceLocation> computeVariableCoverage(
           IndexLines.insert({NameIt->second, L.second});
       }
       if (!Lines)
-        ResultLines = std::move(IndexLines);
+        assert("Source lines found in bitcode but not in DWARF");
       else
         set_intersect(ResultLines, IndexLines);
     }
@@ -226,108 +232,127 @@ static bool isInScope(MDNode *Scope, const DebugLoc &Loc) {
   return true;
 }
 
-static bool isLoop(BasicBlock *Origin, BasicBlock *BB,
-                   SmallPtrSet<BasicBlock *, 8> &Visited) {
-  for (auto *P : predecessors(BB)) {
-    if (P == Origin)
+/// Determines whether an instruction stores to a location. For the purposes of
+/// this analysis, we consider any call-like instruction with the location as an
+/// argument to be a store to it.
+static bool isStoreToLocation(const DataLayout &DL, Instruction &I,
+                              Value *Loc) {
+  std::optional<at::AssignmentInfo> Info;
+  if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
+    if (SI->getPointerOperand() == Loc)
       return true;
-    if (!Visited.count(P)) {
-      Visited.insert(P);
-      if (isLoop(Origin, P, Visited))
-        return true;
-    }
+    Info = at::getAssignmentInfo(DL, SI);
+  } else if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(&I)) {
+    if (MI->getDest() == Loc)
+      return true;
+    Info = at::getAssignmentInfo(DL, MI);
+  } else if (CallBase *CI = dyn_cast<CallBase>(&I)) {
+    return CI->hasArgument(Loc);
   }
-  return false;
+  return Info && Info->Base == Loc;
 }
+
+typedef SmallDenseMap<BasicBlock *, Instruction *, 8> VarDefinitionMap;
 
 struct VarState {
   DbgVariableRecord &DVR;
-  DenseSet<std::pair<StringRef, uint32_t>> Lines;
-  SmallPtrSet<BasicBlock *, 8> LiveOut;
+  VarDefinitionMap Definitions;
 };
 
-/// Given an instruction that stores to a variable and its basic block,
-/// recursively searches its successor instructions/basic blocks and adds lines
-/// where the variable has a defined value to the variable's line set.
-static void getSuccessorLines(VarState &Var, BasicBlock *BB, Instruction *I) {
-  // Process the basic block if it contains the store instruction or the
-  // variable is defined in all of its predecessors, excluding any that are part
-  // of a loop that contains the current block.
-  bool ShouldProcess = I;
-  if (!ShouldProcess) {
-    ShouldProcess = true;
-    for (auto *P : predecessors(BB)) {
-      SmallPtrSet<BasicBlock *, 8> Visited;
-      if (!Var.LiveOut.count(P) && !isLoop(BB, P, Visited)) {
-        ShouldProcess = false;
-        break;
-      }
-    }
-  }
-  if (!ShouldProcess || Var.LiveOut.count(BB))
-    return;
-  Var.LiveOut.insert(BB);
-
-  // Add lines that are within the variable's scope, starting from the store
-  // instruction or the start of the block if this is a successor block.
-  auto *Next = I ? I : &BB->front();
+/// Adds source locations to the line set for instructions in a basic block,
+/// starting with a specific instruction.
+static void addModuleLines(Instruction *I, VarState &Var,
+                           DenseSet<std::pair<StringRef, uint32_t>> &Lines) {
   auto *VarScope = Var.DVR.getVariable()->getScope();
   do {
-    auto &Loc = Next->getDebugLoc();
+    auto &Loc = I->getDebugLoc();
     DIScope *Scope;
     if (Loc && isInScope(VarScope, Loc) && Loc.getLine() &&
         (Scope = dyn_cast_if_present<DIScope>(Loc.getScope()))) {
-      Var.Lines.insert({Scope->getFilename(), Loc.getLine()});
+      Lines.insert({Scope->getFilename(), Loc.getLine()});
     }
-  } while ((Next = Next->getNextNode()));
-  for (auto *S : successors(BB))
-    getSuccessorLines(Var, S, nullptr);
+  } while ((I = I->getNextNode()));
 }
 
 /// Computes the defined lines of all variables in an IR module.
-static LineMap processModule(Module *Mod) {
-  LineMap Result;
-
+static BitcodeLineMap processModule(Module *Mod) {
+  BitcodeLineMap Result;
+  std::vector<VarState> Vars;
   for (auto &F : Mod->functions()) {
-    std::vector<VarState> Vars;
+    Vars.clear();
     for (auto &BB : F) {
       for (auto &I : BB) {
         for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange())) {
+          if (DVR.isKillLocation()) {
+            assert("Variable in bitcode has been optimized out");
+            continue;
+          }
           if (DVR.isDbgDeclare()) {
             // For #dbg_declare, don't treat the variable as live until we find
             // a store to it.
-            Vars.push_back({DVR, {}, {}});
+            Vars.push_back(VarState{DVR, VarDefinitionMap()});
           } else if (DVR.isDbgValue()) {
             // For #dbg_value, the variable is live immediately from this point.
+            if (DVR.getDebugLoc().getInlinedAt() != nullptr) {
+              assert("Variable in bitcode has been inlined");
+              continue;
+            }
             auto Var = find_if(Vars, [&](auto &Var) {
               return Var.DVR.getVariable() == DVR.getVariable();
             });
-            if (Var != Vars.end()) {
-              getSuccessorLines(*Var, &BB, &I);
-            } else {
-              Vars.push_back({DVR, {}, {}});
-              getSuccessorLines(Vars.back(), &BB, &I);
-            }
+            if (Var != Vars.end())
+              // If a basic block contains multiple stores to a variable, use
+              // the earliest one by allowing the insertion to silently fail if
+              // the basic block is already in the map.
+              Var->Definitions.insert({&BB, &I});
+            else
+              Vars.push_back(VarState{DVR, {{&BB, &I}}});
           }
         }
       }
     }
 
-    // Search for stores to any declared variables. For the purposes of this
-    // analysis, we consider any instruction that isn't a load and has the
-    // variable as an operand to potentially store to it.
     for (auto &BB : F)
       for (auto &I : BB)
-        if (I.getOpcode() != Instruction::Load)
-          for (auto *Value : I.operand_values())
-            for (auto &Var : Vars)
-              if (Value == Var.DVR.getValue())
-                // The variable is live from the instruction after the store.
-                getSuccessorLines(Var, &BB, I.getNextNode());
+        for (auto &Var : Vars)
+          if (isStoreToLocation(Mod->getDataLayout(), I, Var.DVR.getValue()))
+            // The variable is live from the instruction after the store. As
+            // above, the earliest store in this basic block will be used.
+            Var.Definitions.insert({&BB, I.getNextNode()});
 
     for (auto &Var : Vars) {
-      StringPair Key(F.getName(), Var.DVR.getVariable()->getName());
-      Result.emplace(Key, Var.Lines);
+      SmallPtrSet<BasicBlock *, 8> Visited;
+      DenseSet<std::pair<StringRef, uint32_t>> Lines;
+
+      // Visit all basic blocks that are reachable from the entry block without
+      // going through a block that stores to the variable.
+      SmallVector<BasicBlock *> BlocksToVisit{&F.getEntryBlock()};
+      while (!BlocksToVisit.empty()) {
+        BasicBlock *BB = BlocksToVisit.pop_back_val();
+        if (!Visited.insert(BB).second)
+          continue;
+
+        auto I = Var.Definitions.find(BB);
+        if (I != Var.Definitions.end()) {
+          // Block contains a definition: add all lines after it to the set
+          if (I->second != nullptr)
+            addModuleLines(I->second, Var, Lines);
+        } else {
+          // Block does not contain a definition: visit its successors
+          auto S = successors(BB);
+          BlocksToVisit.append(S.begin(), S.end());
+        }
+      }
+
+      // All unvisited basic blocks must only be reachable by going through a
+      // block that stores to the variable, so add lines to the set for all of
+      // their instructions.
+      for (auto &BB : F)
+        if (!Visited.count(&BB))
+          addModuleLines(&*BB.begin(), Var, Lines);
+
+      BitcodeVarKey Key(F.getName(), Var.DVR.getVariable()->getName());
+      Result.emplace(Key, Lines);
     }
   }
   return Result;
@@ -435,7 +460,7 @@ bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
                                      DWARFContext *BaselineCtx,
                                      StringRef BitcodeFile,
                                      bool CombineInstances, raw_ostream &OS) {
-  LineMap LM;
+  BitcodeLineMap LM;
   LLVMContext Context;
   if (!BitcodeFile.empty()) {
     SMDiagnostic Err;

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -27,8 +27,12 @@ using namespace llvm;
 using namespace llvm::dwarf;
 using namespace llvm::object;
 
+typedef std::pair<std::string, std::string> StringPair;
 /// Pair of file index and line number representing a source location.
 typedef std::pair<uint16_t, size_t> SourceLocation;
+typedef std::map<StringPair,
+                 std::optional<DenseSet<std::pair<StringRef, uint32_t>>>>
+    LineMap;
 
 /// Adds source locations to the line set that correspond to an address range.
 static void addLines(const DWARFDebugLine::LineTable *LineTable,
@@ -48,9 +52,9 @@ static void addLines(const DWARFDebugLine::LineTable *LineTable,
   }
 }
 
-// Converts the file index of each line in the set to use our own internal
-// file index. This is required for a reliable comparison as the DWARF index may
-// differ across compilations.
+/// Converts the file index of each line in the set to use our own internal
+/// file index. This is required for a reliable comparison as the DWARF index
+/// may differ across compilations.
 static DenseSet<SourceLocation>
 convertFileIndices(DenseSet<SourceLocation> Lines,
                    const DWARFDebugLine::LineTable *const LineTable,
@@ -89,11 +93,10 @@ convertFileIndices(DenseSet<SourceLocation> Lines,
 /// Returns the set of source lines covered by a variable's debug information,
 /// computed by intersecting the variable's location ranges and the containing
 /// scope's address ranges.
-static DenseSet<SourceLocation>
-computeVariableCoverage(DWARFDie VariableDIE,
-                        const DWARFDebugLine::LineTable *const LineTable,
-                        DenseMap<uint16_t, uint16_t> &FileIndexMap,
-                        StringMap<uint16_t> &FileNameMap) {
+static DenseSet<SourceLocation> computeVariableCoverage(
+    DWARFDie VariableDIE, const DWARFDebugLine::LineTable *const LineTable,
+    DenseMap<uint16_t, uint16_t> &FileIndexMap,
+    StringMap<uint16_t> &FileNameMap, LineMap::value_type *DefinedLines) {
   // The optionals below will be empty if no address ranges were found, and
   // present (but containing an empty set) if ranges were found but contained no
   // source locations, in order to distinguish the two cases.
@@ -132,11 +135,28 @@ computeVariableCoverage(DWARFDie VariableDIE,
   else if (ParentLines)
     set_intersect(*Lines, *ParentLines);
 
-  if (!Lines)
-    return {};
+  auto ResultLines =
+      convertFileIndices(Lines.value_or(DenseSet<SourceLocation>()), LineTable,
+                         FileIndexMap, FileNameMap);
 
-  return convertFileIndices(Lines.value_or(DenseSet<SourceLocation>()),
-                            LineTable, FileIndexMap, FileNameMap);
+  if (DefinedLines) {
+    // Remove any lines where the variable does not have a defined value.
+    auto &DL = DefinedLines->second;
+    if (DL) {
+      DenseSet<SourceLocation> IndexLines;
+      for (const auto &L : *DL) {
+        auto NameIt = FileNameMap.find(L.first);
+        if (NameIt != FileNameMap.end())
+          IndexLines.insert({NameIt->second, L.second});
+      }
+      if (!Lines)
+        ResultLines = std::move(IndexLines);
+      else
+        set_intersect(ResultLines, IndexLines);
+    }
+  }
+
+  return ResultLines;
 }
 
 /// Adds source locations to the line set that are within an inlined subroutine.
@@ -193,6 +213,124 @@ static const SmallVector<DWARFDie> getParentSubroutines(DWARFDie DIE) {
       Parents.push_back(Parent);
   } while ((Parent = Parent.getParent()));
   return Parents;
+}
+
+static bool isInScope(MDNode *Scope, const DebugLoc &Loc) {
+  MDNode *Parent = Loc.getScope();
+  while (Parent != Scope) {
+    auto *S = dyn_cast_if_present<DIScope>(Parent);
+    if (!S)
+      return false;
+    Parent = S->getScope();
+  }
+  return true;
+}
+
+static bool isLoop(BasicBlock *Origin, BasicBlock *BB,
+                   SmallPtrSet<BasicBlock *, 8> &Visited) {
+  for (auto *P : predecessors(BB)) {
+    if (P == Origin)
+      return true;
+    if (!Visited.count(P)) {
+      Visited.insert(P);
+      if (isLoop(Origin, P, Visited))
+        return true;
+    }
+  }
+  return false;
+}
+
+struct VarState {
+  DbgVariableRecord &DVR;
+  DenseSet<std::pair<StringRef, uint32_t>> Lines;
+  SmallPtrSet<BasicBlock *, 8> LiveOut;
+};
+
+/// Given an instruction that stores to a variable and its basic block,
+/// recursively searches its successor instructions/basic blocks and adds lines
+/// where the variable has a defined value to the variable's line set.
+static void getSuccessorLines(VarState &Var, BasicBlock *BB, Instruction *I) {
+  // Process the basic block if it contains the store instruction or the
+  // variable is defined in all of its predecessors, excluding any that are part
+  // of a loop that contains the current block.
+  bool ShouldProcess = I;
+  if (!ShouldProcess) {
+    ShouldProcess = true;
+    for (auto *P : predecessors(BB)) {
+      SmallPtrSet<BasicBlock *, 8> Visited;
+      if (!Var.LiveOut.count(P) && !isLoop(BB, P, Visited)) {
+        ShouldProcess = false;
+        break;
+      }
+    }
+  }
+  if (!ShouldProcess || Var.LiveOut.count(BB))
+    return;
+  Var.LiveOut.insert(BB);
+
+  // Add lines that are within the variable's scope, starting from the store
+  // instruction or the start of the block if this is a successor block.
+  auto *Next = I ? I : &BB->front();
+  auto *VarScope = Var.DVR.getVariable()->getScope();
+  do {
+    auto &Loc = Next->getDebugLoc();
+    DIScope *Scope;
+    if (Loc && isInScope(VarScope, Loc) && Loc.getLine() &&
+        (Scope = dyn_cast_if_present<DIScope>(Loc.getScope()))) {
+      Var.Lines.insert({Scope->getFilename(), Loc.getLine()});
+    }
+  } while ((Next = Next->getNextNode()));
+  for (auto *S : successors(BB))
+    getSuccessorLines(Var, S, nullptr);
+}
+
+/// Computes the defined lines of all variables in an IR module.
+static LineMap processModule(Module *Mod) {
+  LineMap Result;
+
+  for (auto &F : Mod->functions()) {
+    std::vector<VarState> Vars;
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange())) {
+          if (DVR.isDbgDeclare()) {
+            // For #dbg_declare, don't treat the variable as live until we find
+            // a store to it.
+            Vars.push_back({DVR, {}, {}});
+          } else if (DVR.isDbgValue()) {
+            // For #dbg_value, the variable is live immediately from this point.
+            auto Var = find_if(Vars, [&](auto &Var) {
+              return Var.DVR.getVariable() == DVR.getVariable();
+            });
+            if (Var != Vars.end()) {
+              getSuccessorLines(*Var, &BB, &I);
+            } else {
+              Vars.push_back({DVR, {}, {}});
+              getSuccessorLines(Vars.back(), &BB, &I);
+            }
+          }
+        }
+      }
+    }
+
+    // Search for stores to any declared variables. For the purposes of this
+    // analysis, we consider any instruction that isn't a load and has the
+    // variable as an operand to potentially store to it.
+    for (auto &BB : F)
+      for (auto &I : BB)
+        if (I.getOpcode() != Instruction::Load)
+          for (auto *Value : I.operand_values())
+            for (auto &Var : Vars)
+              if (Value == Var.DVR.getValue())
+                // The variable is live from the instruction after the store.
+                getSuccessorLines(Var, &BB, I.getNextNode());
+
+    for (auto &Var : Vars) {
+      StringPair Key(F.getName(), Var.DVR.getVariable()->getName());
+      Result.emplace(Key, Var.Lines);
+    }
+  }
+  return Result;
 }
 
 struct VarKey {
@@ -295,7 +433,19 @@ static void displayVariableCoverage(const VarKey &Key, const VarCoverage &Var,
 bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
                                      ObjectFile *BaselineObj,
                                      DWARFContext *BaselineCtx,
+                                     StringRef BitcodeFile,
                                      bool CombineInstances, raw_ostream &OS) {
+  LineMap LM;
+  LLVMContext Context;
+  if (!BitcodeFile.empty()) {
+    SMDiagnostic Err;
+    std::unique_ptr<Module> Mod = parseIRFile(BitcodeFile, Err, Context);
+    if (!Err.getMessage().empty())
+      Err.print("llvm-dwarfdump", OS);
+    else
+      LM = processModule(Mod.get());
+  }
+
   BaselineVarMap BaselineVars;
   StringMap<uint16_t> FileNameMap;
 
@@ -317,8 +467,10 @@ bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
         if (!Key)
           continue;
 
-        auto Cov =
-            computeVariableCoverage(VariableDIE, LT, FileIndexMap, FileNameMap);
+        const auto DefinedLines = LM.find({Key->SubprogramName, Key->Name});
+        auto Cov = computeVariableCoverage(
+            VariableDIE, LT, FileIndexMap, FileNameMap,
+            DefinedLines != LM.end() ? &*DefinedLines : nullptr);
         const auto SubroutineCov = computeSubroutineCoverage(
             SubroutineDIE, LT, FileIndexMap, FileNameMap);
         set_intersect(Cov, SubroutineCov);
@@ -349,8 +501,10 @@ bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
       if (!Key)
         continue;
 
-      auto Cov =
-          computeVariableCoverage(VariableDIE, LT, FileIndexMap, FileNameMap);
+      const auto DefinedLines = LM.find({Key->SubprogramName, Key->Name});
+      auto Cov = computeVariableCoverage(
+          VariableDIE, LT, FileIndexMap, FileNameMap,
+          DefinedLines != LM.end() ? &*DefinedLines : nullptr);
       const auto SubroutineCov = computeSubroutineCoverage(
           SubroutineDIE, LT, FileIndexMap, FileNameMap);
       set_intersect(Cov, SubroutineCov);

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -63,7 +63,7 @@ static DenseSet<SourceLocation>
 convertFileIndices(DenseSet<SourceLocation> Lines,
                    const DWARFDebugLine::LineTable *const LineTable,
                    DenseMap<uint16_t, uint16_t> &FileIndexMap,
-                   StringMap<uint16_t> &FileNameMap) {
+                   StringMap<std::optional<uint16_t>> &FileNameMap) {
   DenseSet<SourceLocation> ResultLines;
   for (const auto &L : Lines) {
     uint16_t Index;
@@ -78,8 +78,8 @@ convertFileIndices(DenseSet<SourceLocation> Lines,
       assert(ValidIndex && "File index was not valid for its own line table");
 
       auto NameIt = FileNameMap.find(Name);
-      if (NameIt != FileNameMap.end()) {
-        Index = NameIt->second;
+      if (NameIt != FileNameMap.end() && NameIt->second) {
+        Index = *NameIt->second;
       } else {
         Index = FileNameMap.size();
         FileNameMap.insert({Name, Index});
@@ -101,7 +101,7 @@ static DenseSet<SourceLocation>
 computeVariableCoverage(DWARFDie VariableDIE,
                         const DWARFDebugLine::LineTable *const LineTable,
                         DenseMap<uint16_t, uint16_t> &FileIndexMap,
-                        StringMap<uint16_t> &FileNameMap,
+                        StringMap<std::optional<uint16_t>> &FileNameMap,
                         BitcodeLineMap::value_type *DefinedLines) {
   // The optionals below will be empty if no address ranges were found, and
   // present (but containing an empty set) if ranges were found but contained no
@@ -152,11 +152,29 @@ computeVariableCoverage(DWARFDie VariableDIE,
       DenseSet<SourceLocation> IndexLines;
       for (const auto &L : *DL) {
         auto NameIt = FileNameMap.find(L.first);
-        if (NameIt != FileNameMap.end())
-          IndexLines.insert({NameIt->second, L.second});
+        if (NameIt != FileNameMap.end()) {
+          if (NameIt->second)
+            IndexLines.insert({*NameIt->second, L.second});
+        } else {
+          // LineTable::getFileNameByIndex can return absolute paths even when
+          // relative paths are requested, so search for keys that end with this
+          // path as well.
+          for (const auto &NameEntry : FileNameMap) {
+            auto Name = NameEntry.first();
+            if (Name.find(L.first, Name.size() - L.first.size()) !=
+                std::string_view::npos) {
+              FileNameMap.insert({L.first, NameEntry.second});
+              IndexLines.insert({*NameEntry.second, L.second});
+            }
+          }
+          if (FileNameMap.find(L.first) == FileNameMap.end()) {
+            assert(0 && "Files found in bitcode but not in DWARF");
+            FileNameMap.insert({L.first, std::nullopt});
+          }
+        }
       }
       if (!Lines)
-        assert("Source lines found in bitcode but not in DWARF");
+        assert(0 && "Source lines found in bitcode but not in DWARF");
       else
         set_intersect(ResultLines, IndexLines);
     }
@@ -189,7 +207,7 @@ static DenseSet<SourceLocation>
 computeSubroutineCoverage(DWARFDie SubroutineDIE,
                           const DWARFDebugLine::LineTable *const LineTable,
                           DenseMap<uint16_t, uint16_t> &FileIndexMap,
-                          StringMap<uint16_t> &FileNameMap) {
+                          StringMap<std::optional<uint16_t>> &FileNameMap) {
   auto Ranges = SubroutineDIE.getAddressRanges();
   DenseSet<SourceLocation> Lines;
   if (Ranges) {
@@ -284,7 +302,7 @@ static BitcodeLineMap processModule(Module *Mod) {
       for (auto &I : BB) {
         for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange())) {
           if (DVR.isKillLocation()) {
-            assert("Variable in bitcode has been optimized out");
+            assert(0 && "Variable in bitcode has been optimized out");
             continue;
           }
           if (DVR.isDbgDeclare()) {
@@ -294,7 +312,7 @@ static BitcodeLineMap processModule(Module *Mod) {
           } else if (DVR.isDbgValue()) {
             // For #dbg_value, the variable is live immediately from this point.
             if (DVR.getDebugLoc().getInlinedAt() != nullptr) {
-              assert("Variable in bitcode has been inlined");
+              assert(0 && "Variable in bitcode has been inlined");
               continue;
             }
             auto Var = find_if(Vars, [&](auto &Var) {
@@ -312,13 +330,17 @@ static BitcodeLineMap processModule(Module *Mod) {
       }
     }
 
-    for (auto &BB : F)
-      for (auto &I : BB)
-        for (auto &Var : Vars)
-          if (isStoreToLocation(Mod->getDataLayout(), I, Var.DVR.getValue()))
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        for (auto &Var : Vars) {
+          if (isStoreToLocation(Mod->getDataLayout(), I, Var.DVR.getValue())) {
             // The variable is live from the instruction after the store. As
             // above, the earliest store in this basic block will be used.
             Var.Definitions.insert({&BB, I.getNextNode()});
+          }
+        }
+      }
+    }
 
     for (auto &Var : Vars) {
       SmallPtrSet<BasicBlock *, 8> Visited;
@@ -472,7 +494,7 @@ bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
   }
 
   BaselineVarMap BaselineVars;
-  StringMap<uint16_t> FileNameMap;
+  StringMap<std::optional<uint16_t>> FileNameMap;
 
   if (BaselineCtx) {
     for (const auto &U : BaselineCtx->info_section_units()) {

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -343,11 +343,12 @@ static opt<std::string>
                      desc("File to use as the baseline for variable coverage "
                           "statistics (implies --show-variable-coverage)"),
                      value_desc("filename"), cat(DwarfDumpCategory));
-static opt<std::string> BitcodeFile(
-    "variable-coverage-bitcode-file",
-    desc("File containing bitcode used for calculating variable definedness in "
-         "coverage statistics (implies --show-variable-coverage)"),
-    value_desc("filename"), cat(DwarfDumpCategory));
+static opt<std::string>
+    BitcodeFile("variable-coverage-bitcode-file",
+                desc("File containing LLVM IR (bitcode or textual) used for "
+                     "calculating variable definedness in coverage statistics "
+                     "(implies --show-variable-coverage)"),
+                value_desc("filename"), cat(DwarfDumpCategory));
 static opt<bool> CombineInstances(
     "combine-inline-variable-instances",
     desc(
@@ -926,7 +927,7 @@ int main(int argc, char **argv) {
   if (DumpAll)
     DumpType = DIDT_All;
   if (DumpType == DIDT_Null && !ShowVariableCoverage &&
-      CoverageBaseline.empty()) {
+      CoverageBaseline.empty() && BitcodeFile.empty()) {
     if (Verbose || Verify)
       DumpType = DIDT_All;
     else

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -343,6 +343,11 @@ static opt<std::string>
                      desc("File to use as the baseline for variable coverage "
                           "statistics (implies --show-variable-coverage)"),
                      value_desc("filename"), cat(DwarfDumpCategory));
+static opt<std::string> BitcodeFile(
+    "variable-coverage-bitcode-file",
+    desc("File containing bitcode used for calculating variable definedness in "
+         "coverage statistics (implies --show-variable-coverage)"),
+    value_desc("filename"), cat(DwarfDumpCategory));
 static opt<bool> CombineInstances(
     "combine-inline-variable-instances",
     desc(
@@ -980,17 +985,17 @@ int main(int argc, char **argv) {
       auto showCoverage = [&](ObjectFile &Obj, DWARFContext &DICtx,
                               const Twine &Filename, raw_ostream &OS) {
         return showVariableCoverage(Obj, DICtx, &BaselineObj, &BaselineCtx,
-                                    CombineInstances, OS);
+                                    BitcodeFile, CombineInstances, OS);
       };
       for (StringRef Object : Objects)
         Success &= handleFile(Object, showCoverage, OutputFile.os());
       return true;
     };
     Success &= handleFile(CoverageBaseline, handleBaseline, OutputFile.os());
-  } else if (ShowVariableCoverage) {
+  } else if (ShowVariableCoverage || !BitcodeFile.empty()) {
     auto showCoverage = [&](ObjectFile &Obj, DWARFContext &DICtx,
                             const Twine &Filename, raw_ostream &OS) {
-      return showVariableCoverage(Obj, DICtx, nullptr, nullptr,
+      return showVariableCoverage(Obj, DICtx, nullptr, nullptr, BitcodeFile,
                                   CombineInstances, OS);
     };
     for (StringRef Object : Objects)

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.h
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.h
@@ -41,8 +41,8 @@ bool collectObjectSectionSizes(object::ObjectFile &Obj, DWARFContext &DICtx,
 
 bool showVariableCoverage(object::ObjectFile &Obj, DWARFContext &DICtx,
                           object::ObjectFile *BaselineObj,
-                          DWARFContext *BaselineCtx, bool CombineInstances,
-                          raw_ostream &OS);
+                          DWARFContext *BaselineCtx, StringRef BitcodeFile,
+                          bool CombineInstances, raw_ostream &OS);
 } // namespace dwarfdump
 } // namespace llvm
 


### PR DESCRIPTION
Patch 3 of 3 to add to llvm-dwarfdump the ability to measure DWARF coverage of local variables in terms of source lines, as discussed in [this RFC](https://discourse.llvm.org/t/rfc-debug-info-coverage-tool-v2/83266).

This patch adds an IR-level analysis in order to more accurately compute the defined ranges for each variable. This avoids the problem of the more naïve approach relying on source scopes, which overcounts as coverable those lines where the variable is not yet defined (e.g. stack variables).

The IR analysis requires IR to be provided to llvm-dwarfdump as a separate `--variable-coverage-bitcode-file` argument (either textual IR or bitcode; can be produced by various means e.g. `--save-temps --emit-llvm`, `-ffat-lto-objects`, [wllvm](https://github.com/travitch/whole-program-llvm)). The recommended way to obtain a whole-program bitcode file is to use wllvm as follows:
```sh
$ export LLVM_COMPILER=clang
$ CC=wllvm make  # build as usual, but replace clang/clang++ with wllvm/wllvm++
$ extract-bc binfile  # produces binfile.bc, which can be passed to llvm-dwarfdump
```

Example output:
```
$ llvm-dwarfdump --show-variable-coverage somefile-O2 --coverage-baseline somefile-O0 --variable-coverage-bitcode-file somefile-O0.bc
Variable coverage statistics:
Function InlChain                   Variable Decl                  LinesCovered Baseline CoveredRatio LinesPresent LinesPresentRatio
foo                                 bar      path/to/somefile.h:54 3            6        0.5          5            0.833
foo      path/to/someotherfile.c:32 bar      path/to/somefile.h:54 2            6        0.333        5            0.833
foo                                 baz      main.c:76             9            12       0.75         9            0.75
```