### PR TITLE
[clang-tidy] Skip user headers named like C headers in `modernize-deprecated-headers`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
@@ -175,6 +175,10 @@ void IncludeModernizePPCallbacks::InclusionDirective(
   if (SM.isInSystemHeader(HashLoc))
     return;
 
+  // Skip headers that happen to use the same name as a standard library header.
+  if (!File || !SrcMgr::isSystem(FileType))
+    return;
+
   // FIXME: Take care of library symbols from the global namespace.
   //
   // Reasonable options for the check:

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -318,12 +318,13 @@ TEST(DiagnosticsTest, ClangTidy) {
     }
   )cpp");
   auto TU = TestTU::withCode(Test.code());
-  TU.HeaderFilename = "assert.h"; // Suppress "not found" error.
+  TU.AdditionalFiles["system/assert.h"] = ""; // Suppress "not found" error.
   TU.ClangTidyProvider = addTidyChecks("bugprone-sizeof-expression,"
                                        "bugprone-macro-repeated-side-effects,"
                                        "modernize-deprecated-headers,"
                                        "modernize-use-trailing-return-type,"
                                        "misc-no-recursion");
+  TU.ExtraArgs.push_back("-isystem" + testPath("system"));
   TU.ExtraArgs.push_back("-Wno-unsequenced");
   EXPECT_THAT(
       TU.build().getDiagnostics(),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -408,6 +408,11 @@ Changes in existing checks
   Because it only sees one file at a time, the check can't be sure
   such entities aren't referenced in any other files of that module.
 
+- Improved :doc:`modernize-deprecated-headers
+  <clang-tidy/checks/modernize/deprecated-headers>` check by avoiding false
+  positives on project headers that use the same name as a standard library
+  header.
+
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/deprecated-headers/user/assert.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/deprecated-headers/user/assert.h
@@ -1,0 +1,1 @@
+#define USER_ASSERT_H 1

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-user.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-user.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11 %s modernize-deprecated-headers %t -- -extra-arg-before=-iquote%S/Inputs/deprecated-headers/user -extra-arg-before=-isystem%S/Inputs/deprecated-headers
+// RUN: %check_clang_tidy -std=c++11-or-later %s modernize-deprecated-headers %t -- -extra-arg-before=-iquote%S/Inputs/deprecated-headers/user -extra-arg-before=-isystem%S/Inputs/deprecated-headers
 
 #include "assert.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-user.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/deprecated-headers-user.cpp
@@ -1,0 +1,9 @@
+// RUN: %check_clang_tidy -std=c++11 %s modernize-deprecated-headers %t -- -extra-arg-before=-iquote%S/Inputs/deprecated-headers/user -extra-arg-before=-isystem%S/Inputs/deprecated-headers
+
+#include "assert.h"
+
+#include <assert.h>
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
+// CHECK-FIXES: #include <cassert>
+
+int user_header = USER_ASSERT_H;


### PR DESCRIPTION
Previously `modernize-deprecated-headers` would match on any header with the same name as standard library headers. This commit fixes the problem by checking whether the include resolves to a system header.

Closes #45991 