### PR TITLE
[clang][bytecode] Fix an assertion for composite array roots

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2083,8 +2083,9 @@ static void setLifeStateRecurse(const Pointer &Ptr, Lifetime L) {
 
   if (const Descriptor *FieldDesc = Ptr.getFieldDesc();
       FieldDesc->isCompositeArray()) {
-    // No endLifetime() for array roots.
-    assert(Ptr.getLifetime() == Lifetime::Started);
+    // No endLifetime() for primitive array roots.
+    if (Ptr.getFieldDesc()->isPrimitiveArray())
+      assert(Ptr.getLifetime() == Lifetime::Started);
     for (unsigned I = 0; I != FieldDesc->getNumElems(); ++I)
       setLifeStateRecurse(Ptr.atIndex(I).narrow(), L);
     return;

--- a/clang/test/AST/ByteCode/lifetimes.cpp
+++ b/clang/test/AST/ByteCode/lifetimes.cpp
@@ -96,12 +96,10 @@ namespace CallScope {
   constexpr Q *out_of_lifetime(Q q) { return &q; } // both-warning {{address of stack}} \
                                                    // both-note 2{{declared here}}
   constexpr int k3 = out_of_lifetime({})->n; // both-error {{must be initialized by a constant expression}} \
-                                             // expected-note {{read of object outside its lifetime}} \
-                                             // ref-note {{read of object outside its lifetime}}
+                                             // both-note {{read of object outside its lifetime}}
 
   constexpr int k4 = out_of_lifetime({})->f(); // both-error {{must be initialized by a constant expression}} \
-                                               // expected-note {{member call on object outside its lifetime}} \
-                                               // ref-note {{member call on object outside its lifetime}}
+                                               // both-note {{member call on object outside its lifetime}}
 }
 
 namespace ExprDoubleDestroy {
@@ -114,4 +112,13 @@ namespace ExprDoubleDestroy {
   struct S { int x; };
   constexpr bool t = test<S>(); // both-error {{must be initialized by a constant expression}} \
                                 // both-note {{in call to}}
+}
+
+namespace CompositeArrayRootAssertion {
+  class C {
+  public:
+    bool B[2][2];
+    constexpr ~C() {}
+  };
+  void foo(int i) { C c; }
 }


### PR DESCRIPTION
The assertion only holds if the array is primitive.