### PR TITLE
[DirectX] Add missing test update for #191528

### DIFF
--- a/llvm/test/CodeGen/DirectX/ContainerData/RuntimeInfoCS.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RuntimeInfoCS.ll
@@ -30,6 +30,10 @@ attributes #0 = { "hlsl.numthreads"="8,8,1" "hlsl.shader"="compute" }
 ; DXC-NEXT:      NumThreadsZ:     1
 ; DXC-NEXT:      EntryName:       cs_main
 ; DXC-NEXT:      ResourceStride:  24
+; DXC-NEXT:      RuntimeInfoSize: 52
+; DXC-NEXT:      StringTable:
+; DXC-NEXT:      - String: cs_main
+; DXC-NEXT:      Offset: 1
 ; DXC-NEXT:      Resources:       []
 ; DXC-NEXT:      SigInputElements: []
 ; DXC-NEXT:      SigOutputElements: []


### PR DESCRIPTION
In #191528 we added the string table to the YAML and updated many tests that were affected, but it looks like this one was missed.