### PR TITLE
clang: Fix using sm_52 as default subtarget for cuda spirv

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4922,7 +4922,9 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
   // Fill in the default architectures if not provided explicitly.
   if (Archs.empty()) {
     if (Kind == Action::OFK_Cuda) {
-      Archs.insert(OffloadArchToString(OffloadArch::CudaDefault));
+      Archs.insert(OffloadArchToString(TC.getTriple().isSPIRV()
+                                           ? OffloadArch::Unused
+                                           : OffloadArch::CudaDefault));
     } else if (Kind == Action::OFK_HIP) {
       Archs.insert(OffloadArchToString(TC.getTriple().isSPIRV()
                                            ? OffloadArch::Generic

--- a/clang/test/Driver/cuda-device-triple.cu
+++ b/clang/test/Driver/cuda-device-triple.cu
@@ -1,5 +1,5 @@
-
 // RUN: %clang -### -emit-llvm --cuda-device-only \
 // RUN:   -nocudalib -nocudainc --offload=spirv32-unknown-unknown -c %s 2>&1 | FileCheck %s
 
-// CHECK: "-cc1" "-triple" "spirv32-unknown-unknown" {{.*}} "-fcuda-is-device" {{.*}}
+// Make sure there's no sm_* suffix on the output name
+// CHECK: "-cc1" "-triple" "spirv32-unknown-unknown" {{.*}} "-fcuda-is-device" {{.*}} "-o" "cuda-device-triple-cuda-spirv32-unknown-unknown.bc"


### PR DESCRIPTION
Copy what the HIP path does, except use "Unused" instead of "Generic".
Avoids assertions in future patch.