### PR TITLE
[X86][test][NFC] Regenerate subcarry.ll CHECKs

### DIFF
--- a/llvm/test/CodeGen/X86/subcarry.ll
+++ b/llvm/test/CodeGen/X86/subcarry.ll
@@ -37,6 +37,14 @@ define i128 @sub128(i128 %a, i128 %b) nounwind {
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: sub128:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    retq
 entry:
   %0 = sub i128 %a, %b
   ret i128 %0
@@ -86,6 +94,19 @@ define i256 @sub256(i256 %a, i256 %b) nounwind {
 ; X86-NEXT:    movl %ecx, 28(%eax)
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: sub256:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %r9, %rsi
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rdx
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rcx
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %r8
+; AVX512-NEXT:    movq %rcx, 16(%rdi)
+; AVX512-NEXT:    movq %rdx, 8(%rdi)
+; AVX512-NEXT:    movq %rsi, (%rdi)
+; AVX512-NEXT:    movq %r8, 24(%rdi)
+; AVX512-NEXT:    retq
 entry:
   %0 = sub i256 %a, %b
   ret i256 %0
@@ -157,6 +178,23 @@ define %S @negate(ptr nocapture readonly %this) nounwind {
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: negate:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    xorl %ecx, %ecx
+; AVX512-NEXT:    xorl %edx, %edx
+; AVX512-NEXT:    subq (%rsi), %rdx
+; AVX512-NEXT:    movl $0, %edi
+; AVX512-NEXT:    sbbq 8(%rsi), %rdi
+; AVX512-NEXT:    movl $0, %r8d
+; AVX512-NEXT:    sbbq 16(%rsi), %r8
+; AVX512-NEXT:    sbbq 24(%rsi), %rcx
+; AVX512-NEXT:    movq %rdx, (%rax)
+; AVX512-NEXT:    movq %rdi, 8(%rax)
+; AVX512-NEXT:    movq %r8, 16(%rax)
+; AVX512-NEXT:    movq %rcx, 24(%rax)
+; AVX512-NEXT:    retq
 entry:
   %0 = load i64, ptr %this, align 8
   %1 = xor i64 %0, -1
@@ -304,6 +342,33 @@ define %S @sub(ptr nocapture readonly %this, %S %arg.b) nounwind {
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: sub:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    movq (%rsi), %rdi
+; AVX512-NEXT:    movq 8(%rsi), %r10
+; AVX512-NEXT:    subq %rdx, %rdi
+; AVX512-NEXT:    setae %dl
+; AVX512-NEXT:    addb $-1, %dl
+; AVX512-NEXT:    adcq $0, %r10
+; AVX512-NEXT:    setb %dl
+; AVX512-NEXT:    movzbl %dl, %edx
+; AVX512-NEXT:    notq %rcx
+; AVX512-NEXT:    addq %r10, %rcx
+; AVX512-NEXT:    adcq 16(%rsi), %rdx
+; AVX512-NEXT:    setb %r10b
+; AVX512-NEXT:    movzbl %r10b, %r10d
+; AVX512-NEXT:    notq %r8
+; AVX512-NEXT:    addq %rdx, %r8
+; AVX512-NEXT:    adcq 24(%rsi), %r10
+; AVX512-NEXT:    notq %r9
+; AVX512-NEXT:    addq %r10, %r9
+; AVX512-NEXT:    movq %rdi, (%rax)
+; AVX512-NEXT:    movq %rcx, 8(%rax)
+; AVX512-NEXT:    movq %r8, 16(%rax)
+; AVX512-NEXT:    movq %r9, 24(%rax)
+; AVX512-NEXT:    retq
 entry:
   %0 = extractvalue %S %arg.b, 0
   %.elt6 = extractvalue [4 x i64] %0, 1
@@ -382,6 +447,15 @@ define i64 @sub_from_carry(i64 %x, i64 %y, ptr %valout, i64 %z) nounwind {
 ; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %edx
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: sub_from_carry:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rcx, %rax
+; AVX512-NEXT:    negq %rax
+; AVX512-NEXT:    addq %rsi, %rdi
+; AVX512-NEXT:    movq %rdi, (%rdx)
+; AVX512-NEXT:    adcq $0, %rax
+; AVX512-NEXT:    retq
   %agg = call {i64, i1} @llvm.uadd.with.overflow(i64 %x, i64 %y)
   %val = extractvalue {i64, i1} %agg, 0
   %ov = extractvalue {i64, i1} %agg, 1
@@ -430,6 +504,15 @@ define { i64, i64, i1 } @subcarry_2x64(i64 %x0, i64 %x1, i64 %y0, i64 %y1) nounw
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: subcarry_2x64:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    retq
   %t0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %x0, i64 %y0)
   %s0 = extractvalue { i64, i1 } %t0, 0
   %k0 = extractvalue { i64, i1 } %t0, 1
@@ -489,6 +572,15 @@ define { i64, i64, i1 } @subcarry_2x64_or_reversed(i64 %x0, i64 %x1, i64 %y0, i6
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: subcarry_2x64_or_reversed:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    retq
   %t0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %x0, i64 %y0)
   %s0 = extractvalue { i64, i1 } %t0, 0
   %k0 = extractvalue { i64, i1 } %t0, 1
@@ -548,6 +640,15 @@ define { i64, i64, i1 } @subcarry_2x64_xor_reversed(i64 %x0, i64 %x1, i64 %y0, i
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: subcarry_2x64_xor_reversed:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    retq
   %t0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %x0, i64 %y0)
   %s0 = extractvalue { i64, i1 } %t0, 0
   %k0 = extractvalue { i64, i1 } %t0, 1
@@ -607,6 +708,15 @@ define { i64, i64, i1 } @subcarry_2x64_and_reversed(i64 %x0, i64 %x1, i64 %y0, i
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: subcarry_2x64_and_reversed:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    xorl %ecx, %ecx
+; AVX512-NEXT:    retq
   %t0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %x0, i64 %y0)
   %s0 = extractvalue { i64, i1 } %t0, 0
   %k0 = extractvalue { i64, i1 } %t0, 1
@@ -666,6 +776,15 @@ define { i64, i64, i1 } @subcarry_2x64_add_reversed(i64 %x0, i64 %x1, i64 %y0, i
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: subcarry_2x64_add_reversed:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    movq %rsi, %rdx
+; AVX512-NEXT:    retq
   %t0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %x0, i64 %y0)
   %s0 = extractvalue { i64, i1 } %t0, 0
   %k0 = extractvalue { i64, i1 } %t0, 1
@@ -713,6 +832,14 @@ define { i64, i1 } @subcarry_fake_carry(i64 %a, i64 %b, i1 %carryin) nounwind {
 ; X86-NEXT:    orb %ch, %cl
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_fake_carry:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    btl $0, %edx
+; AVX512-NEXT:    sbbq %rsi, %rax
+; AVX512-NEXT:    setb %dl
+; AVX512-NEXT:    retq
     %t1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
     %partial = extractvalue { i64, i1 } %t1, 0
     %k1 = extractvalue { i64, i1 } %t1, 1
@@ -751,6 +878,16 @@ define { i64, i1 } @subcarry_carry_not_zext(i64 %a, i64 %b, i64 %carryin) nounwi
 ; X86-NEXT:    setb %cl
 ; X86-NEXT:    orb %ch, %cl
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_carry_not_zext:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rsi, %rax
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    setb %dl
+; AVX512-NEXT:    orb %cl, %dl
+; AVX512-NEXT:    retq
     %t1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
     %partial = extractvalue { i64, i1 } %t1, 0
     %k1 = extractvalue { i64, i1 } %t1, 1
@@ -792,6 +929,17 @@ define { i64, i1 } @subcarry_carry_not_i1(i64 %a, i64 %b, i8 %carryin) nounwind 
 ; X86-NEXT:    orb %bl, %cl
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_carry_not_i1:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    subq %rsi, %rax
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    movzbl %dl, %edx
+; AVX512-NEXT:    subq %rdx, %rax
+; AVX512-NEXT:    setb %dl
+; AVX512-NEXT:    orb %cl, %dl
+; AVX512-NEXT:    retq
     %t1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
     %partial = extractvalue { i64, i1 } %t1, 0
     %k1 = extractvalue { i64, i1 } %t1, 1
@@ -903,6 +1051,17 @@ define i32 @sub_U320_without_i128_or(ptr nocapture dereferenceable(40) %0, i64 %
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: sub_U320_without_i128_or:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    subq %rsi, (%rdi)
+; AVX512-NEXT:    sbbq %rdx, 8(%rdi)
+; AVX512-NEXT:    sbbq %rcx, 16(%rdi)
+; AVX512-NEXT:    sbbq %r8, 24(%rdi)
+; AVX512-NEXT:    sbbq %r9, 32(%rdi)
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    movzbl %al, %eax
+; AVX512-NEXT:    retq
   %7 = load i64, ptr %0, align 8
   %8 = getelementptr inbounds %struct.U320, ptr %0, i64 0, i32 0, i64 1
   %9 = load i64, ptr %8, align 8
@@ -1039,6 +1198,17 @@ define i32 @sub_U320_usubo(ptr nocapture dereferenceable(40) %0, i64 %1, i64 %2,
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: sub_U320_usubo:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    subq %rsi, (%rdi)
+; AVX512-NEXT:    sbbq %rdx, 8(%rdi)
+; AVX512-NEXT:    sbbq %rcx, 16(%rdi)
+; AVX512-NEXT:    sbbq %r8, 24(%rdi)
+; AVX512-NEXT:    sbbq %r9, 32(%rdi)
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    movzbl %al, %eax
+; AVX512-NEXT:    retq
   %7 = load i64, ptr %0, align 8
   %8 = getelementptr inbounds %struct.U320, ptr %0, i64 0, i32 0, i64 1
   %9 = load i64, ptr %8, align 8
@@ -1149,6 +1319,20 @@ define void @PR39464(ptr noalias nocapture sret(%struct.U192) %0, ptr nocapture 
 ; X86-NEXT:    popl %edi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: PR39464:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    movq (%rsi), %rcx
+; AVX512-NEXT:    subq (%rdx), %rcx
+; AVX512-NEXT:    movq %rcx, (%rdi)
+; AVX512-NEXT:    movq 8(%rsi), %rcx
+; AVX512-NEXT:    sbbq 8(%rdx), %rcx
+; AVX512-NEXT:    movq %rcx, 8(%rdi)
+; AVX512-NEXT:    movq 16(%rsi), %rcx
+; AVX512-NEXT:    sbbq 16(%rdx), %rcx
+; AVX512-NEXT:    movq %rcx, 16(%rdi)
+; AVX512-NEXT:    retq
   %4 = load i64, ptr %1, align 8
   %5 = load i64, ptr %2, align 8
   %6 = tail call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %4, i64 %5)
@@ -1268,6 +1452,27 @@ define void @sub_U256_without_i128_or_recursive(ptr sret(%uint256) %0, ptr %1, p
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl $4
+;
+; AVX512-LABEL: sub_U256_without_i128_or_recursive:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq %rdi, %rax
+; AVX512-NEXT:    movq (%rsi), %rcx
+; AVX512-NEXT:    movq 8(%rsi), %rdi
+; AVX512-NEXT:    movq 16(%rsi), %r8
+; AVX512-NEXT:    movq 24(%rsi), %rsi
+; AVX512-NEXT:    xorl %r9d, %r9d
+; AVX512-NEXT:    subq 16(%rdx), %r8
+; AVX512-NEXT:    setb %r9b
+; AVX512-NEXT:    subq 24(%rdx), %rsi
+; AVX512-NEXT:    subq (%rdx), %rcx
+; AVX512-NEXT:    sbbq 8(%rdx), %rdi
+; AVX512-NEXT:    sbbq $0, %r8
+; AVX512-NEXT:    sbbq %r9, %rsi
+; AVX512-NEXT:    movq %rcx, (%rax)
+; AVX512-NEXT:    movq %rdi, 8(%rax)
+; AVX512-NEXT:    movq %r8, 16(%rax)
+; AVX512-NEXT:    movq %rsi, 24(%rax)
+; AVX512-NEXT:    retq
   %4 = load i64, ptr %1, align 8
   %5 = getelementptr inbounds %uint256, ptr %1, i64 0, i32 0, i32 1
   %6 = load i64, ptr %5, align 8
@@ -1343,6 +1548,16 @@ define i1 @subcarry_ult_2x64(i64 %x0, i64 %x1, i64 %y0, i64 %y1) nounwind {
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    popl %ebx
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_ult_2x64:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    subq %rcx, %rsi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    cmpq %rdx, %rdi
+; AVX512-NEXT:    sbbq $0, %rsi
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    orb %cl, %al
+; AVX512-NEXT:    retq
   %b0 = icmp ult i64 %x0, %y0
   %d1 = sub i64 %x1, %y1
   %b10 = icmp ult i64 %x1, %y1
@@ -1379,6 +1594,13 @@ define i1 @subcarry_ult_2x64_2(i64 %x0, i64 %x1, i64 %y0, i64 %y1) nounwind {
 ; X86-NEXT:    setb %al
 ; X86-NEXT:    popl %esi
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_ult_2x64_2:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    cmpq %rdx, %rdi
+; AVX512-NEXT:    sbbq %rcx, %rsi
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    retq
 entry:
   %0 = icmp ult i64 %x0, %y0
   %1 = icmp ult i64 %x1, %y1
@@ -1414,6 +1636,15 @@ define i1 @subcarry_ult_2x64_1x64(i64 %x0, i64 %x1, i64 %y) nounwind {
 ; X86-NEXT:    sete %al
 ; X86-NEXT:    andb %cl, %al
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_ult_2x64_1x64:
+; AVX512:       # %bb.0: # %entry
+; AVX512-NEXT:    cmpq %rdx, %rdi
+; AVX512-NEXT:    setb %cl
+; AVX512-NEXT:    testq %rsi, %rsi
+; AVX512-NEXT:    sete %al
+; AVX512-NEXT:    andb %cl, %al
+; AVX512-NEXT:    retq
 entry:
   %0 = icmp ult i64 %x0, %y
   %1 = icmp eq i64 %x1, 0
@@ -1458,6 +1689,15 @@ define i1 @subcarry_ult_2x128(i128 %x0, i128 %x1, i128 %y0, i128 %y1) nounwind {
 ; X86-NEXT:    movl %ebp, %esp
 ; X86-NEXT:    popl %ebp
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_ult_2x128:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    cmpq %r8, %rdi
+; AVX512-NEXT:    sbbq %r9, %rsi
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rdx
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rcx
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    retq
   %b0 = icmp ult i128 %x0, %y0
   %b1 = icmp ult i128 %x1, %y1
   %e1 = icmp eq i128 %x1, %y1
@@ -1470,55 +1710,70 @@ define i1 @subcarry_ult_2x128(i128 %x0, i128 %x1, i128 %y0, i128 %y1) nounwind {
 define i1 @subcarry_ult_2x256(i256 %x0, i256 %x1, i256 %y0, i256 %y1) nounwind {
 ; X64-LABEL: subcarry_ult_2x256:
 ; X64:       # %bb.0:
-; X64-NEXT:    movq 16(%rsp), %rax
-; X64-NEXT:    movq 8(%rsp), %r10
-; X64-NEXT:    cmpq 24(%rsp), %rdi
-; X64-NEXT:    sbbq 32(%rsp), %rsi
-; X64-NEXT:    sbbq 40(%rsp), %rdx
-; X64-NEXT:    sbbq 48(%rsp), %rcx
-; X64-NEXT:    sbbq 56(%rsp), %r8
-; X64-NEXT:    sbbq 64(%rsp), %r9
-; X64-NEXT:    sbbq 72(%rsp), %r10
-; X64-NEXT:    sbbq 80(%rsp), %rax
+; X64-NEXT:    movq {{[0-9]+}}(%rsp), %rax
+; X64-NEXT:    movq {{[0-9]+}}(%rsp), %r10
+; X64-NEXT:    cmpq {{[0-9]+}}(%rsp), %rdi
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %rsi
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %rdx
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %rcx
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %r8
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %r9
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %r10
+; X64-NEXT:    sbbq {{[0-9]+}}(%rsp), %rax
 ; X64-NEXT:    setb %al
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: subcarry_ult_2x256:
 ; X86:       # %bb.0:
-; X86-NEXT:    movl 4(%esp), %eax
-; X86-NEXT:    cmpl 68(%esp), %eax
-; X86-NEXT:    movl 8(%esp), %eax
-; X86-NEXT:    sbbl 72(%esp), %eax
-; X86-NEXT:    movl 12(%esp), %eax
-; X86-NEXT:    sbbl 76(%esp), %eax
-; X86-NEXT:    movl 16(%esp), %eax
-; X86-NEXT:    sbbl 80(%esp), %eax
-; X86-NEXT:    movl 20(%esp), %eax
-; X86-NEXT:    sbbl 84(%esp), %eax
-; X86-NEXT:    movl 24(%esp), %eax
-; X86-NEXT:    sbbl 88(%esp), %eax
-; X86-NEXT:    movl 28(%esp), %eax
-; X86-NEXT:    sbbl 92(%esp), %eax
-; X86-NEXT:    movl 32(%esp), %eax
-; X86-NEXT:    sbbl 96(%esp), %eax
-; X86-NEXT:    movl 36(%esp), %eax
-; X86-NEXT:    sbbl 100(%esp), %eax
-; X86-NEXT:    movl 40(%esp), %eax
-; X86-NEXT:    sbbl 104(%esp), %eax
-; X86-NEXT:    movl 44(%esp), %eax
-; X86-NEXT:    sbbl 108(%esp), %eax
-; X86-NEXT:    movl 48(%esp), %eax
-; X86-NEXT:    sbbl 112(%esp), %eax
-; X86-NEXT:    movl 52(%esp), %eax
-; X86-NEXT:    sbbl 116(%esp), %eax
-; X86-NEXT:    movl 56(%esp), %eax
-; X86-NEXT:    sbbl 120(%esp), %eax
-; X86-NEXT:    movl 60(%esp), %eax
-; X86-NEXT:    sbbl 124(%esp), %eax
-; X86-NEXT:    movl 64(%esp), %eax
-; X86-NEXT:    sbbl 128(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    cmpl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    setb %al
 ; X86-NEXT:    retl
+;
+; AVX512-LABEL: subcarry_ult_2x256:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    movq {{[0-9]+}}(%rsp), %rax
+; AVX512-NEXT:    movq {{[0-9]+}}(%rsp), %r10
+; AVX512-NEXT:    cmpq {{[0-9]+}}(%rsp), %rdi
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rsi
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rdx
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rcx
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %r8
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %r9
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %rax
+; AVX512-NEXT:    sbbq {{[0-9]+}}(%rsp), %r10
+; AVX512-NEXT:    setb %al
+; AVX512-NEXT:    retq
   %b0 = icmp ult i256 %x0, %y0
   %b1 = icmp ult i256 %x1, %y1
   %e1 = icmp eq i256 %x1, %y1
@@ -1528,6 +1783,52 @@ define i1 @subcarry_ult_2x256(i256 %x0, i256 %x1, i256 %y0, i256 %y1) nounwind {
 }
 ; Negative test: vector types are not a borrow chain.
 define <4 x i1> @no_subcarry_vector(<4 x i32> %x0, <4 x i32> %x1, <4 x i32> %y0, <4 x i32> %y1) nounwind {
+; X64-LABEL: no_subcarry_vector:
+; X64:       # %bb.0:
+; X64-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
+; X64-NEXT:    pxor %xmm4, %xmm0
+; X64-NEXT:    pxor %xmm4, %xmm2
+; X64-NEXT:    pcmpgtd %xmm0, %xmm2
+; X64-NEXT:    movdqa %xmm1, %xmm0
+; X64-NEXT:    pxor %xmm4, %xmm0
+; X64-NEXT:    pxor %xmm3, %xmm4
+; X64-NEXT:    pcmpgtd %xmm0, %xmm4
+; X64-NEXT:    pcmpeqd %xmm3, %xmm1
+; X64-NEXT:    pand %xmm2, %xmm1
+; X64-NEXT:    por %xmm1, %xmm4
+; X64-NEXT:    movdqa %xmm4, %xmm0
+; X64-NEXT:    retq
+;
+; X86-LABEL: no_subcarry_vector:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    cmpl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    setb %al
+; X86-NEXT:    addb %al, %al
+; X86-NEXT:    cmpl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    adcb $0, %al
+; X86-NEXT:    shlb $2, %al
+; X86-NEXT:    cmpl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    setb %dl
+; X86-NEXT:    addb %dl, %dl
+; X86-NEXT:    cmpl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    sbbl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    adcb %al, %dl
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    andb $15, %dl
+; X86-NEXT:    movb %dl, (%eax)
+; X86-NEXT:    retl $4
+;
 ; AVX512-LABEL: no_subcarry_vector:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpcmpltud %xmm2, %xmm0, %k1
@@ -1537,36 +1838,6 @@ define <4 x i1> @no_subcarry_vector(<4 x i32> %x0, <4 x i32> %x1, <4 x i32> %y0,
 ; AVX512-NEXT:    vpcmpeqd %xmm0, %xmm0, %xmm0
 ; AVX512-NEXT:    vmovdqa32 %xmm0, %xmm0 {%k1} {z}
 ; AVX512-NEXT:    retq
-;
-; X86-LABEL: no_subcarry_vector:
-; X86:       # %bb.0:
-; X86-NEXT:    movl 16(%esp), %ecx
-; X86-NEXT:    movl 20(%esp), %eax
-; X86-NEXT:    cmpl 52(%esp), %eax
-; X86-NEXT:    movl 36(%esp), %eax
-; X86-NEXT:    sbbl 68(%esp), %eax
-; X86-NEXT:    setb %al
-; X86-NEXT:    addb %al, %al
-; X86-NEXT:    cmpl 48(%esp), %ecx
-; X86-NEXT:    movl 32(%esp), %ecx
-; X86-NEXT:    sbbl 64(%esp), %ecx
-; X86-NEXT:    movl 12(%esp), %ecx
-; X86-NEXT:    adcb $0, %al
-; X86-NEXT:    shlb $2, %al
-; X86-NEXT:    cmpl 44(%esp), %ecx
-; X86-NEXT:    movl 28(%esp), %ecx
-; X86-NEXT:    sbbl 60(%esp), %ecx
-; X86-NEXT:    movl 8(%esp), %ecx
-; X86-NEXT:    setb %dl
-; X86-NEXT:    addb %dl, %dl
-; X86-NEXT:    cmpl 40(%esp), %ecx
-; X86-NEXT:    movl 24(%esp), %ecx
-; X86-NEXT:    sbbl 56(%esp), %ecx
-; X86-NEXT:    adcb %al, %dl
-; X86-NEXT:    movl 4(%esp), %eax
-; X86-NEXT:    andb $15, %dl
-; X86-NEXT:    movb %dl, (%eax)
-; X86-NEXT:    retl $4
   %b0 = icmp ult <4 x i32> %x0, %y0
   %b1 = icmp ult <4 x i32> %x1, %y1
   %e1 = icmp eq <4 x i32> %x1, %y1


### PR DESCRIPTION
The AVX512 RUN line lacked CHECK blocks for almost every function in the file, so its codegen wasn't actually being verified.