### PR TITLE
[orc-rt] Change SPS controller-interface naming conventions.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -85,12 +85,12 @@ const char *RunAsIntFunctionWrapperName =
 
 const SimpleExecutorMemoryManagerSymbolNames
     orc_rt_SimpleNativeMemoryMapSPSSymbols = {
-        "orc_rt_SimpleNativeMemoryMap_Instance",
-        "orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper",
-        "orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper",
-        "orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper",
-        "orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper",
-};
+        "orc_rt_ci_SimpleNativeMemoryMap_Instance",
+        "orc_rt_ci_sps_SimpleNativeMemoryMap_reserve",
+        "orc_rt_ci_sps_SimpleNativeMemoryMap_initialize",
+        "orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple",
+        "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple",
+    };
 
 } // end namespace rt
 namespace rt_alt {

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -90,7 +90,7 @@ const SimpleExecutorMemoryManagerSymbolNames
         "orc_rt_ci_sps_SimpleNativeMemoryMap_initialize",
         "orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple",
         "orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple",
-    };
+};
 
 } // end namespace rt
 namespace rt_alt {

--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -50,7 +50,7 @@ public:
   /// SimpleSymbolTable (typically the BootstrapInfo table).
   static Expected<std::unique_ptr<SimpleNativeMemoryMap>>
   Create(Session &S, SimpleSymbolTable &ST,
-         const char *InstanceName = "orc_rt_SimpleNativeMemoryMap_Instance",
+         const char *InstanceName = "orc_rt_ci_SimpleNativeMemoryMap_Instance",
          SimpleSymbolTable::MutatorFn AddInterface =
              sps_ci::addSimpleNativeMemoryMap);
 

--- a/orc-rt/lib/executor/sps-ci/MemoryAccessSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/MemoryAccessSPSCI.cpp
@@ -76,79 +76,79 @@ void readStrings(
 } // anonymous namespace
 namespace orc_rt::sps_ci {
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_write_uint8s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_write_uint8s,
                    void(SPSSequence<SPSTuple<SPSExecutorAddr, uint8_t>>),
                    writePrimitives<uint8_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_write_uint16s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_write_uint16s,
                    void(SPSSequence<SPSTuple<SPSExecutorAddr, uint16_t>>),
                    writePrimitives<uint16_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_write_uint32s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_write_uint32s,
                    void(SPSSequence<SPSTuple<SPSExecutorAddr, uint32_t>>),
                    writePrimitives<uint32_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_write_uint64s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_write_uint64s,
                    void(SPSSequence<SPSTuple<SPSExecutorAddr, uint64_t>>),
                    writePrimitives<uint64_t>);
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_mem_write_pointers_sps_wrapper,
+    orc_rt_ci_sps_mem_write_pointers,
     void(SPSSequence<SPSTuple<SPSExecutorAddr, SPSExecutorAddr>>),
     writePrimitives<void *>);
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_mem_write_buffers_sps_wrapper,
+    orc_rt_ci_sps_mem_write_buffers,
     void(SPSSequence<SPSTuple<SPSExecutorAddr, SPSSequence<char>>>),
     writeBuffers);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_uint8s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_uint8s,
                    SPSSequence<uint8_t>(SPSSequence<SPSExecutorAddr>),
                    readPrimitives<uint8_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_uint16s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_uint16s,
                    SPSSequence<uint16_t>(SPSSequence<SPSExecutorAddr>),
                    readPrimitives<uint16_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_uint32s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_uint32s,
                    SPSSequence<uint32_t>(SPSSequence<SPSExecutorAddr>),
                    readPrimitives<uint32_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_uint64s_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_uint64s,
                    SPSSequence<uint64_t>(SPSSequence<SPSExecutorAddr>),
                    readPrimitives<uint64_t>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_pointers_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_pointers,
                    SPSSequence<SPSExecutorAddr>(SPSSequence<SPSExecutorAddr>),
                    readPrimitives<void *>);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_buffers_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_buffers,
                    SPSSequence<SPSSequence<char>>(
                        SPSSequence<SPSTuple<SPSExecutorAddr, uint64_t>>),
                    readBuffers);
 
-ORC_RT_SPS_WRAPPER(orc_rt_sps_ci_mem_read_strings_sps_wrapper,
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_mem_read_strings,
                    SPSSequence<SPSString>(SPSSequence<SPSExecutorAddr>),
                    readStrings);
 
 static std::pair<const char *, const void *>
