### PR TITLE
[NFC][LLVM][ADT] Remove function names from Doxygen comments

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -2495,13 +2495,13 @@ LLVM_ABI APInt clmulh(const APInt &LHS, const APInt &RHS);
 // order to compile LLVM with IBM xlC compiler.
 LLVM_ABI hash_code hash_value(const APInt &Arg);
 
-/// StoreIntToMemory - Fills the StoreBytes bytes of memory starting from Dst
-/// with the integer held in IntVal.
+/// Fills the StoreBytes bytes of memory starting from Dst with the integer held
+/// in IntVal.
 LLVM_ABI void StoreIntToMemory(const APInt &IntVal, uint8_t *Dst,
                                unsigned StoreBytes);
 
-/// LoadIntFromMemory - Loads the integer stored in the LoadBytes bytes starting
-/// from Src into IntVal, which is assumed to be wide enough and to hold zero.
+/// Loads the integer stored in the LoadBytes bytes starting from Src into
+/// IntVal, which is assumed to be wide enough and to hold zero.
 LLVM_ABI void LoadIntFromMemory(APInt &IntVal, const uint8_t *Src,
                                 unsigned LoadBytes);
 

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -25,7 +25,7 @@
 namespace llvm {
   template<typename T> class [[nodiscard]] MutableArrayRef;
 
-  /// ArrayRef - Represent a constant reference to an array (0 or more elements
+  /// Represent a constant reference to an array (0 or more elements
   /// consecutively in memory), i.e. a start pointer and a length.  It allows
   /// various APIs to take consecutive elements easily and conveniently.
   ///
@@ -133,21 +133,21 @@ namespace llvm {
     reverse_iterator rbegin() const { return reverse_iterator(end()); }
     reverse_iterator rend() const { return reverse_iterator(begin()); }
 
-    /// empty - Check if the array is empty.
+    /// Check if the array is empty.
     bool empty() const { return Length == 0; }
 
     const T *data() const { return Data; }
 
-    /// size - Get the array size.
+    /// Get the array size.
     size_t size() const { return Length; }
 
-    /// front - Get the first element.
+    /// Get the first element.
     const T &front() const {
       assert(!empty());
       return Data[0];
     }
 
-    /// back - Get the last element.
+    /// Get the last element.
     const T &back() const {
       assert(!empty());
       return Data[Length-1];
@@ -174,7 +174,7 @@ namespace llvm {
       return MutableArrayRef<T>(Buff, Length);
     }
 
-    /// equals - Check for element-wise equality.
+    /// Check for element-wise equality.
     bool equals(ArrayRef RHS) const {
       if (Length != RHS.Length)
         return false;
@@ -282,9 +282,9 @@ namespace llvm {
     /// @}
   };
 
-  /// MutableArrayRef - Represent a mutable reference to an array (0 or more
-  /// elements consecutively in memory), i.e. a start pointer and a length.  It
-  /// allows various APIs to take and modify consecutive elements easily and
+  /// Represent a mutable reference to an array (0 or more elements
+  /// consecutively in memory), i.e. a start pointer and a length.  It allows
+  /// various APIs to take and modify consecutive elements easily and
   /// conveniently.
   ///
   /// This class does not own the underlying data, it is expected to be used in
@@ -345,40 +345,40 @@ namespace llvm {
     reverse_iterator rbegin() const { return reverse_iterator(end()); }
     reverse_iterator rend() const { return reverse_iterator(begin()); }
 
-    /// front - Get the first element.
+    /// Get the first element.
     T &front() const {
       assert(!this->empty());
       return data()[0];
     }
 
-    /// back - Get the last element.
+    /// Get the last element.
     T &back() const {
       assert(!this->empty());
       return data()[this->size()-1];
     }
 
-    /// consume_front() - Returns the first element and drops it from ArrayRef.
+    /// Returns the first element and drops it from ArrayRef.
     T &consume_front() {
       T &Ret = front();
       *this = drop_front();
       return Ret;
     }
 
-    /// consume_back() - Returns the last element and drops it from ArrayRef.
+    /// Returns the last element and drops it from ArrayRef.
     T &consume_back() {
       T &Ret = back();
       *this = drop_back();
       return Ret;
     }
 
-    /// slice(n, m) - Chop off the first N elements of the array, and keep M
-    /// elements in the array.
+    /// Chop off the first \p N elements of the array, and keep \p M elements
+    /// in the array.
     MutableArrayRef<T> slice(size_t N, size_t M) const {
       assert(N + M <= this->size() && "Invalid specifier");
       return MutableArrayRef<T>(this->data() + N, M);
     }
 
-    /// slice(n) - Chop off the first N elements of the array.
+    /// Chop off the first \p N elements of the array.
     MutableArrayRef<T> slice(size_t N) const {
       return slice(N, this->size() - N);
     }

--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -171,7 +171,7 @@ public:
       clear_unused_bits();
   }
 
-  /// returns whether there are no bits in this bitvector.
+  /// Returns whether there are no bits in this bitvector.
   bool empty() const { return Size == 0; }
 
   /// Returns the number of bits in this bitvector.
@@ -359,14 +359,17 @@ public:
     clear_unused_bits();
   }
 
+  /// Reserve space for atleast \p N bits in the bitvector.
   void reserve(unsigned N) { Bits.reserve(NumBitWords(N)); }
 
+  /// Set all bits in the bitvector.
   BitVector &set() {
     init_words(true);
     clear_unused_bits();
     return *this;
   }
 
+  // Set bit \p Idx in the bitvector.
   BitVector &set(unsigned Idx) {
     assert(Idx < Size && "access in bound");
     Bits[Idx / BITWORD_SIZE] |= BitWord(1) << (Idx % BITWORD_SIZE);
@@ -402,11 +405,13 @@ public:
     return *this;
   }
 
+  /// Reset all bits in the bitvector.
   BitVector &reset() {
     init_words(false);
     return *this;
   }
 
+  /// Reset bit \p Idx in the bitvector.
   BitVector &reset(unsigned Idx) {
     Bits[Idx / BITWORD_SIZE] &= ~(BitWord(1) << (Idx % BITWORD_SIZE));
     return *this;
@@ -441,6 +446,7 @@ public:
     return *this;
   }
 
+  /// Flip all bits in the bitvector.
   BitVector &flip() {
     for (auto &Bit : Bits)
       Bit = ~Bit;
@@ -448,6 +454,7 @@ public:
     return *this;
   }
 
+  /// Flip bit \p Idx in the bitvector.
   BitVector &flip(unsigned Idx) {
     Bits[Idx / BITWORD_SIZE] ^= BitWord(1) << (Idx % BITWORD_SIZE);
     return *this;
@@ -465,17 +472,18 @@ public:
     return (Bits[Idx / BITWORD_SIZE] & Mask) != 0;
   }
 
-  /// Return the last element in the vector.
+  /// Return the last element in the bitvector.
   bool back() const {
     assert(!empty() && "Getting last element of empty vector.");
     return (*this)[size() - 1];
   }
 
+  /// Returns true if bit \p Idx is set.
   bool test(unsigned Idx) const {
     return (*this)[Idx];
   }
 
-  // Push single bit to end of vector.
+  // Push single bit to end of bitvector.
   void push_back(bool Val) {
     unsigned OldSize = Size;
     unsigned NewSize = Size + 1;
@@ -518,7 +526,7 @@ public:
 
   bool operator!=(const BitVector &RHS) const { return !(*this == RHS); }
 
-  /// Intersection, union, disjoint union.
+  /// Intersection of this bitvector with \p RHS.
   BitVector &operator&=(const BitVector &RHS) {
     unsigned ThisWords = Bits.size();
     unsigned RHSWords = RHS.Bits.size();
@@ -575,6 +583,7 @@ public:
     return Out;
   }
 
+  /// Union of this bitvector with \p RHS.
   BitVector &operator|=(const BitVector &RHS) {
     if (size() < RHS.size())
       resize(RHS.size());
@@ -583,6 +592,7 @@ public:
     return *this;
   }
 
+  /// Disjoint union of this bitvector with \p RHS.
   BitVector &operator^=(const BitVector &RHS) {
     if (size() < RHS.size())
       resize(RHS.size());

--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -171,13 +171,13 @@ public:
       clear_unused_bits();
   }
 
-  /// empty - Tests whether there are no bits in this bitvector.
+  /// returns whether there are no bits in this bitvector.
   bool empty() const { return Size == 0; }
 
-  /// size - Returns the number of bits in this bitvector.
+  /// Returns the number of bits in this bitvector.
   size_type size() const { return Size; }
 
-  /// count - Returns the number of bits which are set.
+  /// Returns the number of bits which are set.
   size_type count() const {
     unsigned NumBits = 0;
     for (auto Bit : Bits)
@@ -185,12 +185,12 @@ public:
     return NumBits;
   }
 
-  /// any - Returns true if any bit is set.
+  /// Returns true if any bit is set.
   bool any() const {
     return any_of(Bits, [](BitWord Bit) { return Bit != 0; });
   }
 
-  /// all - Returns true if all bits are set.
+  /// Returns true if all bits are set.
   bool all() const {
     for (unsigned i = 0; i < Size / BITWORD_SIZE; ++i)
       if (Bits[i] != ~BitWord(0))
@@ -203,14 +203,13 @@ public:
     return true;
   }
 
-  /// none - Returns true if none of the bits are set.
+  /// Returns true if none of the bits are set.
   bool none() const {
     return !any();
   }
 
-  /// find_first_in - Returns the index of the first set / unset bit,
-  /// depending on \p Set, in the range [Begin, End).
-  /// Returns -1 if all bits in the range are unset / set.
+  /// Returns the index of the first set/unset bit, depending on \p Set, in
+  /// the range [Begin, End). Returns -1 if all bits in the range are unset/set.
   int find_first_in(unsigned Begin, unsigned End, bool Set = true) const {
     assert(Begin <= End && End <= Size);
     if (Begin == End)
@@ -244,8 +243,8 @@ public:
     return -1;
   }
 
-  /// find_last_in - Returns the index of the last set bit in the range
-  /// [Begin, End).  Returns -1 if all bits in the range are unset.
+  /// Returns the index of the last set bit in the range [Begin, End).
+  /// Returns -1 if all bits in the range are unset.
   int find_last_in(unsigned Begin, unsigned End) const {
     assert(Begin <= End && End <= Size);
     if (Begin == End)
@@ -275,14 +274,14 @@ public:
     return -1;
   }
 
-  /// find_first_unset_in - Returns the index of the first unset bit in the
-  /// range [Begin, End).  Returns -1 if all bits in the range are set.
+  /// Returns the index of the first unset bit in the range [Begin, End).
+  /// Returns -1 if all bits in the range are set.
   int find_first_unset_in(unsigned Begin, unsigned End) const {
     return find_first_in(Begin, End, /* Set = */ false);
   }
 
-  /// find_last_unset_in - Returns the index of the last unset bit in the
-  /// range [Begin, End).  Returns -1 if all bits in the range are set.
+  /// Returns the index of the last unset bit in the range [Begin, End).
+  /// Returns -1 if all bits in the range are set.
   int find_last_unset_in(unsigned Begin, unsigned End) const {
     assert(Begin <= End && End <= Size);
     if (Begin == End)
@@ -314,49 +313,45 @@ public:
     return -1;
   }
 
-  /// find_first - Returns the index of the first set bit, -1 if none
-  /// of the bits are set.
+  /// Returns the index of the first set bit, -1 if none of the bits are set.
   int find_first() const { return find_first_in(0, Size); }
 
-  /// find_last - Returns the index of the last set bit, -1 if none of the bits
-  /// are set.
+  /// Returns the index of the last set bit, -1 if none of the bits are set.
   int find_last() const { return find_last_in(0, Size); }
 
-  /// find_next - Returns the index of the next set bit following the
-  /// "Prev" bit. Returns -1 if the next set bit is not found.
+  /// Returns the index of the next set bit following the "Prev" bit.
+  /// Returns -1 if the next set bit is not found.
   int find_next(unsigned Prev) const { return find_first_in(Prev + 1, Size); }
 
-  /// find_prev - Returns the index of the first set bit that precedes the
-  /// the bit at \p PriorTo.  Returns -1 if all previous bits are unset.
+  /// Returns the index of the first set bit that precedes the bit at
+  /// \p PriorTo. Returns -1 if all previous bits are unset.
   int find_prev(unsigned PriorTo) const { return find_last_in(0, PriorTo); }
 
-  /// find_first_unset - Returns the index of the first unset bit, -1 if all
-  /// of the bits are set.
+  /// Returns the index of the first unset bit, -1 if all of the bits are set.
   int find_first_unset() const { return find_first_unset_in(0, Size); }
 
-  /// find_next_unset - Returns the index of the next unset bit following the
-  /// "Prev" bit.  Returns -1 if all remaining bits are set.
+  /// Returns the index of the next unset bit following the \p Prev bit.
+  /// Returns -1 if all remaining bits are set.
   int find_next_unset(unsigned Prev) const {
     return find_first_unset_in(Prev + 1, Size);
   }
 
-  /// find_last_unset - Returns the index of the last unset bit, -1 if all of
-  /// the bits are set.
+  /// Returns the index of the last unset bit, -1 if all of the bits are set.
   int find_last_unset() const { return find_last_unset_in(0, Size); }
 
-  /// find_prev_unset - Returns the index of the first unset bit that precedes
-  /// the bit at \p PriorTo.  Returns -1 if all previous bits are set.
+  /// Returns the index of the first unset bit that precedes the bit at
+  /// \p PriorTo. Returns -1 if all previous bits are set.
   int find_prev_unset(unsigned PriorTo) const {
     return find_last_unset_in(0, PriorTo);
   }
 
-  /// clear - Removes all bits from the bitvector.
+  /// Removes all bits from the bitvector.
   void clear() {
     Size = 0;
     Bits.clear();
   }
 
-  /// resize - Grow or shrink the bitvector.
+  /// Grow or shrink the bitvector.
   void resize(unsigned N, bool t = false) {
     set_unused_bits(t);
     Size = N;
@@ -366,7 +361,6 @@ public:
 
   void reserve(unsigned N) { Bits.reserve(NumBitWords(N)); }
 
-  // Set, reset, flip
   BitVector &set() {
     init_words(true);
     clear_unused_bits();
@@ -379,7 +373,7 @@ public:
     return *this;
   }
 
-  /// set - Efficiently set a range of bits in [I, E)
+  /// Efficiently set a range of bits in [I, E)
   BitVector &set(unsigned I, unsigned E) {
     assert(I <= E && "Attempted to set backwards range!");
     assert(E <= size() && "Attempted to set out-of-bounds range!");
@@ -418,7 +412,7 @@ public:
     return *this;
   }
 
-  /// reset - Efficiently reset a range of bits in [I, E)
+  /// Efficiently reset a range of bits in [I, E)
   BitVector &reset(unsigned I, unsigned E) {
     assert(I <= E && "Attempted to reset backwards range!");
     assert(E <= size() && "Attempted to reset out-of-bounds range!");
@@ -541,7 +535,7 @@ public:
     return *this;
   }
 
-  /// reset - Reset bits that are set in RHS. Same as *this &= ~RHS.
+  /// Reset bits that are set in RHS. Same as *this &= ~RHS.
   BitVector &reset(const BitVector &RHS) {
     unsigned ThisWords = Bits.size();
     unsigned RHSWords = RHS.Bits.size();
@@ -550,7 +544,7 @@ public:
     return *this;
   }
 
-  /// test - Check if (This - RHS) is non-zero.
+  /// Check if (This - RHS) is non-zero.
   /// This is the same as reset(RHS) and any().
   bool test(const BitVector &RHS) const {
     unsigned ThisWords = Bits.size();
@@ -567,7 +561,7 @@ public:
     return false;
   }
 
-  /// subsetOf - Check if This is a subset of RHS.
+  /// Check if This is a subset of RHS.
   bool subsetOf(const BitVector &RHS) const { return !test(RHS); }
 
   template <class F, class... ArgTys>
@@ -721,25 +715,25 @@ public:
   // bit mask is always a whole multiple of 32 bits.  If no bit mask size is
   // given, the bit mask is assumed to cover the entire BitVector.
 
-  /// setBitsInMask - Add '1' bits from Mask to this vector. Don't resize.
+  /// Add '1' bits from Mask to this vector. Don't resize.
   /// This computes "*this |= Mask".
   void setBitsInMask(const uint32_t *Mask, unsigned MaskWords = ~0u) {
     applyMask<true, false>(Mask, MaskWords);
   }
 
-  /// clearBitsInMask - Clear any bits in this vector that are set in Mask.
+  /// Clear any bits in this vector that are set in Mask.
   /// Don't resize. This computes "*this &= ~Mask".
   void clearBitsInMask(const uint32_t *Mask, unsigned MaskWords = ~0u) {
     applyMask<false, false>(Mask, MaskWords);
   }
 
-  /// setBitsNotInMask - Add a bit to this vector for every '0' bit in Mask.
+  /// Add a bit to this vector for every '0' bit in Mask.
   /// Don't resize.  This computes "*this |= ~Mask".
   void setBitsNotInMask(const uint32_t *Mask, unsigned MaskWords = ~0u) {
     applyMask<true, true>(Mask, MaskWords);
   }
 
-  /// clearBitsNotInMask - Clear a bit in this vector for every '0' bit in Mask.
+  /// Clear a bit in this vector for every '0' bit in Mask.
   /// Don't resize.  This computes "*this &= Mask".
   void clearBitsNotInMask(const uint32_t *Mask, unsigned MaskWords = ~0u) {
     applyMask<false, true>(Mask, MaskWords);

--- a/llvm/include/llvm/ADT/ConcurrentHashtable.h
+++ b/llvm/include/llvm/ADT/ConcurrentHashtable.h
@@ -27,7 +27,7 @@
 
 namespace llvm {
 
-/// ConcurrentHashTable - is a resizeable concurrent hashtable.
+/// ConcurrentHashTable is a resizeable concurrent hashtable.
 /// The number of resizings limited up to x2^31. This hashtable is
 /// useful to have efficient access to aggregate data(like strings,
 /// type descriptors...) and to keep only single copy of such

--- a/llvm/include/llvm/ADT/DAGDeltaAlgorithm.h
+++ b/llvm/include/llvm/ADT/DAGDeltaAlgorithm.h
@@ -15,7 +15,7 @@
 
 namespace llvm {
 
-/// DAGDeltaAlgorithm - Implements a "delta debugging" algorithm for minimizing
+/// Implements a "delta debugging" algorithm for minimizing
 /// directed acyclic graphs using a predicate function.
 ///
 /// The result of the algorithm is a subset of the input change set which is
@@ -50,7 +50,7 @@ public:
 public:
   virtual ~DAGDeltaAlgorithm() = default;
 
-  /// Run - Minimize the DAG formed by the \p Changes vertices and the
+  /// Minimize the DAG formed by the \p Changes vertices and the
   /// \p Dependencies edges by executing \see ExecuteOneTest() on subsets of
   /// changes and returning the smallest set which still satisfies the test
   /// predicate and the input \p Dependencies.
@@ -65,12 +65,12 @@ public:
   changeset_ty Run(const changeset_ty &Changes,
                    const std::vector<edge_ty> &Dependencies);
 
-  /// UpdatedSearchState - Callback used when the search state changes.
+  /// Callback used when the search state changes.
   virtual void UpdatedSearchState(const changeset_ty &Changes,
                                   const changesetlist_ty &Sets,
                                   const changeset_ty &Required) {}
 
-  /// ExecuteOneTest - Execute a single test predicate on the change set \p S.
+  /// Execute a single test predicate on the change set \p S.
   virtual bool ExecuteOneTest(const changeset_ty &S) = 0;
 };
 

--- a/llvm/include/llvm/ADT/DeltaAlgorithm.h
+++ b/llvm/include/llvm/ADT/DeltaAlgorithm.h
@@ -14,7 +14,7 @@
 
 namespace llvm {
 
-/// DeltaAlgorithm - Implements the delta debugging algorithm (A. Zeller '99)
+/// Implements the delta debugging algorithm (A. Zeller '99)
 /// for minimizing arbitrary sets using a predicate function.
 ///
 /// The result of the algorithm is a subset of the input change set which is
@@ -45,22 +45,22 @@ private:
   /// since we always reduce following a success.
   std::set<changeset_ty> FailedTestsCache;
 
-  /// GetTestResult - Get the test result for the \p Changes from the
-  /// cache, executing the test if necessary.
+  /// Get the test result for the \p Changes from the cache, executing the test
+  /// if necessary.
   ///
   /// \param Changes - The change set to test.
   /// \return - The test result.
   bool GetTestResult(const changeset_ty &Changes);
 
-  /// Split - Partition a set of changes \p S into one or two subsets.
+  /// Partition a set of changes \p S into one or two subsets.
   void Split(const changeset_ty &S, changesetlist_ty &Res);
 
-  /// Delta - Minimize a set of \p Changes which has been partitioned into
+  /// Minimize a set of \p Changes which has been partitioned into
   /// smaller sets, by attempting to remove individual subsets.
   changeset_ty Delta(const changeset_ty &Changes,
                      const changesetlist_ty &Sets);
 
-  /// Search - Search for a subset (or subsets) in \p Sets which can be
+  /// Search for a subset (or subsets) in \p Sets which can be
   /// removed from \p Changes while still satisfying the predicate.
   ///
   /// \param Res - On success, a subset of Changes which satisfies the
@@ -70,11 +70,11 @@ private:
               changeset_ty &Res);
 
 protected:
-  /// UpdatedSearchState - Callback used when the search state changes.
+  /// Callback used when the search state changes.
   virtual void UpdatedSearchState(const changeset_ty &Changes,
                                   const changesetlist_ty &Sets) {}
 
-  /// ExecuteOneTest - Execute a single test predicate on the change set \p S.
+  /// Execute a single test predicate on the change set \p S.
   virtual bool ExecuteOneTest(const changeset_ty &S) = 0;
 
   DeltaAlgorithm& operator=(const DeltaAlgorithm&) = default;
@@ -82,7 +82,7 @@ protected:
 public:
   virtual ~DeltaAlgorithm();
 
-  /// Run - Minimize the set \p Changes by executing \see ExecuteOneTest() on
+  /// Minimize the set \p Changes by executing \see ExecuteOneTest() on
   /// subsets of changes and returning the smallest set which still satisfies
   /// the test predicate.
   changeset_ty Run(const changeset_ty &Changes);

--- a/llvm/include/llvm/ADT/DeltaTree.h
+++ b/llvm/include/llvm/ADT/DeltaTree.h
@@ -17,7 +17,7 @@
 
 namespace llvm {
 
-/// DeltaTree - a multiway search tree (BTree) structure with some fancy
+/// A multiway search tree (BTree) structure with some fancy
 /// features.  B-Trees are generally more memory and cache efficient than
 /// binary trees, because they store multiple keys/values in each node.  This
 /// implements a key/value mapping from index to delta, and allows fast lookup
@@ -36,12 +36,12 @@ public:
   DeltaTree &operator=(const DeltaTree &) = delete;
   LLVM_ABI ~DeltaTree();
 
-  /// getDeltaAt - Return the accumulated delta at the specified file offset.
+  /// Return the accumulated delta at the specified file offset.
   /// This includes all insertions or delections that occurred *before* the
   /// specified file index.
   LLVM_ABI int getDeltaAt(unsigned FileIndex) const;
 
-  /// AddDelta - When a change is made that shifts around the text buffer,
+  /// When a change is made that shifts around the text buffer,
   /// this method is used to record that info.  It inserts a delta of 'Delta'
   /// into the current DeltaTree at offset FileIndex.
   LLVM_ABI void AddDelta(unsigned FileIndex, int Delta);

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -200,8 +200,8 @@ public:
     return end();
   }
 
-  /// lookup - Return the entry for the specified key, or a default
-  /// constructed value if no such entry exists.
+  /// Return the entry for the specified key, or a default constructed value if
+  /// no such entry exists.
   [[nodiscard]] ValueT lookup(const_arg_type_t<KeyT> Val) const {
     if (const BucketT *Bucket = doFind(Val))
       return Bucket->getSecond();
@@ -219,16 +219,14 @@ public:
     return Default;
   }
 
-  /// at - Return the entry for the specified key, or abort if no such
-  /// entry exists.
+  /// Return the entry for the specified key, or abort if no such entry exists.
   [[nodiscard]] ValueT &at(const_arg_type_t<KeyT> Val) {
     auto Iter = this->find(std::move(Val));
     assert(Iter != this->end() && "DenseMap::at failed due to a missing key");
     return Iter->second;
   }
 
-  /// at - Return the entry for the specified key, or abort if no such
-  /// entry exists.
+  /// Return the entry for the specified key, or abort if no such entry exists.
   [[nodiscard]] const ValueT &at(const_arg_type_t<KeyT> Val) const {
     auto Iter = this->find(std::move(Val));
     assert(Iter != this->end() && "DenseMap::at failed due to a missing key");
@@ -284,7 +282,7 @@ public:
     return {makeIterator(TheBucket), true};
   }
 
-  /// insert - Range insertion of pairs.
+  /// Range insertion of pairs.
   template <typename InputIt> void insert(InputIt I, InputIt E) {
     for (; I != E; ++I)
       insert(*I);
@@ -354,9 +352,8 @@ public:
     return lookupOrInsertIntoBucket(std::move(Key)).first->second;
   }
 
-  /// isPointerIntoBucketsArray - Return true if the specified pointer points
-  /// somewhere into the DenseMap's array of buckets (i.e. either to a key or
-  /// value in the DenseMap).
+  /// Return true if the specified pointer points somewhere into the DenseMap's
+  /// array of buckets (i.e. either to a key or value in the DenseMap).
   [[nodiscard]] bool isPointerIntoBucketsArray(const void *Ptr) const {
     return Ptr >= getBuckets() && Ptr < getBucketsEnd();
   }
@@ -642,10 +639,9 @@ private:
         static_cast<const DenseMapBase *>(this)->doFind(Val));
   }
 
-  /// LookupBucketFor - Lookup the appropriate bucket for Val, returning it in
-  /// FoundBucket.  If the bucket contains the key and a value, this returns
-  /// true, otherwise it returns a bucket with an empty marker or tombstone and
-  /// returns false.
+  /// Lookup the appropriate bucket for Val, returning it in FoundBucket. If the
+  /// bucket contains the key and a value, this returns true, otherwise it
+  /// returns a bucket with an empty marker or tombstone and returns false.
   template <typename LookupKeyT>
   bool LookupBucketFor(const LookupKeyT &Val, BucketT *&FoundBucket) {
     BucketT *BucketsPtr = getBuckets();


### PR DESCRIPTION
Adopt LLVM CS recommendation to not repeat function or class name is Doxygen comments.
https://llvm.org/docs/CodingStandards.html#doxygen-use-in-documentation-comments