### PR TITLE
[flang][OpenMP] Fix data race with LINEAR clause on PARALLEL DO SIMD

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3527,6 +3527,17 @@ static mlir::omp::DistributeOp genCompositeDistributeParallelDoSimd(
   genSimdClauses(converter, semaCtx, simdItem->clauses, loc, simdClauseOps,
                  simdReductionSyms, &reductionVarCache);
 
+  // Same as genCompositeDoSimd.
+  if (!simdClauseOps.linearVars.empty()) {
+    wsloopClauseOps.linearVars = std::move(simdClauseOps.linearVars);
+    wsloopClauseOps.linearStepVars = std::move(simdClauseOps.linearStepVars);
+    wsloopClauseOps.linearVarTypes = simdClauseOps.linearVarTypes;
+    wsloopClauseOps.linearModifiers = simdClauseOps.linearModifiers;
+    simdClauseOps.linearVars.clear();
+    simdClauseOps.linearStepVars.clear();
+    simdClauseOps.linearVarTypes = nullptr;
+    simdClauseOps.linearModifiers = nullptr;
+  }
   DataSharingProcessor simdItemDSP(converter, semaCtx, simdItem->clauses, eval,
                                    /*shouldCollectPreDeterminedSymbols=*/true,
                                    /*useDelayedPrivatization=*/true, symTable);
@@ -3662,6 +3673,19 @@ static mlir::omp::WsloopOp genCompositeDoSimd(
   genSimdClauses(converter, semaCtx, simdItem->clauses, loc, simdClauseOps,
                  simdReductionSyms, &reductionVarCache);
 
+  // omp.simd writes back linear vars unconditionally, causing a race when
+  // inside a parallel region. Move them to wsloop which has proper last-iter
+  // write-back guarded by a barrier.
+  if (!simdClauseOps.linearVars.empty()) {
+    wsloopClauseOps.linearVars = std::move(simdClauseOps.linearVars);
+    wsloopClauseOps.linearStepVars = std::move(simdClauseOps.linearStepVars);
+    wsloopClauseOps.linearVarTypes = simdClauseOps.linearVarTypes;
+    wsloopClauseOps.linearModifiers = simdClauseOps.linearModifiers;
+    simdClauseOps.linearVars.clear();
+    simdClauseOps.linearStepVars.clear();
+    simdClauseOps.linearVarTypes = nullptr;
+    simdClauseOps.linearModifiers = nullptr;
+  }
   DataSharingProcessor wsloopItemDSP(
       converter, semaCtx, doItem->clauses, eval,
       /*shouldCollectPreDeterminedSymbols=*/false,

--- a/flang/test/Lower/OpenMP/composite_simd_linear.f90
+++ b/flang/test/Lower/OpenMP/composite_simd_linear.f90
@@ -7,13 +7,13 @@ subroutine do_simd
 !CHECK: %[[X:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdo_simdEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK: %[[CONST:.*]] = arith.constant 1 : i32
 !CHECK: %{{.*}} = arith.constant 1 : i32
-!CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
-!CHECK: omp.wsloop {
-!DEFAULT: omp.simd linear(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32, %[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) private(@_QFdo_simdEi_private_i32 {{.*}} -> %arg0 : !fir.ref<i32>) {
-!OPENMP52: omp.simd linear(val(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32), val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) private(@_QFdo_simdEi_private_i32 {{.*}} -> %arg0 : !fir.ref<i32>) {
+!CHECK: %{{.*}} = arith.constant 1 : i32
+!DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = {{.*}}) {
+!OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = {{.*}})) {
+!CHECK: omp.simd linear({{.*}}) private(@_QFdo_simdEi_private_i32 {{.*}} -> %arg0 : !fir.ref<i32>) {
 !CHECK: }
-!CHECK: } {linear_var_types = [i32, i32], omp.composite}
-!CHECK: } {omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
     integer :: x
     !$omp do simd linear(x:1)
     do i = 1, N
@@ -45,15 +45,18 @@ subroutine distribute_parallel_do
 !CHECK: omp.teams {
 !CHECK: omp.parallel {
 !CHECK: %[[CONST]] = arith.constant 1 : i32
+!CHECK: %{{.*}} = arith.constant 1 : i32
+!CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
 !CHECK: omp.distribute {
-!CHECK: omp.wsloop {
-!DEFAULT: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[CONST]] : i32) private(@_QFdistribute_parallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
-!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[CONST]] : i32)) private(@_QFdistribute_parallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
+!DEFAULT: omp.wsloop linear(%[[I]]#0 : !fir.ref<i32> = {{.*}}) {
+!OPENMP52: omp.wsloop linear(val(%[[I]]#0 : !fir.ref<i32> = {{.*}})) {
+!CHECK: omp.simd linear({{.*}}) private(@_QFdistribute_parallel_doEi_private_i32 {{.*}}) {
     !$omp teams
     !$omp distribute parallel do simd linear(i:1)
     do i = 1, N
     end do
     !$omp end distribute parallel do simd
+!CHECK: } {linear_var_types = [i32], omp.composite}
 !CHECK: } {linear_var_types = [i32], omp.composite}
     !$omp end teams
 end subroutine distribute_parallel_do
@@ -64,16 +67,17 @@ subroutine parallel_do
 !CHECK: omp.parallel {
 !CHECK: %[[LINEAR_STEP:.*]] = arith.constant 2 : i32
 !CHECK: %{{.*}} = arith.constant 1 : i32
-!CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
-!CHECK: omp.wsloop {
-!DEFAULT: omp.simd linear(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32, %[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) private(@_QFparallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
-!OPENMP52: omp.simd linear(val(%[[X]]#0 : !fir.ref<i32> = %[[LINEAR_STEP]] : i32), val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) private(@_QFparallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
+!CHECK: %{{.*}} = arith.constant 1 : i32
+!DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = {{.*}}) {
+!OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = {{.*}})) {
+!CHECK: omp.simd linear({{.*}}) private(@_QFparallel_doEi_private_i32 {{.*}}) {
     integer :: x
     !$omp parallel do simd linear(x:2)
     do i = 1, N
     end do
     !$omp end parallel do simd
-!CHECK: } {linear_var_types = [i32, i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine parallel_do
 
 subroutine teams_distribute
@@ -103,13 +107,14 @@ subroutine teams_distribute_parallel_do
 !CHECK: %{{.*}} = arith.constant 1 : i32
 !CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
 !CHECK: omp.distribute {
-!CHECK: omp.wsloop {
-!DEFAULT: omp.simd linear(%[[X]]#0 : !fir.ref<i32> = %c1_i32 : i32, %[[I]]#0 : !fir.ref<i32> = %c1_i32_1 : i32) private(@_QFteams_distribute_parallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
-!OPENMP52: omp.simd linear(val(%[[X]]#0 : !fir.ref<i32> = %c1_i32 : i32), val(%[[I]]#0 : !fir.ref<i32> = %c1_i32_1 : i32)) private(@_QFteams_distribute_parallel_doEi_private_i32 %[[I]]#0 -> %arg0 : !fir.ref<i32>) {
+!DEFAULT: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = {{.*}}) {
+!OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = {{.*}})) {
+!CHECK: omp.simd linear({{.*}}) private(@_QFteams_distribute_parallel_doEi_private_i32 {{.*}}) {
     integer :: x
     !$omp teams distribute parallel do simd linear(x)
     do i = 1, N
     end do
     !$omp end teams distribute parallel do simd
-!CHECK: } {linear_var_types = [i32, i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine teams_distribute_parallel_do

--- a/flang/test/Lower/OpenMP/linear_modifier.f90
+++ b/flang/test/Lower/OpenMP/linear_modifier.f90
@@ -41,14 +41,15 @@ subroutine do_simd_linear
 !CHECK: %[[CONST:.*]] = arith.constant 1 : i32
 !CHECK: %{{.*}} = arith.constant 1 : i32
 !CHECK: %[[IV_STEP:.*]] = arith.constant 1 : i32
-!CHECK: omp.wsloop {
-!OPENMP52: omp.simd linear(val(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32), val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) private({{.*}}) {
-!OPENMP45: omp.simd linear(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32, %[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) private({{.*}}) {
+!OPENMP52: omp.wsloop linear(val(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32)) {
+!OPENMP45: omp.wsloop linear(%[[X]]#0 : !fir.ref<i32> = %[[CONST]] : i32) {
+!OPENMP52: omp.simd linear(val(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32)) private({{.*}}) {
+!OPENMP45: omp.simd linear(%[[I]]#0 : !fir.ref<i32> = %[[IV_STEP]] : i32) private({{.*}}) {
     integer :: x
     !$omp do simd linear(x:1)
     do i = 1, 10
     end do
     !$omp end do simd
-!CHECK: } {linear_var_types = [i32, i32], omp.composite}
-!CHECK: } {omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
+!CHECK: } {linear_var_types = [i32], omp.composite}
 end subroutine do_simd_linear


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/180093
LINEAR variables on composite DO SIMD were being lowered onto omp.simd, which writes back unconditionally causing a race inside PARALLEL. Move them to omp.wsloop instead, which already has correct last-iter write-back with a barrier.