### PR TITLE
[Offload][NFC] Rename `omp::target` namespace to `offload`

### DIFF
--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -17,6 +17,7 @@
 #include "PluginManager.h"
 
 using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 enum kmp_target_offload_kind_t {
   tgt_disabled = 0,

--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -16,7 +16,7 @@
 
 #include "PluginManager.h"
 
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 enum kmp_target_offload_kind_t {
   tgt_disabled = 0,

--- a/offload/include/OpenMP/OMPT/Callback.h
+++ b/offload/include/OpenMP/OMPT/Callback.h
@@ -29,7 +29,7 @@
 
 #define performIfOmptInitialized(stmt)                                         \
   do {                                                                         \
-    if (llvm::omp::target::ompt::Initialized) {                                \
+    if (llvm::offload::ompt::Initialized) {                                    \
       stmt;                                                                    \
     }                                                                          \
   } while (0)
@@ -45,8 +45,7 @@
 typedef uint64_t (*IdInterfaceTy)();
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace ompt {
 
 #define declareOmptCallback(Name, Type, Code) extern Name##_t Name##_fn;
@@ -92,8 +91,7 @@ void connectLibrary();
 extern bool Initialized;
 
 } // namespace ompt
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #pragma pop_macro("DEBUG_PREFIX")

--- a/offload/include/OpenMP/OMPT/Connector.h
+++ b/offload/include/OpenMP/OMPT/Connector.h
@@ -28,6 +28,7 @@
 #include "Shared/Debug.h"
 
 using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX

--- a/offload/include/OpenMP/OMPT/Connector.h
+++ b/offload/include/OpenMP/OMPT/Connector.h
@@ -27,7 +27,7 @@
 
 #include "Shared/Debug.h"
 
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX

--- a/offload/include/OpenMP/OMPT/Interface.h
+++ b/offload/include/OpenMP/OMPT/Interface.h
@@ -33,8 +33,7 @@ typedef ompt_data_t *(*ompt_get_task_data_t)();
 typedef ompt_data_t *(*ompt_get_target_task_data_t)();
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace ompt {
 
 /// Function pointers that will be used to track task_data and
@@ -315,12 +314,11 @@ private:
 };
 
 } // namespace ompt
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 // The getter returns the address stored in the thread local variable.
-#define OMPT_GET_RETURN_ADDRESS llvm::omp::target::ompt::ReturnAddress
+#define OMPT_GET_RETURN_ADDRESS llvm::offload::ompt::ReturnAddress
 
 #else
 #define OMPT_IF_BUILT(stmt)

--- a/offload/include/PluginManager.h
+++ b/offload/include/PluginManager.h
@@ -37,7 +37,7 @@
 
 #include "OpenMP/InteropAPI.h"
 
-using GenericPluginTy = llvm::omp::target::plugin::GenericPluginTy;
+using GenericPluginTy = llvm::offload::plugin::GenericPluginTy;
 
 /// Struct for the data required to handle plugins
 struct PluginManager {

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -576,6 +576,11 @@ constexpr const char *OLDT_Alloc = "Alloc";
 constexpr const char *OLDT_Tool = "Tool";
 constexpr const char *OLDT_Module = "Module";
 
+} // namespace llvm::offload::debug
+
+namespace llvm::omp::target::debug {
+using namespace llvm::offload::debug;
+
 enum OmpDebugLevel : uint32_t {
   ODL_Default = 1,
   ODL_Error = ODL_Default,
@@ -605,11 +610,6 @@ constexpr const char *ODT_Alloc = OLDT_Alloc;
 constexpr const char *ODT_Tool = OLDT_Tool;
 constexpr const char *ODT_Module = OLDT_Module;
 constexpr const char *ODT_Interop = "Interop";
-
-} // namespace llvm::offload::debug
-
-namespace llvm::omp::target::debug {
-using namespace llvm::offload::debug;
 
 static inline odbg_ostream reportErrorStream() {
 #ifdef OMPTARGET_DEBUG

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -578,8 +578,7 @@ constexpr const char *OLDT_Module = "Module";
 
 } // namespace llvm::offload::debug
 
-namespace llvm::omp::target::debug {
-using namespace llvm::offload::debug;
+namespace llvm::offload::debug {
 
 enum OmpDebugLevel : uint32_t {
   ODL_Default = 1,
@@ -644,7 +643,7 @@ static inline odbg_ostream reportErrorStream() {
 
 // helper macro to support old DP and REPORT macros with printf syntax
 #define FORMAT_TO_STR(Format, ...)                                             \
-  ::llvm::omp::target::debug::formatToStr(Format __VA_OPT__(, ) __VA_ARGS__)
+  ::llvm::offload::debug::formatToStr(Format __VA_OPT__(, ) __VA_ARGS__)
 
 template <uint32_t InfoId> static constexpr const char *InfoIdToODT() {
   constexpr auto getId = []() {
@@ -676,7 +675,7 @@ template <uint32_t InfoId> static constexpr const char *InfoIdToODT() {
 
 // Transform the INFO id to the corresponding debug type and print the message
 #define INFO_DEBUG_INT(_flags, _id, ...)                                       \
-  ODBG(::llvm::omp::target::debug::InfoIdToODT<_flags>())                      \
+  ODBG(::llvm::offload::debug::InfoIdToODT<_flags>())                          \
       << FORMAT_TO_STR(__VA_ARGS__);
 
 // Define default format for pointers
@@ -694,8 +693,8 @@ static inline raw_ostream &operator<<(raw_ostream &Os, void *Ptr) {
 #endif // OMPTARGET_DEBUG
 
 // New REPORT macro in the same style as ODBG
-#define REPORT() ::llvm::omp::target::debug::reportErrorStream()
+#define REPORT() ::llvm::offload::debug::reportErrorStream()
 
-} // namespace llvm::omp::target::debug
+} // namespace llvm::offload::debug
 
 #endif // OMPTARGET_SHARED_DEBUG_H

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -576,10 +576,6 @@ constexpr const char *OLDT_Alloc = "Alloc";
 constexpr const char *OLDT_Tool = "Tool";
 constexpr const char *OLDT_Module = "Module";
 
-} // namespace llvm::offload::debug
-
-namespace llvm::offload::debug {
-
 enum OmpDebugLevel : uint32_t {
   ODL_Default = 1,
   ODL_Error = ODL_Default,
@@ -609,6 +605,11 @@ constexpr const char *ODT_Alloc = OLDT_Alloc;
 constexpr const char *ODT_Tool = OLDT_Tool;
 constexpr const char *ODT_Module = OLDT_Module;
 constexpr const char *ODT_Interop = "Interop";
+
+} // namespace llvm::offload::debug
+
+namespace llvm::omp::target::debug {
+using namespace llvm::offload::debug;
 
 static inline odbg_ostream reportErrorStream() {
 #ifdef OMPTARGET_DEBUG
@@ -643,7 +644,7 @@ static inline odbg_ostream reportErrorStream() {
 
 // helper macro to support old DP and REPORT macros with printf syntax
 #define FORMAT_TO_STR(Format, ...)                                             \
-  ::llvm::offload::debug::formatToStr(Format __VA_OPT__(, ) __VA_ARGS__)
+  ::llvm::omp::target::debug::formatToStr(Format __VA_OPT__(, ) __VA_ARGS__)
 
 template <uint32_t InfoId> static constexpr const char *InfoIdToODT() {
   constexpr auto getId = []() {
@@ -675,7 +676,7 @@ template <uint32_t InfoId> static constexpr const char *InfoIdToODT() {
 
 // Transform the INFO id to the corresponding debug type and print the message
 #define INFO_DEBUG_INT(_flags, _id, ...)                                       \
-  ODBG(::llvm::offload::debug::InfoIdToODT<_flags>())                          \
+  ODBG(::llvm::omp::target::debug::InfoIdToODT<_flags>())                      \
       << FORMAT_TO_STR(__VA_ARGS__);
 
 // Define default format for pointers
@@ -693,8 +694,8 @@ static inline raw_ostream &operator<<(raw_ostream &Os, void *Ptr) {
 #endif // OMPTARGET_DEBUG
 
 // New REPORT macro in the same style as ODBG
-#define REPORT() ::llvm::offload::debug::reportErrorStream()
+#define REPORT() ::llvm::omp::target::debug::reportErrorStream()
 
-} // namespace llvm::offload::debug
+} // namespace llvm::omp::target::debug
 
 #endif // OMPTARGET_SHARED_DEBUG_H

--- a/offload/include/Shared/RefCnt.h
+++ b/offload/include/Shared/RefCnt.h
@@ -17,8 +17,7 @@
 #include <memory>
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 
 /// Utility class for thread-safe reference counting. Any class that needs
 /// objects' reference counting can inherit from this entity or have it as a
@@ -49,8 +48,7 @@ private:
   /// The atomic reference counter.
   std::atomic<Ty> Refs;
 };
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif

--- a/offload/include/device.h
+++ b/offload/include/device.h
@@ -36,9 +36,9 @@
 #include "GlobalHandler.h"
 #include "PluginInterface.h"
 
-using GenericPluginTy = llvm::omp::target::plugin::GenericPluginTy;
-using DeviceInfo = llvm::omp::target::plugin::DeviceInfo;
-using InfoTreeNode = llvm::omp::target::plugin::InfoTreeNode;
+using GenericPluginTy = llvm::offload::plugin::GenericPluginTy;
+using DeviceInfo = llvm::offload::plugin::DeviceInfo;
+using InfoTreeNode = llvm::offload::plugin::InfoTreeNode;
 
 // Forward declarations.
 struct __tgt_bin_desc;

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -27,17 +27,17 @@
 // it would be better to allow the plugins to implement callbacks without
 // pulling in details from libomptarget.
 #ifdef OMPT_SUPPORT
-namespace llvm::omp::target {
+namespace llvm::offload {
 namespace ompt {
 bool Initialized = false;
 ompt_get_callback_t lookupCallbackByCode = nullptr;
 ompt_function_lookup_t lookupCallbackByName = nullptr;
 } // namespace ompt
-} // namespace llvm::omp::target
+} // namespace llvm::offload
 #endif
 
-using namespace llvm::omp::target;
-using namespace llvm::omp::target::plugin;
+using namespace llvm::offload;
+using namespace llvm::offload::plugin;
 using namespace error;
 
 struct ol_platform_impl_t {

--- a/offload/libomptarget/LegacyAPI.cpp
+++ b/offload/libomptarget/LegacyAPI.cpp
@@ -17,9 +17,9 @@
 #include "Shared/Profile.h"
 
 #ifdef OMPT_SUPPORT
-using namespace llvm::omp::target::ompt;
+using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 EXTERN void __tgt_target_data_begin(int64_t DeviceId, int32_t ArgNum,
                                     void **ArgsBase, void **Args,

--- a/offload/libomptarget/LegacyAPI.cpp
+++ b/offload/libomptarget/LegacyAPI.cpp
@@ -19,7 +19,7 @@
 #ifdef OMPT_SUPPORT
 using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 EXTERN void __tgt_target_data_begin(int64_t DeviceId, int32_t ArgNum,
                                     void **ArgsBase, void **Args,

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -17,9 +17,9 @@
 #include "Shared/Profile.h"
 
 #ifdef OMPT_SUPPORT
-extern void llvm::omp::target::ompt::connectLibrary();
+extern void llvm::offload::ompt::connectLibrary();
 #endif
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 static std::mutex PluginMtx;
 static uint32_t RefCount = 0;
@@ -50,7 +50,7 @@ void initRuntime() {
     ODBG(ODT_Init) << "Init offload library!";
 #ifdef OMPT_SUPPORT
     // Initialize OMPT first
-    llvm::omp::target::ompt::connectLibrary();
+    llvm::offload::ompt::connectLibrary();
 #endif
 
     PM->init();

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -19,7 +19,7 @@
 #ifdef OMPT_SUPPORT
 extern void llvm::offload::ompt::connectLibrary();
 #endif
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 static std::mutex PluginMtx;
 static uint32_t RefCount = 0;

--- a/offload/libomptarget/OpenMP/API.cpp
+++ b/offload/libomptarget/OpenMP/API.cpp
@@ -39,7 +39,7 @@ EXTERN void ompx_dump_mapping_tables() {
 #ifdef OMPT_SUPPORT
 using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 using GenericDeviceTy = llvm::offload::plugin::GenericDeviceTy;
 

--- a/offload/libomptarget/OpenMP/API.cpp
+++ b/offload/libomptarget/OpenMP/API.cpp
@@ -37,11 +37,11 @@ EXTERN void ompx_dump_mapping_tables() {
 }
 
 #ifdef OMPT_SUPPORT
-using namespace llvm::omp::target::ompt;
+using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
-using GenericDeviceTy = llvm::omp::target::plugin::GenericDeviceTy;
+using GenericDeviceTy = llvm::offload::plugin::GenericDeviceTy;
 
 void *targetAllocExplicit(size_t Size, int DeviceNum, int Kind,
                           const char *Name);

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -18,7 +18,7 @@
 #include <cstdlib>
 #include <cstring>
 
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 namespace {
 omp_interop_rc_t getPropertyErrorType(omp_interop_property_t Property) {

--- a/offload/libomptarget/OpenMP/InteropAPI.cpp
+++ b/offload/libomptarget/OpenMP/InteropAPI.cpp
@@ -18,7 +18,7 @@
 #include <cstdlib>
 #include <cstring>
 
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 namespace {
 omp_interop_rc_t getPropertyErrorType(omp_interop_property_t Property) {

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -15,7 +15,7 @@
 #include "Shared/Requirements.h"
 #include "device.h"
 
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 /// Dump a table of all the host-target pointer pairs on failure
 void dumpTargetPointerMappings(const ident_t *Loc, DeviceTy &Device,

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -15,7 +15,7 @@
 #include "Shared/Requirements.h"
 #include "device.h"
 
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 /// Dump a table of all the host-target pointer pairs on failure
 void dumpTargetPointerMappings(const ident_t *Loc, DeviceTy &Device,

--- a/offload/libomptarget/OpenMP/OMPT/Callback.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/Callback.cpp
@@ -29,7 +29,7 @@
 
 // Define OMPT callback functions (bound to actual callbacks later on)
 #define defineOmptCallback(Name, Type, Code)                                   \
-  Name##_t llvm::omp::target::ompt::Name##_fn = nullptr;
+  Name##_t llvm::offload::ompt::Name##_fn = nullptr;
 FOREACH_OMPT_NOEMI_EVENT(defineOmptCallback)
 FOREACH_OMPT_EMI_EVENT(defineOmptCallback)
 #undef defineOmptCallback
@@ -37,8 +37,8 @@ FOREACH_OMPT_EMI_EVENT(defineOmptCallback)
 // See definition in OpenMP (omp.h.var/omp_lib.(F90|h).var)
 #define omp_initial_device -1
 
-using namespace llvm::omp::target::ompt;
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::ompt;
+using namespace llvm::offload::debug;
 
 /// Forward declaration
 class LibomptargetRtlFinalizer;
@@ -46,14 +46,14 @@ class LibomptargetRtlFinalizer;
 /// Object that will maintain the RTL finalizer from the plugin
 LibomptargetRtlFinalizer *LibraryFinalizer = nullptr;
 
-thread_local Interface llvm::omp::target::ompt::RegionInterface;
+thread_local Interface llvm::offload::ompt::RegionInterface;
 
-thread_local void *llvm::omp::target::ompt::ReturnAddress = nullptr;
+thread_local void *llvm::offload::ompt::ReturnAddress = nullptr;
 
-bool llvm::omp::target::ompt::Initialized = false;
+bool llvm::offload::ompt::Initialized = false;
 
-ompt_get_callback_t llvm::omp::target::ompt::lookupCallbackByCode = nullptr;
-ompt_function_lookup_t llvm::omp::target::ompt::lookupCallbackByName = nullptr;
+ompt_get_callback_t llvm::offload::ompt::lookupCallbackByCode = nullptr;
+ompt_function_lookup_t llvm::offload::ompt::lookupCallbackByName = nullptr;
 ompt_get_target_task_data_t ompt_get_target_task_data_fn = nullptr;
 ompt_get_task_data_t ompt_get_task_data_fn = nullptr;
 
@@ -466,9 +466,9 @@ private:
   llvm::SmallVector<ompt_finalize_t> RtlFinalizationFunctions;
 };
 
-int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
-                                               int initial_device_num,
-                                               ompt_data_t *tool_data) {
+int llvm::offload::ompt::initializeLibrary(ompt_function_lookup_t lookup,
+                                           int initial_device_num,
+                                           ompt_data_t *tool_data) {
   ODBG(ODT_Tool) << "Executing initializeLibrary";
 #define bindOmptFunctionName(OmptFunction, DestinationFunction)                \
   if (lookup)                                                                  \
@@ -499,7 +499,7 @@ int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
   return 0;
 }
 
-void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
+void llvm::offload::ompt::finalizeLibrary(ompt_data_t *data) {
   ODBG(ODT_Tool) << "Executing finalizeLibrary";
   // Before disabling OMPT, call the (plugin) finalizations that were registered
   // with this library
@@ -508,7 +508,7 @@ void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
   Initialized = false;
 }
 
-void llvm::omp::target::ompt::connectLibrary() {
+void llvm::offload::ompt::connectLibrary() {
   ODBG(ODT_Tool) << "Entering connectLibrary";
   // Connect with libomp
   static OmptLibraryConnectorTy LibompConnector("libomp");
@@ -527,7 +527,7 @@ void llvm::omp::target::ompt::connectLibrary() {
   if (lookupCallbackByCode)                                                    \
     lookupCallbackByCode(                                                      \
         (ompt_callbacks_t)(Code),                                              \
-        (ompt_callback_t *)&(llvm::omp::target::ompt::Name##_fn));
+        (ompt_callback_t *)&(llvm::offload::ompt::Name##_fn));
   FOREACH_OMPT_NOEMI_EVENT(bindOmptCallback)
   FOREACH_OMPT_EMI_EVENT(bindOmptCallback)
 #undef bindOmptCallback

--- a/offload/libomptarget/OpenMP/OMPT/Callback.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/Callback.cpp
@@ -38,7 +38,7 @@ FOREACH_OMPT_EMI_EVENT(defineOmptCallback)
 #define omp_initial_device -1
 
 using namespace llvm::offload::ompt;
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 /// Forward declaration
 class LibomptargetRtlFinalizer;

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -22,7 +22,7 @@
 
 using namespace llvm;
 using namespace llvm::sys;
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 PluginManager *PM = nullptr;
 

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -22,7 +22,7 @@
 
 using namespace llvm;
 using namespace llvm::sys;
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 PluginManager *PM = nullptr;
 

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -38,7 +38,7 @@ using namespace llvm::offload::ompt;
 #endif
 
 using namespace llvm::offload::plugin;
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 int HostDataToTargetTy::addEventIfNecessary(DeviceTy &Device,
                                             AsyncInfoTy &AsyncInfo) const {

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -34,11 +34,11 @@
 #include <thread>
 
 #ifdef OMPT_SUPPORT
-using namespace llvm::omp::target::ompt;
+using namespace llvm::offload::ompt;
 #endif
 
-using namespace llvm::omp::target::plugin;
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::plugin;
+using namespace llvm::offload::debug;
 
 int HostDataToTargetTy::addEventIfNecessary(DeviceTy &Device,
                                             AsyncInfoTy &AsyncInfo) const {

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -34,9 +34,9 @@
 #include <vector>
 
 #ifdef OMPT_SUPPORT
-using namespace llvm::omp::target::ompt;
+using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 // If offload is enabled, ensure that device DeviceID has been initialized.
 //

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -36,7 +36,7 @@
 #ifdef OMPT_SUPPORT
 using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 // If offload is enabled, ensure that device DeviceID has been initialized.
 //
@@ -436,7 +436,7 @@ static inline int targetKernel(ident_t *Loc, int64_t DeviceId, int32_t NumTeams,
                     /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
   int Rc = OFFLOAD_SUCCESS;
-  Rc = target(Loc, *DeviceOrErr, HostPtr, *KernelArgs, AsyncInfo);
+  Rc = ::target(Loc, *DeviceOrErr, HostPtr, *KernelArgs, AsyncInfo);
   { // required to show synchronization
     TIMESCOPE_WITH_DETAILS_AND_IDENT("Runtime: synchronize", "", Loc);
     if (Rc == OFFLOAD_SUCCESS)

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -39,9 +39,9 @@
 
 using llvm::SmallVector;
 #ifdef OMPT_SUPPORT
-using namespace llvm::omp::target::ompt;
+using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::omp::target::debug;
+using namespace llvm::offload::debug;
 
 int AsyncInfoTy::synchronize() {
   int Result = OFFLOAD_SUCCESS;

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -41,7 +41,7 @@ using llvm::SmallVector;
 #ifdef OMPT_SUPPORT
 using namespace llvm::offload::ompt;
 #endif
-using namespace llvm::offload::debug;
+using namespace llvm::omp::target::debug;
 
 int AsyncInfoTy::synchronize() {
   int Result = OFFLOAD_SUCCESS;

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -80,8 +80,7 @@ using namespace llvm::offload::debug;
 using namespace error;
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 /// Forward declarations for all specialized data structures.
@@ -4369,12 +4368,11 @@ void AMDGPUQueueTy::callbackError(hsa_status_t Status, hsa_queue_t *Source,
 }
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 extern "C" {
-llvm::omp::target::plugin::GenericPluginTy *createPlugin_amdgpu() {
-  return new llvm::omp::target::plugin::AMDGPUPluginTy();
+llvm::offload::plugin::GenericPluginTy *createPlugin_amdgpu() {
+  return new llvm::offload::plugin::AMDGPUPluginTy();
 }
 }

--- a/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
+++ b/offload/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
@@ -21,8 +21,7 @@
 #include "llvm/Frontend/Offloading/Utility.h"
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 namespace hsa_utils {
 
@@ -75,6 +74,5 @@ void initImplArg(AMDGPUImplicitArgsTy *Base,
 
 } // namespace hsa_utils
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm

--- a/offload/plugins-nextgen/common/include/ErrorReporting.h
+++ b/offload/plugins-nextgen/common/include/ErrorReporting.h
@@ -30,8 +30,7 @@
 #include <string>
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 class ErrorReporter {
@@ -370,8 +369,7 @@ public:
 };
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif // OFFLOAD_PLUGINS_NEXTGEN_COMMON_ERROR_REPORTING_H

--- a/offload/plugins-nextgen/common/include/GlobalHandler.h
+++ b/offload/plugins-nextgen/common/include/GlobalHandler.h
@@ -25,8 +25,7 @@
 #include "omptarget.h"
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 class DeviceImageTy;
@@ -217,8 +216,7 @@ public:
 };
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif // LLVM_OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_COMMON_GLOBALHANDLER_H

--- a/offload/plugins-nextgen/common/include/JIT.h
+++ b/offload/plugins-nextgen/common/include/JIT.h
@@ -32,8 +32,7 @@ struct __tgt_device_image;
 namespace llvm {
 class MemoryBuffer;
 
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 struct GenericDeviceTy;
 } // namespace plugin
@@ -52,7 +51,7 @@ struct JITEngine {
   /// return \p Image. It is expected to return a memory buffer containing the
   /// generated device image that could be loaded to the device directly.
   Expected<std::unique_ptr<MemoryBuffer>>
-  process(StringRef Image, target::plugin::GenericDeviceTy &Device);
+  process(StringRef Image, plugin::GenericDeviceTy &Device);
 
 private:
   /// Compile the bitcode image \p Image and generate the binary image that can
@@ -107,8 +106,7 @@ private:
   BoolEnvar JITSkipOpt = BoolEnvar("LIBOMPTARGET_JIT_SKIP_OPT", false);
 };
 
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_COMMON_JIT_H

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -56,10 +56,10 @@
 #include "llvm/TargetParser/Triple.h"
 
 using namespace llvm::offload::debug;
+using namespace llvm::omp;
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 
 namespace plugin {
 
@@ -1940,8 +1940,7 @@ protected:
 };
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_COMMON_PLUGININTERFACE_H

--- a/offload/plugins-nextgen/common/include/RPC.h
+++ b/offload/plugins-nextgen/common/include/RPC.h
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <thread>
 
-namespace llvm::omp::target {
+namespace llvm::offload {
 namespace plugin {
 struct GenericPluginTy;
 struct GenericDeviceTy;
@@ -166,6 +166,6 @@ public:
   std::unique_ptr<ServerThread> Thread;
 };
 
-} // namespace llvm::omp::target
+} // namespace llvm::offload
 
 #endif

--- a/offload/plugins-nextgen/common/include/RecordReplay.h
+++ b/offload/plugins-nextgen/common/include/RecordReplay.h
@@ -33,8 +33,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 struct GenericKernelTy;
@@ -295,8 +294,7 @@ private:
 };
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_COMMON_RECORDREPLAY_H

--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -24,8 +24,7 @@
 #include <string>
 
 using namespace llvm;
-using namespace omp;
-using namespace target;
+using namespace offload;
 using namespace plugin;
 using namespace error;
 using namespace llvm::offload::debug;

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -44,8 +44,7 @@
 
 using namespace llvm;
 using namespace llvm::object;
-using namespace omp;
-using namespace omp::target;
+using namespace offload;
 
 namespace {
 
@@ -283,7 +282,7 @@ JITEngine::compile(StringRef Image, const std::string &ComputeUnitKind,
 }
 
 Expected<std::unique_ptr<MemoryBuffer>>
-JITEngine::process(StringRef Image, target::plugin::GenericDeviceTy &Device) {
+JITEngine::process(StringRef Image, plugin::GenericDeviceTy &Device) {
   assert(identify_magic(Image) == file_magic::bitcode && "Image not LLVM-IR");
 
   const std::string &ComputeUnitKind = Device.getComputeUnitKind();

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -38,8 +38,7 @@
 #include <limits>
 
 using namespace llvm;
-using namespace omp;
-using namespace target;
+using namespace offload;
 using namespace plugin;
 using namespace error;
 using namespace llvm::offload::debug;

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -22,8 +22,7 @@
 #endif
 
 using namespace llvm;
-using namespace omp;
-using namespace target;
+using namespace offload;
 
 template <uint32_t NumLanes>
 rpc::RPCStatus handleOffloadOpcodes(plugin::GenericDeviceTy &Device,

--- a/offload/plugins-nextgen/common/src/RecordReplay.cpp
+++ b/offload/plugins-nextgen/common/src/RecordReplay.cpp
@@ -24,8 +24,7 @@
 #include <functional>
 
 using namespace llvm;
-using namespace omp;
-using namespace target;
+using namespace offload;
 using namespace plugin;
 using namespace error;
 

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -44,8 +44,7 @@ using namespace llvm::offload::debug;
 using namespace error;
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 /// Forward declarations for all specialized data structures.
@@ -1750,12 +1749,11 @@ static Error Plugin::check(int32_t Code, const char *ErrFmt, ArgsTy... Args) {
 }
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 extern "C" {
-llvm::omp::target::plugin::GenericPluginTy *createPlugin_cuda() {
-  return new llvm::omp::target::plugin::CUDAPluginTy();
+llvm::offload::plugin::GenericPluginTy *createPlugin_cuda() {
+  return new llvm::offload::plugin::CUDAPluginTy();
 }
 }

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -50,8 +50,7 @@
 using namespace llvm::offload::debug;
 
 namespace llvm {
-namespace omp {
-namespace target {
+namespace offload {
 namespace plugin {
 
 /// Forward declarations for all specialized data structures.
@@ -570,12 +569,11 @@ static Error Plugin::check(int32_t Code, const char *ErrMsg, ArgsTy... Args) {
 }
 
 } // namespace plugin
-} // namespace target
-} // namespace omp
+} // namespace offload
 } // namespace llvm
 
 extern "C" {
-llvm::omp::target::plugin::GenericPluginTy *createPlugin_host() {
-  return new llvm::omp::target::plugin::GenELF64PluginTy();
+llvm::offload::plugin::GenericPluginTy *createPlugin_host() {
+  return new llvm::offload::plugin::GenELF64PluginTy();
 }
 }

--- a/offload/plugins-nextgen/level_zero/include/AsyncQueue.h
+++ b/offload/plugins-nextgen/level_zero/include/AsyncQueue.h
@@ -17,7 +17,7 @@
 
 #include "L0Memory.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 /// Abstract queue that supports asynchronous command submission.
 struct AsyncQueueTy {
@@ -40,5 +40,5 @@ struct AsyncQueueTy {
 
 using AsyncQueuePoolTy = ObjPool<AsyncQueueTy>;
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_ASYNCQUEUE_H

--- a/offload/plugins-nextgen/level_zero/include/L0Context.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Context.h
@@ -16,7 +16,7 @@
 #include "L0Memory.h"
 #include "PerThreadTable.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 class LevelZeroPluginTy;
 
@@ -142,6 +142,6 @@ public:
       uint32_t *pArgSize) = nullptr;
 };
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0CONTEXT_H

--- a/offload/plugins-nextgen/level_zero/include/L0Defs.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Defs.h
@@ -25,7 +25,7 @@ enum class AllocOptionTy : int32_t {
   ALLOC_OPT_SLM = 4,
 };
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 /// Default alignmnet for allocation.
 constexpr size_t L0DefaultAlignment = 0;
@@ -43,6 +43,6 @@ constexpr uint64_t L0DefaultTimeout = std::numeric_limits<uint64_t>::max();
 using ZeHandleTy = void *;
 
 using error::ErrorCode;
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0DEFS_H

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -23,7 +23,7 @@
 #include "PluginInterface.h"
 #include "TLS.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 using OmpInteropTy = omp_interop_val_t *;
 class LevelZeroPluginTy;
@@ -690,5 +690,5 @@ public:
                                          interop_spec_t *Prefers) override;
 };
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0DEVICE_H

--- a/offload/plugins-nextgen/level_zero/include/L0Interop.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Interop.h
@@ -13,7 +13,7 @@
 #ifndef OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0INTEROP_H
 #define OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0INTEROP_H
 
-namespace llvm::omp::target::plugin::L0Interop {
+namespace llvm::offload::plugin::L0Interop {
 
 /// Level Zero interop property.
 struct Property {
@@ -23,6 +23,6 @@ struct Property {
   ze_command_list_handle_t ImmCmdList;
 };
 
-} // namespace llvm::omp::target::plugin::L0Interop
+} // namespace llvm::offload::plugin::L0Interop
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0INTEROP_H

--- a/offload/plugins-nextgen/level_zero/include/L0Kernel.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Kernel.h
@@ -18,7 +18,7 @@
 #include "L0Trace.h"
 #include "PluginInterface.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 class L0DeviceTy;
 class L0ProgramTy;
@@ -149,6 +149,6 @@ public:
                        L0LaunchEnvTy &KEnv) const;
 };
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0KERNEL_H

--- a/offload/plugins-nextgen/level_zero/include/L0Memory.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Memory.h
@@ -23,7 +23,7 @@
 #include "L0Defs.h"
 #include "L0Trace.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 class L0DeviceTy;
 
@@ -599,6 +599,6 @@ public:
   Expected<void *> get(bool Next) { return Next ? getNext() : get(); }
 };
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0MEMORY_H

--- a/offload/plugins-nextgen/level_zero/include/L0Options.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Options.h
@@ -19,7 +19,7 @@
 
 #include "L0Defs.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 /// Command submission mode.
 enum class CommandModeTy { Sync = 0, Async, AsyncOrdered };
 
@@ -161,6 +161,6 @@ struct L0OptionsTy {
 
 }; // L0OptionsTy
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0OPTIONS_H

--- a/offload/plugins-nextgen/level_zero/include/L0Plugin.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Plugin.h
@@ -21,7 +21,7 @@
 #include "L0Program.h"
 #include "TLS.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 /// Class implementing the LevelZero specific functionalities of the plugin.
 class LevelZeroPluginTy final : public GenericPluginTy {
@@ -111,6 +111,6 @@ public:
   Expected<bool> isImageCompatible(StringRef Image) const override;
 };
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0PLUGIN_H

--- a/offload/plugins-nextgen/level_zero/include/L0Program.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Program.h
@@ -15,7 +15,7 @@
 
 #include "L0Kernel.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 class L0DeviceTy;
 
@@ -128,6 +128,6 @@ struct L0GlobalHandlerTy final : public GenericGlobalHandlerTy {
 
 bool isValidOneOmpImage(StringRef Image, uint64_t &MajorVer,
                         uint64_t &MinorVer);
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_L0PROGRAM_H

--- a/offload/plugins-nextgen/level_zero/include/TLS.h
+++ b/offload/plugins-nextgen/level_zero/include/TLS.h
@@ -20,7 +20,7 @@
 #include "L0Trace.h"
 #include "PerThreadTable.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 /// All thread-local data used by the Plugin.
 class L0ThreadTLSTy {
@@ -66,6 +66,6 @@ public:
 
 using L0ThreadTblTy = PerThread<L0ThreadTLSTy>;
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 #endif // OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_LEVEL_ZERO_TLS_H

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -13,7 +13,7 @@
 #include "L0Context.h"
 #include "L0Plugin.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 Error L0ContextTy::init() {
   auto cleanupOnError = [&]() {
@@ -68,4 +68,4 @@ StagingBufferTy &L0ContextTy::getStagingBuffer() {
   return Buffer;
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -22,7 +22,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Object/ELF.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 L0DeviceTLSTy &L0DeviceTy::getTLS() {
   return getPlugin().getDeviceTLS(getDeviceId());
@@ -1378,4 +1378,4 @@ Error L0DeviceTy::callGlobalCtorDtorCommon(GenericPluginTy &Plugin,
   return CleanupBufferAndErr(std::move(Err));
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -17,7 +17,7 @@
 
 #include "llvm/ADT/ScopeExit.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 bool KernelPropertiesTy::reuseGroupParams(const int32_t NumTeamsIn,
                                           const int32_t ThreadLimitIn,
@@ -521,4 +521,4 @@ Error L0KernelTy::launchImpl(GenericDeviceTy &GenericDevice,
   return launchKernelWithCmdQueue(l0Device, zeKernel, KEnv);
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Memory.cpp
@@ -14,7 +14,7 @@
 #include "L0Device.h"
 #include "L0Plugin.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 static const char *allocKindToStr(int32_t Kind) {
   switch (Kind) {
@@ -746,4 +746,4 @@ Error EventPoolTy::releaseEvent(ze_event_handle_t Event, L0DeviceTy &Device) {
   return Plugin::success();
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Options.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Options.cpp
@@ -16,7 +16,7 @@
 #include "L0Options.h"
 #include "L0Trace.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 /// Read environment variables.
 void L0OptionsTy::processEnvironmentVars() {
@@ -195,4 +195,4 @@ void L0OptionsTy::processEnvironmentVars() {
   ZeDebugEnabled = BoolEnvar("ZET_ENABLE_PROGRAM_DEBUGGING", false);
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -20,9 +20,9 @@
 
 #include "llvm/Object/OffloadBinary.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
-using namespace llvm::omp::target;
+using namespace llvm::offload;
 using namespace error;
 
 Expected<int32_t> LevelZeroPluginTy::findDevices() {
@@ -274,10 +274,10 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
   return Plugin::success();
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin
 
 extern "C" {
-llvm::omp::target::plugin::GenericPluginTy *createPlugin_level_zero() {
-  return new llvm::omp::target::plugin::LevelZeroPluginTy();
+llvm::offload::plugin::GenericPluginTy *createPlugin_level_zero() {
+  return new llvm::offload::plugin::LevelZeroPluginTy();
 }
 }

--- a/offload/plugins-nextgen/level_zero/src/L0Program.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Program.cpp
@@ -23,7 +23,7 @@
 #include "L0Plugin.h"
 #include "L0Program.h"
 
-namespace llvm::omp::target::plugin {
+namespace llvm::offload::plugin {
 
 Error L0GlobalHandlerTy::getGlobalMetadataFromDevice(GenericDeviceTy &Device,
                                                      DeviceImageTy &Image,
@@ -609,4 +609,4 @@ Error L0ProgramTy::loadModuleKernels() {
   return Plugin::success();
 }
 
-} // namespace llvm::omp::target::plugin
+} // namespace llvm::offload::plugin


### PR DESCRIPTION
Summary:
We should minimize specifically referring to 'OpenMP' in the plugin
interface. These functions are not exported so we are free to rename
them.
