### PR TITLE
[TableGen] Fix null-pointer assert in RecordVal::setValue on failed cast

### DIFF
--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -2891,10 +2891,11 @@ bool RecordVal::setValue(const Init *V) {
     return false;
   }
 
-  Value = V->getCastTo(getType());
-  if (!Value)
+  const Init *NewValue = V->getCastTo(getType());
+  if (!NewValue)
     return true;
 
+  Value = NewValue;
   assert(!isa<TypedInit>(Value) ||
          cast<TypedInit>(Value)->getType()->typeIsA(getType()));
   if (const auto *BTy = dyn_cast<BitsRecTy>(getType())) {

--- a/llvm/test/TableGen/incompatible-field-override.td
+++ b/llvm/test/TableGen/incompatible-field-override.td
@@ -1,0 +1,18 @@
+// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
+
+// Redeclaring a field with an incompatible type used to leave the field's
+// Value as nullptr, causing an isa<UnsetInit>(nullptr) assert when a later
+// def tried to resolve an expression referring to that field.
+
+class X {
+  int F = 0;
+  int D = !add(F, 1);
+}
+
+// CHECK: error: Field 'F' of type 'int' is incompatible with value '"0"' of type 'string'
+// CHECK-NOT: Assertion `Val && "isa<> used on a null pointer"'
+class Y : X  {
+  string F = "0";
+}
+
+def y : Y;


### PR DESCRIPTION
When setValue's getCastTo failed, Value was overwritten with nullptr instead of being left untouched. 
The "no value set" sentinel is UnsetInit, not nullptr, so a downstream RecordResolver::resolve that called isa<UnsetInit>(RV->getValue()) would assert on the null pointer when a later def tried to resolve an expression referring to that field.

Compute the cast into a local and only commit to Value on success, so a type-incompatible override (e.g. redeclaring an int field as string in a subclass) reports the existing "is incompatible" error and exits cleanly instead of aborting.

Fixes issue : https://github.com/llvm/llvm-project/issues/184879
Assisted by Claude.