### PR TITLE
[dsymutil] Update module-warnings.test to run with both linkers

### DIFF
--- a/llvm/test/tools/dsymutil/X86/module-warnings.test
+++ b/llvm/test/tools/dsymutil/X86/module-warnings.test
@@ -25,6 +25,8 @@
 #
 # RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y \
 # RUN:   %p/dummy-debug-map.map -o %t 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir -y \
+# RUN:   %p/dummy-debug-map.map -o %t 2>&1 | FileCheck %s
 #
 # Module-not-found should be reported only once.
 # The exact error message depends on the OS so we don't check for it.
@@ -33,16 +35,24 @@
 #
 # RUN: cp %p/../Inputs/module-warnings/libstatic.a %t.dir
 # RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 | FileCheck %s
+# RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 | FileCheck %s
 # CHECK: rebuild the module cache
 # CHECK-NOT: static libraries
 #
 # RUN: rm -rf %t.dir/ModuleCache
 # RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 \
+# RUN:   | FileCheck %s --check-prefixes=STATIC,STATIC-CLASSIC
+# RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir -y %s -o %t 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=STATIC
 # STATIC: warning: {{.*}}Bar.pcm:
 # STATIC: note: Linking a static library
 # STATIC: warning: {{.*}}Foo.pcm:
-# STATIC: warning: couldn`t find compile unit for the macro table with offset = 0x0
+
+## The classic linker emits a combined .debug_macinfo table and warns about
+## MacroLists it has to drop because no compile unit references them. The
+## parallel linker emits .debug_macinfo per compile unit, so unreferenced lists
+## are never emitted and have no corresponding warning.
+# STATIC-CLASSIC: warning: couldn`t find compile unit for the macro table with offset = 0x0
 # STATIC-NOT: warning:
 
 ---
@@ -52,5 +62,3 @@ objects:
     symbols:
       - { sym: __Z3foov, objAddr: 0x0, binAddr: 0x10000, size: 0x10 }
 ...
-
-## FIXME: Support --linker parallel


### PR DESCRIPTION
The classic linker emits a combined .debug_macinfo table and warns about MacroLists it has to drop because no compile unit references them. The parallel linker emits .debug_macinfo per compile unit, so unreferenced lists are never emitted and have no corresponding warning.