### PR TITLE
[libc] Fix personality buildbot failures

### DIFF
--- a/libc/src/sys/personality/personality.h
+++ b/libc/src/sys/personality/personality.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_SYS_PERSONALITY_PERSONALITY_H
 
 #include "src/__support/macros/config.h"
-#include <sys/personality.h>
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
Remove the `#include <sys/personality.h>` from the implementation header. On buildbots, the generated header does not exist at compile time, so `-idirafter/usr/include` pulls in glibc's version instead. Glibc's header uses `__BEGIN_DECLS` and `__THROW`, which are unavailable in the freestanding build.

The include was unnecessary. The function signature only uses basic types.

Fixes buildbot failures introduced by #195065:
- libc-aarch64-ubuntu-fullbuild-dbg
- libc-x86_64-debian-fullbuild-dbg-asan
- libc-x86_64-debian-fullbuild-dbg
- libc-x86_64-debian-gcc-fullbuild-dbg