### PR TITLE
[cmake][compiler-rt][darwin] builtin libraries don't build for armv6m in Darwin

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -450,11 +450,14 @@ macro(darwin_add_builtin_libraries)
                               OS ${os}
                               ARCH ${arch}
                               MIN_VERSION ${DARWIN_${os}_BUILTIN_MIN_VER})
+      cmake_push_check_state()
+      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -arch ${arch}")
       check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }"
                               COMPILER_RT_HAS_${arch}_FLOAT16)
       append_list_if(COMPILER_RT_HAS_${arch}_FLOAT16 -DCOMPILER_RT_HAS_FLOAT16 BUILTIN_CFLAGS_${arch})
       check_c_source_compiles("__bf16 foo(__bf16 x) { return x; }"
                               COMPILER_RT_HAS_${arch}_BFLOAT16)
+      cmake_pop_check_state()
       # Build BF16 files only when "__bf16" is available.
       if(COMPILER_RT_HAS_${arch}_BFLOAT16)
         list(APPEND ${arch}_SOURCES ${BF16_SOURCES})

--- a/compiler-rt/lib/builtins/arm/aeabi_cdcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_cdcmp.S
@@ -156,7 +156,13 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_cdrcmple)
         mov r1, r3
         mov r3, ip
 
+#if defined(USE_THUMB_1)
+        push {r0, lr}
+        bl __aeabi_cdcmple
+        pop {r0, pc}
+#else
         b __aeabi_cdcmple
+#endif
 END_COMPILERRT_FUNCTION(__aeabi_cdrcmple)
 
 NO_EXEC_STACK_DIRECTIVE

--- a/compiler-rt/lib/builtins/arm/aeabi_cfcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_cfcmp.S
@@ -151,7 +151,13 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_cfrcmple)
         mov r0, r1
         mov r1, ip
 
+#if defined(USE_THUMB_1)
+        push {r0, lr}
+        bl __aeabi_cfcmple
+        pop {r0, pc}
+#else
         b __aeabi_cfcmple
+#endif
 END_COMPILERRT_FUNCTION(__aeabi_cfrcmple)
 
 NO_EXEC_STACK_DIRECTIVE


### PR DESCRIPTION
darwin_add_builtin_libraries tests for _Float16 and __bf16 for the host architecture rather than the one being built, add -arch to fix that so that armv6m correctly reports that it does not support __bf16. cfcmp/cdcmp get "error: unsupported relocation type" on their "Branch to target address" to c{f,d}cmple. Switch those to "Call a subroutine" instructions on Thumb-1 (e.g. armv6m).

Assisted-by: Claude Code

rdar://167828904