### PR TITLE
[lldb] Add lldb.summary and lldb.synthetic decorators

### DIFF
--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -282,6 +282,60 @@ def command(command_name=None, doc=None):
 
     return callable
 
+
+def _add_formatter(kind: str, type_name: str, options: dict):
+    import shlex
+
+    type_name = shlex.quote(type_name)
+
+    flag_list = []
+    # Convert `option=True` to "--option", all other cases convert to "--option value".
+    for key, value in options.values():
+        flag = key.replace("_", "-")
+        if value is True:
+            flag_list.append(f"--{flag}")
+        else:
+            flag_list.extend((f"--{flag}", value))
+
+    def decorator(obj):
+        qualified = f"{obj.__module__}.{obj.__qualname__}"
+        if isinstance(obj, type):
+            flag_list.extend(("--python-class", qualified))
+        elif callable(obj):
+            flag_list.extend(("--python-function", qualified))
+
+        result = SBCommandReturnObject()
+        flags = " ".join(flag_list)
+        interp = debugger.GetCommandInterpreter()
+        interp.HandleCommand(f"type {kind} add {flags} {type_name}", result)
+        if not result.Succeeded():
+            raise RuntimeError(result.GetError())
+        return obj
+
+    return decorator
+
+
+def summary(type_name, **kwargs):
+    """A decorator that registers a function as an LLDB type summary provider.
+
+    @lldb.summary("MyType")
+    def MyTypeSummary(valobj, _):
+        return "summary string"
+    """
+    return _add_formatter("summary", type_name, kwargs)
+
+
+def synthetic(type_name, **kwargs):
+    """A decorator that registers a class as an LLDB synthetic child provider.
+
+    @lldb.synthetic("MyType")
+    class MyTypeSynthetic:
+        def __init__(self, valobj, _):
+            ...
+    """
+    return _add_formatter("synthetic", type_name, kwargs)
+
+
 class declaration(object):
     '''A class that represents a source declaration location with file, line and column.'''
     def __init__(self, file, line, col):
@@ -608,45 +662,5 @@ def is_numeric_type(basic_type):
 %}
 
 %pythoncode %{
-
-def _type_spec(type_name, regex):
-    type_spec = f"'{type_name}'"
-    if regex:
-        type_spec = f"-x {type_spec}"
-    return type_spec
-
-def summary(type_name, regex=False):
-    """A decorator that registers a function as an LLDB type summary provider.
-
-    @lldb.summary("MyType")
-    def MyTypeSummary(valobj, internal_dict):
-        return "summary string"
-    """
-    type_spec = _type_spec(type_name, regex)
-    def decorator(func):
-        qualified = f"{func.__module__}.{func.__qualname__}"
-        func._lldb_register_command = f"type summary add -F {qualified} {type_spec}"
-        return func
-    return decorator
-
-def synthetic(type_name, regex=False):
-    """A decorator that registers a class as an LLDB synthetic child provider.
-
-    @lldb.synthetic("MyType")
-    class MyTypeSynthetic:
-        def __init__(self, valobj, internal_dict):
-            ...
-    """
-    type_spec = _type_spec(type_name, regex)
-    def decorator(cls):
-        qualified = f"{cls.__module__}.{cls.__qualname__}"
-        cls._lldb_register_command = f"type synthetic add -l {qualified} {type_spec}"
-        return cls
-    return decorator
-
-def _register_lldb_decorators(module, debugger):
-    for obj in vars(module).values():
-        if cmd := getattr(obj, '_lldb_register_command', None):
-            debugger.HandleCommand(cmd)
 
 %}

--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -290,7 +290,7 @@ def _add_formatter(kind: str, type_name: str, options: dict):
 
     # Convert `option=True` to "--option", all others to "--option value".
     flag_list = []
-    for key, value in options.values():
+    for key, value in options.items():
         flag = key.replace("_", "-")
         if value is True:
             flag_list.append(f"--{flag}")
@@ -658,9 +658,5 @@ def is_numeric_type(basic_type):
     if basic_type == eBasicTypeNullPtr: return (False,False)
     #if basic_type == eBasicTypeOther:
     return (False,False)
