### PR TITLE
[CHERI] Relax addrspace(0) requirement for counting null-pointer comparisons as non-capturing.

### DIFF
--- a/llvm/lib/Analysis/CaptureTracking.cpp
+++ b/llvm/lib/Analysis/CaptureTracking.cpp
@@ -379,9 +379,8 @@ UseCaptureInfo llvm::DetermineUseCaptureKind(const Use &U, const Value *Base) {
       // Don't count comparisons of a no-alias return value against null as
       // captures. This allows us to ignore comparisons of malloc results
       // with null, for example.
-      if (U->getType()->getPointerAddressSpace() == 0)
-        if (isNoAliasCall(U.get()->stripPointerCasts()))
-          return CaptureComponents::None;
+      if (isNoAliasCall(U.get()->stripPointerCasts()))
+        return CaptureComponents::None;
 
       // Check whether this is a comparison of the base pointer against
       // null.


### PR DESCRIPTION
Because the comparison uses a ConstantPointerNull of the same pointer type, this does not make any assumptions about the bit pattern of null, and thus does not need to be constrained to only the default address space. In particular, this change is needed on CHERI targets where the default is addrspace(200) instead.
