### PR TITLE
[SystemZ,test] Cover non-preemptible PLTOFF

### DIFF
--- a/lld/test/ELF/systemz-reloc-gotrel.s
+++ b/lld/test/ELF/systemz-reloc-gotrel.s
@@ -2,7 +2,7 @@
 # RUN: llvm-mc -filetype=obj -triple=s390x-unknown-linux %s -o %t.o
 # RUN: ld.lld -shared %t.o -soname=t.so -o %t.so
 
-# RUN: llvm-readelf -S -s -x .data %t.so | FileCheck %s
+# RUN: llvm-readelf -S -s -x .data -x .data1 %t.so | FileCheck %s
 
 # CHECK: Section Headers:
 # CHECK: .plt PROGBITS 0000000000001290
@@ -10,27 +10,50 @@
 
 # CHECK: Symbol table '.symtab'
 # CHECK: 0000000000001288 {{.*}}  bar
+# CHECK: 000000000000128a {{.*}}  baz
 
-## Note: foo is the first (and only) PLT entry, which resides at .plt + 32
-## PLTOFF (foo) is (.plt + 32) - .got == 0x12b0 - 0x2390 == 0xffffef20
-## GOTOFF (bar) is bar - .got == 0x1288 - 0x2390 == 0xffffeef8
+## .data holds relocations against non-preemptible symbols (link-time
+## constants): GOTOFF (bar) and PLTOFF (baz). For PLTOFF (baz) the scan
+## rewrites R_PLT_GOTREL → R_GOTREL via fromPlt so the result is
+## baz - .got, not the offset of a PLT entry.
+## GOTOFF (bar) = bar - .got = 0x1288 - 0x2390 = 0xffffeef8
+## PLTOFF (baz) = baz - .got = 0x128a - 0x2390 = 0xffffeefa
 # CHECK: Hex dump of section '.data':
-# CHECK-NEXT: eef8ef20 ffffeef8 ffffef20 ffffffff
-# CHECK-NEXT: ffffeef8 ffffffff ffffef20
+# CHECK-NEXT: eef8eefa ffffeef8 ffffeefa ffffffff
+# CHECK-NEXT: ffffeef8 ffffffff ffffeefa
+
+## .data1 holds relocations against the preemptible foo, which uses the
+## first (and only) PLT entry at .plt + 32.
+## PLTOFF (foo) = (.plt + 32) - .got = 0x12b0 - 0x2390 = 0xffffef20
+# CHECK: Hex dump of section '.data1':
+# CHECK-NEXT: ef20ffff ef20ffff ffffffff ef20
 
 bar:
+  br %r14
+
+.hidden baz
+.globl baz
+baz:
   br %r14
 
 .data
 .reloc ., R_390_GOTOFF16, bar
 .space 2
-.reloc ., R_390_PLTOFF16, foo
+.reloc ., R_390_PLTOFF16, baz
 .space 2
 .reloc ., R_390_GOTOFF, bar
 .space 4
-.reloc ., R_390_PLTOFF32, foo
+.reloc ., R_390_PLTOFF32, baz
 .space 4
 .reloc ., R_390_GOTOFF64, bar
 .space 8
+.reloc ., R_390_PLTOFF64, baz
+.space 8
+
+.section .data1,"aw"
+.reloc ., R_390_PLTOFF16, foo
+.space 2
+.reloc ., R_390_PLTOFF32, foo
+.space 4
 .reloc ., R_390_PLTOFF64, foo
 .space 8


### PR DESCRIPTION
R_390_PLTOFF{16,32,64} against a non-preemptible (hidden) symbol takes
fromPlt(R_PLT_GOTREL) → R_GOTREL in RelocScan::process so the relocation
resolves to symbol - .got with no PLT entry. Add tests to fix the
the test gap from the initial SystemZ port (fe3406e349884e4ef61480dd0607f1e237102c74).