### PR TITLE
[clang][NFC] Mark CWG2785 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -204,6 +204,19 @@ void g() {
 
 } // namespace cwg2780
 
+namespace cwg2785 { // cwg2785: 10
+#if __cplusplus >= 202002L
+void g(void *); // #cwg2785-g
+
+template <typename T>
+void f() {
+  g(requires { T(); });
+  // since-cxx20-error@-1 {{no matching function for call to 'g'}}
+  //   since-cxx20-note@#cwg2785-g {{candidate function not viable: no known conversion from 'bool' to 'void *' for 1st argument}}
+}
+#endif
+} // namespace cwg2785
+
 namespace cwg2789 { // cwg2789: 18
 #if __cplusplus >= 202302L
 template <typename T = int>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -19304,7 +19304,7 @@
     <td>[<a href="https://wg21.link/temp.dep.expr">temp.dep.expr</a>]</td>
     <td>CD7</td>
     <td>Type-dependence of <I>requires-expression</I></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 10</td>
   </tr>
   <tr class="open" id="2786">
     <td><a href="https://cplusplus.github.io/CWG/issues/2786.html">2786</a></td>


### PR DESCRIPTION
[CWG2785](https://wg21.link/cwg2785) clarifies that a *requires-expression* is never type-dependent, it always has type `bool`. That means that in a snippet like this:
```cpp
void g(void *);

template <typename T>
void f() {
  g(requires { T(); });
}
```
The call to `g` should be diagnosed as invalid (`bool` is not convertible to `void *`) even if the template is never instantiated. Clang does the right thing since version 10: https://godbolt.org/z/s61rEbsfz