### PR TITLE
[libsycl] Add explicit LLVMSupport dependency

### DIFF
--- a/libsycl/src/CMakeLists.txt
+++ b/libsycl/src/CMakeLists.txt
@@ -71,6 +71,7 @@ function(add_sycl_rt_library LIB_TARGET_NAME LIB_OBJ_NAME LIB_OUTPUT_NAME)
       ${CMAKE_THREAD_LIBS_INIT}
       LLVMOffload
       LLVMObject
+      LLVMSupport
   )
 
   set_target_properties(${LIB_TARGET_NAME}


### PR DESCRIPTION
libLLVMSYCL.so includes <llvm/Object/OffloadBinary.h>, which transitively instantiates LLVMSupport templates.
With -Wl,-z,defs those symbols must be on the direct link line. LLVMObject (which contains OffloadBinary.cpp) was already linked, but LLVMSupport was not, causing undefined-reference errors in clean builds.