### PR TITLE
[ARM] Replace AddLikeOrOp with add_like

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
@@ -60,13 +60,12 @@ public:
   ARMDAGToDAGISel() = delete;
 
   explicit ARMDAGToDAGISel(ARMBaseTargetMachine &tm, CodeGenOptLevel OptLevel)
-      : SelectionDAGISel(tm, OptLevel) {}
+      : SelectionDAGISel(tm, OptLevel), Subtarget(nullptr) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override {
     // Reset the subtarget each time through.
     Subtarget = &MF.getSubtarget<ARMSubtarget>();
-    SelectionDAGISel::runOnMachineFunction(MF);
-    return true;
+    return SelectionDAGISel::runOnMachineFunction(MF);
   }
 
   void PreprocessISelDAG() override;
@@ -105,8 +104,6 @@ public:
       return false;
     return SelectImmShifterOperand(N, A, B, false);
   }
-
-  bool SelectAddLikeOr(SDNode *Parent, SDValue N, SDValue &Out);
 
   bool SelectAddrModeImm12(SDValue N, SDValue &Base, SDValue &OffImm);
   bool SelectLdStSOReg(SDValue N, SDValue &Base, SDValue &Offset, SDValue &Opc);
@@ -652,15 +649,6 @@ bool ARMDAGToDAGISel::SelectRegShifterOperand(SDValue N,
                                   SDLoc(N), MVT::i32);
   return true;
 }
-
-// Determine whether an ISD::OR's operands are suitable to turn the operation
-// into an addition, which often has more compact encodings.
-bool ARMDAGToDAGISel::SelectAddLikeOr(SDNode *Parent, SDValue N, SDValue &Out) {
-  assert(Parent->getOpcode() == ISD::OR && "unexpected parent");
-  Out = N;
-  return CurDAG->haveNoCommonBitsSet(N, Parent->getOperand(1));
-}
-
 
 bool ARMDAGToDAGISel::SelectAddrModeImm12(SDValue N,
                                           SDValue &Base,

--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -286,11 +286,6 @@ def t_addrmode_sp : MemOperand,
   let MIOperandInfo = (ops GPR:$base, i32imm:$offsimm);
 }
 
-// Inspects parent to determine whether an or instruction can be implemented as
-// an add (i.e. whether we know overflow won't occur in the add).
-let WantsParent = true in
-def AddLikeOrOp : ComplexPattern<i32, 1, "SelectAddLikeOr">;
-
 // Pattern to exclude immediates from matching
 def non_imm32 : PatLeaf<(i32 GPR), [{ return !isa<ConstantSDNode>(N); }]>;
 
