### PR TITLE
[dsymutil] Relax tests to accept both linker outputs

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/typedefs-with-same-name.test
+++ b/llvm/test/tools/dsymutil/AArch64/typedefs-with-same-name.test
@@ -1,16 +1,25 @@
+#RUN: dsymutil --linker=classic -f -oso-prepend-path=%p/../Inputs/ -y %s -o %t.dwarf
+#RUN: llvm-dwarfdump %t.dwarf | FileCheck %s --check-prefix=CLASSIC
 #RUN: dsymutil --linker=parallel -f -oso-prepend-path=%p/../Inputs/ -y %s -o %t.dwarf
-#RUN: llvm-dwarfdump %t.dwarf | FileCheck %s
-
-## FIXME: Support --linker classic
+#RUN: llvm-dwarfdump %t.dwarf | FileCheck %s --check-prefix=PARALLEL
 
 # There should be two typedef DIE named "BarInt" in the resultant .dwarf file.
-# The second should refer to the first, which refer to "Foo<int>".
-# CHECK:      0x[[FIRST_BARINT_ADDR:[0-9a-f]*]]:  DW_TAG_typedef
-# CHECK-NEXT:     DW_AT_type  (0x{{([[:xdigit:]]*)}} "Foo<int>")
-# CHECK-NEXT:     DW_AT_name  ("BarInt")
-# CHECK:      0x{{([[:xdigit:]]*)}}:  DW_TAG_typedef
-# CHECK-NEXT:     DW_AT_type  (0x[[FIRST_BARINT_ADDR]] "BarInt")
-# CHECK-NEXT:     DW_AT_name  ("BarInt")
+# One refers to "Foo<int>", the other refers to the first. The linkers differ
+# in which typedef they emit first, so we split the ordering expectations.
+
+# CLASSIC:      0x{{[0-9a-f]+}}:  DW_TAG_typedef
+# CLASSIC-NEXT:     DW_AT_type  (0x[[#%x,FIRST_BARINT_ADDR:]] "BarInt")
+# CLASSIC-NEXT:     DW_AT_name  ("BarInt")
+# CLASSIC:      0x[[#%.8x,FIRST_BARINT_ADDR]]:  DW_TAG_typedef
+# CLASSIC-NEXT:     DW_AT_type  (0x{{[0-9a-f]+}} "Foo<int>")
+# CLASSIC-NEXT:     DW_AT_name  ("BarInt")
+
+# PARALLEL:      0x[[#%x,FIRST_BARINT_ADDR:]]:  DW_TAG_typedef
+# PARALLEL-NEXT:     DW_AT_type  (0x{{[0-9a-f]+}} "Foo<int>")
+# PARALLEL-NEXT:     DW_AT_name  ("BarInt")
+# PARALLEL:      0x{{[0-9a-f]+}}:  DW_TAG_typedef
+# PARALLEL-NEXT:     DW_AT_type  (0x[[#%.8x,FIRST_BARINT_ADDR]] "BarInt")
+# PARALLEL-NEXT:     DW_AT_name  ("BarInt")
 
 # Source:
 #

--- a/llvm/test/tools/dsymutil/X86/dwarf5-addrbase-broken.test
+++ b/llvm/test/tools/dsymutil/X86/dwarf5-addrbase-broken.test
@@ -13,6 +13,7 @@
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil --linker classic -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
@@ -25,14 +26,14 @@
 # CHECK: DW_TAG_variable
 # CHECK: DW_AT_name{{.*}}"var1"
 # CHECK: DW_AT_location        (DW_OP_addr
-# CHECK: 0x00000043:   NULL
+# CHECK: 0x{{[0-9a-f]+}}:   NULL
 # CHECK: Compile Unit:
 # CHECK: DW_TAG_compile_unit
 # CHECK-NOT: DW_AT_low_pc
 # CHECK: DW_AT_name{{.*}}"BadCU"
 # CHECK-NOT: DW_TAG_subprogram
 # CHECK-NOT: DW_TAG_variable
-# CHECK: 0x0000005b:   NULL
+# CHECK: 0x{{[0-9a-f]+}}:   NULL
 
 --- !mach-o
 FileHeader:
@@ -282,5 +283,3 @@ DWARF:
       Entries:
         - Address: 0x10
 ...
