### PR TITLE
[LLDB][FreeBSD] Implement DoStopIDBumped on FreeBSD

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -1089,3 +1089,11 @@ NativeProcessFreeBSD::SaveCore(llvm::StringRef path_hint) {
       "PT_COREDUMP not supported in the FreeBSD version used to build LLDB");
 #endif
 }
+
+void NativeProcessFreeBSD::DoStopIDBumped(uint32_t newBumpId) {
+  Log *log = GetLog(POSIXLog::Process);
+  LLDB_LOG(log, "newBumpId={0}", newBumpId);
+  LLDB_LOG(log, "clearing {0} entries from memory region cache",
+           m_mem_region_cache.size());
+  m_mem_region_cache.clear();
+}

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.h
@@ -92,6 +92,8 @@ public:
 
   llvm::Expected<std::string> SaveCore(llvm::StringRef path_hint) override;
 
+  void DoStopIDBumped(uint32_t newBumpId) override;
+
 protected:
   llvm::Expected<llvm::ArrayRef<uint8_t>>
   GetSoftwareBreakpointTrapOpcode(size_t size_hint) override;

--- a/lldb/test/Shell/Breakpoint/Inputs/break_stepout.c
+++ b/lldb/test/Shell/Breakpoint/Inputs/break_stepout.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+int main() { printf("Hello World\n"); }

--- a/lldb/test/Shell/Breakpoint/step-out.test
+++ b/lldb/test/Shell/Breakpoint/step-out.test
@@ -1,0 +1,10 @@
+# RUN: cp %p/Inputs/break_stepout.c %t.c
+# RUN: %clang_host -g -o %t %t.c
+# RUN: rm %t.c
+# RUN: %lldb -b -o "br set -n vfprintf" -o run -o "thread step-out" -o "thread step-out" %t 2>&1 | FileCheck %s
+
+## Check if we step-out twice sucessfully
+
+CHECK: stop reason = step out
+CHECK: stop reason = step out
+


### PR DESCRIPTION
When stopping, we should clear the mmap cache and repopulate all regions to properly handle new mmap syscalls. Without this, binaries loaded via dlopen or user-initiated mmap calls will not be recognized as valid memory regions.

Fixes: https://github.com/llvm/llvm-project/issues/180445