### PR TITLE
[ELF] Simplify checkDuplicate; cover SharedSymbol/CommonSymbol resolve. NFC

### DIFF
--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -579,7 +579,7 @@ void elf::reportDuplicate(Ctx &ctx, const Symbol &sym, const InputFile *newFile,
 }
 
 void Symbol::checkDuplicate(Ctx &ctx, const Defined &other) const {
-  if (isDefined() && !isWeak() && !other.isWeak())
+  if (!isWeak() && !other.isWeak())
     reportDuplicate(ctx, *this, other.file,
                     dyn_cast_or_null<InputSectionBase>(other.section),
                     other.value);

--- a/lld/test/ELF/common-shared.s
+++ b/lld/test/ELF/common-shared.s
@@ -1,16 +1,28 @@
 # REQUIRES: x86
 ## When a common symbol is merged with a shared symbol, pick the larger st_size.
 
-# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
-# RUN: echo '.globl com; .comm com, 16' | llvm-mc -filetype=obj -triple=x86_64 - -o %t1.o
-# RUN: ld.lld -shared %t1.o -o %t1.so
+# RUN: split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 small.s -o small.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 big.s -o big.o
+# RUN: ld.lld -shared big.o -o big.so
+# RUN: ld.lld -shared small.o -o small.so
 
-# RUN: ld.lld %t.o %t1.so -o %t
-# RUN: llvm-readelf -s %t | FileCheck %s
-# RUN: ld.lld %t1.so %t.o -o %t
-# RUN: llvm-readelf -s %t | FileCheck %s
+## Common arrives first, then larger shared.
+# RUN: ld.lld small.o big.so -o out1
+# RUN: llvm-readelf -s out1 | FileCheck %s
+## Larger shared first, then common (overwrite path, size > this->size).
+# RUN: ld.lld big.so small.o -o out2
+# RUN: llvm-readelf -s out2 | FileCheck %s
+## Smaller shared first, then larger common (overwrite path, size <= this->size).
+# RUN: ld.lld small.so big.o -o out3
+# RUN: llvm-readelf -s out3 | FileCheck %s
 
 # CHECK: 16 OBJECT GLOBAL DEFAULT [[#]] com
 
+#--- small.s
 .globl com
 .comm com,1
+
+#--- big.s
+.globl com
+.comm com,16


### PR DESCRIPTION
Drop the redundant isDefined() check.

Extend common-shared.s to also exercise the case where the SharedSymbol's
st_size is not larger than the incoming CommonSymbol's.