### PR TITLE
[NFC][LLVM][Intrinsics] Add `hasStructReturnType` helper

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -257,10 +257,8 @@ namespace Intrinsic {
     }
   };
 
-  /// Returns true if \p id has a struct return type in the first component of
-  /// the return value, and the number of struct elements in the second
-  /// component of the return value.
-  LLVM_ABI std::pair<bool, uint32_t> hasStructReturnType(ID id);
+  /// Returns true if \p id has a struct return type.
+  LLVM_ABI bool hasStructReturnType(ID id);
 
   /// Return the IIT table descriptor for the specified intrinsic into an array
   /// of IITDescriptors.

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -257,6 +257,11 @@ namespace Intrinsic {
     }
   };
 
+  /// Returns true if \p id has a struct return type in the first component of
+  /// the return value, and the number of struct elements in the second
+  /// component of the return value.
+  LLVM_ABI std::pair<bool, uint32_t> hasStructReturnType(ID id);
+
   /// Return the IIT table descriptor for the specified intrinsic into an array
   /// of IITDescriptors.
   LLVM_ABI void getIntrinsicInfoTableEntries(ID id,

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1869,10 +1869,8 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
     // intrinsics declared to return a struct, not for intrinsics with
     // overloaded return type, in which case the exact struct type will be
     // mangled into the name.
-    SmallVector<Intrinsic::IITDescriptor> Desc;
-    Intrinsic::getIntrinsicInfoTableEntries(F->getIntrinsicID(), Desc);
-    if (Desc.front().Kind == Intrinsic::IITDescriptor::Struct) {
-      auto *FT = F->getFunctionType();
+    if (Intrinsic::hasStructReturnType(F->getIntrinsicID()).first) {
+      FunctionType *FT = F->getFunctionType();
       auto *NewST = StructType::get(ST->getContext(), ST->elements());
       auto *NewFT = FunctionType::get(NewST, FT->params(), FT->isVarArg());
       std::string Name = F->getName().str();

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1869,7 +1869,7 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
     // intrinsics declared to return a struct, not for intrinsics with
     // overloaded return type, in which case the exact struct type will be
     // mangled into the name.
-    if (Intrinsic::hasStructReturnType(F->getIntrinsicID()).first) {
+    if (Intrinsic::hasStructReturnType(F->getIntrinsicID())) {
       FunctionType *FT = F->getFunctionType();
       auto *NewST = StructType::get(ST->getContext(), ST->elements());
       auto *NewFT = FunctionType::get(NewST, FT->params(), FT->isVarArg());

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1143,13 +1143,11 @@ bool Intrinsic::matchIntrinsicSignature(
   return false;
 }
 
-std::pair<bool, uint32_t> Intrinsic::hasStructReturnType(ID id) {
+bool Intrinsic::hasStructReturnType(ID id) {
   using namespace Intrinsic;
   SmallVector<IITDescriptor> Table;
   getIntrinsicInfoTableEntries(id, Table);
-  if (!Table.empty() && Table[0].Kind == IITDescriptor::Struct)
-    return {true, Table[0].StructNumElements};
-  return {false, 0};
+  return !Table.empty() && Table[0].Kind == IITDescriptor::Struct;
 }
 
 bool Intrinsic::isSignatureValid(Intrinsic::ID ID, FunctionType *FT,

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1143,6 +1143,15 @@ bool Intrinsic::matchIntrinsicSignature(
   return false;
 }
 
+std::pair<bool, uint32_t> Intrinsic::hasStructReturnType(ID id) {
+  using namespace Intrinsic;
+  SmallVector<IITDescriptor> Table;
+  getIntrinsicInfoTableEntries(id, Table);
+  if (!Table.empty() && Table[0].Kind == IITDescriptor::Struct)
+    return {true, Table[0].StructNumElements};
+  return {false, 0};
+}
+
 bool Intrinsic::isSignatureValid(Intrinsic::ID ID, FunctionType *FT,
                                  SmallVectorImpl<Type *> &OverloadTys,
                                  raw_ostream &OS) {


### PR DESCRIPTION
Add a helper function to query if an intrinsic has a struct return type and use it in AutoUpgrade