### PR TITLE
[RFC][IR] Support vector splats in `ConstantPointerNull`

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -64,6 +64,10 @@ Makes programs 10x faster by doing Special New Thing.
 * The `"nooutline"` attribute is now writen as `nooutline`. Existing IR and
   bitcode will be automatically updated.
 
+* `ConstantPointerNull` can now represent fixed and scalable vector splats of
+  null pointers. Such constants may print as `splat (ptr null)` instead of
+  `zeroinitializer`.
+
 * LLVM IR floating-point literals have greatly changed:
 
   * The old hexadecimal bitwise representation is deprecated and will be removed

--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -696,12 +696,13 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-/// A constant pointer value that points to null
+/// A constant pointer value that points to null. This represents both scalar
+/// pointer nulls and vector splats of pointer nulls.
 ///
 class ConstantPointerNull final : public ConstantData {
   friend class Constant;
 
-  explicit ConstantPointerNull(PointerType *T)
+  explicit ConstantPointerNull(Type *T)
       : ConstantData(T, Value::ConstantPointerNullVal) {}
 
   void destroyConstantImpl();
@@ -709,13 +710,15 @@ class ConstantPointerNull final : public ConstantData {
 public:
   ConstantPointerNull(const ConstantPointerNull &) = delete;
 
-  /// Static factory methods - Return objects of the specified value
+  /// Static factory methods - Return objects of the specified value. If Ty is a
+  /// vector type, return a ConstantPointerNull with a splat of null pointer
+  /// values. Otherwise return a ConstantPointerNull for the given pointer type.
   LLVM_ABI static ConstantPointerNull *get(PointerType *T);
+  LLVM_ABI static ConstantPointerNull *get(Type *T);
 
-  /// Specialize the getType() method to always return an PointerType,
-  /// which reduces the amount of casting needed in parts of the compiler.
-  inline PointerType *getType() const {
-    return cast<PointerType>(Value::getType());
+  /// Return the scalar pointer type for this null value.
+  PointerType *getPointerType() const {
+    return cast<PointerType>(Value::getType()->getScalarType());
   }
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:

--- a/llvm/include/llvm/SandboxIR/Constant.h
+++ b/llvm/include/llvm/SandboxIR/Constant.h
@@ -773,7 +773,8 @@ class ConstantPointerNull final : public Constant {
 public:
   LLVM_ABI static ConstantPointerNull *get(PointerType *Ty);
 
-  LLVM_ABI PointerType *getType() const;
+  LLVM_ABI Type *getType() const;
+  LLVM_ABI PointerType *getPointerType() const;
 
   /// For isa/dyn_cast.
   static bool classof(const sandboxir::Value *From) {

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1640,10 +1640,10 @@ AliasResult BasicAAResult::aliasCheck(const Value *V1, LocationSize V1Size,
   // Null values in the default address space don't point to any object, so they
   // don't alias any other pointer.
   if (const ConstantPointerNull *CPN = dyn_cast<ConstantPointerNull>(O1))
-    if (!NullPointerIsDefined(&F, CPN->getType()->getAddressSpace()))
+    if (!NullPointerIsDefined(&F, CPN->getPointerType()->getAddressSpace()))
       return AliasResult::NoAlias;
   if (const ConstantPointerNull *CPN = dyn_cast<ConstantPointerNull>(O2))
-    if (!NullPointerIsDefined(&F, CPN->getType()->getAddressSpace()))
+    if (!NullPointerIsDefined(&F, CPN->getPointerType()->getAddressSpace()))
       return AliasResult::NoAlias;
 
   if (O1 != O2) {

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -773,7 +773,7 @@ bool GlobalsAAResult::isNonEscapingGlobalNoAlias(const GlobalValue *GV,
       if (auto *CPN = dyn_cast<ConstantPointerNull>(Input)) {
         // Null pointer cannot alias with a non-addr-taken global.
         const Function *F = CtxI->getFunction();
-        if (!NullPointerIsDefined(F, CPN->getType()->getAddressSpace()))
+        if (!NullPointerIsDefined(F, CPN->getPointerType()->getAddressSpace()))
           continue;
       }
 

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -1016,7 +1016,7 @@ ObjectSizeOffsetVisitor::visitConstantPointerNull(ConstantPointerNull &CPN) {
   // TODO: How should this work with address space casts? We currently just drop
   // them on the floor, but it's unclear what we should do when a NULL from
   // addrspace(1) gets casted to addrspace(0) (or vice-versa).
-  if (Options.NullIsUnknownSize || CPN.getType()->getAddressSpace())
+  if (Options.NullIsUnknownSize || CPN.getPointerType()->getAddressSpace())
     return ObjectSizeOffsetVisitor::unknown();
   return OffsetSpan(Zero, Zero);
 }

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1813,7 +1813,16 @@ static void writeConstantInternal(raw_ostream &Out, const Constant *CV,
     return;
   }
 
-  if (isa<ConstantPointerNull>(CV)) {
+  if (const auto *CPN = dyn_cast<ConstantPointerNull>(CV)) {
+    if (auto *VT = dyn_cast<VectorType>(CPN->getType())) {
+      Out << "splat (";
+      writeAsOperandInternal(Out,
+                             ConstantPointerNull::get(VT->getElementType()),
+                             WriterCtx, /*PrintType=*/true);
+      Out << ')';
+      return;
+    }
+
     Out << "null";
     return;
   }

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -48,6 +48,22 @@ static cl::opt<bool> UseConstantIntForScalableSplat(
 static cl::opt<bool> UseConstantFPForScalableSplat(
     "use-constant-fp-for-scalable-splat", cl::init(true), cl::Hidden,
     cl::desc("Use ConstantFP's native scalable vector splat support."));
+static cl::opt<bool> UseConstantPtrNullForFixedLengthSplat(
+    "use-constant-ptrnull-for-fixed-length-splat", cl::init(true), cl::Hidden,
+    cl::desc("Use ConstantPointerNull's native fixed-length vector splat "
+             "support."));
+static cl::opt<bool> UseConstantPtrNullForScalableSplat(
+    "use-constant-ptrnull-for-scalable-splat", cl::init(true), cl::Hidden,
+    cl::desc(
+        "Use ConstantPointerNull's native scalable vector splat support."));
+
+static bool shouldUseConstantPointerNullForVector(VectorType *VTy) {
+  if (!VTy->getElementType()->isPointerTy())
+    return false;
+  return VTy->getElementCount().isScalable()
+             ? UseConstantPtrNullForScalableSplat
+             : UseConstantPtrNullForFixedLengthSplat;
+}
 
 //===----------------------------------------------------------------------===//
 //                              Constant Class
@@ -404,10 +420,13 @@ Constant *Constant::getNullValue(Type *Ty) {
                            APFloat::getZero(Ty->getFltSemantics()));
   case Type::PointerTyID:
     return ConstantPointerNull::get(cast<PointerType>(Ty));
-  case Type::StructTyID:
-  case Type::ArrayTyID:
   case Type::FixedVectorTyID:
   case Type::ScalableVectorTyID:
+    if (shouldUseConstantPointerNullForVector(cast<VectorType>(Ty)))
+      return ConstantPointerNull::get(Ty);
+    return ConstantAggregateZero::get(Ty);
+  case Type::StructTyID:
+  case Type::ArrayTyID:
     return ConstantAggregateZero::get(Ty);
   case Type::TokenTyID:
     return ConstantTokenNone::get(Ty->getContext());
@@ -491,6 +510,13 @@ Constant *Constant::getAggregateElement(unsigned Elt) const {
                        .getKnownMinValue()
                ? ConstantFP::get(getContext(), CFP->getValue())
                : nullptr;
+
+  if (isa<ConstantPointerNull>(this)) {
+    auto *VT = cast<VectorType>(getType());
+    return Elt < VT->getElementCount().getKnownMinValue()
+               ? ConstantPointerNull::get(VT->getElementType())
+               : nullptr;
+  }
 
   // FIXME: getNumElements() will fail for non-fixed vector types.
   if (isa<ScalableVectorType>(getType()))
@@ -1591,16 +1617,21 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
   bool isSplatFP = UseConstantFPForFixedLengthSplat && isa<ConstantFP>(C);
   bool isSplatInt = UseConstantIntForFixedLengthSplat && isa<ConstantInt>(C);
   bool isSplatByte = isa<ConstantByte>(C);
+  bool isSplatPtrNull =
+      UseConstantPtrNullForFixedLengthSplat && isa<ConstantPointerNull>(C);
 
-  if (isZero || isUndef || isSplatFP || isSplatInt || isSplatByte) {
+  if (isZero || isUndef || isSplatFP || isSplatInt || isSplatByte ||
+      isSplatPtrNull) {
     for (unsigned i = 1, e = V.size(); i != e; ++i)
       if (V[i] != C) {
         isZero = isUndef = isPoison = isSplatFP = isSplatInt = isSplatByte =
-            false;
+            isSplatPtrNull = false;
         break;
       }
   }
 
+  if (isSplatPtrNull)
+    return ConstantPointerNull::get(T);
   if (isZero)
     return ConstantAggregateZero::get(T);
   if (isPoison)
@@ -1628,6 +1659,12 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
 }
 
 Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
+  if (isa<ConstantPointerNull>(V)) {
+    VectorType *VTy = VectorType::get(V->getType(), EC);
+    if (shouldUseConstantPointerNullForVector(VTy))
+      return ConstantPointerNull::get(VTy);
+  }
+
   if (!EC.isScalable()) {
     // Maintain special handling of zero.
     if (!V->isNullValue()) {
@@ -1884,6 +1921,8 @@ Constant *Constant::getSplatValue(bool AllowPoison) const {
     return ConstantByte::get(getContext(), CB->getValue());
   if (auto *CFP = dyn_cast<ConstantFP>(this))
     return ConstantFP::get(getContext(), CFP->getValue());
+  if (auto *CPN = dyn_cast<ConstantPointerNull>(this))
+    return ConstantPointerNull::get(CPN->getPointerType());
   if (const ConstantDataVector *CV = dyn_cast<ConstantDataVector>(this))
     return CV->getSplatValue();
   if (const ConstantVector *CV = dyn_cast<ConstantVector>(this))
@@ -2001,11 +2040,17 @@ ConstantRange Constant::toConstantRange() const {
 //
 
 ConstantPointerNull *ConstantPointerNull::get(PointerType *Ty) {
+  return get(static_cast<Type *>(Ty));
+}
+
+ConstantPointerNull *ConstantPointerNull::get(Type *Ty) {
+  assert(Ty->isPtrOrPtrVectorTy() && "invalid type for null pointer constant");
   std::unique_ptr<ConstantPointerNull> &Entry =
       Ty->getContext().pImpl->CPNConstants[Ty];
   if (!Entry)
     Entry.reset(new ConstantPointerNull(Ty));
 
+  assert(Entry->getType() == Ty);
   return Entry.get();
 }
 

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1697,7 +1697,7 @@ public:
   using VectorConstantsTy = ConstantUniqueMap<ConstantVector>;
   VectorConstantsTy VectorConstants;
 
-  DenseMap<PointerType *, std::unique_ptr<ConstantPointerNull>> CPNConstants;
+  DenseMap<Type *, std::unique_ptr<ConstantPointerNull>> CPNConstants;
 
   DenseMap<TargetExtType *, std::unique_ptr<ConstantTargetNone>> CTNConstants;
 

--- a/llvm/lib/SandboxIR/Constant.cpp
+++ b/llvm/lib/SandboxIR/Constant.cpp
@@ -225,9 +225,13 @@ ConstantPointerNull *ConstantPointerNull::get(PointerType *Ty) {
   return cast<ConstantPointerNull>(Ty->getContext().getOrCreateConstant(LLVMC));
 }
 
-PointerType *ConstantPointerNull::getType() const {
+Type *ConstantPointerNull::getType() const {
+  return Ctx.getType(cast<llvm::ConstantPointerNull>(Val)->getType());
+}
+
+PointerType *ConstantPointerNull::getPointerType() const {
   return cast<PointerType>(
-      Ctx.getType(cast<llvm::ConstantPointerNull>(Val)->getType()));
+      Ctx.getType(cast<llvm::ConstantPointerNull>(Val)->getPointerType()));
 }
 
 UndefValue *UndefValue::get(Type *T) {

--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -538,6 +538,8 @@ Register AArch64FastISel::fastMaterializeConstant(const Constant *C) {
   // arm64_32 has 32-bit pointers held in 64-bit registers. Because of that,
   // 'null' pointers need to have a somewhat special treatment.
   if (isa<ConstantPointerNull>(C)) {
+    if (C->getType()->isVectorTy())
+      return Register();
     assert(VT == MVT::i64 && "Expected 64-bit pointers");
     return materializeInt(ConstantInt::get(Type::getInt64Ty(*Context), 0), VT);
   }

--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -539,7 +539,7 @@ Value *Mapper::mapValue(const Value *V) {
   if (isa<ConstantTargetNone>(C))
     return getVM()[V] = Constant::getNullValue(NewTy);
   assert(isa<ConstantPointerNull>(C));
-  return getVM()[V] = ConstantPointerNull::get(cast<PointerType>(NewTy));
+  return getVM()[V] = ConstantPointerNull::get(NewTy);
 }
 
 void Mapper::remapDbgRecord(DbgRecord &DR) {

--- a/llvm/test/Assembler/ConstantExprFold.ll
+++ b/llvm/test/Assembler/ConstantExprFold.ll
@@ -37,8 +37,8 @@
 ; CHECK: @cons = weak global i32 0, align 8
 ; CHECK: @gep1 = global <2 x ptr> undef
 ; CHECK: @gep2 = global <2 x ptr> undef
-; CHECK: @gep3 = global <2 x ptr> zeroinitializer
-; CHECK: @gep4 = global <2 x ptr> zeroinitializer
+; CHECK: @gep3 = global <2 x ptr> splat (ptr null)
+; CHECK: @gep4 = global <2 x ptr> splat (ptr null)
 ; CHECK: @bitcast1 = global <2 x i32> splat (i32 -1)
 ; CHECK: @bitcast2 = global <4 x i16> splat (i16 -1)
 ;.

--- a/llvm/test/Assembler/aggregate-constant-values.ll
+++ b/llvm/test/Assembler/aggregate-constant-values.ll
@@ -1,4 +1,5 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
+; RUN: llvm-as -use-constant-ptrnull-for-fixed-length-splat=false -use-constant-ptrnull-for-scalable-splat=false < %s | llvm-dis -use-constant-ptrnull-for-fixed-length-splat=false -use-constant-ptrnull-for-scalable-splat=false | FileCheck %s --check-prefix=DISABLED
 ; RUN: verify-uselistorder %s
 
 ; CHECK: @foo
@@ -49,3 +50,26 @@ define void @qux_empty(ptr %x) nounwind {
   ret void
 }
 
+; CHECK: @fixed_ptr_null_splat
+; CHECK: ret <2 x ptr> splat (ptr null)
+; DISABLED: @fixed_ptr_null_splat
+; DISABLED: ret <2 x ptr> zeroinitializer
+define <2 x ptr> @fixed_ptr_null_splat() {
+  ret <2 x ptr> zeroinitializer
+}
+
+; CHECK: @scalable_ptr_null_splat
+; CHECK: ret <vscale x 2 x ptr> splat (ptr null)
+; DISABLED: @scalable_ptr_null_splat
+; DISABLED: ret <vscale x 2 x ptr> zeroinitializer
+define <vscale x 2 x ptr> @scalable_ptr_null_splat() {
+  ret <vscale x 2 x ptr> zeroinitializer
+}
+
+; CHECK: @explicit_fixed_ptr_null_splat
+; CHECK: ret <2 x ptr> splat (ptr null)
+; DISABLED: @explicit_fixed_ptr_null_splat
+; DISABLED: ret <2 x ptr> zeroinitializer
+define <2 x ptr> @explicit_fixed_ptr_null_splat() {
+  ret <2 x ptr> splat (ptr null)
+}

--- a/llvm/test/Assembler/opaque-ptr.ll
+++ b/llvm/test/Assembler/opaque-ptr.ll
@@ -92,7 +92,7 @@ define <2 x ptr> @gep_constexpr_vec1(ptr %a) {
 }
 
 ; CHECK: define <2 x ptr> @gep_constexpr_vec2(<2 x ptr> %a)
-; CHECK:     ret <2 x ptr> getelementptr (i16, <2 x ptr> zeroinitializer, <2 x i32> splat (i32 3))
+; CHECK:     ret <2 x ptr> getelementptr (i16, <2 x ptr> splat (ptr null), <2 x i32> splat (i32 3))
 define <2 x ptr> @gep_constexpr_vec2(<2 x ptr> %a) {
   ret <2 x ptr> getelementptr (i16, <2 x ptr> zeroinitializer, i32 3)
 }

--- a/llvm/test/CodeGen/AMDGPU/codegen-prepare-addrspacecast-non-null-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/codegen-prepare-addrspacecast-non-null-vector.ll
@@ -5,7 +5,7 @@
 
 define <4 x ptr> @vec_of_local_to_flat_nonnull_arg() {
 ; OPT-LABEL: define <4 x ptr> @vec_of_local_to_flat_nonnull_arg() {
-; OPT-NEXT:    [[X:%.*]] = addrspacecast <4 x ptr addrspace(3)> zeroinitializer to <4 x ptr>
+; OPT-NEXT:    [[X:%.*]] = addrspacecast <4 x ptr addrspace(3)> splat (ptr addrspace(3) null) to <4 x ptr>
 ; OPT-NEXT:    ret <4 x ptr> [[X]]
 ;
   %x = addrspacecast <4 x ptr addrspace(3)> zeroinitializer to <4 x ptr>

--- a/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-constants.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-constants.ll
@@ -209,7 +209,7 @@ define ptr addrspace(7) @inttoptr() {
 define <2 x ptr addrspace(7)> @inttoptr_vec() {
 ; CHECK-LABEL: define { <2 x ptr addrspace(8)>, <2 x i32> } @inttoptr_vec
 ; CHECK-SAME: () #[[ATTR0]] {
-; CHECK-NEXT:    ret { <2 x ptr addrspace(8)>, <2 x i32> } { <2 x ptr addrspace(8)> zeroinitializer, <2 x i32> <i32 1, i32 2> }
+; CHECK-NEXT:    ret { <2 x ptr addrspace(8)>, <2 x i32> } { <2 x ptr addrspace(8)> splat (ptr addrspace(8) null), <2 x i32> <i32 1, i32 2> }
 ;
   ret <2 x ptr addrspace(7)> inttoptr (<2 x i160> <i160 1, i160 2> to <2 x ptr addrspace(7)>)
 }

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
@@ -91,7 +91,7 @@ define amdgpu_kernel void @scalar_alloca_ptr_with_vector_gep_offset_select_nullp
 ; CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[TMP12]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds [1024 x [4 x i32]], ptr addrspace(3) @scalar_alloca_ptr_with_vector_gep_offset_select_nullptr0.alloca, i32 0, i32 [[TMP13]]
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[TMP14]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> zeroinitializer, <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> splat (ptr addrspace(3) null), <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
 ; CHECK-NEXT:    [[EXTRACTELEMENT:%.*]] = extractelement <4 x ptr addrspace(3)> [[SELECT]], i64 1
 ; CHECK-NEXT:    store i32 0, ptr addrspace(3) [[EXTRACTELEMENT]], align 4
 ; CHECK-NEXT:    ret void
@@ -125,7 +125,7 @@ define amdgpu_kernel void @scalar_alloca_ptr_with_vector_gep_offset_select_nullp
 ; CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[TMP12]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds [1024 x [4 x i32]], ptr addrspace(3) @scalar_alloca_ptr_with_vector_gep_offset_select_nullptr1.alloca, i32 0, i32 [[TMP13]]
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[TMP14]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> [[GETELEMENTPTR0]], <4 x ptr addrspace(3)> zeroinitializer
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> [[GETELEMENTPTR0]], <4 x ptr addrspace(3)> splat (ptr addrspace(3) null)
 ; CHECK-NEXT:    [[EXTRACTELEMENT:%.*]] = extractelement <4 x ptr addrspace(3)> [[SELECT]], i64 1
 ; CHECK-NEXT:    store i32 0, ptr addrspace(3) [[EXTRACTELEMENT]], align 4
 ; CHECK-NEXT:    ret void
@@ -159,8 +159,8 @@ define amdgpu_kernel void @scalar_alloca_ptr_with_vector_gep_offset_icmp_nullptr
 ; CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[TMP12]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds [1024 x [4 x i32]], ptr addrspace(3) @scalar_alloca_ptr_with_vector_gep_offset_icmp_nullptr0.alloca, i32 0, i32 [[TMP13]]
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[TMP14]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> zeroinitializer, <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <4 x ptr addrspace(3)> [[SELECT]], zeroinitializer
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> splat (ptr addrspace(3) null), <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
+; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <4 x ptr addrspace(3)> [[SELECT]], splat (ptr addrspace(3) null)
 ; CHECK-NEXT:    store <4 x i1> [[ICMP]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -193,8 +193,8 @@ define amdgpu_kernel void @scalar_alloca_ptr_with_vector_gep_offset_icmp_nullptr
 ; CHECK-NEXT:    [[TMP13:%.*]] = add i32 [[TMP12]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds [1024 x [4 x i32]], ptr addrspace(3) @scalar_alloca_ptr_with_vector_gep_offset_icmp_nullptr1.alloca, i32 0, i32 [[TMP13]]
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[TMP14]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> zeroinitializer, <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <4 x ptr addrspace(3)> zeroinitializer, [[SELECT]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], <4 x ptr addrspace(3)> splat (ptr addrspace(3) null), <4 x ptr addrspace(3)> [[GETELEMENTPTR0]]
+; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <4 x ptr addrspace(3)> splat (ptr addrspace(3) null), [[SELECT]]
 ; CHECK-NEXT:    store <4 x i1> [[ICMP]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -231,7 +231,7 @@ define amdgpu_kernel void @scalar_alloca_ptr_with_vector_gep_offset_phi_nullptr(
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr inbounds i8, ptr addrspace(3) [[TMP14]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
 ; CHECK-NEXT:    br label %[[BB2]]
 ; CHECK:       [[BB2]]:
-; CHECK-NEXT:    [[PHI:%.*]] = phi <4 x ptr addrspace(3)> [ [[GETELEMENTPTR0]], %[[BB1]] ], [ zeroinitializer, %[[BB0]] ]
+; CHECK-NEXT:    [[PHI:%.*]] = phi <4 x ptr addrspace(3)> [ [[GETELEMENTPTR0]], %[[BB1]] ], [ splat (ptr addrspace(3) null), %[[BB0]] ]
 ; CHECK-NEXT:    [[EXTRACTELEMENT:%.*]] = extractelement <4 x ptr addrspace(3)> [[PHI]], i64 2
 ; CHECK-NEXT:    store i32 0, ptr addrspace(3) [[EXTRACTELEMENT]], align 4
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Instrumentation/MemorySanitizer/msan_basic.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/msan_basic.ll
@@ -2093,7 +2093,7 @@ define <2 x i1> @ICmpSLT_vector_Zero(<2 x ptr> %x) nounwind uwtable readnone san
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp ult <2 x i64> [[TMP5]], splat (i64 -9223372036854775808)
 ; CHECK-NEXT:    [[TMP16:%.*]] = icmp ult <2 x i64> [[TMP6]], splat (i64 -9223372036854775808)
 ; CHECK-NEXT:    [[TMP17:%.*]] = xor <2 x i1> [[TMP9]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = icmp slt <2 x ptr> [[X]], zeroinitializer
+; CHECK-NEXT:    [[TMP18:%.*]] = icmp slt <2 x ptr> [[X]], splat (ptr null)
 ; CHECK-NEXT:    store <2 x i1> [[TMP17]], ptr @__msan_retval_tls, align 8
 ; CHECK-NEXT:    ret <2 x i1> [[TMP18]]
 ;
@@ -2110,7 +2110,7 @@ define <2 x i1> @ICmpSLT_vector_Zero(<2 x ptr> %x) nounwind uwtable readnone san
 ; ORIGIN-NEXT:    [[TMP10:%.*]] = icmp ult <2 x i64> [[TMP6]], splat (i64 -9223372036854775808)
 ; ORIGIN-NEXT:    [[TMP17:%.*]] = icmp ult <2 x i64> [[TMP7]], splat (i64 -9223372036854775808)
 ; ORIGIN-NEXT:    [[TMP18:%.*]] = xor <2 x i1> [[TMP10]], [[TMP17]]
-; ORIGIN-NEXT:    [[TMP19:%.*]] = icmp slt <2 x ptr> [[X]], zeroinitializer
+; ORIGIN-NEXT:    [[TMP19:%.*]] = icmp slt <2 x ptr> [[X]], splat (ptr null)
 ; ORIGIN-NEXT:    store <2 x i1> [[TMP18]], ptr @__msan_retval_tls, align 8
 ; ORIGIN-NEXT:    store i32 [[TMP2]], ptr @__msan_retval_origin_tls, align 4
 ; ORIGIN-NEXT:    ret <2 x i1> [[TMP19]]
@@ -2128,7 +2128,7 @@ define <2 x i1> @ICmpSLT_vector_Zero(<2 x ptr> %x) nounwind uwtable readnone san
 ; CALLS-NEXT:    [[TMP10:%.*]] = icmp ult <2 x i64> [[TMP6]], splat (i64 -9223372036854775808)
 ; CALLS-NEXT:    [[TMP17:%.*]] = icmp ult <2 x i64> [[TMP7]], splat (i64 -9223372036854775808)
 ; CALLS-NEXT:    [[TMP18:%.*]] = xor <2 x i1> [[TMP10]], [[TMP17]]
-; CALLS-NEXT:    [[TMP19:%.*]] = icmp slt <2 x ptr> [[X]], zeroinitializer
+; CALLS-NEXT:    [[TMP19:%.*]] = icmp slt <2 x ptr> [[X]], splat (ptr null)
 ; CALLS-NEXT:    store <2 x i1> [[TMP18]], ptr @__msan_retval_tls, align 8
 ; CALLS-NEXT:    store i32 [[TMP2]], ptr @__msan_retval_origin_tls, align 4
 ; CALLS-NEXT:    ret <2 x i1> [[TMP19]]
@@ -2746,7 +2746,7 @@ define void @VAStart(i32 %x, ...) sanitize_memory {
 ; CHECK-NEXT:    [[TMP6:%.*]] = xor i64 [[TMP5]], 87960930222080
 ; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 4 [[TMP7]], i8 -1, i64 4, i1 false)
-; CHECK-NEXT:    [[VA:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CHECK-NEXT:    [[VA:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CHECK-NEXT:    [[TMP8:%.*]] = ptrtoint ptr [[VA]] to i64
 ; CHECK-NEXT:    [[TMP9:%.*]] = xor i64 [[TMP8]], 87960930222080
 ; CHECK-NEXT:    [[TMP10:%.*]] = inttoptr i64 [[TMP9]] to ptr
@@ -2799,7 +2799,7 @@ define void @VAStart(i32 %x, ...) sanitize_memory {
 ; ORIGIN-NEXT:    [[TMP12:%.*]] = inttoptr i64 [[TMP11]] to ptr
 ; ORIGIN-NEXT:    call void @llvm.memset.p0.i64(ptr align 4 [[TMP9]], i8 -1, i64 4, i1 false)
 ; ORIGIN-NEXT:    call void @__msan_set_alloca_origin_with_descr(ptr [[X_ADDR]], i64 4, ptr @[[GLOB4:[0-9]+]], ptr @[[GLOB5:[0-9]+]])
-; ORIGIN-NEXT:    [[VA:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; ORIGIN-NEXT:    [[VA:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; ORIGIN-NEXT:    [[TMP13:%.*]] = ptrtoint ptr [[VA]] to i64
 ; ORIGIN-NEXT:    [[TMP14:%.*]] = xor i64 [[TMP13]], 87960930222080
 ; ORIGIN-NEXT:    [[TMP15:%.*]] = inttoptr i64 [[TMP14]] to ptr
@@ -2873,7 +2873,7 @@ define void @VAStart(i32 %x, ...) sanitize_memory {
 ; CALLS-NEXT:    [[TMP12:%.*]] = inttoptr i64 [[TMP11]] to ptr
 ; CALLS-NEXT:    call void @llvm.memset.p0.i64(ptr align 4 [[TMP9]], i8 -1, i64 4, i1 false)
 ; CALLS-NEXT:    call void @__msan_set_alloca_origin_with_descr(ptr [[X_ADDR]], i64 4, ptr @[[GLOB4:[0-9]+]], ptr @[[GLOB5:[0-9]+]])
-; CALLS-NEXT:    [[VA:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+; CALLS-NEXT:    [[VA:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
 ; CALLS-NEXT:    [[TMP13:%.*]] = ptrtoint ptr [[VA]] to i64
 ; CALLS-NEXT:    [[TMP14:%.*]] = xor i64 [[TMP13]], 87960930222080
 ; CALLS-NEXT:    [[TMP15:%.*]] = inttoptr i64 [[TMP14]] to ptr

--- a/llvm/test/Transforms/CodeGenPrepare/AArch64/reduce-or-opt.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/AArch64/reduce-or-opt.ll
@@ -10,7 +10,7 @@ define i64 @select_or_reduce_v2i1(ptr nocapture noundef readonly %src) {
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds ptr, ptr [[SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x ptr>, ptr [[ARRAYIDX]], align 8
-; CHECK-NEXT:    [[COND:%.*]] = icmp eq <2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq <2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[OR_REDUC:%.*]] = tail call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> [[COND]])
 ; CHECK-NEXT:    [[IV_CMP:%.*]] = icmp eq i64 [[INDEX_NEXT]], 4
@@ -48,7 +48,7 @@ define i64 @br_or_reduce_v2i1(ptr nocapture noundef readonly %src, ptr noundef r
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds ptr, ptr [[SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <2 x ptr>, ptr [[ARRAYIDX]], align 8
-; CHECK-NEXT:    [[COND:%.*]] = icmp eq <2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq <2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
 ; CHECK-NEXT:    [[OR_REDUC:%.*]] = tail call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> [[COND]])
 ; CHECK-NEXT:    [[IV_CMP:%.*]] = icmp eq i64 [[INDEX_NEXT]], 4
@@ -96,7 +96,7 @@ define i64 @select_or_reduce_nxv2i1(ptr nocapture noundef readonly %src) {
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds ptr, ptr [[SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <vscale x 2 x ptr>, ptr [[ARRAYIDX]], align 8
-; CHECK-NEXT:    [[COND:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl nuw nsw i64 [[TMP0]], 1
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP1]]
@@ -105,7 +105,7 @@ define i64 @select_or_reduce_nxv2i1(ptr nocapture noundef readonly %src) {
 ; CHECK-NEXT:    [[EXIT_COND:%.*]] = or i1 [[OR_REDUC]], [[IV_CMP]]
 ; CHECK-NEXT:    br i1 [[EXIT_COND]], label %[[MIDDLE_SPLIT:.*]], label %[[VECTOR_BODY]]
 ; CHECK:       [[MIDDLE_SPLIT]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i1 @llvm.vector.reduce.or.nxv2i1(<vscale x 2 x i1> [[TMP2]])
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[TMP3]], i64 1, i64 0
 ; CHECK-NEXT:    ret i64 [[SEL]]
@@ -140,7 +140,7 @@ define i64 @br_or_reduce_nxv2i1(ptr nocapture noundef readonly %src, ptr noundef
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds ptr, ptr [[SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <vscale x 2 x ptr>, ptr [[ARRAYIDX]], align 8
-; CHECK-NEXT:    [[COND:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl nuw nsw i64 [[TMP0]], 1
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP1]]
@@ -149,7 +149,7 @@ define i64 @br_or_reduce_nxv2i1(ptr nocapture noundef readonly %src, ptr noundef
 ; CHECK-NEXT:    [[EXIT_COND:%.*]] = or i1 [[OR_REDUC]], [[IV_CMP]]
 ; CHECK-NEXT:    br i1 [[EXIT_COND]], label %[[MIDDLE_SPLIT:.*]], label %[[VECTOR_BODY]]
 ; CHECK:       [[MIDDLE_SPLIT]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <vscale x 2 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i1 @llvm.vector.reduce.or.nxv2i1(<vscale x 2 x i1> [[TMP2]])
 ; CHECK-NEXT:    br i1 [[TMP3]], label %[[FOUND:.*]], label %[[NOTFOUND:.*]]
 ; CHECK:       [[FOUND]]:

--- a/llvm/test/Transforms/ConstraintElimination/geps-ptrvector.ll
+++ b/llvm/test/Transforms/ConstraintElimination/geps-ptrvector.ll
@@ -5,7 +5,7 @@
 define <2 x i1> @test.vectorgep(<2 x ptr> %vec) {
 ; CHECK-LABEL: @test.vectorgep(
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i32, <2 x ptr> [[VEC:%.*]], i64 0
-; CHECK-NEXT:    [[COND:%.*]] = icmp ule <2 x ptr> [[GEP]], zeroinitializer
+; CHECK-NEXT:    [[COND:%.*]] = icmp ule <2 x ptr> [[GEP]], splat (ptr null)
 ; CHECK-NEXT:    ret <2 x i1> [[COND]]
 ;
   %gep = getelementptr inbounds i32, <2 x ptr> %vec, i64 0

--- a/llvm/test/Transforms/FunctionAttrs/vector-of-pointers-getunderlyingobject-crash.ll
+++ b/llvm/test/Transforms/FunctionAttrs/vector-of-pointers-getunderlyingobject-crash.ll
@@ -4,7 +4,7 @@
 define double @getUnderlyingObject_vector_ptr(<4 x i1> %arg0, <4 x i1> %arg1) {
 ; CHECK-LABEL: define double @getUnderlyingObject_vector_ptr(
 ; CHECK-SAME: <4 x i1> [[ARG0:%.*]], <4 x i1> [[ARG1:%.*]]) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    [[GATHER:%.*]] = tail call <4 x double> @llvm.masked.gather.v4f64.v4p0(<4 x ptr> align 8 getelementptr inbounds (i8, <4 x ptr> zeroinitializer, <4 x i64> splat (i64 8)), <4 x i1> [[ARG0]], <4 x double> zeroinitializer)
+; CHECK-NEXT:    [[GATHER:%.*]] = tail call <4 x double> @llvm.masked.gather.v4f64.v4p0(<4 x ptr> align 8 getelementptr inbounds (i8, <4 x ptr> splat (ptr null), <4 x i64> splat (i64 8)), <4 x i1> [[ARG0]], <4 x double> zeroinitializer)
 ; CHECK-NEXT:    [[REDUCE_FADD:%.*]] = tail call double @llvm.vector.reduce.fadd.v4f64(double 0.000000e+00, <4 x double> [[GATHER]])
 ; CHECK-NEXT:    ret double [[REDUCE_FADD]]
 ;

--- a/llvm/test/Transforms/InferAddressSpaces/AMDGPU/issue110433.ll
+++ b/llvm/test/Transforms/InferAddressSpaces/AMDGPU/issue110433.ll
@@ -18,7 +18,7 @@ define <8 x i1> @load_vector_of_flat_ptr_from_global(ptr addrspace(1) %ptr) {
 ; CHECK-LABEL: define <8 x i1> @load_vector_of_flat_ptr_from_global(
 ; CHECK-SAME: ptr addrspace(1) [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[LD:%.*]] = load <8 x ptr>, ptr addrspace(1) [[PTR]], align 128
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <8 x ptr> [[LD]], zeroinitializer
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <8 x ptr> [[LD]], splat (ptr null)
 ; CHECK-NEXT:    ret <8 x i1> [[CMP]]
 ;
   %ld = load <8 x ptr>, ptr addrspace(1) %ptr, align 128
@@ -30,7 +30,7 @@ define <8 x i1> @load_vector_of_flat_ptr_from_global_invariant(ptr addrspace(1) 
 ; CHECK-LABEL: define <8 x i1> @load_vector_of_flat_ptr_from_global_invariant(
 ; CHECK-SAME: ptr addrspace(1) [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[LD:%.*]] = load <8 x ptr>, ptr addrspace(1) [[PTR]], align 128, !invariant [[META0:![0-9]+]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <8 x ptr> [[LD]], zeroinitializer
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <8 x ptr> [[LD]], splat (ptr null)
 ; CHECK-NEXT:    ret <8 x i1> [[CMP]]
 ;
   %ld = load <8 x ptr>, ptr addrspace(1) %ptr, align 128, !invariant !0

--- a/llvm/test/Transforms/InstCombine/call.ll
+++ b/llvm/test/Transforms/InstCombine/call.ll
@@ -247,7 +247,7 @@ define ptr @test11_mixed_as() {
 ; Return type that's a vector of pointers
 define <2 x ptr> @test12a() {
 ; CHECK-LABEL: define <2 x ptr> @test12a() {
-; CHECK-NEXT:    ret <2 x ptr> zeroinitializer
+; CHECK-NEXT:    ret <2 x ptr> splat (ptr null)
 ;
   ret <2 x ptr> zeroinitializer
 }
@@ -263,7 +263,7 @@ define <2 x ptr> @test12() {
 
 define <2 x ptr addrspace(1)> @test12a_mixed_as() {
 ; CHECK-LABEL: define <2 x ptr addrspace(1)> @test12a_mixed_as() {
-; CHECK-NEXT:    ret <2 x ptr addrspace(1)> zeroinitializer
+; CHECK-NEXT:    ret <2 x ptr addrspace(1)> splat (ptr addrspace(1) null)
 ;
   ret <2 x ptr addrspace(1)> zeroinitializer
 }

--- a/llvm/test/Transforms/InstCombine/gep-inbounds-null.ll
+++ b/llvm/test/Transforms/InstCombine/gep-inbounds-null.ll
@@ -76,7 +76,7 @@ entry:
 define <2 x i1> @test_vector_base(<2 x ptr> %base, i64 %idx) {
 ; CHECK-LABEL: @test_vector_base(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CND:%.*]] = icmp eq <2 x ptr> [[BASE:%.*]], zeroinitializer
+; CHECK-NEXT:    [[CND:%.*]] = icmp eq <2 x ptr> [[BASE:%.*]], splat (ptr null)
 ; CHECK-NEXT:    ret <2 x i1> [[CND]]
 ;
 entry:
@@ -89,7 +89,7 @@ define <2 x i1> @test_vector_index(ptr %base, <2 x i64> %idx) {
 ; CHECK-LABEL: @test_vector_index(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <2 x ptr> poison, ptr [[BASE:%.*]], i64 0
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq <2 x ptr> [[DOTSPLATINSERT]], zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq <2 x ptr> [[DOTSPLATINSERT]], splat (ptr null)
 ; CHECK-NEXT:    [[CND:%.*]] = shufflevector <2 x i1> [[TMP0]], <2 x i1> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[CND]]
 ;
@@ -102,7 +102,7 @@ entry:
 define <2 x i1> @test_vector_both(<2 x ptr> %base, <2 x i64> %idx) {
 ; CHECK-LABEL: @test_vector_both(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[CND:%.*]] = icmp eq <2 x ptr> [[BASE:%.*]], zeroinitializer
+; CHECK-NEXT:    [[CND:%.*]] = icmp eq <2 x ptr> [[BASE:%.*]], splat (ptr null)
 ; CHECK-NEXT:    ret <2 x i1> [[CND]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -4735,7 +4735,7 @@ define i1 @PR35794(ptr %a) {
 define <2 x i1> @PR36583(<2 x ptr>)  {
 ; CHECK-LABEL: define <2 x i1> @PR36583(
 ; CHECK-SAME: <2 x ptr> [[TMP0:%.*]]) {
-; CHECK-NEXT:    [[RES:%.*]] = icmp eq <2 x ptr> [[TMP0]], zeroinitializer
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq <2 x ptr> [[TMP0]], splat (ptr null)
 ; CHECK-NEXT:    ret <2 x i1> [[RES]]
 ;
   %cast = ptrtoint <2 x ptr> %0 to <2 x i64>

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -317,8 +317,8 @@ define i1 @test27(ptr %A, ptr %B) {
 
 define <2 x i1> @test27vec(<2 x ptr> %A, <2 x ptr> %B) {
 ; CHECK-LABEL: @test27vec(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <2 x ptr> [[A:%.*]], zeroinitializer
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <2 x ptr> [[B:%.*]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <2 x ptr> [[A:%.*]], splat (ptr null)
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <2 x ptr> [[B:%.*]], splat (ptr null)
 ; CHECK-NEXT:    [[E:%.*]] = and <2 x i1> [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    ret <2 x i1> [[E]]
 ;
@@ -373,8 +373,8 @@ define i1 @test29(ptr %A, ptr %B) {
 
 define <2 x i1> @test29vec(<2 x ptr> %A, <2 x ptr> %B) {
 ; CHECK-LABEL: @test29vec(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <2 x ptr> [[A:%.*]], zeroinitializer
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne <2 x ptr> [[B:%.*]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <2 x ptr> [[A:%.*]], splat (ptr null)
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne <2 x ptr> [[B:%.*]], splat (ptr null)
 ; CHECK-NEXT:    [[E:%.*]] = or <2 x i1> [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    ret <2 x i1> [[E]]
 ;

--- a/llvm/test/Transforms/InstCombine/scalar_vector_gep.ll
+++ b/llvm/test/Transforms/InstCombine/scalar_vector_gep.ll
@@ -14,7 +14,7 @@ define <8 x i64> @pluto.6(ptr %arg1, i64 %mul, <8 x i64> %shufflevector, <8 x i6
 ; CHECK-NEXT:    [[DOTSPLAT:%.*]] = shufflevector <8 x i64> [[DOTSPLATINSERT]], <8 x i64> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    [[GETELEMENTPTR13:%.*]] = getelementptr [8 x i8], ptr [[ARG1]], i64 [[MUL]]
 ; CHECK-NEXT:    [[GETELEMENTPTR24:%.*]] = getelementptr i8, ptr [[GETELEMENTPTR13]], <8 x i64> [[SHUFFLEVECTOR]]
-; CHECK-NEXT:    [[ICMP25:%.*]] = icmp ne <8 x ptr> [[GETELEMENTPTR24]], zeroinitializer
+; CHECK-NEXT:    [[ICMP25:%.*]] = icmp ne <8 x ptr> [[GETELEMENTPTR24]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP0:%.*]] = add <8 x i64> [[DOTSPLAT]], [[PHI16]]
 ; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne <8 x i64> [[GETELEMENTPTR19_IDX]], [[TMP0]]
 ; CHECK-NEXT:    [[ADD211:%.*]] = or <8 x i1> [[ICMP25]], [[ICMP]]

--- a/llvm/test/Transforms/InstCombine/vscale_cmp.ll
+++ b/llvm/test/Transforms/InstCombine/vscale_cmp.ll
@@ -13,7 +13,7 @@ define <vscale x 2 x i1> @sge(<vscale x 2 x i8> %x) {
 define <vscale x 2 x i1> @gep_scalevector1(ptr %X) nounwind {
 ; CHECK-LABEL: @gep_scalevector1(
 ; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <vscale x 2 x ptr> poison, ptr [[X:%.*]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <vscale x 2 x ptr> [[DOTSPLATINSERT]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <vscale x 2 x ptr> [[DOTSPLATINSERT]], splat (ptr null)
 ; CHECK-NEXT:    [[C:%.*]] = shufflevector <vscale x 2 x i1> [[TMP1]], <vscale x 2 x i1> poison, <vscale x 2 x i32> zeroinitializer
 ; CHECK-NEXT:    ret <vscale x 2 x i1> [[C]]
 ;

--- a/llvm/test/Transforms/InstSimplify/ConstProp/inttoptr-gep-nonintegral.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/inttoptr-gep-nonintegral.ll
@@ -77,7 +77,7 @@ define ptr addrspace(3) @test_inttoptr_base_external() {
 
 define <2 x ptr> @test_vec_null_base_normal() {
 ; CHECK-LABEL: define <2 x ptr> @test_vec_null_base_normal() {
-; CHECK-NEXT:    ret <2 x ptr> getelementptr (i8, <2 x ptr> zeroinitializer, <2 x i16> <i16 -2, i16 -3>)
+; CHECK-NEXT:    ret <2 x ptr> getelementptr (i8, <2 x ptr> splat (ptr null), <2 x i16> <i16 -2, i16 -3>)
 ;
   %gep = getelementptr i8, <2 x ptr> <ptr null, ptr null>, <2 x i8> <i8 -2, i8 -3>
   ret <2 x ptr> %gep
@@ -95,7 +95,7 @@ define <2 x ptr> @test_vec_inttoptr_base_normal() {
 ;; the index bits: (i8 -2 == i16 254)
 define <2 x ptr addrspace(1)> @test_vec_null_base_nonintegral() {
 ; CHECK-LABEL: define <2 x ptr addrspace(1)> @test_vec_null_base_nonintegral() {
-; CHECK-NEXT:    ret <2 x ptr addrspace(1)> getelementptr (i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i8> <i8 -2, i8 -3>)
+; CHECK-NEXT:    ret <2 x ptr addrspace(1)> getelementptr (i8, <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i8> <i8 -2, i8 -3>)
 ;
   %gep = getelementptr i8, <2 x ptr addrspace(1)> <ptr addrspace(1) null, ptr addrspace(1) null>, <2 x i8> <i8 -2, i8 -3>
   ret <2 x ptr addrspace(1)> %gep
@@ -112,7 +112,7 @@ define <2 x ptr addrspace(1)> @test_vec_inttoptr_base_nonintegral() {
 ;; For unstable pointers we should avoid any introduction of inttoptr
 define <2 x ptr addrspace(2)> @test_vec_null_base_unstable() {
 ; CHECK-LABEL: define <2 x ptr addrspace(2)> @test_vec_null_base_unstable() {
-; CHECK-NEXT:    ret <2 x ptr addrspace(2)> getelementptr (i8, <2 x ptr addrspace(2)> zeroinitializer, <2 x i8> <i8 -2, i8 -3>)
+; CHECK-NEXT:    ret <2 x ptr addrspace(2)> getelementptr (i8, <2 x ptr addrspace(2)> splat (ptr addrspace(2) null), <2 x i8> <i8 -2, i8 -3>)
 ;
   %gep = getelementptr i8, <2 x ptr addrspace(2)> <ptr addrspace(2) null, ptr addrspace(2) null>, <2 x i8> <i8 -2, i8 -3>
   ret <2 x ptr addrspace(2)> %gep
@@ -129,7 +129,7 @@ define <2 x ptr addrspace(2)> @test_vec_inttoptr_base_unstable() {
 ;; The same is true for pointers with external state: no new inttoptr
 define <2 x ptr addrspace(3)> @test_vec_null_base_external() {
 ; CHECK-LABEL: define <2 x ptr addrspace(3)> @test_vec_null_base_external() {
-; CHECK-NEXT:    ret <2 x ptr addrspace(3)> getelementptr (i8, <2 x ptr addrspace(3)> zeroinitializer, <2 x i8> <i8 -2, i8 -3>)
+; CHECK-NEXT:    ret <2 x ptr addrspace(3)> getelementptr (i8, <2 x ptr addrspace(3)> splat (ptr addrspace(3) null), <2 x i8> <i8 -2, i8 -3>)
 ;
   %gep = getelementptr i8, <2 x ptr addrspace(3)> <ptr addrspace(3) null, ptr addrspace(3) null>, <2 x i8> <i8 -2, i8 -3>
   ret <2 x ptr addrspace(3)> %gep

--- a/llvm/test/Transforms/InstSimplify/gep.ll
+++ b/llvm/test/Transforms/InstSimplify/gep.ll
@@ -225,7 +225,7 @@ define <4 x ptr> @ptr_idx_mix_scalar_vector(){
 
 define <4 x ptr> @vector_idx_scalar() {
 ; CHECK-LABEL: @vector_idx_scalar(
-; CHECK-NEXT:    ret <4 x ptr> getelementptr (i32, <4 x ptr> zeroinitializer, <4 x i64> splat (i64 1))
+; CHECK-NEXT:    ret <4 x ptr> getelementptr (i32, <4 x ptr> splat (ptr null), <4 x i64> splat (i64 1))
 ;
   %gep = getelementptr i32, <4 x ptr> zeroinitializer, i64 1
   ret <4 x ptr> %gep
@@ -233,7 +233,7 @@ define <4 x ptr> @vector_idx_scalar() {
 
 define <4 x ptr> @vector_idx_vector() {
 ; CHECK-LABEL: @vector_idx_vector(
-; CHECK-NEXT:    ret <4 x ptr> getelementptr (i32, <4 x ptr> zeroinitializer, <4 x i64> splat (i64 1))
+; CHECK-NEXT:    ret <4 x ptr> getelementptr (i32, <4 x ptr> splat (ptr null), <4 x i64> splat (i64 1))
 ;
   %gep = getelementptr i32, <4 x ptr> zeroinitializer, <4 x i64> <i64 1, i64 1, i64 1, i64 1>
   ret <4 x ptr> %gep
@@ -242,7 +242,7 @@ define <4 x ptr> @vector_idx_vector() {
 %struct = type { double, float }
 define <4 x ptr> @vector_idx_mix_scalar_vector() {
 ; CHECK-LABEL: @vector_idx_mix_scalar_vector(
-; CHECK-NEXT:    ret <4 x ptr> getelementptr ([[STRUCT:%.*]], <4 x ptr> zeroinitializer, <4 x i64> zeroinitializer, i32 1)
+; CHECK-NEXT:    ret <4 x ptr> getelementptr ([[STRUCT:%.*]], <4 x ptr> splat (ptr null), <4 x i64> zeroinitializer, i32 1)
 ;
   %gep = getelementptr %struct, <4 x ptr> zeroinitializer, i32 0, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
   ret <4 x ptr> %gep
@@ -252,7 +252,7 @@ define <4 x ptr> @vector_idx_mix_scalar_vector() {
 
 define <vscale x 4 x ptr> @scalable_idx_scalar() {
 ; CHECK-LABEL: @scalable_idx_scalar(
-; CHECK-NEXT:    ret <vscale x 4 x ptr> getelementptr (i32, <vscale x 4 x ptr> zeroinitializer, <vscale x 4 x i64> splat (i64 1))
+; CHECK-NEXT:    ret <vscale x 4 x ptr> getelementptr (i32, <vscale x 4 x ptr> splat (ptr null), <vscale x 4 x i64> splat (i64 1))
 ;
   %gep = getelementptr i32, <vscale x 4 x ptr> zeroinitializer, i64 1
   ret <vscale x 4 x ptr> %gep
@@ -260,7 +260,7 @@ define <vscale x 4 x ptr> @scalable_idx_scalar() {
 
 define <vscale x 4 x ptr> @scalable_vector_idx_mix_scalar_vector() {
 ; CHECK-LABEL: @scalable_vector_idx_mix_scalar_vector(
-; CHECK-NEXT:    ret <vscale x 4 x ptr> getelementptr ([[STRUCT:%.*]], <vscale x 4 x ptr> zeroinitializer, <vscale x 4 x i64> zeroinitializer, i32 1)
+; CHECK-NEXT:    ret <vscale x 4 x ptr> getelementptr ([[STRUCT:%.*]], <vscale x 4 x ptr> splat (ptr null), <vscale x 4 x i64> zeroinitializer, i32 1)
 ;
   %gep = getelementptr %struct, <vscale x 4 x ptr> zeroinitializer, i32 0, i32 1
   ret <vscale x 4 x ptr> %gep
@@ -268,7 +268,7 @@ define <vscale x 4 x ptr> @scalable_vector_idx_mix_scalar_vector() {
 
 define <vscale x 2 x ptr> @ptr_idx_mix_scalar_scalable_vector() {
 ; CHECK-LABEL: @ptr_idx_mix_scalar_scalable_vector(
-; CHECK-NEXT:    ret <vscale x 2 x ptr> zeroinitializer
+; CHECK-NEXT:    ret <vscale x 2 x ptr> splat (ptr null)
 ;
   %v = getelementptr [2 x i64], ptr null, i64 0, <vscale x 2 x i64> zeroinitializer
   ret <vscale x 2 x ptr> %v
@@ -425,7 +425,7 @@ define ptr @gep_null_inbounds_different_type(i64 %idx1, i64 %idx2) {
 
 define <2 x ptr> @gep_inbounds_null_vec(i64 %idx) {
 ; CHECK-LABEL: @gep_inbounds_null_vec(
-; CHECK-NEXT:    [[P:%.*]] = getelementptr inbounds i8, <2 x ptr> zeroinitializer, i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[P:%.*]] = getelementptr inbounds i8, <2 x ptr> splat (ptr null), i64 [[IDX:%.*]]
 ; CHECK-NEXT:    ret <2 x ptr> [[P]]
 ;
   %p = getelementptr inbounds i8, <2 x ptr> zeroinitializer, i64 %idx

--- a/llvm/test/Transforms/InstSimplify/vscale.ll
+++ b/llvm/test/Transforms/InstSimplify/vscale.ll
@@ -168,7 +168,7 @@ define <vscale x 4 x float> @bitcast() {
 
 define <vscale x 4 x ptr> @getelementptr_constant_foldable_1() {
 ; CHECK-LABEL: @getelementptr_constant_foldable_1(
-; CHECK-NEXT:    ret <vscale x 4 x ptr> zeroinitializer
+; CHECK-NEXT:    ret <vscale x 4 x ptr> splat (ptr null)
 ;
   %ptr = getelementptr i32, <vscale x 4 x ptr> zeroinitializer, <vscale x 4 x i64> undef
   ret <vscale x 4 x ptr> %ptr
@@ -176,7 +176,7 @@ define <vscale x 4 x ptr> @getelementptr_constant_foldable_1() {
 
 define <vscale x 4 x ptr> @getelementptr_constant_foldable_2() {
 ; CHECK-LABEL: @getelementptr_constant_foldable_2(
-; CHECK-NEXT:    ret <vscale x 4 x ptr> zeroinitializer
+; CHECK-NEXT:    ret <vscale x 4 x ptr> splat (ptr null)
 ;
   %ptr = getelementptr <vscale x 4 x i32>, ptr null, <vscale x 4 x i64> undef
   ret <vscale x 4 x ptr> %ptr

--- a/llvm/test/Transforms/LoadStoreVectorizer/NVPTX/4x2xhalf.ll
+++ b/llvm/test/Transforms/LoadStoreVectorizer/NVPTX/4x2xhalf.ll
@@ -112,23 +112,23 @@ define void @no_pointer_vector(ptr nocapture align 16 %rd0) {
 ; CHECK-LABEL: define void @no_pointer_vector(
 ; CHECK-SAME: ptr align 16 captures(none) [[RD0:%.*]]) {
 ; CHECK-NEXT:    [[LOAD1:%.*]] = load <2 x ptr>, ptr [[RD0]], align 16
-; CHECK-NEXT:    [[P1:%.*]] = icmp ne <2 x ptr> [[LOAD1]], zeroinitializer
-; CHECK-NEXT:    [[S1:%.*]] = select <2 x i1> [[P1]], <2 x ptr> [[LOAD1]], <2 x ptr> zeroinitializer
+; CHECK-NEXT:    [[P1:%.*]] = icmp ne <2 x ptr> [[LOAD1]], splat (ptr null)
+; CHECK-NEXT:    [[S1:%.*]] = select <2 x i1> [[P1]], <2 x ptr> [[LOAD1]], <2 x ptr> splat (ptr null)
 ; CHECK-NEXT:    store <2 x ptr> [[S1]], ptr [[RD0]], align 16
 ; CHECK-NEXT:    [[IN2:%.*]] = getelementptr ptr, ptr [[RD0]], i64 2
 ; CHECK-NEXT:    [[LOAD2:%.*]] = load <2 x ptr>, ptr [[IN2]], align 4
-; CHECK-NEXT:    [[P2:%.*]] = icmp ne <2 x ptr> [[LOAD2]], zeroinitializer
-; CHECK-NEXT:    [[S2:%.*]] = select <2 x i1> [[P2]], <2 x ptr> [[LOAD2]], <2 x ptr> zeroinitializer
+; CHECK-NEXT:    [[P2:%.*]] = icmp ne <2 x ptr> [[LOAD2]], splat (ptr null)
+; CHECK-NEXT:    [[S2:%.*]] = select <2 x i1> [[P2]], <2 x ptr> [[LOAD2]], <2 x ptr> splat (ptr null)
 ; CHECK-NEXT:    store <2 x ptr> [[S2]], ptr [[IN2]], align 4
 ; CHECK-NEXT:    [[IN3:%.*]] = getelementptr ptr, ptr [[RD0]], i64 4
 ; CHECK-NEXT:    [[LOAD3:%.*]] = load <2 x ptr>, ptr [[IN3]], align 4
-; CHECK-NEXT:    [[P3:%.*]] = icmp ne <2 x ptr> [[LOAD3]], zeroinitializer
-; CHECK-NEXT:    [[S3:%.*]] = select <2 x i1> [[P3]], <2 x ptr> [[LOAD3]], <2 x ptr> zeroinitializer
+; CHECK-NEXT:    [[P3:%.*]] = icmp ne <2 x ptr> [[LOAD3]], splat (ptr null)
+; CHECK-NEXT:    [[S3:%.*]] = select <2 x i1> [[P3]], <2 x ptr> [[LOAD3]], <2 x ptr> splat (ptr null)
 ; CHECK-NEXT:    store <2 x ptr> [[S3]], ptr [[IN3]], align 4
 ; CHECK-NEXT:    [[IN4:%.*]] = getelementptr ptr, ptr [[RD0]], i64 6
 ; CHECK-NEXT:    [[LOAD4:%.*]] = load <2 x ptr>, ptr [[IN4]], align 4
-; CHECK-NEXT:    [[P4:%.*]] = icmp ne <2 x ptr> [[LOAD4]], zeroinitializer
-; CHECK-NEXT:    [[S4:%.*]] = select <2 x i1> [[P4]], <2 x ptr> [[LOAD4]], <2 x ptr> zeroinitializer
+; CHECK-NEXT:    [[P4:%.*]] = icmp ne <2 x ptr> [[LOAD4]], splat (ptr null)
+; CHECK-NEXT:    [[S4:%.*]] = select <2 x i1> [[P4]], <2 x ptr> [[LOAD4]], <2 x ptr> splat (ptr null)
 ; CHECK-NEXT:    store <2 x ptr> [[S4]], ptr [[IN4]], align 4
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/LoopIdiom/non-integral-pointers.ll
+++ b/llvm/test/Transforms/LoopIdiom/non-integral-pointers.ll
@@ -72,11 +72,11 @@ for.end:
 define void @f_2(ptr %ptr) {
 ; CHECK-LABEL: @f_2(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 [[PTR:%.*]], i8 0, i64 80000, i1 false)
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
 ; CHECK:       for.body:
 ; CHECK-NEXT:    [[INDVAR:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDVAR_NEXT:%.*]], [[FOR_BODY]] ]
-; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr ptr addrspace(4), ptr [[PTR:%.*]], i64 [[INDVAR]]
-; CHECK-NEXT:    store <2 x ptr addrspace(4)> zeroinitializer, ptr [[ARRAYIDX]], align 8
+; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr ptr addrspace(4), ptr [[PTR]], i64 [[INDVAR]]
 ; CHECK-NEXT:    [[INDVAR_NEXT]] = add i64 [[INDVAR]], 2
 ; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp eq i64 [[INDVAR_NEXT]], 10000
 ; CHECK-NEXT:    br i1 [[EXITCOND]], label [[FOR_END:%.*]], label [[FOR_BODY]]

--- a/llvm/test/Transforms/LoopVectorize/AArch64/epilog-vectorization-widen-inductions.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/epilog-vectorization-widen-inductions.ll
@@ -19,12 +19,12 @@ define void @test_widen_ptr_induction(ptr %ptr.start.1) {
 ; CHECK-NEXT:    [[VECTOR_GEP:%.*]] = getelementptr i8, ptr [[POINTER_PHI]], <4 x i64> <i64 0, i64 1, i64 2, i64 3>
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x ptr> [[VECTOR_GEP]], i64 0
 ; CHECK-NEXT:    [[STEP_ADD:%.*]] = getelementptr i8, <4 x ptr> [[VECTOR_GEP]], <4 x i64> splat (i64 4)
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne <4 x ptr> [[VECTOR_GEP]], zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne <4 x ptr> [[VECTOR_GEP]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <4 x i1> [[TMP2]], i64 0
 ; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <4 x i1> [[TMP2]], i64 1
 ; CHECK-NEXT:    [[TMP13:%.*]] = extractelement <4 x i1> [[TMP2]], i64 2
 ; CHECK-NEXT:    [[TMP14:%.*]] = extractelement <4 x i1> [[TMP2]], i64 3
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ne <4 x ptr> [[STEP_ADD]], zeroinitializer
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp ne <4 x ptr> [[STEP_ADD]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP8:%.*]] = extractelement <4 x i1> [[TMP7]], i64 0
 ; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <4 x i1> [[TMP7]], i64 1
 ; CHECK-NEXT:    [[TMP10:%.*]] = extractelement <4 x i1> [[TMP7]], i64 2
@@ -58,7 +58,7 @@ define void @test_widen_ptr_induction(ptr %ptr.start.1) {
 ; CHECK-NEXT:    [[POINTER_PHI2:%.*]] = phi ptr [ [[BC_RESUME_VAL1]], [[VEC_EPILOG_PH]] ], [ [[PTR_IND5:%.*]], [[VEC_EPILOG_VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr i8, ptr [[POINTER_PHI2]], <2 x i64> <i64 0, i64 1>
 ; CHECK-NEXT:    [[NEXT_GEP7:%.*]] = extractelement <2 x ptr> [[TMP20]], i64 0
-; CHECK-NEXT:    [[TMP21:%.*]] = icmp ne <2 x ptr> [[TMP20]], zeroinitializer
+; CHECK-NEXT:    [[TMP21:%.*]] = icmp ne <2 x ptr> [[TMP20]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <2 x i1> [[TMP21]], i64 0
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i1> [[TMP21]], i64 1
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[TMP22]])

--- a/llvm/test/Transforms/LoopVectorize/AArch64/sve-widen-phi.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/sve-widen-phi.ll
@@ -306,7 +306,7 @@ define void @phi_used_in_vector_compare_and_scalar_indvar_update_and_store(ptr %
 ; CHECK-NEXT:    [[TMP5:%.*]] = shl <vscale x 2 x i64> [[TMP4]], splat (i64 1)
 ; CHECK-NEXT:    [[VECTOR_GEP:%.*]] = getelementptr i8, ptr [[POINTER_PHI]], <vscale x 2 x i64> [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <vscale x 2 x ptr> [[VECTOR_GEP]], i64 0
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ne <vscale x 2 x ptr> [[VECTOR_GEP]], zeroinitializer
+; CHECK-NEXT:    [[TMP6:%.*]] = icmp ne <vscale x 2 x ptr> [[VECTOR_GEP]], splat (ptr null)
 ; CHECK-NEXT:    call void @llvm.masked.store.nxv2i16.p0(<vscale x 2 x i16> zeroinitializer, ptr align 2 [[TMP7]], <vscale x 2 x i1> [[TMP6]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = shl nuw nsw i64 [[TMP0]], 2

--- a/llvm/test/Transforms/LoopVectorize/RISCV/truncate-to-minimal-bitwidth-evl-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/truncate-to-minimal-bitwidth-evl-crash.ll
@@ -15,7 +15,7 @@ define void @truncate_to_minimal_bitwidths_widen_cast_recipe(ptr %src) {
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[AVL:%.*]] = phi i64 [ 9, %[[VECTOR_PH]] ], [ [[AVL_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call i32 @llvm.experimental.get.vector.length.i64(i64 [[AVL]], i32 8, i1 true)
-; CHECK-NEXT:    call void @llvm.vp.scatter.nxv8i8.nxv8p0(<vscale x 8 x i8> zeroinitializer, <vscale x 8 x ptr> align 1 zeroinitializer, <vscale x 8 x i1> splat (i1 true), i32 [[TMP7]])
+; CHECK-NEXT:    call void @llvm.vp.scatter.nxv8i8.nxv8p0(<vscale x 8 x i8> zeroinitializer, <vscale x 8 x ptr> align 1 splat (ptr null), <vscale x 8 x i1> splat (i1 true), i32 [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = zext i32 [[TMP7]] to i64
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i64 [[AVL]], [[TMP9]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = icmp eq i64 [[AVL_NEXT]], 0

--- a/llvm/test/Transforms/LoopVectorize/RISCV/type-info-cache-evl-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/RISCV/type-info-cache-evl-crash.ll
@@ -35,7 +35,7 @@ define void @type_info_cache_clobber(ptr %dstv, ptr %src, i64 %wide.trip.count) 
 ; CHECK-NEXT:    [[TMP17:%.*]] = select <vscale x 8 x i1> [[TMP16]], <vscale x 8 x i32> [[TMP23]], <vscale x 8 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP24:%.*]] = trunc <vscale x 8 x i32> [[TMP17]] to <vscale x 8 x i8>
 ; CHECK-NEXT:    call void @llvm.vp.scatter.nxv8i8.nxv8p0(<vscale x 8 x i8> [[TMP24]], <vscale x 8 x ptr> align 1 [[BROADCAST_SPLAT]], <vscale x 8 x i1> splat (i1 true), i32 [[TMP11]]), !alias.scope [[META3:![0-9]+]], !noalias [[META0]]
-; CHECK-NEXT:    call void @llvm.vp.scatter.nxv8i16.nxv8p0(<vscale x 8 x i16> zeroinitializer, <vscale x 8 x ptr> align 2 zeroinitializer, <vscale x 8 x i1> splat (i1 true), i32 [[TMP11]])
+; CHECK-NEXT:    call void @llvm.vp.scatter.nxv8i16.nxv8p0(<vscale x 8 x i16> zeroinitializer, <vscale x 8 x ptr> align 2 splat (ptr null), <vscale x 8 x i1> splat (i1 true), i32 [[TMP11]])
 ; CHECK-NEXT:    [[TMP20:%.*]] = zext i32 [[TMP11]] to i64
 ; CHECK-NEXT:    [[INDEX_EVL_NEXT]] = add i64 [[TMP20]], [[EVL_BASED_IV]]
 ; CHECK-NEXT:    [[AVL_NEXT]] = sub nuw i64 [[AVL]], [[TMP20]]

--- a/llvm/test/Transforms/LoopVectorize/X86/cost-model.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/cost-model.ll
@@ -449,8 +449,8 @@ define i1 @any_of_cost(ptr %start, ptr %end) #0 {
 ; CHECK-NEXT:    [[TMP19:%.*]] = load ptr, ptr [[TMP13]], align 8
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <2 x ptr> poison, ptr [[TMP18]], i32 0
 ; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <2 x ptr> [[TMP20]], ptr [[TMP19]], i32 1
-; CHECK-NEXT:    [[TMP24:%.*]] = icmp ne <2 x ptr> [[TMP17]], zeroinitializer
-; CHECK-NEXT:    [[TMP25:%.*]] = icmp ne <2 x ptr> [[TMP21]], zeroinitializer
+; CHECK-NEXT:    [[TMP24:%.*]] = icmp ne <2 x ptr> [[TMP17]], splat (ptr null)
+; CHECK-NEXT:    [[TMP25:%.*]] = icmp ne <2 x ptr> [[TMP21]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP26]] = or <2 x i1> [[VEC_PHI]], [[TMP24]]
 ; CHECK-NEXT:    [[TMP27]] = or <2 x i1> [[VEC_PHI3]], [[TMP25]]
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4

--- a/llvm/test/Transforms/LoopVectorize/X86/interleave-opaque-pointers.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/interleave-opaque-pointers.ll
@@ -28,7 +28,7 @@ define void @test_pr55375_interleave_opaque_ptr(ptr %start, ptr %end) {
 ; CHECK-NEXT:    [[POINTER_PHI:%.*]] = phi ptr [ [[START]], [[VECTOR_PH]] ], [ [[PTR_IND:%.*]], [[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i8, ptr [[POINTER_PHI]], <2 x i64> <i64 0, i64 16>
 ; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <2 x ptr> [[TMP10]], i64 0
-; CHECK-NEXT:    [[TMP12:%.*]] = shufflevector <2 x ptr> zeroinitializer, <2 x ptr> [[TMP10]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[TMP12:%.*]] = shufflevector <2 x ptr> splat (ptr null), <2 x ptr> [[TMP10]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:    [[INTERLEAVED_VEC:%.*]] = shufflevector <4 x ptr> [[TMP12]], <4 x ptr> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
 ; CHECK-NEXT:    store <4 x ptr> [[INTERLEAVED_VEC]], ptr [[TMP7]], align 8
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2

--- a/llvm/test/Transforms/LoopVectorize/X86/invariant-load-gather.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/invariant-load-gather.ll
@@ -28,7 +28,7 @@ define i32 @inv_load_conditional(ptr %a, i64 %n, ptr %b, i32 %k) {
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[SMAX2]], [[N_MOD_VF]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <16 x ptr> poison, ptr [[A]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <16 x ptr> [[BROADCAST_SPLATINSERT]], <16 x ptr> poison, <16 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <16 x ptr> [[BROADCAST_SPLAT]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <16 x ptr> [[BROADCAST_SPLAT]], splat (ptr null)
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT4:%.*]] = insertelement <16 x i32> poison, i32 [[NTRUNC]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT5:%.*]] = shufflevector <16 x i32> [[BROADCAST_SPLATINSERT4]], <16 x i32> poison, <16 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
@@ -55,7 +55,7 @@ define i32 @inv_load_conditional(ptr %a, i64 %n, ptr %b, i32 %k) {
 ; CHECK-NEXT:    [[N_VEC7:%.*]] = sub i64 [[SMAX2]], [[N_MOD_VF6]]
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT8:%.*]] = insertelement <8 x ptr> poison, ptr [[A]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT9:%.*]] = shufflevector <8 x ptr> [[BROADCAST_SPLATINSERT8]], <8 x ptr> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ne <8 x ptr> [[BROADCAST_SPLAT9]], zeroinitializer
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp ne <8 x ptr> [[BROADCAST_SPLAT9]], splat (ptr null)
 ; CHECK-NEXT:    [[BROADCAST_SPLATINSERT11:%.*]] = insertelement <8 x i32> poison, i32 [[NTRUNC]], i64 0
 ; CHECK-NEXT:    [[BROADCAST_SPLAT12:%.*]] = shufflevector <8 x i32> [[BROADCAST_SPLATINSERT11]], <8 x i32> poison, <8 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VEC_EPILOG_VECTOR_BODY:%.*]]

--- a/llvm/test/Transforms/LoopVectorize/X86/masked_load_store.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/masked_load_store.ll
@@ -1331,10 +1331,10 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP20]], <4 x i1> [[TMP15]], <4 x ptr> poison)
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP21]], <4 x i1> [[TMP16]], <4 x ptr> poison)
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD6:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP22]], <4 x i1> [[TMP17]], <4 x ptr> poison)
-; AVX1-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], zeroinitializer
-; AVX1-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX1-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX1-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
+; AVX1-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], splat (ptr null)
+; AVX1-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX1-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX1-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
 ; AVX1-NEXT:    [[TMP31:%.*]] = select <4 x i1> [[TMP14]], <4 x i1> [[TMP27]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP32:%.*]] = select <4 x i1> [[TMP15]], <4 x i1> [[TMP28]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP33:%.*]] = select <4 x i1> [[TMP16]], <4 x i1> [[TMP29]], <4 x i1> zeroinitializer
@@ -1369,7 +1369,7 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX1-NEXT:    [[TMP46:%.*]] = icmp ne <4 x i8> [[TMP44]], zeroinitializer
 ; AVX1-NEXT:    [[TMP47:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP47]], <4 x i1> [[TMP46]], <4 x ptr> poison)
-; AVX1-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX1-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX1-NEXT:    [[TMP51:%.*]] = select <4 x i1> [[TMP46]], <4 x i1> [[TMP50]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX1-NEXT:    call void @llvm.masked.store.v4f64.p0(<4 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <4 x i1> [[TMP51]])
@@ -1423,10 +1423,10 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP20]], <4 x i1> [[TMP15]], <4 x ptr> poison)
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP21]], <4 x i1> [[TMP16]], <4 x ptr> poison)
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD6:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP22]], <4 x i1> [[TMP17]], <4 x ptr> poison)
-; AVX2-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], zeroinitializer
-; AVX2-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX2-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX2-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
+; AVX2-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], splat (ptr null)
+; AVX2-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX2-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX2-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
 ; AVX2-NEXT:    [[TMP31:%.*]] = select <4 x i1> [[TMP14]], <4 x i1> [[TMP27]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP32:%.*]] = select <4 x i1> [[TMP15]], <4 x i1> [[TMP28]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP33:%.*]] = select <4 x i1> [[TMP16]], <4 x i1> [[TMP29]], <4 x i1> zeroinitializer
@@ -1461,7 +1461,7 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX2-NEXT:    [[TMP46:%.*]] = icmp ne <4 x i8> [[TMP44]], zeroinitializer
 ; AVX2-NEXT:    [[TMP47:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP47]], <4 x i1> [[TMP46]], <4 x ptr> poison)
-; AVX2-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX2-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX2-NEXT:    [[TMP51:%.*]] = select <4 x i1> [[TMP46]], <4 x i1> [[TMP50]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX2-NEXT:    call void @llvm.masked.store.v4f64.p0(<4 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <4 x i1> [[TMP51]])
@@ -1515,10 +1515,10 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP20]], <8 x i1> [[TMP15]], <8 x ptr> poison)
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP21]], <8 x i1> [[TMP16]], <8 x ptr> poison)
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD6:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP22]], <8 x i1> [[TMP17]], <8 x ptr> poison)
-; AVX512-NEXT:    [[TMP27:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD]], zeroinitializer
-; AVX512-NEXT:    [[TMP28:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX512-NEXT:    [[TMP29:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX512-NEXT:    [[TMP30:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
+; AVX512-NEXT:    [[TMP27:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD]], splat (ptr null)
+; AVX512-NEXT:    [[TMP28:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX512-NEXT:    [[TMP29:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX512-NEXT:    [[TMP30:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
 ; AVX512-NEXT:    [[TMP31:%.*]] = select <8 x i1> [[TMP14]], <8 x i1> [[TMP27]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP32:%.*]] = select <8 x i1> [[TMP15]], <8 x i1> [[TMP28]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP33:%.*]] = select <8 x i1> [[TMP16]], <8 x i1> [[TMP29]], <8 x i1> zeroinitializer
@@ -1553,7 +1553,7 @@ define void @foo7(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX512-NEXT:    [[TMP46:%.*]] = icmp ne <8 x i8> [[TMP44]], zeroinitializer
 ; AVX512-NEXT:    [[TMP47:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP47]], <8 x i1> [[TMP46]], <8 x ptr> poison)
-; AVX512-NEXT:    [[TMP50:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX512-NEXT:    [[TMP50:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX512-NEXT:    [[TMP51:%.*]] = select <8 x i1> [[TMP46]], <8 x i1> [[TMP50]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX512-NEXT:    call void @llvm.masked.store.v8f64.p0(<8 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <8 x i1> [[TMP51]])
@@ -1652,10 +1652,10 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP20]], <4 x i1> [[TMP15]], <4 x ptr> poison)
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP21]], <4 x i1> [[TMP16]], <4 x ptr> poison)
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD6:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP22]], <4 x i1> [[TMP17]], <4 x ptr> poison)
-; AVX1-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], zeroinitializer
-; AVX1-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX1-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX1-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
+; AVX1-NEXT:    [[TMP27:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD]], splat (ptr null)
+; AVX1-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX1-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX1-NEXT:    [[TMP30:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
 ; AVX1-NEXT:    [[TMP31:%.*]] = select <4 x i1> [[TMP14]], <4 x i1> [[TMP27]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP32:%.*]] = select <4 x i1> [[TMP15]], <4 x i1> [[TMP28]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP33:%.*]] = select <4 x i1> [[TMP16]], <4 x i1> [[TMP29]], <4 x i1> zeroinitializer
@@ -1690,7 +1690,7 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX1-NEXT:    [[TMP46:%.*]] = icmp ne <4 x i8> [[TMP44]], zeroinitializer
 ; AVX1-NEXT:    [[TMP45:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX1-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP45]], <4 x i1> [[TMP46]], <4 x ptr> poison)
-; AVX1-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX1-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX1-NEXT:    [[TMP51:%.*]] = select <4 x i1> [[TMP46]], <4 x i1> [[TMP50]], <4 x i1> zeroinitializer
 ; AVX1-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX1-NEXT:    call void @llvm.masked.store.v4f64.p0(<4 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <4 x i1> [[TMP51]])
@@ -1744,10 +1744,10 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP19]], <4 x i1> [[TMP15]], <4 x ptr> poison)
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP20]], <4 x i1> [[TMP16]], <4 x ptr> poison)
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD7:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP23]], <4 x i1> [[TMP12]], <4 x ptr> poison)
-; AVX2-NEXT:    [[TMP18:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
-; AVX2-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX2-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX2-NEXT:    [[TMP21:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD7]], zeroinitializer
+; AVX2-NEXT:    [[TMP18:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
+; AVX2-NEXT:    [[TMP28:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX2-NEXT:    [[TMP29:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX2-NEXT:    [[TMP21:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD7]], splat (ptr null)
 ; AVX2-NEXT:    [[TMP31:%.*]] = select <4 x i1> [[TMP17]], <4 x i1> [[TMP18]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP32:%.*]] = select <4 x i1> [[TMP15]], <4 x i1> [[TMP28]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP33:%.*]] = select <4 x i1> [[TMP16]], <4 x i1> [[TMP29]], <4 x i1> zeroinitializer
@@ -1782,7 +1782,7 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX2-NEXT:    [[TMP46:%.*]] = icmp ne <4 x i8> [[TMP44]], zeroinitializer
 ; AVX2-NEXT:    [[TMP47:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX2-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr align 8 [[TMP47]], <4 x i1> [[TMP46]], <4 x ptr> poison)
-; AVX2-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX2-NEXT:    [[TMP50:%.*]] = icmp ne <4 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX2-NEXT:    [[TMP51:%.*]] = select <4 x i1> [[TMP46]], <4 x i1> [[TMP50]], <4 x i1> zeroinitializer
 ; AVX2-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX2-NEXT:    call void @llvm.masked.store.v4f64.p0(<4 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <4 x i1> [[TMP51]])
@@ -1836,10 +1836,10 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD4:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP20]], <8 x i1> [[TMP15]], <8 x ptr> poison)
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD5:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP21]], <8 x i1> [[TMP16]], <8 x ptr> poison)
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD6:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP22]], <8 x i1> [[TMP17]], <8 x ptr> poison)
-; AVX512-NEXT:    [[TMP27:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD]], zeroinitializer
-; AVX512-NEXT:    [[TMP28:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD4]], zeroinitializer
-; AVX512-NEXT:    [[TMP29:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD5]], zeroinitializer
-; AVX512-NEXT:    [[TMP30:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD6]], zeroinitializer
+; AVX512-NEXT:    [[TMP27:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD]], splat (ptr null)
+; AVX512-NEXT:    [[TMP28:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD4]], splat (ptr null)
+; AVX512-NEXT:    [[TMP29:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD5]], splat (ptr null)
+; AVX512-NEXT:    [[TMP30:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD6]], splat (ptr null)
 ; AVX512-NEXT:    [[TMP31:%.*]] = select <8 x i1> [[TMP14]], <8 x i1> [[TMP27]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP32:%.*]] = select <8 x i1> [[TMP15]], <8 x i1> [[TMP28]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP33:%.*]] = select <8 x i1> [[TMP16]], <8 x i1> [[TMP29]], <8 x i1> zeroinitializer
@@ -1874,7 +1874,7 @@ define void @foo8(ptr noalias nocapture %out, ptr noalias nocapture readonly %in
 ; AVX512-NEXT:    [[TMP46:%.*]] = icmp ne <8 x i8> [[TMP44]], zeroinitializer
 ; AVX512-NEXT:    [[TMP47:%.*]] = getelementptr ptr, ptr [[IN]], i64 [[INDEX10]]
 ; AVX512-NEXT:    [[WIDE_MASKED_LOAD12:%.*]] = call <8 x ptr> @llvm.masked.load.v8p0.p0(ptr align 8 [[TMP47]], <8 x i1> [[TMP46]], <8 x ptr> poison)
-; AVX512-NEXT:    [[TMP50:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD12]], zeroinitializer
+; AVX512-NEXT:    [[TMP50:%.*]] = icmp ne <8 x ptr> [[WIDE_MASKED_LOAD12]], splat (ptr null)
 ; AVX512-NEXT:    [[TMP51:%.*]] = select <8 x i1> [[TMP46]], <8 x i1> [[TMP50]], <8 x i1> zeroinitializer
 ; AVX512-NEXT:    [[TMP52:%.*]] = getelementptr double, ptr [[OUT]], i64 [[INDEX10]]
 ; AVX512-NEXT:    call void @llvm.masked.store.v8f64.p0(<8 x double> splat (double 5.000000e-01), ptr align 8 [[TMP52]], <8 x i1> [[TMP51]])

--- a/llvm/test/Transforms/LoopVectorize/X86/optsize.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/optsize.ll
@@ -346,7 +346,7 @@ define void @tail_folded_store_avx512(ptr %start, ptr %end) #3 {
 ; CHECK-NEXT:    [[VEC_IV:%.*]] = phi <64 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr [[POINTER_PHI]], <64 x i32> <i32 0, i32 -72, i32 -144, i32 -216, i32 -288, i32 -360, i32 -432, i32 -504, i32 -576, i32 -648, i32 -720, i32 -792, i32 -864, i32 -936, i32 -1008, i32 -1080, i32 -1152, i32 -1224, i32 -1296, i32 -1368, i32 -1440, i32 -1512, i32 -1584, i32 -1656, i32 -1728, i32 -1800, i32 -1872, i32 -1944, i32 -2016, i32 -2088, i32 -2160, i32 -2232, i32 -2304, i32 -2376, i32 -2448, i32 -2520, i32 -2592, i32 -2664, i32 -2736, i32 -2808, i32 -2880, i32 -2952, i32 -3024, i32 -3096, i32 -3168, i32 -3240, i32 -3312, i32 -3384, i32 -3456, i32 -3528, i32 -3600, i32 -3672, i32 -3744, i32 -3816, i32 -3888, i32 -3960, i32 -4032, i32 -4104, i32 -4176, i32 -4248, i32 -4320, i32 -4392, i32 -4464, i32 -4536>
 ; CHECK-NEXT:    [[TMP6:%.*]] = icmp ule <64 x i32> [[VEC_IV]], [[BROADCAST_SPLAT4]]
-; CHECK-NEXT:    call void @llvm.masked.scatter.v64p0.v64p0(<64 x ptr> zeroinitializer, <64 x ptr> align 8 [[TMP5]], <64 x i1> [[TMP6]])
+; CHECK-NEXT:    call void @llvm.masked.scatter.v64p0.v64p0(<64 x ptr> splat (ptr null), <64 x ptr> align 8 [[TMP5]], <64 x i1> [[TMP6]])
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 64
 ; CHECK-NEXT:    [[PTR_IND]] = getelementptr i8, ptr [[POINTER_PHI]], i32 -4608
 ; CHECK-NEXT:    [[VEC_IND_NEXT]] = add nuw <64 x i32> [[VEC_IV]], splat (i32 64)
@@ -381,7 +381,7 @@ define void @tail_folded_store_avx512(ptr %start, ptr %end) #3 {
 ; AUTOVF-NEXT:    [[VEC_IV:%.*]] = phi <8 x i32> [ <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>, %[[VECTOR_PH]] ], [ [[VEC_IND_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; AUTOVF-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr [[POINTER_PHI]], <8 x i32> <i32 0, i32 -72, i32 -144, i32 -216, i32 -288, i32 -360, i32 -432, i32 -504>
 ; AUTOVF-NEXT:    [[TMP6:%.*]] = icmp ule <8 x i32> [[VEC_IV]], [[BROADCAST_SPLAT4]]
-; AUTOVF-NEXT:    call void @llvm.masked.scatter.v8p0.v8p0(<8 x ptr> zeroinitializer, <8 x ptr> align 8 [[TMP5]], <8 x i1> [[TMP6]])
+; AUTOVF-NEXT:    call void @llvm.masked.scatter.v8p0.v8p0(<8 x ptr> splat (ptr null), <8 x ptr> align 8 [[TMP5]], <8 x i1> [[TMP6]])
 ; AUTOVF-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 8
 ; AUTOVF-NEXT:    [[PTR_IND]] = getelementptr i8, ptr [[POINTER_PHI]], i32 -576
 ; AUTOVF-NEXT:    [[VEC_IND_NEXT]] = add nuw <8 x i32> [[VEC_IV]], splat (i32 8)

--- a/llvm/test/Transforms/LoopVectorize/find-last.ll
+++ b/llvm/test/Transforms/LoopVectorize/find-last.ll
@@ -283,7 +283,7 @@ define ptr @loop_inv_select_condition_issue_185682(i32 %a, i32 %b) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = select i1 [[TMP2]], <4 x i1> [[TMP0]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    br label [[MIDDLE_BLOCK:%.*]]
 ; CHECK:       middle.block:
-; CHECK-NEXT:    [[TMP6:%.*]] = call ptr @llvm.experimental.vector.extract.last.active.v4p0(<4 x ptr> zeroinitializer, <4 x i1> [[TMP3]], ptr null)
+; CHECK-NEXT:    [[TMP6:%.*]] = call ptr @llvm.experimental.vector.extract.last.active.v4p0(<4 x ptr> splat (ptr null), <4 x i1> [[TMP3]], ptr null)
 ; CHECK-NEXT:    br label [[EXIT:%.*]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret ptr [[TMP6]]

--- a/llvm/test/Transforms/LoopVectorize/single_early_exit.ll
+++ b/llvm/test/Transforms/LoopVectorize/single_early_exit.ll
@@ -310,7 +310,7 @@ define void @inner_loop_trip_count_depends_on_outer_iv(ptr align 8 dereferenceab
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY_INTERIM:%.*]] ]
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr ptr, ptr [[GEP_SRC]], i64 [[INDEX]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x ptr>, ptr [[TMP0]], align 8
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <4 x ptr> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq <4 x ptr> [[WIDE_LOAD]], splat (ptr null)
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 4
 ; CHECK-NEXT:    [[TMP2:%.*]] = freeze <4 x i1> [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> [[TMP2]])

--- a/llvm/test/Transforms/LoopVectorize/vector-loop-backedge-elimination-outside-iv-users.ll
+++ b/llvm/test/Transforms/LoopVectorize/vector-loop-backedge-elimination-outside-iv-users.ll
@@ -12,8 +12,8 @@ define i64 @remove_loop_region_int_iv_used_outside(ptr %dst) {
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr ptr, ptr [[DST]], i64 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[DST]], align 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[TMP2]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[DST]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[TMP2]], align 8
 ; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
@@ -45,8 +45,8 @@ define i64 @remove_loop_region_int_iv_inc_used_outside(ptr %dst) {
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr ptr, ptr [[DST]], i64 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[DST]], align 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[TMP2]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[DST]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[TMP2]], align 8
 ; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]
@@ -79,8 +79,8 @@ define ptr @remove_loop_region_ptr_iv_used_outside(ptr %dst) {
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr ptr, ptr [[DST]], i64 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[DST]], align 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[TMP2]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[DST]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[TMP2]], align 8
 ; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    [[IND_ESCAPE:%.*]] = getelementptr i8, ptr [[TMP0]], i64 -8
@@ -115,8 +115,8 @@ define ptr @remove_loop_region_ptr_iv_inc_used_outside(ptr %dst) {
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr ptr, ptr [[DST]], i64 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[DST]], align 8
-; CHECK-NEXT:    store <8 x ptr> zeroinitializer, ptr [[TMP2]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[DST]], align 8
+; CHECK-NEXT:    store <8 x ptr> splat (ptr null), ptr [[TMP2]], align 8
 ; CHECK-NEXT:    br label %[[MIDDLE_BLOCK:.*]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
 ; CHECK-NEXT:    br label %[[EXIT:.*]]

--- a/llvm/test/Transforms/RewriteStatepointsForGC/base-inference.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/base-inference.ll
@@ -160,9 +160,11 @@ define <2 x ptr addrspace(1)> @test_vec_passthrough(<2 x ptr addrspace(1)> %a) g
 
 define <2 x ptr addrspace(1)> @test_insert(ptr addrspace(1) %a) gc "statepoint-example" {
 ; CHECK-LABEL: @test_insert(
-; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[A:%.*]], i64 0
-; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[VEC]]) ]
-; CHECK-NEXT:    [[VEC_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 0, i32 0)
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[A:%.*]], i64 0, !is_base_value [[META0:![0-9]+]]
+; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), ptr addrspace(1) [[A]], i64 0
+; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[VEC]], <2 x ptr addrspace(1)> [[VEC_BASE]]) ]
+; CHECK-NEXT:    [[VEC_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
+; CHECK-NEXT:    [[VEC_BASE_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 1)
 ; CHECK-NEXT:    ret <2 x ptr addrspace(1)> [[VEC_RELOCATED]]
 ;
   %vec = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) %a, i64 0
@@ -223,10 +225,13 @@ define <4 x ptr addrspace(1)> @test_shuffle_concat(<2 x ptr addrspace(1)> %a1, <
 define <2 x ptr addrspace(1)> @test_shuffle_broadcast(ptr addrspace(1) %a) gc "statepoint-example" {
 ; CHECK-LABEL: @test_shuffle_broadcast(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[IE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[A:%.*]], i64 0
+; CHECK-NEXT:    [[IE_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[A:%.*]], i64 0, !is_base_value [[META0]]
+; CHECK-NEXT:    [[IE:%.*]] = insertelement <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), ptr addrspace(1) [[A]], i64 0
+; CHECK-NEXT:    [[BROADCAST_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> [[IE_BASE]], <2 x ptr addrspace(1)> poison, <2 x i32> zeroinitializer, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BROADCAST:%.*]] = shufflevector <2 x ptr addrspace(1)> [[IE]], <2 x ptr addrspace(1)> undef, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[BROADCAST]]) ]
-; CHECK-NEXT:    [[BROADCAST_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 0, i32 0)
+; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[BROADCAST]], <2 x ptr addrspace(1)> [[BROADCAST_BASE]]) ]
+; CHECK-NEXT:    [[BROADCAST_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
+; CHECK-NEXT:    [[BROADCAST_BASE_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 1)
 ; CHECK-NEXT:    ret <2 x ptr addrspace(1)> [[BROADCAST_RELOCATED]]
 ;
 entry:
@@ -271,11 +276,15 @@ define i8 @test_subgraph2(i1 %c, ptr addrspace(1) %a1, ptr addrspace(1) %a2) gc 
 ; CHECK-LABEL: @test_subgraph2(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C:%.*]], ptr addrspace(1) [[A1:%.*]], ptr addrspace(1) [[A2:%.*]]
-; CHECK-NEXT:    [[IE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[SEL]], i64 0
+; CHECK-NEXT:    [[IE_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[SEL]], i64 0, !is_base_value [[META0]]
+; CHECK-NEXT:    [[IE:%.*]] = insertelement <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), ptr addrspace(1) [[SEL]], i64 0
+; CHECK-NEXT:    [[BROADCAST_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> [[IE_BASE]], <2 x ptr addrspace(1)> poison, <2 x i32> zeroinitializer, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BROADCAST:%.*]] = shufflevector <2 x ptr addrspace(1)> [[IE]], <2 x ptr addrspace(1)> [[IE]], <2 x i32> zeroinitializer
+; CHECK-NEXT:    [[EE_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[BROADCAST_BASE]], i32 1, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[EE:%.*]] = extractelement <2 x ptr addrspace(1)> [[BROADCAST]], i32 1
-; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(ptr addrspace(1) [[EE]]) ]
-; CHECK-NEXT:    [[EE_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 0, i32 0)
+; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(ptr addrspace(1) [[EE]], ptr addrspace(1) [[EE_BASE]]) ]
+; CHECK-NEXT:    [[EE_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
+; CHECK-NEXT:    [[EE_BASE_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 1)
 ; CHECK-NEXT:    [[RES:%.*]] = load i8, ptr addrspace(1) [[EE_RELOCATED]], align 1
 ; CHECK-NEXT:    ret i8 [[RES]]
 ;

--- a/llvm/test/Transforms/RewriteStatepointsForGC/base-pointers.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/base-pointers.ll
@@ -88,13 +88,13 @@ define void @test2(i1 %cnd, ptr addrspace(1) %base_obj, ptr addrspace(1) %base_a
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[DOT0:%.*]] = phi ptr addrspace(1) [ [[BASE_ARG2:%.*]], [[ENTRY:%.*]] ], [ [[BASE_ARG2_RELOCATED:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[CURRENT_BASE:%.*]] = phi ptr addrspace(1) [ [[BASE_OBJ]], [[ENTRY]] ], [ [[NEXT_BASE_RELOCATED:%.*]], [[LOOP]] ], !is_base_value !0
+; CHECK-NEXT:    [[CURRENT_BASE:%.*]] = phi ptr addrspace(1) [ [[BASE_OBJ]], [[ENTRY]] ], [ [[NEXT_BASE_RELOCATED:%.*]], [[LOOP]] ], !is_base_value [[META0:![0-9]+]]
 ; CHECK-NEXT:    [[CURRENT:%.*]] = phi ptr addrspace(1) [ [[OBJ]], [[ENTRY]] ], [ [[NEXT_RELOCATED:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[EXTRA:%.*]] = phi ptr addrspace(1) [ [[OBJ]], [[ENTRY]] ], [ [[EXTRA2_RELOCATED:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[NEXTA:%.*]] = getelementptr i64, ptr addrspace(1) [[CURRENT]], i32 1
-; CHECK-NEXT:    [[NEXT_BASE:%.*]] = select i1 [[CND:%.*]], ptr addrspace(1) [[CURRENT_BASE]], ptr addrspace(1) [[DOT0]], !is_base_value !0
+; CHECK-NEXT:    [[NEXT_BASE:%.*]] = select i1 [[CND:%.*]], ptr addrspace(1) [[CURRENT_BASE]], ptr addrspace(1) [[DOT0]], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[NEXT:%.*]] = select i1 [[CND]], ptr addrspace(1) [[NEXTA]], ptr addrspace(1) [[DOT0]]
-; CHECK-NEXT:    [[EXTRA2_BASE:%.*]] = select i1 [[CND]], ptr addrspace(1) [[CURRENT_BASE]], ptr addrspace(1) [[DOT0]], !is_base_value !0
+; CHECK-NEXT:    [[EXTRA2_BASE:%.*]] = select i1 [[CND]], ptr addrspace(1) [[CURRENT_BASE]], ptr addrspace(1) [[DOT0]], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[EXTRA2:%.*]] = select i1 [[CND]], ptr addrspace(1) [[NEXTA]], ptr addrspace(1) [[DOT0]]
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "deopt"(i32 0, i32 -1, i32 0, i32 0, i32 0), "gc-live"(ptr addrspace(1) [[NEXT_BASE]], ptr addrspace(1) [[NEXT]], ptr addrspace(1) [[EXTRA2]], ptr addrspace(1) [[DOT0]], ptr addrspace(1) [[EXTRA2_BASE]]) ]
 ; CHECK-NEXT:    [[NEXT_BASE_RELOCATED]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 0, i32 0)
@@ -226,12 +226,12 @@ declare i32 @snork()
 define void @test7() gc "statepoint-example" {
 ; CHECK-LABEL: @test7(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i64> <i64 888, i64 908>
-; CHECK-NEXT:    [[SHUFFLEVECTOR_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>, !is_base_value !0
-; CHECK-NEXT:    [[SHUFFLEVECTOR:%.*]] = shufflevector <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[SHUFFLEVECTOR1_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>, !is_base_value !0
-; CHECK-NEXT:    [[SHUFFLEVECTOR1:%.*]] = shufflevector <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[SELECT_BASE:%.*]] = select i1 false, <4 x ptr addrspace(1)> [[SHUFFLEVECTOR1_BASE]], <4 x ptr addrspace(1)> [[SHUFFLEVECTOR_BASE]], !is_base_value !0
+; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i64> <i64 888, i64 908>
+; CHECK-NEXT:    [[SHUFFLEVECTOR_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>, !is_base_value [[META0]]
+; CHECK-NEXT:    [[SHUFFLEVECTOR:%.*]] = shufflevector <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[SHUFFLEVECTOR1_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 1, i32 2, i32 3>, !is_base_value [[META0]]
+; CHECK-NEXT:    [[SHUFFLEVECTOR1:%.*]] = shufflevector <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[SELECT_BASE:%.*]] = select i1 false, <4 x ptr addrspace(1)> [[SHUFFLEVECTOR1_BASE]], <4 x ptr addrspace(1)> [[SHUFFLEVECTOR_BASE]], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 false, <4 x ptr addrspace(1)> [[SHUFFLEVECTOR1]], <4 x ptr addrspace(1)> [[SHUFFLEVECTOR]]
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(i32 ()) @snork, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<4 x ptr addrspace(1)> [[SELECT]], <4 x ptr addrspace(1)> [[SELECT_BASE]]) ]
 ; CHECK-NEXT:    [[SELECT_RELOCATED:%.*]] = call coldcc <4 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v4p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)

--- a/llvm/test/Transforms/RewriteStatepointsForGC/base-vector.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/base-vector.ll
@@ -75,9 +75,9 @@ merge2:                                           ; preds = %untaken2, %taken2
 define ptr addrspace(1) @test3(ptr addrspace(1) %ptr) gc "statepoint-example" {
 ; CHECK-LABEL: @test3(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[PTR:%.*]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[PTR:%.*]], i32 0, !is_base_value [[META0:![0-9]+]]
 ; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[PTR]], i32 0
-; CHECK-NEXT:    [[OBJ_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[OBJ_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[OBJ:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @do_safepoint, i32 0, i32 0, i32 0, i32 0) [ "deopt"(), "gc-live"(ptr addrspace(1) [[OBJ]], ptr addrspace(1) [[OBJ_BASE]]) ]
 ; CHECK-NEXT:    [[OBJ_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
@@ -97,11 +97,11 @@ define ptr addrspace(1) @test4(ptr addrspace(1) %ptr) gc "statepoint-example" {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[DERIVED:%.*]] = getelementptr i64, ptr addrspace(1) [[PTR:%.*]], i64 16
-; CHECK-NEXT:    [[VECA_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[PTR]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VECA_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[PTR]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VECA:%.*]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[DERIVED]], i32 0
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> [[VECA_BASE]], ptr addrspace(1) [[PTR]], i32 1, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> [[VECA_BASE]], ptr addrspace(1) [[PTR]], i32 1, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> [[VECA]], ptr addrspace(1) [[PTR]], i32 1
-; CHECK-NEXT:    [[OBJ_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[OBJ_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[OBJ:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @do_safepoint, i32 0, i32 0, i32 0, i32 0) [ "deopt"(), "gc-live"(ptr addrspace(1) [[OBJ]], ptr addrspace(1) [[OBJ_BASE]]) ]
 ; CHECK-NEXT:    [[OBJ_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
@@ -125,9 +125,9 @@ define void @test5(i1 %cnd, ptr addrspace(1) %obj) gc "statepoint-example" {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ:%.*]], i64 1
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[GEP]], i32 0
-; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BDV:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @do_safepoint, i32 0, i32 0, i32 0, i32 0) [ "deopt"(i32 0, i32 -1, i32 0, i32 0, i32 0), "gc-live"(ptr addrspace(1) [[BDV]], ptr addrspace(1) [[BDV_BASE]]) ]
 ; CHECK-NEXT:    [[BDV_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
@@ -151,9 +151,9 @@ define void @test6(i1 %cnd, ptr addrspace(1) %obj, i64 %idx) gc "statepoint-exam
 ; CHECK-LABEL: @test6(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ:%.*]], i64 1
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[GEP]], i32 0
-; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i64 [[IDX:%.*]], !is_base_value !0
+; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i64 [[IDX:%.*]], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BDV:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC]], i64 [[IDX]]
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @do_safepoint, i32 0, i32 0, i32 0, i32 0) [ "deopt"(i32 0, i32 -1, i32 0, i32 0, i32 0), "gc-live"(ptr addrspace(1) [[BDV]], ptr addrspace(1) [[BDV_BASE]]) ]
 ; CHECK-NEXT:    [[BDV_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
@@ -173,22 +173,22 @@ entry:
 define ptr addrspace(1) @test7(i1 %cnd, ptr addrspace(1) %obj, ptr addrspace(1) %obj2) gc "statepoint-example" {
 ; CHECK-LABEL: @test7(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2:%.*]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2:%.*]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[OBJ2]], i32 0
 ; CHECK-NEXT:    br label [[MERGE1:%.*]]
 ; CHECK:       merge1:
-; CHECK-NEXT:    [[VEC2_BASE:%.*]] = phi <2 x ptr addrspace(1)> [ [[VEC_BASE]], [[ENTRY:%.*]] ], [ [[VEC3_BASE:%.*]], [[MERGE1]] ], !is_base_value !0
+; CHECK-NEXT:    [[VEC2_BASE:%.*]] = phi <2 x ptr addrspace(1)> [ [[VEC_BASE]], [[ENTRY:%.*]] ], [ [[VEC3_BASE:%.*]], [[MERGE1]] ], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC2:%.*]] = phi <2 x ptr addrspace(1)> [ [[VEC]], [[ENTRY]] ], [ [[VEC3:%.*]], [[MERGE1]] ]
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ2]], i64 1
-; CHECK-NEXT:    [[VEC3_BASE]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC3_BASE]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC3]] = insertelement <2 x ptr addrspace(1)> undef, ptr addrspace(1) [[GEP]], i32 0
 ; CHECK-NEXT:    br i1 [[CND:%.*]], label [[MERGE1]], label [[NEXT1:%.*]]
 ; CHECK:       next1:
-; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC2_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC2_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BDV:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC2]], i32 0
 ; CHECK-NEXT:    br label [[MERGE:%.*]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[OBJB_BASE:%.*]] = phi ptr addrspace(1) [ [[OBJ:%.*]], [[NEXT1]] ], [ [[BDV_BASE]], [[MERGE]] ], !is_base_value !0
+; CHECK-NEXT:    [[OBJB_BASE:%.*]] = phi ptr addrspace(1) [ [[OBJ:%.*]], [[NEXT1]] ], [ [[BDV_BASE]], [[MERGE]] ], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[OBJB:%.*]] = phi ptr addrspace(1) [ [[OBJ]], [[NEXT1]] ], [ [[BDV]], [[MERGE]] ]
 ; CHECK-NEXT:    br i1 [[CND]], label [[MERGE]], label [[NEXT:%.*]]
 ; CHECK:       next:
@@ -226,13 +226,13 @@ define void @test8(ptr addrspace(1) %obj, i64 %idx) gc "statepoint-example" {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ:%.*]], i64 1
 ; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i64, ptr addrspace(1) [[OBJ]], i64 2
-; CHECK-NEXT:    [[VEC1_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC1_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC1:%.*]] = insertelement <4 x ptr addrspace(1)> undef, ptr addrspace(1) [[GEP]], i32 0
-; CHECK-NEXT:    [[VEC2_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 2, !is_base_value !0
+; CHECK-NEXT:    [[VEC2_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ]], i32 2, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC2:%.*]] = insertelement <4 x ptr addrspace(1)> undef, ptr addrspace(1) [[GEP2]], i32 2
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = shufflevector <4 x ptr addrspace(1)> [[VEC1_BASE]], <4 x ptr addrspace(1)> [[VEC2_BASE]], <2 x i32> <i32 0, i32 2>, !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = shufflevector <4 x ptr addrspace(1)> [[VEC1_BASE]], <4 x ptr addrspace(1)> [[VEC2_BASE]], <2 x i32> <i32 0, i32 2>, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = shufflevector <4 x ptr addrspace(1)> [[VEC1]], <4 x ptr addrspace(1)> [[VEC2]], <2 x i32> <i32 0, i32 2>
-; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i64 [[IDX:%.*]], !is_base_value !0
+; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC_BASE]], i64 [[IDX:%.*]], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BDV:%.*]] = extractelement <2 x ptr addrspace(1)> [[VEC]], i64 [[IDX]]
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(void ()) @do_safepoint, i32 0, i32 0, i32 0, i32 0) [ "deopt"(i32 0, i32 -1, i32 0, i32 0, i32 0), "gc-live"(ptr addrspace(1) [[BDV]], ptr addrspace(1) [[BDV_BASE]]) ]
 ; CHECK-NEXT:    [[BDV_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
@@ -277,19 +277,19 @@ entry:
 define ptr addrspace(1) @test10(i1 %cnd, ptr addrspace(1) %obj, ptr addrspace(1) %obj2) gc "statepoint-example" {
 ; CHECK-LABEL: @test10(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[VEC1_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ:%.*]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[VEC1_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ:%.*]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC1:%.*]] = insertelement <4 x ptr addrspace(1)> undef, ptr addrspace(1) [[OBJ]], i32 0
 ; CHECK-NEXT:    br i1 [[CND:%.*]], label [[HERE:%.*]], label [[MERGE:%.*]]
 ; CHECK:       here:
-; CHECK-NEXT:    [[VEC2_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2:%.*]], i32 2, !is_base_value !0
+; CHECK-NEXT:    [[VEC2_BASE:%.*]] = insertelement <4 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[OBJ2:%.*]], i32 2, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC2:%.*]] = insertelement <4 x ptr addrspace(1)> undef, ptr addrspace(1) [[OBJ2]], i32 2
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
-; CHECK-NEXT:    [[VEC_BASE:%.*]] = phi <4 x ptr addrspace(1)> [ [[VEC1_BASE]], [[ENTRY:%.*]] ], [ [[VEC2_BASE]], [[HERE]] ], [ [[VEC3_BASE:%.*]], [[MERGE]] ], !is_base_value !0
+; CHECK-NEXT:    [[VEC_BASE:%.*]] = phi <4 x ptr addrspace(1)> [ [[VEC1_BASE]], [[ENTRY:%.*]] ], [ [[VEC2_BASE]], [[HERE]] ], [ [[VEC3_BASE:%.*]], [[MERGE]] ], !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC:%.*]] = phi <4 x ptr addrspace(1)> [ [[VEC1]], [[ENTRY]] ], [ [[VEC2]], [[HERE]] ], [ [[VEC3:%.*]], [[MERGE]] ]
-; CHECK-NEXT:    [[VEC3_BASE]] = shufflevector <4 x ptr addrspace(1)> [[VEC_BASE]], <4 x ptr addrspace(1)> [[VEC_BASE]], <4 x i32> <i32 2, i32 0, i32 1, i32 3>, !is_base_value !0
+; CHECK-NEXT:    [[VEC3_BASE]] = shufflevector <4 x ptr addrspace(1)> [[VEC_BASE]], <4 x ptr addrspace(1)> [[VEC_BASE]], <4 x i32> <i32 2, i32 0, i32 1, i32 3>, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[VEC3]] = shufflevector <4 x ptr addrspace(1)> [[VEC]], <4 x ptr addrspace(1)> [[VEC]], <4 x i32> <i32 2, i32 0, i32 1, i32 3>
-; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <4 x ptr addrspace(1)> [[VEC3_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[BDV_BASE:%.*]] = extractelement <4 x ptr addrspace(1)> [[VEC3_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[BDV:%.*]] = extractelement <4 x ptr addrspace(1)> [[VEC3]], i32 0
 ; CHECK-NEXT:    br i1 [[CND]], label [[MERGE]], label [[NEXT:%.*]]
 ; CHECK:       next:
@@ -354,16 +354,16 @@ entry:
 }
 
 define i32 @test13() gc "statepoint-example" {
-; CHECK-LABEL: define i32 @test13() gc "statepoint-example" {
+; CHECK-LABEL: @test13(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i64> <i64 948, i64 896>
-; CHECK-NEXT:    [[SHUFFLEVECTOR_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 3, i32 1, i32 2>, !is_base_value !0
-; CHECK-NEXT:    [[SHUFFLEVECTOR:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <4 x i32> <i32 0, i32 3, i32 1, i32 2>
+; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i64> <i64 948, i64 896>
+; CHECK-NEXT:    [[SHUFFLEVECTOR_BASE:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <4 x i32> <i32 0, i32 3, i32 1, i32 2>, !is_base_value [[META0]]
+; CHECK-NEXT:    [[SHUFFLEVECTOR:%.*]] = shufflevector <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x ptr addrspace(1)> [[GETELEMENTPTR]], <4 x i32> <i32 0, i32 3, i32 1, i32 2>
 ; CHECK-NEXT:    br label [[BB1:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[PHI_BASE:%.*]] = phi <4 x ptr addrspace(1)> [ [[SHUFFLEVECTOR_BASE]], [[BB:%.*]] ], [ zeroinitializer, [[BB1]] ], !is_base_value !0
-; CHECK-NEXT:    [[PHI:%.*]] = phi <4 x ptr addrspace(1)> [ [[SHUFFLEVECTOR]], [[BB]] ], [ zeroinitializer, [[BB1]] ]
-; CHECK-NEXT:    [[EXTRACTELEMENT_BASE:%.*]] = extractelement <4 x ptr addrspace(1)> [[PHI_BASE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[PHI_BASE:%.*]] = phi <4 x ptr addrspace(1)> [ [[SHUFFLEVECTOR_BASE]], [[BB:%.*]] ], [ zeroinitializer, [[BB1]] ], !is_base_value [[META0]]
+; CHECK-NEXT:    [[PHI:%.*]] = phi <4 x ptr addrspace(1)> [ [[SHUFFLEVECTOR]], [[BB]] ], [ splat (ptr addrspace(1) null), [[BB1]] ]
+; CHECK-NEXT:    [[EXTRACTELEMENT_BASE:%.*]] = extractelement <4 x ptr addrspace(1)> [[PHI_BASE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[EXTRACTELEMENT:%.*]] = extractelement <4 x ptr addrspace(1)> [[PHI]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(i32 ()) @spam, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(ptr addrspace(1) [[EXTRACTELEMENT]], ptr addrspace(1) [[EXTRACTELEMENT_BASE]]) ]
 ; CHECK-NEXT:    [[EXTRACTELEMENT_RELOCATED:%.*]] = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)

--- a/llvm/test/Transforms/RewriteStatepointsForGC/insert-extract.ll
+++ b/llvm/test/Transforms/RewriteStatepointsForGC/insert-extract.ll
@@ -6,11 +6,11 @@ target triple = "x86_64-unknown-linux-gnu"
 define void @barney() gc "statepoint-example" {
 ; CHECK-LABEL: define void @barney() gc "statepoint-example" {
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i64> <i64 16, i64 8>
-; CHECK-NEXT:    [[EXTRACTELEMENT_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> zeroinitializer, i32 0, !is_base_value !0
+; CHECK-NEXT:    [[GETELEMENTPTR:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i64> <i64 16, i64 8>
+; CHECK-NEXT:    [[EXTRACTELEMENT_BASE:%.*]] = extractelement <2 x ptr addrspace(1)> zeroinitializer, i32 0, !is_base_value [[META0:![0-9]+]]
 ; CHECK-NEXT:    [[EXTRACTELEMENT:%.*]] = extractelement <2 x ptr addrspace(1)> [[GETELEMENTPTR]], i32 0
-; CHECK-NEXT:    [[INSERTELEMENT_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[EXTRACTELEMENT_BASE]], i32 0, !is_base_value !0
-; CHECK-NEXT:    [[INSERTELEMENT:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[EXTRACTELEMENT]], i32 0
+; CHECK-NEXT:    [[INSERTELEMENT_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[EXTRACTELEMENT_BASE]], i32 0, !is_base_value [[META0]]
+; CHECK-NEXT:    [[INSERTELEMENT:%.*]] = insertelement <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), ptr addrspace(1) [[EXTRACTELEMENT]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(i8 ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[INSERTELEMENT]], <2 x ptr addrspace(1)> [[INSERTELEMENT_BASE]]) ]
 ; CHECK-NEXT:    [[INSERTELEMENT_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)
 ; CHECK-NEXT:    [[INSERTELEMENT_BASE_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 1)
@@ -31,12 +31,12 @@ bb:
 define void @bart() gc "statepoint-example" {
 ; CHECK-LABEL: define void @bart() gc "statepoint-example" {
 ; CHECK-NEXT:  always_continue:
-; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> zeroinitializer, <2 x i64> <i64 16, i64 8>
-; CHECK-NEXT:    [[BASE_EE:%.*]] = extractelement <2 x ptr addrspace(1)> zeroinitializer, i32 0, !is_base_value !0
+; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i64> <i64 16, i64 8>
+; CHECK-NEXT:    [[BASE_EE:%.*]] = extractelement <2 x ptr addrspace(1)> zeroinitializer, i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x ptr addrspace(1)> [[TMP0]], i32 0
-; CHECK-NEXT:    [[BASE_IE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[BASE_EE]], i32 0, !is_base_value !0
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[TMP1]], i32 0
-; CHECK-NEXT:    [[OTHER_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> [[BASE_IE]], ptr addrspace(1) [[BASE_EE]], i32 0, !is_base_value !0
+; CHECK-NEXT:    [[BASE_IE:%.*]] = insertelement <2 x ptr addrspace(1)> zeroinitializer, ptr addrspace(1) [[BASE_EE]], i32 0, !is_base_value [[META0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), ptr addrspace(1) [[TMP1]], i32 0
+; CHECK-NEXT:    [[OTHER_BASE:%.*]] = insertelement <2 x ptr addrspace(1)> [[BASE_IE]], ptr addrspace(1) [[BASE_EE]], i32 0, !is_base_value [[META0]]
 ; CHECK-NEXT:    [[OTHER:%.*]] = insertelement <2 x ptr addrspace(1)> [[TMP2]], ptr addrspace(1) [[TMP1]], i32 0
 ; CHECK-NEXT:    [[STATEPOINT_TOKEN:%.*]] = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr elementtype(i8 ()) @foo, i32 0, i32 0, i32 0, i32 0) [ "gc-live"(<2 x ptr addrspace(1)> [[OTHER]], <2 x ptr addrspace(1)> [[OTHER_BASE]]) ]
 ; CHECK-NEXT:    [[OTHER_RELOCATED:%.*]] = call coldcc <2 x ptr addrspace(1)> @llvm.experimental.gc.relocate.v2p1(token [[STATEPOINT_TOKEN]], i32 1, i32 0)

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/InstructionsState-is-invalid-0.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/InstructionsState-is-invalid-0.ll
@@ -12,12 +12,12 @@ define void @foo(ptr %0) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x ptr> poison, ptr [[TMP0]], i32 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x ptr> [[TMP1]], ptr [[SCEVGEP]], i32 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x ptr> [[TMP2]], <4 x ptr> poison, <4 x i32> <i32 0, i32 0, i32 0, i32 1>
-; CHECK-NEXT:    [[TMP4:%.*]] = icmp ult <4 x ptr> [[TMP3]], zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp ult <4 x ptr> [[TMP3]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP5:%.*]] = and <4 x i1> [[TMP4]], zeroinitializer
 ; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <4 x ptr> poison, ptr [[TMP0]], i32 0
 ; CHECK-NEXT:    [[TMP7:%.*]] = insertelement <4 x ptr> [[TMP6]], ptr [[SCEVGEP3]], i32 1
 ; CHECK-NEXT:    [[TMP8:%.*]] = shufflevector <4 x ptr> [[TMP7]], <4 x ptr> poison, <4 x i32> <i32 0, i32 0, i32 0, i32 1>
-; CHECK-NEXT:    [[TMP9:%.*]] = icmp ult <4 x ptr> [[TMP8]], zeroinitializer
+; CHECK-NEXT:    [[TMP9:%.*]] = icmp ult <4 x ptr> [[TMP8]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP10:%.*]] = and <4 x i1> [[TMP9]], zeroinitializer
 ; CHECK-NEXT:    [[RDX_OP:%.*]] = or <4 x i1> [[TMP5]], [[TMP10]]
 ; CHECK-NEXT:    [[OP_RDX:%.*]] = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> [[RDX_OP]])

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/long-non-power-of-2.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/long-non-power-of-2.ll
@@ -39,7 +39,7 @@ define i1 @test(ptr %arg, ptr %arg1, i64 %arg2, ptr %arg3) {
 ; CHECK-NEXT:    [[TMP21:%.*]] = and <4 x i1> zeroinitializer, [[TMP20]]
 ; CHECK-NEXT:    [[ICMP58:%.*]] = icmp ult ptr [[GETELEMENTPTR]], null
 ; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <2 x ptr> <ptr poison, ptr null>, ptr [[GETELEMENTPTR]], i32 0
-; CHECK-NEXT:    [[TMP23:%.*]] = icmp ult <2 x ptr> [[TMP22]], zeroinitializer
+; CHECK-NEXT:    [[TMP23:%.*]] = icmp ult <2 x ptr> [[TMP22]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <8 x ptr> <ptr null, ptr null, ptr null, ptr null, ptr poison, ptr poison, ptr null, ptr null>, ptr [[ARG]], i32 4
 ; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <8 x ptr> [[TMP24]], ptr [[ARG1]], i32 5
 ; CHECK-NEXT:    [[TMP26:%.*]] = icmp ult <8 x ptr> [[TMP25]], [[TMP4]]

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/non-power-of-2-with-adjusted-gathers.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/non-power-of-2-with-adjusted-gathers.ll
@@ -18,7 +18,7 @@ define i1 @test(ptr %arg, ptr %arg1, i1 %arg2, i1 %arg3, i1 %arg4) {
 ; CHECK-NEXT:    [[AND12:%.*]] = and i1 false, [[ICMP11]]
 ; CHECK-NEXT:    [[ICMP14:%.*]] = icmp ult ptr null, null
 ; CHECK-NEXT:    [[AND15:%.*]] = and i1 false, [[ICMP14]]
-; CHECK-NEXT:    [[TMP4:%.*]] = icmp ult <8 x ptr> [[TMP2]], zeroinitializer
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp ult <8 x ptr> [[TMP2]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <8 x i1> <i1 false, i1 poison, i1 false, i1 false, i1 false, i1 false, i1 false, i1 false>, i1 [[ARG2]], i32 1
 ; CHECK-NEXT:    [[TMP6:%.*]] = and <8 x i1> [[TMP4]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <8 x ptr> [[TMP2]], i32 3

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/complex-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/complex-loads.ll
@@ -154,7 +154,7 @@ define i32 @test(ptr %pix1, ptr %pix2, i64 %idx.ext, i64 %idx.ext63, ptr %add.pt
 ; THR15-NEXT:    [[ARRAYIDX3_2:%.*]] = getelementptr i8, ptr [[ADD_PTR_1]], i64 4
 ; THR15-NEXT:    [[ARRAYIDX5_2:%.*]] = getelementptr i8, ptr [[ADD_PTR64_1]], i64 4
 ; THR15-NEXT:    [[ARRAYIDX5_3:%.*]] = getelementptr i8, ptr null, i64 4
-; THR15-NEXT:    [[TMP0:%.*]] = call <2 x i8> @llvm.masked.gather.v2i8.v2p0(<2 x ptr> align 1 zeroinitializer, <2 x i1> splat (i1 true), <2 x i8> poison)
+; THR15-NEXT:    [[TMP0:%.*]] = call <2 x i8> @llvm.masked.gather.v2i8.v2p0(<2 x ptr> align 1 splat (ptr null), <2 x i1> splat (i1 true), <2 x i8> poison)
 ; THR15-NEXT:    [[TMP2:%.*]] = load <4 x i8>, ptr [[PIX1]], align 1
 ; THR15-NEXT:    [[TMP3:%.*]] = zext <4 x i8> [[TMP2]] to <4 x i32>
 ; THR15-NEXT:    [[TMP4:%.*]] = load <4 x i8>, ptr [[PIX2]], align 1

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/remarks-insert-into-small-vector.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/remarks-insert-into-small-vector.ll
@@ -17,7 +17,7 @@ define void @test() {
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP2:%.*]] = load float, ptr null, align 4
-; CHECK-NEXT:    [[TMP5:%.*]] = call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> align 4 zeroinitializer, <2 x i1> splat (i1 true), <2 x float> poison)
+; CHECK-NEXT:    [[TMP5:%.*]] = call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> align 4 splat (ptr null), <2 x i1> splat (i1 true), <2 x float> poison)
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <2 x float> <float poison, float 0.000000e+00>, float [[TMP2]], i32 0
 ; CHECK-NEXT:    [[TMP6:%.*]] = fcmp ogt <2 x float> [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = shufflevector <2 x i1> [[TMP6]], <2 x i1> poison, <4 x i32> <i32 0, i32 1, i32 0, i32 1>

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/strided-loads-with-external-indices.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/strided-loads-with-external-indices.ll
@@ -10,7 +10,7 @@ define void @test() {
 ; CHECK-NEXT:    [[SUB4_I_I65_US:%.*]] = or i64 0, 1
 ; CHECK-NEXT:    br label [[BODY:%.*]]
 ; CHECK:       body:
-; CHECK-NEXT:    [[TMP0:%.*]] = call <2 x i32> @llvm.masked.gather.v2i32.v2p0(<2 x ptr> align 4 getelementptr ([[CLASS_A:%.*]], <2 x ptr> zeroinitializer, <2 x i64> <i64 0, i64 1>), <2 x i1> splat (i1 true), <2 x i32> poison)
+; CHECK-NEXT:    [[TMP0:%.*]] = call <2 x i32> @llvm.masked.gather.v2i32.v2p0(<2 x ptr> align 4 getelementptr ([[CLASS_A:%.*]], <2 x ptr> splat (ptr null), <2 x i64> <i64 0, i64 1>), <2 x i1> splat (i1 true), <2 x i32> poison)
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x i32> [[TMP0]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x i32> [[TMP0]], i32 1
 ; CHECK-NEXT:    [[CMP_I_I_I_I67_US:%.*]] = icmp slt i32 [[TMP1]], [[TMP2]]

--- a/llvm/test/Transforms/SLPVectorizer/X86/catchswitch-block-in-use.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/catchswitch-block-in-use.ll
@@ -10,7 +10,7 @@ define void @test() personality ptr null {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    br label %[[FOR_COND109:.*]]
 ; CHECK:       [[FOR_COND109]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = phi <2 x ptr> [ zeroinitializer, %[[ENTRY]] ], [ zeroinitializer, %[[IF_END153:.*]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = phi <2 x ptr> [ splat (ptr null), %[[ENTRY]] ], [ splat (ptr null), %[[IF_END153:.*]] ]
 ; CHECK-NEXT:    br label %[[INIT_ATTEMPT_I664:.*]]
 ; CHECK:       [[INIT_ATTEMPT_I664]]:
 ; CHECK-NEXT:    [[CALL_I666:%.*]] = invoke ptr null(ptr null)
@@ -18,8 +18,8 @@ define void @test() personality ptr null {
 ; CHECK:       [[INVOKE_CONT_I668]]:
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[CATCH_DISPATCH]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = catchswitch within none [label %catch] unwind to caller
-; CHECK:       [[CATCH:.*]]:
+; CHECK-NEXT:    [[TMP1:%.*]] = catchswitch within none [label %[[CATCH:.*]]] unwind to caller
+; CHECK:       [[CATCH]]:
 ; CHECK-NEXT:    [[TMP2:%.*]] = catchpad within [[TMP1]] [ptr null, i32 0, ptr null]
 ; CHECK-NEXT:    br i1 false, label %[[IF_END153]], label %[[INVOKE_CONT149:.*]]
 ; CHECK:       [[INVOKE_CONT149]]:

--- a/llvm/test/Transforms/SLPVectorizer/X86/many-uses-parent-node.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/many-uses-parent-node.ll
@@ -249,7 +249,7 @@ define i32 @test(ptr addrspace(1) %arg) {
 ; CHECK-NEXT:    [[TMP5:%.*]] = phi <2 x ptr addrspace(1)> [ poison, %[[BB142]] ], [ [[TMP4]], %[[BB73]] ], [ poison, %[[BB79]] ], [ poison, %[[BB85]] ]
 ; CHECK-NEXT:    br label %[[BB150]]
 ; CHECK:       [[BB150]]:
-; CHECK-NEXT:    [[TMP6:%.*]] = phi <2 x ptr addrspace(1)> [ [[TMP2]], %[[BB75]] ], [ poison, %[[BB80]] ], [ zeroinitializer, %[[BB146]] ], [ [[TMP3]], %[[BB1]] ]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi <2 x ptr addrspace(1)> [ [[TMP2]], %[[BB75]] ], [ poison, %[[BB80]] ], [ splat (ptr addrspace(1) null), %[[BB146]] ], [ [[TMP3]], %[[BB1]] ]
 ; CHECK-NEXT:    br label %[[BB153]]
 ; CHECK:       [[BB153]]:
 ; CHECK-NEXT:    [[PHI154:%.*]] = phi ptr addrspace(1) [ null, %[[BB150]] ], [ [[GETELEMENTPTR3]], %[[BB76]] ]

--- a/llvm/test/Transforms/SLPVectorizer/X86/scatter-vectorize-reorder-non-empty.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/scatter-vectorize-reorder-non-empty.ll
@@ -5,7 +5,7 @@ define double @test01() {
 ; CHECK-LABEL: define double @test01
 ; CHECK-SAME: () #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <2 x i32>, ptr null, align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr double, <2 x ptr> zeroinitializer, <2 x i32> [[TMP1]]
+; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr double, <2 x ptr> splat (ptr null), <2 x i32> [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x double> @llvm.masked.gather.v2f64.v2p0(<2 x ptr> align 8 [[TMP2]], <2 x i1> splat (i1 true), <2 x double> poison)
 ; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <2 x double> [[TMP3]], <2 x double> poison, <4 x i32> <i32 0, i32 0, i32 0, i32 1>
 ; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x double> [[TMP4]], i32 0

--- a/llvm/test/Transforms/SLPVectorizer/X86/split-vectorize-phi-user.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/split-vectorize-phi-user.ll
@@ -5,7 +5,7 @@ define i32 @test() {
 ; CHECK-LABEL: define i32 @test(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[BB:.*]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = call <4 x i32> @llvm.masked.gather.v4i32.v4p3(<4 x ptr addrspace(3)> align 4 zeroinitializer, <4 x i1> splat (i1 true), <4 x i32> poison)
+; CHECK-NEXT:    [[TMP0:%.*]] = call <4 x i32> @llvm.masked.gather.v4i32.v4p3(<4 x ptr addrspace(3)> align 4 splat (ptr addrspace(3) null), <4 x i1> splat (i1 true), <4 x i32> poison)
 ; CHECK-NEXT:    br i1 false, label %[[BB4:.*]], label %[[BB8:.*]]
 ; CHECK:       [[BB4]]:
 ; CHECK-NEXT:    [[PHI:%.*]] = phi i32 [ 0, %[[BB]] ]

--- a/llvm/test/Transforms/SLPVectorizer/extract-vectorized-operand.ll
+++ b/llvm/test/Transforms/SLPVectorizer/extract-vectorized-operand.ll
@@ -5,16 +5,16 @@
 define void @test() {
 ; CHECK-LABEL: define void @test() {
 ; CHECK-NEXT:  [[BB:.*]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x ptr addrspace(1)> zeroinitializer, <2 x ptr addrspace(1)> zeroinitializer, <2 x i32> <i32 1, i32 0>
+; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x ptr addrspace(1)> splat (ptr addrspace(1) null), <2 x i32> <i32 1, i32 0>
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x ptr addrspace(1)> [[TMP0]], i32 0
 ; CHECK-NEXT:    br label %[[BB43:.*]]
 ; CHECK:       [[BB20:.*]]:
 ; CHECK-NEXT:    br label %[[BB105:.*]]
 ; CHECK:       [[BB43]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = phi <2 x ptr addrspace(1)> [ [[TMP3:%.*]], %[[BB51:.*]] ], [ zeroinitializer, %[[BB]] ]
+; CHECK-NEXT:    [[TMP2:%.*]] = phi <2 x ptr addrspace(1)> [ [[TMP3:%.*]], %[[BB51:.*]] ], [ splat (ptr addrspace(1) null), %[[BB]] ]
 ; CHECK-NEXT:    br i1 false, label %[[BB105]], label %[[BB51]]
 ; CHECK:       [[BB51]]:
-; CHECK-NEXT:    [[TMP3]] = phi <2 x ptr addrspace(1)> [ poison, %[[BB54:.*]] ], [ zeroinitializer, %[[BB43]] ]
+; CHECK-NEXT:    [[TMP3]] = phi <2 x ptr addrspace(1)> [ poison, %[[BB54:.*]] ], [ splat (ptr addrspace(1) null), %[[BB43]] ]
 ; CHECK-NEXT:    br label %[[BB43]]
 ; CHECK:       [[BB54]]:
 ; CHECK-NEXT:    br label %[[BB51]]

--- a/llvm/test/Transforms/SLPVectorizer/gep-with-extractelement-many-users.ll
+++ b/llvm/test/Transforms/SLPVectorizer/gep-with-extractelement-many-users.ll
@@ -8,7 +8,7 @@ define void @test() {
 ; CHECK-NEXT:    store double 0.000000e+00, ptr inttoptr (i64 872 to ptr), align 8
 ; CHECK-NEXT:    br label [[BB9:%.*]]
 ; CHECK:       bb9:
-; CHECK-NEXT:    [[TMP1:%.*]] = phi <2 x ptr> [ getelementptr (i8, <2 x ptr> zeroinitializer, <2 x i64> <i64 32, i64 872>), [[BB:%.*]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = phi <2 x ptr> [ getelementptr (i8, <2 x ptr> splat (ptr null), <2 x i64> <i64 32, i64 872>), [[BB:%.*]] ]
 ; CHECK-NEXT:    ret void
 ;
 bb:

--- a/llvm/test/Transforms/SLPVectorizer/revec.ll
+++ b/llvm/test/Transforms/SLPVectorizer/revec.ll
@@ -64,7 +64,7 @@ define void @test3(ptr %x, ptr %y, ptr %z) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <2 x ptr> poison, ptr [[X:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x ptr> [[TMP0]], ptr [[Y:%.*]], i32 1
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <2 x ptr> [[TMP1]], zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <2 x ptr> [[TMP1]], splat (ptr null)
 ; CHECK-NEXT:    [[TMP3:%.*]] = load <8 x i32>, ptr [[X]], align 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = load <8 x i32>, ptr [[Y]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <2 x i1> [[TMP2]], <2 x i1> poison, <8 x i32> <i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1>
@@ -125,7 +125,7 @@ define void @test5(ptr %ptr0, ptr %ptr1) {
 ; CHECK-NEXT:    [[GETELEMENTPTR0:%.*]] = getelementptr i8, ptr null, i64 0
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x ptr> <ptr null, ptr null, ptr undef, ptr undef>, ptr [[GETELEMENTPTR0]], i32 2
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x ptr> [[TMP0]], ptr null, i32 3
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult <4 x ptr> zeroinitializer, [[TMP1]]
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult <4 x ptr> splat (ptr null), [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x ptr> <ptr poison, ptr null, ptr null, ptr null>, ptr [[PTR0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <4 x ptr> [[TMP1]], ptr [[PTR1:%.*]], i32 3
 ; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult <4 x ptr> [[TMP3]], [[TMP4]]

--- a/llvm/test/Transforms/SROA/vector-promotion.ll
+++ b/llvm/test/Transforms/SROA/vector-promotion.ll
@@ -1374,7 +1374,7 @@ define <4 x ptr> @ptrLoadStoreTysPtr(ptr %init, i64 %val2) {
 ; CHECK-LABEL: @ptrLoadStoreTysPtr(
 ; CHECK-NEXT:    [[VAL0:%.*]] = load ptr, ptr [[INIT:%.*]], align 8
 ; CHECK-NEXT:    [[OBJ:%.*]] = alloca <4 x ptr>, align 16
-; CHECK-NEXT:    store <4 x ptr> zeroinitializer, ptr [[OBJ]], align 16
+; CHECK-NEXT:    store <4 x ptr> splat (ptr null), ptr [[OBJ]], align 16
 ; CHECK-NEXT:    store ptr [[VAL0]], ptr [[OBJ]], align 16
 ; CHECK-NEXT:    [[OBJ_8_PTR2_SROA_IDX:%.*]] = getelementptr inbounds i8, ptr [[OBJ]], i64 8
 ; CHECK-NEXT:    store i64 [[VAL2:%.*]], ptr [[OBJ_8_PTR2_SROA_IDX]], align 8
@@ -1388,7 +1388,7 @@ define <4 x ptr> @ptrLoadStoreTysPtr(ptr %init, i64 %val2) {
 ; DEBUG-NEXT:      #dbg_value(ptr [[VAL0]], [[META536:![0-9]+]], !DIExpression(), [[DBG541]])
 ; DEBUG-NEXT:    [[OBJ:%.*]] = alloca <4 x ptr>, align 16, !dbg [[DBG542:![0-9]+]]
 ; DEBUG-NEXT:      #dbg_value(ptr [[OBJ]], [[META537:![0-9]+]], !DIExpression(), [[DBG542]])
-; DEBUG-NEXT:    store <4 x ptr> zeroinitializer, ptr [[OBJ]], align 16, !dbg [[DBG543:![0-9]+]]
+; DEBUG-NEXT:    store <4 x ptr> splat (ptr null), ptr [[OBJ]], align 16, !dbg [[DBG543:![0-9]+]]
 ; DEBUG-NEXT:    store ptr [[VAL0]], ptr [[OBJ]], align 16, !dbg [[DBG544:![0-9]+]]
 ; DEBUG-NEXT:      #dbg_value(ptr undef, [[META538:![0-9]+]], !DIExpression(), [[META545:![0-9]+]])
 ; DEBUG-NEXT:    [[OBJ_8_PTR2_SROA_IDX:%.*]] = getelementptr inbounds i8, ptr [[OBJ]], i64 8, !dbg [[DBG546:![0-9]+]]

--- a/llvm/test/Transforms/Scalarizer/constant-extractelement.ll
+++ b/llvm/test/Transforms/Scalarizer/constant-extractelement.ll
@@ -20,7 +20,7 @@ define i32 @f1(ptr %src, i32 %index) {
 ; Test that out-of-bounds extractelement doesn't crash the scalarizer.
 define ptr @oob_extract() {
 ; ALL-LABEL: @oob_extract(
-; ALL-NEXT:    [[E:%.*]] = extractelement <4 x ptr> zeroinitializer, i32 100
+; ALL-NEXT:    [[E:%.*]] = extractelement <4 x ptr> splat (ptr null), i32 100
 ; ALL-NEXT:    ret ptr [[E]]
 ;
   %E = extractelement <4 x ptr> zeroinitializer, i32 100

--- a/llvm/test/Verifier/opaque-ptr.ll
+++ b/llvm/test/Verifier/opaque-ptr.ll
@@ -54,7 +54,7 @@ define void @intrinsic_calls(ptr %a) {
 ; CHECK-LABEL: @intrinsic_calls(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <2 x i32> @llvm.masked.load.v2i32.p0(ptr align 4 [[A:%.*]], <2 x i1> zeroinitializer, <2 x i32> zeroinitializer)
 ; CHECK-NEXT:    call void @llvm.masked.store.v2i32.p0(<2 x i32> zeroinitializer, ptr align 4 [[A]], <2 x i1> zeroinitializer)
-; CHECK-NEXT:    [[TMP2:%.*]] = call <2 x i64> @llvm.masked.gather.v2i64.v2p0(<2 x ptr> align 4 zeroinitializer, <2 x i1> zeroinitializer, <2 x i64> zeroinitializer)
+; CHECK-NEXT:    [[TMP2:%.*]] = call <2 x i64> @llvm.masked.gather.v2i64.v2p0(<2 x ptr> align 4 splat (ptr null), <2 x i1> zeroinitializer, <2 x i64> zeroinitializer)
 ; CHECK-NEXT:    [[TMP3:%.*]] = call ptr @llvm.preserve.array.access.index.p0.p0(ptr elementtype(i32) null, i32 0, i32 0)
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Verifier/ptrmask.ll
+++ b/llvm/test/Verifier/ptrmask.ll
@@ -24,14 +24,14 @@ define void @scalar_vector_mismatch_1() {
 }
 
 ; CHECK: llvm.ptrmask intrinsic arguments must be both scalars or both vectors
-; CHECK: %1 = call <2 x ptr> @llvm.ptrmask.v2p0.i64(<2 x ptr> zeroinitializer, i64 0)
+; CHECK: %1 = call <2 x ptr> @llvm.ptrmask.v2p0.i64(<2 x ptr> splat (ptr null), i64 0)
 define void @scalar_vector_mismatch_2() {
   call <2 x ptr> @llvm.ptrmask.v2p0.i64(<2 x ptr> zeroinitializer, i64 0)
   ret void
 }
 
 ; CHECK: llvm.ptrmask intrinsic arguments must have the same number of elements
-; CHECK: %1 = call <2 x ptr> @llvm.ptrmask.v2p0.v4i64(<2 x ptr> zeroinitializer, <4 x i64> zeroinitializer)
+; CHECK: %1 = call <2 x ptr> @llvm.ptrmask.v2p0.v4i64(<2 x ptr> splat (ptr null), <4 x i64> zeroinitializer)
 define void @vector_size_mismatch() {
   call <2 x ptr> @llvm.ptrmask.v2p0.v4i64(<2 x ptr> zeroinitializer, <4 x i64> zeroinitializer)
   ret void

--- a/llvm/test/tools/llvm-reduce/reduce-operands-ptr.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-operands-ptr.ll
@@ -16,7 +16,7 @@
 
 ; ZERO: load i32, ptr null
 ; ZERO: load i32, ptr null
-; ZERO: extractelement <4 x ptr> zeroinitializer, i32 11
+; ZERO: extractelement <4 x ptr> splat (ptr null), i32 11
 
 @g = global i32 0
 

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -771,6 +771,34 @@ TEST(ConstantsTest, GetSplatValueRoundTrip) {
   }
 }
 
+TEST(ConstantsTest, ConstantPointerNullVectorSplat) {
+  LLVMContext Context;
+
+  PointerType *PtrTy = PointerType::getUnqual(Context);
+  Constant *ScalarNull = ConstantPointerNull::get(PtrTy);
+
+  for (unsigned Min : {1, 2, 8}) {
+    ElementCount ScalableEC = ElementCount::getScalable(Min);
+    ElementCount FixedEC = ElementCount::getFixed(Min);
+
+    for (ElementCount EC : {ScalableEC, FixedEC}) {
+      VectorType *VecTy = VectorType::get(PtrTy, EC);
+      Constant *Null = Constant::getNullValue(VecTy);
+
+      ASSERT_TRUE(isa<ConstantPointerNull>(Null));
+      EXPECT_EQ(VecTy, Null->getType());
+      EXPECT_TRUE(Null->isNullValue());
+      EXPECT_EQ(ScalarNull, Null->getSplatValue());
+      EXPECT_EQ(ScalarNull, Null->getAggregateElement(0U));
+      EXPECT_EQ(PtrTy, cast<ConstantPointerNull>(Null)->getPointerType());
+
+      Constant *Splat = ConstantVector::getSplat(EC, ScalarNull);
+      EXPECT_EQ(Null, Splat);
+      EXPECT_EQ(ScalarNull, Splat->getSplatValue());
+    }
+  }
+}
+
 TEST(ConstantsTest, ComdatUserTracking) {
   LLVMContext Context;
   Module M("MyModule", Context);


### PR DESCRIPTION
This PR allows `ConstantPointerNull` to represent both scalar pointer nulls and fixed or scalable vector splats of pointer nulls. This change first aligns with the native splat behavior of `ConstantInt` and `ConstantFP`, and second, makes it easier to eventually change the semantics of `ConstantPointerNull` to represent a semantic null pointer instead of a zero value, which is what it represents today.

---

This PR is with help with AI but I reviewed all the code changes.