-
-## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/keep-func.test
+++ b/llvm/test/tools/dsymutil/X86/keep-func.test
@@ -25,14 +25,17 @@ RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/priva
 RUN: llvm-dwarfdump %t.omit.dSYM | FileCheck %s --check-prefix OMIT
 RUN: llvm-dwarfdump %t.keep.dSYM | FileCheck %s --check-prefix KEEP
 
-KEEP:     DW_AT_name	("MyDummyVar")
-KEEP:     DW_AT_name	("FOO_VAR_TYPE")
-KEEP:     DW_AT_name	("x1")
-KEEP:     DW_AT_name	("x2")
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.omit.dSYM
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/keep_func/main.out -o %t.keep.dSYM -keep-function-for-static
+RUN: llvm-dwarfdump %t.omit.dSYM | FileCheck %s --check-prefix OMIT
+RUN: llvm-dwarfdump %t.keep.dSYM | FileCheck %s --check-prefix KEEP
+
+KEEP-DAG:     DW_AT_name	("MyDummyVar")
+KEEP-DAG:     DW_AT_name	("FOO_VAR_TYPE")
+KEEP-DAG:     DW_AT_name	("x1")
+KEEP-DAG:     DW_AT_name	("x2")
 
 OMIT-NOT: DW_AT_name	("MyDummyVar")
 OMIT-NOT: DW_AT_name	("FOO_VAR_TYPE")
 OMIT-NOT: DW_AT_name	("x1")
 OMIT-NOT: DW_AT_name	("x2")
-
-## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
+++ b/llvm/test/tools/dsymutil/X86/linker-llvm-union-fwd-decl.test
@@ -48,7 +48,10 @@ Note that the link order in the last command matters for this test.
 RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
 RUN: llvm-dwarfdump --debug-info %t.dSYM | FileCheck %s
 
