### PR TITLE
[NFC][LLVM][ADT] Remove function names from Doxygen comments

### DIFF
--- a/llvm/include/llvm/ADT/ImmutableList.h
+++ b/llvm/include/llvm/ADT/ImmutableList.h
@@ -53,14 +53,13 @@ public:
   }
 };
 
-/// ImmutableList - This class represents an immutable (functional) list.
-///  It is implemented as a smart pointer (wraps ImmutableListImpl), so it
-///  it is intended to always be copied by value as if it were a pointer.
-///  This interface matches ImmutableSet and ImmutableMap.  ImmutableList
-///  objects should almost never be created directly, and instead should
-///  be created by ImmutableListFactory objects that manage the lifetime
-///  of a group of lists.  When the factory object is reclaimed, all lists
-///  created by that factory are released as well.
+/// This class represents an immutable (functional) list. It is implemented as a
+/// smart pointer (wraps ImmutableListImpl), so it is intended to always be
+/// copied by value as if it were a pointer. This interface matches ImmutableSet
+/// and ImmutableMap. ImmutableList objects should almost never be created
+/// directly, and instead should be created by ImmutableListFactory objects that
+/// manage the lifetime of a group of lists. When the factory object is
+/// reclaimed, all lists created by that factory are released as well.
 template <typename T>
 class ImmutableList {
 public:
@@ -101,15 +100,15 @@ public:
     ImmutableList getList() const { return L; }
   };
 
-  /// begin - Returns an iterator referring to the head of the list, or
-  ///  an iterator denoting the end of the list if the list is empty.
+  /// Returns an iterator referring to the head of the list, or an iterator
+  /// denoting the end of the list if the list is empty.
   iterator begin() const { return iterator(X); }
 
-  /// end - Returns an iterator denoting the end of the list.  This iterator
-  ///  does not refer to a valid list element.
+  /// Returns an iterator denoting the end of the list. This iterator does not
+  /// refer to a valid list element.
   iterator end() const { return iterator(); }
 
-  /// isEmpty - Returns true if the list is empty.
+  /// Returns true if the list is empty.
   bool isEmpty() const { return !X; }
 
   bool contains(const T& V) const {
@@ -120,23 +119,22 @@ public:
     return false;
   }
 
-  /// isEqual - Returns true if two lists are equal.  Because all lists created
-  ///  from the same ImmutableListFactory are uniqued, this has O(1) complexity
-  ///  because it the contents of the list do not need to be compared.  Note
-  ///  that you should only compare two lists created from the same
-  ///  ImmutableListFactory.
+  /// Returns true if two lists are equal.  Because all lists created from the
+  /// same ImmutableListFactory are uniqued, this has O(1) complexity because it
+  /// the contents of the list do not need to be compared. Note that you should
+  /// only compare two lists created from the same ImmutableListFactory.
   bool isEqual(const ImmutableList& L) const { return X == L.X; }
 
   bool operator==(const ImmutableList& L) const { return isEqual(L); }
 
-  /// getHead - Returns the head of the list.
+  /// Returns the head of the list.
   const T& getHead() const {
     assert(!isEmpty() && "Cannot get the head of an empty list.");
     return X->getHead();
   }
 
-  /// getTail - Returns the tail of the list, which is another (possibly empty)
-  ///  ImmutableList.
+  /// Returns the tail of the list, which is another (possibly empty)
+  /// ImmutableList.
   ImmutableList getTail() const {
     return X ? X->getTail() : nullptr;
   }

--- a/llvm/include/llvm/ADT/ImmutableMap.h
+++ b/llvm/include/llvm/ADT/ImmutableMap.h
@@ -21,9 +21,9 @@
 
 namespace llvm {
 
-/// ImutKeyValueInfo -Traits class used by ImmutableMap.  While both the first
-/// and second elements in a pair are used to generate profile information,
-/// only the first element (the key) is used by isEqual and isLess.
+/// Traits class used by ImmutableMap. While both the first and second elements
+/// in a pair are used to generate profile information, only the first element
+/// (the key) is used by isEqual and isLess.
 template <typename T, typename S>
 struct ImutKeyValueInfo {
   using value_type = const std::pair<T,S>;
@@ -175,9 +175,9 @@ public:
     return nullptr;
   }
 
-  /// getMaxElement - Returns the <key,value> pair in the ImmutableMap for
-  ///  which key is the highest in the ordering of keys in the map.  This
-  ///  method returns NULL if the map is empty.
+  /// Returns the <key,value> pair in the ImmutableMap for which key is the
+  /// highest in the ordering of keys in the map. This method returns NULL if
+  /// the map is empty.
   [[nodiscard]] value_type *getMaxElement() const {
     return Root ? &(Root->getMaxElement()->getValue()) : nullptr;
   }
@@ -307,9 +307,9 @@ public:
     return nullptr;
   }
 
