### PR TITLE
[CIR][CUDA][NVPTX] Set ptx_kernel calling convention on CUDA kernels

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -38,6 +38,7 @@ struct MissingFeatures {
   static bool opGlobalPragmaClangSection() { return false; }
   static bool opGlobalAnnotations() { return false; }
   static bool opGlobalCtorPriority() { return false; }
+  static bool emitNVVMMetadata() { return false; }
   static bool setDSOLocal() { return false; }
 
   static bool supportIFuncAttr() { return false; }
@@ -88,6 +89,7 @@ struct MissingFeatures {
   static bool opFuncUnwindTablesAttr() { return false; }
   static bool opFuncWillReturn() { return false; }
   static bool opFuncNoReturn() { return false; }
+  static bool handleCUDALaunchBoundsAttr() { return false; }
   static bool setLLVMFunctionFEnvAttributes() { return false; }
 
   // CallOp handling

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -6,6 +6,7 @@
 #include "clang/Basic/AddressSpaces.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/MissingFeatures.h"
 
 using namespace clang;
 using namespace clang::CIRGen;
@@ -135,20 +136,42 @@ public:
 
   void setTargetAttributes(const clang::Decl *decl, mlir::Operation *global,
                            CIRGenModule &cgm) const override {
-    auto func = mlir::dyn_cast<cir::FuncOp>(global);
-    if (!func || func.isDeclaration())
+    auto globalValue = mlir::dyn_cast<cir::CIRGlobalValueInterface>(global);
+    if (globalValue && globalValue.isDeclaration())
       return;
+
+    const auto *vd = dyn_cast_or_null<VarDecl>(decl);
+    if (vd) {
+      if (cgm.getLangOpts().CUDA) {
+        if (vd->getType()->isCUDADeviceBuiltinSurfaceType() ||
+            vd->getType()->isCUDADeviceBuiltinTextureType())
+          assert(!cir::MissingFeatures::emitNVVMMetadata());
+        return;
+      }
+    }
 
     const auto *fd = dyn_cast_or_null<FunctionDecl>(decl);
     if (!fd)
       return;
 
-    if (cgm.getLangOpts().CUDA && fd->hasAttr<CUDAGlobalAttr>())
-      func.setCallingConv(cir::CallingConv::PTXKernel);
+    auto func = mlir::cast<cir::FuncOp>(global);
 
-    // TODO(CIR): NoInline on kernels, CUDALaunchBoundsAttr,
-    // CUDAGridConstantAttr param attrs, nvvm.annotations for
-    // surface/texture VarDecls.
+    // Perform special handling in OpenCL/CUDA mode.
+    if (cgm.getLangOpts().OpenCL || cgm.getLangOpts().CUDA) {
+      // Use function attributes to check for kernel functions. By default, all
+      // functions are device functions.
+      if (fd->hasAttr<DeviceKernelAttr>() || fd->hasAttr<CUDAGlobalAttr>()) {
+        // OpenCL/CUDA kernel functions get kernel metadata. Kernel functions
+        // are also not subject to inlining.
+        func.setInlineKind(cir::InlineKind::NoInline);
+        if (fd->hasAttr<CUDAGlobalAttr>()) {
+          func.setCallingConv(cir::CallingConv::PTXKernel);
+          assert(!cir::MissingFeatures::opFuncParameterAttributes());
+        }
+        if (fd->hasAttr<CUDALaunchBoundsAttr>())
+          assert(!cir::MissingFeatures::handleCUDALaunchBoundsAttr());
+      }
+    }
   }
 };
 } // namespace

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -132,6 +132,24 @@ class NVPTXTargetCIRGenInfo : public TargetCIRGenInfo {
 public:
   NVPTXTargetCIRGenInfo(CIRGenTypes &cgt)
       : TargetCIRGenInfo(std::make_unique<NVPTXABIInfo>(cgt)) {}
+
+  void setTargetAttributes(const clang::Decl *decl, mlir::Operation *global,
+                           CIRGenModule &cgm) const override {
+    auto func = mlir::dyn_cast<cir::FuncOp>(global);
+    if (!func || func.isDeclaration())
+      return;
+
+    const auto *fd = dyn_cast_or_null<FunctionDecl>(decl);
+    if (!fd)
+      return;
+
+    if (cgm.getLangOpts().CUDA && fd->hasAttr<CUDAGlobalAttr>())
+      func.setCallingConv(cir::CallingConv::PTXKernel);
+
+    // TODO(CIR): NoInline on kernels, CUDALaunchBoundsAttr,
+    // CUDAGridConstantAttr param attrs, nvvm.annotations for
+    // surface/texture VarDecls.
+  }
 };
 } // namespace
 

