### PR TITLE
[ModuleInliner] Skip function declarations during candidate scan

### DIFF
--- a/llvm/lib/Transforms/IPO/ModuleInliner.cpp
+++ b/llvm/lib/Transforms/IPO/ModuleInliner.cpp
@@ -139,6 +139,8 @@ PreservedAnalyses ModuleInlinerPass::run(Module &M,
   // Populate the initial list of calls in this module.
   SetVector<std::pair<CallBase *, Function *>> ICPCandidates;
   for (Function &F : M) {
+    if (F.isDeclaration())
+      continue;
     auto &ORE = FAM.getResult<OptimizationRemarkEmitterAnalysis>(F);
     for (Instruction &I : instructions(F)) {
       if (auto *CB = dyn_cast<CallBase>(&I)) {


### PR DESCRIPTION
This patch skips function declarations during the candidate scan in
ModuleInlinerPass::run as declarations do not have bodies.
