### PR TITLE
Respect group size limit for kernel

### DIFF
--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -389,9 +389,11 @@ Error L0KernelTy::setKernelGroups(L0DeviceTy &l0Device, L0LaunchEnvTy &KEnv,
 
   if (HasUserDefinedGroups) {
     KEnv.GroupCounts = {NumBlocks[0], NumBlocks[1], NumBlocks[2]};
-    GroupSizes[0] = NumThreads[0];
-    GroupSizes[1] = NumThreads[1];
-    GroupSizes[2] = NumThreads[2];
+    // Respect max group size attribute in the kernel.
+    uint32_t MaxGroupSize = KEnv.KernelPR.MaxThreadGroupSize;
+    GroupSizes[0] = std::min<uint32_t>(MaxGroupSize, NumThreads[0]);
+    GroupSizes[1] = std::min<uint32_t>(MaxGroupSize, NumThreads[1]);
+    GroupSizes[2] = std::min<uint32_t>(MaxGroupSize, NumThreads[2]);
   } else {
     int32_t NumTeams = NumBlocks[0];
     int32_t ThreadLimit = NumThreads[0];


### PR DESCRIPTION
The case with user-defined group sizes still needs to respect the group size attribute for the kernel. Level Zero will return error otherwise.