### PR TITLE
[Codegen] Initialize RValue IsVolatile field in constructor

### DIFF
--- a/clang/lib/CodeGen/CGValue.h
+++ b/clang/lib/CodeGen/CGValue.h
@@ -59,7 +59,7 @@ class RValue {
   unsigned Flavor : 2;
 
 public:
-  RValue() : Vals{nullptr, nullptr}, Flavor(Scalar) {}
+  RValue() : Vals{nullptr, nullptr}, IsVolatile(false), Flavor(Scalar) {}
 
   bool isScalar() const { return Flavor == Scalar; }
   bool isComplex() const { return Flavor == Complex; }


### PR DESCRIPTION
Static analysis flagged that in some cases IsVolatile is left uninitialzed. I adjusted the constructor to initialize IsVolatile.