-
-%}
-
-%pythoncode %{
 
 %}

--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -288,8 +288,8 @@ def _add_formatter(kind: str, type_name: str, options: dict):
 
     type_name = shlex.quote(type_name)
 
+    # Convert `option=True` to "--option", all others to "--option value".
     flag_list = []
-    # Convert `option=True` to "--option", all other cases convert to "--option value".
     for key, value in options.values():
         flag = key.replace("_", "-")
         if value is True:

--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -283,7 +283,7 @@ def command(command_name=None, doc=None):
     return callable
 
 
-def _add_formatter(kind: str, type_name: str, options: dict):
+def _add_formatter(cmd: str, type_name: str, options: dict):
     import shlex
 
     type_name = shlex.quote(type_name)
@@ -307,7 +307,7 @@ def _add_formatter(kind: str, type_name: str, options: dict):
         result = SBCommandReturnObject()
         flags = " ".join(flag_list)
         interp = debugger.GetCommandInterpreter()
-        interp.HandleCommand(f"type {kind} add {flags} {type_name}", result)
+        interp.HandleCommand(f"{cmd} {flags} {type_name}", result)
         if not result.Succeeded():
             raise RuntimeError(result.GetError())
         return obj
@@ -322,7 +322,7 @@ def summary(type_name, **kwargs):
     def MyTypeSummary(valobj, _):
         return "summary string"
     """
-    return _add_formatter("summary", type_name, kwargs)
+    return _add_formatter("type summary add", type_name, kwargs)
 
 
 def synthetic(type_name, **kwargs):
@@ -333,7 +333,7 @@ def synthetic(type_name, **kwargs):
         def __init__(self, valobj, _):
             ...
     """
-    return _add_formatter("synthetic", type_name, kwargs)
+    return _add_formatter("type synthetic add", type_name, kwargs)
 
 
 class declaration(object):

--- a/lldb/bindings/python/python-extensions.swig
+++ b/lldb/bindings/python/python-extensions.swig
@@ -606,3 +606,47 @@ def is_numeric_type(basic_type):
     return (False,False)
 
 %}
+
+%pythoncode %{
+
+def _type_spec(type_name, regex):
+    type_spec = f"'{type_name}'"
+    if regex:
+        type_spec = f"-x {type_spec}"
+    return type_spec
+
+def summary(type_name, regex=False):
+    """A decorator that registers a function as an LLDB type summary provider.
+
+    @lldb.summary("MyType")
+    def MyTypeSummary(valobj, internal_dict):
+        return "summary string"
+    """
+    type_spec = _type_spec(type_name, regex)
+    def decorator(func):
+        qualified = f"{func.__module__}.{func.__qualname__}"
+        func._lldb_register_command = f"type summary add -F {qualified} {type_spec}"
+        return func
+    return decorator
+
+def synthetic(type_name, regex=False):
+    """A decorator that registers a class as an LLDB synthetic child provider.
+
+    @lldb.synthetic("MyType")
+    class MyTypeSynthetic:
+        def __init__(self, valobj, internal_dict):
+            ...
+    """
+    type_spec = _type_spec(type_name, regex)
+    def decorator(cls):
+        qualified = f"{cls.__module__}.{cls.__qualname__}"
+        cls._lldb_register_command = f"type synthetic add -l {qualified} {type_spec}"
+        return cls
+    return decorator
+
+def _register_lldb_decorators(module, debugger):
+    for obj in vars(module).values():
+        if cmd := getattr(obj, '_lldb_register_command', None):
+            debugger.HandleCommand(cmd)
+
+%}

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -1007,10 +1007,23 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleInit(
 
   // This method is optional and need not exist.  So if we don't find it,
   // it's actually a success, not a failure.
-  if (!pfunc.IsAllocated())
-    return true;
+  if (pfunc.IsAllocated())
+    pfunc(SWIGBridge::ToSWIGWrapper(debugger), dict);
 
-  pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), dict);
+  // Scan the module for @lldb.summary and @lldb.synthetic decorators.
+  auto lldb_module =
+      unwrapIgnoringErrors(PythonModule::Import("lldb"));
+  if (lldb_module.IsAllocated()) {
+    auto register_func =
+        lldb_module.ResolveName<PythonCallable>("_register_lldb_decorators");
+    if (register_func.IsAllocated()) {
+      auto user_module =
+          unwrapIgnoringErrors(PythonModule::Import(python_module_name));
+      if (user_module.IsAllocated())
+        register_func(std::move(user_module),
+                       SWIGBridge::ToSWIGWrapper(std::move(debugger)));
+    }
+  }
 
   return true;
 }

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -1007,23 +1007,10 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleInit(
 
   // This method is optional and need not exist.  So if we don't find it,
   // it's actually a success, not a failure.
-  if (pfunc.IsAllocated())
-    pfunc(SWIGBridge::ToSWIGWrapper(debugger), dict);
+  if (!pfunc.IsAllocated())
+    return true;
 
-  // Scan the module for @lldb.summary and @lldb.synthetic decorators.
-  auto lldb_module =
-      unwrapIgnoringErrors(PythonModule::Import("lldb"));
-  if (lldb_module.IsAllocated()) {
-    auto register_func =
-        lldb_module.ResolveName<PythonCallable>("_register_lldb_decorators");
-    if (register_func.IsAllocated()) {
-      auto user_module =
-          unwrapIgnoringErrors(PythonModule::Import(python_module_name));
-      if (user_module.IsAllocated())
-        register_func(std::move(user_module),
-                       SWIGBridge::ToSWIGWrapper(std::move(debugger)));
-    }
-  }
+  pfunc(SWIGBridge::ToSWIGWrapper(std::move(debugger)), dict);
 
   return true;
 }

