### PR TITLE
[test] Cover R_RISCV_ADD/SUB and R_RISCV_RVC_{BRANCH,JUMP}

### DIFF
--- a/lld/test/ELF/riscv-reloc-add.s
+++ b/lld/test/ELF/riscv-reloc-add.s
@@ -1,23 +1,30 @@
 # REQUIRES: riscv
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax %s -o %t.32.o
 # RUN: ld.lld -pie %t.32.o -o %t.32
-# RUN: llvm-readelf -x .rodata %t.32 | FileCheck --check-prefix=HEX %s
+# RUN: llvm-readelf -x .rodata -x .debug_info %t.32 | FileCheck --check-prefix=HEX %s
 
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax %s -o %t.64.o
 # RUN: ld.lld -shared %t.64.o -o %t.64
-# RUN: llvm-readelf -x .rodata %t.64 | FileCheck --check-prefix=HEX %s
+# RUN: llvm-readelf -x .rodata -x .debug_info %t.64 | FileCheck --check-prefix=HEX %s
 
 # HEX:      section '.rodata':
 # HEX-NEXT: 0x{{[0-9a-f]+}} 04000000 00000000 04000000 040004
+# HEX:      section '.debug_info':
+# HEX-NEXT: 0x{{[0-9a-f]+}} 04000000 00000000
 
 ## R_RISCV_ADD* and R_RISCV_SUB* are link-time constants, otherwise they are
-## not allowed in -pie/-shared mode.
+## not allowed in -pie/-shared mode. Place .L0 and .L1 in distinct sections so
+## the assembler cannot fold the differences.
 
-.global _start
+.section .text.f0,"ax",@progbits
+.globl _start
 _start:
 .L0:
   ret
+
+.section .text.f1,"ax",@progbits
 .L1:
+  ret
 
 .rodata
 .dword .L1 - .L0

--- a/lld/test/ELF/riscv-reloc-rvc.s
+++ b/lld/test/ELF/riscv-reloc-rvc.s
@@ -1,0 +1,48 @@
+# REQUIRES: riscv
+## R_RISCV_RVC_BRANCH and R_RISCV_RVC_JUMP encode 9-bit and 12-bit signed
+## PC-relative offsets. RVC_BRANCH applies to c.beqz/c.bnez; RVC_JUMP applies
+## to c.j and (rv32-only) c.jal — different opcode bits, same imm layout.
+## Use .reloc to attach the compressed relocation; without it the assembler
+## converts a cross-section c.beqz/c.j to an extended branch sequence.
+
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+c %s -o a.o
+
+## c.beqz val=-32  = 0b111100000     : imm8, imm7_6, imm5
+## c.bnez val=+30  = 0b000011110     : imm4_3, imm2_1
+## c.j    val=-128 = 0b111110000000  : imm11, imm10, imm9_8, imm7
+## c.jal  val=+126 = 0b000001111110  : imm6, imm5, imm4, imm3_1 + opcode mask
+# RUN: ld.lld -Ttext=0x10000 a.o --defsym ba=_start-32 --defsym bb=_start+32 \
+# RUN:   --defsym ja=_start-124 --defsym jb=_start+132
+# RUN: llvm-objdump -d -M no-aliases --no-show-raw-insn a.out | FileCheck %s
+# CHECK-LABEL: <_start>:
+# CHECK-NEXT:    c.beqz a0, 0xffe0
+# CHECK-NEXT:    c.bnez a0, 0x10020
+# CHECK-NEXT:    c.j 0xff84
+# CHECK-NEXT:    c.jal 0x10084
+
+## Out of range. Untouched relocations stay in range.
+# RUN: not ld.lld -Ttext=0x10000 a.o --defsym ba=_start+0x100 --defsym bb=_start \
+# RUN:   --defsym ja=_start+0x804 --defsym jb=_start+6 2>&1 \
+# RUN:   | FileCheck --check-prefix=RANGE %s --implicit-check-not=error:
+# RANGE: error: a.o:(.text+0x0): relocation R_RISCV_RVC_BRANCH out of range: 256 is not in [-256, 255]; references 'ba'
+# RANGE: error: a.o:(.text+0x4): relocation R_RISCV_RVC_JUMP out of range: 2048 is not in [-2048, 2047]; references 'ja'
+
+## Misalignment.
+# RUN: not ld.lld -Ttext=0x10000 a.o --defsym ba=_start+5 --defsym bb=_start \
+# RUN:   --defsym ja=_start+5 --defsym jb=_start+6 2>&1 \
+# RUN:   | FileCheck --check-prefix=ALIGN %s --implicit-check-not=error:
+# ALIGN: error: a.o:(.text+0x0): improper alignment for relocation R_RISCV_RVC_BRANCH: 0x5 is not aligned to 2 bytes
+# ALIGN: error: a.o:(.text+0x4): improper alignment for relocation R_RISCV_RVC_JUMP: 0x1 is not aligned to 2 bytes
+
+.option arch, +c
+.global _start
+_start:
+  .reloc ., R_RISCV_RVC_BRANCH, ba
+  c.beqz a0, 0
+  .reloc ., R_RISCV_RVC_BRANCH, bb
+  c.bnez a0, 0
+  .reloc ., R_RISCV_RVC_JUMP, ja
+  c.j 0
+  .reloc ., R_RISCV_RVC_JUMP, jb
+  c.jal 0


### PR DESCRIPTION
These were uncovered according to an LLVM_BUILD_INSTRUMENTED_COVERAGE
build.

llvm-mc resolves `.L1 - .L0` differences at assembly time, so
riscv-reloc-add.s doesn't emit the R_RISCV_ADD*/R_RISCV_SUB* pairs it
was meant to test.

Add riscv-reloc-rvc.s, modeled on riscv-branch.s/riscv-jal.s, to
exercise R_RISCV_RVC_BRANCH and R_RISCV_RVC_JUMP. Drive offsets via
-Ttext + --defsym to land precise values that isolate complementary
extractBits groups.