### PR TITLE
[lldb] Make VariableList::FindVariable const (NFC)

### DIFF
--- a/lldb/include/lldb/Symbol/VariableList.h
+++ b/lldb/include/lldb/Symbol/VariableList.h
@@ -42,11 +42,10 @@ public:
   lldb::VariableSP RemoveVariableAtIndex(size_t idx);
 
   lldb::VariableSP FindVariable(ConstString name,
-                                bool include_static_members = true);
+                                bool include_static_members = true) const;
 
-  lldb::VariableSP FindVariable(ConstString name,
-                                lldb::ValueType value_type,
-                                bool include_static_members = true);
+  lldb::VariableSP FindVariable(ConstString name, lldb::ValueType value_type,
+                                bool include_static_members = true) const;
 
   uint32_t FindVariableIndex(const lldb::VariableSP &var_sp);
 

--- a/lldb/source/Symbol/VariableList.cpp
+++ b/lldb/source/Symbol/VariableList.cpp
@@ -70,34 +70,22 @@ uint32_t VariableList::FindVariableIndex(const VariableSP &var_sp) {
 }
 
 VariableSP VariableList::FindVariable(ConstString name,
-                                      bool include_static_members) {
-  VariableSP var_sp;
-  iterator pos, end = m_variables.end();
-  for (pos = m_variables.begin(); pos != end; ++pos) {
-    if ((*pos)->NameMatches(name)) {
-      if (include_static_members || !(*pos)->IsStaticMember()) {
-        var_sp = (*pos);
-        break;
-      }
-    }
-  }
-  return var_sp;
+                                      bool include_static_members) const {
+  for (const auto &var_sp : m_variables)
+    if (var_sp->NameMatches(name))
+      if (include_static_members || !var_sp->IsStaticMember())
+        return var_sp;
+  return {};
 }
 
 VariableSP VariableList::FindVariable(ConstString name,
                                       lldb::ValueType value_type,
-                                      bool include_static_members) {
-  VariableSP var_sp;
-  iterator pos, end = m_variables.end();
-  for (pos = m_variables.begin(); pos != end; ++pos) {
-    if ((*pos)->NameMatches(name) && (*pos)->GetScope() == value_type) {
-      if (include_static_members || !(*pos)->IsStaticMember()) {
-        var_sp = (*pos);
-        break;
-      }
-    }
-  }
-  return var_sp;
+                                      bool include_static_members) const {
+  for (const auto &var_sp : m_variables)
+    if (var_sp->NameMatches(name) && var_sp->GetScope() == value_type)
+      if (include_static_members || !var_sp->IsStaticMember())
+        return var_sp;
+  return {};
 }
 
 size_t VariableList::AppendVariablesIfUnique(VariableList &var_list) {


### PR DESCRIPTION
I was surprised to find `FindVariable` was not `const`. While making it `const`, I also replaced the iterator based loop with a ranged based loop.