-    orc_rt_sps_ci_MemoryAccess_sps_interface[] = {
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_uint8s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_uint16s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_uint32s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_uint64s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_pointers_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_write_buffers_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_uint8s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_uint16s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_uint32s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_uint64s_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_pointers_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_buffers_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_mem_read_strings_sps_wrapper)};
+    orc_rt_ci_MemoryAccess_sps_interface[] = {
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_uint8s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_uint16s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_uint32s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_uint64s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_pointers),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_write_buffers),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_uint8s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_uint16s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_uint32s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_uint64s),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_pointers),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_buffers),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_mem_read_strings)};
 
 Error addMemoryAccess(SimpleSymbolTable &ST) {
-  return ST.addUnique(orc_rt_sps_ci_MemoryAccess_sps_interface);
+  return ST.addUnique(orc_rt_ci_MemoryAccess_sps_interface);
 }
 
 } // namespace orc_rt::sps_ci

--- a/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
@@ -17,30 +17,29 @@
 namespace orc_rt::sps_ci {
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_NativeDylibManager_load_sps_wrapper,
+    orc_rt_ci_sps_NativeDylibManager_load,
     SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSString),
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::load))
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_NativeDylibManager_unload_sps_wrapper,
+    orc_rt_ci_sps_NativeDylibManager_unload,
     SPSError(SPSExecutorAddr, SPSExecutorAddr),
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::unload))
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_NativeDylibManager_lookup_sps_wrapper,
+    orc_rt_ci_sps_NativeDylibManager_lookup,
     SPSExpected<SPSSequence<SPSExecutorAddr>>(SPSExecutorAddr, SPSExecutorAddr,
                                               SPSSequence<SPSString>),
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::lookup))
 
 static std::pair<const char *, const void *>
-    orc_rt_sps_ci_NativeDylibManager_sps_interface[] = {
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_NativeDylibManager_load_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(orc_rt_sps_ci_NativeDylibManager_unload_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(
-            orc_rt_sps_ci_NativeDylibManager_lookup_sps_wrapper)};
+    orc_rt_ci_NativeDylibManager_sps_interface[] = {
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_load),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_unload),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_lookup)};
 
 Error addNativeDylibManager(SimpleSymbolTable &ST) {
-  return ST.addUnique(orc_rt_sps_ci_NativeDylibManager_sps_interface);
+  return ST.addUnique(orc_rt_ci_NativeDylibManager_sps_interface);
 }
 
 } // namespace orc_rt::sps_ci

--- a/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/SimpleNativeMemoryMapSPSCI.cpp
@@ -63,41 +63,36 @@ public:
 namespace sps_ci {
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper,
+    orc_rt_ci_sps_SimpleNativeMemoryMap_reserve,
     SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSSize),
     WrapperFunction::handleWithAsyncMethod(&SimpleNativeMemoryMap::reserve))
 
-ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper,
-    SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>),
-    WrapperFunction::handleWithAsyncMethod(
-        &SimpleNativeMemoryMap::releaseMultiple))
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple,
+                   SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>),
+                   WrapperFunction::handleWithAsyncMethod(
+                       &SimpleNativeMemoryMap::releaseMultiple))
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_SimpleNativeMemoryMap_initialize_sps_wrapper,
+    orc_rt_ci_sps_SimpleNativeMemoryMap_initialize,
     SPSExpected<SPSExecutorAddr>(SPSExecutorAddr,
                                  SPSSimpleNativeMemoryMapInitializeRequest),
     WrapperFunction::handleWithAsyncMethod(&SimpleNativeMemoryMap::initialize))
 
-ORC_RT_SPS_WRAPPER(
-    orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper,
-    SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>),
-    WrapperFunction::handleWithAsyncMethod(
-        &SimpleNativeMemoryMap::deinitializeMultiple))
+ORC_RT_SPS_WRAPPER(orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple,
+                   SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>),
+                   WrapperFunction::handleWithAsyncMethod(
+                       &SimpleNativeMemoryMap::deinitializeMultiple))
 
 static std::pair<const char *, const void *>
