### PR TITLE
[VPlan] Add SCEV support for abs intrinsic

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -258,6 +258,13 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getSMinExpr(Ops[0], Ops[1]);
     });
+  const APInt *IsIntMinPoison;
+  if (match(V, m_Intrinsic<Intrinsic::abs>(m_VPValue(LHSVal),
+                                           m_APInt(IsIntMinPoison))) &&
+      IsIntMinPoison->getBitWidth() == 1)
+    return CreateSCEV({LHSVal}, [&](ArrayRef<SCEVUse> Ops) {
+      return SE.getAbsExpr(Ops[0], IsIntMinPoison->isOne());
+    });
 
   ArrayRef<VPValue *> Ops;
   Type *SourceElementType;

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -258,12 +258,15 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getSMinExpr(Ops[0], Ops[1]);
     });
-  const APInt *IsIntMinPoison;
-  if (match(V, m_Intrinsic<Intrinsic::abs>(m_VPValue(LHSVal),
-                                           m_APInt(IsIntMinPoison))) &&
-      IsIntMinPoison->getBitWidth() == 1)
+  if (match(V, m_Intrinsic<Intrinsic::abs>(m_VPValue(LHSVal), m_VPValue())))
     return CreateSCEV({LHSVal}, [&](ArrayRef<SCEVUse> Ops) {
-      return SE.getAbsExpr(Ops[0], IsIntMinPoison->isOne());
+      // The is_int_min_poison operand of llvm.abs only states that this
+      // particular call is poison if its input is INT_MIN; it does not
+      // prove the input is never INT_MIN elsewhere. Forwarding it as
+      // SCEV's IsNSW would tag the cached negation SCEV as no-signed-wrap
+      // globally, which is unsound for other uses of the same SCEV.
+      // Revisit once getAbsExpr can carry the flag on a SCEVUse.
+      return SE.getAbsExpr(Ops[0], /*IsNSW=*/false);
     });
 
   ArrayRef<VPValue *> Ops;

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -260,12 +260,10 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     });
   if (match(V, m_Intrinsic<Intrinsic::abs>(m_VPValue(LHSVal), m_VPValue())))
     return CreateSCEV({LHSVal}, [&](ArrayRef<SCEVUse> Ops) {
-      // The is_int_min_poison operand of llvm.abs only states that this
-      // particular call is poison if its input is INT_MIN; it does not
-      // prove the input is never INT_MIN elsewhere. Forwarding it as
-      // SCEV's IsNSW would tag the cached negation SCEV as no-signed-wrap
-      // globally, which is unsound for other uses of the same SCEV.
-      // Revisit once getAbsExpr can carry the flag on a SCEVUse.
+      // is_int_min_poison only makes this call poison on INT_MIN; it does
+      // not prove the input is never INT_MIN, so forwarding it as IsNSW
+      // would attach a no-signed-wrap fact to the SCEV that is unsound
+      // for any other use of the same expression.
       return SE.getAbsExpr(Ops[0], /*IsNSW=*/false);
     });
 

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -260,10 +260,9 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     });
   if (match(V, m_Intrinsic<Intrinsic::abs>(m_VPValue(LHSVal), m_VPValue())))
     return CreateSCEV({LHSVal}, [&](ArrayRef<SCEVUse> Ops) {
-      // is_int_min_poison only makes this call poison on INT_MIN; it does
-      // not prove the input is never INT_MIN, so forwarding it as IsNSW
-      // would attach a no-signed-wrap fact to the SCEV that is unsound
-      // for any other use of the same expression.
+      // is_int_min_poison is local to this intrinsic: poison on INT_MIN is
+      // not proof that the input is never INT_MIN, nor that poison reaches
+      // UB. Do not translate it to SCEV's global IsNSW flag.
       return SE.getAbsExpr(Ops[0], /*IsNSW=*/false);
     });
 

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -42,12 +42,7 @@ define void @f(i32 %x) {
 entry:
   br label %loop
 loop:
-  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
-  %iv.next = add nuw nsw i32 %iv, 1
-  %exit = icmp eq i32 %iv.next, 4
-  br i1 %exit, label %exit.block, label %loop
-exit.block:
-  ret void
+  br label %loop
 }
 )";
 

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -57,18 +57,19 @@ loop:
   Argument *X = F->getArg(0);
   VPValue *Op = Plan.getOrAddLiveIn(X);
 
