### PR TITLE
[lldb] Add a packet-test-delay setting for testing slow connections

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "GDBRemoteCommunication.h"
+#include "ProcessGDBRemote.h"
 #include "ProcessGDBRemoteLog.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/FileSystem.h"
@@ -30,6 +31,7 @@
 #include <climits>
 #include <cstring>
 #include <sys/stat.h>
+#include <thread>
 #include <variant>
 
 #if HAVE_LIBCOMPRESSION
@@ -136,6 +138,10 @@ GDBRemoteCommunication::SendNotificationPacketNoLock(
 GDBRemoteCommunication::PacketResult
 GDBRemoteCommunication::SendRawPacketNoLock(llvm::StringRef packet,
                                             bool skip_ack) {
+  std::chrono::milliseconds delay = ProcessGDBRemote::GetPacketTestDelay();
+  if (delay.count() > 0)
+    std::this_thread::sleep_for(delay);
+
   if (IsConnected()) {
     Log *log = GetLog(GDBRLog::Packets);
     ConnectionStatus status = eConnectionStatusSuccess;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -177,6 +177,12 @@ public:
     const uint32_t idx = ePropertyUseGPacketForReading;
     return GetPropertyAtIndexAs<bool>(idx, true);
   }
+
+  uint64_t GetPacketTestDelay() const {
+    const uint32_t idx = ePropertyPacketTestDelay;
+    return GetPropertyAtIndexAs<uint64_t>(
+        idx, g_processgdbremote_properties[idx].default_uint_value);
+  }
 };
 
 std::chrono::seconds ResumeTimeout() { return std::chrono::seconds(5); }
@@ -223,6 +229,11 @@ void ProcessGDBRemote::DumpPluginHistory(Stream &s) {
 
 std::chrono::seconds ProcessGDBRemote::GetPacketTimeout() {
   return std::chrono::seconds(GetGlobalPluginProperties().GetPacketTimeout());
+}
+
+std::chrono::milliseconds ProcessGDBRemote::GetPacketTestDelay() {
+  return std::chrono::milliseconds(
+      GetGlobalPluginProperties().GetPacketTestDelay());
 }
 
 ArchSpec ProcessGDBRemote::GetSystemArchitecture() {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -67,6 +67,8 @@ public:
 
   static std::chrono::seconds GetPacketTimeout();
 
+  static std::chrono::milliseconds GetPacketTestDelay();
+
   ArchSpec GetSystemArchitecture() override;
 
   // Check if a given Process

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemoteProperties.td
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemoteProperties.td
@@ -21,4 +21,10 @@ let Definition = "processgdbremote", Path = "plugin.process.gdb-remote" in {
     Global,
     DefaultFalse,
     Desc<"Specify if the server should use 'g' packets to read registers.">;
+  def PacketTestDelay
+      : Property<"packet-test-delay", "UInt64">,
+        Global,
+        DefaultUnsignedValue<0>,
+        Desc<"Specify an artificial delay in milliseconds inserted before "
+             "sending each packet, for testing purposes.">;
 }

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPacketTestDelay.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPacketTestDelay.py
@@ -1,0 +1,39 @@
+import time
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class TestPacketTestDelay(GDBRemoteTestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_packet_test_delay(self):
+        """Verify that packet-test-delay inserts a delay before each sent packet."""
+
+        # 1000ms should be long enough that this test doesn't pass by
+        # accident even on slow machines, but not too long to waste test
+        # suite time.
+        DELAY_MS = 1000
+
+        class MyResponder(MockGDBServerResponder):
+            def x(self, addr, length):
+                return "foobar"
+
+        self.server.responder = MyResponder()
+        target = self.dbg.CreateTargetWithFileAndTargetTriple("", "x86_64-pc-linux")
+        process = self.connect(target)
+
+        error = lldb.SBError()
+        start = time.time()
+        self.runCmd(
+            "settings set plugin.process.gdb-remote.packet-test-delay %d" % DELAY_MS
+        )
+        # Send a single dummy packet so we can observe the delay.
+        process.ReadMemory(0x1000, 10, error)
+        elapsed_ms = (time.time() - start) * 1000
+
+        self.assertGreaterEqual(
+            elapsed_ms, DELAY_MS, "Packet was sent faster than the set test delay?"
+        )


### PR DESCRIPTION
[lldb] Add a packet-test-delay setting for testing slow connections

Sending/receiving packets to/from a non-host devices adds latency to
the gdb-remote communication that induces substantial slowdown into the
debugging experience.

This patch adds an artificial delay before sending a packet to
simulate this latency without requiring an emulated/physical device.

The test checks only checks that there is a delay when this setting is
activated, but not that there is no delay when the setting is not
activated. The reason for this is that this negative test would either
require a large delay (which further slows down the test suite) or be
prone to accidential failures on overloaded test bots.

There is also the question whether we should have dynamic delays that
depend on the number of transferred bytes. From talking to Felipe it
seems the real bottleneck is really just the latency and not the
transfer speed. From my own testing, it seems that a simple fixed array
mostly simulated the remote debugging performance, and the delays I can
see on my own machine seem to mostly resemble the delays we can see
when debugging on a remote device.

This patch also required wrapping `SendPacketAndWaitForResponse` so we
can sync this setting on a per-packet basis for the
GDBRemoteCommunication class. Without this, we could only set the delay
before connecting and then never change afterwards which would make
this feature less useful and writing a simple test impossible.