### PR TITLE
[clang][bytecode] Allow constructor calls on extern RVO pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -904,8 +904,6 @@ static bool CheckInvoke(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
   if (!Ptr.isDummy() && !isConstexprUnknown(Ptr)) {
     if (!CheckLive(S, OpPC, Ptr, AK_MemberCall))
       return false;
-    if (!CheckExtern(S, OpPC, Ptr))
-      return false;
     if (!CheckRange(S, OpPC, Ptr, AK_MemberCall))
       return false;
     if (!IsCtorDtor && !CheckLifetime(S, OpPC, Ptr, AK_MemberCall))

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -2000,3 +2000,14 @@ namespace EmptyRecords {
                                   // both-note {{in call}}
   constexpr int testc = f(e3, 3);
 }
+
+namespace RVOPtrIsExtern {
+  struct __ph {
+  } extern const _1;
+  constexpr void test(__ph) {}
+  constexpr bool test_all() {
+    test(_1);
+    return true;
+  }
+  static_assert(test_all(), "");
+}


### PR DESCRIPTION
Turns out 8b258206819d48ff6410ea99f3c63738318bd178 caused a regression in that it broke function calls with extern RVO pointers. However, that check in CheckInvoke() seems unneeded anyway, so remove it.