--- a/clang/test/CIR/CodeGenCUDA/address-spaces.cu
+++ b/clang/test/CIR/CodeGenCUDA/address-spaces.cu
@@ -86,7 +86,7 @@ __global__ void fn() {
 // CIR-DEVICE:   cir.store {{.*}}%[[VAL]], %[[J]] : !s32i, !cir.ptr<!s32i>
 // CIR-DEVICE:   cir.return
 
-// LLVM-DEVICE: define dso_local void @_Z2fnv()
+// LLVM-DEVICE: define dso_local ptx_kernel void @_Z2fnv()
 // LLVM-DEVICE:   %[[ALLOCA:.*]] = alloca i32, i64 1, align 4
 // LLVM-DEVICE:   store i32 0, ptr %[[ALLOCA]], align 4
 // LLVM-DEVICE:   %[[VAL:.*]] = load i32, ptr %[[ALLOCA]], align 4

--- a/clang/test/CIR/CodeGenCUDA/ptx-kernels.cu
+++ b/clang/test/CIR/CodeGenCUDA/ptx-kernels.cu
@@ -1,0 +1,42 @@
+// REQUIRES: nvptx-registered-target
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR %s --input-file=%t.cir
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda -fclangir \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM %s --input-file=%t.ll
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
+// RUN:            -fcuda-is-device -emit-llvm %s -o %t.ogcg.ll
+// RUN: FileCheck --check-prefix=OGCG %s --input-file=%t.ogcg.ll
+
+#include "Inputs/cuda.h"
+
+// CIR: cir.func {{.*}} @device_function()
+// LLVM: define{{.*}} void @device_function
+// OGCG: define{{.*}} void @device_function
+extern "C"
+__device__ void device_function() {}
+
+// CIR: cir.func {{.*}} @global_function() cc(ptx_kernel)
+// LLVM: define{{.*}} ptx_kernel void @global_function
+// OGCG: define{{.*}} ptx_kernel void @global_function
+extern "C"
+__global__ void global_function() {
+  device_function();
+}
+
+template <typename T> __global__ void templated_kernel(T param) {}
+template __global__ void templated_kernel<int>(int);
+// CIR-DAG: cir.func {{.*}} @_Z16templated_kernelIiEvT_({{.*}}) cc(ptx_kernel)
+// LLVM-DAG: define{{.*}} ptx_kernel void @_Z16templated_kernelIiEvT_(
+// OGCG-DAG: define{{.*}} ptx_kernel void @_Z16templated_kernelIiEvT_(
+
+namespace {
+__global__ void anonymous_ns_kernel() {}
+// CIR-DAG: cir.func {{.*}} @_ZN12_GLOBAL__N_119anonymous_ns_kernelEv() cc(ptx_kernel)
+// LLVM-DAG: define{{.*}} ptx_kernel void @_ZN12_GLOBAL__N_119anonymous_ns_kernelEv(
+// OGCG-DAG: define{{.*}} ptx_kernel void @_ZN12_GLOBAL__N_119anonymous_ns_kernelEv(
+}


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/issues/179278, https://github.com/llvm/llvm-project/issues/175871

More target attributes like: NoInline on kernels, CUDALaunchBoundsAttr, CUDAGridConstantAttr param attrs, nvvm.annotations for surface/texture VarDecls to be deferred for later patches.