-    orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface[] = {
+    orc_rt_ci_SimpleNativeMemoryMap_sps_interface[] = {
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_SimpleNativeMemoryMap_reserve),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple),
+        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_SimpleNativeMemoryMap_initialize),
         ORC_RT_SYMTAB_PAIR(
-            orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(
-            orc_rt_sps_ci_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(
-            orc_rt_sps_ci_SimpleNativeMemoryMap_initialize_sps_wrapper),
-        ORC_RT_SYMTAB_PAIR(
-            orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper)};
+            orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple)};
 
 Error addSimpleNativeMemoryMap(SimpleSymbolTable &ST) {
-  return ST.addUnique(orc_rt_sps_ci_SimpleNativeMemoryMap_sps_interface);
+  return ST.addUnique(orc_rt_ci_SimpleNativeMemoryMap_sps_interface);
 }
 
 } // namespace sps_ci

--- a/orc-rt/unittests/BootstrapInfoTest.cpp
+++ b/orc-rt/unittests/BootstrapInfoTest.cpp
@@ -75,8 +75,8 @@ TEST(BootstrapInfoTest, CreateDefaultContainsSPSCISymbols) {
             noErrors);
   auto BI = cantFail(BootstrapInfo::CreateDefault(S));
   // The default addAll should have registered SPS CI symbols.
