### PR TITLE
[MLIR] Fix offload map metadata order

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/Dialect/OpenMPCommon.h
+++ b/mlir/include/mlir/Target/LLVMIR/Dialect/OpenMPCommon.h
@@ -24,10 +24,14 @@ namespace mlir {
 namespace LLVM {
 
 /// Create a constant string location from the MLIR Location information.
+/// When \p ForOffloadMap is true, the layout matches Clang's
+/// \c emitMappingInformation (first \c ';'-delimited field is the map name for
+/// \c libomptarget). When false, the layout matches \c ident_t (file then
+/// function name in the encoded string).
 llvm::Constant *createSourceLocStrFromLocation(Location loc,
                                                llvm::OpenMPIRBuilder &builder,
-                                               StringRef name,
-                                               uint32_t &strLen);
+                                               StringRef name, uint32_t &strLen,
+                                               bool ForOffloadMap = false);
 
 /// Create a constant string representing the mapping information extracted from
 /// the MLIR location information.

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMPCommon.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMPCommon.cpp
@@ -12,14 +12,16 @@
 
 #include "mlir/Target/LLVMIR/Dialect/OpenMPCommon.h"
 
-llvm::Constant *
-mlir::LLVM::createSourceLocStrFromLocation(Location loc,
-                                           llvm::OpenMPIRBuilder &builder,
-                                           StringRef name, uint32_t &strLen) {
+llvm::Constant *mlir::LLVM::createSourceLocStrFromLocation(
+    Location loc, llvm::OpenMPIRBuilder &builder, StringRef name,
+    uint32_t &strLen, bool forOffloadMap) {
   if (auto fileLoc = dyn_cast<FileLineColLoc>(loc)) {
     StringRef fileName = fileLoc.getFilename();
     unsigned lineNo = fileLoc.getLine();
     unsigned colNo = fileLoc.getColumn();
+    if (forOffloadMap)
+      return builder.getOrCreateSrcLocStr(fileName, name, lineNo, colNo,
+                                          strLen);
     return builder.getOrCreateSrcLocStr(name, fileName, lineNo, colNo, strLen);
   }
   std::string locStr;
@@ -35,7 +37,8 @@ mlir::LLVM::createMappingInformation(Location loc,
   if (auto nameLoc = dyn_cast<NameLoc>(loc)) {
     StringRef name = nameLoc.getName();
     return createSourceLocStrFromLocation(nameLoc.getChildLoc(), builder, name,
-                                          strLen);
+                                          strLen, /*forOffloadMap=*/true);
   }
-  return createSourceLocStrFromLocation(loc, builder, "unknown", strLen);
+  return createSourceLocStrFromLocation(loc, builder, "unknown", strLen,
+                                        /*forOffloadMap=*/true);
 }

--- a/mlir/test/Target/LLVMIR/openacc-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openacc-llvm.mlir
@@ -11,8 +11,8 @@ llvm.func @testenterdataop(%arg0: !llvm.ptr, %arg1 : !llvm.ptr) {
 
 // CHECK: @[[LOCSTR:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};testenterdataop;{{[0-9]*}};{{[0-9]*}};;\00", align 1
 // CHECK: @[[LOCGLOBAL:.*]] = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 {{[0-9]*}}, ptr @[[LOCSTR]] }, align 8
-// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00", align 1
-// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00", align 1
+// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00", align 1
+// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00", align 1
 // CHECK: @[[MAPTYPES:.*]] = private unnamed_addr constant [{{[0-9]*}} x i64] [i64 0, i64 1]
 // CHECK: @[[MAPNAMES:.*]] = private constant [{{[0-9]*}} x ptr] [ptr @[[MAPNAME1]], ptr @[[MAPNAME2]]]
 
@@ -60,8 +60,8 @@ llvm.func @testexitdataop(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
 
 // CHECK: @[[LOCSTR:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};testexitdataop;{{[0-9]*}};{{[0-9]*}};;\00"
 // CHECK: @[[LOCGLOBAL:.*]] = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 {{[0-9]*}}, ptr @[[LOCSTR]] }
-// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00"
-// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00"
+// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00"
+// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00"
 // CHECK: @[[MAPTYPES:.*]] = private unnamed_addr constant [{{[0-9]*}} x i64] [i64 8, i64 2]
 // CHECK: @[[MAPNAMES:.*]] = private constant [{{[0-9]*}} x ptr] [ptr @[[MAPNAME1]], ptr @[[MAPNAME2]]]
 
@@ -104,7 +104,7 @@ llvm.func @testupdateop(%arg1: !llvm.ptr) {
 
 // CHECK: [[LOCSTR:@.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};testupdateop;{{[0-9]*}};{{[0-9]*}};;\00", align 1
 // CHECK: [[LOCGLOBAL:@.*]] = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 {{[0-9]*}}, ptr [[LOCSTR]] }, align 8
-// CHECK: [[MAPNAME1:@.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00", align 1
+// CHECK: [[MAPNAME1:@.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00", align 1
 // CHECK: [[MAPTYPES:@.*]] = private unnamed_addr constant [{{[0-9]*}} x i64] [i64 1]
 // CHECK: [[MAPNAMES:@.*]] = private constant [{{[0-9]*}} x ptr] [ptr [[MAPNAME1]]]
 
@@ -147,8 +147,8 @@ llvm.func @testdataop(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
 // CHECK: %struct.ident_t = type { i32, i32, i32, i32, ptr }
 // CHECK: @[[LOCSTR:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};testdataop;{{[0-9]*}};{{[0-9]*}};;\00"
 // CHECK: @[[LOCGLOBAL:.*]] = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 {{[0-9]*}}, ptr @[[LOCSTR]] }
-// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00"
-// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";{{.*}};unknown;{{[0-9]*}};{{[0-9]*}};;\00"
+// CHECK: @[[MAPNAME1:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00"
+// CHECK: @[[MAPNAME2:.*]] = private unnamed_addr constant [{{[0-9]*}} x i8] c";unknown;{{.*}};{{[0-9]*}};{{[0-9]*}};;\00"
 // CHECK: @[[MAPTYPES:.*]] = private unnamed_addr constant [{{[0-9]*}} x i64] [i64 8193, i64 8192]
 // CHECK: @[[MAPNAMES:.*]] = private constant [{{[0-9]*}} x ptr] [ptr @[[MAPNAME1]], ptr @[[MAPNAME2]]]
 


### PR DESCRIPTION
This fixes one part of https://github.com/llvm/llvm-project/issues/195333.

There are two different semicolon-field orders in offload/include/Shared/SourceInfo.h:

1. Per-map strings (`map_var_info_t`): first field is the mapped name, second
is the file path:
```
/// Type alias for source location information for variable mappings with
/// data layout ";name;filename;row;col;;\0" from clang.
using map_var_info_t = void *;
```

2. `ident_t` region strings: first field is the file path, second is the
function name:
```
/// The ident structure that describes a source location from kmp.h. with
/// source location string data as ";filename;function;line;column;;\0".
struct ident_t {
```

`SourceInfo` reflects that with two constructors: `SourceInfo(const ident_t *)`
parses `getSubstring(0)` as the filename field and `getSubstring(1)` as the
name (function); `SourceInfo(const map_var_info_t)` uses `getSubstring(0)` for
the map name and `getSubstring(1)` for the filename path.

`OpenMPIRBuilder::getOrCreateSrcLocStr(FunctionName, FileName, line, col)`
always builds the same wire shape: the second parameter is emitted first,
then the first i.e. ;FileName;FunctionName;line;col;.

Clang passes arguments accordingly in two places:

1. per-map metadata (`emitMappingInformation`):
Calls `getOrCreateSrcLocStr(FileName, ExprName, ...)`
so the buffer is ";expr;path;…", matching `map_var_info_t` and
`getNameFromMapping`.

2. ident / update location (`emitUpdateLocation`):
Calls `getOrCreateSrcLocStr(FunctionName, FileName, ...)` so the buffer is
";file;function;…", matching ident_t.

MLIR previously called the same helper in only the ident-like way for both
uses which is why we see file paths in the map name slot.

I would have preferred if we can keep the same order in both cases. But I am not
aware of the history of why it was done like this. I have instead fixed it by adding
`ForOffloadMap` to `createSourceLocStrFromLocation` so mapping uses the same
argument order as Clang's `emitMappingInformation`, while ident-style callers
keep the existing order. 

Adjusted a test accordingly.