### PR TITLE
workflows/release-tasks: remove duplicate environment specification

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -96,7 +96,6 @@ jobs:
       id-token: write # Requred for pypi publishing
     needs:
       - validate-tag
-    environment: pypi
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
reason: https://github.com/llvm/llvm-project/actions/runs/25296229341/workflow
related: https://github.com/llvm/llvm-project/commit/2ffa00fc247ce32c5eb40b0c0df95d5c3526cbdb