### PR TITLE
[DWARFLinker] Add assembly-label range handling to parallel linker

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -816,6 +816,22 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
               .value_or(UINT64_MAX) <= LowPc)
         return false;
 
+      // For assembly-language CUs there are typically no DW_TAG_subprogram
+      // DIEs, so labels are the only addresses we see. Fall back to the
+      // assembly-range lookup to recover a function range for the line-table
+      // filter; otherwise the output line table would be empty.
+      uint16_t Language = dwarf::toUnsigned(
+          Entry.CU->getOrigUnit().getUnitDIE().find(dwarf::DW_AT_language), 0);
+      if (Language == dwarf::DW_LANG_Mips_Assembler ||
+          Language == dwarf::DW_LANG_Assembly) {
+        if (auto Range = Entry.CU->getContaingFile()
+                             .Addresses->getAssemblyRangeForAddress(*LowPc)) {
+          Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
+                                     *RelocAdjustment);
+          return true;
+        }
+      }
+
       Entry.CU->addLabelLowPc(*LowPc, *RelocAdjustment);
     }
   } else

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -780,7 +780,6 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
   std::optional<uint64_t> LowPc;
   std::optional<uint64_t> HighPc;
   std::optional<int64_t> RelocAdjustment;
-  bool LabelHandledByAsmRange = false;
   if (Info.getTrackLiveness()) {
     LowPc = dwarf::toAddress(LowPCVal);
     if (!LowPc)
@@ -831,15 +830,12 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
       if (Language == dwarf::DW_LANG_Mips_Assembler ||
           Language == dwarf::DW_LANG_Assembly) {
         if (auto Range = Entry.CU->getContaingFile()
-                             .Addresses->getAssemblyRangeForAddress(*LowPc)) {
+                             .Addresses->getAssemblyRangeForAddress(*LowPc))
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
-          LabelHandledByAsmRange = true;
-        }
       }
 
-      if (!LabelHandledByAsmRange)
-        Entry.CU->addLabelLowPc(*LowPc, *RelocAdjustment);
+      Entry.CU->addLabelLowPc(*LowPc, *RelocAdjustment);
     }
   } else
     Info.setHasAnAddress();

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -722,6 +722,16 @@ DependencyTracker::getRootForSpecifiedEntry(UnitEntryPairTy Entry) {
   return Result;
 }
 
+static void dumpKeptDIE(const DWARFDie &DIE, StringRef Kind, bool Verbose) {
+  if (!Verbose)
+    return;
+  outs() << "Keeping " << Kind << " DIE:";
+  DIDumpOptions DumpOpts;
+  DumpOpts.ChildRecurseDepth = 0;
+  DumpOpts.Verbose = Verbose;
+  DIE.dump(outs(), /*Indent=*/8, DumpOpts);
+}
+
 bool DependencyTracker::isLiveVariableEntry(const UnitEntryPairTy &Entry,
                                             bool IsLiveParent) {
   DWARFDie DIE = Entry.CU->getDIE(Entry.DieEntry);
@@ -756,13 +766,7 @@ bool DependencyTracker::isLiveVariableEntry(const UnitEntryPairTy &Entry,
   }
   Info.setHasAnAddress();
 
-  if (Entry.CU->getGlobalData().getOptions().Verbose) {
-    outs() << "Keeping variable DIE:";
-    DIDumpOptions DumpOpts;
-    DumpOpts.ChildRecurseDepth = 0;
-    DumpOpts.Verbose = Entry.CU->getGlobalData().getOptions().Verbose;
-    DIE.dump(outs(), 8 /* Indent */, DumpOpts);
-  }
+  dumpKeptDIE(DIE, "variable", Entry.CU->getGlobalData().getOptions().Verbose);
 
   return true;
 }
@@ -772,9 +776,11 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
   CompileUnit::DIEInfo &Info = Entry.CU->getDIEInfo(Entry.DieEntry);
   std::optional<DWARFFormValue> LowPCVal = DIE.find(dwarf::DW_AT_low_pc);
 
+  const bool Verbose = Entry.CU->getGlobalData().getOptions().Verbose;
   std::optional<uint64_t> LowPc;
   std::optional<uint64_t> HighPc;
   std::optional<int64_t> RelocAdjustment;
+  bool LabelHandledByAsmRange = false;
   if (Info.getTrackLiveness()) {
     LowPc = dwarf::toAddress(LowPCVal);
     if (!LowPc)
@@ -784,7 +790,7 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
 
     RelocAdjustment =
         Entry.CU->getContaingFile().Addresses->getSubprogramRelocAdjustment(
-            DIE, Entry.CU->getGlobalData().getOptions().Verbose);
+            DIE, Verbose);
     if (!RelocAdjustment)
       return false;
 
