### PR TITLE
[MLIR] Refactor DCE helper to expose worklist entry-point, and use this helper in CSE

### DIFF
--- a/flang/test/Fir/affine-promotion.fir
+++ b/flang/test/Fir/affine-promotion.fir
@@ -49,26 +49,25 @@ func.func @loop_with_load_and_store(%a1: !arr_d1, %a2: !arr_d1, %a3: !arr_d1) {
 // CHECK:  func @loop_with_load_and_store(%[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_1:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_2:.*]]: !fir.ref<!fir.array<?xf32>>) {
 // CHECK:    %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK:    %[[VAL_4:.*]] = arith.constant 100 : index
-// CHECK:    %[[VAL_5:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
-// CHECK:    %[[VAL_6:.*]] = affine.apply #{{.*}}(){{\[}}%[[VAL_3]], %[[VAL_4]]]
-// CHECK:    %[[VAL_7:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_6]]
-// CHECK:    %[[VAL_8:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
-// CHECK:    %[[VAL_9:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
-// CHECK:    %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
-// CHECK:    affine.for %[[VAL_11:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_4]]] {
-// CHECK:      %[[VAL_12:.*]] = affine.apply #{{.*}}(%[[VAL_11]]){{\[}}%[[VAL_3]], %[[VAL_4]], %[[VAL_3]]]
-// CHECK:      %[[VAL_13:.*]] = affine.load %[[VAL_8]]{{\[}}%[[VAL_12]]] : memref<?xf32>
-// CHECK:      %[[VAL_14:.*]] = affine.load %[[VAL_9]]{{\[}}%[[VAL_12]]] : memref<?xf32>
-// CHECK:      %[[VAL_15:.*]] = arith.addf %[[VAL_13]], %[[VAL_14]] : f32
-// CHECK:      affine.store %[[VAL_15]], %[[VAL_10]]{{\[}}%[[VAL_12]]] : memref<?xf32>
+// CHECK:    %[[VAL_5:.*]] = affine.apply #{{.*}}(){{\[}}%[[VAL_3]], %[[VAL_4]]]
+// CHECK:    %[[VAL_6:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_5]]
+// CHECK:    %[[VAL_7:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
+// CHECK:    %[[VAL_8:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
+// CHECK:    %[[VAL_9:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
+// CHECK:    affine.for %[[VAL_10:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_4]]] {
+// CHECK:      %[[VAL_11:.*]] = affine.apply #{{.*}}(%[[VAL_10]]){{\[}}%[[VAL_3]], %[[VAL_4]], %[[VAL_3]]]
+// CHECK:      %[[VAL_12:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_11]]] : memref<?xf32>
+// CHECK:      %[[VAL_13:.*]] = affine.load %[[VAL_8]]{{\[}}%[[VAL_11]]] : memref<?xf32>
+// CHECK:      %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f32
+// CHECK:      affine.store %[[VAL_14]], %[[VAL_9]]{{\[}}%[[VAL_11]]] : memref<?xf32>
 // CHECK:    }
-// CHECK:    %[[VAL_16:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
-// CHECK:    affine.for %[[VAL_17:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_4]]] {
-// CHECK:      %[[VAL_18:.*]] = affine.apply #{{.*}}(%[[VAL_17]]){{\[}}%[[VAL_3]], %[[VAL_4]], %[[VAL_3]]]
-// CHECK:      %[[VAL_19:.*]] = affine.load %[[VAL_10]]{{\[}}%[[VAL_18]]] : memref<?xf32>
-// CHECK:      %[[VAL_20:.*]] = affine.load %[[VAL_9]]{{\[}}%[[VAL_18]]] : memref<?xf32>
-// CHECK:      %[[VAL_21:.*]] = arith.mulf %[[VAL_19]], %[[VAL_20]] : f32
-// CHECK:      affine.store %[[VAL_21]], %[[VAL_16]]{{\[}}%[[VAL_18]]] : memref<?xf32>
+// CHECK:    %[[VAL_15:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
+// CHECK:    affine.for %[[VAL_16:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_4]]] {
+// CHECK:      %[[VAL_17:.*]] = affine.apply #{{.*}}(%[[VAL_16]]){{\[}}%[[VAL_3]], %[[VAL_4]], %[[VAL_3]]]
+// CHECK:      %[[VAL_18:.*]] = affine.load %[[VAL_9]]{{\[}}%[[VAL_17]]] : memref<?xf32>
+// CHECK:      %[[VAL_19:.*]] = affine.load %[[VAL_8]]{{\[}}%[[VAL_17]]] : memref<?xf32>
+// CHECK:      %[[VAL_20:.*]] = arith.mulf %[[VAL_18]], %[[VAL_19]] : f32
+// CHECK:      affine.store %[[VAL_20]], %[[VAL_15]]{{\[}}%[[VAL_17]]] : memref<?xf32>
 // CHECK:    }
 // CHECK:    return
 // CHECK:  }
@@ -108,25 +107,21 @@ func.func @loop_with_if(%a: !arr_d1, %v: f32) {
 }
 
 // CHECK: func @loop_with_if(%[[VAL_0:.*]]: !fir.ref<!fir.array<?xf32>>, %[[VAL_1:.*]]: f32) {
-// CHECK:   %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK:   %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK:   %[[VAL_4:.*]] = arith.constant 2 : index
-// CHECK:   %[[VAL_5:.*]] = arith.constant 100 : index
-// CHECK:   %[[VAL_6:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
-// CHECK:   %[[VAL_7:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
-// CHECK:   affine.for %[[VAL_8:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_5]]] {
-// CHECK:     %[[VAL_9:.*]] = affine.apply #{{.*}}(%[[VAL_8]]){{\[}}%[[VAL_3]], %[[VAL_5]], %[[VAL_3]]]
-// CHECK:     affine.store %[[VAL_1]], %[[VAL_7]]{{\[}}%[[VAL_9]]] : memref<?xf32>
+// CHECK:   %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK:   %[[VAL_3:.*]] = arith.constant 100 : index
+// CHECK:   %[[VAL_4:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.array<?xf32>>) -> memref<?xf32>
+// CHECK:   affine.for %[[VAL_5:.*]] = %[[VAL_2]] to #{{.*}}(){{\[}}%[[VAL_3]]] {
+// CHECK:     %[[VAL_6:.*]] = affine.apply #{{.*}}(%[[VAL_5]]){{\[}}%[[VAL_2]], %[[VAL_3]], %[[VAL_2]]]
+// CHECK:     affine.store %[[VAL_1]], %[[VAL_4]]{{\[}}%[[VAL_6]]] : memref<?xf32>
 // CHECK:   }
-// CHECK:   affine.for %[[VAL_10:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_5]]] {
-// CHECK:     %[[VAL_11:.*]] = affine.apply #{{.*}}(%[[VAL_10]]){{\[}}%[[VAL_3]], %[[VAL_5]], %[[VAL_3]]]
-// CHECK:     affine.store %[[VAL_1]], %[[VAL_7]]{{\[}}%[[VAL_11]]] : memref<?xf32>
+// CHECK:   affine.for %[[VAL_7:.*]] = %[[VAL_2]] to #{{.*}}(){{\[}}%[[VAL_3]]] {
+// CHECK:     %[[VAL_8:.*]] = affine.apply #{{.*}}(%[[VAL_7]]){{\[}}%[[VAL_2]], %[[VAL_3]], %[[VAL_2]]]
+// CHECK:     affine.store %[[VAL_1]], %[[VAL_4]]{{\[}}%[[VAL_8]]] : memref<?xf32>
 // CHECK:   }
-// CHECK:   affine.for %[[VAL_12:.*]] = %[[VAL_3]] to #{{.*}}(){{\[}}%[[VAL_5]]] {
-// CHECK:     %[[VAL_13:.*]] = arith.subi %[[VAL_12]], %[[VAL_4]] : index
-// CHECK:     affine.if #set(%[[VAL_12]]) {
-// CHECK:       %[[VAL_14:.*]] = affine.apply #{{.*}}(%[[VAL_12]]){{\[}}%[[VAL_3]], %[[VAL_5]], %[[VAL_3]]]
-// CHECK:       affine.store %[[VAL_1]], %[[VAL_7]]{{\[}}%[[VAL_14]]] : memref<?xf32>
+// CHECK:   affine.for %[[VAL_9:.*]] = %[[VAL_2]] to #{{.*}}(){{\[}}%[[VAL_3]]] {
+// CHECK:     affine.if #set(%[[VAL_9]]) {
+// CHECK:       %[[VAL_10:.*]] = affine.apply #{{.*}}(%[[VAL_9]]){{\[}}%[[VAL_2]], %[[VAL_3]], %[[VAL_2]]]
+// CHECK:       affine.store %[[VAL_1]], %[[VAL_4]]{{\[}}%[[VAL_10]]] : memref<?xf32>
 // CHECK:     }
 // CHECK:   }
 // CHECK:   return
@@ -180,40 +175,39 @@ func.func @loop_with_result(%arg0: !fir.ref<!fir.array<100xf32>>, %arg1: !fir.re
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[VAL_2:.*]] = arith.constant 100 : index
-// CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
-// CHECK:           %[[VAL_4:.*]] = fir.shape %[[VAL_2]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
-// CHECK:           %[[VAL_5:.*]] = fir.alloca i32
-// CHECK:           %[[VAL_6:.*]] = fir.convert %[[ARG0]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
-// CHECK:           %[[VAL_7:.*]] = affine.for %[[VAL_8:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_9:.*]] = %[[VAL_1]]) -> (f32) {
-// CHECK:             %[[VAL_10:.*]] = affine.apply #{{.*}}(%[[VAL_8]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
-// CHECK:             %[[VAL_11:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_10]]] : memref<?xf32>
-// CHECK:             %[[VAL_12:.*]] = arith.addf %[[VAL_9]], %[[VAL_11]] fastmath<contract> : f32
-// CHECK:             affine.yield %[[VAL_12]] : f32
+// CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_2]], %[[VAL_2]] : (index, index) -> !fir.shape<2>
+// CHECK:           %[[VAL_4:.*]] = fir.alloca i32
+// CHECK:           %[[VAL_5:.*]] = fir.convert %[[ARG0]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
+// CHECK:           %[[VAL_6:.*]] = affine.for %[[VAL_7:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_8:.*]] = %[[VAL_1]]) -> (f32) {
+// CHECK:             %[[VAL_9:.*]] = affine.apply #{{.*}}(%[[VAL_7]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
+// CHECK:             %[[VAL_10:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_9]]] : memref<?xf32>
+// CHECK:             %[[VAL_11:.*]] = arith.addf %[[VAL_8]], %[[VAL_10]] fastmath<contract> : f32
+// CHECK:             affine.yield %[[VAL_11]] : f32
 // CHECK:           }
-// CHECK:           %[[VAL_13:.*]]:2 = fir.do_loop %[[VAL_14:.*]] = %[[VAL_0]] to %[[VAL_2]] step %[[VAL_0]] iter_args(%[[VAL_15:.*]] = %[[VAL_7]]) -> (index, f32) {
-// CHECK:             %[[VAL_16:.*]] = fir.array_coor %[[ARG1]](%[[VAL_4]]) %[[VAL_0]], %[[VAL_14]] : (!fir.ref<!fir.array<100x100xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-// CHECK:             %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<f32>) -> !fir.ref<!fir.array<100xf32>>
-// CHECK:             %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
-// CHECK:             %[[VAL_19:.*]] = affine.for %[[VAL_20:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_21:.*]] = %[[VAL_15]]) -> (f32) {
-// CHECK:               %[[VAL_22:.*]] = affine.apply #{{.*}}(%[[VAL_20]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
-// CHECK:               %[[VAL_23:.*]] = affine.load %[[VAL_18]]{{\[}}%[[VAL_22]]] : memref<?xf32>
-// CHECK:               %[[VAL_24:.*]] = arith.addf %[[VAL_21]], %[[VAL_23]] fastmath<contract> : f32
-// CHECK:               affine.yield %[[VAL_24]] : f32
+// CHECK:           %[[VAL_12:.*]]:2 = fir.do_loop %[[VAL_13:.*]] = %[[VAL_0]] to %[[VAL_2]] step %[[VAL_0]] iter_args(%[[VAL_14:.*]] = %[[VAL_6]]) -> (index, f32) {
+// CHECK:             %[[VAL_15:.*]] = fir.array_coor %[[ARG1]](%[[VAL_3]]) %[[VAL_0]], %[[VAL_13]] : (!fir.ref<!fir.array<100x100xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+// CHECK:             %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<f32>) -> !fir.ref<!fir.array<100xf32>>
+// CHECK:             %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
+// CHECK:             %[[VAL_18:.*]] = affine.for %[[VAL_19:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_20:.*]] = %[[VAL_14]]) -> (f32) {
+// CHECK:               %[[VAL_21:.*]] = affine.apply #{{.*}}(%[[VAL_19]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
+// CHECK:               %[[VAL_22:.*]] = affine.load %[[VAL_17]]{{\[}}%[[VAL_21]]] : memref<?xf32>
+// CHECK:               %[[VAL_23:.*]] = arith.addf %[[VAL_20]], %[[VAL_22]] fastmath<contract> : f32
+// CHECK:               affine.yield %[[VAL_23]] : f32
 // CHECK:             }
-// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_14]], %[[VAL_0]] overflow<nsw> : index
-// CHECK:             fir.result %[[VAL_25]], %[[VAL_19]] : index, f32
+// CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_13]], %[[VAL_0]] overflow<nsw> : index
+// CHECK:             fir.result %[[VAL_24]], %[[VAL_18]] : index, f32
 // CHECK:           }
-// CHECK:           %[[VAL_26:.*]] = fir.convert %[[ARG2]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
-// CHECK:           %[[VAL_27:.*]]:2 = affine.for %[[VAL_28:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_29:.*]] = %[[VAL_30:.*]]#1, %[[VAL_31:.*]] = %[[VAL_1]]) -> (f32, f32) {
-// CHECK:             %[[VAL_32:.*]] = affine.apply #{{.*}}(%[[VAL_28]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
-// CHECK:             %[[VAL_33:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_32]]] : memref<?xf32>
+// CHECK:           %[[VAL_25:.*]] = fir.convert %[[ARG2]] : (!fir.ref<!fir.array<100xf32>>) -> memref<?xf32>
+// CHECK:           %[[VAL_26:.*]]:2 = affine.for %[[VAL_27:.*]] = %[[VAL_0]] to #{{.*}}(){{\[}}%[[VAL_2]]] iter_args(%[[VAL_28:.*]] = %[[VAL_12]]#1, %[[VAL_29:.*]] = %[[VAL_1]]) -> (f32, f32) {
+// CHECK:             %[[VAL_30:.*]] = affine.apply #{{.*}}(%[[VAL_27]]){{\[}}%[[VAL_0]], %[[VAL_2]], %[[VAL_0]]]
+// CHECK:             %[[VAL_31:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_30]]] : memref<?xf32>
+// CHECK:             %[[VAL_32:.*]] = arith.addf %[[VAL_28]], %[[VAL_31]] fastmath<contract> : f32
+// CHECK:             %[[VAL_33:.*]] = affine.load %[[VAL_25]]{{\[}}%[[VAL_30]]] : memref<?xf32>
 // CHECK:             %[[VAL_34:.*]] = arith.addf %[[VAL_29]], %[[VAL_33]] fastmath<contract> : f32
-// CHECK:             %[[VAL_35:.*]] = affine.load %[[VAL_26]]{{\[}}%[[VAL_32]]] : memref<?xf32>
-// CHECK:             %[[VAL_36:.*]] = arith.addf %[[VAL_31]], %[[VAL_35]] fastmath<contract> : f32
-// CHECK:             affine.yield %[[VAL_34]], %[[VAL_36]] : f32, f32
+// CHECK:             affine.yield %[[VAL_32]], %[[VAL_34]] : f32, f32
 // CHECK:           }
-// CHECK:           %[[VAL_37:.*]] = arith.addf %[[VAL_38:.*]]#0, %[[VAL_38]]#1 fastmath<contract> : f32
-// CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_40:.*]]#0 : (index) -> i32
-// CHECK:           fir.store %[[VAL_39]] to %[[VAL_5]] : !fir.ref<i32>
-// CHECK:           return %[[VAL_37]] : f32
+// CHECK:           %[[VAL_35:.*]] = arith.addf %[[VAL_26]]#0, %[[VAL_26]]#1 fastmath<contract> : f32
+// CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_12]]#0 : (index) -> i32
+// CHECK:           fir.store %[[VAL_36]] to %[[VAL_4]] : !fir.ref<i32>
+// CHECK:           return %[[VAL_35]] : f32
 // CHECK:         }

--- a/mlir/include/mlir/Transforms/RegionUtils.h
+++ b/mlir/include/mlir/Transforms/RegionUtils.h
@@ -15,6 +15,8 @@
 
 #include "llvm/ADT/SetVector.h"
 
+#include <cstdint>
+
 namespace mlir {
 class DominanceInfo;
 class RewriterBase;
@@ -108,6 +110,19 @@ LogicalResult moveValueDefinitions(RewriterBase &rewriter, ValueRange values,
                                    DominanceInfo &dominance);
 LogicalResult moveValueDefinitions(RewriterBase &rewriter, ValueRange values,
                                    Operation *insertionPoint);
+
+/// Remove trivially dead operations starting with the provided worklist.
+///
+/// The provided \p worklist must contain only operations directly in \p region
+/// that are already known to be trivially dead. Operand-defining ops are
+/// re-evaluated after each erasure, so chains of dead ops are eliminated in a
+/// single pass.
+/// An optional callback \p markOpForDeletionInParent can be provided to mark
+/// operations for deletion in a parent region. Returns the number of erased
+/// worklist operations.
+int64_t eliminateTriviallyDeadOps(
+    RewriterBase &rewriter, Region &region, SmallVector<Operation *> &worklist,
+    function_ref<void(Operation *)> markOpForDeletionInParent = nullptr);
 
 /// Remove trivially dead operations from \p region. An operation is trivially
 /// dead when it has no users and is side-effect-free. Operand-defining ops are

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -387,21 +387,22 @@ DiagnosedSilenceableFailure transform::ApplyPatternsOp::applyToOne(
     return DiagnosedSilenceableFailure::success();
   }
 
-  // Non-isolated case: gather the ops manually because the op-list
-  // GreedyPatternRewriteDriver overload only performs a single iteration and
-  // does not simplify regions. CSE is driven externally to reach a fixpoint.
-  SmallVector<Operation *> ops;
-  target->walk([&](Operation *nestedOp) {
-    if (target != nestedOp)
-      ops.push_back(nestedOp);
-  });
-
   // One or two iterations should be sufficient. Stop iterating after a certain
   // threshold to make debugging easier.
   static const int64_t kNumMaxIterations = 50;
   int64_t iteration = 0;
   bool cseChanged = false;
   do {
+    // Non-isolated case: gather the ops manually because the op-list
+    // GreedyPatternRewriteDriver overload only performs a single iteration and
+    // does not simplify regions. Refresh the list on every iteration because
+    // the greedy driver and CSE may erase payload ops.
+    SmallVector<Operation *> ops;
+    target->walk([&](Operation *nestedOp) {
+      if (target != nestedOp)
+        ops.push_back(nestedOp);
+    });
+
     if (failed(applyOpPatternsGreedily(ops, frozenPatterns, config))) {
       return emitSilenceableFailure(target)
              << "greedy pattern application failed";

--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -51,7 +51,10 @@ void CSE::runOnOperation() {
     return markAllAnalysesPreserved();
 
   // We only delete redundant operations without moving any operation to a
-  // different block, so the dominance tree structure remains unchanged and
-  // DominanceInfo/PostDominanceInfo can be safely preserved.
-  markAnalysesPreserved<DominanceInfo, PostDominanceInfo>();
+  // different block, so the dominance tree structure remains unchanged. The
+  // CSE driver invalidates cached dominance for regions owned by erased ops.
+  // TODO: Preserve PostDominanceInfo as well by threading the analysis into
+  // the CSE driver and invalidating cached post-dominance for regions owned by
+  // erased ops, matching the DominanceInfo handling above.
+  markAnalysesPreserved<DominanceInfo>();
 }

--- a/mlir/lib/Transforms/Utils/CSE.cpp
+++ b/mlir/lib/Transforms/Utils/CSE.cpp
@@ -16,9 +16,11 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/RecyclingAllocator.h"
 #include <deque>
 
@@ -56,10 +58,22 @@ public:
       : rewriter(rewriter), domInfo(domInfo) {}
 
   /// Simplify all operations within the given op.
-  void simplify(Operation *op, bool *changed = nullptr);
+  ///
+  /// When simplifying nested regions, \p markOpForDeletionInParent is used to
+  /// notify the enclosing region that one of its directly nested ops may have
+  /// become trivially dead.
+  void
+  simplify(Operation *op, bool *changed = nullptr,
+           function_ref<void(Operation *)> markOpForDeletionInParent = nullptr);
 
   /// Simplify operations within the given region.
-  void simplify(Region &region, bool *changed = nullptr);
+  ///
+  /// When simplifying a nested region, \p markOpForDeletionInParent is used to
+  /// notify the enclosing region that one of its directly nested ops may have
+  /// become trivially dead.
+  void
+  simplify(Region &region, bool *changed = nullptr,
+           function_ref<void(Operation *)> markOpForDeletionInParent = nullptr);
 
   int64_t getNumCSE() const { return numCSE; }
   int64_t getNumDCE() const { return numDCE; }
@@ -95,18 +109,45 @@ private:
     bool processed = false;
   };
 
-  /// Attempt to eliminate a redundant operation. Returns success if the
-  /// operation was marked for removal, failure otherwise.
-  LogicalResult simplifyOperation(ScopedMapTy &knownValues, Operation *op,
-                                  bool hasSSADominance);
-  void simplifyBlock(ScopedMapTy &knownValues, Block *bb, bool hasSSADominance);
-  void simplifyRegion(ScopedMapTy &knownValues, Region &region);
+  /// Attempt to CSE \p op against an equivalent known operation.
+  ///
+  /// If CSE succeeds, uses of \p op that are valid to rewrite are replaced with
+  /// the existing operation's results. If \p op then has no remaining uses,
+  /// \p markCSEDuplicateForDeletion records it as a CSE duplicate that should
+  /// be erased after the current traversal scope unwinds.
+  LogicalResult
+  simplifyOperation(ScopedMapTy &knownValues, Operation *op,
+                    function_ref<void(Operation *)> markCSEDuplicateForDeletion,
+                    bool hasSSADominance);
+  /// Simplify operations in \p bb.
+  ///
+  /// \p markKnownDeadOpForDeletion records operations that are already
+  /// trivially dead before CSE inspects them. \p markCSEDuplicateForDeletion
+  /// records operations whose uses were replaced by CSE.
+  bool
+  simplifyBlock(ScopedMapTy &knownValues, Block *bb, bool hasSSADominance,
+                function_ref<void(Operation *)> markKnownDeadOpForDeletion,
+                function_ref<void(Operation *)> markCSEDuplicateForDeletion);
+  /// Simplify operations in \p region.
+  ///
+  /// \p markKnownDeadOpForDeletionInParent is forwarded to nested regions so
+  /// they can notify this region when deleting nested uses makes a parent
+  /// operation trivially dead.
+  bool simplifyRegion(
+      ScopedMapTy &knownValues, Region &region,
+      function_ref<void(Operation *)> markKnownDeadOpForDeletionInParent);
 
-  /// Erase all operations queued for deletion by the simplification routines.
-  void eraseDeadOps(bool *changed);
-
-  void replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
-                            Operation *existing, bool hasSSADominance);
+  /// Replace uses of \p op with \p existing and schedule \p op for deletion
+  /// when all remaining uses can be removed safely.
+  ///
+  /// In regions with SSA dominance, all uses can be replaced immediately. In
+  /// graph regions, only uses owned by operations that have not already been
+  /// visited are rewritten. If no uses remain, \p markCSEDuplicateForDeletion
+  /// records \p op as a duplicate produced by CSE.
+  void replaceUsesAndDelete(
+      ScopedMapTy &knownValues, Operation *op, Operation *existing,
+      function_ref<void(Operation *)> markCSEDuplicateForDeletion,
+      bool hasSSADominance);
 
   /// Check if there is side-effecting operations other than the given effect
   /// between the two operations.
@@ -115,8 +156,6 @@ private:
   /// A rewriter for modifying the IR.
   RewriterBase &rewriter;
 
-  /// Operations marked as dead and to be erased.
-  std::vector<Operation *> opsToErase;
   DominanceInfo *domInfo = nullptr;
   MemEffectsCache memEffectsCache;
 
@@ -126,9 +165,10 @@ private:
 };
 } // namespace
 
