### PR TITLE
[NFCI] clarify that asan-*linux.cpp files affect *nix OS'es

### DIFF
--- a/compiler-rt/lib/asan/asan_linux.cpp
+++ b/compiler-rt/lib/asan/asan_linux.cpp
@@ -8,7 +8,7 @@
 //
 // This file is a part of AddressSanitizer, an address sanity checker.
 //
-// Linux-specific details.
+// Linux-specific (and Unix/Unix-like) details.
 //===----------------------------------------------------------------------===//
 
 #include "sanitizer_common/sanitizer_platform.h"

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -8,7 +8,7 @@
 //
 // This file is a part of AddressSanitizer, an address sanity checker.
 //
-// Linux-specific malloc interception.
+// Linux-speficic (and Unix/Unix-like) malloc interception.
 // We simply define functions like malloc, free, realloc, etc.
 // They will replace the corresponding libc functions automagically.
 //===----------------------------------------------------------------------===//

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -8,7 +8,7 @@
 //
 // This file is a part of AddressSanitizer, an address sanity checker.
 //
-// Linux-speficic (and Unix/Unix-like) malloc interception.
+// Linux-specific (and Unix/Unix-like) malloc interception.
 // We simply define functions like malloc, free, realloc, etc.
 // They will replace the corresponding libc functions automagically.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
**Prior Work:** Aims to supersede (#132263), which seems inactive, specifically by applying my own comment: https://github.com/llvm/llvm-project/pull/132263#issuecomment-3051238734

**Context:** It aims to minimally document that the `asan_(malloc_)?linux.cpp` files may impact non-linux OS'es (despite the name) such as Solaris, BSD, and other *nix OS'es.  This is worth documenting as otherwise we risk breakage due to confusion, as occurred [here](https://github.com/llvm/llvm-project/pull/131975#issuecomment-2741097471).

This is done simply by minimally augmenting the file header comment saying precisely this.
Unlike the prior PR, this does not rename any files, which should reduce the 'git noise' impact of this change.

_Thanks!_