### PR TITLE
[clang-format][docs] Clarify AllowShortFunctionsOnASingleLine deprecation

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -1912,8 +1912,7 @@ the configuration (without a prefix: ``Auto``).
   * ``InlineOnly``
     Only merge functions defined inside a class. Same as ``inline``,
     except it does not implies ``empty``: i.e. top level empty functions
-    are not merged either. This option is **deprecated** and is retained
-    for backwards compatibility. See ``Inline`` of ``ShortFunctionStyle``.
+    are not merged either. See ``Inline`` of ``ShortFunctionStyle``.
 
     .. code-block:: c++
 
@@ -1927,9 +1926,7 @@ the configuration (without a prefix: ``Auto``).
       }
 
   * ``Empty``
-    Only merge empty functions. This option is **deprecated** and is
-    retained for backwards compatibility. See ``Empty`` of
-    ``ShortFunctionStyle``.
+    Only merge empty functions. See ``Empty`` of ``ShortFunctionStyle``.
 
     .. code-block:: c++
 
@@ -1939,9 +1936,8 @@ the configuration (without a prefix: ``Auto``).
       }
 
   * ``Inline``
-    Only merge functions defined inside a class. Implies ``empty``. This
-    option is **deprecated** and is retained for backwards compatibility.
-    See ``Inline`` and ``Empty`` of ``ShortFunctionStyle``.
+    Only merge functions defined inside a class. Implies ``empty``. See
+    ``Inline`` and ``Empty`` of ``ShortFunctionStyle``.
 
     .. code-block:: c++
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -889,7 +889,6 @@ struct FormatStyle {
   ///     Inline: true
   ///     Other: false
   /// \endcode
-  ///
   struct ShortFunctionStyle {
     /// Merge top-level empty functions.
     /// \code

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -835,8 +835,7 @@ struct FormatStyle {
   /// * ``InlineOnly``
   ///   Only merge functions defined inside a class. Same as ``inline``,
   ///   except it does not implies ``empty``: i.e. top level empty functions
-  ///   are not merged either. This option is **deprecated** and is retained
-  ///   for backwards compatibility. See ``Inline`` of ``ShortFunctionStyle``.
+  ///   are not merged either. See ``Inline`` of ``ShortFunctionStyle``.
   ///   \code
   ///     class Foo {
   ///       void f() { foo(); }
@@ -849,9 +848,7 @@ struct FormatStyle {
   ///   \endcode
   ///
   /// * ``Empty``
-  ///   Only merge empty functions. This option is **deprecated** and is
-  ///   retained for backwards compatibility. See ``Empty`` of
-  ///   ``ShortFunctionStyle``.
+  ///   Only merge empty functions. See ``Empty`` of ``ShortFunctionStyle``.
   ///   \code
   ///     void f() {}
   ///     void f2() {
@@ -860,9 +857,8 @@ struct FormatStyle {
   ///   \endcode
   ///
   /// * ``Inline``
-  ///   Only merge functions defined inside a class. Implies ``empty``. This
-  ///   option is **deprecated** and is retained for backwards compatibility.
-  ///   See ``Inline`` and ``Empty`` of ``ShortFunctionStyle``.
+  ///   Only merge functions defined inside a class. Implies ``empty``. See
+  ///   ``Inline`` and ``Empty`` of ``ShortFunctionStyle``.
   ///   \code
   ///     class Foo {
   ///       void f() { foo(); }
@@ -893,6 +889,7 @@ struct FormatStyle {
   ///     Inline: true
   ///     Other: false
   /// \endcode
+  ///
   struct ShortFunctionStyle {
     /// Merge top-level empty functions.
     /// \code


### PR DESCRIPTION
Addresses #195326. I went through the docs and I believe InlineOnly looks fine as is since it’s properly marked as deprecated. The confusing part is Inline, because it refers to both the deprecated AllowShortFunctionsOnASingleLine: Inline and the nested flag AllowShortFunctionsOnASingleLine: { Inline: true, ... } which is still valid. Making that distinction explicit in the docs might be helpful. 