### PR TITLE
[libc++] Drop transitive includes by default

### DIFF
--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx_tsan -O1 %s %link_libcxx_tsan -fsanitize=thread -o %t
 // RUN: %run %t 128
 
+#include <cstdlib>
 #include <mutex>
-#include <string>
 #include <vector>
 
 int main(int argc, char *argv[]) {

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -60,6 +60,7 @@ Improvements and New Features
   for ``std::deque<int>`` iterators.
 - ``std::copy(CharT*, CharT*, ostreambuf_iterator<CharT>)`` has been optimized, resulting in performance improvements
   of up to 25x.
+- A lot of transitive includes have been removed, resulting in significant compile time improvements.
 
 Deprecations and Removals
 -------------------------
@@ -75,6 +76,11 @@ Deprecations and Removals
 
 Potentially breaking changes
 ----------------------------
+
+- libc++ has dropped a lot of transitive includes in all language modes. This improves compile time significantly, but
+  causes programs which rely on these includes to not compile anymore. Any errors caused by this should be fixable by
+  including the correct header. To ease the transition ``_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23`` can be defined, which
+  includes the removed headers again. This macro will be removed in LLVM 24.
 
 Announcements About Future Releases
 -----------------------------------

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -17,6 +17,7 @@
 #include <__functional/binary_function.h>
 #include <__functional/unary_function.h>
 #include <__memory/addressof.h>
+#include <__new/placement_new_delete.h>
 #include <__type_traits/aligned_storage.h>
 #include <__type_traits/decay.h>
 #include <__type_traits/invoke.h>

--- a/libcxx/include/algorithm
+++ b/libcxx/include/algorithm
@@ -2104,11 +2104,11 @@ template <class BidirectionalIterator, class Compare>
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 14
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER == 14
 #    include <execution>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <bit>
 #    include <concepts>

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -558,11 +558,11 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 17
 #    include <chrono>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdlib>
@@ -574,7 +574,7 @@ _LIBCPP_POP_MACROS
 #    include <variant>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <cstring>
 #    include <limits>
 #  endif

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -594,7 +594,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -630,7 +630,7 @@ template <class T>
 #    error <atomic> is not implemented
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cmath>
 #    include <compare>
 #    include <cstddef>

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -192,7 +192,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <iterator>

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -90,7 +90,7 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstdlib>
 #    include <iosfwd>
 #    include <limits>

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -971,7 +971,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstdlib>
 #    include <optional>

--- a/libcxx/include/charconv
+++ b/libcxx/include/charconv
@@ -104,7 +104,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cmath>
 #    include <concepts>
 #    include <cstddef>

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -1148,13 +1148,13 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 17
 #    include <cstdint>
 #    include <stdexcept>
 #    include <string_view>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <bit>
 #    include <concepts>
 #    include <cstring>
@@ -1164,7 +1164,7 @@ namespace std {
 #    include <vector>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER == 20
 #    include <charconv>
 #    if _LIBCPP_HAS_LOCALIZATION
 #      include <locale>

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -612,7 +612,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <type_traits>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -587,7 +587,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstddef>

--- a/libcxx/include/compare
+++ b/libcxx/include/compare
@@ -167,7 +167,7 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cmath>
 #    include <cstddef>
 #    include <type_traits>

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1484,7 +1484,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <iosfwd>
 #    include <stdexcept>
 #    include <type_traits>

--- a/libcxx/include/concepts
+++ b/libcxx/include/concepts
@@ -161,7 +161,7 @@ namespace std {
 
 #  include <version>
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <type_traits>
 #  endif

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -350,7 +350,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdint>

--- a/libcxx/include/coroutine
+++ b/libcxx/include/coroutine
@@ -61,7 +61,7 @@ struct suspend_always;
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <iosfwd>
 #    include <limits>

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -258,7 +258,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -2543,7 +2543,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <atomic>
 #    include <concepts>

--- a/libcxx/include/exception
+++ b/libcxx/include/exception
@@ -91,13 +91,13 @@ template <class E> void rethrow_if_nested(const E& e);
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <new>
 #    include <type_traits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <cstdlib>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/execution
+++ b/libcxx/include/execution
@@ -155,7 +155,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  endif // _LIBCPP_HAS_EXPERIMENTAL_PSTL && _LIBCPP_STD_VER >= 17
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/experimental/iterator
+++ b/libcxx/include/experimental/iterator
@@ -124,14 +124,14 @@ _LIBCPP_END_NAMESPACE_LFTS
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <iosfwd>
 #    include <optional>
 #    include <type_traits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <locale>
 #  endif
 

--- a/libcxx/include/experimental/memory
+++ b/libcxx/include/experimental/memory
@@ -196,7 +196,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  endif // _LIBCPP_ENABLE_EXPERIMENTAL
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <limits>
 #  endif

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -488,7 +488,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <type_traits>
 #  endif

--- a/libcxx/include/experimental/simd
+++ b/libcxx/include/experimental/simd
@@ -88,7 +88,7 @@ inline namespace parallelism_v2 {
 #  include <experimental/__simd/traits.h>
 #  include <experimental/__simd/vec_ext.h>
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/experimental/type_traits
+++ b/libcxx/include/experimental/type_traits
@@ -151,7 +151,7 @@ constexpr bool is_detected_convertible_v = is_detected_convertible<_To, _Op, _Ar
 
 _LIBCPP_END_NAMESPACE_LFTS
 
-#    if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #      include <cstddef>
 #    endif
 

--- a/libcxx/include/experimental/utility
+++ b/libcxx/include/experimental/utility
@@ -46,7 +46,7 @@ struct erased_type {};
 
 _LIBCPP_END_NAMESPACE_LFTS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/ext/hash_map
+++ b/libcxx/include/ext/hash_map
@@ -825,7 +825,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const hash_multimap<_Key, _Tp, _Has
 
 } // namespace __gnu_cxx
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <iterator>
 #    include <type_traits>

--- a/libcxx/include/ext/hash_set
+++ b/libcxx/include/ext/hash_set
@@ -572,7 +572,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const hash_multiset<_Value, _Hash, 
 
 } // namespace __gnu_cxx
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <iterator>
 #    include <type_traits>

--- a/libcxx/include/filesystem
+++ b/libcxx/include/filesystem
@@ -568,7 +568,7 @@ inline constexpr bool std::ranges::enable_view<std::filesystem::recursive_direct
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstdlib>
 #    include <cstring>

--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -233,11 +233,11 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <cmath>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <array>
 #    include <cctype>
 #    include <cerrno>

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -1603,7 +1603,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <atomic>
 #    include <concepts>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1624,7 +1624,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdlib>
@@ -1636,7 +1636,7 @@ _LIBCPP_POP_MACROS
 #    include <type_traits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <filesystem>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/functional
+++ b/libcxx/include/functional
@@ -577,18 +577,18 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && defined(_LIBCPP_CXX03_LANG)
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && defined(_LIBCPP_CXX03_LANG)
 #    include <limits>
 #    include <new>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 14
 #    include <array>
 #    include <initializer_list>
 #    include <unordered_map>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdlib>
@@ -603,7 +603,7 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 #    include <vector>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER == 23
 #    include <__vector/vector.h>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -2065,11 +2065,11 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 17
 #    include <chrono>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <cstdlib>
 #    include <exception>

--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -105,7 +105,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ep* end(initia
 
 } // namespace std
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -538,7 +538,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <array>
 #    include <bitset>
 #    include <deque>
@@ -553,7 +553,7 @@ _LIBCPP_END_NAMESPACE_STD
 #    include <vector>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <locale>
 #  endif
 

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -875,12 +875,12 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <ctime>
 #    include <ratio>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstddef>

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -1413,14 +1413,14 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <iosfwd>
 #    include <ostream>
 #    include <type_traits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <locale>
 #  endif
 

--- a/libcxx/include/iterator
+++ b/libcxx/include/iterator
@@ -751,11 +751,11 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 17
 #    include <variant>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <cstdlib>
 #    include <exception>

--- a/libcxx/include/latch
+++ b/libcxx/include/latch
@@ -128,7 +128,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <cstddef>
 #  endif

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -528,7 +528,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <type_traits>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -1815,7 +1815,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <atomic>
 #    include <concepts>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -210,7 +210,7 @@ template <class charT> class messages_byname;
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdarg>

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -2275,7 +2275,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstdlib>
 #    include <functional>

--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -987,7 +987,7 @@ template<class Pointer = void, class Smart, class... Args>
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstddef>

--- a/libcxx/include/memory_resource
+++ b/libcxx/include/memory_resource
@@ -69,11 +69,11 @@ namespace std::pmr {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER >= 17 && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER >= 17 && _LIBCPP_STD_VER <= 20
 #    include <mutex>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <stdexcept>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -837,7 +837,11 @@ module std [system] {
       header "__algorithm/stable_sort.h"
       export std.memory.unique_temporary_buffer // TODO: Workaround for https://llvm.org/PR120108
     }
-    module swap_ranges                            { header "__algorithm/swap_ranges.h" }
+    module swap_ranges                            {
+      header "__algorithm/swap_ranges.h"
+      export std.algorithm.iterator_operations
+      export std.algorithm.iter_swap
+    }
     module three_way_comp_ref_type                { header "__algorithm/three_way_comp_ref_type.h" }
     module transform                              { header "__algorithm/transform.h" }
     module uniform_random_bit_generator_adaptor   { header "__algorithm/uniform_random_bit_generator_adaptor.h" }
@@ -1696,6 +1700,7 @@ module std [system] {
     }
     module uninitialized_algorithms {
       header "__memory/uninitialized_algorithms.h"
+      export std.memory.destroy
       export std.utility.pair
     }
     module unique_ptr {
@@ -1834,7 +1839,10 @@ module std [system] {
     module clamp_to_integral                  { header "__random/clamp_to_integral.h" }
     module default_random_engine              { header "__random/default_random_engine.h" }
     module discard_block_engine               { header "__random/discard_block_engine.h" }
-    module discrete_distribution              { header "__random/discrete_distribution.h" }
+    module discrete_distribution              {
+      header "__random/discrete_distribution.h"
+      export std.vector.vector
+    }
     module exponential_distribution           { header "__random/exponential_distribution.h" }
     module extreme_value_distribution         { header "__random/extreme_value_distribution.h" }
     module fisher_f_distribution              { header "__random/fisher_f_distribution.h" }

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -503,11 +503,11 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <typeinfo>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -114,7 +114,7 @@ void  operator delete[](void* ptr, void*) noexcept;                     // const
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <cstdlib>
 #    include <type_traits>

--- a/libcxx/include/numbers
+++ b/libcxx/include/numbers
@@ -159,7 +159,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  endif // _LIBCPP_STD_VER >= 20
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstddef>
 #    include <type_traits>

--- a/libcxx/include/numeric
+++ b/libcxx/include/numeric
@@ -190,12 +190,12 @@ constexpr T saturating_cast(U x) noexcept;                    // freestanding, S
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 14
 #    include <initializer_list>
 #    include <limits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <climits>
 #    include <cmath>
 #    include <concepts>

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -1754,7 +1754,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <climits>
 #    include <concepts>

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -193,7 +193,7 @@ void vprint_nonunicode(ostream& os, string_view fmt, format_args args);         
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdio>
@@ -206,7 +206,7 @@ void vprint_nonunicode(ostream& os, string_view fmt, format_args args);         
 #    include <type_traits>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <locale>
 #  endif
 

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -970,7 +970,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstdlib>
 #    include <functional>

--- a/libcxx/include/random
+++ b/libcxx/include/random
@@ -1726,7 +1726,7 @@ class piecewise_linear_distribution
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <climits>
 #    include <cmath>

--- a/libcxx/include/ranges
+++ b/libcxx/include/ranges
@@ -545,7 +545,7 @@ namespace std {
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstdlib>
 #    include <iosfwd>
 #    include <type_traits>

--- a/libcxx/include/ratio
+++ b/libcxx/include/ratio
@@ -491,7 +491,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <type_traits>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -5834,7 +5834,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -564,7 +564,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <climits>
 #    include <concepts>

--- a/libcxx/include/semaphore
+++ b/libcxx/include/semaphore
@@ -180,7 +180,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <cstddef>
 #  endif

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -1569,7 +1569,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <cstdlib>
 #    include <functional>

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -449,7 +449,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <optional>
 #    include <system_error>
 #  endif

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -636,7 +636,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <array>
 #    include <concepts>
 #    include <functional>

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -1296,7 +1296,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if _LIBCPP_STD_VER <= 20 && !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <ostream>
 #    include <type_traits>
 #  endif

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -377,7 +377,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <concepts>
 #    include <functional>
 #    include <type_traits>

--- a/libcxx/include/stdexcept
+++ b/libcxx/include/stdexcept
@@ -282,7 +282,7 @@ _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <cstdlib>
 #    include <exception>

--- a/libcxx/include/stop_token
+++ b/libcxx/include/stop_token
@@ -52,7 +52,7 @@ namespace std {
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <iosfwd>
 #  endif

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -438,7 +438,7 @@ _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstdint>
 #    include <optional>
 #  endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -3962,7 +3962,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -971,7 +971,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -164,7 +164,7 @@ template <> struct hash<std::error_condition>;
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstdint>
 #    include <cstring>
 #    include <limits>

--- a/libcxx/include/thread
+++ b/libcxx/include/thread
@@ -117,11 +117,11 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 
 #  endif // _LIBCPP_HAS_THREADS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 17
 #    include <chrono>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstring>
 #    include <functional>
 #    include <new>

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -1458,7 +1458,7 @@ _LIBCPP_POP_MACROS
 
 // clang-format on
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <exception>
 #    include <iosfwd>

--- a/libcxx/include/typeindex
+++ b/libcxx/include/typeindex
@@ -102,7 +102,7 @@ struct hash<type_index> : public __unary_function<type_index, size_t> {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <iosfwd>
 #    include <new>

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -389,7 +389,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 }
 _LIBCPP_END_NAMESPACE_STD
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <cstdlib>
 #    include <type_traits>

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -2381,7 +2381,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <bit>
 #    include <cmath>

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -1848,7 +1848,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cmath>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/utility
+++ b/libcxx/include/utility
@@ -332,14 +332,11 @@ template <class T>
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#    include <limits>
-#  endif
-
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <cstdlib>
 #    include <iosfwd>
+#    include <limits>
 #    include <type_traits>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -3306,7 +3306,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <concepts>
 #    include <cstdlib>

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1644,7 +1644,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <cstddef>
 #    include <exception>
 #    include <tuple>

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -348,7 +348,7 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 #    pragma GCC system_header
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <array>
 #    include <cerrno>
 #    include <clocale>
@@ -357,7 +357,7 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 #    include <typeinfo>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 20
 #    include <algorithm>
 #    include <atomic>
 #    include <cctype>

--- a/libcxx/test/libcxx/transitive_includes.gen.py
+++ b/libcxx/test/libcxx/transitive_includes.gen.py
@@ -46,7 +46,7 @@ if regenerate_expected_results:
         normalized_header = re.sub("/", "_", str(header))
         print(
             f"""\
-// RUN: echo "#include <{header}>" | %{{cxx}} -xc++ - %{{flags}} %{{compile_flags}} --trace-includes -fshow-skipped-includes --preprocess > /dev/null 2> %t/trace-includes.{normalized_header}.txt
+// RUN: echo "#include <{header}>" | %{{cxx}} -xc++ - %{{flags}} %{{compile_flags}} -D_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23 --trace-includes -fshow-skipped-includes --preprocess > /dev/null 2> %t/trace-includes.{normalized_header}.txt
 """
         )
         all_traces.append(f"%t/trace-includes.{normalized_header}.txt")
@@ -89,7 +89,7 @@ else:
 // UNSUPPORTED: LIBCXX-FREEBSD-FIXME
 
 // RUN: mkdir %t
-// RUN: %{{cxx}} %s %{{flags}} %{{compile_flags}} -Wno-deprecated --trace-includes -fshow-skipped-includes --preprocess > /dev/null 2> %t/trace-includes.txt
+// RUN: %{{cxx}} %s %{{flags}} %{{compile_flags}} -D_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23 -Wno-deprecated --trace-includes -fshow-skipped-includes --preprocess > /dev/null 2> %t/trace-includes.txt
 // RUN: %{{python}} %{{libcxx-dir}}/test/libcxx/transitive_includes/to_csv.py %t/trace-includes.txt > %t/actual_transitive_includes.csv
 // RUN: cat %{{libcxx-dir}}/test/libcxx/transitive_includes/%{{cxx_std}}.csv | awk '/^{escaped_header} / {{ print }}' > %t/expected_transitive_includes.csv
 // RUN: diff -w %t/expected_transitive_includes.csv %t/actual_transitive_includes.csv

--- a/libcxx/test/std/utilities/function.objects/func.wrap/func.wrap.func/derive_from.pass.cpp
+++ b/libcxx/test/std/utilities/function.objects/func.wrap/func.wrap.func/derive_from.pass.cpp
@@ -13,6 +13,7 @@
 // See https://llvm.org/PR20002
 
 #include <functional>
+#include <memory>
 #include <type_traits>
 
 #include "test_macros.h"

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.const/pr40459.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.const/pr40459.pass.cpp
@@ -39,11 +39,7 @@ struct Deleter {
 };
 
 int main(int, char**) {
-#if TEST_STD_VER >= 11
-  alignas(B) char buffer[sizeof(B)];
-#else
-  std::aligned_storage<sizeof(B), std::alignment_of<B>::value>::type buffer;
-#endif
+  TEST_ALIGNAS(TEST_ALIGNOF(B)) char buffer[sizeof(B)];
   B* pb                 = ::new ((void*)&buffer) B();
   std::shared_ptr<B> sp = std::shared_ptr<B>(pb, Deleter());
   std::weak_ptr<B> wp   = sp;

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
@@ -12,6 +12,7 @@ class TestSharedPtr(TestBase):
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
+    @skipIf(bugnumber="https://llvm.org/PR200154")
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
@@ -12,6 +12,7 @@ class TestSharedPtr(TestBase):
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(bugnumber="https://llvm.org/PR200154")
     def test(self):
         self.build()
 


### PR DESCRIPTION
This patch removes the unused transitive includes by default. `_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23` can be defined to keep the transitive includes around for an easier transition. The macro will be removed in LLVM 24.

This patch implements https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157