-void CSEDriver::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
-                                     Operation *existing,
-                                     bool hasSSADominance) {
+void CSEDriver::replaceUsesAndDelete(
+    ScopedMapTy &knownValues, Operation *op, Operation *existing,
+    function_ref<void(Operation *)> markCSEDuplicateForDeletion,
+    bool hasSSADominance) {
   // If we find one then replace all uses of the current operation with the
   // existing one and mark it for deletion. We can only replace an operand in
   // an operation if it has not been visited yet.
@@ -137,7 +177,7 @@ void CSEDriver::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
     // visited any use of the current operation.
     // Replace all uses, but do not remove the operation yet.
     rewriter.replaceAllOpUsesWith(op, existing->getResults());
-    opsToErase.push_back(op);
+    markCSEDuplicateForDeletion(op);
   } else {
     // When the region does not have SSA dominance, we need to check if we
     // have visited a use before replacing any use.
@@ -157,7 +197,7 @@ void CSEDriver::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
 
     // There may be some remaining uses of the operation.
     if (op->use_empty())
-      opsToErase.push_back(op);
+      markCSEDuplicateForDeletion(op);
   }
 
   // If the existing operation has an unknown location and the current
@@ -246,9 +286,10 @@ bool CSEDriver::hasOtherSideEffectingOpInBetween(Operation *fromOp,
 }
 
 /// Attempt to eliminate a redundant operation.
-LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
-                                           Operation *op,
-                                           bool hasSSADominance) {
+LogicalResult CSEDriver::simplifyOperation(
+    ScopedMapTy &knownValues, Operation *op,
+    function_ref<void(Operation *)> markCSEDuplicateForDeletion,
+    bool hasSSADominance) {
   // Don't simplify terminator operations.
   if (op->hasTrait<OpTrait::IsTerminator>())
     return failure();
@@ -275,7 +316,8 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
         // The operation that can be deleted has been reach with no
         // side-effecting operations in between the existing operation and
         // this one so we can remove the duplicate.
-        replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
+        replaceUsesAndDelete(knownValues, op, existing,
+                             markCSEDuplicateForDeletion, hasSSADominance);
         return success();
       }
     }
