### PR TITLE
[DWARFLinker] Treat NULL DIE references as resolution failures in parallel

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DIEAttributeCloner.cpp
@@ -243,7 +243,7 @@ size_t DIEAttributeCloner::cloneDieRefAttr(
       InUnit.resolveDIEReference(Val, ResolveInterCUReferencesMode::Resolve);
   if (!RefDiePair || !RefDiePair->DieEntry) {
     // If the referenced DIE is not found,  drop the attribute.
-    InUnit.warn("cann't find referenced DIE.", InputDieEntry);
+    InUnit.warn("could not find referenced DIE", InputDieEntry);
     return 0;
   }
 

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -404,8 +404,14 @@ std::optional<UnitEntryPairTy> CompileUnit::resolveDIEReference(
 
   if (RefCU == this) {
     // Referenced DIE is in current compile unit.
-    if (std::optional<uint32_t> RefDieIdx = getDIEIndexForOffset(RefDIEOffset))
-      return UnitEntryPairTy{this, getDebugInfoEntry(*RefDieIdx)};
+    if (std::optional<uint32_t> RefDieIdx =
+            getDIEIndexForOffset(RefDIEOffset)) {
+      const DWARFDebugInfoEntry *RefEntry = getDebugInfoEntry(*RefDieIdx);
+      // In a file with broken references, an attribute might point to a
+      // NULL DIE. Treat that as a resolution failure so callers can warn.
+      if (RefEntry && RefEntry->getAbbreviationDeclarationPtr())
+        return UnitEntryPairTy{this, RefEntry};
+    }
   } else if (RefCU && CanResolveInterCUReferences) {
     // Referenced DIE is in other compile unit.
 
@@ -415,8 +421,12 @@ std::optional<UnitEntryPairTy> CompileUnit::resolveDIEReference(
       return UnitEntryPairTy{RefCU, nullptr};
 
     if (std::optional<uint32_t> RefDieIdx =
-            RefCU->getDIEIndexForOffset(RefDIEOffset))
-      return UnitEntryPairTy{RefCU, RefCU->getDebugInfoEntry(*RefDieIdx)};
+            RefCU->getDIEIndexForOffset(RefDIEOffset)) {
+      const DWARFDebugInfoEntry *RefEntry =
+          RefCU->getDebugInfoEntry(*RefDieIdx);
+      if (RefEntry && RefEntry->getAbbreviationDeclarationPtr())
+        return UnitEntryPairTy{RefCU, RefEntry};
+    }
   } else {
     return UnitEntryPairTy{RefCU, nullptr};
   }

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -639,7 +639,7 @@ bool DependencyTracker::maybeAddReferencedRoots(
                  ? ResolveInterCUReferencesMode::Resolve
                  : ResolveInterCUReferencesMode::AvoidResolving);
     if (!RefDie) {
-      Entry.CU->warn("cann't find referenced DIE", Entry.DieEntry);
+      Entry.CU->warn("could not find referenced DIE", Entry.DieEntry);
       continue;
     }
 

--- a/llvm/test/tools/dsymutil/null-die.test
+++ b/llvm/test/tools/dsymutil/null-die.test
@@ -1,7 +1,8 @@
 #RUN: dsymutil --linker classic -f -oso-prepend-path=%p/Inputs/ -y %s -no-output 2>&1 \
 #RUN:   |  FileCheck %s
 
-## FIXME: Support --linker parallel
+#RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/Inputs/ -y %s -no-output 2>&1 \
+#RUN:   |  FileCheck %s
 
 # CHECK: warning: could not find referenced DIE
 


### PR DESCRIPTION
CompileUnit::resolveDIEReference returned whatever getDIEIndexForOffset pointed at, even when the entry was a NULL tombstone. The classic linker checks DWARFDie::isNULL(). Mirror that here so callers get std::nullopt and warn.

Also fix the "cann't" typo at the two warning sites to match classic, and enable `--linker parallel` in null-die.test.