-  EXPECT_TRUE(BI.symbols().count(
-      "orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper"));
+  EXPECT_TRUE(
+      BI.symbols().count("orc_rt_ci_sps_SimpleNativeMemoryMap_reserve"));
 }
 
 TEST(BootstrapInfoTest, CreateDefaultWithNoSymbolsBuilder) {
@@ -87,8 +87,8 @@ TEST(BootstrapInfoTest, CreateDefaultWithNoSymbolsBuilder) {
   // Should still contain the session symbol (added unconditionally).
   ASSERT_TRUE(BI.symbols().count("orc_rt_Session_Instance"));
   // But no SPS CI symbols.
-  EXPECT_FALSE(BI.symbols().count(
-      "orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper"));
+  EXPECT_FALSE(
+      BI.symbols().count("orc_rt_ci_sps_SimpleNativeMemoryMap_reserve"));
 }
 
 TEST(BootstrapInfoTest, CreateDefaultWithCustomValuesBuilder) {

--- a/orc-rt/unittests/MemoryAccessSPSCITest.cpp
+++ b/orc-rt/unittests/MemoryAccessSPSCITest.cpp
@@ -32,19 +32,19 @@ protected:
 };
 
 TEST_F(MemoryAccessSPSCITest, Registration) {
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_uint8s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_uint16s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_uint32s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_uint64s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_pointers_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_write_buffers_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_uint8s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_uint16s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_uint32s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_uint64s_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_pointers_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_buffers_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_mem_read_strings_sps_wrapper"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_uint8s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_uint16s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_uint32s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_uint64s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_pointers"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_write_buffers"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_uint8s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_uint16s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_uint32s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_uint64s"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_pointers"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_buffers"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_mem_read_strings"));
 }
 
 TEST_F(MemoryAccessSPSCITest, WriteUInt8s) {
@@ -53,7 +53,7 @@ TEST_F(MemoryAccessSPSCITest, WriteUInt8s) {
   std::vector<std::pair<ExecutorAddr, uint8_t>> Writes = {
       {ExecutorAddr::fromPtr(&X), 42}, {ExecutorAddr::fromPtr(&Y), 255}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_uint8s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_uint8s"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(X, 42U);
   EXPECT_EQ(Y, 255U);
@@ -65,7 +65,7 @@ TEST_F(MemoryAccessSPSCITest, WriteUInt16s) {
   std::vector<std::pair<ExecutorAddr, uint16_t>> Writes = {
       {ExecutorAddr::fromPtr(&X), 1000}, {ExecutorAddr::fromPtr(&Y), 65535}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_uint16s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_uint16s"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(X, 1000U);
   EXPECT_EQ(Y, 65535U);
@@ -78,7 +78,7 @@ TEST_F(MemoryAccessSPSCITest, WriteUInt32s) {
       {ExecutorAddr::fromPtr(&X), 100000},
       {ExecutorAddr::fromPtr(&Y), 0xdeadbeef}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_uint32s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_uint32s"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(X, 100000U);
   EXPECT_EQ(Y, 0xdeadbeefU);
@@ -91,7 +91,7 @@ TEST_F(MemoryAccessSPSCITest, WriteUInt64s) {
       {ExecutorAddr::fromPtr(&X), 0x0102030405060708ULL},
       {ExecutorAddr::fromPtr(&Y), 0xdeadbeefcafef00dULL}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_uint64s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_uint64s"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(X, 0x0102030405060708ULL);
   EXPECT_EQ(Y, 0xdeadbeefcafef00dULL);
@@ -105,7 +105,7 @@ TEST_F(MemoryAccessSPSCITest, WritePointers) {
       {ExecutorAddr::fromPtr(&X), ExecutorAddr::fromPtr(&A)},
       {ExecutorAddr::fromPtr(&Y), ExecutorAddr::fromPtr(&B)}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_pointers_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_pointers"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(X, static_cast<void *>(&A));
   EXPECT_EQ(Y, static_cast<void *>(&B));
@@ -119,7 +119,7 @@ TEST_F(MemoryAccessSPSCITest, WriteBuffers) {
   std::vector<std::pair<ExecutorAddr, span<char>>> Writes = {
       {ExecutorAddr::fromPtr(Buf), span<char>(Content, sizeof(Content))}};
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_write_buffers_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_write_buffers"),
       [](Error Err) { cantFail(std::move(Err)); }, std::move(Writes));
   EXPECT_EQ(Buf[0], 'h');
   EXPECT_EQ(Buf[1], 'e');
@@ -136,7 +136,7 @@ TEST_F(MemoryAccessSPSCITest, ReadUInt8s) {
                                      ExecutorAddr::fromPtr(&Y)};
   std::vector<uint8_t> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_uint8s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_uint8s"),
       [&](Expected<std::vector<uint8_t>> R) {
         Result = cantFail(std::move(R));
       },
@@ -153,7 +153,7 @@ TEST_F(MemoryAccessSPSCITest, ReadUInt16s) {
                                      ExecutorAddr::fromPtr(&Y)};
   std::vector<uint16_t> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_uint16s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_uint16s"),
       [&](Expected<std::vector<uint16_t>> R) {
         Result = cantFail(std::move(R));
       },
@@ -170,7 +170,7 @@ TEST_F(MemoryAccessSPSCITest, ReadUInt32s) {
                                      ExecutorAddr::fromPtr(&Y)};
   std::vector<uint32_t> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_uint32s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_uint32s"),
       [&](Expected<std::vector<uint32_t>> R) {
         Result = cantFail(std::move(R));
       },
@@ -187,7 +187,7 @@ TEST_F(MemoryAccessSPSCITest, ReadUInt64s) {
                                      ExecutorAddr::fromPtr(&Y)};
   std::vector<uint64_t> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_uint64s_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_uint64s"),
       [&](Expected<std::vector<uint64_t>> R) {
         Result = cantFail(std::move(R));
       },
@@ -205,7 +205,7 @@ TEST_F(MemoryAccessSPSCITest, ReadPointers) {
                                      ExecutorAddr::fromPtr(&Y)};
   std::vector<void *> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_pointers_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_pointers"),
       [&](Expected<std::vector<void *>> R) { Result = cantFail(std::move(R)); },
       std::move(Addrs));
   ASSERT_EQ(Result.size(), 2U);
@@ -222,7 +222,7 @@ TEST_F(MemoryAccessSPSCITest, ReadBuffers) {
       {ExecutorAddr::fromPtr(Src + 6), 5}}; // "world"
   std::vector<std::vector<char>> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_buffers_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_buffers"),
       [&](Expected<std::vector<std::vector<char>>> R) {
         Result = cantFail(std::move(R));
       },
@@ -240,7 +240,7 @@ TEST_F(MemoryAccessSPSCITest, ReadStrings) {
                                      ExecutorAddr::fromPtr(Str2)};
   std::vector<std::string> Result;
   SPSWrapperFunction<SPSSig>::call(
-      caller("orc_rt_sps_ci_mem_read_strings_sps_wrapper"),
+      caller("orc_rt_ci_sps_mem_read_strings"),
       [&](Expected<std::vector<std::string>> R) {
         Result = cantFail(std::move(R));
       },

--- a/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
@@ -51,7 +51,7 @@ protected:
   void spsLoad(OnCompleteFn &&OnComplete, std::string Path) {
     using SPSSig = SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSString);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_NativeDylibManager_load_sps_wrapper"),
+        caller("orc_rt_ci_sps_NativeDylibManager_load"),
         std::forward<OnCompleteFn>(OnComplete), NDM.get(), std::move(Path));
   }
 
@@ -59,7 +59,7 @@ protected:
   void spsUnload(OnCompleteFn &&OnComplete, void *Handle) {
     using SPSSig = SPSError(SPSExecutorAddr, SPSExecutorAddr);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_NativeDylibManager_unload_sps_wrapper"),
+        caller("orc_rt_ci_sps_NativeDylibManager_unload"),
         std::forward<OnCompleteFn>(OnComplete), NDM.get(), Handle);
   }
 
@@ -69,7 +69,7 @@ protected:
     using SPSSig = SPSExpected<SPSSequence<SPSExecutorAddr>>(
         SPSExecutorAddr, SPSExecutorAddr, SPSSequence<SPSString>);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_NativeDylibManager_lookup_sps_wrapper"),
+        caller("orc_rt_ci_sps_NativeDylibManager_lookup"),
         std::forward<OnCompleteFn>(OnComplete), NDM.get(), Handle,
         std::move(Names));
   }
@@ -80,9 +80,9 @@ protected:
 };
 
 TEST_F(NativeDylibManagerSPSCITest, Registration) {
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_NativeDylibManager_load_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_NativeDylibManager_unload_sps_wrapper"));
-  EXPECT_TRUE(CI.count("orc_rt_sps_ci_NativeDylibManager_lookup_sps_wrapper"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_load"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_unload"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_lookup"));
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LoadAndUnload) {

--- a/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapSPSCITest.cpp
@@ -135,7 +135,7 @@ protected:
   void spsReserve(OnCompleteFn &&OnComplete, size_t Size) {
     using SPSSig = SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSSize);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper"),
+        caller("orc_rt_ci_sps_SimpleNativeMemoryMap_reserve"),
         std::forward<OnCompleteFn>(OnComplete), SNMM.get(), Size);
   }
 
@@ -143,8 +143,7 @@ protected:
   void spsReleaseMultiple(OnCompleteFn &&OnComplete, span<void *> Addrs) {
     using SPSSig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);
     SPSWrapperFunction<SPSSig>::call(
-        caller(
-            "orc_rt_sps_ci_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper"),
+        caller("orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple"),
         std::forward<OnCompleteFn>(OnComplete), SNMM.get(), Addrs);
   }
 
@@ -153,7 +152,7 @@ protected:
     using SPSSig = SPSExpected<SPSExecutorAddr>(
         SPSExecutorAddr, SPSSimpleNativeMemoryMapInitializeRequest);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_SimpleNativeMemoryMap_initialize_sps_wrapper"),
+        caller("orc_rt_ci_sps_SimpleNativeMemoryMap_initialize"),
         std::forward<OnCompleteFn>(OnComplete), SNMM.get(), std::move(IR));
   }
 
@@ -161,8 +160,7 @@ protected:
   void spsDeinitializeMultiple(OnCompleteFn &&OnComplete, span<void *> Bases) {
     using SPSSig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);
     SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_"
-               "wrapper"),
+        caller("orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple"),
         std::forward<OnCompleteFn>(OnComplete), SNMM.get(), Bases);
   }
 
