### PR TITLE
[LangRef] Clarify requirement for non-pow-2 align bundle

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3152,7 +3152,7 @@ the behavior is undefined, unless one of the following exceptions applies:
 
 * ``"align"`` operand bundles may specify a non-power-of-two alignment
   (including a zero alignment). If this is the case, then the pointer value
-  must be a null pointer, otherwise the behavior is undefined.
+  must be an all-zero pointer, otherwise the behavior is undefined.
 
 * ``dereferenceable(<n>)`` operand bundles only guarantee the pointer is
   dereferenceable at the point of the assumption. The pointer may not be


### PR DESCRIPTION
Now that null pointers are not necessarily zero pointers, I believe that `"align"` with a non-power-of-two alignment should be requiring a zero pointer specifically, not a null pointer.

This is because a zero pointer is aligned for any alignment (which we can generalize to non-power-of-two alignments), while a -1 null pointer only has alignment 1.