### PR TITLE
[clang][NFC] Mark CWG2629 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg26xx.cpp
+++ b/clang/test/CXX/drs/cwg26xx.cpp
@@ -148,6 +148,13 @@ void f() {
 #endif
 } // namespace cwg2628
 
+namespace cwg2629 { // cwg2629: 2.7
+void f() {
+  switch (double d = 0.0) {}
+  // expected-error@-1 {{statement requires expression of integer type ('double' invalid)}}
+}
+} // namespace cwg2629
+
 // cwg2630 is in cwg2630.cpp
 
 namespace cwg2631 { // cwg2631: 16

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -18208,7 +18208,7 @@
     <td>[<a href="https://wg21.link/stmt.switch">stmt.switch</a>]</td>
     <td>C++23</td>
     <td>Variables of floating-point type as <TT>switch</TT> conditions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="2630">
     <td><a href="https://cplusplus.github.io/CWG/issues/2630.html">2630</a></td>


### PR DESCRIPTION
This is ill-formed:
```cpp
switch (0.0) {}
```
Before [CWG2629](https://wg21.link/cwg2629) though, this was allowed:
```cpp
switch (double d = 0.0) {} // Value of 'd' is implicitly converted to an integer
```
Clang however has always rejected both: https://godbolt.org/z/GYc4hhrnz