### PR TITLE
[flang-rt] Fix for TIMEF test case hanging on Windows

### DIFF
--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -459,10 +459,8 @@ double RTNAME(Timef)() {
     return duration;
   }
 #else
-  // TODO: Windows implementation. Currently, we return a dummy
-  // non-zero value to prevent the `TIMEF` unittest from
-  // hanging
-  return 1.0;
+  // TODO: Windows implementation.
+  return 0.0;
 #endif
 }
 

--- a/flang-rt/unittests/Runtime/Time.cpp
+++ b/flang-rt/unittests/Runtime/Time.cpp
@@ -41,10 +41,9 @@ TEST(TimeIntrinsics, Timef) {
   // Loop until we get a different value from Timef. If we don't get one
   // before we time out, then we should probably look into an implementation
   // for Timef with a better timer resolution.
-  // By default, this loop should burn for 1 second or until the end of
-  // the iteration count.
-  int max_iterations{10000000};
-  for (int iter = 0, end = start; end == start && iter < max_iterations;
+  constexpr int max_iterations{10000000};
+  int iter{0};
+  for (end = start; end == start && iter < max_iterations;
       end = RTNAME(Timef)(), iter++) {
     ASSERT_GE(end, 0.0);
     ASSERT_GE(end, start);

--- a/flang-rt/unittests/Runtime/Time.cpp
+++ b/flang-rt/unittests/Runtime/Time.cpp
@@ -32,6 +32,11 @@ TEST(TimeIntrinsics, CpuTime) {
 }
 
 TEST(TimeIntrinsics, Timef) {
+  #ifdef _WIN32
+  // TODO: remove this after TIMEF() is implemented on Windows
+  GTEST_SKIP() << "Timef() is not implemented on Windows";
+  #endif
+  
   // We can't really test that we get the "right" result for Timef, but we
   // can have a smoke test to see that we get something reasonable on the
   // platforms where we expect to support it.

--- a/flang-rt/unittests/Runtime/Time.cpp
+++ b/flang-rt/unittests/Runtime/Time.cpp
@@ -32,10 +32,10 @@ TEST(TimeIntrinsics, CpuTime) {
 }
 
 TEST(TimeIntrinsics, Timef) {
-  #ifdef _WIN32
+#ifdef _WIN32
   // TODO: remove this after TIMEF() is implemented on Windows
   GTEST_SKIP() << "Timef() is not implemented on Windows";
-  #endif
+#endif
   
   // We can't really test that we get the "right" result for Timef, but we
   // can have a smoke test to see that we get something reasonable on the

--- a/flang-rt/unittests/Runtime/Time.cpp
+++ b/flang-rt/unittests/Runtime/Time.cpp
@@ -41,8 +41,11 @@ TEST(TimeIntrinsics, Timef) {
   // Loop until we get a different value from Timef. If we don't get one
   // before we time out, then we should probably look into an implementation
   // for Timef with a better timer resolution.
-  // By default, this loop should burn for 1 second.
-  for (end = start; end == start; end = RTNAME(Timef)()) {
+  // By default, this loop should burn for 1 second or until the end of
+  // the iteration count.
+  int max_iterations{10000000};
+  for (int iter = 0, end = start; end == start && iter < max_iterations;
+      end = RTNAME(Timef)(), iter++) {
     ASSERT_GE(end, 0.0);
     ASSERT_GE(end, start);
   }

--- a/flang-rt/unittests/Runtime/Time.cpp
+++ b/flang-rt/unittests/Runtime/Time.cpp
@@ -36,7 +36,7 @@ TEST(TimeIntrinsics, Timef) {
   // TODO: remove this after TIMEF() is implemented on Windows
   GTEST_SKIP() << "Timef() is not implemented on Windows";
 #endif
-  
+
   // We can't really test that we get the "right" result for Timef, but we
   // can have a smoke test to see that we get something reasonable on the
   // platforms where we expect to support it.


### PR DESCRIPTION
The merging of PR https://github.com/llvm/llvm-project/pull/185377 caused a test case to hang on Windows. This PR fixes the same by adding an upper bound on the number of iterations of the test-loop, post which the test gracefully exits irrespective of whether the TIMEF functionality is supported on Windows or not.