### PR TITLE
[SimplifyLibCalls] Avoid implicit truncation for char

### DIFF
--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -1669,7 +1669,7 @@ Value *llvm::emitStrChr(Value *Ptr, char C, IRBuilderBase &B,
   Type *CharPtrTy = B.getPtrTy();
   Type *IntTy = getIntTy(B, TLI);
   return emitLibCall(LibFunc_strchr, CharPtrTy, {CharPtrTy, IntTy},
-                     {Ptr, ConstantInt::get(IntTy, C)}, B, TLI);
+                     {Ptr, ConstantInt::get(IntTy, (unsigned char)C)}, B, TLI);
 }
 
 Value *llvm::emitStrNCmp(Value *Ptr1, Value *Ptr2, Value *Len, IRBuilderBase &B,

--- a/llvm/test/Transforms/InstCombine/strstr-1.ll
+++ b/llvm/test/Transforms/InstCombine/strstr-1.ll
@@ -9,6 +9,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 @.str1 = private constant [2 x i8] c"a\00"
 @.str2 = private constant [6 x i8] c"abcde\00"
 @.str3 = private constant [4 x i8] c"bcd\00"
+@.str.hi = private constant [2 x i8] c"\a0\00"
 
 declare ptr @strstr(ptr, ptr)
 
@@ -30,6 +31,15 @@ define ptr @test_simplify2(ptr %str) {
 ; CHECK-NEXT:    ret ptr [[STRCHR]]
 ;
   %ret = call ptr @strstr(ptr %str, ptr @.str1)
+  ret ptr %ret
+}
+
+define ptr @test_simplify2_hi(ptr %str) {
+; CHECK-LABEL: @test_simplify2_hi(
+; CHECK-NEXT:    [[STRCHR:%.*]] = call ptr @strchr(ptr noundef nonnull dereferenceable(1) [[STR:%.*]], i32 160)
+; CHECK-NEXT:    ret ptr [[STRCHR]]
+;
+  %ret = call ptr @strstr(ptr %str, ptr @.str.hi)
   ret ptr %ret
 }
 


### PR DESCRIPTION
Explicitly cast char to unsigned char to avoid implicit truncation
if the char type is signed.

Fixes https://github.com/llvm/llvm-project/issues/194487.