### PR TITLE
[clang][docs] Rename Hexagon HVX option section

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -221,7 +221,7 @@ def m_sparc_Features_Group : OptionGroup<"<sparc features group>">,
 // The features added by this group will not be added to target features.
 // These are explicitly handled.
 def m_hexagon_Features_HVX_Group : OptionGroup<"<hexagon features group>">,
-                                   Group<m_Group>, DocName<"Hexagon">;
+                                   Group<m_Group>, DocName<"Hexagon HVX">;
 def m_m68k_Features_Group: OptionGroup<"<m68k features group>">,
                            Group<m_Group>, DocName<"M68k">;
 def m_mips_Features_Group : OptionGroup<"<mips features group>">,


### PR DESCRIPTION
There were two `hexagon` sections in the docs, but the second one was just the hvx flags so I renamed that one to `hexagon hvx`.

Fixes #194072

