### PR TITLE
[clang-format] Align stuff containing multi-line comment

### DIFF
--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -1120,7 +1120,7 @@ void BreakableLineCommentSection::adaptStartOfLine(
         /*Spaces=*/LineColumn,
         /*StartOfTokenColumn=*/LineColumn,
         /*AlignedTo=*/tokenAt(0).NewlinesBefore == 0 ? &tokenAt(0) : nullptr,
-        /*InPPDirective=*/false);
+        /*InPPDirective=*/false, /*IndentedFromColumn=*/StartColumn);
   }
   if (OriginalPrefix[LineIndex] != Prefix[LineIndex]) {
     // Adjust the prefix if necessary.

--- a/clang/unittests/Format/AlignmentTest.cpp
+++ b/clang/unittests/Format/AlignmentTest.cpp
@@ -1280,6 +1280,13 @@ TEST_F(AlignmentTest, ConsecutiveDeclarations) {
   verifyFormat("int         a = method();\n"
                "float const oneTwoThree = 133;",
                Alignment);
+  verifyFormat(
+      "foo          fooNode(ConvertStdStringToUString(fieldNames[chIdx]),\n"
+      "                     // asdf\n"
+      "                     // foo1 foo2 foo12345\n"
+      "                     SomeFunctionAB(a123456789012345));\n"
+      "const size_t v1234567890123456789012345678901234;",
+      Alignment);
   verifyFormat("int i = 1, j = 10;\n"
                "something = 2000;",
                Alignment);


### PR DESCRIPTION
Fixes #194717.

Previously the information about the comment's scope could get lost. Then the program would not align it.

new

```C++
foo          fooNode(ConvertStdStringToUString(fieldNames[chIdx]),
                     // asdf
                     // foo1 foo2 foo12345
                     SomeFunctionAB(a123456789012345));
const size_t v1234567890123456789012345678901234;
```

old

```C++
foo          fooNode(ConvertStdStringToUString(fieldNames[chIdx]),
                     // asdf
            // foo1 foo2 foo12345
            SomeFunctionAB(a123456789012345));
const size_t v1234567890123456789012345678901234;
```