--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -882,6 +882,10 @@ you to input a Python script as a summary:
   LLDB will emit a warning if it is unable to find the function you passed, but
   will still register the binding.
 
+- using the ``@lldb.summary`` decorator on a function definition. This combines
+  the definition and registration into a single step. See
+  :ref:`decorator-formatters` for details.
+
 Regular Expression Typenames
 ----------------------------
 
@@ -1146,6 +1150,10 @@ children provider in LLDB:
       y = "Hello world"
    }
 
+As an alternative to the two-step import-then-register pattern above, you can
+use the ``@lldb.synthetic`` decorator to combine both steps. See
+:ref:`decorator-formatters` for details.
+
 LLDB has synthetic children providers for a core subset of STL classes, both in
 the version provided by libstdcpp and by libcxx, as well as for several
 Foundation classes.
@@ -1211,6 +1219,100 @@ The reason for this is that classes might have an overloaded ``operator []``,
 or other special provisions and the expression command chooses to ignore
 synthetic children in the interest of equivalency with code you asked to have
 compiled from source.
+
+.. _decorator-formatters:
+
+Decorator-Based Formatter Registration
+---------------------------------------
+
+Beginning in version 23, LLDB provides Python decorators that combine the
+definition and registration of formatters into a single step. When a module
+using these decorators is loaded via ``command script import``, the formatters
+are automatically registered.
+
+``@lldb.summary``
++++++++++++++++++
+
+The ``@lldb.summary`` decorator registers a Python function as a type summary
+provider:
+
+.. code-block:: python
+
+   import lldb
+
+   @lldb.summary("Person")
+   def PersonSummary(valobj: lldb.SBValue, _) -> str:
+       name = valobj.GetChildMemberWithName("name").GetSummary()
+       age = valobj.GetChildMemberWithName("age").GetValueAsUnsigned()
+       return f"name={name}, age={age}"
+
+This is equivalent to defining the function and then running:
+
+::
+
+   (lldb) type summary add --python-function module.PersonSummary Person
+
+``@lldb.synthetic``
++++++++++++++++++++
+
+The ``@lldb.synthetic`` decorator registers a Python class as a synthetic child
+provider:
+
+.. code-block:: python
+
+   import lldb
+
+   @lldb.synthetic("Person")
+   class PersonChildren:
+       def __init__(self, valobj: lldb.SBValue, _) -> None:
+           self.valobj = valobj
+
+       def update(self) -> bool:
+           self.name = self.valobj.GetChildMemberWithName("name")
+           self.age = self.valobj.GetChildMemberWithName("age")
+           return True
+
+       def num_children(self) -> int:
+           return 2
+
+       def get_child_at_index(self, index) -> lldb.SBValue:
+           if index == 0:
+               return self.name
+           if index == 1:
+               return self.age
+           return lldb.SBValue()
+
+This is equivalent to defining the class and then running:
+
+::
+
+   (lldb) type synthetic add --python-class module.PersonChildren Person
+
+Passing Options
++++++++++++++++
+
+Both decorators accept keyword arguments that map to command-line flags of the
+corresponding ``type summary add`` or ``type synthetic add`` commands.
+Underscores in keyword names are converted to hyphens. A value of ``True``
+produces a bare flag; any other value is passed as the flag's argument.
+
+For example, to register a summary for a regex type pattern with the expand
+flag:
+
+.. code-block:: python
+
+   @lldb.summary("^std::vector<.+>$", regex=True, expand=True)
+   def VectorSummary(valobj, internal_dict):
+       ...
+
+This is equivalent to:
+
+::
+
+   (lldb) type summary add --python-function module.VectorSummary --regex --expand "^std::vector<.+>$"
+
+Other commonly used options include ``category`` to place the formatter in a
+specific category.
 
 Filters
 -------

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/Makefile
@@ -1,0 +1,2 @@
+CXX_SOURCES := main.cpp
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
@@ -1,0 +1,31 @@
+"""
+Test @lldb.summary and @lldb.synthetic decorators lead to automatic formatter
+registration, when using `command script import`.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_summary(self):
+        self.build()
+        self.runCmd("command script import formatters.py")
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+        frame = thread.selected_frame
+        p = frame.var("p")
+        self.assertEqual(p.summary, "(1, 2)")
+
+    def test_synthetic(self):
+        self.build()
+        self.runCmd("command script import formatters.py")
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+        self.expect("v c", substrs=["[0] = 10", "[1] = 20", "[2] = 30"])

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
@@ -32,3 +32,6 @@ class TestCase(TestBase):
         )
         self.expect("v ic", substrs=["[0] = 10", "[1] = 20"])
         self.expect("v fc", substrs=["[0] = 10.5", "[1] = 20.25"])
+
+    def test_failure(self):
+        self.expect("command script import broken_formatter.py", error=True)

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/TestDecoratorFormatters.py
@@ -19,8 +19,10 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
         frame = thread.selected_frame
-        p = frame.var("p")
-        self.assertEqual(p.summary, "(1, 2)")
+        ic = frame.var("ic")
+        self.assertEqual(ic.summary, "size=2")
+        fc = frame.var("fc")
+        self.assertEqual(fc.summary, "size=2")
 
     def test_synthetic(self):
         self.build()
@@ -28,4 +30,5 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
-        self.expect("v c", substrs=["[0] = 10", "[1] = 20", "[2] = 30"])
+        self.expect("v ic", substrs=["[0] = 10", "[1] = 20"])
+        self.expect("v fc", substrs=["[0] = 10.5", "[1] = 20.25"])

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/broken_formatter.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/broken_formatter.py
@@ -1,0 +1,6 @@
+import lldb
+
+
+@lldb.summary("Ignored", invalid=True)
+def IgnoredSummary(valobj: lldb.SBValue, _) -> str:
+    return "nope"

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/formatters.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/formatters.py
@@ -1,0 +1,29 @@
+import lldb
+
+
+@lldb.summary("Pair")
+def pair_summary(valobj, _):
+    first = valobj.GetChildMemberWithName("first").GetValueAsSigned()
+    second = valobj.GetChildMemberWithName("second").GetValueAsSigned()
+    return f"({first}, {second})"
+
+
+@lldb.synthetic("Container")
+class ContainerSyntheticProvider:
+    valobj: lldb.SBValue
+    count: int
+    items: lldb.SBValue
+
+    def __init__(self, valobj: lldb.SBValue, _) -> None:
+        self.valobj = valobj
+
+    def update(self) -> bool:
+        self.count = self.valobj.GetChildMemberWithName("size").GetValueAsSigned()
+        self.items = self.valobj.GetChildMemberWithName("items")
+        return True
+
+    def num_children(self) -> int:
+        return self.count
+
+    def get_child_at_index(self, index: int) -> lldb.SBValue:
+        return self.items.GetChildAtIndex(index)

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/formatters.py
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/formatters.py
@@ -1,15 +1,26 @@
 import lldb
 
 
-@lldb.summary("Pair")
-def pair_summary(valobj, _):
-    first = valobj.GetChildMemberWithName("first").GetValueAsSigned()
-    second = valobj.GetChildMemberWithName("second").GetValueAsSigned()
-    return f"({first}, {second})"
+def _summary(valobj: lldb.SBValue) -> str:
+    size = (
+        valobj.GetNonSyntheticValue()
+        .GetChildMemberWithName("size")
+        .GetValueAsUnsigned()
+    )
+    return f"size={size}"
 
 
-@lldb.synthetic("Container")
-class ContainerSyntheticProvider:
+@lldb.summary("IntContainer", expand=True)
+def IntContainerSummary(valobj: lldb.SBValue, _):
+    return _summary(valobj)
+
+
+@lldb.summary("^Container<.+>$", regex=True, expand=True)
+def ContainerSummary(valobj, _):
+    return _summary(valobj)
+
+
+class _ContainerSyntheticBase:
     valobj: lldb.SBValue
     count: int
     items: lldb.SBValue
@@ -27,3 +38,13 @@ class ContainerSyntheticProvider:
 
     def get_child_at_index(self, index: int) -> lldb.SBValue:
         return self.items.GetChildAtIndex(index)
+
+
+@lldb.synthetic("IntContainer")
+class IntContainerSynthetic(_ContainerSyntheticBase):
+    pass
+
+
+@lldb.synthetic("^Container<.+>$", regex=True)
+class ContainerSynthetic(_ContainerSyntheticBase):
+    pass

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/main.cpp
@@ -1,0 +1,15 @@
+struct Pair {
+  int first;
+  int second;
+};
+
+struct Container {
+  int items[3];
+  int size;
+};
+
+int main() {
+  Pair p = {1, 2};
+  Container c = {{10, 20, 30}, 3};
+  return 0; // break here
+}

--- a/lldb/test/API/functionalities/data-formatter/decorator-formatters/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/decorator-formatters/main.cpp
@@ -1,15 +1,15 @@
-struct Pair {
-  int first;
-  int second;
-};
-
-struct Container {
+struct IntContainer {
   int items[3];
   int size;
 };
 
+template <typename T> struct Container {
+  T items[3];
+  int size;
+};
+
 int main() {
-  Pair p = {1, 2};
-  Container c = {{10, 20, 30}, 3};
+  IntContainer ic = {{10, 20, 0}, 2};
+  Container<float> fc = {{10.5, 20.25, 0}, 2};
   return 0; // break here
 }


### PR DESCRIPTION
Adds two new decorators, `@lldb.summary` and `@lldb.synthetic`, analogous to the existing `@lldb.command` decorator.

```python
@lldb.summary("MyType")
def MyType_summary(valobj, _):
      return "summary string"

@lldb.synthetic("MyContainer")
class MyContainerSynthetic:
    def __init__(self, valobj, _): ...
```

These decorators result in `type summary add` and `type synthetic add` commands being run.

An additional motivation: these decorators will make it straightforward to invoke the Python-to-LLDB formatter bytecode compiler (`formatter_bytecode.Compiler`), which currently requires command-line flags to know how to register formatters. With these decorators, the registration metadata is associated directly with the implementing function or class.

See the docstrings and formatters.py test fixture for usage examples.

Assisted-by: claude