@@ -285,7 +327,8 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
 
   // Look for an existing definition for the operation.
   if (auto *existing = knownValues.lookup(op)) {
-    replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
+    replaceUsesAndDelete(knownValues, op, existing, markCSEDuplicateForDeletion,
+                         hasSSADominance);
     return success();
   }
 
@@ -294,15 +337,17 @@ LogicalResult CSEDriver::simplifyOperation(ScopedMapTy &knownValues,
   return failure();
 }
 
-void CSEDriver::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
-                              bool hasSSADominance) {
+bool CSEDriver::simplifyBlock(
+    ScopedMapTy &knownValues, Block *bb, bool hasSSADominance,
+    function_ref<void(Operation *)> markKnownDeadOpForDeletion,
+    function_ref<void(Operation *)> markCSEDuplicateForDeletion) {
+  bool changed = false;
   for (auto &op : llvm::make_early_inc_range(*bb)) {
     // If the operation is already trivially dead just add it to the erase list.
     // This also avoids calling `simplifyRegion` on dead region ops
     // unnecessarily.
     if (isOpTriviallyDead(&op)) {
-      opsToErase.push_back(&op);
-      ++numDCE;
+      markKnownDeadOpForDeletion(&op);
       continue;
     }
 
@@ -314,41 +359,118 @@ void CSEDriver::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
       if (op.mightHaveTrait<OpTrait::IsIsolatedFromAbove>()) {
         ScopedMapTy nestedKnownValues;
         for (auto &region : op.getRegions())
-          simplifyRegion(nestedKnownValues, region);
+          changed |= simplifyRegion(nestedKnownValues, region,
+                                    markKnownDeadOpForDeletion);
       } else {
         // Otherwise, process nested regions normally.
         for (auto &region : op.getRegions())
-          simplifyRegion(knownValues, region);
+          changed |=
+              simplifyRegion(knownValues, region, markKnownDeadOpForDeletion);
       }
     }
 
-    // If the operation is simplified, we don't process any held regions.
-    if (succeeded(simplifyOperation(knownValues, &op, hasSSADominance)))
+    if (succeeded(simplifyOperation(
+            knownValues, &op, markCSEDuplicateForDeletion, hasSSADominance)))
       continue;
   }
   // Clear the MemoryEffects cache since its usage is by block only.
   memEffectsCache.clear();
+  return changed;
 }
 
