### PR TITLE
[mlir] Fix C++ name hiding bug in PDLPatternMatch for Op classes

### DIFF
--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -14,6 +14,7 @@
 #if MLIR_ENABLE_PDL_IN_PATTERNMATCH
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir {
 //===----------------------------------------------------------------------===//
@@ -519,6 +520,7 @@ template <typename T>
 struct ProcessPDLValue<T, std::enable_if_t<std::is_base_of<OpState, T>::value>>
     : public ProcessDerivedPDLValue<T, Operation *> {
   static T processAsArg(Operation *value) { return cast<T>(value); }
+  using ProcessDerivedPDLValue<T, Operation *>::processAsArg;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Tools/PDLL/TestPDLL.cpp
+++ b/mlir/test/lib/Tools/PDLL/TestPDLL.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TestDialect.h"
+#include "TestOps.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/Interfaces/CastInterfaces.h"

--- a/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
+++ b/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
@@ -9,8 +9,20 @@
 #include "TestOps.td"
 #include "mlir/Interfaces/CastInterfaces.td"
 
+Constraint TestConstraintWithNamedOpOperand(testOp: Op<test.op_a>) [{
+    return success();
+}];
+
+
 /// A simple pattern that matches and replaces an operation.
 Pattern TestSimplePattern => replace op<test.simple> with op<test.success>;
 
 // Test the import of interfaces.
 Pattern TestInterface => replace _: CastOpInterface with op<test.success>;
+
+// Test application of constraint.
+Pattern {
+  let op = op<test.op_a>(input: Value);
+  TestConstraintWithNamedOpOperand(op);
+  replace op with op<test.success>;
+}

--- a/mlir/test/mlir-pdll/Integration/test-pdll.mlir
+++ b/mlir/test/mlir-pdll/Integration/test-pdll.mlir
@@ -15,3 +15,10 @@ func.func @testImportedInterface() -> i1 {
   %value = "builtin.unrealized_conversion_cast"() : () -> (i1)
   return %value : i1
 }
+
+// CHECK-LABEL: func @testWithConstraint
+func.func @testWithConstraint(%a: i32) {
+    // CHECK: test.success
+    %b = "test.op_a"(%a) { attr = 0 : i32} : (i32) -> (i32)
+    return
+}


### PR DESCRIPTION
Native constraints with a named operation operand type failed because of name hiding in `ProcessPDLValue`.
i.e. previously a constraint like:
```
Constraint TestConstraintWithNamedOpOperand(testOp: Op<test.op_a>) [{
    return success();
}];
```
would fail with:
```
In file included from /home/jumerckx/llvm-project/mlir/include/mlir/IR/PatternMatch.h:814,
                 from /home/jumerckx/llvm-project/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h:13,
                 from /home/jumerckx/llvm-project/mlir/include/mlir/Dialect/Bufferization/IR/Bufferization.h:14,
                 from /home/jumerckx/llvm-project/mlir/test/lib/Tools/PDLL/../../Dialect/Test/TestDialect.h:21,
                 from /home/jumerckx/llvm-project/mlir/test/lib/Tools/PDLL/TestPDLL.cpp:9:
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PDLPatternMatch.h.inc: In instantiation of ‘typename FnTraitsT::result_t mlir::detail::pdl_function_builder::processArgsAndInvokeConstraint(PDLFnT&, mlir::PatternRewriter&, llvm::ArrayRef<mlir::PDLValue>, std::index_sequence<InputIndexes ...>) [with PDLFnT = llvm::LogicalResult (* const)(mlir::PatternRewriter&, test::OpA); long unsigned int ...I = {0}; FnTraitsT = llvm::function_traits<llvm::LogicalResult (* const)(mlir::PatternRewriter&, test::OpA), false>; typename FnTraitsT::result_t = llvm::LogicalResult; std::index_sequence<InputIndexes ...> = std::integer_sequence<long unsigned int, 0>]’:
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PDLPatternMatch.h.inc:733:42:   required from ‘std::enable_if_t<(! std::is_convertible<ConstraintFnT, std::function<llvm::LogicalResult(mlir::PatternRewriter&, mlir::PDLResultList&, llvm::ArrayRef<mlir::PDLValue>)> >::value), std::function<llvm::LogicalResult(mlir::PatternRewriter&, mlir::PDLResultList&, llvm::ArrayRef<mlir::PDLValue>)> > mlir::detail::pdl_function_builder::buildConstraintFn(ConstraintFnT&&) [with ConstraintFnT = llvm::LogicalResult (&)(mlir::PatternRewriter&, test::OpA); std::enable_if_t<(! std::is_convertible<ConstraintFnT, std::function<llvm::LogicalResult(mlir::PatternRewriter&, mlir::PDLResultList&, llvm::ArrayRef<mlir::PDLValue>)> >::value), std::function<llvm::LogicalResult(mlir::PatternRewriter&, mlir::PDLResultList&, llvm::ArrayRef<mlir::PDLValue>)> > = std::function<llvm::LogicalResult(mlir::PatternRewriter&, mlir::PDLResultList&, llvm::ArrayRef<mlir::PDLValue>)>]’
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PDLPatternMatch.h.inc:868:79:   required from ‘void mlir::PDLPatternModule::registerConstraintFunction(llvm::StringRef, ConstraintFnT&&) [with ConstraintFnT = llvm::LogicalResult (&)(mlir::PatternRewriter&, test::OpA)]’
/home/jumerckx/llvm-project/build/tools/mlir/test/lib/Tools/PDLL/TestPDLLPatterns.h.inc:64:31:   required from ‘{anonymous}::GeneratedPDLLPattern0::GeneratedPDLLPattern0(mlir::MLIRContext*, ConfigsT&& ...) [with ConfigsT = {}]’
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PatternMatch.h:1017:25:   required from ‘std::enable_if_t<std::is_base_of<mlir::PDLPatternModule, T>::value> mlir::RewritePatternSet:addImpl(llvm::ArrayRef<llvm::StringRef>, Args&& ...) [with T = {anonymous}::GeneratedPDLLPattern0; Args = {mlir::MLIRContext*}; std::enable_if_t<std::is_base_of<mlir::PDLPatternModule, T>::value> = void]’
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PatternMatch.h:864:17:   required from ‘mlir::RewritePatternSet& mlir::RewritePatternSet::add(ConstructorArg&&, ConstructorArgs&& ...) [with Ts = {{anonymous}::GeneratedPDLLPattern0}; ConstructorArg = mlir::MLIRContext*; ConstructorArgs = {}; <template-parameter-1-4> = void]’
/home/jumerckx/llvm-project/build/tools/mlir/test/lib/Tools/PDLL/TestPDLLPatterns.h.inc:74:38:   required from ‘void populateGeneratedPDLLPatterns(mlir::RewritePatternSet&, ConfigsT&& ...) [with ConfigsT = {}]’
/home/jumerckx/llvm-project/mlir/test/lib/Tools/PDLL/TestPDLL.cpp:36:34:   required from here
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PDLPatternMatch.h.inc:702:80: error: cannot convert ‘const mlir::PDLValue’ to ‘mlir::Operation*’
  702 |       (ProcessPDLValue<typename FnTraitsT::template arg_t<I + 1>>::processAsArg(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  703 |           values[I]))...);
      |           ~~~~~~~~~~~
/home/jumerckx/llvm-project/mlir/include/mlir/IR/PDLPatternMatch.h.inc:522:36: note:   initializing argument 1 of ‘static T mlir::detail::pdl_function_builder::ProcessPDLValue<T, typename std::enable_if<std::is_base_of<mlir::OpState, T>::value, void>::type>::processAsArg(mlir::Operation*) [with T = test::OpA]’
  522 |   static T processAsArg(Operation *value) { return cast<T>(value); }
      |                         ~~~~~~~~~~~^~~~~
```
This pr fixes that.