### PR TITLE
Remove historic comment in DWP about MCStreamer

### DIFF
--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -50,7 +50,7 @@ enum DWPSectionId : unsigned {
   DS_NumSections
 };
 
-/// Direct ELF writer for DWP output, bypassing MCStreamer.
+/// Direct ELF writer for DWP output.
 ///
 /// Section data is stored as zero-copy StringRef chunks pointing to the
 /// mmap'd input files, plus an inline buffer for constructed data

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -239,7 +239,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
     OS = &*BOS;
   }
 
-  // Use DWPWriter for direct ELF output, bypassing MCStreamer.
+  // Use DWPWriter for direct ELF output
   DWPWriter Writer;
 
   if (auto Err = write(Writer, DWOFilenames, OverflowOptValue,


### PR DESCRIPTION
Follow-up from #192112
@dwblaikie asked me to remove the comment mentioning MCStreamer as it's a historical context and no longer relevant.