-void CSEDriver::simplifyRegion(ScopedMapTy &knownValues, Region &region) {
+bool CSEDriver::simplifyRegion(
+    ScopedMapTy &knownValues, Region &region,
+    function_ref<void(Operation *)> markKnownDeadOpForDeletionInParent) {
   // If the region is empty there is nothing to do.
   if (region.empty())
-    return;
+    return false;
 
   bool hasSSADominance = domInfo->hasSSADominance(&region);
+  bool changed = false;
+
+  // Operations that were already trivially dead when encountered during CSE.
+  // These go through the DCE helper so deleting them can propagate deadness to
+  // their producers, including producers in parent regions.
+  SmallVector<Operation *> triviallyDeadOps;
+
+  // Operations whose uses were replaced by CSE. Keep these separate from
+  // triviallyDeadOps so CSE erasures are not counted as DCE erasures.
+  SmallVector<Operation *> deadOpsAfterCSE;
+
+  // Install a listener while erasing deferred ops so dominance caches for
+  // nested regions owned by erased ops are invalidated before the operation
+  // storage is destroyed.
+  struct CSEErasureListener final : RewriterBase::ForwardingListener {
+    CSEErasureListener(OpBuilder::Listener *listener, DominanceInfo &domInfo)
+        : RewriterBase::ForwardingListener(listener), domInfo(domInfo) {}
+
+    void notifyOperationErased(Operation *op) override {
+      for (Region &region : op->getRegions())
+        domInfo.invalidate(&region);
+      RewriterBase::ForwardingListener::notifyOperationErased(op);
+    }
+
+    DominanceInfo &domInfo;
+  };
+
+  // Record an operation that is known to be trivially dead independently of
+  // CSE. If the op belongs to the parent region, notify the parent traversal
+  // instead of queuing it in this region.
+  auto markKnownDeadOpForDeletion = [&](Operation *op) {
+    LDBG(2) << "Marking operation for deletion: "
+            << OpWithFlags(op, OpPrintingFlags().skipRegions());
+    if (op->getParentRegion() != &region) {
+      LDBG(2) << "Operation is not in the current region";
+      if (markKnownDeadOpForDeletionInParent)
+        markKnownDeadOpForDeletionInParent(op);
+      return;
+    }
+    if (isOpTriviallyDead(op))
+      triviallyDeadOps.push_back(op);
+  };
+
+  // Record a duplicate operation whose uses have been replaced by CSE. These
+  // ops are erased after the current scoped known-values table has unwound.
+  auto markCSEDuplicateForDeletion = [&](Operation *op) {
+    LDBG(2) << "Marking CSE duplicate for deletion: "
+            << OpWithFlags(op, OpPrintingFlags().skipRegions());
+    deadOpsAfterCSE.push_back(op);
+  };
+
+  // Erase queued ops after the traversal scope has unwound. Known-dead ops use
+  // the DCE helper so deadness propagates through operands; CSE duplicates are
+  // erased separately so they remain classified as CSE erasures.
+  auto eraseOpsToDelete = [&]() {
+    OpBuilder::Listener *previousListener = rewriter.getListener();
+    CSEErasureListener listener(previousListener, *domInfo);
+    rewriter.setListener(&listener);
+    int64_t erasedCount = eliminateTriviallyDeadOps(
+        rewriter, region, triviallyDeadOps, markKnownDeadOpForDeletionInParent);
+    numDCE += erasedCount;
+    int64_t cseErasedCount = deadOpsAfterCSE.size();
+    for (Operation *op : deadOpsAfterCSE)
+      rewriter.eraseOp(op);
+    rewriter.setListener(previousListener);
+    return erasedCount != 0 || cseErasedCount != 0;
+  };
 
   // If the region only contains one block, then simplify it directly.
   if (region.hasOneBlock()) {
-    ScopedMapTy::ScopeTy scope(knownValues);
-    simplifyBlock(knownValues, &region.front(), hasSSADominance);
-    return;
+    {
+      ScopedMapTy::ScopeTy scope(knownValues);
+      changed |= simplifyBlock(knownValues, &region.front(), hasSSADominance,
+                               markKnownDeadOpForDeletion,
+                               markCSEDuplicateForDeletion);
+    }
+    changed |= eraseOpsToDelete();
+    return changed;
   }
 
   // If the region does not have dominanceInfo, then skip it.
   // TODO: Regions without SSA dominance should define a different
   // traversal order which is appropriate and can be used here.
   if (!hasSSADominance)
-    return;
+    return false;
 
   // Note, deque is being used here because there was significant performance
   // gains over vector when the container becomes very large due to the
@@ -368,8 +490,9 @@ void CSEDriver::simplifyRegion(ScopedMapTy &knownValues, Region &region) {
     // Check to see if we need to process this node.
     if (!currentNode->processed) {
       currentNode->processed = true;
-      simplifyBlock(knownValues, currentNode->node->getBlock(),
-                    hasSSADominance);
+      changed |= simplifyBlock(knownValues, currentNode->node->getBlock(),
+                               hasSSADominance, markKnownDeadOpForDeletion,
+                               markCSEDuplicateForDeletion);
     }
 
     // Otherwise, check to see if we need to process a child node.
@@ -383,36 +506,31 @@ void CSEDriver::simplifyRegion(ScopedMapTy &knownValues, Region &region) {
       stack.pop_back();
     }
   }
+  changed |= eraseOpsToDelete();
+  return changed;
 }
 
-void CSEDriver::eraseDeadOps(bool *changed) {
-  // Erase any operations that were marked as dead during simplification, and
-  // remove their associated dominator trees.
-  for (auto *op : opsToErase) {
-    for (Region &region : op->getRegions())
-      domInfo->invalidate(&region);
-    rewriter.eraseOp(op);
-  }
-  if (changed)
-    *changed = !opsToErase.empty();
-  opsToErase.clear();
-
-  // Note: CSE does currently not remove ops with regions, so DominanceInfo
-  // does not have to be invalidated.
-}
-
-void CSEDriver::simplify(Operation *op, bool *changed) {
+void CSEDriver::simplify(
+    Operation *op, bool *changed,
+    function_ref<void(Operation *)> markOpForDeletionInParent) {
   // Simplify all regions.
   ScopedMapTy knownValues;
+  bool anyChanged = false;
   for (auto &region : op->getRegions())
-    simplifyRegion(knownValues, region);
-  eraseDeadOps(changed);
+    anyChanged |=
+        simplifyRegion(knownValues, region, markOpForDeletionInParent);
+  if (changed)
+    *changed = anyChanged;
 }
 
-void CSEDriver::simplify(Region &region, bool *changed) {
+void CSEDriver::simplify(
+    Region &region, bool *changed,
+    function_ref<void(Operation *)> markOpForDeletionInParent) {
   ScopedMapTy knownValues;
-  simplifyRegion(knownValues, region);
-  eraseDeadOps(changed);
+  bool anyChanged =
+      simplifyRegion(knownValues, region, markOpForDeletionInParent);
+  if (changed)
+    *changed = anyChanged;
 }
 
 void mlir::eliminateCommonSubExpressions(RewriterBase &rewriter,

--- a/mlir/lib/Transforms/Utils/RegionUtils.cpp
+++ b/mlir/lib/Transforms/Utils/RegionUtils.cpp
@@ -510,6 +510,63 @@ LogicalResult mlir::runRegionDCE(RewriterBase &rewriter,
   return deleteDeadness(rewriter, regions, liveMap);
 }
 
+int64_t mlir::eliminateTriviallyDeadOps(
+    RewriterBase &rewriter, Region &region, SmallVector<Operation *> &worklist,
+    function_ref<void(Operation *)> markOpForDeletionInParent) {
+  LDBG(2) << "Initial worklist size: " << worklist.size();
+  int64_t numErased = 0;
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    LDBG(2) << "Popped operation from worklist: "
+            << OpWithFlags(op, OpPrintingFlags().skipRegions());
+    /// Erase each operand to drop its use count before checking its defining
+    /// op: by the time we call isOpTriviallyDead on defOp, the
+    /// about-to-be-erased `op` is no longer counted as a user. Only
+    /// actually-dead ops enter the worklist.
+    ///
+    /// Walk nested operations as well because erasing `op` also implicitly
+    /// erases every operation nested under it and therefore drops their operand
+    /// uses.
+    op->walk([&](Operation *erasedOp) {
+      LDBG(3) << "Processing operands of operation erased: "
+              << OpWithFlags(erasedOp, OpPrintingFlags().skipRegions());
+      for (OpOperand &opOperand : erasedOp->getOpOperands()) {
+        Operation *defOp = opOperand.get().getDefiningOp();
+        if (!defOp) {
+          LDBG(4) << "Skipping operand #" << opOperand.getOperandNumber()
+                  << ": value has no defining operation";
+          continue;
+        }
+        if (defOp->getParentRegion() != &region) {
+          LDBG(4) << "Skipping operand #" << opOperand.getOperandNumber()
+                  << ": defining operation is outside the current region";
+          opOperand.drop();
+          if (isOpTriviallyDead(defOp) && markOpForDeletionInParent)
+            markOpForDeletionInParent(defOp);
+          continue;
+        }
+        LDBG(4) << "Dropping operand #" << opOperand.getOperandNumber()
+                << " from defining operation: "
+                << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
+        opOperand.drop();
+        if (isOpTriviallyDead(defOp)) {
+          LDBG(2) << "Enqueued newly trivially dead defining operation: "
+                  << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
+          worklist.push_back(defOp);
+        } else {
+          LDBG(4) << "Defining operation is still not trivially dead: "
+                  << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
+        }
+      }
+    });
+    LDBG() << "Erasing trivially dead worklist operation: "
+           << OpWithFlags(op, OpPrintingFlags().skipRegions());
+    rewriter.eraseOp(op);
+    ++numErased;
+  }
+  return numErased;
+}
+
 bool mlir::eliminateTriviallyDeadOps(RewriterBase &rewriter, Region &region,
                                      bool includeNestedRegions) {
   LDBG() << "Starting eliminateTriviallyDeadOps with "
@@ -520,9 +577,8 @@ bool mlir::eliminateTriviallyDeadOps(RewriterBase &rewriter, Region &region,
             << OpWithFlags(parentOp, OpPrintingFlags().skipRegions());
 
   bool changed = false;
-  unsigned erasedOps = 0;
-  unsigned seededOps = 0;
-  unsigned enqueuedDefs = 0;
+  int64_t erasedOps = 0;
+  int64_t seededOps = 0;
 
   // Step 1: walk each op in reverse program order. If the op is already
   // trivially dead, erase it outright — there's no point recursing into
@@ -564,8 +620,8 @@ bool mlir::eliminateTriviallyDeadOps(RewriterBase &rewriter, Region &region,
 
   // Step 2: worklist over ops in this region only.
   //
-  // Worklist invariant: an op is pushed only once we have verified it is
-  // trivially dead. No speculative enqueues: every op on the worklist will
+  // Worklist invariant: an op is pushed *only* once we have verified it is
+  // trivially dead. No speculative enqueues — every op on the worklist will
   // be erased when popped. Two things enforce this:
   //   - the initial seed below calls isOpTriviallyDead before enqueueing,
   //   - the propagation inside the loop drops the erasing op's use of
@@ -581,62 +637,16 @@ bool mlir::eliminateTriviallyDeadOps(RewriterBase &rewriter, Region &region,
       LDBG(2) << "Seeded worklist with operation: "
               << OpWithFlags(&op, OpPrintingFlags().skipRegions());
       worklist.push_back(&op);
-      changed = true;
       ++seededOps;
     }
   }
-  LDBG(2) << "Initial worklist size: " << worklist.size();
-
-  while (!worklist.empty()) {
-    Operation *op = worklist.pop_back_val();
-    LDBG(2) << "Popped operation from worklist: "
-            << OpWithFlags(op, OpPrintingFlags().skipRegions());
-    /// Erase each operand to drop its use count before checking its defining
-    /// op: by the time we call isOpTriviallyDead on defOp, the
-    /// about-to-be-erased `op` is no longer counted as a user. Only
-    /// actually-dead ops enter the worklist.
-    ///
-    /// Walk nested operations as well because erasing `op` also implicitly
-    /// erases every operation nested under it and therefore drops their operand
-    /// uses.
-    op->walk([&](Operation *erasedOp) {
-      LDBG(3) << "Processing operands of operation erased: "
-              << OpWithFlags(erasedOp, OpPrintingFlags().skipRegions());
-      for (OpOperand &opOperand : erasedOp->getOpOperands()) {
-        Operation *defOp = opOperand.get().getDefiningOp();
-        if (!defOp) {
-          LDBG(4) << "Skipping operand #" << opOperand.getOperandNumber()
-                  << ": value has no defining operation";
-          continue;
-        }
-        if (defOp->getParentRegion() != &region) {
-          LDBG(4) << "Skipping operand #" << opOperand.getOperandNumber()
-                  << ": defining operation is outside the current region";
-          continue;
-        }
-        LDBG(4) << "Dropping operand #" << opOperand.getOperandNumber()
-                << " from defining operation: "
-                << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
-        opOperand.drop();
-        if (isOpTriviallyDead(defOp)) {
-          LDBG(2) << "Enqueued newly trivially dead defining operation: "
-                  << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
-          worklist.push_back(defOp);
-          ++enqueuedDefs;
-        } else {
-          LDBG(4) << "Defining operation is still not trivially dead: "
-                  << OpWithFlags(defOp, OpPrintingFlags().skipRegions());
-        }
-      }
-    });
-    LDBG() << "Erasing trivially dead worklist operation: "
-           << OpWithFlags(op, OpPrintingFlags().skipRegions());
-    rewriter.eraseOp(op);
-    ++erasedOps;
-  }
+  int64_t worklistErasedOps =
+      eliminateTriviallyDeadOps(rewriter, region, worklist);
+  erasedOps += worklistErasedOps;
+  changed |= worklistErasedOps != 0;
   LDBG() << "Finished eliminateTriviallyDeadOps, erased " << erasedOps
-         << " operations, seeded " << seededOps << " operations, enqueued "
-         << enqueuedDefs << " defining operations, changed=" << changed;
+         << " operations, seeded " << seededOps
+         << " operations, changed=" << changed;
   return changed;
 }
 

--- a/mlir/test/Conversion/MemRefToLLVM/expand-then-convert-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/expand-then-convert-to-llvm.mlir
@@ -599,9 +599,6 @@ func.func @expand_shape_dynamic(%arg0 : memref<1x?xf32>, %sz0: index) -> memref<
 // CHECK:           %[[UNREALIZED_CONVERSION_CAST_1:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : memref<1x?xf32> to !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_0:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_1:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][1] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-// CHECK:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64)>
-// CHECK:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[EXTRACTVALUE_0]], %[[MLIR_0]][0] : !llvm.struct<(ptr, ptr, i64)>
-// CHECK:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[EXTRACTVALUE_1]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr, ptr, i64)>
 // CHECK:           %[[MLIR_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK:           %[[EXTRACTVALUE_2:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][4, 0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[MLIR_2:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
@@ -637,10 +634,6 @@ func.func @expand_shape_dynamic_with_non_identity_layout(
 // CHECK:           %[[UNREALIZED_CONVERSION_CAST_1:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : memref<1x?xf32, strided<[?, ?], offset: ?>> to !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_0:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_1:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][1] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-// CHECK:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64)>
-// CHECK:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[EXTRACTVALUE_0]], %[[MLIR_0]][0] : !llvm.struct<(ptr, ptr, i64)>
-// CHECK:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[EXTRACTVALUE_1]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr, ptr, i64)>
-// CHECK:           %[[MLIR_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK:           %[[EXTRACTVALUE_2:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][2] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_3:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][4, 0] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK:           %[[EXTRACTVALUE_4:.*]] = llvm.extractvalue %[[UNREALIZED_CONVERSION_CAST_1]][4, 1] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>

--- a/mlir/test/Dialect/Tensor/bufferize.mlir
+++ b/mlir/test/Dialect/Tensor/bufferize.mlir
@@ -568,9 +568,7 @@ func.func @tensor.pad(%t1: tensor<?x10xindex>, %l2: index, %h1: index,
                       %h2: index) -> tensor<?x?xindex> {
   // CHECK-DAG: %[[m1:.*]] = bufferization.to_buffer %[[t1]] : tensor<?x10xindex> to memref<?x10xindex>
   // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[dim0:.*]] = memref.dim %[[m1]], %[[c0]]
-  // CHECK-DAG: %[[dim1:.*]] = memref.dim %[[m1]], %[[c1]]
   // CHECK-DAG: %[[size0:.*]] = affine.apply #[[$sum_map_1]]()[%[[dim0]], %[[h1]]]
   // CHECK-DAG: %[[size1:.*]] = affine.apply #[[$sum_map_2]]()[%[[l2]], %[[h2]]]
   // CHECK:     %[[alloc:.*]] = memref.alloc(%[[size0]], %[[size1]]) {{.*}} : memref<?x?xindex>
@@ -786,4 +784,3 @@ func.func @parallel_insert_slice_copy_before_write(%in: tensor<4xf32>, %out: ten
 }
 
 // -----
-

--- a/mlir/test/Dialect/Transform/test-pattern-application.mlir
+++ b/mlir/test/Dialect/Transform/test-pattern-application.mlir
@@ -278,6 +278,32 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
+// CHECK-LABEL: func @non_isolated_apply_patterns_cse_changed_resets()
+//   CHECK:       "test.ssacfg_region"
+//   CHECK:       %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-NEXT:  "test.use"(%[[C0]], %[[C0]]) : (index, index) -> ()
+func.func @non_isolated_apply_patterns_cse_changed_resets() {
+  "test.ssacfg_region"() ({
+    %c0 = arith.constant 0 : index
+    %c0_dup = arith.constant 0 : index
+    "test.use"(%c0, %c0_dup) : (index, index) -> ()
+  }) : () -> ()
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op) {
+    %0 = transform.structured.match ops{["test.ssacfg_region"]} in %arg1
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.canonicalization
+    } {apply_cse} : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
 // CHECK-LABEL: func @full_dialect_conversion
 //  CHECK-NEXT:   %[[m:.*]] = "test.new_op"() : () -> memref<5xf32>
 //  CHECK-NEXT:   %[[cast:.*]] = builtin.unrealized_conversion_cast %0 : memref<5xf32> to tensor<5xf32>

--- a/mlir/test/Transforms/cse.mlir
+++ b/mlir/test/Transforms/cse.mlir
@@ -12,6 +12,43 @@ func.func @simple_constant() -> (i32, i32) {
 
 // -----
 
+// CHECK-LABEL: @cse_erases_duplicate_producer_after_scope
+func.func @cse_erases_duplicate_producer_after_scope(%arg0: index)
+    -> (index, index) {
+  // CHECK-NEXT: %[[C1:.*]] = arith.constant 1 : index
+  %c1 = arith.constant 1 : index
+  %duplicate_c1 = arith.constant 1 : index
+  // CHECK-NEXT: %[[SUM:.*]] = arith.addi %arg0, %[[C1]] : index
+  %sum0 = arith.addi %arg0, %c1 : index
+  %sum1 = arith.addi %arg0, %duplicate_c1 : index
+  // CHECK-NEXT: return %[[SUM]], %[[SUM]] : index, index
+  return %sum0, %sum1 : index, index
+}
+
+// -----
+
+// Test that CSE performs simple DCE, including when an op from a parent region becomes
+// dead after deletion of an operation in a nested region.
+// CHECK-LABEL: func.func @cse_performs_dce
+// CHECK-SAME: (%[[ARG0:.*]]: i32) -> i32
+// CHECK-NOT: arith.constant
+// CHECK-NOT: arith.addi
+module {
+  func.func @cse_performs_dce(%arg0: i32) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = affine.for %arg1 = 0 to 10 iter_args(%arg2 = %arg0) -> (i32) {
+      %1 = affine.for %arg3 = 0 to 10 iter_args(%arg4 = %arg2) -> (i32) {
+        %2 = arith.addi %c0_i32, %c0_i32 : i32 // Dead
+        affine.yield %arg4 : i32
+      }
+      affine.yield %1 : i32
+    }
+    return %0 : i32
+  }
+}
+
+// -----
+
 // CHECK: #[[$MAP:.*]] = affine_map<(d0) -> (d0 mod 2)>
 #map0 = affine_map<(d0) -> (d0 mod 2)>
 


### PR DESCRIPTION
Replace CSE's private erase list with the shared trivial-DCE worklist helper,
while preserving CSE's scoped known-values invariants.

CSE stores operations in an llvm::ScopedHashTable keyed by
OperationEquivalence. If the new DCE helper erases a producer while the current
region scope is still active, the scoped table can later try to pop an entry for
an operation whose storage has already been erased. 
Run the helper only after the known-values scope has unwound so erased
operations are no longer table entries.

Make the worklist helper explicit about its contract and let it return the
number of erased operations directly, which callers can use for both change
detection and statistics without an out-parameter. Callers that need erasure
notifications can use the rewriter listener that already fires before eraseOp
removes each operation.

When CSE removes dead operations from a nested region, let the DCE helper notify
the enclosing CSE traversal about parent-region defining ops that may have
become dead. The helper drops the erased operand use before testing the parent
op, so the parent callback preserves the invariant that only trivially dead ops
enter the deletion worklist.

CSE installs a forwarding listener around worklist erasure to invalidate cached
dominance for regions owned by erased operations before the IR is destroyed. The
pass intentionally preserves only DominanceInfo for now; a TODO documents that
preserving PostDominanceInfo as well would require threading that analysis into
the CSE driver and invalidating its cached regions in the same way.

Also make the helper and CSE traversal report only the changes made by the
current invocation. The helper only enqueues operations after proving they are
trivially dead, so it does not need a worklist visited set. CSE keeps separate
queues for known-dead ops and CSE duplicates so statistics and transform
fixpoint loops do not depend on stale state.

Assisted-by: Codex