### PR TITLE
[openmp][flang] To add a cmake option to build OPENMP Fortran modules only without building the libomp lib

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -109,6 +109,12 @@ set(LIBOMP_BUILD_DATE "No_Timestamp")
 set(LIBOMP_FORTRAN_MODULES FALSE CACHE BOOL
   "Create Fortran module files? (requires fortran compiler)")
 
+option(LIBOMP_FORTRAN_MODULES_ONLY
+  "Build only Fortran modules without libomp runtime library" OFF)
+if(LIBOMP_FORTRAN_MODULES_ONLY)
+  set(LIBOMP_FORTRAN_MODULES TRUE)
+endif()
+
 # Set up testing infrastructure.
 include(OpenMPTesting)
 
@@ -148,7 +154,9 @@ else()
 
   # Build host runtime library, after LIBOMPTARGET variables are set since they
   # are needed to enable time profiling support in the OpenMP runtime.
-  add_subdirectory(runtime)
+  if(NOT LIBOMP_FORTRAN_MODULES_ONLY)
+    add_subdirectory(runtime)
+  endif()	
 
   set(ENABLE_OMPT_TOOLS ON)
   # Currently tools are not tested well on Windows or MacOS X.


### PR DESCRIPTION
PR #192687 Introduces a dependency to the Fortran intrinsic module when building `openmp` Fortran modules, which requires a Flang enabled llvm build in order to build `openmp` Fortran modules.

This PR is to add a cmake option `LIBOMP_FORTRAN_MODULES_ONLY` to allow users to build 'openmp` Fortran modules only for Flang without building the libomp runtime library. 
This will allow libomp.a/so build still be independent from the Flang build as before.

E.g. To build `openmp` Fortran modules only for Flang, one would need to use the following options.
```
cmake \
...
  -DLIBOMP_FORTRAN_MODULES_ONLY=ON \
  -DLLVM_ENABLE_PROJECTS="flang" \
  -DLLVM_ENABLE_RUNTIMES="openmp" \
  ...