@@ -172,14 +170,11 @@ protected:
 };
 
 TEST_F(SimpleNativeMemoryMapSPSCITest, Registration) {
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_SimpleNativeMemoryMap_reserve"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_SimpleNativeMemoryMap_releaseMultiple"));
+  EXPECT_TRUE(CI.count("orc_rt_ci_sps_SimpleNativeMemoryMap_initialize"));
   EXPECT_TRUE(
-      CI.count("orc_rt_sps_ci_SimpleNativeMemoryMap_reserve_sps_wrapper"));
-  EXPECT_TRUE(CI.count(
-      "orc_rt_sps_ci_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper"));
-  EXPECT_TRUE(
-      CI.count("orc_rt_sps_ci_SimpleNativeMemoryMap_initialize_sps_wrapper"));
-  EXPECT_TRUE(CI.count(
-      "orc_rt_sps_ci_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper"));
+      CI.count("orc_rt_ci_sps_SimpleNativeMemoryMap_deinitializeMultiple"));
 }
 
 TEST_F(SimpleNativeMemoryMapSPSCITest, ReserveAndRelease) {


### PR DESCRIPTION
This commit makes two changes to the naming conventions for SPS CI symbols:

1. The orc_rt_sps_ci_ prefix is replaced with orc_rt_ci_sps_ (for SPS wrapper functions) and orc_rt_ci_ (without the "sps_" suffix) for data symbols.

2. The _sps_wrapper suffix is dropped from wrapper functions, since the prefix now distinguishes between SPS-wrappers and data symbols.