-  /// getMaxElement - Returns the <key,value> pair in the ImmutableMap for
-  ///  which key is the highest in the ordering of keys in the map.  This
-  ///  method returns NULL if the map is empty.
+  /// Returns the <key,value> pair in the ImmutableMap for which key is the
+  /// highest in the ordering of keys in the map.  This method returns NULL if
+  /// the map is empty.
   [[nodiscard]] value_type *getMaxElement() const {
     return Root ? &(Root->getMaxElement()->getValue()) : nullptr;
   }

--- a/llvm/include/llvm/ADT/ImmutableSet.h
+++ b/llvm/include/llvm/ADT/ImmutableSet.h
@@ -67,15 +67,14 @@ public:
   ///  NULL if there is no right subtree.
   ImutAVLTree *getRight() const { return right; }
 
-  /// getHeight - Returns the height of the tree.  A tree with no subtrees
-  ///  has a height of 1.
+  /// Returns the height of the tree. A tree with no subtrees has a height of 1.
   unsigned getHeight() const { return height; }
 
-  /// getValue - Returns the data value associated with the tree node.
+  /// Returns the data value associated with the tree node.
   const value_type& getValue() const { return value; }
 
-  /// find - Finds the subtree associated with the specified key value.
-  ///  This method returns NULL if no matching subtree is found.
+  /// Finds the subtree associated with the specified key value. This method
+  /// returns NULL if no matching subtree is found.
   ImutAVLTree* find(key_type_ref K) {
     ImutAVLTree *T = this;
     while (T) {
@@ -90,8 +89,7 @@ public:
     return nullptr;
   }
 
-  /// getMaxElement - Find the subtree associated with the highest ranged
-  ///  key value.
+  /// Find the subtree associated with the highest ranged key value.
   ImutAVLTree* getMaxElement() {
     ImutAVLTree *T = this;
     ImutAVLTree *Right = T->getRight();
@@ -99,8 +97,8 @@ public:
     return T;
   }
 
-  /// size - Returns the number of nodes in the tree, which includes
-  ///  both leaves and non-leaf nodes.
+  /// Returns the number of nodes in the tree, which includes both leaves and
+  // non-leaf nodes.
   unsigned size() const {
     unsigned n = 1;
     if (const ImutAVLTree* L = getLeft())
@@ -110,13 +108,13 @@ public:
     return n;
   }
 
-  /// begin - Returns an iterator that iterates over the nodes of the tree
-  ///  in an inorder traversal.  The returned iterator thus refers to the
-  ///  the tree node with the minimum data element.
+  /// Returns an iterator that iterates over the nodes of the tree in an inorder
+  /// traversal. The returned iterator thus refers to the tree node with the
+  /// minimum data element.
   iterator begin() const { return iterator(this); }
 
-  /// end - Returns an iterator for the tree that denotes the end of an
-  ///  inorder traversal.
+  /// Returns an iterator for the tree that denotes the end of an inorder
+  /// traversal.
   iterator end() const { return iterator(); }
 
   bool isElementEqual(value_type_ref V) const {
@@ -137,9 +135,9 @@ public:
     return isElementEqual(RHS->getValue());
   }
 
-  /// isEqual - Compares two trees for structural equality and returns true
-  ///   if they are equal.  This worst case performance of this operation is
-  //    linear in the sizes of the trees.
+  /// Compares two trees for structural equality and returns true if they are
+  /// equal. The worst case performance of this operation is linear in the sizes
+  /// of the trees.
   bool isEqual(const ImutAVLTree& RHS) const {
     if (&RHS == this)
       return true;
@@ -164,21 +162,20 @@ public:
     return LItr == LEnd && RItr == REnd;
   }
 
-  /// isNotEqual - Compares two trees for structural inequality.  Performance
-  ///  is the same is isEqual.
+  /// Compares two trees for structural inequality.  Performance is the same as
+  /// isEqual.
   bool isNotEqual(const ImutAVLTree& RHS) const { return !isEqual(RHS); }
 
-  /// contains - Returns true if this tree contains a subtree (node) that
-  ///  has an data element that matches the specified key.  Complexity
-  ///  is logarithmic in the size of the tree.
+  /// Returns true if this tree contains a subtree (node) that has an data
+  /// element that matches the specified key. Complexity is logarithmic in the
+  /// size of the tree.
   bool contains(key_type_ref K) { return (bool) find(K); }
 
-  /// validateTree - A utility method that checks that the balancing and
-  ///  ordering invariants of the tree are satisfied.  It is a recursive
-  ///  method that returns the height of the tree, which is then consumed
-  ///  by the enclosing validateTree call.  External callers should ignore the
-  ///  return value.  An invalid tree will cause an assertion to fire in
-  ///  a debug build.
+  /// A utility method that checks that the balancing and ordering invariants of
+  /// the tree are satisfied. It is a recursive method that returns the height
+  /// of the tree, which is then consumed by the enclosing validateTree call.
+  /// External callers should ignore the return value.  An invalid tree will
+  /// cause an assertion to fire in a debug build.
   unsigned validateTree() const {
     unsigned HL = getLeft() ? getLeft()->validateTree() : 0;
     unsigned HR = getRight() ? getRight()->validateTree() : 0;
@@ -232,8 +229,7 @@ private:
   //===----------------------------------------------------===//
 
 private:
-  /// ImutAVLTree - Internal constructor that is only called by
-  ///   ImutAVLFactory.
+  /// Internal constructor that is only called by ImutAVLFactory.
   ImutAVLTree(Factory *f, ImutAVLTree* l, ImutAVLTree* r, value_type_ref v,
               unsigned height)
     : factory(f), left(l), right(r), height(height), IsMutable(true),
@@ -243,7 +239,7 @@ private:
     if (right) right->retain();
   }
 
-  /// isMutable - Returns true if the left and right subtree references
+  /// Returns true if the left and right subtree references
   ///  (as well as height) can be changed.  If this method returns false,
   ///  the tree is truly immutable.  Trees returned from an ImutAVLFactory
   ///  object should always have this method return true.  Further, if this
@@ -251,8 +247,8 @@ private:
   ///  will also have this method return false.  The converse is not true.
   bool isMutable() const { return IsMutable; }
 
-  /// hasCachedDigest - Returns true if the digest for this tree is cached.
-  ///  This can only be true if the tree is immutable.
+  /// Returns true if the digest for this tree is cached. This can only be true
+  /// if the tree is immutable.
   bool hasCachedDigest() const { return IsDigestCached; }
 
   //===----------------------------------------------------===//
@@ -266,21 +262,20 @@ private:
   // immutable.
   //===----------------------------------------------------===//
 
-  /// markImmutable - Clears the mutable flag for a tree.  After this happens,
-  ///   it is an error to call setLeft(), setRight(), and setHeight().
+  /// Clears the mutable flag for a tree.  After this happens,
+  /// it is an error to call setLeft(), setRight(), and setHeight().
   void markImmutable() {
     assert(isMutable() && "Mutable flag already removed.");
     IsMutable = false;
   }
 
-  /// markedCachedDigest - Clears the NoCachedDigest flag for a tree.
+  /// Clears the NoCachedDigest flag for a tree.
   void markedCachedDigest() {
     assert(!hasCachedDigest() && "NoCachedDigest flag already removed.");
     IsDigestCached = true;
   }
 
-  /// setHeight - Changes the height of the tree.  Used internally by
-  ///  ImutAVLFactory.
+  /// Changes the height of the tree.  Used internally by ImutAVLFactory.
   void setHeight(unsigned h) {
     assert(isMutable() && "Only a mutable tree can have its height changed.");
     height = h;
@@ -487,8 +482,7 @@ protected:
     createdNodes.clear();
   }
 
-  /// balanceTree - Used by add_internal and remove_internal to
-  ///  balance a newly created tree.
+  /// Used by add_internal and remove_internal to balance a newly created tree.
   TreeTy* balanceTree(TreeTy* L, value_type_ref V, TreeTy* R) {
     unsigned hl = getHeight(L);
     unsigned hr = getHeight(R);
@@ -613,8 +607,7 @@ protected:
                        getValue(T), getRight(T));
   }
 
