### PR TITLE
[clang][bytecode] Diagnose copying empty mutable unions

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6796,12 +6796,13 @@ bool Compiler<Emitter>::compileConstructor(const CXXConstructorDecl *Ctor) {
     return false;
   bool IsUnion = R->isUnion();
 
+  // Union copy and move ctors are special.
   if (IsUnion && Ctor->isCopyOrMoveConstructor()) {
     LocOverrideScope<Emitter> LOS(this, SourceInfo{});
 
-    if (R->getNumFields() == 0)
-      return this->emitRetVoid(Ctor);
-    // union copy and move ctors are special.
+    // No special case for NumFields == 0 here, so the Memcpy op
+    // below also does its checks in those cases.
+
     assert(cast<CompoundStmt>(Ctor->getBody())->body_empty());
     if (!this->emitThis(Ctor))
       return false;

--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -29,7 +29,8 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
     Constexpr = F->isConstexpr();
     if (const auto *CD = dyn_cast<CXXConstructorDecl>(F)) {
       Virtual = CD->isVirtual();
-      Kind = FunctionKind::Ctor;
+      Kind = CD->isCopyOrMoveConstructor() ? FunctionKind::CopyOrMoveCtor
+                                           : FunctionKind::Ctor;
     } else if (const auto *CD = dyn_cast<CXXDestructorDecl>(F)) {
       Virtual = CD->isVirtual();
       Kind = FunctionKind::Dtor;

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -101,6 +101,7 @@ public:
   enum class FunctionKind {
     Normal,
     Ctor,
+    CopyOrMoveCtor,
     Dtor,
     LambdaStaticInvoker,
     LambdaCallOperator,
@@ -185,7 +186,13 @@ public:
   bool isConstexpr() const { return Constexpr; }
 
   /// Checks if the function is a constructor.
-  bool isConstructor() const { return Kind == FunctionKind::Ctor; }
+  bool isConstructor() const {
+    return Kind == FunctionKind::Ctor || Kind == FunctionKind::CopyOrMoveCtor;
+  }
+  bool isCopyOrMoveConstructor() const {
+    return Kind == FunctionKind::CopyOrMoveCtor;
+  }
+
   /// Checks if the function is a destructor.
   bool isDestructor() const { return Kind == FunctionKind::Dtor; }
   /// Checks if the function is copy or move operator.

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -910,6 +910,8 @@ static bool CheckInvoke(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
       return false;
     if (!IsCtorDtor && !CheckLifetime(S, OpPC, Ptr, AK_MemberCall))
       return false;
+    if (!CheckMutable(S, OpPC, Ptr))
+      return false;
   }
   return true;
 }
@@ -1781,6 +1783,14 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
       if (!CheckInvoke(S, OpPC, ThisPtr,
                        Func->isConstructor() || Func->isDestructor()))
         return cleanup();
+
+      if (Func->isCopyOrMoveOperator() || Func->isCopyOrMoveConstructor()) {
+        const Pointer &RVOPtr =
+            S.Stk.peek<Pointer>(ThisOffset - align(sizeof(Pointer)));
+        if (!CheckInvoke(S, OpPC, RVOPtr, /*IsCtorDtor=*/true))
+          return cleanup();
+      }
+
       if (!Func->isConstructor() && !Func->isDestructor() &&
           !CheckActive(S, OpPC, ThisPtr, AK_MemberCall))
         return false;

--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -150,11 +150,6 @@ static bool shouldSkipInBacktrace(const Function *F) {
       MD && MD->getParent()->isAnonymousStructOrUnion())
     return true;
 
-  if (const auto *Ctor = dyn_cast<CXXConstructorDecl>(FD);
-      Ctor && Ctor->isDefaulted() && Ctor->isTrivial() &&
-      Ctor->isCopyOrMoveConstructor() && Ctor->inits().empty())
-    return true;
-
   return false;
 }
 

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1964,3 +1964,39 @@ namespace FieldLifetimeNotStarted {
                  // both-note {{declared here}} \
                  // both-note {{in implicit default constructor for 'FieldLifetimeNotStarted::R' first required here}}
 }
+
+namespace EmptyRecords {
+  struct E1 {} e1;
+  union E2 {} e2; // both-note 4{{here}}
+  struct E3 : E1 {} e3;
+
+  template<typename E>
+  constexpr int f(E &a, int kind) {
+    switch (kind) {
+    case 0: { E e(a); return 0; } // both-note {{read}} \
+                                  // both-note {{in call}}
+    case 1: { E e(static_cast<E&&>(a)); return 0; } // both-note {{read}} \
+                                                    // both-note {{in call}}
+    case 2: { E e; e = a; return 0; } // both-note {{read}} \
+                                      // both-note {{in call}}
+    case 3: { E e; e = static_cast<E&&>(a); return 0; } // both-note {{read}} \
+                                                        // both-note {{in call}}
+    }
+  }
+  constexpr int test1 = f(e1, 0);
+  constexpr int test2 = f(e2, 0); // both-error {{constant expression}} \
+                                  // both-note {{in call}}
+  constexpr int test3 = f(e3, 0);
+  constexpr int test4 = f(e1, 1);
+  constexpr int test5 = f(e2, 1); // both-error {{constant expression}} \
+                                  // both-note {{in call}}
+  constexpr int test6 = f(e3, 1);
+  constexpr int test7 = f(e1, 2);
+  constexpr int test8 = f(e2, 2); // both-error {{constant expression}} \
+                                  // both-note {{in call}}
+  constexpr int test9 = f(e3, 2);
+  constexpr int testa = f(e1, 3);
+  constexpr int testb = f(e2, 3); // both-error {{constant expression}} \
+                                  // both-note {{in call}}
+  constexpr int testc = f(e3, 3);
+}


### PR DESCRIPTION
We had a special case for copy/move ctors of empty unions. Remove that. Everything else is just so we don't regress diagnostics.