-  // is_int_min_poison is intentionally ignored when building the SCEV: it
-  // is a local poison property of the call, not a global no-wrap fact.
-  // Both forms must therefore produce the same wrapping abs SCEV.
-  const SCEV *ExpectedExpr = SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/false);
+  // is_int_min_poison is local to the call, not a global no-wrap fact.
+  // Exercise both getAbsExpr flag paths; SCEV drops IsNSW for this input.
+  const SCEV *XSCEV = SE->getSCEV(X);
 
   VPWidenIntrinsicRecipe Abs(Intrinsic::abs, {Op, Plan.getTrue()},
                              X->getType());
-  EXPECT_EQ(ExpectedExpr, vputils::getSCEVExprForVPValue(&Abs, PSE, L));
+  EXPECT_EQ(SE->getAbsExpr(XSCEV, /*IsNSW=*/true),
+            vputils::getSCEVExprForVPValue(&Abs, PSE, L));
 
   VPWidenIntrinsicRecipe WrappingAbs(Intrinsic::abs, {Op, Plan.getFalse()},
                                      X->getType());
-  EXPECT_EQ(ExpectedExpr, vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L));
+  EXPECT_EQ(SE->getAbsExpr(XSCEV, /*IsNSW=*/false),
+            vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L));
 }
 
 TEST_F(VPInstructionTest, insertBefore) {

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -10,6 +10,7 @@
 #include "../lib/Transforms/Vectorize/VPlan.h"
 #include "../lib/Transforms/Vectorize/VPlanCFG.h"
 #include "../lib/Transforms/Vectorize/VPlanHelpers.h"
+#include "../lib/Transforms/Vectorize/VPlanUtils.h"
 #include "VPlanTestBase.h"
 #include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -33,6 +34,45 @@ namespace {
   } while (0)
 
 using VPInstructionTest = VPlanTestBase;
