### PR TITLE
[NFC][AMDGPU] Generalize some LDS MemoryUtils

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
@@ -91,7 +91,7 @@ template <typename T> SmallVector<T> sortByName(SmallVector<T> &&V) {
 
 // Main utility function for special LDS variables lowering.
 static bool lowerExecSyncGlobalVariables(
-    Module &M, LDSUsesInfoTy &LDSUsesInfo,
+    Module &M, GVUsesInfoTy &LDSUsesInfo,
     VariableFunctionMap &LDSToKernelsThatNeedToAccessItIndirectly) {
   bool Changed = false;
   const DataLayout &DL = M.getDataLayout();
@@ -110,7 +110,7 @@ static bool lowerExecSyncGlobalVariables(
     } else {
       // leave it to the 2nd round, which will give a kernel-relative
       // assignment if it is only indirectly accessed by one kernel
-      LDSUsesInfo.direct_access[*K.second.begin()].insert(GV);
+      LDSUsesInfo.DirectAccess[*K.second.begin()].insert(GV);
     }
     LDSToKernelsThatNeedToAccessItIndirectly.erase(GV);
   }
@@ -132,7 +132,7 @@ static bool lowerExecSyncGlobalVariables(
   // either only indirectly accessed by single kernel or only directly
   // accessed by multiple kernels.
   SmallVector<Function *> OrderedKernels;
-  for (auto &K : LDSUsesInfo.direct_access) {
+  for (auto &K : LDSUsesInfo.DirectAccess) {
     Function *F = K.first;
     assert(isKernel(*F));
     OrderedKernels.push_back(F);
@@ -141,11 +141,11 @@ static bool lowerExecSyncGlobalVariables(
 
   DenseMap<Function *, uint32_t> Kernel2BarId;
   for (Function *F : OrderedKernels) {
-    for (GlobalVariable *GV : LDSUsesInfo.direct_access[F]) {
+    for (GlobalVariable *GV : LDSUsesInfo.DirectAccess[F]) {
       if (!isNamedBarrier(*GV))
         continue;
 
-      LDSUsesInfo.direct_access[F].erase(GV);
+      LDSUsesInfo.DirectAccess[F].erase(GV);
       if (GV->isAbsoluteSymbolRef()) {
         // already assigned
         continue;
@@ -169,7 +169,7 @@ static bool lowerExecSyncGlobalVariables(
     OrderedGVs.clear();
   }
   // Also erase those special LDS variables from indirect_access.
-  for (auto &K : LDSUsesInfo.indirect_access) {
+  for (auto &K : LDSUsesInfo.IndirectAccess) {
     assert(isKernel(*K.first));
     for (GlobalVariable *GV : K.second) {
       if (isNamedBarrier(*GV))
@@ -177,6 +177,18 @@ static bool lowerExecSyncGlobalVariables(
     }
   }
   return Changed;
+}
+
+static bool hasBarrierToLower(const GVUsesInfoTy &LDSUsesInfo) {
+  for (auto &Map : {LDSUsesInfo.DirectAccess, LDSUsesInfo.IndirectAccess}) {
+    for (auto &[Fn, GVs] : Map) {
+      for (auto &GV : GVs) {
+        if (AMDGPU::isNamedBarrier(*GV))
+          return true;
+      }
+    }
+  }
+  return false;
 }
 
 // With object linking, barrier ID assignment is deferred to the linker.
@@ -225,15 +237,16 @@ static bool runLowerExecSyncGlobals(Module &M) {
 
   CallGraph CG = CallGraph(M);
   bool Changed = false;
-  Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+  Changed |=
+      eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
   // For each kernel, what variables does it access directly or through
   // callees
-  LDSUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDS(CG, M);
+  GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
   // For each variable accessed through callees, which kernels access it
   VariableFunctionMap LDSToKernelsThatNeedToAccessItIndirectly;
-  for (auto &K : LDSUsesInfo.indirect_access) {
+  for (auto &K : LDSUsesInfo.IndirectAccess) {
     Function *F = K.first;
     assert(isKernel(*F));
     for (GlobalVariable *GV : K.second) {
@@ -241,11 +254,12 @@ static bool runLowerExecSyncGlobals(Module &M) {
     }
   }
 
-  if (LDSUsesInfo.HasSpecialGVs) {
+  if (hasBarrierToLower(LDSUsesInfo)) {
     // Special LDS variables need special address assignment
     Changed |= lowerExecSyncGlobalVariables(
         M, LDSUsesInfo, LDSToKernelsThatNeedToAccessItIndirectly);
   }
+
   return Changed;
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
@@ -84,7 +84,7 @@ unsigned allocateExecSyncID(T &NextAvailableIDTracker,
 
 // Main utility function for special LDS variables lowering.
 static bool lowerExecSyncGlobalVariables(Module &M,
-                                         LDSUsesInfoTy &LDSUsesInfo) {
+                                         GVUsesInfoTy &GVUsesInfo) {
   bool Changed = false;
   const DataLayout &DL = M.getDataLayout();
 
@@ -92,7 +92,7 @@ static bool lowerExecSyncGlobalVariables(Module &M,
   MapVector<GlobalVariable *, SmallVector<Function *>> AllocationQ;
   DenseMap<Function *, SmallVector<unsigned, NumBarScopes>> KernelBarrierIDs;
 
-  for (auto &[F, GVs] : LDSUsesInfo.indirect_access) {
+  for (auto &[F, GVs] : GVUsesInfo.IndirectAccess) {
     for (auto *GV : GVs) {
       if (!isNamedBarrier(*GV) || GV->isAbsoluteSymbolRef())
         continue;
@@ -104,7 +104,7 @@ static bool lowerExecSyncGlobalVariables(Module &M,
     }
   }
 
-  for (auto &[F, GVs] : LDSUsesInfo.direct_access) {
+  for (auto &[F, GVs] : GVUsesInfo.DirectAccess) {
     for (auto *GV : GVs) {
       if (!isNamedBarrier(*GV) || GV->isAbsoluteSymbolRef())
         continue;
@@ -149,11 +149,23 @@ static bool lowerExecSyncGlobalVariables(Module &M,
   }
 
   // Also erase those special LDS variables from indirect_access.
-  for (auto &K : LDSUsesInfo.indirect_access) {
+  for (auto &K : GVUsesInfo.IndirectAccess) {
     assert(isKernel(*K.first));
     K.second.remove_if([](GlobalVariable *GV) { return isNamedBarrier(*GV); });
   }
   return Changed;
+}
+
+static bool hasBarrierToLower(const GVUsesInfoTy &GVUsesInfo) {
+  for (auto &Map : {GVUsesInfo.DirectAccess, GVUsesInfo.IndirectAccess}) {
+    for (auto &[Fn, GVs] : Map) {
+      for (auto &GV : GVs) {
+        if (AMDGPU::isNamedBarrier(*GV))
+          return true;
+      }
+    }
+  }
+  return false;
 }
 
 // With object linking, barrier ID assignment is deferred to the linker.
@@ -202,16 +214,18 @@ static bool runLowerExecSyncGlobals(Module &M) {
 
   CallGraph CG = CallGraph(M);
   bool Changed = false;
-  Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+  Changed |=
+      eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
   // For each kernel, what variables does it access directly or through
   // callees
-  LDSUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDS(CG, M);
+  GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
-  if (LDSUsesInfo.HasSpecialGVs) {
+  if (hasBarrierToLower(LDSUsesInfo)) {
     // Special LDS variables need special address assignment
     Changed |= lowerExecSyncGlobalVariables(M, LDSUsesInfo);
   }
+
   return Changed;
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerExecSync.cpp
@@ -83,8 +83,7 @@ unsigned allocateExecSyncID(T &NextAvailableIDTracker,
 }
 
 // Main utility function for special LDS variables lowering.
-static bool lowerExecSyncGlobalVariables(Module &M,
-                                         GVUsesInfoTy &GVUsesInfo) {
+static bool lowerExecSyncGlobalVariables(Module &M, GVUsesInfoTy &GVUsesInfo) {
   bool Changed = false;
   const DataLayout &DL = M.getDataLayout();
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -426,7 +426,7 @@ public:
   }
 
   static DenseSet<Function *> kernelsThatIndirectlyAccessAnyOfPassedVariables(
-      Module &M, LDSUsesInfoTy &LDSUsesInfo,
+      Module &M, GVUsesInfoTy &LDSUsesInfo,
       DenseSet<GlobalVariable *> const &VariableSet) {
 
     DenseSet<Function *> KernelSet;
@@ -437,7 +437,7 @@ public:
     for (Function &Func : M.functions()) {
       if (Func.isDeclaration() || !isKernel(Func))
         continue;
-      for (GlobalVariable *GV : LDSUsesInfo.indirect_access[&Func]) {
+      for (GlobalVariable *GV : LDSUsesInfo.IndirectAccess[&Func]) {
         if (VariableSet.contains(GV)) {
           KernelSet.insert(&Func);
           break;
@@ -581,7 +581,7 @@ public:
   }
 
   static void partitionVariablesIntoIndirectStrategies(
-      Module &M, LDSUsesInfoTy const &LDSUsesInfo,
+      Module &M, GVUsesInfoTy const &LDSUsesInfo,
       VariableFunctionMap &LDSToKernelsThatNeedToAccessItIndirectly,
       DenseSet<GlobalVariable *> &ModuleScopeVariables,
       DenseSet<GlobalVariable *> &TableLookupVariables,
@@ -726,7 +726,7 @@ public:
 
   static DenseMap<Function *, LDSVariableReplacement>
   lowerKernelScopeStructVariables(
-      Module &M, LDSUsesInfoTy &LDSUsesInfo,
+      Module &M, GVUsesInfoTy &LDSUsesInfo,
       DenseSet<GlobalVariable *> const &ModuleScopeVariables,
       DenseSet<Function *> const &KernelsThatAllocateModuleLDS,
       GlobalVariable *MaybeModuleScopeStruct) {
@@ -741,7 +741,7 @@ public:
       DenseSet<GlobalVariable *> KernelUsedVariables;
       // Allocating variables that are used directly in this struct to get
       // alignment aware allocation and predictable frame size.
-      for (auto &v : LDSUsesInfo.direct_access[&Func]) {
+      for (auto &v : LDSUsesInfo.DirectAccess[&Func]) {
         if (!AMDGPU::isDynamicLDS(*v)) {
           KernelUsedVariables.insert(v);
         }
@@ -749,7 +749,7 @@ public:
 
       // Allocating variables that are accessed indirectly so that a lookup of
       // this struct instance can find them from nested functions.
-      for (auto &v : LDSUsesInfo.indirect_access[&Func]) {
+      for (auto &v : LDSUsesInfo.IndirectAccess[&Func]) {
         if (!AMDGPU::isDynamicLDS(*v)) {
           KernelUsedVariables.insert(v);
         }
@@ -788,8 +788,8 @@ public:
       // If any indirect uses, create a direct use to ensure allocation
       // TODO: Simpler to unconditionally mark used but that regresses
       // codegen in test/CodeGen/AMDGPU/noclobber-barrier.ll
-      auto Accesses = LDSUsesInfo.indirect_access.find(&Func);
-      if ((Accesses != LDSUsesInfo.indirect_access.end()) &&
+      auto Accesses = LDSUsesInfo.IndirectAccess.find(&Func);
+      if ((Accesses != LDSUsesInfo.IndirectAccess.end()) &&
           !Accesses->second.empty())
         markUsedByKernel(&Func, Replacement.SGV);
 
@@ -808,7 +808,7 @@ public:
   }
 
   static GlobalVariable *
-  buildRepresentativeDynamicLDSInstance(Module &M, LDSUsesInfoTy &LDSUsesInfo,
+  buildRepresentativeDynamicLDSInstance(Module &M, GVUsesInfoTy &LDSUsesInfo,
                                         Function *func) {
     // Create a dynamic lds variable with a name associated with the passed
     // function that has the maximum alignment of any dynamic lds variable
@@ -833,11 +833,11 @@ public:
       }
     };
 
-    for (GlobalVariable *GV : LDSUsesInfo.indirect_access[func]) {
+    for (GlobalVariable *GV : LDSUsesInfo.IndirectAccess[func]) {
       UpdateMaxAlignment(GV);
     }
 
-    for (GlobalVariable *GV : LDSUsesInfo.direct_access[func]) {
+    for (GlobalVariable *GV : LDSUsesInfo.DirectAccess[func]) {
       UpdateMaxAlignment(GV);
     }
 
@@ -854,7 +854,7 @@ public:
   }
 
   DenseMap<Function *, GlobalVariable *> lowerDynamicLDSVariables(
-      Module &M, LDSUsesInfoTy &LDSUsesInfo,
+      Module &M, GVUsesInfoTy &LDSUsesInfo,
       DenseSet<Function *> const &KernelsThatIndirectlyAllocateDynamicLDS,
       DenseSet<GlobalVariable *> const &DynamicVariables,
       std::vector<Function *> const &OrderedKernels) {
@@ -916,11 +916,13 @@ public:
   // assign offsets across TUs.
   bool runOnModuleLinkTime(Module &M) {
     bool Changed = superAlignLDSGlobals(M);
-    Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+    Changed |=
+        eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
     CallGraph CG(M);
     FunctionVariableMap KernelLDSUses, FunctionLDSUses;
-    getUsesOfLDSByFunction(CG, M, KernelLDSUses, FunctionLDSUses);
+    getUsesOfGVByFunction(CG, M, isLDSVariableToLower, KernelLDSUses,
+                          FunctionLDSUses);
 
     if (KernelLDSUses.empty() && FunctionLDSUses.empty())
       return Changed;
@@ -1079,17 +1081,18 @@ public:
     CallGraph CG = CallGraph(M);
     bool Changed = superAlignLDSGlobals(M);
 
-    Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+    Changed |=
+        eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
     Changed = true; // todo: narrow this down
 
     // For each kernel, what variables does it access directly or through
     // callees
-    LDSUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDS(CG, M);
+    GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
     // For each variable accessed through callees, which kernels access it
     VariableFunctionMap LDSToKernelsThatNeedToAccessItIndirectly;
-    for (auto &K : LDSUsesInfo.indirect_access) {
+    for (auto &K : LDSUsesInfo.IndirectAccess) {
       Function *F = K.first;
       assert(isKernel(*F));
       for (GlobalVariable *GV : K.second) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
@@ -111,40 +111,29 @@ bool isLDSVariableToLower(const GlobalVariable &GV) {
   return true;
 }
 
-bool eliminateConstantExprUsesOfLDSFromAllInstructions(Module &M) {
-  // Constants are uniqued within LLVM. A ConstantExpr referring to a LDS
-  // global may have uses from multiple different functions as a result.
-  // This pass specialises LDS variables with respect to the kernel that
-  // allocates them.
-
-  // This is semantically equivalent to (the unimplemented as slow):
-  // for (auto &F : M.functions())
-  //   for (auto &BB : F)
-  //     for (auto &I : BB)
-  //       for (Use &Op : I.operands())
-  //         if (constantExprUsesLDS(Op))
-  //           replaceConstantExprInFunction(I, Op);
-
-  SmallVector<Constant *> LDSGlobals;
+bool eliminateGVConstantExprUsesFromAllInstructions(
+    Module &M, function_ref<bool(const GlobalVariable &)> Filter) {
+  SmallVector<Constant *> Worklist;
   for (auto &GV : M.globals())
-    if (AMDGPU::isLDSVariableToLower(GV))
-      LDSGlobals.push_back(&GV);
-  return convertUsersOfConstantsToInstructions(LDSGlobals);
+    if (Filter(GV))
+      Worklist.push_back(&GV);
+  return convertUsersOfConstantsToInstructions(Worklist);
 }
 
-void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
-                            FunctionVariableMap &kernels,
-                            FunctionVariableMap &Functions) {
+void getUsesOfGVByFunction(const CallGraph &CG, Module &M,
+                           function_ref<bool(const GlobalVariable &)> Filter,
+                           FunctionVariableMap &Kernels,
+                           FunctionVariableMap &Functions) {
   // Get uses from the current function, excluding uses by called Functions
   // Two output variables to avoid walking the globals list twice
   for (auto &GV : M.globals()) {
-    if (!AMDGPU::isLDSVariableToLower(GV))
+    if (!Filter(GV))
       continue;
     for (User *V : GV.users()) {
       if (auto *I = dyn_cast<Instruction>(V)) {
         Function *F = I->getFunction();
         if (isKernel(*F))
-          kernels[F].insert(&GV);
+          Kernels[F].insert(&GV);
         else
           Functions[F].insert(&GV);
       }
@@ -152,11 +141,13 @@ void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
   }
 }
 
-LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
+GVUsesInfoTy
+getTransitiveUsesOfGV(const CallGraph &CG, Module &M,
+                      function_ref<bool(const GlobalVariable &)> Filter) {
 
   FunctionVariableMap DirectMapKernel;
   FunctionVariableMap DirectMapFunction;
-  getUsesOfLDSByFunction(CG, M, DirectMapKernel, DirectMapFunction);
+  getUsesOfGVByFunction(CG, M, Filter, DirectMapKernel, DirectMapFunction);
 
   // Collect functions whose address has escaped
   DenseSet<Function *> AddressTakenFuncs;
@@ -280,32 +271,36 @@ LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
     }
   }
 
+  return {std::move(DirectMapKernel), std::move(IndirectMapKernel)};
+}
+
+GVUsesInfoTy getTransitiveUsesOfLDSForLowering(const CallGraph &CG, Module &M) {
+  GVUsesInfoTy UsesInfo = getTransitiveUsesOfGV(CG, M, isLDSVariableToLower);
   // Verify that we fall into one of 2 cases:
   //    - All variables are either absolute
   //      or direct mapped dynamic LDS that is not lowered.
-  //      this is a re-run of the pass
-  //      so we don't have anything to do.
   //    - No variables are absolute.
   // Named-barriers which are absolute symbols are removed
   // from the maps.
   std::optional<bool> HasAbsoluteGVs;
-  bool HasSpecialGVs = false;
-  for (auto &Map : {DirectMapKernel, IndirectMapKernel}) {
+  for (auto &Map : {UsesInfo.DirectAccess, UsesInfo.IndirectAccess}) {
     for (auto &[Fn, GVs] : Map) {
       for (auto *GV : GVs) {
         bool IsAbsolute = GV->isAbsoluteSymbolRef();
         bool IsDirectMapDynLDSGV =
-            AMDGPU::isDynamicLDS(*GV) && DirectMapKernel.contains(Fn);
+            AMDGPU::isDynamicLDS(*GV) && UsesInfo.DirectAccess.contains(Fn);
         if (IsDirectMapDynLDSGV)
           continue;
+
+        // TODO: Remove once barriers are no longer in the LDS AS.
         if (isNamedBarrier(*GV)) {
           if (IsAbsolute) {
-            DirectMapKernel[Fn].erase(GV);
-            IndirectMapKernel[Fn].erase(GV);
+            UsesInfo.DirectAccess[Fn].erase(GV);
+            UsesInfo.IndirectAccess[Fn].erase(GV);
           }
-          HasSpecialGVs = true;
           continue;
         }
+
         if (HasAbsoluteGVs.has_value()) {
           if (*HasAbsoluteGVs != IsAbsolute) {
             reportFatalUsageError(
@@ -320,10 +315,9 @@ LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
   // If we only had absolute GVs, we have nothing to do, return an empty
   // result.
   if (HasAbsoluteGVs && *HasAbsoluteGVs)
-    return {FunctionVariableMap(), FunctionVariableMap(), false};
+    return GVUsesInfoTy();
 
-  return {std::move(DirectMapKernel), std::move(IndirectMapKernel),
-          HasSpecialGVs};
+  return UsesInfo;
 }
 
 void removeFnAttrFromReachable(CallGraph &CG, Function *KernelRoot,

--- a/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.cpp
@@ -94,40 +94,29 @@ bool isLDSVariableToLower(const GlobalVariable &GV) {
   return true;
 }
 
-bool eliminateConstantExprUsesOfLDSFromAllInstructions(Module &M) {
-  // Constants are uniqued within LLVM. A ConstantExpr referring to a LDS
-  // global may have uses from multiple different functions as a result.
-  // This pass specialises LDS variables with respect to the kernel that
-  // allocates them.
-
-  // This is semantically equivalent to (the unimplemented as slow):
-  // for (auto &F : M.functions())
-  //   for (auto &BB : F)
-  //     for (auto &I : BB)
-  //       for (Use &Op : I.operands())
-  //         if (constantExprUsesLDS(Op))
-  //           replaceConstantExprInFunction(I, Op);
-
-  SmallVector<Constant *> LDSGlobals;
+bool eliminateGVConstantExprUsesFromAllInstructions(
+    Module &M, function_ref<bool(const GlobalVariable &)> Filter) {
+  SmallVector<Constant *> Worklist;
   for (auto &GV : M.globals())
-    if (AMDGPU::isLDSVariableToLower(GV))
-      LDSGlobals.push_back(&GV);
-  return convertUsersOfConstantsToInstructions(LDSGlobals);
+    if (Filter(GV))
+      Worklist.push_back(&GV);
+  return convertUsersOfConstantsToInstructions(Worklist);
 }
 
-void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
-                            FunctionVariableMap &kernels,
-                            FunctionVariableMap &Functions) {
+void getUsesOfGVByFunction(const CallGraph &CG, Module &M,
+                           function_ref<bool(const GlobalVariable &)> Filter,
+                           FunctionVariableMap &Kernels,
+                           FunctionVariableMap &Functions) {
   // Get uses from the current function, excluding uses by called Functions
   // Two output variables to avoid walking the globals list twice
   for (auto &GV : M.globals()) {
-    if (!AMDGPU::isLDSVariableToLower(GV))
+    if (!Filter(GV))
       continue;
     for (User *V : GV.users()) {
       if (auto *I = dyn_cast<Instruction>(V)) {
         Function *F = I->getFunction();
         if (isKernel(*F))
-          kernels[F].insert(&GV);
+          Kernels[F].insert(&GV);
         else
           Functions[F].insert(&GV);
       }
@@ -135,11 +124,13 @@ void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
   }
 }
 
-LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
+GVUsesInfoTy
+getTransitiveUsesOfGV(const CallGraph &CG, Module &M,
+                      function_ref<bool(const GlobalVariable &)> Filter) {
 
   FunctionVariableMap DirectMapKernel;
   FunctionVariableMap DirectMapFunction;
-  getUsesOfLDSByFunction(CG, M, DirectMapKernel, DirectMapFunction);
+  getUsesOfGVByFunction(CG, M, Filter, DirectMapKernel, DirectMapFunction);
 
   // Collect functions whose address has escaped
   DenseSet<Function *> AddressTakenFuncs;
@@ -263,32 +254,36 @@ LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
     }
   }
 
+  return {std::move(DirectMapKernel), std::move(IndirectMapKernel)};
+}
+
+GVUsesInfoTy getTransitiveUsesOfLDSForLowering(const CallGraph &CG, Module &M) {
+  GVUsesInfoTy UsesInfo = getTransitiveUsesOfGV(CG, M, isLDSVariableToLower);
   // Verify that we fall into one of 2 cases:
   //    - All variables are either absolute
   //      or direct mapped dynamic LDS that is not lowered.
-  //      this is a re-run of the pass
-  //      so we don't have anything to do.
   //    - No variables are absolute.
   // Named-barriers which are absolute symbols are removed
   // from the maps.
   std::optional<bool> HasAbsoluteGVs;
-  bool HasSpecialGVs = false;
-  for (auto &Map : {DirectMapKernel, IndirectMapKernel}) {
+  for (auto &Map : {UsesInfo.DirectAccess, UsesInfo.IndirectAccess}) {
     for (auto &[Fn, GVs] : Map) {
       for (auto *GV : GVs) {
         bool IsAbsolute = GV->isAbsoluteSymbolRef();
         bool IsDirectMapDynLDSGV =
-            AMDGPU::isDynamicLDS(*GV) && DirectMapKernel.contains(Fn);
+            AMDGPU::isDynamicLDS(*GV) && UsesInfo.DirectAccess.contains(Fn);
         if (IsDirectMapDynLDSGV)
           continue;
+
+        // TODO: Remove once barriers are no longer in the LDS AS.
         if (isNamedBarrier(*GV)) {
           if (IsAbsolute) {
-            DirectMapKernel[Fn].erase(GV);
-            IndirectMapKernel[Fn].erase(GV);
+            UsesInfo.DirectAccess[Fn].erase(GV);
+            UsesInfo.IndirectAccess[Fn].erase(GV);
           }
-          HasSpecialGVs = true;
           continue;
         }
+
         if (HasAbsoluteGVs.has_value()) {
           if (*HasAbsoluteGVs != IsAbsolute) {
             reportFatalUsageError(
@@ -303,10 +298,9 @@ LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M) {
   // If we only had absolute GVs, we have nothing to do, return an empty
   // result.
   if (HasAbsoluteGVs && *HasAbsoluteGVs)
-    return {FunctionVariableMap(), FunctionVariableMap(), false};
+    return GVUsesInfoTy();
 
-  return {std::move(DirectMapKernel), std::move(IndirectMapKernel),
-          HasSpecialGVs};
+  return UsesInfo;
 }
 
 void removeFnAttrFromReachable(CallGraph &CG, Function *KernelRoot,

--- a/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.h
@@ -41,19 +41,47 @@ TargetExtType *isNamedBarrier(const GlobalVariable &GV);
 bool isDynamicLDS(const GlobalVariable &GV);
 bool isLDSVariableToLower(const GlobalVariable &GV);
 
-struct LDSUsesInfoTy {
-  FunctionVariableMap direct_access;
-  FunctionVariableMap indirect_access;
-  bool HasSpecialGVs = false;
+struct GVUsesInfoTy {
+  FunctionVariableMap DirectAccess;
+  FunctionVariableMap IndirectAccess;
 };
 
-bool eliminateConstantExprUsesOfLDSFromAllInstructions(Module &M);
+/// Iterates over all GlobalVariables in \p M, and whenever \p Filter returns
+/// true, replace all constant users of the GV with instructions.
+bool eliminateGVConstantExprUsesFromAllInstructions(
+    Module &M, function_ref<bool(const GlobalVariable &)> Filter);
 
-void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
-                            FunctionVariableMap &kernels,
-                            FunctionVariableMap &functions);
+/// Finds uses of Global Variables on a per-function basis.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \param Filter Function that returns true for GVs that need to be considered.
+/// \param Kernels[out] Maps kernels to global variables used by that kernel.
+/// \param Functions[out] Maps functions to global variables used by that
+/// function.
+void getUsesOfGVByFunction(const CallGraph &CG, Module &M,
+                           function_ref<bool(const GlobalVariable &)> Filter,
+                           FunctionVariableMap &Kernels,
+                           FunctionVariableMap &Functions);
 
-LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M);
+/// Collects all uses of Global Variables in \p M using
+/// \ref getUsesOfGVByFunction.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \param Filter Filter for \ref getUsesOfGVByFunction - only GVs for which the
+/// filter returns true will be considered.
+/// \returns Uses of GVs that were found within each function, sorted by
+/// direct and indirect accesses.
+GVUsesInfoTy
+getTransitiveUsesOfGV(const CallGraph &CG, Module &M,
+                      function_ref<bool(const GlobalVariable &)> Filter);
+
+/// Collects all uses of LDS Global Variables in \p M using
+/// \ref getUsesOfGVByFunction, with \ref isLDSVariableToLower as the filter.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \returns Uses of LDS GVs that need lowering that were found within each
+/// function, sorted by direct and indirect accesses.
+GVUsesInfoTy getTransitiveUsesOfLDSForLowering(const CallGraph &CG, Module &M);
 
 /// Strip FnAttr attribute from any functions where we may have
 /// introduced its use.

--- a/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMemoryUtils.h
@@ -46,19 +46,47 @@ TargetExtType *isNamedBarrier(const GlobalVariable &GV);
 bool isDynamicLDS(const GlobalVariable &GV);
 bool isLDSVariableToLower(const GlobalVariable &GV);
 
-struct LDSUsesInfoTy {
-  FunctionVariableMap direct_access;
-  FunctionVariableMap indirect_access;
-  bool HasSpecialGVs = false;
+struct GVUsesInfoTy {
+  FunctionVariableMap DirectAccess;
+  FunctionVariableMap IndirectAccess;
 };
 
-bool eliminateConstantExprUsesOfLDSFromAllInstructions(Module &M);
+/// Iterates over all GlobalVariables in \p M, and whenever \p Filter returns
+/// true, replace all constant users of the GV with instructions.
+bool eliminateGVConstantExprUsesFromAllInstructions(
+    Module &M, function_ref<bool(const GlobalVariable &)> Filter);
 
-void getUsesOfLDSByFunction(const CallGraph &CG, Module &M,
-                            FunctionVariableMap &kernels,
-                            FunctionVariableMap &functions);
+/// Finds uses of Global Variables on a per-function basis.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \param Filter Function that returns true for GVs that need to be considered.
+/// \param Kernels[out] Maps kernels to global variables used by that kernel.
+/// \param Functions[out] Maps functions to global variables used by that
+/// function.
+void getUsesOfGVByFunction(const CallGraph &CG, Module &M,
+                           function_ref<bool(const GlobalVariable &)> Filter,
+                           FunctionVariableMap &Kernels,
+                           FunctionVariableMap &Functions);
 
-LDSUsesInfoTy getTransitiveUsesOfLDS(const CallGraph &CG, Module &M);
+/// Collects all uses of Global Variables in \p M using
+/// \ref getUsesOfGVByFunction.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \param Filter Filter for \ref getUsesOfGVByFunction - only GVs for which the
+/// filter returns true will be considered.
+/// \returns Uses of GVs that were found within each function, sorted by
+/// direct and indirect accesses.
+GVUsesInfoTy
+getTransitiveUsesOfGV(const CallGraph &CG, Module &M,
+                      function_ref<bool(const GlobalVariable &)> Filter);
+
+/// Collects all uses of LDS Global Variables in \p M using
+/// \ref getUsesOfGVByFunction, with \ref isLDSVariableToLower as the filter.
+/// \param CG \p M Call Graph
+/// \param M Module
+/// \returns Uses of LDS GVs that need lowering that were found within each
+/// function, sorted by direct and indirect accesses.
+GVUsesInfoTy getTransitiveUsesOfLDSForLowering(const CallGraph &CG, Module &M);
 
 /// Strip FnAttr attribute from any functions where we may have
 /// introduced its use.

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -1158,15 +1158,16 @@ bool AMDGPUSwLowerLDS::run() {
 
   CallGraph CG = CallGraph(M);
 
-  Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+  Changed |=
+      eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
   // Get all the direct and indirect access of LDS for all the kernels.
-  LDSUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDS(CG, M);
+  GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
   // Flag to decide whether to lower all the LDS accesses
   // based on sanitize_address attribute.
-  bool LowerAllLDS = hasFnWithSanitizeAddressAttr(LDSUsesInfo.direct_access) ||
-                     hasFnWithSanitizeAddressAttr(LDSUsesInfo.indirect_access);
+  bool LowerAllLDS = hasFnWithSanitizeAddressAttr(LDSUsesInfo.DirectAccess) ||
+                     hasFnWithSanitizeAddressAttr(LDSUsesInfo.IndirectAccess);
 
   if (!LowerAllLDS)
     return Changed;
@@ -1205,8 +1206,8 @@ bool AMDGPUSwLowerLDS::run() {
     }
   };
 
-  PopulateKernelStaticDynamicLDS(LDSUsesInfo.direct_access, true);
-  PopulateKernelStaticDynamicLDS(LDSUsesInfo.indirect_access, false);
+  PopulateKernelStaticDynamicLDS(LDSUsesInfo.DirectAccess, true);
+  PopulateKernelStaticDynamicLDS(LDSUsesInfo.IndirectAccess, false);
 
   // Get address sanitizer scale.
   initAsanInfo();

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -1208,15 +1208,16 @@ bool AMDGPUSwLowerLDS::run() {
 
   CallGraph CG = CallGraph(M);
 
-  Changed |= eliminateConstantExprUsesOfLDSFromAllInstructions(M);
+  Changed |=
+      eliminateGVConstantExprUsesFromAllInstructions(M, isLDSVariableToLower);
 
   // Get all the direct and indirect access of LDS for all the kernels.
-  LDSUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDS(CG, M);
+  GVUsesInfoTy LDSUsesInfo = getTransitiveUsesOfLDSForLowering(CG, M);
 
   // Flag to decide whether to lower all the LDS accesses
   // based on sanitize_address attribute.
-  bool LowerAllLDS = hasFnWithSanitizeAddressAttr(LDSUsesInfo.direct_access) ||
-                     hasFnWithSanitizeAddressAttr(LDSUsesInfo.indirect_access);
+  bool LowerAllLDS = hasFnWithSanitizeAddressAttr(LDSUsesInfo.DirectAccess) ||
+                     hasFnWithSanitizeAddressAttr(LDSUsesInfo.IndirectAccess);
 
   if (!LowerAllLDS)
     return Changed;
@@ -1255,8 +1256,8 @@ bool AMDGPUSwLowerLDS::run() {
     }
   };
 
-  PopulateKernelStaticDynamicLDS(LDSUsesInfo.direct_access, true);
-  PopulateKernelStaticDynamicLDS(LDSUsesInfo.indirect_access, false);
+  PopulateKernelStaticDynamicLDS(LDSUsesInfo.DirectAccess, true);
+  PopulateKernelStaticDynamicLDS(LDSUsesInfo.IndirectAccess, false);
 
   // Get address sanitizer scale.
   initAsanInfo();


### PR DESCRIPTION
In preparation for upcoming work, I need some functions used by the LDS lowering
system to work on any GV. I removed the LDS specific queries inside these functions
and replaced them with functors passed by the caller, so these utility functions can be reused.

I also cleaned-up a few things that weren't up to code, such as lowercase variable names.