### PR TITLE
[Clang] Fix infinite loop on '::' inside parens in C mode

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -511,6 +511,7 @@ Bug Fixes in This Version
 - Clang now emits an error for friend declarations of lambda members. (#GH26540)
 - Fixed a crash caused by lambda capture handling in delayed default arguments. (#GH176534)
 - Fixed a crash when parsing invalid ``static_assert`` declarations with string-literal messages (#GH187690).
+- Fixed an infinite loop in the parser when a ``::`` token appears inside a parenthesized expression in C mode (e.g. ``int x = (::h);``). (#GH195367)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5632,6 +5632,8 @@ bool Parser::isTypeSpecifierQualifier(const Token &Tok) {
     return isTypeSpecifierQualifier(getCurToken());
 
   case tok::coloncolon:   // ::foo::bar
+    if (!getLangOpts().CPlusPlus && !getLangOpts().ObjC)
+      return false;
     if (NextToken().is(tok::kw_new) ||    // ::new
         NextToken().is(tok::kw_delete))   // ::delete
       return false;

--- a/clang/test/Parser/c-global-scope-coloncolon.c
+++ b/clang/test/Parser/c-global-scope-coloncolon.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fsyntax-only -verify=c   -x c   %s
+// RUN: %clang_cc1 -fsyntax-only -verify=cxx -x c++ %s
+
+int x = (::h); // c-error {{expected expression}} \
+                  cxx-error {{no member named 'h' in the global namespace}}


### PR DESCRIPTION
`Parser::isTypeSpecifierQualifier` was recursing on the same `::` token forever when called from `isTypeIdInParens` while parsing a parenthesized expression in C mode.

Fixes: #195367