-  /// markImmutable - Clears the mutable bits of a root and all of its
-  ///  descendants.
+  /// Clears the mutable bits of a root and all of its descendants.
   void markImmutable(TreeTy* T) {
     if (!T || !T->isMutable())
       return;
@@ -925,9 +918,9 @@ struct ImutProfileInfo<T*> {
 //  for element profiling.
 //===----------------------------------------------------------------------===//
 
-/// ImutContainerInfo - Generic definition of comparison operations for
-///   elements of immutable containers that defaults to using
-///   std::equal_to<> and std::less<> to perform comparison of elements.
+/// Generic definition of comparison operations for elements of immutable
+/// containers that defaults to using std::equal_to<> and std::less<> to perform
+/// comparison of elements.
 template <typename T> struct ImutContainerInfo : ImutProfileInfo<T> {
   using value_type = typename ImutProfileInfo<T>::value_type;
   using value_type_ref = typename ImutProfileInfo<T>::value_type_ref;
@@ -950,9 +943,8 @@ template <typename T> struct ImutContainerInfo : ImutProfileInfo<T> {
   static bool isDataEqual(data_type_ref, data_type_ref) { return true; }
 };
 
-/// ImutContainerInfo - Specialization for pointer values to treat pointers
-///  as references to unique objects.  Pointers are thus compared by
-///  their addresses.
+/// Specialization for pointer values to treat pointers as references to unique
+/// objects. Pointers are thus compared by their addresses.
 template <typename T> struct ImutContainerInfo<T *> : ImutProfileInfo<T *> {
   using value_type = typename ImutProfileInfo<T*>::value_type;
   using value_type_ref = typename ImutProfileInfo<T*>::value_type_ref;
@@ -1006,30 +998,30 @@ public:
     Factory(const Factory& RHS) = delete;
     void operator=(const Factory& RHS) = delete;
 
-    /// getEmptySet - Returns an immutable set that contains no elements.
+    /// Returns an immutable set that contains no elements.
     ImmutableSet getEmptySet() {
       return ImmutableSet(F.getEmptyTree());
     }
 
-    /// add - Creates a new immutable set that contains all of the values
-    ///  of the original set with the addition of the specified value.  If
-    ///  the original set already included the value, then the original set is
-    ///  returned and no memory is allocated.  The time and space complexity
-    ///  of this operation is logarithmic in the size of the original set.
-    ///  The memory allocated to represent the set is released when the
-    ///  factory object that created the set is destroyed.
+    /// Creates a new immutable set that contains all of the values
+    /// of the original set with the addition of the specified value.  If
+    /// the original set already included the value, then the original set is
+    /// returned and no memory is allocated.  The time and space complexity
+    /// of this operation is logarithmic in the size of the original set.
+    /// The memory allocated to represent the set is released when the
+    /// factory object that created the set is destroyed.
     [[nodiscard]] ImmutableSet add(ImmutableSet Old, value_type_ref V) {
       TreeTy *NewT = F.add(Old.Root.get(), V);
       return ImmutableSet(Canonicalize ? F.getCanonicalTree(NewT) : NewT);
     }
 
-    /// remove - Creates a new immutable set that contains all of the values
-    ///  of the original set with the exception of the specified value.  If
-    ///  the original set did not contain the value, the original set is
-    ///  returned and no memory is allocated.  The time and space complexity
-    ///  of this operation is logarithmic in the size of the original set.
-    ///  The memory allocated to represent the set is released when the
-    ///  factory object that created the set is destroyed.
+    /// Creates a new immutable set that contains all of the values
+    /// of the original set with the exception of the specified value.  If
+    /// the original set did not contain the value, the original set is
+    /// returned and no memory is allocated.  The time and space complexity
+    /// of this operation is logarithmic in the size of the original set.
+    /// The memory allocated to represent the set is released when the
+    /// factory object that created the set is destroyed.
     [[nodiscard]] ImmutableSet remove(ImmutableSet Old, value_type_ref V) {
       TreeTy *NewT = F.remove(Old.Root.get(), V);
       return ImmutableSet(Canonicalize ? F.getCanonicalTree(NewT) : NewT);
@@ -1065,11 +1057,11 @@ public:
 
   TreeTy *getRootWithoutRetain() const { return Root.get(); }
 
-  /// isEmpty - Return true if the set contains no elements.
+  /// Return true if the set contains no elements.
   bool isEmpty() const { return !Root; }
 
-  /// isSingleton - Return true if the set contains exactly one element.
-  ///   This method runs in constant time.
+  /// Return true if the set contains exactly one element.
+  /// This method runs in constant time.
   bool isSingleton() const { return getHeight() == 1; }
 
   //===--------------------------------------------------===//
@@ -1153,11 +1145,11 @@ public:
                             : Root != RHS.Root;
   }
 
-  /// isEmpty - Return true if the set contains no elements.
+  /// Return true if the set contains no elements.
   bool isEmpty() const { return !Root; }
 
-  /// isSingleton - Return true if the set contains exactly one element.
-  ///   This method runs in constant time.
+  /// Return true if the set contains exactly one element.
+  /// This method runs in constant time.
   bool isSingleton() const { return getHeight() == 1; }
 
   //===--------------------------------------------------===//


### PR DESCRIPTION
Adopt LLVM CS recommendation to not repeat function or class name is Doxygen comments.
https://llvm.org/docs/CodingStandards.html#doxygen-use-in-documentation-comments