### PR TITLE
[NFC][TableGen] Drop OperandInfo::addField/fields() wrappers and use OperandInfo::Fields instead

### DIFF
--- a/llvm/utils/TableGen/Common/InstructionEncoding.cpp
+++ b/llvm/utils/TableGen/Common/InstructionEncoding.cpp
@@ -205,7 +205,8 @@ void InstructionEncoding::parseVarLenOperands(const VarLenInst &VLI) {
     if (!OpName.empty()) {
       auto OpSubOpPair = Inst->Operands.parseOperandName(OpName);
       unsigned OpIdx = Inst->Operands.getFlattenedOperandNumber(OpSubOpPair);
-      Operands[OpIdx].addField(CurrBitPos, EncodingSegment.BitWidth, Offset);
+      Operands[OpIdx].Fields.emplace_back(CurrBitPos, EncodingSegment.BitWidth,
+                                          Offset);
       if (!EncodingSegment.CustomDecoder.empty())
         Operands[OpIdx].Decoder = EncodingSegment.CustomDecoder.str();
 
@@ -213,7 +214,8 @@ void InstructionEncoding::parseVarLenOperands(const VarLenInst &VLI) {
       if (TiedReg != -1) {
         unsigned OpIdx = Inst->Operands.getFlattenedOperandNumber(
             {TiedReg, OpSubOpPair.second});
-        Operands[OpIdx].addField(CurrBitPos, EncodingSegment.BitWidth, Offset);
+        Operands[OpIdx].Fields.emplace_back(CurrBitPos,
+                                            EncodingSegment.BitWidth, Offset);
       }
     }
 
@@ -311,10 +313,10 @@ static void addOneOperandFields(const Record *EncodingDef,
     if (I == J)
       ++J;
     else
-      OpInfo.addField(I, J - I, Offset);
+      OpInfo.Fields.emplace_back(I, J - I, Offset);
   }
 
-  if (!OpInfo.InitValue && OpInfo.fields().empty()) {
+  if (!OpInfo.InitValue && OpInfo.Fields.empty()) {
     // We found a field in InstructionEncoding record that corresponds to the
     // named operand, but that field has no constant bits and doesn't contribute
     // to the Inst field. For now, treat that field as if it didn't exist.

--- a/llvm/utils/TableGen/Common/InstructionEncoding.h
+++ b/llvm/utils/TableGen/Common/InstructionEncoding.h
@@ -49,12 +49,6 @@ struct OperandInfo {
   std::optional<uint64_t> InitValue;
 
   OperandInfo(std::string D, bool HCD) : Decoder(D), HasCompleteDecoder(HCD) {}
-
-  void addField(unsigned Base, unsigned Width, unsigned Offset) {
-    Fields.emplace_back(Base, Width, Offset);
-  }
-
-  ArrayRef<EncodingField> fields() const { return Fields; }
 };
 
 /// Represents a parsed InstructionEncoding record or a record derived from it.

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -707,16 +707,16 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
     return;
   }
 
-  if (OpInfo.fields().empty()) {
+  if (OpInfo.Fields.empty()) {
     // Only a constant part. The old behavior is to not decode this operand.
     if (IgnoreFullyDefinedOperands)
       return;
     // Initialize `tmp` with the constant part.
     OS << Indent << "tmp = " << format_hex(*OpInfo.InitValue, 0) << ";\n";
-  } else if (OpInfo.fields().size() == 1 && !OpInfo.InitValue.value_or(0)) {
+  } else if (OpInfo.Fields.size() == 1 && !OpInfo.InitValue.value_or(0)) {
     // One variable part and no/zero constant part. Initialize `tmp` with the
     // variable part.
-    auto [Base, Width, Offset] = OpInfo.fields().front();
+    auto [Base, Width, Offset] = OpInfo.Fields.front();
     OS << Indent << "tmp = fieldFromInstruction(insn, " << Base << ", " << Width
        << ')';
     if (Offset)
@@ -727,7 +727,7 @@ static void emitBinaryParser(raw_ostream &OS, indent Indent,
     // insert the variable parts into it.
     OS << Indent << "tmp = " << format_hex(OpInfo.InitValue.value_or(0), 0)
        << ";\n";
-    for (auto [Base, Width, Offset] : OpInfo.fields()) {
+    for (auto [Base, Width, Offset] : OpInfo.Fields) {
       OS << Indent << "tmp |= fieldFromInstruction(insn, " << Base << ", "
          << Width << ')';
       if (Offset)


### PR DESCRIPTION
Fields is already a public member; the wrappers added no semantic value beyond a thin storage indirection (and ArrayRef-typed reads). Use Fields directly at all call sites for consistency with the rest of the struct's plain-data style.

Assisted by Claude.