### PR TITLE
[mlir][MathToLLVM] Fix vector type checks in math.absi lowering.

### DIFF
--- a/mlir/lib/Conversion/MathToLLVM/MathToLLVM.cpp
+++ b/mlir/lib/Conversion/MathToLLVM/MathToLLVM.cpp
@@ -143,7 +143,7 @@ struct IntOpWithFlagLowering
       return success();
     }
 
-    if (!isa<VectorType>(llvmResultType))
+    if (!isa<VectorType>(resultType))
       return failure();
 
     return LLVM::detail::handleMultidimensionalVectors(

--- a/mlir/test/Conversion/MathToLLVM/math-to-llvm.mlir
+++ b/mlir/test/Conversion/MathToLLVM/math-to-llvm.mlir
@@ -41,6 +41,17 @@ func.func @absi_0dvector(%arg0 : vector<i32>) {
 
 // -----
 
+// CHECK-LABEL: func @absi_2dvector(
+func.func @absi_2dvector(%arg0 : vector<4x3xi32>) {
+  // CHECK: %[[EXTRACT:.*]] = llvm.extractvalue %{{.*}}[0] : !llvm.array<4 x vector<3xi32>>
+  // CHECK: %[[ABS:.*]] = "llvm.intr.abs"(%[[EXTRACT]]) <{is_int_min_poison = false}> : (vector<3xi32>) -> vector<3xi32>
+  // CHECK: %[[INSERT:.*]] = llvm.insertvalue %[[ABS]], %{{.*}}[0] : !llvm.array<4 x vector<3xi32>>
+  %0 = math.absi %arg0 : vector<4x3xi32>
+  func.return
+}
+
+// -----
+
 // CHECK-LABEL: func @log1p(
 // CHECK-SAME: f32
 func.func @log1p(%arg0 : f32) {


### PR DESCRIPTION
For vector types, the lowered type is LLVMArrayType not VectorType. We should use the original result type to guide if we can do the lowering for vectors or not.