+using VPlanSCEVTest = VPlanTestIRBase;
+
+TEST_F(VPlanSCEVTest, GetSCEVExprForVPValueAbs) {
+  const char *ModuleString =
+      "define void @f(i32 %x) {\n"
+      "entry:\n"
+      "  br label %loop\n"
+      "loop:\n"
+      "  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]\n"
+      "  %iv.next = add nuw nsw i32 %iv, 1\n"
+      "  %exit = icmp eq i32 %iv.next, 4\n"
+      "  br i1 %exit, label %exit.block, label %loop\n"
+      "exit.block:\n"
+      "  ret void\n"
+      "}\n";
+
+  Module &M = parseModule(ModuleString);
+  Function *F = M.getFunction("f");
+  BasicBlock *LoopHeader = F->getEntryBlock().getSingleSuccessor();
+  doAnalysis(*F);
+
+  Loop *L = LI->getLoopFor(LoopHeader);
+  PredicatedScalarEvolution PSE(*SE, *L);
+  VPlan Plan(LoopHeader);
+  Argument *X = F->getArg(0);
+  VPValue *Op = Plan.getOrAddLiveIn(X);
+  VPValue *IsIntMinPoison = Plan.getOrAddLiveIn(ConstantInt::getTrue(*Ctx));
+  VPWidenIntrinsicRecipe Abs(Intrinsic::abs, {Op, IsIntMinPoison},
+                             X->getType());
+
+  const SCEV *Expr = vputils::getSCEVExprForVPValue(&Abs, PSE, L);
+  EXPECT_EQ(SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/true), Expr);
+
+  IsIntMinPoison = Plan.getOrAddLiveIn(ConstantInt::getFalse(*Ctx));
+  VPWidenIntrinsicRecipe WrappingAbs(Intrinsic::abs, {Op, IsIntMinPoison},
+                                     X->getType());
+  Expr = vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L);
+  EXPECT_EQ(SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/false), Expr);
+}
 
 TEST_F(VPInstructionTest, insertBefore) {
   VPInstruction *I1 = new VPInstruction(VPInstruction::StepVector, {});

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -37,18 +37,19 @@ using VPInstructionTest = VPlanTestBase;
 using VPlanSCEVTest = VPlanTestIRBase;
 
 TEST_F(VPlanSCEVTest, GetSCEVExprForVPValueAbs) {
-  const char *ModuleString =
-      "define void @f(i32 %x) {\n"
-      "entry:\n"
-      "  br label %loop\n"
-      "loop:\n"
-      "  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]\n"
-      "  %iv.next = add nuw nsw i32 %iv, 1\n"
-      "  %exit = icmp eq i32 %iv.next, 4\n"
-      "  br i1 %exit, label %exit.block, label %loop\n"
-      "exit.block:\n"
-      "  ret void\n"
-      "}\n";
+  const char *ModuleString = R"(
+define void @f(i32 %x) {
+entry:
+  br label %loop
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %exit = icmp eq i32 %iv.next, 4
+  br i1 %exit, label %exit.block, label %loop
+exit.block:
+  ret void
+}
+)";
 
   Module &M = parseModule(ModuleString);
   Function *F = M.getFunction("f");
@@ -60,14 +61,14 @@ TEST_F(VPlanSCEVTest, GetSCEVExprForVPValueAbs) {
   VPlan Plan(LoopHeader);
   Argument *X = F->getArg(0);
   VPValue *Op = Plan.getOrAddLiveIn(X);
-  VPValue *IsIntMinPoison = Plan.getOrAddLiveIn(ConstantInt::getTrue(*Ctx));
+  VPValue *IsIntMinPoison = Plan.getTrue();
   VPWidenIntrinsicRecipe Abs(Intrinsic::abs, {Op, IsIntMinPoison},
                              X->getType());
 
   const SCEV *Expr = vputils::getSCEVExprForVPValue(&Abs, PSE, L);
   EXPECT_EQ(SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/true), Expr);
 
-  IsIntMinPoison = Plan.getOrAddLiveIn(ConstantInt::getFalse(*Ctx));
+  IsIntMinPoison = Plan.getFalse();
   VPWidenIntrinsicRecipe WrappingAbs(Intrinsic::abs, {Op, IsIntMinPoison},
                                      X->getType());
   Expr = vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L);

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -61,18 +61,19 @@ exit.block:
   VPlan Plan(LoopHeader);
   Argument *X = F->getArg(0);
   VPValue *Op = Plan.getOrAddLiveIn(X);
-  VPValue *IsIntMinPoison = Plan.getTrue();
-  VPWidenIntrinsicRecipe Abs(Intrinsic::abs, {Op, IsIntMinPoison},
+
+  // is_int_min_poison is intentionally ignored when building the SCEV: it
+  // is a local poison property of the call, not a global no-wrap fact.
+  // Both forms must therefore produce the same wrapping abs SCEV.
+  const SCEV *ExpectedExpr = SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/false);
+
+  VPWidenIntrinsicRecipe Abs(Intrinsic::abs, {Op, Plan.getTrue()},
                              X->getType());
+  EXPECT_EQ(ExpectedExpr, vputils::getSCEVExprForVPValue(&Abs, PSE, L));
 
-  const SCEV *Expr = vputils::getSCEVExprForVPValue(&Abs, PSE, L);
-  EXPECT_EQ(SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/true), Expr);
-
-  IsIntMinPoison = Plan.getFalse();
-  VPWidenIntrinsicRecipe WrappingAbs(Intrinsic::abs, {Op, IsIntMinPoison},
+  VPWidenIntrinsicRecipe WrappingAbs(Intrinsic::abs, {Op, Plan.getFalse()},
                                      X->getType());
-  Expr = vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L);
-  EXPECT_EQ(SE->getAbsExpr(SE->getSCEV(X), /*IsNSW=*/false), Expr);
+  EXPECT_EQ(ExpectedExpr, vputils::getSCEVExprForVPValue(&WrappingAbs, PSE, L));
 }
 
 TEST_F(VPInstructionTest, insertBefore) {


### PR DESCRIPTION
Teach `getSCEVExprForVPValue` to model `llvm.abs` via `ScalarEvolution::getAbsExpr`, preserving the intrinsic's is_int_min_poison flag as the SCEV IsNSW argument. Add a unit test covering both poison and wrapping llvm.abs forms.