@@ -828,29 +834,17 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
                              .Addresses->getAssemblyRangeForAddress(*LowPc)) {
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
-          if (Entry.CU->getGlobalData().getOptions().Verbose) {
-            outs() << "Keeping subprogram DIE:";
-            DIDumpOptions DumpOpts;
-            DumpOpts.ChildRecurseDepth = 0;
-            DumpOpts.Verbose = Entry.CU->getGlobalData().getOptions().Verbose;
-            DIE.dump(outs(), 8 /* Indent */, DumpOpts);
-          }
-          return true;
+          LabelHandledByAsmRange = true;
         }
       }
 
-      Entry.CU->addLabelLowPc(*LowPc, *RelocAdjustment);
+      if (!LabelHandledByAsmRange)
+        Entry.CU->addLabelLowPc(*LowPc, *RelocAdjustment);
     }
   } else
     Info.setHasAnAddress();
 
-  if (Entry.CU->getGlobalData().getOptions().Verbose) {
-    outs() << "Keeping subprogram DIE:";
-    DIDumpOptions DumpOpts;
-    DumpOpts.ChildRecurseDepth = 0;
-    DumpOpts.Verbose = Entry.CU->getGlobalData().getOptions().Verbose;
-    DIE.dump(outs(), 8 /* Indent */, DumpOpts);
-  }
+  dumpKeptDIE(DIE, "subprogram", Verbose);
 
   if (!Info.getTrackLiveness() || DIE.getTag() == dwarf::DW_TAG_label)
     return true;

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -828,6 +828,13 @@ bool DependencyTracker::isLiveSubprogramEntry(const UnitEntryPairTy &Entry) {
                              .Addresses->getAssemblyRangeForAddress(*LowPc)) {
           Entry.CU->addFunctionRange(Range->LowPC, Range->HighPC,
                                      *RelocAdjustment);
+          if (Entry.CU->getGlobalData().getOptions().Verbose) {
+            outs() << "Keeping subprogram DIE:";
+            DIDumpOptions DumpOpts;
+            DumpOpts.ChildRecurseDepth = 0;
+            DumpOpts.Verbose = Entry.CU->getGlobalData().getOptions().Verbose;
+            DIE.dump(outs(), 8 /* Indent */, DumpOpts);
+          }
           return true;
         }
       }

--- a/llvm/test/tools/dsymutil/asm-line-tables.test
+++ b/llvm/test/tools/dsymutil/asm-line-tables.test
@@ -8,7 +8,8 @@ REQUIRES: aarch64-registered-target
 RUN: dsymutil --linker classic -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
 RUN: llvm-dwarfdump --debug-line %t.dSYM | FileCheck %s
 
-## FIXME: Support --linker parallel
+RUN: dsymutil --linker parallel -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
+RUN: llvm-dwarfdump --debug-line %t.dSYM | FileCheck %s
 
 CHECK:      0x00000001000002e8      5      0      0   0             0       0  is_stmt
 CHECK-NEXT: 0x00000001000002ec      9      0      0   0             0       0  is_stmt

--- a/llvm/test/tools/dsymutil/asm-line-tables.test
+++ b/llvm/test/tools/dsymutil/asm-line-tables.test
@@ -5,13 +5,20 @@ $ clang -target arm64-apple-macos26 asm-line-tables.s -o asm-line-tables.o -c -g
 $ clang -target arm64-apple-macos26 -o asm-line-tables.arm64 asm-line-tables.o -nodefaultlibs -nostdlib -static -Wl,-oso_prefix,$PWD
 
 REQUIRES: aarch64-registered-target
-RUN: dsymutil --linker classic -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
+RUN: dsymutil --linker classic --verbose -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM | FileCheck %s --check-prefix=VERBOSE
 RUN: llvm-dwarfdump --debug-line %t.dSYM | FileCheck %s
 
-RUN: dsymutil --linker parallel -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM
+RUN: dsymutil --linker parallel --verbose -oso-prepend-path %p/Inputs/ %p/Inputs/private/tmp/asm/asm-line-tables.arm64 -o %t.dSYM | FileCheck %s --check-prefix=VERBOSE
 RUN: llvm-dwarfdump --debug-line %t.dSYM | FileCheck %s
 
 CHECK:      0x00000001000002e8      5      0      0   0             0       0  is_stmt
 CHECK-NEXT: 0x00000001000002ec      9      0      0   0             0       0  is_stmt
 CHECK-NEXT: 0x00000001000002f0     10      0      0   0             0       0  is_stmt
 CHECK-NEXT: 0x00000001000002f4     10      0      0   0             0       0  is_stmt end_sequence
+
+VERBOSE:      Keeping subprogram DIE:
+VERBOSE-NEXT: DW_TAG_label
+VERBOSE:      DW_AT_name {{.*}}("foo")
+VERBOSE:      Keeping subprogram DIE:
+VERBOSE-NEXT: DW_TAG_label
+VERBOSE:      DW_AT_name {{.*}}("start")


### PR DESCRIPTION
Assembly CUs typically have DW_TAG_label entries instead of subprograms, so the parallel linker's line-table filter saw no function ranges and dropped every row. Mirror the classic linker: for labels in Mips_Assembler or Assembly CUs, look up an assembly range via getAssemblyRangeForAddress and call addFunctionRange before falling back to addLabelLowPc.