### PR TITLE
[VPlan] Apply flags, metadata when executing scalar casts (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1625,6 +1625,10 @@ void VPInstructionWithType::execute(VPTransformState &State) {
     Value *Op = State.get(getOperand(0), VPLane(0));
     Value *Cast = State.Builder.CreateCast(Instruction::CastOps(getOpcode()),
                                            Op, ResultTy);
+    if (auto *CastOp = dyn_cast<Instruction>(Cast)) {
+      applyFlags(*CastOp);
+      applyMetadata(*CastOp);
+    }
     State.set(this, Cast, VPLane(0));
     return;
   }


### PR DESCRIPTION
The change is non-functional because scalar casts are only ever created by VPlanConstruction, which are turned into wide or replicate recipes prior to execution. The change is in preparation to make scalar casts flow through unconverted.