-## FIXME: Support --linker classic
+## This test is parallel-specific by design: it checks that the parallel
+## linker's artificial type unit carries the full definition of
+## Container_ivars with the expected layout. The classic linker's
+## handling of the same input is covered by union-fwd-decl.test.
 
 CHECK:       DW_TAG_compile_unit
 CHECK-NEXT:    DW_AT_producer    ("llvm DWARFLinkerParallel library

--- a/llvm/test/tools/dsymutil/X86/objc.test
+++ b/llvm/test/tools/dsymutil/X86/objc.test
@@ -1,8 +1,14 @@
 RUN: dsymutil --linker classic --verify-dwarf=output -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d4
 RUN: llvm-dwarfdump -apple-types -apple-objc %t.d4 | FileCheck %s
 
+RUN: dsymutil --linker parallel --verify-dwarf=output -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d4
+RUN: llvm-dwarfdump -apple-types -apple-objc %t.d4 | FileCheck %s
+
 ; Test DWARF 5 tables
 RUN: dsymutil --linker classic --verify-dwarf=output --accelerator='Dwarf' -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d5
+RUN: llvm-dwarfdump -debug-names %t.d5 | FileCheck %s --check-prefix=D5
+
+RUN: dsymutil --linker parallel --verify-dwarf=output --accelerator='Dwarf' -f -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.d5
 RUN: llvm-dwarfdump -debug-names %t.d5 | FileCheck %s --check-prefix=D5
 
 D5: String: {{.*}} "method1:"
@@ -13,7 +19,7 @@ D5: String: {{.*}} "-[A method1:]"
 D5: String: {{.*}} "-[Amethod2:]"
 
 CHECK: .apple_types contents:
-CHECK: String: 0x00000066 "A"
+CHECK: String: 0x{{[0-9a-f]+}} "A"
 CHECK-NEXT: Data 0 [
 CHECK-NEXT:   Atom[0]: 0x0000012d
 CHECK-NEXT:   Atom[1]: 0x0013 (DW_TAG_structure_type)
@@ -42,7 +48,7 @@ CHECK-NEXT: ]
 CHECK-NEXT: Bucket 0 [
 CHECK-NEXT:   Hash 0x2b5e6 [
 CHECK-NEXT:     Name@0x38 {
-CHECK-NEXT:       String: 0x00000066 "A"
+CHECK-NEXT:       String: 0x{{[0-9a-f]+}} "A"
 CHECK-NEXT:       Data 0 [
 CHECK-NEXT:         Atom[0]: 0x00000027
 CHECK-NEXT:       ]
@@ -55,12 +61,10 @@ CHECK-NEXT: ]
 CHECK-NEXT: Bucket 1 [
 CHECK-NEXT:   Hash 0x3fa0f4b5 [
 CHECK-NEXT:     Name@0x4c {
-CHECK-NEXT:       String: 0x0000009d "A(Category)"
+CHECK-NEXT:       String: 0x{{[0-9a-f]+}} "A(Category)"
 CHECK-NEXT:       Data 0 [
 CHECK-NEXT:         Atom[0]: 0x0000007a
 CHECK-NEXT:       ]
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 CHECK-NEXT: ]
-
-## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/X86/odr-two-units-in-single-file.test
@@ -12,27 +12,32 @@
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil --linker classic -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+
+# The two input CUs both define "class1"; dsymutil must unique it to a
+# single DW_TAG_class_type DIE that both CUs' variables reference. The
+# classic linker keeps the DIE in the first defining CU; the parallel
+# linker hoists it into an artificial type unit. Either way, both var1
+# (in CU1) and var2 (in CU2) must reference the same class1 DIE offset.
+#
+# The %.16x format specifier in the DW_AT_type references matches
+# llvm-dwarfdump's current 16-char zero-padded emission of 64-bit DWARF
+# attribute values; if that padding ever changes the CHECKs here will
+# need to be updated.
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
-# CHECK: Compile Unit:
-# CHECK: DW_TAG_compile_unit
-# CHECK: DW_AT_name{{.*}}"CU1"
-# CHECK: DW_TAG_class_type{{.*[[:space:]].*}}DW_AT_name{{.*}}"class1"
+# CHECK: 0x[[#%x,CLASS1:]]: DW_TAG_class_type
+# CHECK-NEXT:                 DW_AT_name{{.*}}"class1"
+# CHECK-NOT:                   DW_TAG_class_type
+
 # CHECK: DW_TAG_variable
 # CHECK: DW_AT_name{{.*}}"var1"
-# CHECK: DW_AT_const_value
-# CHECK: DW_AT_type (0x00000000[[CLASS1:[0-9a-f]*]]
+# CHECK: DW_AT_type (0x[[#%.16x,CLASS1]] "class1")
 
-# CHECK: Compile Unit:
-# CHECK: DW_TAG_compile_unit
-# CHECK: DW_AT_name{{.*}}"CU2"
-# CHECK-NOT: DW_TAG_class_type
-# CHECK-NOT: "class1"
 # CHECK: DW_TAG_variable
 # CHECK: DW_AT_name{{.*}}"var2"
-# CHECK: DW_AT_const_value
-# CHECK: DW_AT_type (0x00000000[[CLASS1]]
+# CHECK: DW_AT_type (0x[[#%.16x,CLASS1]] "class1")
 
 
 
@@ -198,5 +203,3 @@ DWARF:
             - Value:  0x0000001a
         - AbbrCode: 0
 ...
-
-## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/X86/union-fwd-decl.test
+++ b/llvm/test/tools/dsymutil/X86/union-fwd-decl.test
@@ -46,18 +46,22 @@ $ clang++ use.o container.o -o a.out
 Note that the link order in the last command matters for this test.
 
 RUN: dsymutil --linker classic -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
-RUN: llvm-dwarfdump %t.dSYM | FileCheck %s
+RUN: llvm-dwarfdump %t.dSYM | FileCheck %s --check-prefixes=CHECK,CLASSIC
+RUN: dsymutil --linker parallel -oso-prepend-path %p/../Inputs %p/../Inputs/private/tmp/union/a.out -o %t.dSYM
+RUN: llvm-dwarfdump %t.dSYM | FileCheck %s --check-prefix=CHECK
 
-CHECK: DW_TAG_compile_unit
+# The linker must resolve use.cpp's forward declaration of
+# Container_ivars to the full definition provided by container.cpp, not
+# drop the definition. In either linker the full definition must exist.
+# The classic linker additionally preserves the forward declaration DIE
+# (DW_AT_declaration=true) from use.cpp; the parallel linker consolidates
+# the full definition into an artificial type unit, so the forward-decl
+# DIE does not survive there.
 
-CHECK:          DW_AT_name      ("Container_ivars")
-CHECK-NEXT:     DW_AT_declaration       (true)
+# CLASSIC:     DW_AT_name      ("Container_ivars")
+# CLASSIC-NEXT:     DW_AT_declaration       (true)
 
-CHECK: DW_TAG_compile_unit
-
-CHECK:          DW_AT_name      ("Container_ivars")
-CHECK-NEXT:     DW_AT_byte_size (0x01)
-CHECK-NEXT:     DW_AT_decl_file ("{{.*}}container.cpp")
-CHECK-NEXT:     DW_AT_decl_line (4)
-
-## FIXME: Support --linker parallel
+# CHECK: DW_AT_name      ("Container_ivars")
+# CHECK-DAG: DW_AT_byte_size (0x01)
+# CHECK-DAG: DW_AT_decl_file ("{{.*}}container.cpp")
+# CHECK-DAG: DW_AT_decl_line (4)

--- a/llvm/test/tools/dsymutil/X86/update-one-CU.test
+++ b/llvm/test/tools/dsymutil/X86/update-one-CU.test
@@ -2,10 +2,14 @@ RUN: dsymutil --linker classic -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x
 RUN: dsymutil --linker classic -update %t.dSYM
 RUN: llvm-dwarfdump -apple-types -apple-objc %t.dSYM | FileCheck %s
 
+RUN: dsymutil --linker parallel -oso-prepend-path=%p/.. %p/../Inputs/objc.macho.x86_64 -o %t.dSYM
+RUN: dsymutil --linker parallel -update %t.dSYM
+RUN: llvm-dwarfdump -apple-types -apple-objc %t.dSYM | FileCheck %s
+
 CHECK: .apple_types contents:
 CHECK: Hash 0x2b5e6 [
 CHECK-NEXT:    Name@0x145 {
-CHECK-NEXT:      String: 0x00000066 "A"
+CHECK-NEXT:      String: 0x{{[0-9a-f]+}} "A"
 CHECK-NEXT:      Data 0 [
 CHECK-NEXT:        Atom[0]: 0x0000012d
 CHECK-NEXT:        Atom[1]: 0x0013
@@ -18,7 +22,7 @@ CHECK-NEXT:  ]
 CHECK: .apple_objc contents:
 CHECK: Hash 0x2b5e6
 CHECK-NEXT: Name@0x38 {
-CHECK-NEXT:   String: 0x00000066 "A"
+CHECK-NEXT:   String: 0x{{[0-9a-f]+}} "A"
 CHECK-NEXT:   Data 0 [
 CHECK-NEXT:     Atom[0]: 0x00000027
 CHECK-NEXT:   ]
@@ -28,10 +32,8 @@ CHECK-NEXT:   ]
 CHECK-NEXT: }
 CHECK: Hash 0x3fa0f4b5
 CHECK-NEXT: Name@0x4c {
-CHECK-NEXT:   String: 0x0000009d "A(Category)"
+CHECK-NEXT:   String: 0x{{[0-9a-f]+}} "A(Category)"
 CHECK-NEXT:   Data 0 [
 CHECK-NEXT:     Atom[0]: 0x0000007a
 CHECK-NEXT:   ]
 CHECK-NEXT: }
-
-## FIXME: Support --linker parallel

--- a/llvm/test/tools/dsymutil/odr-two-units-in-single-file.test
+++ b/llvm/test/tools/dsymutil/odr-two-units-in-single-file.test
@@ -9,18 +9,22 @@
 # RUN: echo '      - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }' >> %t2.map
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil --linker classic -y -j 16 %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
+# RUN: dsymutil --linker parallel -y -j 16 %t2.map -f -o - | llvm-dwarfdump -a - | FileCheck %s
 
-## FIXME: Support --linker parallel
-
+# Both input CUs define "class1"; verify it is uniqued to exactly one
+# DW_TAG_class_type in the linked output (the classic linker leaves it in
+# the last defining CU; the parallel linker hoists it into an artificial
+# type unit). Either way, exactly one DW_TAG_class_type should remain,
+# both input CUs must be preserved, and both variables must be present.
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
-# CHECK: Compile Unit:
-# CHECK: DW_TAG_compile_unit
-# CHECK-NOT: DW_TAG_class_type
-# CHECK: Compile Unit:
-# CHECK: DW_TAG_compile_unit
-# CHECK: DW_TAG_class_type
-# CHECK: NULL
+# CHECK-COUNT-1: DW_TAG_class_type
+# CHECK-NOT:     DW_TAG_class_type
+# CHECK:         .debug_str contents:
+# CHECK-DAG:     "CU1"
+# CHECK-DAG:     "CU2"
+# CHECK-DAG:     "var1"
+# CHECK-DAG:     "var2"
 
 
 --- !mach-o


### PR DESCRIPTION
Remove the FIXMEs from tests whose divergence between the classic and parallel linkers was cosmetic. Typical relaxations consist of using CHECK-DAG for reordered attributes and allowing DIE and string offsets to differ.