### PR TITLE
[ELF] Remove duplicate SHT_CREL writeTo branch and cover discarded section symbol path. NFC

### DIFF
--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -536,12 +536,6 @@ void OutputSection::writeTo(Ctx &ctx, uint8_t *buf, parallel::TaskGroup &tg) {
   if (nonZeroFiller)
     fill(buf, sections.empty() ? size : sections[0]->outSecOff, filler);
 
-  if (type == SHT_CREL && !(flags & SHF_ALLOC)) {
-    buf += encodeULEB128(crelHeader, buf);
-    memcpy(buf, crelBody.data(), crelBody.size());
-    return;
-  }
-
   auto fn = [=, &ctx](size_t begin, size_t end) {
     size_t numSections = sections.size();
     for (size_t i = begin; i != end; ++i) {

--- a/lld/test/ELF/relocatable-crel.s
+++ b/lld/test/ELF/relocatable-crel.s
@@ -105,3 +105,25 @@ fb:
 .rept 12
 .long _start
 .endr
+
+#--- c.s
+## The section symbol is demoted to Undefined, so encodeOneCrel emits R_*_NONE with symidx=0.
+# RUN: llvm-mc -filetype=obj -triple=x86_64 -crel c.s -o c.o
+# RUN: ld.lld -r -T c.lds c.o -o out3
+# RUN: llvm-readobj -r out3 | FileCheck %s --check-prefix=DISCARD
+
+# DISCARD:      .crel.data {
+# DISCARD-NEXT:   0x0 R_X86_64_32 foo 0x1
+# DISCARD-NEXT:   0x4 R_X86_64_NONE - 0x0
+# DISCARD-NEXT:   0x8 R_X86_64_32 foo 0x2
+# DISCARD-NEXT: }
+.section .text.discard,"ax"
+.byte 0
+
+.data
+.long foo+1
+.long .text.discard
+.long foo+2
+
+#--- c.lds
+SECTIONS { /DISCARD/ : { *(.text.discard) } }


### PR DESCRIPTION
OutputSection::writeTo had two identical
`if (type == SHT_CREL && !(flags & SHF_ALLOC))` blocks added together in
0af07c078798 (#98115). Drop a dead copy.

A section relocation against a /DISCARD/'d section sees the section
symbol demoted to Undefined. Add a -r --crel case to relocatable-crel.s
that exercises that path.