### PR TITLE
[libunwind] Move wasm definition of `__cpp_exception`

### DIFF
--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set_source_files_properties(${LIBUNWIND_C_SOURCES}
 set(LIBUNWIND_ASM_SOURCES
     UnwindRegistersRestore.S
     UnwindRegistersSave.S
+    __cpp_exception.S
     )
 
 set(LIBUNWIND_HEADERS

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -69,21 +69,6 @@ _Unwind_RaiseException(_Unwind_Exception *exception_object) {
   __builtin_wasm_throw(0, exception_object);
 }
 
-// Define the `__cpp_exception` symbol which `__builtin_wasm_throw` above will
-// reference. This is defined here in `libunwind` as the single canonical
-// definition for this API and it's required for users to ensure that there's
-// only one copy of `libunwind` within a wasm module to ensure this is only
-// defined once and exactly once.
-__asm__(".globl __cpp_exception\n"
-#if defined(__wasm32__)
-        ".tagtype __cpp_exception i32\n"
-#elif defined(__wasm64__)
-        ".tagtype __cpp_exception i64\n"
-#else
-#error "Unsupported Wasm architecture"
-#endif
-        "__cpp_exception:\n");
-
 /// Called by __cxa_end_catch.
 _LIBUNWIND_EXPORT void
 _Unwind_DeleteException(_Unwind_Exception *exception_object) {

--- a/libunwind/src/__cpp_exception.S
+++ b/libunwind/src/__cpp_exception.S
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if !defined(__wasm__)
+
+#include "assembly.h"
+
+NO_EXEC_STACK_DIRECTIVE
+
+#endif // !defined(__wasm__)
+
+#ifdef __WASM_EXCEPTIONS__
+
+// Define the `__cpp_exception` symbol which `__builtin_wasm_throw` will
+// reference. This is defined here in `libunwind` as the single canonical
+// definition for this API and it's required for users to ensure that there's
+// only one copy of `libunwind` within a wasm module to ensure this is only
+// defined once and exactly once.
+.globl __cpp_exception
+#if defined(__wasm32__)
+.tagtype __cpp_exception i32
+#elif defined(__wasm64__)
+.tagtype __cpp_exception i64
+#else
+#error "Unsupported Wasm architecture"
+#endif
+__cpp_exception:
+
+#endif // defined(__WASM_EXCEPTIONS__)


### PR DESCRIPTION
This moves the definition of `__cpp_exception` from an inline assembly definition in the `Unwind-wasm.c` file of libunwind to a dedicated `*.S` external file, for now called `__cpp_exception.S` to match Emscripten. This is done due to a bug in LTO, #195311, where the inline assembly definition means that compiling with LTO leads to linking failures. This is intended to be a temporary workaround until the true underlying issue is fixed.