@@ -988,7 +983,7 @@ let isAdd = 1, hasSideEffects = 0 in {
     T1sIGenEncodeImm<0b01110, (outs tGPR:$Rd), (ins tGPR:$Rm, imm0_7:$imm3),
                      IIC_iALUi,
                      "add", "\t$Rd, $Rm, $imm3",
-                     [(set tGPR:$Rd, (add tGPR:$Rm, imm0_7:$imm3))]>,
+                     [(set tGPR:$Rd, (add_like tGPR:$Rm, imm0_7:$imm3))]>,
                      Sched<[WriteALU]> {
     bits<3> imm3;
     let Inst{8-6} = imm3;
@@ -998,7 +993,7 @@ let isAdd = 1, hasSideEffects = 0 in {
     T1sItGenEncodeImm<{1,1,0,?,?}, (outs tGPR:$Rdn),
                       (ins tGPR:$Rn, imm0_255_expr:$imm8), IIC_iALUi,
                       "add", "\t$Rdn, $imm8",
-                      [(set tGPR:$Rdn, (add tGPR:$Rn, imm0_255_expr:$imm8))]>,
+                      [(set tGPR:$Rdn, (add_like tGPR:$Rn, imm0_255_expr:$imm8))]>,
                       Sched<[WriteALU]>;
 
   // Add register
@@ -1007,7 +1002,7 @@ let isAdd = 1, hasSideEffects = 0 in {
     T1sIGenEncode<0b01100, (outs tGPR:$Rd), (ins tGPR:$Rn, tGPR:$Rm),
                   IIC_iALUr,
                   "add", "\t$Rd, $Rn, $Rm",
-                  [(set tGPR:$Rd, (add tGPR:$Rn, tGPR:$Rm))]>,
+                  [(set tGPR:$Rd, (add_like tGPR:$Rn, tGPR:$Rm))]>,
                   Sched<[WriteALU]>;
 
   /// Similar to the above except these set the 's' bit so the
@@ -1059,15 +1054,6 @@ let isAdd = 1, hasSideEffects = 0 in {
     let Inst{2-0} = Rdn{2-0};
   }
 }
-
-// Thumb has more flexible short encodings for ADD than ORR, so use those where
-// possible.
-def : T1Pat<(or AddLikeOrOp:$Rn, imm0_7:$imm), (tADDi3 $Rn, imm0_7:$imm)>;
-
-def : T1Pat<(or AddLikeOrOp:$Rn, imm8_255:$imm), (tADDi8 $Rn, imm8_255:$imm)>;
-
-def : T1Pat<(or AddLikeOrOp:$Rn, tGPR:$Rm), (tADDrr $Rn, $Rm)>;
-
 
 def : tInstAlias <"add${s}${p} $Rdn, $Rm",
                  (tADDrr tGPR:$Rdn,s_cc_out:$s, tGPR:$Rdn, tGPR:$Rm, pred:$p)>;

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -3040,13 +3040,13 @@ def : T2Pat<(t2_so_imm_not:$src),
 // There are shorter Thumb encodings for ADD than ORR, so to increase
 // Thumb2SizeReduction's chances later on we select a t2ADD for an or where
 // possible.
-def : T2Pat<(or AddLikeOrOp:$Rn, t2_so_imm:$imm),
+def : T2Pat<(or_disjoint rGPR:$Rn, t2_so_imm:$imm),
             (t2ADDri rGPR:$Rn, t2_so_imm:$imm)>;
 
-def : T2Pat<(or AddLikeOrOp:$Rn, imm0_4095:$Rm),
+def : T2Pat<(or_disjoint rGPR:$Rn, imm0_4095:$Rm),
             (t2ADDri12 rGPR:$Rn, imm0_4095:$Rm)>;
 
-def : T2Pat<(or AddLikeOrOp:$Rn, non_imm32:$Rm),
+def : T2Pat<(or_disjoint rGPR:$Rn, non_imm32:$Rm),
             (t2ADDrr $Rn, $Rm)>;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/ARM/add-like-or.ll
+++ b/llvm/test/CodeGen/ARM/add-like-or.ll
@@ -258,8 +258,8 @@ define i32 @multiuse(i32 %i, ptr %x, ptr %y) {
 ;
 ; CHECK-T2-LABEL: multiuse:
 ; CHECK-T2:       @ %bb.0: @ %entry
-; CHECK-T2-NEXT:    lsls r0, r0, #1
-; CHECK-T2-NEXT:    adds r0, #1
+; CHECK-T2-NEXT:    movs r2, #1
+; CHECK-T2-NEXT:    orr.w r0, r2, r0, lsl #1
 ; CHECK-T2-NEXT:    ldr.w r1, [r1, r0, lsl #2]
 ; CHECK-T2-NEXT:    add r0, r1
 ; CHECK-T2-NEXT:    bx lr

--- a/llvm/test/CodeGen/ARM/combine-vmovdrr.ll
+++ b/llvm/test/CodeGen/ARM/combine-vmovdrr.ll
@@ -47,8 +47,8 @@ define void @dynamicIndex(ptr %addr, ptr %addr2, i32 %index) {
 ; CHECK-NEXT:    sub.w r4, r7, #8
 ; CHECK-NEXT:    lsls r0, r0, #2
 ; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128], r0
-; CHECK-NEXT:    lsls r0, r2, #1
-; CHECK-NEXT:    adds r0, #1
+; CHECK-NEXT:    movs r0, #1
+; CHECK-NEXT:    orr.w r0, r0, r2, lsl #1
 ; CHECK-NEXT:    and r0, r0, #3
 ; CHECK-NEXT:    ldr r2, [r3]
 ; CHECK-NEXT:    vldr d18, [r1]

--- a/llvm/test/CodeGen/ARM/shift-combine.ll
+++ b/llvm/test/CodeGen/ARM/shift-combine.ll
@@ -2205,15 +2205,15 @@ define <2 x i64> @lshr_into_vsri_shift1_i64(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK-ALIGN-NEXT:    ldr.w lr, [sp, #20]
 ; CHECK-ALIGN-NEXT:    and r2, r2, #-2147483648
 ; CHECK-ALIGN-NEXT:    lsrs.w r12, r12, #1
-; CHECK-ALIGN-NEXT:    orr.w r1, r1, r12
+; CHECK-ALIGN-NEXT:    add r1, r12
 ; CHECK-ALIGN-NEXT:    ldr.w r12, [sp, #8]
 ; CHECK-ALIGN-NEXT:    rrx r12, r12
-; CHECK-ALIGN-NEXT:    orr.w r0, r0, r12
+; CHECK-ALIGN-NEXT:    add r0, r12
 ; CHECK-ALIGN-NEXT:    ldr.w r12, [sp, #16]
 ; CHECK-ALIGN-NEXT:    lsrs.w lr, lr, #1
-; CHECK-ALIGN-NEXT:    orr.w r3, r3, lr
+; CHECK-ALIGN-NEXT:    add r3, lr
 ; CHECK-ALIGN-NEXT:    rrx r12, r12
-; CHECK-ALIGN-NEXT:    orr.w r2, r2, r12
+; CHECK-ALIGN-NEXT:    add r2, r12
 ; CHECK-ALIGN-NEXT:    pop {r7, pc}
 ;
 ; CHECK-V6M-LABEL: lshr_into_vsri_shift1_i64:
@@ -2228,18 +2228,18 @@ define <2 x i64> @lshr_into_vsri_shift1_i64(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK-V6M-NEXT:    ldr r7, [sp, #24]
 ; CHECK-V6M-NEXT:    lsrs r7, r7, #1
 ; CHECK-V6M-NEXT:    adds r6, r7, r6
-; CHECK-V6M-NEXT:    orrs r0, r6
+; CHECK-V6M-NEXT:    adds r0, r6, r0
 ; CHECK-V6M-NEXT:    ands r2, r4
 ; CHECK-V6M-NEXT:    ldr r4, [sp, #36]
 ; CHECK-V6M-NEXT:    lsls r6, r4, #31
 ; CHECK-V6M-NEXT:    ldr r7, [sp, #32]
 ; CHECK-V6M-NEXT:    lsrs r7, r7, #1
 ; CHECK-V6M-NEXT:    adds r6, r7, r6
-; CHECK-V6M-NEXT:    orrs r2, r6
+; CHECK-V6M-NEXT:    adds r2, r6, r2
 ; CHECK-V6M-NEXT:    lsrs r5, r5, #1
-; CHECK-V6M-NEXT:    orrs r1, r5
+; CHECK-V6M-NEXT:    adds r1, r5, r1
 ; CHECK-V6M-NEXT:    lsrs r4, r4, #1
-; CHECK-V6M-NEXT:    orrs r3, r4
+; CHECK-V6M-NEXT:    adds r3, r4, r3
 ; CHECK-V6M-NEXT:    add sp, #4
 ; CHECK-V6M-NEXT:    pop {r4, r5, r6, r7, pc}
 bb1:

--- a/llvm/test/CodeGen/Thumb2/mve-vecreduce-addpred.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vecreduce-addpred.ll
@@ -210,7 +210,7 @@ define arm_aapcs_vfpcc i64 @add_v8i16_v8i64_zext(<8 x i16> %x, <8 x i16> %b) {
 ; CHECK-NEXT:    vpsel q7, q7, q2
 ; CHECK-NEXT:    vmov r0, r1, d15
 ; CHECK-NEXT:    vmov r2, r3, d14
-; CHECK-NEXT:    orrs r1, r3
+; CHECK-NEXT:    add r1, r3
 ; CHECK-NEXT:    add r0, r2
 ; CHECK-NEXT:    vmov r2, r3, d13
 ; CHECK-NEXT:    vmov q6[2], q6[0], r2, r3
@@ -430,7 +430,7 @@ define arm_aapcs_vfpcc i64 @add_v2i16_v2i64_zext(<2 x i16> %x, <2 x i16> %b) {
 ; CHECK-NEXT:    vmov r0, r1, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
 ; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    orrs r1, r3
+; CHECK-NEXT:    add r1, r3
 ; CHECK-NEXT:    bx lr
 entry:
   %c = icmp eq <2 x i16> %b, zeroinitializer
@@ -701,7 +701,7 @@ define arm_aapcs_vfpcc i64 @add_v16i8_v16i64_zext(<16 x i8> %x, <16 x i8> %b) {
 ; CHECK-NEXT:    vpsel q0, q0, q4
 ; CHECK-NEXT:    vmov r0, r1, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
-; CHECK-NEXT:    orrs r1, r3
+; CHECK-NEXT:    add r1, r3
 ; CHECK-NEXT:    add r0, r2
 ; CHECK-NEXT:    vmov r2, r3, d15
 ; CHECK-NEXT:    vmov.i8 q7, #0x0
@@ -1116,7 +1116,7 @@ define arm_aapcs_vfpcc i64 @add_v8i8_v8i64_zext(<8 x i8> %x, <8 x i8> %b) {
 ; CHECK-NEXT:    vpsel q7, q7, q2
 ; CHECK-NEXT:    vmov r0, r1, d15
 ; CHECK-NEXT:    vmov r2, r3, d14
-; CHECK-NEXT:    orrs r1, r3
+; CHECK-NEXT:    add r1, r3
 ; CHECK-NEXT:    add r0, r2
 ; CHECK-NEXT:    vmov r2, r3, d13
 ; CHECK-NEXT:    vmov q6[2], q6[0], r2, r3
@@ -1348,7 +1348,7 @@ define arm_aapcs_vfpcc i64 @add_v2i8_v2i64_zext(<2 x i8> %x, <2 x i8> %b) {
 ; CHECK-NEXT:    vmov r0, r1, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
 ; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    orrs r1, r3
+; CHECK-NEXT:    add r1, r3
 ; CHECK-NEXT:    bx lr
 entry:
   %c = icmp eq <2 x i8> %b, zeroinitializer
@@ -1652,7 +1652,7 @@ define arm_aapcs_vfpcc i64 @add_v8i16_v8i64_acc_zext(<8 x i16> %x, <8 x i16> %b,
 ; CHECK-NEXT:    vpsel q7, q7, q2
 ; CHECK-NEXT:    vmov r12, lr, d15
 ; CHECK-NEXT:    vmov r2, r3, d14
-; CHECK-NEXT:    orr.w lr, lr, r3
+; CHECK-NEXT:    add lr, r3
 ; CHECK-NEXT:    add r12, r2
 ; CHECK-NEXT:    vmov r3, r2, d13
 ; CHECK-NEXT:    vmov q6[2], q6[0], r3, r2
@@ -1850,7 +1850,7 @@ define arm_aapcs_vfpcc i64 @add_v2i16_v2i64_acc_zext(<2 x i16> %x, <2 x i16> %b,
 ; CHECK-NEXT:    vmov r12, lr, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
 ; CHECK-NEXT:    add r2, r12
-; CHECK-NEXT:    orr.w r3, r3, lr
+; CHECK-NEXT:    add r3, lr
 ; CHECK-NEXT:    adds r0, r0, r2
 ; CHECK-NEXT:    adcs r1, r3
 ; CHECK-NEXT:    pop {r7, pc}
@@ -2108,7 +2108,7 @@ define arm_aapcs_vfpcc i64 @add_v16i8_v16i64_acc_zext(<16 x i8> %x, <16 x i8> %b
 ; CHECK-NEXT:    vpsel q0, q0, q4
 ; CHECK-NEXT:    vmov r12, lr, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
-; CHECK-NEXT:    orr.w lr, lr, r3
+; CHECK-NEXT:    add lr, r3
 ; CHECK-NEXT:    add r12, r2
 ; CHECK-NEXT:    vmov r3, r2, d15
 ; CHECK-NEXT:    vmov.i8 q7, #0x0
@@ -2522,7 +2522,7 @@ define arm_aapcs_vfpcc i64 @add_v2i8_v2i64_acc_zext(<2 x i8> %x, <2 x i8> %b, i6
 ; CHECK-NEXT:    vmov r12, lr, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
 ; CHECK-NEXT:    add r2, r12
-; CHECK-NEXT:    orr.w r3, r3, lr
+; CHECK-NEXT:    add r3, lr
 ; CHECK-NEXT:    adds r0, r0, r2
 ; CHECK-NEXT:    adcs r1, r3
 ; CHECK-NEXT:    pop {r7, pc}


### PR DESCRIPTION
AddLikeOrOp is redundant now that we have add_like for the patterns.