### PR TITLE
[RFC][NFCI][IR] Rename isNullValue and getNullValue to isZeroValue and getZeroValue

### DIFF
--- a/clang/include/clang/Basic/arm_mve_defs.td
+++ b/clang/include/clang/Basic/arm_mve_defs.td
@@ -98,7 +98,7 @@ def vreinterpret: CGFHelperFn<"ARMMVEVectorReinterpret">;
 def extend: CGHelperFn<"SignOrZeroExtend"> {
   let special_params = [IRBuilderIntParam<2, "bool">];
 }
-def zeroinit: IRFunction<"llvm::Constant::getNullValue">;
+def zeroinit: IRFunction<"llvm::Constant::getZeroValue">;
 def int_min: CGHelperFn<"ARMMVEConstantSplat<1,0>">;
 def int_max: CGHelperFn<"ARMMVEConstantSplat<0,1>">;
 def uint_max: CGHelperFn<"ARMMVEConstantSplat<1,1>">;

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -95,7 +95,7 @@ public:
   }
 
   // Creates constant null value for integral type ty.
-  cir::ConstantOp getNullValue(mlir::Type ty, mlir::Location loc) {
+  cir::ConstantOp getZeroValue(mlir::Type ty, mlir::Location loc) {
     return getConstant(loc, getZeroInitAttr(ty));
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -315,7 +315,7 @@ def CIR_IntAttr : CIR_ValueLikeAttr<"Int", "int"> {
   let extraClassDeclaration = [{
     int64_t getSInt() const;
     uint64_t getUInt() const;
-    bool isNullValue() const;
+    bool isZeroValue() const;
     bool isSigned() const;
     bool isUnsigned() const;
     uint64_t getBitWidth() const;
@@ -328,7 +328,7 @@ def CIR_IntAttr : CIR_ValueLikeAttr<"Int", "int"> {
     uint64_t $cppClass::getUInt() const {
       return getValue().getZExtValue();
     }
-    bool $cppClass::isNullValue() const {
+    bool $cppClass::isZeroValue() const {
       return getValue() == 0;
     }
     bool $cppClass::isSigned() const {
@@ -521,7 +521,7 @@ def CIR_ConstPtrAttr : CIR_ValueLikeAttr<"ConstPtr", "ptr"> {
     }]>
   ];
   let extraClassDeclaration = [{
-    bool isNullValue() const { return getValue().getInt() == 0; }
+    bool isZeroValue() const { return getValue().getInt() == 0; }
   }];
 
   let assemblyFormat = [{
@@ -1009,7 +1009,7 @@ def CIR_TargetAddressSpaceAttr : CIR_Attr< "TargetAddressSpace",
     The TargetAddressSpaceAttr represents a target-specific numeric address space,
     corresponding to the LLVM IR `addrspace` qualifier and the clang
      `address_space` attribute.
-    
+
     A value of zero represents the default address space. The semantics of non-zero
     address spaces are target-specific.
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -244,7 +244,7 @@ def CIR_CastOp : CIR_Op<"cast", [
     ```
     %4 = cir.cast int_to_bool %3 : i32 -> !cir.bool
     ...
-    %x = cir.cast array_to_ptrdecay %0 
+    %x = cir.cast array_to_ptrdecay %0
        : !cir.ptr<!cir.array<i32 x 10>> -> !cir.ptr<i32>
     ```
   }];
@@ -429,7 +429,7 @@ def CIR_ConstantOp : CIR_Op<"const", [
   let extraClassDeclaration = [{
     bool isNullPtr() {
       if (const auto ptrAttr = mlir::dyn_cast<cir::ConstPtrAttr>(getValue()))
-        return ptrAttr.isNullValue();
+        return ptrAttr.isZeroValue();
       return false;
     }
 
@@ -741,7 +741,7 @@ def CIR_VecMaskedLoadOp : CIR_Op<"vec.masked_load", [
   let results = (outs CIR_AnyType:$result);
 
   let assemblyFormat = [{
-    (`align` `(` $alignment^ `)`)? 
+    (`align` `(` $alignment^ `)`)?
     $addr `,` $mask `,` $pass_thru
     `:` qualified(type($addr)) `,` type($mask) `,` type($pass_thru)
     `->` type($result)
@@ -1433,9 +1433,9 @@ def CIR_SwitchOp : CIR_Op<"switch", [
     is an integral condition value.
 
     Besides taking an integer condition and CIR regions, it also accepts an
-    `all_enum_cases_covered` attribute indicating whether all enum cases are 
-    handled by the operation. Note that the presence of a default CaseOp does 
-    not imply `all_enum_cases_covered`. The original AST switch must explicitly list 
+    `all_enum_cases_covered` attribute indicating whether all enum cases are
+    handled by the operation. Note that the presence of a default CaseOp does
+    not imply `all_enum_cases_covered`. The original AST switch must explicitly list
     every enum case.
 
     The set of `cir.case` operations and their enclosing `cir.switch`
@@ -1564,7 +1564,7 @@ def CIR_SwitchOp : CIR_Op<"switch", [
     ```
   }];
 
-  let arguments = (ins 
+  let arguments = (ins
     CIR_IntType:$condition,
     UnitAttr:$all_enum_cases_covered
   );
@@ -1578,7 +1578,7 @@ def CIR_SwitchOp : CIR_Op<"switch", [
   ];
 
   let assemblyFormat = [{
-    `(` $condition `:` qualified(type($condition)) `)` 
+    `(` $condition `:` qualified(type($condition)) `)`
      (`all_enum_cases_covered` $all_enum_cases_covered^)?
     $body
     attr-dict
@@ -2404,7 +2404,7 @@ def CIR_AddOp : CIR_BinaryOpWithOverflowFlags<"add", CIR_AnyArithType> {
     or unsigned overflow occurs, respectively. The optional `sat` (saturated)
     attribute clamps the result to the type's representable range instead of
     wrapping. The `nsw`/`nuw` flags and `sat` are mutually exclusive.
-    
+
     Example:
 
     ```
@@ -2432,7 +2432,7 @@ def CIR_SubOp : CIR_BinaryOpWithOverflowFlags<"sub", CIR_AnyArithType> {
     or unsigned overflow occurs, respectively. The optional `sat` (saturated)
     attribute clamps the result to the type's representable range. The
     `nsw`/`nuw` flags and `sat` are mutually exclusive.
-    
+
     Example:
 
     ```
@@ -2467,7 +2467,7 @@ def CIR_MulOp : CIR_BinaryOp<"mul", CIR_AnyArithType> {
     %3 = cir.mul %a, %b : !cir.float
     ```
   }];
-  
+
   let arguments = (ins
     CIR_AnyArithType:$lhs, CIR_AnyArithType:$rhs,
     UnitProp:$no_signed_wrap,
@@ -2513,7 +2513,7 @@ def CIR_RemOp : CIR_BinaryOp<"rem", CIR_AnyArithType> {
     The `cir.rem` operation computes the remainder of division on integer or
     floating-point operands. Both operands and the result must have the same
     type.
-    
+
     Example:
 
     ```
@@ -2535,7 +2535,7 @@ def CIR_AndOp : CIR_BinaryOp<"and", CIR_AnyBitwiseType, [
   let description = [{
     The `cir.and` operation performs a bitwise AND on integer operands.
     Both operands and the result must have the same integer type.
-    
+
     Example:
 
     ```
@@ -2556,7 +2556,7 @@ def CIR_OrOp : CIR_BinaryOp<"or", CIR_AnyBitwiseType, [
   let description = [{
     The `cir.or` operation performs a bitwise OR on integer operands.
     Both operands and the result must have the same integer type.
-    
+
     Example:
 
     ```
@@ -2684,13 +2684,13 @@ def CIR_SelectOp : CIR_Op<"select", [
     The `cir.select` operation takes three operands. The first operand
     `condition` is either a boolean value of type `!cir.bool` or a boolean
     vector of type `!cir.bool`.  The second and the third operand can be of
-    any CIR types, but their types must be the same. If the first operand 
+    any CIR types, but their types must be the same. If the first operand
     is `true`, the operation yields its second operand. Otherwise, the
     operation yields its third operand.
 
-    In the case where the first operand is a boolean vector, then the second 
+    In the case where the first operand is a boolean vector, then the second
     and third operand needs to also be of some vectors of the same type to
-    each other and that the number of elements of all three operands needs to 
+    each other and that the number of elements of all three operands needs to
     be the same as well.
 
     Example:
@@ -2703,7 +2703,7 @@ def CIR_SelectOp : CIR_Op<"select", [
     ```
   }];
 
-  let arguments = (ins 
+  let arguments = (ins
     CIR_ScalarOrVectorOf<CIR_BoolType>:$condition,
     CIR_AnyType:$true_value,
     CIR_AnyType:$false_value
@@ -3704,7 +3704,7 @@ def CIR_FuncOp : CIR_Op<"func", [
 
     // Inline information
     cir.func no_inline @some_method(...)
-    
+
     // Builtin function
     cir.func builtin @__builtin_coro_end(!cir.ptr<i8>, !cir.bool) -> !cir.bool
     // Coroutine
@@ -4077,7 +4077,7 @@ def CIR_TryCallOp : CIR_CallOpBase<"try_call",[
     Similar to `cir.call` but requires two destination blocks,
     one which is used if the call returns without throwing an
     exception (the "normal" destination) and another which is used
-    if an exception is thrown (the "unwind" destination). 
+    if an exception is thrown (the "unwind" destination).
 
     This operation is used only after the CFG flatterning pass.
 
@@ -4107,7 +4107,7 @@ def CIR_TryCallOp : CIR_CallOpBase<"try_call",[
 
   let arguments = commonArgs;
   let results = (outs Optional<CIR_AnyType>:$result);
-  let successors = (successor 
+  let successors = (successor
     AnySuccessor:$normalDest,
     AnySuccessor:$unwindDest
   );
@@ -5437,7 +5437,7 @@ def CIR_BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
-  let hasCXXABILowering = true;  
+  let hasCXXABILowering = true;
 }
 
 def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
@@ -5462,7 +5462,7 @@ def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
-  let hasCXXABILowering = true;  
+  let hasCXXABILowering = true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -5500,7 +5500,7 @@ def CIR_BaseMethodOp : CIR_Op<"base_method", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
-  let hasCXXABILowering = true;  
+  let hasCXXABILowering = true;
 }
 
 def CIR_DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
@@ -5534,7 +5534,7 @@ def CIR_DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
-  let hasCXXABILowering = true;  
+  let hasCXXABILowering = true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -5969,7 +5969,7 @@ def CIR_BitReverseOp : CIR_BitOpBase<"bitreverse",
     %1 = cir.bitreverse %0: !u32i
     ```
   }];
-  
+
   let append traits = [Involution];
 }
 
@@ -5994,7 +5994,7 @@ def CIR_ByteSwapOp : CIR_BitOpBase<"byte_swap",
     %1 = cir.byte_swap %0 : !u32i
     ```
   }];
-  
+
   let append traits = [Involution];
 }
 
@@ -6255,7 +6255,7 @@ def CIR_PrefetchOp : CIR_Op<"prefetch"> {
     $locality is a temporal locality specifier ranging from (0) - no locality,
     to (3) - extremely local, keep in cache. If $locality is not present, the
     default value is 3.
-    
+
     $isWrite specifies whether the prefetch is for a 'read' or 'write'. If
     $isWrite is not specified, it means that prefetch is prepared for 'read'.
   }];
@@ -6394,7 +6394,7 @@ def CIR_PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
   let results = (outs CIR_AnyFundamentalIntType:$result);
 
   let assemblyFormat = [{
-    $lhs `,` $rhs  `:` qualified(type($lhs)) `->` qualified(type($result)) 
+    $lhs `,` $rhs  `:` qualified(type($lhs)) `->` qualified(type($result))
     attr-dict
   }];
 }
@@ -6416,7 +6416,7 @@ class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
 
 def CIR_SqrtOp : CIR_UnaryFPToFPBuiltinOp<"sqrt", "SqrtOp"> {
   let summary = "Floating-point square root operation";
-  
+
   let description = [{
     Computes the square root of a floating-point value or vector.
 
@@ -7279,10 +7279,10 @@ def CIR_EhTypeIdOp : CIR_Op<"eh.typeid",
 def CIR_EhSetjmpOp : CIR_Op<"eh.setjmp"> {
   let summary = "CIR setjmp operation";
   let description = [{
-    Saves call-site information (e.g., stack pointer, instruction pointer, 
-    signal mask, and other registers) in memory at `env` for use by longjmp(). 
+    Saves call-site information (e.g., stack pointer, instruction pointer,
+    signal mask, and other registers) in memory at `env` for use by longjmp().
     In this case, setjmp() returns 0. Following a successful longjmp(),
-    execution proceeds from cir.eh.setjmp with the operation yielding a 
+    execution proceeds from cir.eh.setjmp with the operation yielding a
     non-zero value.
 
     Examples:
@@ -7855,7 +7855,7 @@ def CIR_AtomicCmpXchgOp : CIR_Op<"atomic.cmpxchg", [
     allows "spurious failures", meaning that be treated as if the comparison
     failed and not exchange values even if `*ptr` and `expected` indeed compare
     equal.
-    
+
     The type of `expected` and `desired` must be the same. The pointee type of
     `ptr` must be the same as the type of `expected` and `desired`.
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -208,7 +208,7 @@ mlir::Attribute clang::CIRGen::CIRGenBuilderTy::getConstRecordOrZeroAttr(
 
   // Return zero or anonymous constant record.
   const bool isZero = llvm::all_of(
-      arrayAttr, [&](mlir::Attribute a) { return isNullValue(a); });
+      arrayAttr, [&](mlir::Attribute a) { return isZeroValue(a); });
   if (isZero)
     return cir::ZeroAttr::get(recordTy);
   return cir::ConstRecordAttr::get(recordTy, arrayAttr);

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -279,15 +279,15 @@ public:
 
   // Return true if the value is a null constant such as null pointer, (+0.0)
   // for floating-point or zero initializer
-  bool isNullValue(mlir::Attribute attr) const {
+  bool isZeroValue(mlir::Attribute attr) const {
     if (mlir::isa<cir::ZeroAttr>(attr))
       return true;
 
     if (const auto ptrVal = mlir::dyn_cast<cir::ConstPtrAttr>(attr))
-      return ptrVal.isNullValue();
+      return ptrVal.isZeroValue();
 
     if (const auto intVal = mlir::dyn_cast<cir::IntAttr>(attr))
-      return intVal.isNullValue();
+      return intVal.isZeroValue();
 
     if (const auto boolVal = mlir::dyn_cast<cir::BoolAttr>(attr))
       return !boolVal.getValue();
@@ -305,7 +305,7 @@ public:
         // FIXME(cir): the record's ID should not be considered a member.
         if (mlir::isa<mlir::StringAttr>(elt))
           continue;
-        if (!isNullValue(elt))
+        if (!isZeroValue(elt))
           return false;
       }
       return true;
@@ -317,7 +317,7 @@ public:
 
       return llvm::all_of(
           mlir::cast<mlir::ArrayAttr>(arrayVal.getElts()),
-          [&](const mlir::Attribute &elt) { return isNullValue(elt); });
+          [&](const mlir::Attribute &elt) { return isZeroValue(elt); });
     }
     return false;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -103,7 +103,7 @@ static RValue emitBuiltinBitOpWithFallback(CIRGenFunction &cgf,
 
   CIRGenBuilderTy &builder = cgf.getBuilder();
   mlir::Location loc = cgf.getLoc(e->getSourceRange());
-  mlir::Value zero = builder.getNullValue(arg.getType(), loc);
+  mlir::Value zero = builder.getZeroValue(arg.getType(), loc);
   mlir::Value isZero =
       builder.createCompare(loc, cir::CmpOpKind::eq, arg, zero);
   mlir::Value fallbackValue = cgf.emitScalarExpr(e->getArg(1));
@@ -1692,7 +1692,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
         builder.createIsFPClass(loc, arg, cir::FPClassTest::Infinity);
     mlir::Value isNeg = emitSignBit(loc, *this, arg);
     mlir::Type intTy = convertType(e->getType());
-    cir::ConstantOp zero = builder.getNullValue(intTy, loc);
+    cir::ConstantOp zero = builder.getZeroValue(intTy, loc);
     cir::ConstantOp one = builder.getConstant(loc, cir::IntAttr::get(intTy, 1));
     cir::ConstantOp negativeOne =
         builder.getConstant(loc, cir::IntAttr::get(intTy, -1));
@@ -1811,7 +1811,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     Address destPtr = emitPointerWithAlignment(e->getArg(0));
     Address destPtrCast = destPtr.withElementType(builder, cgm.voidTy);
     mlir::Value size = emitScalarExpr(e->getArg(1));
-    mlir::Value zero = builder.getNullValue(builder.getUInt8Ty(), loc);
+    mlir::Value zero = builder.getZeroValue(builder.getUInt8Ty(), loc);
     assert(!cir::MissingFeatures::sanitizers());
     builder.createMemSet(loc, destPtrCast, zero, size);
     assert(!cir::MissingFeatures::generateDebugInfo());

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -341,7 +341,7 @@ emitAArch64CompareBuiltinExpr(CIRGenFunction &cgf, CIRGenBuilderTy &builder,
     src = builder.createBitcast(src, retTy);
   }
 
-  mlir::Value zero = builder.getNullValue(src.getType(), loc);
+  mlir::Value zero = builder.getZeroValue(src.getType(), loc);
 
   if (!scalarCmp)
     return builder.createVecCompare(loc, kind, src, zero);
@@ -1038,7 +1038,7 @@ CIRGenFunction::emitAArch64SVEBuiltinExpr(unsigned builtinID,
 
     // Zero-ing predication
     if (typeFlags.getMergeType() == SVETypeFlags::MergeZeroExp) {
-      auto null = builder.getNullValue(convertType(expr->getType()),
+      auto null = builder.getZeroValue(convertType(expr->getType()),
                                        getLoc(expr->getExprLoc()));
       ops.insert(ops.begin(), null);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -359,7 +359,7 @@ static mlir::Value emitX86MaskedCompareResult(CIRGenBuilderTy &builder,
       indices.push_back(cir::IntAttr::get(i64Ty, i % numElts + numElts));
 
     // This should shuffle between cmp (first vector) and null (second vector)
-    mlir::Value nullVec = builder.getNullValue(cmp.getType(), loc);
+    mlir::Value nullVec = builder.getZeroValue(cmp.getType(), loc);
     cmp = builder.createVecShuffle(loc, cmp, nullVec, indices);
   }
   return builder.createBitcast(cmp, builder.getUIntNTy(std::max(numElts, 8U)));
@@ -375,7 +375,7 @@ emitX86MaskedCompare(CIRGenBuilderTy &builder, unsigned cc, bool isSigned,
   unsigned numElts = cast<cir::VectorType>(ops[0].getType()).getSize();
   mlir::Value cmp;
   if (cc == 3) {
-    cmp = builder.getNullValue(
+    cmp = builder.getZeroValue(
         cir::VectorType::get(builder.getSIntNTy(1), numElts), loc);
   } else if (cc == 7) {
     cir::VectorType resultTy =
@@ -426,7 +426,7 @@ static std::optional<mlir::Value> emitX86ConvertToMask(CIRGenFunction &cgf,
                                                        CIRGenBuilderTy &builder,
                                                        mlir::Value in,
                                                        mlir::Location loc) {
-  cir::ConstantOp zero = builder.getNullValue(in.getType(), loc);
+  cir::ConstantOp zero = builder.getZeroValue(in.getType(), loc);
   return emitX86MaskedCompare(builder, 1, true, {in, zero}, loc);
 }
 
@@ -596,7 +596,7 @@ static mlir::Value emitX86vpcom(CIRGenBuilderTy &builder, mlir::Location loc,
     pred = cir::CmpOpKind::ne;
     break;
   case 0x6:
-    return builder.getNullValue(ty, loc); // FALSE
+    return builder.getZeroValue(ty, loc); // FALSE
   case 0x7: {
     llvm::APInt allOnes = llvm::APInt::getAllOnes(elementTy.getWidth());
     return cir::VecSplatOp::create(
@@ -706,7 +706,7 @@ static mlir::Value emitX86Aes(CIRGenBuilderTy &builder, mlir::Location loc,
       },
       /*elseBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location) {
-        mlir::Value zero = builder.getNullValue(vecType, loc);
+        mlir::Value zero = builder.getZeroValue(vecType, loc);
         builder.createStore(loc, zero, outAddr);
         builder.createYield(loc);
       });
@@ -771,7 +771,7 @@ static mlir::Value emitX86Aeswide(CIRGenBuilderTy &builder, mlir::Location loc,
       },
       /*elseBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location) {
-        mlir::Value zero = builder.getNullValue(vecType, loc);
+        mlir::Value zero = builder.getZeroValue(vecType, loc);
         for (int i = 0; i < 8; i++) {
           cir::ConstantOp idx = builder.getUInt32(i, loc);
           mlir::Value nextOutEleAddr =
@@ -903,7 +903,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     // IR optimizer and backend.
     // TODO: If we had a "freeze" IR instruction to generate a fixed undef
     //  value, we should use that here instead of a zero.
-    return builder.getNullValue(convertType(expr->getType()),
+    return builder.getZeroValue(convertType(expr->getType()),
                                 getLoc(expr->getExprLoc()));
   case X86::BI__builtin_ia32_vec_ext_v4hi:
   case X86::BI__builtin_ia32_vec_ext_v16qi:
@@ -1700,7 +1700,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     // If palignr is shifting the pair of vectors more than the size of two
     // lanes, emit zero.
     if (shiftVal >= 32)
-      return builder.getNullValue(convertType(expr->getType()),
+      return builder.getZeroValue(convertType(expr->getType()),
                                   getLoc(expr->getExprLoc()));
 
     // If palignr is shifting the pair of input vectors more than one lane,
@@ -1709,7 +1709,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
       shiftVal -= 16;
       ops[1] = ops[0];
       ops[0] =
-          builder.getNullValue(ops[0].getType(), getLoc(expr->getExprLoc()));
+          builder.getZeroValue(ops[0].getType(), getLoc(expr->getExprLoc()));
     }
 
     int64_t indices[64];
@@ -1808,7 +1808,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     unsigned numElems = cast<cir::IntType>(ops[0].getType()).getWidth();
 
     if (shiftVal >= numElems)
-      return builder.getNullValue(ops[0].getType(), loc);
+      return builder.getZeroValue(ops[0].getType(), loc);
 
     mlir::Value in = getMaskVecValue(builder, loc, ops[0], numElems);
 
@@ -1817,7 +1817,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     for (auto i : llvm::seq<unsigned>(0, numElems))
       indices.push_back(cir::IntAttr::get(i32Ty, numElems + i - shiftVal));
 
-    mlir::Value zero = builder.getNullValue(in.getType(), loc);
+    mlir::Value zero = builder.getZeroValue(in.getType(), loc);
     mlir::Value sv = builder.createVecShuffle(loc, zero, in, indices);
     return builder.createBitcast(sv, ops[0].getType());
   }
@@ -1832,7 +1832,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     unsigned numElems = cast<cir::IntType>(ops[0].getType()).getWidth();
 
     if (shiftVal >= numElems)
-      return builder.getNullValue(ops[0].getType(), loc);
+      return builder.getZeroValue(ops[0].getType(), loc);
 
     mlir::Value in = getMaskVecValue(builder, loc, ops[0], numElems);
 
@@ -1841,7 +1841,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     for (auto i : llvm::seq<unsigned>(0, numElems))
       indices.push_back(cir::IntAttr::get(i32Ty, i + shiftVal));
 
-    mlir::Value zero = builder.getNullValue(in.getType(), loc);
+    mlir::Value zero = builder.getZeroValue(in.getType(), loc);
     mlir::Value sv = builder.createVecShuffle(loc, in, zero, indices);
     return builder.createBitcast(sv, ops[0].getType());
   }
@@ -1962,7 +1962,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
   case X86::BI__builtin_ia32_kortestzdi: {
     mlir::Location loc = getLoc(expr->getExprLoc());
     cir::IntType ty = cast<cir::IntType>(ops[0].getType());
-    mlir::Value allZerosOp = builder.getNullValue(ty, loc).getResult();
+    mlir::Value allZerosOp = builder.getZeroValue(ty, loc).getResult();
     mlir::Value orOp = emitX86MaskLogic<cir::OrOp>(builder, loc, ops);
     mlir::Value cmp =
         cir::CmpOp::create(builder, loc, cir::CmpOpKind::eq, orOp, allZerosOp);

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -3006,7 +3006,7 @@ CIRGenFunction::emitConditionalBlocks(const AbstractConditionalOperator *e,
     if (!yieldTy) {
       cir::YieldOp::create(builder, loc);
     } else { // Block returns: set null yield value.
-      mlir::Value op0 = builder.getNullValue(yieldTy, loc);
+      mlir::Value op0 = builder.getZeroValue(yieldTy, loc);
       cir::YieldOp::create(builder, loc, op0);
     }
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -317,7 +317,7 @@ static void emitNullBaseClassInitialization(CIRGenFunction &cgf,
   // TODO: isZeroInitializable can be over-conservative in the case where a
   // virtual base contains a member pointer.
   mlir::TypedAttr nullConstantForBase = cgf.cgm.emitNullConstantForBase(base);
-  if (!cgf.getBuilder().isNullValue(nullConstantForBase)) {
+  if (!cgf.getBuilder().isZeroValue(nullConstantForBase)) {
     cgf.cgm.errorNYI(
         base->getSourceRange(),
         "emitNullBaseClassInitialization: base constant is not null");

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -211,12 +211,12 @@ public:
   mlir::Value VisitCXXScalarValueInitExpr(CXXScalarValueInitExpr *e) {
     mlir::Location loc = cgf.getLoc(e->getExprLoc());
     mlir::Type complexTy = cgf.convertType(e->getType());
-    return builder.getNullValue(complexTy, loc);
+    return builder.getZeroValue(complexTy, loc);
   }
   mlir::Value VisitImplicitValueInitExpr(ImplicitValueInitExpr *e) {
     mlir::Location loc = cgf.getLoc(e->getExprLoc());
     mlir::Type complexTy = cgf.convertType(e->getType());
-    return builder.getNullValue(complexTy, loc);
+    return builder.getZeroValue(complexTy, loc);
   }
 
   struct BinOpInfo {
@@ -718,7 +718,7 @@ mlir::Value ComplexExprEmitter::emitBinDiv(const BinOpInfo &op) {
   }
 
   assert(mlir::isa<cir::ComplexType>(op.rhs.getType()));
-  cir::ConstantOp nullValue = builder.getNullValue(op.lhs.getType(), op.loc);
+  cir::ConstantOp nullValue = builder.getZeroValue(op.lhs.getType(), op.loc);
   mlir::Value lhs = builder.createComplexCreate(op.loc, op.lhs, nullValue);
   cir::ComplexRangeKind rangeKind =
       getComplexRangeAttr(op.fpFeatures.getComplexRange());
@@ -1008,7 +1008,7 @@ mlir::Value ComplexExprEmitter::VisitInitListExpr(InitListExpr *e) {
 
   assert(e->getNumInits() == 0 && "Unexpected number of inits");
   mlir::Type complexTy = cgf.convertType(e->getType());
-  return builder.getNullValue(complexTy, loc);
+  return builder.getZeroValue(complexTy, loc);
 }
 
 mlir::Value ComplexExprEmitter::VisitVAArgExpr(VAArgExpr *e) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -266,7 +266,7 @@ bool ConstantAggregateBuilder::addBits(llvm::APInt bits, uint64_t offsetInBits,
       if (*firstElemToUpdate < elements.size()) {
         auto firstEltToUpdate =
             mlir::dyn_cast<cir::IntAttr>(elements[*firstElemToUpdate].element);
-        isNull = firstEltToUpdate && firstEltToUpdate.isNullValue();
+        isNull = firstEltToUpdate && firstEltToUpdate.isZeroValue();
       }
 
       if (*firstElemToUpdate == *lastElemToUpdate || isNull) {
@@ -1144,12 +1144,12 @@ emitArrayConstant(CIRGenModule &cgm, mlir::Type desiredType,
   CIRGenBuilderTy &builder = cgm.getBuilder();
 
   unsigned nonzeroLength = arrayBound;
-  if (elements.size() < nonzeroLength && builder.isNullValue(filler))
+  if (elements.size() < nonzeroLength && builder.isZeroValue(filler))
     nonzeroLength = elements.size();
 
   if (nonzeroLength == elements.size()) {
     while (nonzeroLength > 0 &&
-           builder.isNullValue(elements[nonzeroLength - 1]))
+           builder.isZeroValue(elements[nonzeroLength - 1]))
       --nonzeroLength;
   }
 
@@ -1846,7 +1846,7 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     }
 
     SmallVector<mlir::TypedAttr, 16> elements;
-    if (filler && builder.isNullValue(filler))
+    if (filler && builder.isZeroValue(filler))
       elements.reserve(numInitElts + 1);
     else
       elements.reserve(numInitElts);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1201,7 +1201,7 @@ public:
         lhs = cgf.emitComplexExpr(e->getLHS());
       } else {
         mlir::Value lhsReal = Visit(e->getLHS());
-        mlir::Value lhsImag = builder.getNullValue(convertType(lhsTy), loc);
+        mlir::Value lhsImag = builder.getZeroValue(convertType(lhsTy), loc);
         lhs = builder.createComplexCreate(loc, lhsReal, lhsImag);
       }
 
@@ -1210,7 +1210,7 @@ public:
         rhs = cgf.emitComplexExpr(e->getRHS());
       } else {
         mlir::Value rhsReal = Visit(e->getRHS());
-        mlir::Value rhsImag = builder.getNullValue(convertType(rhsTy), loc);
+        mlir::Value rhsImag = builder.getZeroValue(convertType(rhsTy), loc);
         rhs = builder.createComplexCreate(loc, rhsReal, rhsImag);
       }
 
@@ -1297,7 +1297,7 @@ public:
     if (e->getType()->isVectorType()) {
       mlir::Location loc = cgf.getLoc(e->getExprLoc());
       mlir::Type lhsTy = cgf.convertType(e->getLHS()->getType());
-      mlir::Value zeroVec = builder.getNullValue(lhsTy, loc);
+      mlir::Value zeroVec = builder.getZeroValue(lhsTy, loc);
 
       mlir::Value lhs = Visit(e->getLHS());
       mlir::Value rhs = Visit(e->getRHS());
@@ -1342,7 +1342,7 @@ public:
     if (e->getType()->isVectorType()) {
       mlir::Location loc = cgf.getLoc(e->getExprLoc());
       mlir::Type lhsTy = cgf.convertType(e->getLHS()->getType());
-      mlir::Value zeroVec = builder.getNullValue(lhsTy, loc);
+      mlir::Value zeroVec = builder.getZeroValue(lhsTy, loc);
 
       mlir::Value lhs = Visit(e->getLHS());
       mlir::Value rhs = Visit(e->getRHS());
@@ -2484,7 +2484,7 @@ mlir::Value ScalarExprEmitter::VisitInitListExpr(InitListExpr *e) {
 
     // Zero-initialize any remaining values.
     if (numInitElements < vectorType.getSize()) {
-      const mlir::Value zeroValue = cgf.getBuilder().getNullValue(
+      const mlir::Value zeroValue = cgf.getBuilder().getZeroValue(
           vectorType.getElementType(), cgf.getLoc(e->getSourceRange()));
       std::fill_n(std::back_inserter(elements),
                   vectorType.getSize() - numInitElements, zeroValue);
@@ -2544,7 +2544,7 @@ mlir::Value ScalarExprEmitter::VisitUnaryLNot(const UnaryOperator *e) {
     mlir::Location loc = cgf.getLoc(e->getExprLoc());
     auto operVecTy = mlir::cast<cir::VectorType>(oper.getType());
     auto exprVecTy = mlir::cast<cir::VectorType>(cgf.convertType(e->getType()));
-    mlir::Value zeroVec = builder.getNullValue(operVecTy, loc);
+    mlir::Value zeroVec = builder.getZeroValue(operVecTy, loc);
     return cir::VecCmpOp::create(builder, loc, exprVecTy, cir::CmpOpKind::eq,
                                  oper, zeroVec);
   }
@@ -2807,14 +2807,14 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
 
     mlir::Value lhs = Visit(lhsExpr);
     if (!lhs) {
-      lhs = builder.getNullValue(cgf.voidTy, loc);
+      lhs = builder.getZeroValue(cgf.voidTy, loc);
       lhsIsVoid = true;
     }
 
     mlir::Value rhs = Visit(rhsExpr);
     if (lhsIsVoid) {
       assert(!rhs && "lhs and rhs types must match");
-      rhs = builder.getNullValue(cgf.voidTy, loc);
+      rhs = builder.getZeroValue(cgf.voidTy, loc);
     }
 
     return builder.createSelect(loc, condV, lhs, rhs);
@@ -2870,7 +2870,7 @@ mlir::Value ScalarExprEmitter::VisitAbstractConditionalOperator(
       if (mlir::isa<cir::VoidType>(yieldTy)) {
         cir::YieldOp::create(builder, loc);
       } else { // Block returns: set null yield value.
-        mlir::Value op0 = builder.getNullValue(yieldTy, loc);
+        mlir::Value op0 = builder.getZeroValue(yieldTy, loc);
         cir::YieldOp::create(builder, loc, op0);
       }
     }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -525,7 +525,7 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
     if (fd && fd->hasImplicitReturnZero()) {
       mlir::Type cirRetTy = convertType(returnType.getUnqualifiedType());
       mlir::Location bodyBeginMLIRLoc = getLoc(bodyBeginLoc);
-      mlir::Value zero = builder.getNullValue(cirRetTy, bodyBeginMLIRLoc);
+      mlir::Value zero = builder.getZeroValue(cirRetTy, bodyBeginMLIRLoc);
       builder.CIRBaseBuilderTy::createStore(bodyBeginMLIRLoc, zero,
                                             returnValue.getPointer());
     }
@@ -1284,7 +1284,7 @@ void CIRGenFunction::emitNullInitialization(mlir::Location loc, Address destPtr,
   // Builder.CreateMemSet. In CIR just emit a store of #cir.zero to the
   // respective address.
   // Builder.CreateMemSet(DestPtr, Builder.getInt8(0), SizeVal, false);
-  const mlir::Value zeroValue = builder.getNullValue(convertType(ty), loc);
+  const mlir::Value zeroValue = builder.getZeroValue(convertType(ty), loc);
   builder.createStore(loc, zeroValue, destPtr);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1493,7 +1493,7 @@ void CIRGenModule::emitGlobalVarDefinition(const clang::VarDecl *vd,
     // since common linkage must have zero initializer and must not have
     // explicit section therefore cannot have non-zero initial value.
     std::optional<mlir::Attribute> initializer = gv.getInitialValue();
-    if (initializer && !getBuilder().isNullValue(*initializer))
+    if (initializer && !getBuilder().isZeroValue(*initializer))
       gv.setLinkage(cir::GlobalLinkageKind::WeakAnyLinkage);
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -463,7 +463,7 @@ static mlir::Value lowerScalarToComplexCast(mlir::MLIRContext &ctx,
   builder.setInsertionPoint(op);
 
   mlir::Value src = op.getSrc();
-  mlir::Value imag = builder.getNullValue(src.getType(), op.getLoc());
+  mlir::Value imag = builder.getZeroValue(src.getType(), op.getLoc());
   return builder.createComplexCreate(op.getLoc(), src, imag);
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -452,7 +452,7 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstComplexAttr complexAttr) {
 /// ConstPtrAttr visitor.
 mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstPtrAttr ptrAttr) {
   mlir::Location loc = parentOp->getLoc();
-  if (ptrAttr.isNullValue()) {
+  if (ptrAttr.isZeroValue()) {
     return mlir::LLVM::ZeroOp::create(
         rewriter, loc, converter->convertType(ptrAttr.getType()));
   }
@@ -2008,7 +2008,7 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
   } else if (mlir::isa<cir::PointerType>(op.getType())) {
     // Optimize with dedicated LLVM op for null pointers.
     if (mlir::isa<cir::ConstPtrAttr>(op.getValue())) {
-      if (mlir::cast<cir::ConstPtrAttr>(op.getValue()).isNullValue()) {
+      if (mlir::cast<cir::ConstPtrAttr>(op.getValue()).isZeroValue()) {
         rewriter.replaceOpWithNewOp<mlir::LLVM::ZeroOp>(
             op, typeConverter->convertType(op.getType()));
         return mlir::success();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVMIR.cpp
@@ -40,7 +40,7 @@ public:
 
     if (auto cirOp = llvm::dyn_cast<mlir::LLVM::ZeroOp>(op))
       moduleTranslation.mapValue(cirOp.getResult()) =
-          llvm::Constant::getNullValue(
+          llvm::Constant::getZeroValue(
               moduleTranslation.convertType(cirOp.getType()));
 
     return mlir::success();

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -784,7 +784,7 @@ static Value *EmitSignBit(CodeGenFunction &CGF, Value *V) {
     IntTy = llvm::IntegerType::get(C, Width);
     V = CGF.Builder.CreateTrunc(V, IntTy);
   }
-  Value *Zero = llvm::Constant::getNullValue(IntTy);
+  Value *Zero = llvm::Constant::getZeroValue(IntTy);
   return CGF.Builder.CreateICmpSLT(V, Zero);
 }
 
@@ -1852,8 +1852,8 @@ Value *CodeGenFunction::EmitMSVCBuiltinExpr(MSVCIntrin BuiltinID,
     llvm::Type *IndexType = IndexAddress.getElementType();
     llvm::Type *ResultType = ConvertType(E->getType());
 
-    Value *ArgZero = llvm::Constant::getNullValue(ArgType);
-    Value *ResZero = llvm::Constant::getNullValue(ResultType);
+    Value *ArgZero = llvm::Constant::getZeroValue(ArgType);
+    Value *ResZero = llvm::Constant::getZeroValue(ResultType);
     Value *ResOne = llvm::ConstantInt::get(ResultType, 1);
 
     BasicBlock *Begin = Builder.GetInsertBlock();
@@ -2044,7 +2044,7 @@ Value *CodeGenFunction::EmitCheckedArgForBuiltin(const Expr *E,
   auto CheckHandler = SanitizerHandler::InvalidBuiltin;
   SanitizerDebugLocation SanScope(this, {CheckOrdinal}, CheckHandler);
   Value *Cond = Builder.CreateICmpNE(
-      ArgValue, llvm::Constant::getNullValue(ArgValue->getType()));
+      ArgValue, llvm::Constant::getZeroValue(ArgValue->getType()));
   EmitCheck(std::make_pair(Cond, CheckOrdinal), CheckHandler,
             {EmitCheckSourceLocation(E->getExprLoc()),
              llvm::ConstantInt::get(Builder.getInt8Ty(), Kind)},
@@ -2094,7 +2094,7 @@ static Value *EmitOverflowCheckedAbs(CodeGenFunction &CGF, const CallExpr *E,
 
   SanitizerDebugLocation SanScope(&CGF, Ordinals, CheckHandler);
 
-  Constant *Zero = Constant::getNullValue(ArgValue->getType());
+  Constant *Zero = Constant::getZeroValue(ArgValue->getType());
   Value *ResultAndOverflow = CGF.Builder.CreateBinaryIntrinsic(
       Intrinsic::ssub_with_overflow, Zero, ArgValue);
   Value *Result = CGF.Builder.CreateExtractValue(ResultAndOverflow, 0);
@@ -2386,7 +2386,7 @@ EmitCheckedMixedSignMultiply(CodeGenFunction &CGF, const clang::Expr *Op1,
     Unsigned = CGF.Builder.CreateZExt(Unsigned, Signed->getType(), "op.zext");
 
   llvm::Type *OpTy = Signed->getType();
-  llvm::Value *Zero = llvm::Constant::getNullValue(OpTy);
+  llvm::Value *Zero = llvm::Constant::getZeroValue(OpTy);
   Address ResultPtr = CGF.EmitPointerWithAlignment(ResultArg);
   llvm::Type *ResTy = CGF.getTypes().ConvertType(ResultQTy);
   unsigned OpWidth = std::max(Op1Info.Width, Op2Info.Width);
@@ -3397,7 +3397,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Function *F = CGM.getIntrinsic(Intrinsic::ctlz, ArgType);
 
     llvm::Type *ResultType = ConvertType(E->getType());
-    Value *Zero = llvm::Constant::getNullValue(ArgType);
+    Value *Zero = llvm::Constant::getZeroValue(ArgType);
     Value *IsNeg = Builder.CreateICmpSLT(ArgValue, Zero, "isneg");
     Value *Inverse = Builder.CreateNot(ArgValue, "not");
     Value *Tmp = Builder.CreateSelect(IsNeg, Inverse, ArgValue);
@@ -3438,7 +3438,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     if (!HasFallback)
       return RValue::get(Result);
 
-    Value *Zero = Constant::getNullValue(ArgType);
+    Value *Zero = Constant::getZeroValue(ArgType);
     Value *IsZero = Builder.CreateICmpEQ(ArgValue, Zero, "iszero");
     Value *FallbackValue = EmitScalarExpr(E->getArg(1));
     Value *ResultOrFallback =
@@ -3475,7 +3475,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     if (!HasFallback)
       return RValue::get(Result);
 
-    Value *Zero = Constant::getNullValue(ArgType);
+    Value *Zero = Constant::getZeroValue(ArgType);
     Value *IsZero = Builder.CreateICmpEQ(ArgValue, Zero, "iszero");
     Value *FallbackValue = EmitScalarExpr(E->getArg(1));
     Value *ResultOrFallback =
@@ -3495,7 +3495,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *Tmp =
         Builder.CreateAdd(Builder.CreateCall(F, {ArgValue, Builder.getTrue()}),
                           llvm::ConstantInt::get(ArgType, 1));
-    Value *Zero = llvm::Constant::getNullValue(ArgType);
+    Value *Zero = llvm::Constant::getZeroValue(ArgType);
     Value *IsZero = Builder.CreateICmpEQ(ArgValue, Zero, "iszero");
     Value *Result = Builder.CreateSelect(IsZero, Zero, Tmp, "ffs");
     if (Result->getType() != ResultType)
@@ -4606,7 +4606,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *IsNeg = EmitSignBit(*this, Arg);
 
     llvm::Type *IntTy = ConvertType(E->getType());
-    Value *Zero = Constant::getNullValue(IntTy);
+    Value *Zero = Constant::getZeroValue(IntTy);
     Value *One = ConstantInt::get(IntTy, 1);
     Value *NegativeOne = ConstantInt::getAllOnesValue(IntTy);
     Value *SignResult = Builder.CreateSelect(IsNeg, NegativeOne, One);
@@ -4649,8 +4649,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
     // if (V==0) return FP_ZERO
     Builder.SetInsertPoint(Begin);
-    Value *IsZero = Builder.CreateFCmpOEQ(V, Constant::getNullValue(Ty),
-                                          "iszero");
+    Value *IsZero =
+        Builder.CreateFCmpOEQ(V, Constant::getZeroValue(Ty), "iszero");
     Value *ZeroLiteral = EmitScalarExpr(E->getArg(4));
     BasicBlock *NotZero = createBasicBlock("fpclassify_not_zero", this->CurFn);
     Builder.CreateCondBr(IsZero, End, NotZero);
@@ -4964,8 +4964,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
     EmitBlock(Exit);
     PHINode *Ret = Builder.CreatePHI(Str->getType(), 3);
-    Ret->addIncoming(llvm::Constant::getNullValue(Str->getType()), Entry);
-    Ret->addIncoming(llvm::Constant::getNullValue(Str->getType()), Next);
+    Ret->addIncoming(llvm::Constant::getZeroValue(Str->getType()), Entry);
+    Ret->addIncoming(llvm::Constant::getZeroValue(Str->getType()), Next);
     Ret->addIncoming(FoundChr, CmpEq);
     return RValue::get(Ret);
   }
@@ -5340,7 +5340,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm::Type *ITy = llvm::IntegerType::get(getLLVMContext(),
                                              getContext().getTypeSize(ElTy));
     llvm::StoreInst *Store =
-        Builder.CreateStore(llvm::Constant::getNullValue(ITy), Ptr);
+        Builder.CreateStore(llvm::Constant::getZeroValue(ITy), Ptr);
     Store->setAtomic(llvm::AtomicOrdering::Release);
     return RValue::get(nullptr);
   }
@@ -5374,7 +5374,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       Args.add(RValue::get(EmitScalarExpr(E->getArg(1))),
                getContext().VoidPtrTy);
     else
-      Args.add(RValue::get(llvm::Constant::getNullValue(VoidPtrTy)),
+      Args.add(RValue::get(llvm::Constant::getZeroValue(VoidPtrTy)),
                getContext().VoidPtrTy);
     const CGFunctionInfo &FuncInfo =
         CGM.getTypes().arrangeBuiltinFunctionCall(E->getType(), Args);
@@ -6915,7 +6915,7 @@ RValue CodeGenFunction::EmitBuiltinIsAligned(const CallExpr *E) {
         Builder.CreateBitOrPointerCast(Args.Src, Args.IntType, "src_addr");
   return RValue::get(Builder.CreateICmpEQ(
       Builder.CreateAnd(SrcAddress, Args.Mask, "set_bits"),
-      llvm::Constant::getNullValue(Args.IntType), "is_aligned"));
+      llvm::Constant::getZeroValue(Args.IntType), "is_aligned"));
 }
 
 /// Generate (x & ~(y-1)) to align down or ((x+(y-1)) & ~(y-1)) to align up.

--- a/clang/lib/CodeGen/CGCUDANV.cpp
+++ b/clang/lib/CodeGen/CGCUDANV.cpp
@@ -355,7 +355,7 @@ Address CGNVCUDARuntime::prepareKernelArgsLLVMOffload(CodeGenFunction &CGF,
                           CGF.Builder.CreateStructGEP(KernelLaunchParams, 0));
   CGF.Builder.CreateStore(KernelArgs.emitRawPointer(CGF),
                           CGF.Builder.CreateStructGEP(KernelLaunchParams, 1));
-  CGF.Builder.CreateStore(llvm::Constant::getNullValue(PtrTy),
+  CGF.Builder.CreateStore(llvm::Constant::getZeroValue(PtrTy),
                           CGF.Builder.CreateStructGEP(KernelLaunchParams, 2));
 
   for (unsigned i = 0; i < Args.size(); ++i) {
@@ -924,7 +924,7 @@ llvm::Function *CGNVCUDARuntime::makeModuleCtorFunction() {
     {
       auto *HandleValue = CtorBuilder.CreateLoad(GpuBinaryAddr);
       llvm::Constant *Zero =
-          llvm::Constant::getNullValue(HandleValue->getType());
+          llvm::Constant::getZeroValue(HandleValue->getType());
       llvm::Value *EQZero = CtorBuilder.CreateICmpEQ(HandleValue, Zero);
       CtorBuilder.CreateCondBr(EQZero, IfBlock, ExitBlock);
     }
@@ -1063,7 +1063,7 @@ llvm::Function *CGNVCUDARuntime::makeModuleDtorFunction() {
         llvm::BasicBlock::Create(Context, "if", ModuleDtorFunc);
     llvm::BasicBlock *ExitBlock =
         llvm::BasicBlock::Create(Context, "exit", ModuleDtorFunc);
-    llvm::Constant *Zero = llvm::Constant::getNullValue(HandleValue->getType());
+    llvm::Constant *Zero = llvm::Constant::getZeroValue(HandleValue->getType());
     llvm::Value *NEZero = DtorBuilder.CreateICmpNE(HandleValue, Zero);
     DtorBuilder.CreateCondBr(NEZero, IfBlock, ExitBlock);
 

--- a/clang/lib/CodeGen/CGCUDARuntime.cpp
+++ b/clang/lib/CodeGen/CGCUDARuntime.cpp
@@ -71,7 +71,7 @@ RValue CGCUDARuntime::EmitCUDADeviceKernelCallExpr(
   llvm::Value *Config = emitGetParamBuf(CGF, E);
   CGF.Builder.CreateCondBr(
       CGF.Builder.CreateICmpNE(Config,
-                               llvm::Constant::getNullValue(Config->getType())),
+                               llvm::Constant::getZeroValue(Config->getType())),
       ConfigOKBlock, ContBlock);
 
   CodeGenFunction::ConditionalEvaluation eval(CGF);

--- a/clang/lib/CodeGen/CGCXXABI.cpp
+++ b/clang/lib/CodeGen/CGCXXABI.cpp
@@ -35,7 +35,7 @@ void CGCXXABI::ErrorUnsupportedABI(CodeGenFunction &CGF, StringRef S) {
 }
 
 llvm::Constant *CGCXXABI::GetBogusMemberPointer(QualType T) {
-  return llvm::Constant::getNullValue(CGM.getTypes().ConvertType(T));
+  return llvm::Constant::getZeroValue(CGM.getTypes().ConvertType(T));
 }
 
 llvm::Type *
@@ -54,7 +54,7 @@ CGCallee CGCXXABI::EmitLoadOfMemberFunctionPointer(
       CGF.getAsNaturalPointerTo(This, CGF.getContext().getCanonicalTagType(RD));
   const FunctionProtoType *FPT =
       MPT->getPointeeType()->getAs<FunctionProtoType>();
-  llvm::Constant *FnPtr = llvm::Constant::getNullValue(
+  llvm::Constant *FnPtr = llvm::Constant::getZeroValue(
       llvm::PointerType::getUnqual(CGM.getLLVMContext()));
   return CGCallee::forDirect(FnPtr, FPT);
 }
@@ -65,7 +65,7 @@ llvm::Value *CGCXXABI::EmitMemberDataPointerAddress(
   ErrorUnsupportedABI(CGF, "loads of member pointers");
   llvm::Type *Ty =
       llvm::PointerType::get(CGF.getLLVMContext(), Base.getAddressSpace());
-  return llvm::Constant::getNullValue(Ty);
+  return llvm::Constant::getZeroValue(Ty);
 }
 
 llvm::Value *CGCXXABI::EmitMemberPointerConversion(CodeGenFunction &CGF,

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1593,7 +1593,7 @@ CoerceScalableToFixed(CodeGenFunction &CGF, llvm::FixedVectorType *ToTy,
       FromTy = llvm::ScalableVectorType::get(
           FromTy->getElementType(),
           llvm::alignTo<8>(FromTy->getElementCount().getKnownMinValue()));
-      llvm::Value *ZeroVec = llvm::Constant::getNullValue(FromTy);
+      llvm::Value *ZeroVec = llvm::Constant::getZeroValue(FromTy);
       V = CGF.Builder.CreateInsertVector(FromTy, ZeroVec, V, uint64_t(0));
     }
     FromTy = llvm::ScalableVectorType::get(
@@ -3226,7 +3226,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
     if (FD->hasImplicitReturnZero()) {
       QualType RetTy = FD->getReturnType().getUnqualifiedType();
       llvm::Type *LLVMTy = CGM.getTypes().ConvertType(RetTy);
-      llvm::Constant *Zero = llvm::Constant::getNullValue(LLVMTy);
+      llvm::Constant *Zero = llvm::Constant::getZeroValue(LLVMTy);
       Builder.CreateStore(Zero, ReturnValue);
     }
   }
@@ -5056,7 +5056,7 @@ void CodeGenFunction::EmitCallArg(CallArgList &args, const Expr *E,
                                               Slot.getAddress(), type);
       // This unreachable is a temporary marker which will be removed later.
       llvm::Instruction *IsActive =
-          Builder.CreateFlagLoad(llvm::Constant::getNullValue(Int8PtrTy));
+          Builder.CreateFlagLoad(llvm::Constant::getZeroValue(Int8PtrTy));
       args.addArgCleanupDeactivation(EHStack.stable_begin(), IsActive);
     }
     return;
@@ -5319,7 +5319,7 @@ public:
     Alignment = cast<llvm::ConstantInt>(CGF.EmitScalarExpr(AA->getAlignment()));
     if (Expr *Offset = AA->getOffset()) {
       OffsetCI = cast<llvm::ConstantInt>(CGF.EmitScalarExpr(Offset));
-      if (OffsetCI->isNullValue()) // Canonicalize zero offset to no offset.
+      if (OffsetCI->isZeroValue()) // Canonicalize zero offset to no offset.
         OffsetCI = nullptr;
     }
   }

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -378,7 +378,7 @@ Address CodeGenFunction::GetAddressOfBaseClass(
 
     llvm::PHINode *PHI = Builder.CreatePHI(PtrTy, 2, "cast.result");
     PHI->addIncoming(Value.emitRawPointer(*this), notNullBB);
-    PHI->addIncoming(llvm::Constant::getNullValue(PtrTy), origBB);
+    PHI->addIncoming(llvm::Constant::getZeroValue(PtrTy), origBB);
     Value = Value.withPointer(PHI, NotKnownNonNull);
   }
 
@@ -435,7 +435,7 @@ Address CodeGenFunction::GetAddressOfDerivedClass(
     llvm::Value *Value = Addr.emitRawPointer(*this);
     llvm::PHINode *PHI = Builder.CreatePHI(Value->getType(), 2);
     PHI->addIncoming(Value, CastNotNull);
-    PHI->addIncoming(llvm::Constant::getNullValue(Value->getType()), CastNull);
+    PHI->addIncoming(llvm::Constant::getZeroValue(Value->getType()), CastNull);
     return Address(PHI, Addr.getElementType(),
                    CGM.getClassPointerAlignment(Derived));
   }

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -919,7 +919,7 @@ static bool canEmitInitWithFewStoresAfterBZero(llvm::Constant *Init,
   if (isa<llvm::ConstantInt>(Init) || isa<llvm::ConstantFP>(Init) ||
       isa<llvm::ConstantVector>(Init) || isa<llvm::BlockAddress>(Init) ||
       isa<llvm::ConstantExpr>(Init))
-    return Init->isNullValue() || NumStores--;
+    return Init->isZeroValue() || NumStores--;
 
   // See if we can emit each element.
   if (isa<llvm::ConstantArray>(Init) || isa<llvm::ConstantStruct>(Init)) {
@@ -950,7 +950,7 @@ static bool canEmitInitWithFewStoresAfterBZero(llvm::Constant *Init,
 void CodeGenFunction::emitStoresForInitAfterBZero(llvm::Constant *Init,
                                                   Address Loc, bool isVolatile,
                                                   bool IsAutoInit) {
-  assert(!Init->isNullValue() && !isa<llvm::UndefValue>(Init) &&
+  assert(!Init->isZeroValue() && !isa<llvm::UndefValue>(Init) &&
          "called emitStoresForInitAfterBZero for zero or undef value.");
 
   if (isa<llvm::ConstantInt>(Init) || isa<llvm::ConstantFP>(Init) ||
@@ -969,7 +969,7 @@ void CodeGenFunction::emitStoresForInitAfterBZero(llvm::Constant *Init,
       llvm::Constant *Elt = CDS->getElementAsConstant(i);
 
       // If necessary, get a pointer to the element and emit it.
-      if (!Elt->isNullValue() && !isa<llvm::UndefValue>(Elt))
+      if (!Elt->isZeroValue() && !isa<llvm::UndefValue>(Elt))
         emitStoresForInitAfterBZero(
             Elt, Builder.CreateConstInBoundsGEP2_32(Loc, 0, i), isVolatile,
             IsAutoInit);
@@ -984,7 +984,7 @@ void CodeGenFunction::emitStoresForInitAfterBZero(llvm::Constant *Init,
     llvm::Constant *Elt = cast<llvm::Constant>(Init->getOperand(i));
 
     // If necessary, get a pointer to the element and emit it.
-    if (!Elt->isNullValue() && !isa<llvm::UndefValue>(Elt))
+    if (!Elt->isZeroValue() && !isa<llvm::UndefValue>(Elt))
       emitStoresForInitAfterBZero(Elt,
                                   Builder.CreateConstInBoundsGEP2_32(Loc, 0, i),
                                   isVolatile, IsAutoInit);
@@ -1046,7 +1046,7 @@ static llvm::Constant *patternOrZeroFor(CodeGenModule &CGM, IsPattern isPattern,
   if (isPattern == IsPattern::Yes)
     return initializationPatternFor(CGM, Ty);
   else
-    return llvm::Constant::getNullValue(Ty);
+    return llvm::Constant::getZeroValue(Ty);
 }
 
 static llvm::Constant *constWithPadding(CodeGenModule &CGM, IsPattern isPattern,
@@ -1071,8 +1071,8 @@ static llvm::Constant *constStructWithPadding(CodeGenModule &CGM,
       Values.push_back(patternOrZeroFor(CGM, isPattern, PadTy));
     }
     llvm::Constant *CurOp;
-    if (constant->isNullValue())
-      CurOp = llvm::Constant::getNullValue(STy->getElementType(i));
+    if (constant->isZeroValue())
+      CurOp = llvm::Constant::getZeroValue(STy->getElementType(i));
     else
       CurOp = cast<llvm::Constant>(constant->getAggregateElement(i));
     auto *NewOp = constWithPadding(CGM, isPattern, CurOp);
@@ -1104,10 +1104,10 @@ static llvm::Constant *constWithPadding(CodeGenModule &CGM, IsPattern isPattern,
     if (!Size)
       return constant;
     llvm::Type *ElemTy = ArrayTy->getElementType();
-    bool ZeroInitializer = constant->isNullValue();
+    bool ZeroInitializer = constant->isZeroValue();
     llvm::Constant *OpValue, *PaddedOp;
     if (ZeroInitializer) {
-      OpValue = llvm::Constant::getNullValue(ElemTy);
+      OpValue = llvm::Constant::getZeroValue(ElemTy);
       PaddedOp = constWithPadding(CGM, isPattern, OpValue);
     }
     for (unsigned Op = 0; Op != Size; ++Op) {
@@ -1220,7 +1220,7 @@ void CodeGenFunction::emitStoresForConstant(const VarDecl &D, Address Loc,
       I->addAnnotationMetadata("auto-init");
 
     bool valueAlreadyCorrect =
-        constant->isNullValue() || isa<llvm::UndefValue>(constant);
+        constant->isZeroValue() || isa<llvm::UndefValue>(constant);
     if (!valueAlreadyCorrect) {
       Loc = Loc.withElementType(Ty);
       emitStoresForInitAfterBZero(constant, Loc, isVolatile, IsAutoInit);
@@ -1295,7 +1295,7 @@ void CodeGenFunction::emitStoresForZeroInit(const VarDecl &D, Address Loc,
                                             bool isVolatile) {
   llvm::Type *ElTy = Loc.getElementType();
   llvm::Constant *constant =
-      constWithPadding(CGM, IsPattern::No, llvm::Constant::getNullValue(ElTy));
+      constWithPadding(CGM, IsPattern::No, llvm::Constant::getZeroValue(ElTy));
   emitStoresForConstant(D, Loc, isVolatile, constant,
                         /*IsAutoInit=*/true);
 }
@@ -2024,7 +2024,7 @@ void CodeGenFunction::EmitAutoVarInit(const AutoVarEmission &emission) {
       D.mightBeUsableInConstantExpressions(getContext())) {
     assert(!capturedByInit && "constant init contains a capturing block?");
     constant = ConstantEmitter(*this).tryEmitAbstractForInitializer(D);
-    if (constant && !constant->isNullValue() &&
+    if (constant && !constant->isZeroValue() &&
         (trivialAutoVarInit !=
          LangOptions::TrivialAutoVarInitKind::Uninitialized)) {
       IsPattern isPattern =
@@ -2334,7 +2334,7 @@ void CodeGenFunction::pushDestroyAndDeferDeactivation(
     CleanupKind cleanupKind, Address addr, QualType type, Destroyer *destroyer,
     bool useEHCleanupForArray) {
   llvm::Instruction *DominatingIP =
-      Builder.CreateFlagLoad(llvm::Constant::getNullValue(Int8PtrTy));
+      Builder.CreateFlagLoad(llvm::Constant::getZeroValue(Int8PtrTy));
   pushDestroy(cleanupKind, addr, type, destroyer, useEHCleanupForArray);
   DeferredDeactivationCleanupStack.push_back(
       {EHStack.stable_begin(), DominatingIP});

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -141,7 +141,7 @@ static void EmitDeclDestroy(CodeGenFunction &CGF, const VarDecl &D,
     Func = CodeGenFunction(CGM)
            .generateDestroyHelper(Addr, Type, CGF.getDestroyer(DtorKind),
                                   CGF.needsEHCleanup(DtorKind), &D);
-    Argument = llvm::Constant::getNullValue(CGF.Int8PtrTy);
+    Argument = llvm::Constant::getZeroValue(CGF.Int8PtrTy);
   }
 
   CGM.getCXXABI().registerGlobalDtor(CGF, D, Func, Argument);
@@ -316,7 +316,7 @@ llvm::Function *CodeGenFunction::createTLSAtExitStub(
     call->setCallingConv(DtorFn->getCallingConv());
 
   // Return 0 from function
-  CGF.Builder.CreateStore(llvm::Constant::getNullValue(CGM.IntTy),
+  CGF.Builder.CreateStore(llvm::Constant::getZeroValue(CGM.IntTy),
                           CGF.ReturnValue);
 
   CGF.FinishFunction();

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -989,14 +989,14 @@ static void emitCatchPadBlock(CodeGenFunction &CGF, EHCatchScope &CatchScope) {
 
     CatchTypeInfo TypeInfo = Handler.Type;
     if (!TypeInfo.RTTI)
-      TypeInfo.RTTI = llvm::Constant::getNullValue(CGF.VoidPtrTy);
+      TypeInfo.RTTI = llvm::Constant::getZeroValue(CGF.VoidPtrTy);
 
     CGF.Builder.SetInsertPoint(Handler.Block);
 
     if (EHPersonality::get(CGF).isMSVCXXPersonality()) {
       CGF.Builder.CreateCatchPad(
           CatchSwitch, {TypeInfo.RTTI, CGF.Builder.getInt32(TypeInfo.Flags),
-                        llvm::Constant::getNullValue(CGF.VoidPtrTy)});
+                        llvm::Constant::getZeroValue(CGF.VoidPtrTy)});
     } else {
       CGF.Builder.CreateCatchPad(CatchSwitch, {TypeInfo.RTTI});
     }
@@ -1039,7 +1039,7 @@ static void emitWasmCatchPadBlock(CodeGenFunction &CGF,
     const EHCatchScope::Handler &Handler = CatchScope.getHandler(I);
     CatchTypeInfo TypeInfo = Handler.Type;
     if (!TypeInfo.RTTI)
-      TypeInfo.RTTI = llvm::Constant::getNullValue(CGF.VoidPtrTy);
+      TypeInfo.RTTI = llvm::Constant::getZeroValue(CGF.VoidPtrTy);
     CatchTypes.push_back(TypeInfo.RTTI);
   }
   auto *CPI = CGF.Builder.CreateCatchPad(CatchSwitch, CatchTypes);
@@ -1072,7 +1072,7 @@ static void emitWasmCatchPadBlock(CodeGenFunction &CGF,
     const EHCatchScope::Handler &Handler = CatchScope.getHandler(I);
     CatchTypeInfo TypeInfo = Handler.Type;
     if (!TypeInfo.RTTI)
-      TypeInfo.RTTI = llvm::Constant::getNullValue(CGF.VoidPtrTy);
+      TypeInfo.RTTI = llvm::Constant::getZeroValue(CGF.VoidPtrTy);
 
     // Figure out the next block.
     llvm::BasicBlock *NextBlock;
@@ -1753,7 +1753,7 @@ struct PerformSEHFinally final : EHScopeStack::Cleanup {
     if (!F.isForEHCleanup() && F.hasExitSwitch()) {
       Address Addr = CGF.getNormalCleanupDestSlot();
       llvm::Value *Load = CGF.Builder.CreateLoad(Addr, "cleanup.dest");
-      llvm::Value *Zero = llvm::Constant::getNullValue(CGM.Int32Ty);
+      llvm::Value *Zero = llvm::Constant::getZeroValue(CGM.Int32Ty);
       IsForEH = CGF.Builder.CreateICmpNE(Load, Zero);
     }
 

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -444,7 +444,7 @@ pushTemporaryCleanup(CodeGenFunction &CGF, const MaterializeTemporaryExpr *M,
             ReferenceTemporary, E->getType(), CodeGenFunction::destroyCXXObject,
             CGF.getLangOpts().Exceptions,
             dyn_cast_or_null<VarDecl>(M->getExtendingDecl()));
-        CleanupArg = llvm::Constant::getNullValue(CGF.Int8PtrTy);
+        CleanupArg = llvm::Constant::getZeroValue(CGF.Int8PtrTy);
       } else {
         CleanupFn = CGF.CGM.getAddrAndTypeOfCXXStructor(
             GlobalDecl(ReferenceTemporaryDtor, Dtor_Complete));
@@ -830,7 +830,7 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
 
       // Degenerate case: new X[0] does not need an objectsize check.
       llvm::Constant *ConstantSize = dyn_cast<llvm::Constant>(Size);
-      if (!ConstantSize || !ConstantSize->isNullValue()) {
+      if (!ConstantSize || !ConstantSize->isZeroValue()) {
         // The glvalue must refer to a large enough storage region.
         // FIXME: If Address Sanitizer is enabled, insert dynamic
         // instrumentation
@@ -1607,7 +1607,7 @@ llvm::Value *CodeGenFunction::EmitNonNullRValueCheck(RValue RV, QualType T) {
   llvm::Value *V = RV.getScalarVal();
   if (auto MPT = T->getAs<MemberPointerType>())
     return CGM.getCXXABI().EmitMemberPointerIsNotNull(*this, V, MPT);
-  return Builder.CreateICmpNE(V, llvm::Constant::getNullValue(V->getType()));
+  return Builder.CreateICmpNE(V, llvm::Constant::getZeroValue(V->getType()));
 }
 
 RValue CodeGenFunction::GetUndefRValue(QualType Ty) {
@@ -2294,7 +2294,7 @@ llvm::Value *CodeGenFunction::EmitFromMemory(llvm::Value *Value, QualType Ty) {
   bool HasBoolRep = Ty->hasBooleanRepresentation() || Ty->isExtVectorBoolType();
   if (HasBoolRep && CGM.getCodeGenOpts().isConvertingBoolWithCmp0()) {
     return Builder.CreateICmpNE(
-        Value, llvm::Constant::getNullValue(Value->getType()), "loadedv");
+        Value, llvm::Constant::getZeroValue(Value->getType()), "loadedv");
   }
   if (HasBoolRep || Ty->isBitIntType())
     return Builder.CreateTrunc(Value, ResTy, "loadedv");
@@ -2677,7 +2677,7 @@ RValue CodeGenFunction::EmitLoadOfExtVectorElementLValue(LValue LV) {
   // IR value to a vector here allows the rest of codegen to behave as normal.
   if (getLangOpts().HLSL && !Vec->getType()->isVectorTy()) {
     llvm::Type *DstTy = llvm::FixedVectorType::get(Vec->getType(), 1);
-    llvm::Value *Zero = llvm::Constant::getNullValue(CGM.Int64Ty);
+    llvm::Value *Zero = llvm::Constant::getZeroValue(CGM.Int64Ty);
     Vec = Builder.CreateInsertElement(DstTy, Vec, Zero, "cast.splat");
   }
 
@@ -2698,7 +2698,7 @@ RValue CodeGenFunction::EmitLoadOfExtVectorElementLValue(LValue LV) {
       if (LV.getType()->hasBooleanRepresentation() &&
           CGM.getCodeGenOpts().isConvertingBoolWithCmp0())
         Element = Builder.CreateICmpNE(
-            Element, llvm::Constant::getNullValue(Element->getType()));
+            Element, llvm::Constant::getZeroValue(Element->getType()));
       else
         Element = Builder.CreateTrunc(Element, LVTy);
     }
@@ -2718,7 +2718,7 @@ RValue CodeGenFunction::EmitLoadOfExtVectorElementLValue(LValue LV) {
   if (LV.getType()->isExtVectorBoolType()) {
     if (CGM.getCodeGenOpts().isConvertingBoolWithCmp0())
       Vec = Builder.CreateICmpNE(Vec,
-                                 llvm::Constant::getNullValue(Vec->getType()));
+                                 llvm::Constant::getZeroValue(Vec->getType()));
     else
       Vec = Builder.CreateTrunc(Vec, ConvertType(LV.getType()), "truncv");
   }
@@ -4073,7 +4073,7 @@ llvm::Constant *CodeGenFunction::EmitCheckSourceLocation(SourceLocation Loc) {
     Line = PLoc.getLine();
     Column = PLoc.getColumn();
   } else {
-    Filename = llvm::Constant::getNullValue(Int8PtrTy);
+    Filename = llvm::Constant::getZeroValue(Int8PtrTy);
     Line = Column = 0;
   }
 
@@ -5290,7 +5290,7 @@ LValue CodeGenFunction::EmitArraySectionExpr(const ArraySectionExpr *E,
           EmitScalarExpr(LowerBound), IntPtrTy,
           LowerBound->getType()->hasSignedIntegerRepresentation());
     } else
-      Idx = llvm::ConstantInt::getNullValue(IntPtrTy);
+      Idx = llvm::ConstantInt::getZeroValue(IntPtrTy);
   } else {
     // Try to emit length or lower bound as constant. If this is possible, 1
     // is subtracted from constant length or lower bound. Otherwise, emit LLVM

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -633,7 +633,7 @@ void AggExprEmitter::EmitArrayInit(Address DestPtr, llvm::ArrayType *AType,
     // would actually be quite complex.  Therefore we go through an
     // alloca.
     llvm::Instruction *dominatingIP =
-        Builder.CreateFlagLoad(llvm::ConstantInt::getNullValue(CGF.Int8PtrTy));
+        Builder.CreateFlagLoad(llvm::ConstantInt::getZeroValue(CGF.Int8PtrTy));
     endOfInit = CGF.CreateTempAlloca(begin->getType(), CGF.getPointerAlign(),
                                      "arrayinit.endOfInit");
     Builder.CreateStore(begin, endOfInit);

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -558,7 +558,7 @@ static void EmitNullBaseClassInitialization(CodeGenFunction &CGF,
   // TODO: isZeroInitializable can be over-conservative in the case where a
   // virtual base contains a member pointer.
   llvm::Constant *NullConstantForBase = CGF.CGM.EmitNullConstantForBase(Base);
-  if (!NullConstantForBase->isNullValue()) {
+  if (!NullConstantForBase->isZeroValue()) {
     llvm::GlobalVariable *NullVariable = new llvm::GlobalVariable(
         CGF.CGM.getModule(), NullConstantForBase->getType(),
         /*isConstant=*/true, llvm::GlobalVariable::PrivateLinkage,
@@ -1110,7 +1110,7 @@ void CodeGenFunction::EmitNewArrayInitializer(
       // would actually be quite complex.  Therefore we go through an
       // alloca.
       llvm::Instruction *DominatingIP =
-          Builder.CreateFlagLoad(llvm::ConstantInt::getNullValue(Int8PtrTy));
+          Builder.CreateFlagLoad(llvm::ConstantInt::getZeroValue(Int8PtrTy));
       EndOfInit = CreateTempAlloca(BeginPtr.getType(), getPointerAlign(),
                                    "array.init.end");
       pushIrregularPartialArrayCleanup(BeginPtr.emitRawPointer(*this),
@@ -1291,7 +1291,7 @@ void CodeGenFunction::EmitNewArrayInitializer(
   // Enter a partial-destruction Cleanup if necessary.
   if (!pushedCleanup && needsEHCleanup(DtorKind)) {
     llvm::Instruction *DominatingIP =
-        Builder.CreateFlagLoad(llvm::ConstantInt::getNullValue(Int8PtrTy));
+        Builder.CreateFlagLoad(llvm::ConstantInt::getZeroValue(Int8PtrTy));
     pushRegularPartialArrayCleanup(BeginPtr.emitRawPointer(*this),
                                    CurPtr.emitRawPointer(*this), ElementType,
                                    ElementAlign, getDestroyer(DtorKind));
@@ -1788,7 +1788,7 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
 
     llvm::PHINode *PHI = Builder.CreatePHI(resultPtr->getType(), 2);
     PHI->addIncoming(resultPtr, notNullBB);
-    PHI->addIncoming(llvm::Constant::getNullValue(resultPtr->getType()),
+    PHI->addIncoming(llvm::Constant::getZeroValue(resultPtr->getType()),
                      nullCheckBB);
 
     resultPtr = PHI;
@@ -2237,7 +2237,7 @@ static llvm::Value *EmitDynamicCastToNull(CodeGenFunction &CGF,
                                           QualType DestTy) {
   llvm::Type *DestLTy = CGF.ConvertType(DestTy);
   if (DestTy->isPointerType())
-    return llvm::Constant::getNullValue(DestLTy);
+    return llvm::Constant::getZeroValue(DestLTy);
 
   /// C++ [expr.dynamic.cast]p9:
   ///   A failed cast to reference type throws std::bad_cast

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -243,13 +243,13 @@ public:
   ComplexPairTy VisitCXXScalarValueInitExpr(CXXScalarValueInitExpr *E) {
     assert(E->getType()->isAnyComplexType() && "Expected complex type!");
     QualType Elem = E->getType()->castAs<ComplexType>()->getElementType();
-    llvm::Constant *Null = llvm::Constant::getNullValue(CGF.ConvertType(Elem));
+    llvm::Constant *Null = llvm::Constant::getZeroValue(CGF.ConvertType(Elem));
     return ComplexPairTy(Null, Null);
   }
   ComplexPairTy VisitImplicitValueInitExpr(ImplicitValueInitExpr *E) {
     assert(E->getType()->isAnyComplexType() && "Expected complex type!");
     QualType Elem = E->getType()->castAs<ComplexType>()->getElementType();
-    llvm::Constant *Null = llvm::Constant::getNullValue(CGF.ConvertType(Elem));
+    llvm::Constant *Null = llvm::Constant::getZeroValue(CGF.ConvertType(Elem));
     return ComplexPairTy(Null, Null);
   }
 
@@ -483,7 +483,7 @@ ComplexPairTy ComplexExprEmitter::VisitExpr(Expr *E) {
 ComplexPairTy
 ComplexExprEmitter::VisitImaginaryLiteral(const ImaginaryLiteral *IL) {
   llvm::Value *Imag = CGF.EmitScalarExpr(IL->getSubExpr());
-  return ComplexPairTy(llvm::Constant::getNullValue(Imag->getType()), Imag);
+  return ComplexPairTy(llvm::Constant::getZeroValue(Imag->getType()), Imag);
 }
 
 ComplexPairTy ComplexExprEmitter::VisitCallExpr(const CallExpr *E) {
@@ -533,7 +533,7 @@ ComplexPairTy ComplexExprEmitter::EmitScalarToComplexCast(llvm::Value *Val,
   Val = CGF.EmitScalarConversion(Val, SrcType, DestType, Loc);
 
   // Return (realval, 0).
-  return ComplexPairTy(Val, llvm::Constant::getNullValue(Val->getType()));
+  return ComplexPairTy(Val, llvm::Constant::getZeroValue(Val->getType()));
 }
 
 ComplexPairTy ComplexExprEmitter::EmitCast(CastKind CK, Expr *Op,
@@ -1042,7 +1042,7 @@ ComplexPairTy ComplexExprEmitter::EmitBinDiv(const BinOpInfo &Op) {
     }
     llvm::Value *OrigLHSi = LHSi;
     if (!LHSi)
-      LHSi = llvm::Constant::getNullValue(RHSi->getType());
+      LHSi = llvm::Constant::getZeroValue(RHSi->getType());
     if (Op.FPFeatures.getComplexRange() == LangOptions::CX_Improved ||
         (Op.FPFeatures.getComplexRange() == LangOptions::CX_Promoted &&
          !FPHasBeenPromoted))
@@ -1061,7 +1061,7 @@ ComplexPairTy ComplexExprEmitter::EmitBinDiv(const BinOpInfo &Op) {
       BinOpInfo LibCallOp = Op;
       // If LHS was a real, supply a null imaginary part.
       if (!LHSi)
-        LibCallOp.LHS.second = llvm::Constant::getNullValue(LHSr->getType());
+        LibCallOp.LHS.second = llvm::Constant::getZeroValue(LHSr->getType());
 
       switch (LHSr->getType()->getTypeID()) {
       default:
@@ -1448,7 +1448,7 @@ ComplexPairTy ComplexExprEmitter::VisitInitListExpr(InitListExpr *E) {
   assert(E->getNumInits() == 0 && "Unexpected number of inits");
   QualType Ty = E->getType()->castAs<ComplexType>()->getElementType();
   llvm::Type *LTy = CGF.ConvertType(Ty);
-  llvm::Value *zeroConstant = llvm::Constant::getNullValue(LTy);
+  llvm::Value *zeroConstant = llvm::Constant::getZeroValue(LTy);
   return ComplexPairTy(zeroConstant, zeroConstant);
 }
 

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -49,7 +49,7 @@ llvm::Constant *getPadding(const CodeGenModule &CGM, CharUnits PadSize) {
   if (PadSize > CharUnits::One())
     Ty = llvm::ArrayType::get(Ty, PadSize.getQuantity());
   if (CGM.shouldZeroInitPadding()) {
-    return llvm::Constant::getNullValue(Ty);
+    return llvm::Constant::getZeroValue(Ty);
   }
   return llvm::UndefValue::get(Ty);
 }
@@ -254,7 +254,7 @@ bool ConstantAggregateBuilder::addBits(llvm::APInt Bits, uint64_t OffsetInBits,
       BitsThisChar &= UpdateMask;
 
       if (*FirstElemToUpdate == *LastElemToUpdate ||
-          Elems[*FirstElemToUpdate]->isNullValue() ||
+          Elems[*FirstElemToUpdate]->isZeroValue() ||
           isa<llvm::UndefValue>(Elems[*FirstElemToUpdate])) {
         // All existing bits are either zero or undef.
         add(llvm::ConstantInt::get(CGM.getLLVMContext(), BitsThisChar),
@@ -425,12 +425,12 @@ llvm::Constant *ConstantAggregateBuilder::buildFrom(
 
     bool CanEmitArray = true;
     llvm::Type *CommonType = Elems[0]->getType();
-    llvm::Constant *Filler = llvm::Constant::getNullValue(CommonType);
+    llvm::Constant *Filler = llvm::Constant::getZeroValue(CommonType);
     CharUnits ElemSize = Utils.getSize(ATy->getElementType());
     SmallVector<llvm::Constant*, 32> ArrayElements;
     for (size_t I = 0; I != Elems.size(); ++I) {
       // Skip zeroes; we'll use a zero value as our array filler.
-      if (Elems[I]->isNullValue())
+      if (Elems[I]->isZeroValue())
         continue;
 
       // All remaining elements must be the same type.
@@ -1086,10 +1086,10 @@ EmitArrayConstant(CodeGenModule &CGM, llvm::ArrayType *DesiredType,
                   llvm::Constant *Filler) {
   // Figure out how long the initial prefix of non-zero elements is.
   uint64_t NonzeroLength = ArrayBound;
-  if (Elements.size() < NonzeroLength && Filler->isNullValue())
+  if (Elements.size() < NonzeroLength && Filler->isZeroValue())
     NonzeroLength = Elements.size();
   if (NonzeroLength == Elements.size()) {
-    while (NonzeroLength > 0 && Elements[NonzeroLength - 1]->isNullValue())
+    while (NonzeroLength > 0 && Elements[NonzeroLength - 1]->isZeroValue())
       --NonzeroLength;
   }
 
@@ -1432,7 +1432,7 @@ public:
 
     // Copy initializer elements.
     SmallVector<llvm::Constant *, 16> Elts;
-    if (fillC && fillC->isNullValue())
+    if (fillC && fillC->isZeroValue())
       Elts.reserve(NumInitableElts + 1);
     else
       Elts.reserve(NumElements);
@@ -2704,7 +2704,7 @@ ConstantEmitter::tryEmitPrivate(const APValue &Value, QualType DestType,
 
     // Emit initializer elements.
     SmallVector<llvm::Constant*, 16> Elts;
-    if (Filler && Filler->isNullValue())
+    if (Filler && Filler->isZeroValue())
       Elts.reserve(NumInitElts + 1);
     else
       Elts.reserve(NumElements);
@@ -2855,7 +2855,7 @@ static llvm::Constant *EmitNullConstant(CodeGenModule &CGM,
   // Now go through all other fields and zero them out.
   for (unsigned i = 0; i != numElements; ++i) {
     if (!elements[i])
-      elements[i] = llvm::Constant::getNullValue(structure->getElementType(i));
+      elements[i] = llvm::Constant::getZeroValue(structure->getElementType(i));
   }
 
   return llvm::ConstantStruct::get(structure, elements);
@@ -2869,7 +2869,7 @@ static llvm::Constant *EmitNullConstantForBase(CodeGenModule &CGM,
 
   // Just zero out bases that don't have any pointer to data members.
   if (baseLayout.isZeroInitializableAsBase())
-    return llvm::Constant::getNullValue(baseType);
+    return llvm::Constant::getZeroValue(baseType);
 
   // Otherwise, we can just use its null constant.
   return EmitNullConstant(CGM, base, /*asCompleteObject=*/false);
@@ -2886,7 +2886,7 @@ llvm::Constant *CodeGenModule::EmitNullConstant(QualType T) {
         cast<llvm::PointerType>(getTypes().ConvertTypeForMem(T)), T);
 
   if (getTypes().isZeroInitializable(T))
-    return llvm::Constant::getNullValue(getTypes().ConvertTypeForMem(T));
+    return llvm::Constant::getZeroValue(getTypes().ConvertTypeForMem(T));
 
   if (const ConstantArrayType *CAT = Context.getAsConstantArrayType(T)) {
     llvm::ArrayType *ATy =

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -455,7 +455,7 @@ public:
   /// EmitFloatToBoolConversion - Perform an FP to boolean conversion.
   Value *EmitFloatToBoolConversion(Value *V) {
     // Compare against 0.0 for fp scalars.
-    llvm::Value *Zero = llvm::Constant::getNullValue(V->getType());
+    llvm::Value *Zero = llvm::Constant::getZeroValue(V->getType());
     return Builder.CreateFCmpUNE(V, Zero, "tobool");
   }
 
@@ -2115,7 +2115,7 @@ Value *ScalarExprEmitter::VisitConvertVectorExpr(ConvertVectorExpr *E) {
     assert((SrcEltTy->isFloatingPointTy() ||
             isa<llvm::IntegerType>(SrcEltTy)) && "Unknown boolean conversion");
 
-    llvm::Value *Zero = llvm::Constant::getNullValue(SrcTy);
+    llvm::Value *Zero = llvm::Constant::getZeroValue(SrcTy);
     if (SrcEltTy->isFloatingPointTy()) {
       CodeGenFunction::CGFPOptionsRAII FPOptions(CGF, E);
       return Builder.CreateFCmpUNE(Src, Zero, "tobool");
@@ -2488,7 +2488,7 @@ Value *ScalarExprEmitter::VisitInitListExpr(InitListExpr *E) {
         ColMajorMT ? ColMajorMT->mapRowMajorToColumnMajorFlattenedIndex(CurIdx)
                    : CurIdx;
     Value *Idx = Builder.getInt32(InsertIdx);
-    llvm::Value *Init = llvm::Constant::getNullValue(EltTy);
+    llvm::Value *Init = llvm::Constant::getZeroValue(EltTy);
     V = Builder.CreateInsertElement(V, Init, Idx, "vecinit");
   }
 
@@ -2792,7 +2792,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
                 ScalableSrcTy->getElementType(),
                 llvm::alignTo<8>(
                     ScalableSrcTy->getElementCount().getKnownMinValue()));
-            llvm::Value *ZeroVec = llvm::Constant::getNullValue(ScalableSrcTy);
+            llvm::Value *ZeroVec = llvm::Constant::getZeroValue(ScalableSrcTy);
             Src = Builder.CreateInsertVector(ScalableSrcTy, ZeroVec, Src,
                                              uint64_t(0));
           }
@@ -3139,7 +3139,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     assert((DestTy->isEventT() || DestTy->isQueueT() ||
             DestTy->isOCLIntelSubgroupAVCType()) &&
            "CK_ZeroToOCLEvent cast on non-event type");
-    return llvm::Constant::getNullValue(ConvertType(DestTy));
+    return llvm::Constant::getZeroValue(ConvertType(DestTy));
   }
 
   case CK_IntToOCLSampler:
@@ -3157,7 +3157,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
 
       return Builder.CreateShuffleVector(Vec, Mask, "trunc");
     }
-    llvm::Value *Zero = llvm::Constant::getNullValue(CGF.SizeTy);
+    llvm::Value *Zero = llvm::Constant::getZeroValue(CGF.SizeTy);
     return Builder.CreateExtractElement(Vec, Zero, "cast.vtrunc");
   }
   case CK_HLSLMatrixTruncation: {
@@ -3181,7 +3181,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
 
       return Builder.CreateShuffleVector(Mat, Mask, "trunc");
     }
-    llvm::Value *Zero = llvm::Constant::getNullValue(CGF.SizeTy);
+    llvm::Value *Zero = llvm::Constant::getZeroValue(CGF.SizeTy);
     return Builder.CreateExtractElement(Mat, Zero, "cast.mtrunc");
   }
   case CK_HLSLElementwiseCast: {
@@ -3686,7 +3686,7 @@ Value *ScalarExprEmitter::VisitMinus(const UnaryOperator *E,
   // Emit unary minus with EmitSub so we handle overflow cases etc.
   BinOpInfo BinOp;
   BinOp.RHS = Op;
-  BinOp.LHS = llvm::Constant::getNullValue(BinOp.RHS->getType());
+  BinOp.LHS = llvm::Constant::getZeroValue(BinOp.RHS->getType());
   BinOp.Ty = E->getType();
   BinOp.Opcode = BO_Sub;
   BinOp.FPFeatures = E->getFPFeaturesInEffect(CGF.getLangOpts());
@@ -3706,7 +3706,7 @@ Value *ScalarExprEmitter::VisitUnaryLNot(const UnaryOperator *E) {
       E->getType()->castAs<VectorType>()->getVectorKind() ==
           VectorKind::Generic) {
     Value *Oper = Visit(E->getSubExpr());
-    Value *Zero = llvm::Constant::getNullValue(Oper->getType());
+    Value *Zero = llvm::Constant::getZeroValue(Oper->getType());
     Value *Result;
     if (Oper->getType()->isFPOrFPVectorTy()) {
       CodeGenFunction::CGFPOptionsRAII FPOptsRAII(
@@ -3740,7 +3740,7 @@ Value *ScalarExprEmitter::VisitOffsetOfExpr(OffsetOfExpr *E) {
   // Loop over the components of the offsetof to compute the value.
   unsigned n = E->getNumComponents();
   llvm::Type* ResultType = ConvertType(E->getType());
-  llvm::Value* Result = llvm::Constant::getNullValue(ResultType);
+  llvm::Value *Result = llvm::Constant::getZeroValue(ResultType);
   QualType CurrentType = E->getTypeSourceInfo()->getType();
   for (unsigned i = 0; i != n; ++i) {
     OffsetOfNode ON = E->getComponent(i);
@@ -3959,8 +3959,8 @@ Value *ScalarExprEmitter::VisitImag(const UnaryOperator *E,
   else
     CGF.EmitScalarExpr(Op, true);
   if (!PromotionType.isNull())
-    return llvm::Constant::getNullValue(ConvertType(PromotionType));
-  return llvm::Constant::getNullValue(ConvertType(E->getType()));
+    return llvm::Constant::getZeroValue(ConvertType(PromotionType));
+  return llvm::Constant::getZeroValue(ConvertType(E->getType()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -4261,12 +4261,12 @@ Value *ScalarExprEmitter::EmitDiv(const BinOpInfo &Ops) {
          CGF.SanOpts.has(SanitizerKind::SignedIntegerOverflow)) &&
         Ops.Ty->isIntegerType() &&
         (Ops.mayHaveIntegerDivisionByZero() || Ops.mayHaveIntegerOverflow())) {
-      llvm::Value *Zero = llvm::Constant::getNullValue(ConvertType(Ops.Ty));
+      llvm::Value *Zero = llvm::Constant::getZeroValue(ConvertType(Ops.Ty));
       EmitUndefinedBehaviorIntegerDivAndRemCheck(Ops, Zero, true);
     } else if (CGF.SanOpts.has(SanitizerKind::FloatDivideByZero) &&
                Ops.Ty->isRealFloatingType() &&
                Ops.mayHaveFloatDivisionByZero()) {
-      llvm::Value *Zero = llvm::Constant::getNullValue(ConvertType(Ops.Ty));
+      llvm::Value *Zero = llvm::Constant::getZeroValue(ConvertType(Ops.Ty));
       llvm::Value *NonZero = Builder.CreateFCmpUNE(Ops.RHS, Zero);
       EmitBinOpCheck(
           std::make_pair(NonZero, SanitizerKind::SO_FloatDivideByZero), Ops);
@@ -4314,7 +4314,7 @@ Value *ScalarExprEmitter::EmitRem(const BinOpInfo &Ops) {
                                     {SanitizerKind::SO_IntegerDivideByZero,
                                      SanitizerKind::SO_SignedIntegerOverflow},
                                     SanitizerHandler::DivremOverflow);
-    llvm::Value *Zero = llvm::Constant::getNullValue(ConvertType(Ops.Ty));
+    llvm::Value *Zero = llvm::Constant::getZeroValue(ConvertType(Ops.Ty));
     EmitUndefinedBehaviorIntegerDivAndRemCheck(Ops, Zero, false);
   }
 
@@ -4517,7 +4517,7 @@ llvm::Value *CodeGenFunction::EmitPointerArithmetic(
     llvm::Value *IsZeroIndex = Builder.CreateIsNull(index);
     llvm::Constant *StaticArgs[] = {EmitCheckSourceLocation(BO->getExprLoc())};
     llvm::Type *IntPtrTy = DL.getIntPtrType(PtrTy);
-    llvm::Value *IntPtr = llvm::Constant::getNullValue(IntPtrTy);
+    llvm::Value *IntPtr = llvm::Constant::getZeroValue(IntPtrTy);
     llvm::Value *ComputedGEP = Builder.CreateZExtOrTrunc(index, IntPtrTy);
     llvm::Value *DynamicArgs[] = {IntPtr, ComputedGEP};
     EmitCheck({{IsZeroIndex, CheckOrdinal}}, CheckHandler, StaticArgs,
@@ -5332,7 +5332,7 @@ Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,
       CETy = CTy->getElementType();
     } else {
       LHS.first = Visit(E->getLHS());
-      LHS.second = llvm::Constant::getNullValue(LHS.first->getType());
+      LHS.second = llvm::Constant::getZeroValue(LHS.first->getType());
       CETy = LHSTy;
     }
     if (auto *CTy = RHSTy->getAs<ComplexType>()) {
@@ -5343,7 +5343,7 @@ Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,
       (void)CTy;
     } else {
       RHS.first = Visit(E->getRHS());
-      RHS.second = llvm::Constant::getNullValue(RHS.first->getType());
+      RHS.second = llvm::Constant::getZeroValue(RHS.first->getType());
       assert(CGF.getContext().hasSameUnqualifiedType(CETy, RHSTy) &&
              "The element types must always match.");
     }
@@ -5566,7 +5566,7 @@ Value *ScalarExprEmitter::VisitBinLAnd(const BinaryOperator *E) {
 
       CGF.markStmtMaybeUsed(E->getRHS());
 
-      return llvm::Constant::getNullValue(ResTy);
+      return llvm::Constant::getZeroValue(ResTy);
     }
   }
 
@@ -5898,7 +5898,7 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
     unsigned numElem = vecTy->getNumElements();
     llvm::Type *elemType = vecTy->getElementType();
 
-    llvm::Value *zeroVec = llvm::Constant::getNullValue(vecTy);
+    llvm::Value *zeroVec = llvm::Constant::getZeroValue(vecTy);
     llvm::Value *TestMSB = Builder.CreateICmpSLT(CondV, zeroVec);
     llvm::Value *tmp = Builder.CreateSExt(
         TestMSB, llvm::FixedVectorType::get(elemType, numElem), "sext");
@@ -5939,7 +5939,7 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
       return Builder.CreateSelect(CondV, LHS, RHS, "vector_select");
 
     // OpenCL uses the MSB of the mask vector.
-    llvm::Value *ZeroVec = llvm::Constant::getNullValue(VecTy);
+    llvm::Value *ZeroVec = llvm::Constant::getZeroValue(VecTy);
     if (condExpr->getType()->isExtVectorType())
       CondV = Builder.CreateICmpSLT(CondV, ZeroVec, "vector_cond");
     else
@@ -6309,7 +6309,7 @@ static GEPOffsetAndOverflow EmitGEPOffsetInBytes(Value *BasePtr, Value *GEPVal,
   auto *IntPtrTy = DL.getIntPtrType(GEP->getPointerOperandType());
 
   // Grab references to the signed add/mul overflow intrinsics for intptr_t.
-  auto *Zero = llvm::ConstantInt::getNullValue(IntPtrTy);
+  auto *Zero = llvm::ConstantInt::getZeroValue(IntPtrTy);
   auto *SAddIntrinsic =
       CGM.getIntrinsic(llvm::Intrinsic::sadd_with_overflow, IntPtrTy);
   auto *SMulIntrinsic =
@@ -6418,7 +6418,7 @@ CodeGenFunction::EmitCheckedInBoundsGEP(llvm::Type *ElemTy, Value *Ptr,
          "If the offset got constant-folded, we don't expect that there was an "
          "overflow.");
 
-  auto *Zero = llvm::ConstantInt::getNullValue(IntPtrTy);
+  auto *Zero = llvm::ConstantInt::getZeroValue(IntPtrTy);
 
   // Common case: if the total offset is zero, don't emit a check.
   if (EvaluatedGEP.TotalOffset == Zero)

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -277,7 +277,7 @@ static Value *handleElementwiseF32ToF16(CodeGenFunction &CGF,
     if (NumElements == 0) {
       // a scalar input - simply insert the scalar in the first element
       // of the 2 element float vector
-      Value *Float2 = Constant::getNullValue(PackType);
+      Value *Float2 = Constant::getZeroValue(PackType);
       Float2 = CGF.Builder.CreateInsertElement(Float2, Op0, (uint64_t)0);
       Value *Result = CGF.Builder.CreateIntrinsic(
           ResType, Intrinsic::spv_packhalf2x16, ArrayRef<Value *>{Float2});
@@ -288,7 +288,7 @@ static Value *handleElementwiseF32ToF16(CodeGenFunction &CGF,
     // the input vector calling packhalf2x16 for each element
     Value *Result = PoisonValue::get(ResType);
     for (uint64_t I = 0; I < NumElements; I++) {
-      Value *Float2 = Constant::getNullValue(PackType);
+      Value *Float2 = Constant::getZeroValue(PackType);
       Value *InVal = CGF.Builder.CreateExtractElement(Op0, I);
       Float2 = CGF.Builder.CreateInsertElement(Float2, InVal, (uint64_t)0);
       Value *Res = CGF.Builder.CreateIntrinsic(
@@ -461,7 +461,7 @@ static Value *emitHlslOffset(CodeGenFunction &CGF, const CallExpr *E,
   if (E->getNumArgs() > OffsetArgIndex)
     return CGF.EmitScalarExpr(E->getArg(OffsetArgIndex));
 
-  return llvm::Constant::getNullValue(OffsetTy);
+  return llvm::Constant::getZeroValue(OffsetTy);
 }
 
 static Value *emitHlslClamp(CodeGenFunction &CGF, const CallExpr *E,

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -1239,7 +1239,7 @@ CodeGenFunction::generateObjCGetterBody(const ObjCImplementationDecl *classImpl,
       if (getterMethod->getReturnType()->hasBooleanRepresentation() &&
           CGM.getCodeGenOpts().isConvertingBoolWithCmp0())
         ivarVal = Builder.CreateICmpNE(
-            ivarVal, llvm::Constant::getNullValue(ivarVal->getType()));
+            ivarVal, llvm::Constant::getZeroValue(ivarVal->getType()));
       else
         ivarVal = Builder.CreateTrunc(ivarVal, bitcastType);
     }
@@ -1922,7 +1922,7 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
   llvm::BasicBlock *EmptyBB = createBasicBlock("forcoll.empty");
   llvm::BasicBlock *LoopInitBB = createBasicBlock("forcoll.loopinit");
 
-  llvm::Value *zero = llvm::Constant::getNullValue(NSUIntegerTy);
+  llvm::Value *zero = llvm::Constant::getZeroValue(NSUIntegerTy);
 
   // If the limit pointer was zero to begin with, the collection is
   // empty; skip all this. Set the branch weight assuming this has the same
@@ -2142,7 +2142,7 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
   if (!elementIsVariable) {
     // If the element was not a declaration, set it to be null.
 
-    llvm::Value *null = llvm::Constant::getNullValue(convertedElementType);
+    llvm::Value *null = llvm::Constant::getZeroValue(convertedElementType);
     elementLValue = EmitLValue(cast<Expr>(S.getElement()));
     EmitStoreThroughLValue(RValue::get(null), elementLValue);
   }
@@ -4058,7 +4058,7 @@ static llvm::Value *emitIsPlatformVersionAtLeast(CodeGenFunction &CGF,
   llvm::Value *Check =
       CGF.EmitNounwindRuntimeCall(CGM.IsPlatformVersionAtLeastFn, Args);
   return CGF.Builder.CreateICmpNE(Check,
-                                  llvm::Constant::getNullValue(CGM.Int32Ty));
+                                  llvm::Constant::getZeroValue(CGM.Int32Ty));
 }
 
 llvm::Value *
@@ -4084,7 +4084,7 @@ CodeGenFunction::EmitBuiltinAvailable(const VersionTuple &Version) {
   llvm::Value *CallRes =
       EmitNounwindRuntimeCall(CGM.IsOSVersionAtLeastFn, Args);
 
-  return Builder.CreateICmpNE(CallRes, llvm::Constant::getNullValue(Int32Ty));
+  return Builder.CreateICmpNE(CallRes, llvm::Constant::getZeroValue(Int32Ty));
 }
 
 static bool isFoundationNeededForDarwinAvailabilityCheck(
@@ -4152,7 +4152,7 @@ void CodeGenModule::emitAtAvailableLinkGuard() {
     CodeGenFunction CGF(*this);
     CGF.Builder.SetInsertPoint(CGF.createBasicBlock("", CFLinkCheckFunc));
     CGF.EmitNounwindRuntimeCall(CFFunc,
-                                llvm::Constant::getNullValue(VoidPtrTy));
+                                llvm::Constant::getZeroValue(VoidPtrTy));
     CGF.Builder.CreateUnreachable();
     addCompilerUsedGlobal(CFLinkCheckFunc);
   }

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1528,7 +1528,7 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
         emptyStruct = llvm::StructType::create(
             VMContext, {}, ".objc_section_sentinel", /*isPacked=*/true);
       }
-      auto ZeroInit = llvm::Constant::getNullValue(emptyStruct);
+      auto ZeroInit = llvm::Constant::getZeroValue(emptyStruct);
       auto Sym = [&](StringRef Prefix, StringRef SecSuffix) {
         auto *Sym = new llvm::GlobalVariable(TheModule, emptyStruct,
             /*isConstant*/false,
@@ -3025,8 +3025,8 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
       nilPathBB = Builder.GetInsertBlock();
     }
 
-    llvm::Value *isNil = Builder.CreateICmpEQ(Receiver,
-            llvm::Constant::getNullValue(Receiver->getType()));
+    llvm::Value *isNil = Builder.CreateICmpEQ(
+        Receiver, llvm::Constant::getZeroValue(Receiver->getType()));
     Builder.CreateCondBr(isNil, nilCleanupBB ? nilCleanupBB : continueBB,
                          messageBB);
     CGF.EmitBlock(messageBB);
@@ -3122,11 +3122,11 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
       std::pair<llvm::Value*,llvm::Value*> v = msgRet.getComplexVal();
       llvm::PHINode *phi = Builder.CreatePHI(v.first->getType(), 2);
       phi->addIncoming(v.first, nonNilPathBB);
-      phi->addIncoming(llvm::Constant::getNullValue(v.first->getType()),
+      phi->addIncoming(llvm::Constant::getZeroValue(v.first->getType()),
                        nilPathBB);
       llvm::PHINode *phi2 = Builder.CreatePHI(v.second->getType(), 2);
       phi2->addIncoming(v.second, nonNilPathBB);
-      phi2->addIncoming(llvm::Constant::getNullValue(v.second->getType()),
+      phi2->addIncoming(llvm::Constant::getZeroValue(v.second->getType()),
                         nilPathBB);
       msgRet = RValue::getComplex(phi, phi2);
     }
@@ -4167,8 +4167,8 @@ llvm::Function *CGObjCGNU::ModuleInitFunction() {
       llvm::BasicBlock::Create(VMContext, "no_alias", LoadFunction);
 
     // Branch based on whether the runtime provided class_registerAlias_np()
-    llvm::Value *HasRegisterAlias = Builder.CreateICmpNE(RegisterAlias,
-            llvm::Constant::getNullValue(RegisterAlias->getType()));
+    llvm::Value *HasRegisterAlias = Builder.CreateICmpNE(
+        RegisterAlias, llvm::Constant::getZeroValue(RegisterAlias->getType()));
     Builder.CreateCondBr(HasRegisterAlias, AliasBB, NoAliasBB);
 
     // The true branch (has alias registration function):
@@ -4472,9 +4472,9 @@ llvm::Value *CGObjCGNU::EmitIvarOffset(CodeGenFunction &CGF,
     CharUnits Align = CGM.getIntAlign();
     llvm::Value *Offset = TheModule.getGlobalVariable(name);
     if (!Offset) {
-      auto GV = new llvm::GlobalVariable(TheModule, IntTy,
-          false, llvm::GlobalValue::LinkOnceAnyLinkage,
-          llvm::Constant::getNullValue(IntTy), name);
+      auto GV = new llvm::GlobalVariable(
+          TheModule, IntTy, false, llvm::GlobalValue::LinkOnceAnyLinkage,
+          llvm::Constant::getZeroValue(IntTy), name);
       GV->setAlignment(Align.getAsAlign());
       Offset = GV;
     }

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -1955,7 +1955,7 @@ struct NullReturnState {
 
     // Find the scalar type and its zero value.
     llvm::Type *scalarTy = callResult.first->getType();
-    llvm::Constant *scalarZero = llvm::Constant::getNullValue(scalarTy);
+    llvm::Constant *scalarZero = llvm::Constant::getZeroValue(scalarTy);
 
     // Build phis for both coordinates.
     llvm::PHINode *real = CGF.Builder.CreatePHI(scalarTy, 2);
@@ -2999,7 +2999,7 @@ llvm::Constant *
 CGObjCCommonMac::BuildGCBlockLayout(CodeGenModule &CGM,
                                     const CGBlockInfo &blockInfo) {
 
-  llvm::Constant *nullPtr = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+  llvm::Constant *nullPtr = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
   if (CGM.getLangOpts().getGC() == LangOptions::NonGC)
     return nullPtr;
 
@@ -3354,7 +3354,7 @@ uint64_t CGObjCCommonMac::InlineLayoutInstruction(
 }
 
 llvm::Constant *CGObjCCommonMac::getBitmapBlockLayout(bool ComputeByrefLayout) {
-  llvm::Constant *nullPtr = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+  llvm::Constant *nullPtr = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
   if (RunSkipBlockVars.empty())
     return nullPtr;
   unsigned WordSizeInBits = CGM.getTarget().getPointerWidth(LangAS::Default);
@@ -3617,7 +3617,7 @@ llvm::Constant *CGObjCCommonMac::BuildByrefLayout(CodeGen::CodeGenModule &CGM,
       Result = llvm::ConstantExpr::getIntToPtr(Result, CGM.Int8PtrTy);
     return Result;
   }
-  llvm::Constant *nullPtr = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+  llvm::Constant *nullPtr = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
   return nullPtr;
 }
 
@@ -3772,10 +3772,10 @@ CGObjCMac::EmitProtocolExtension(const ObjCProtocolDecl *PD,
                        PD, ObjCTypes, true);
 
   // Return null if no extension bits are used.
-  if (optInstanceMethods->isNullValue() && optClassMethods->isNullValue() &&
-      extendedMethodTypes->isNullValue() && instanceProperties->isNullValue() &&
-      classProperties->isNullValue()) {
-    return llvm::Constant::getNullValue(ObjCTypes.ProtocolExtensionPtrTy);
+  if (optInstanceMethods->isZeroValue() && optClassMethods->isZeroValue() &&
+      extendedMethodTypes->isZeroValue() && instanceProperties->isZeroValue() &&
+      classProperties->isZeroValue()) {
+    return llvm::Constant::getZeroValue(ObjCTypes.ProtocolExtensionPtrTy);
   }
 
   uint64_t size =
@@ -3809,7 +3809,7 @@ CGObjCMac::EmitProtocolList(Twine name,
   // Just return null for empty protocol lists
   auto PDs = GetRuntimeProtocolList(begin, end);
   if (PDs.empty())
-    return llvm::Constant::getNullValue(ObjCTypes.ProtocolListPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.ProtocolListPtrTy);
 
   ConstantInitBuilder builder(CGM);
   auto values = builder.beginStruct();
@@ -3878,7 +3878,7 @@ llvm::Constant *CGObjCCommonMac::EmitPropertyList(
     const llvm::Triple &Triple = CGM.getTarget().getTriple();
     if ((Triple.isMacOSX() && Triple.isMacOSXVersionLT(10, 11)) ||
         (Triple.isiOS() && Triple.isOSVersionLT(9)))
-      return llvm::Constant::getNullValue(ObjCTypes.PropertyListPtrTy);
+      return llvm::Constant::getZeroValue(ObjCTypes.PropertyListPtrTy);
   }
 
   SmallVector<const ObjCPropertyDecl *, 16> Properties;
@@ -3917,7 +3917,7 @@ llvm::Constant *CGObjCCommonMac::EmitPropertyList(
 
   // Return null for empty list.
   if (Properties.empty())
-    return llvm::Constant::getNullValue(ObjCTypes.PropertyListPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.PropertyListPtrTy);
 
   unsigned propertySize =
       CGM.getDataLayout().getTypeAllocSize(ObjCTypes.PropertyTy);
@@ -3950,7 +3950,7 @@ llvm::Constant *CGObjCCommonMac::EmitProtocolMethodTypes(
     const ObjCCommonTypesHelper &ObjCTypes) {
   // Return null for empty list.
   if (MethodTypes.empty())
-    return llvm::Constant::getNullValue(ObjCTypes.Int8PtrPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.Int8PtrPtrTy);
 
   llvm::ArrayType *AT =
       llvm::ArrayType::get(ObjCTypes.Int8PtrTy, MethodTypes.size());
@@ -4373,8 +4373,8 @@ llvm::Constant *CGObjCMac::EmitClassExtension(const ObjCImplementationDecl *ID,
                        ID, ID->getClassInterface(), ObjCTypes, isMetaclass);
 
   // Return null if no extension bits are used.
-  if (layout->isNullValue() && propertyList->isNullValue()) {
-    return llvm::Constant::getNullValue(ObjCTypes.ClassExtensionPtrTy);
+  if (layout->isZeroValue() && propertyList->isZeroValue()) {
+    return llvm::Constant::getZeroValue(ObjCTypes.ClassExtensionPtrTy);
   }
 
   uint64_t size =
@@ -4411,7 +4411,7 @@ llvm::Constant *CGObjCMac::EmitIvarList(const ObjCImplementationDecl *ID,
   // the cleanest solution would be to make up an ObjCInterfaceDecl
   // for the class.
   if (ForClass)
-    return llvm::Constant::getNullValue(ObjCTypes.IvarListPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.IvarListPtrTy);
 
   const ObjCInterfaceDecl *OID = ID->getClassInterface();
 
@@ -4438,7 +4438,7 @@ llvm::Constant *CGObjCMac::EmitIvarList(const ObjCImplementationDecl *ID,
   if (count == 0) {
     ivars.abandon();
     ivarList.abandon();
-    return llvm::Constant::getNullValue(ObjCTypes.IvarListPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.IvarListPtrTy);
   }
 
   ivars.finishAndAddTo(ivarList);
@@ -4548,7 +4548,7 @@ CGObjCMac::emitMethodList(Twine name, MethodListType MLT,
 
   // Return null for empty list.
   if (methods.empty())
-    return llvm::Constant::getNullValue(
+    return llvm::Constant::getZeroValue(
         forProtocol ? ObjCTypes.MethodDescriptionListPtrTy
                     : ObjCTypes.MethodListPtrTy);
 
@@ -6093,7 +6093,7 @@ llvm::Constant *CGObjCMac::EmitModuleSymbols() {
 
   // Return null if no symbols were defined.
   if (!NumClasses && !NumCategories)
-    return llvm::Constant::getNullValue(ObjCTypes.SymtabPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.SymtabPtrTy);
 
   ConstantInitBuilder builder(CGM);
   auto values = builder.beginStruct();
@@ -6194,7 +6194,7 @@ llvm::Function *CGObjCCommonMac::GetMethodDefinition(const ObjCMethodDecl *MD) {
 llvm::Constant *
 CGObjCCommonMac::GetIvarLayoutName(IdentifierInfo *Ident,
                                    const ObjCCommonTypesHelper &ObjCTypes) {
-  return llvm::Constant::getNullValue(ObjCTypes.Int8PtrTy);
+  return llvm::Constant::getZeroValue(ObjCTypes.Int8PtrTy);
 }
 
 void IvarLayoutBuilder::visitRecord(const RecordType *RT, CharUnits offset) {
@@ -6465,7 +6465,7 @@ CGObjCCommonMac::BuildIvarLayout(const ObjCImplementationDecl *OMD,
   if (CGM.getLangOpts().getGC() == LangOptions::NonGC &&
       !CGM.getLangOpts().ObjCAutoRefCount &&
       (ForStrongLayout || !HasMRCWeakIvars))
-    return llvm::Constant::getNullValue(PtrTy);
+    return llvm::Constant::getZeroValue(PtrTy);
 
   const ObjCInterfaceDecl *OI = OMD->getClassInterface();
   SmallVector<const ObjCIvarDecl *, 32> ivars;
@@ -6503,7 +6503,7 @@ CGObjCCommonMac::BuildIvarLayout(const ObjCImplementationDecl *OMD,
   }
 
   if (ivars.empty())
-    return llvm::Constant::getNullValue(PtrTy);
+    return llvm::Constant::getZeroValue(PtrTy);
 
   IvarLayoutBuilder builder(CGM, baseOffset, endOffset, ForStrongLayout);
 
@@ -6514,7 +6514,7 @@ CGObjCCommonMac::BuildIvarLayout(const ObjCImplementationDecl *OMD,
                          });
 
   if (!builder.hasBitmapData())
-    return llvm::Constant::getNullValue(PtrTy);
+    return llvm::Constant::getZeroValue(PtrTy);
 
   llvm::SmallVector<unsigned char, 4> buffer;
   llvm::Constant *C = builder.buildBitmap(*this, buffer);
@@ -7255,7 +7255,7 @@ llvm::GlobalVariable *CGObjCNonFragileABIMac::BuildClassRoTInitializer(
 
   const PointerAuthSchema &MethListSchema =
       CGM.getCodeGenOpts().PointerAuth.ObjCMethodListPointer;
-  if (!MethListPtr->isNullValue())
+  if (!MethListPtr->isZeroValue())
     values.addSignedPointer(MethListPtr, MethListSchema, GlobalDecl(),
                             QualType());
   else
@@ -7586,7 +7586,7 @@ void CGObjCNonFragileABIMac::GenerateCategory(const ObjCCategoryImplDecl *OCD) {
       listName, MethodListType::CategoryInstanceMethods, instanceMethods);
   const PointerAuthSchema &MethListSchema =
       CGM.getCodeGenOpts().PointerAuth.ObjCMethodListPointer;
-  if (!InstanceMethodList->isNullValue())
+  if (!InstanceMethodList->isZeroValue())
     values.addSignedPointer(InstanceMethodList, MethListSchema, GlobalDecl(),
                             QualType());
   else
@@ -7594,7 +7594,7 @@ void CGObjCNonFragileABIMac::GenerateCategory(const ObjCCategoryImplDecl *OCD) {
 
   llvm::Constant *ClassMethodList = emitMethodList(
       listName, MethodListType::CategoryClassMethods, classMethods);
-  if (!ClassMethodList->isNullValue())
+  if (!ClassMethodList->isZeroValue())
     values.addSignedPointer(ClassMethodList, MethListSchema, GlobalDecl(),
                             QualType());
   else
@@ -7602,7 +7602,7 @@ void CGObjCNonFragileABIMac::GenerateCategory(const ObjCCategoryImplDecl *OCD) {
 
   // Keep track of whether we have actual metadata to emit.
   bool isEmptyCategory =
-      InstanceMethodList->isNullValue() && ClassMethodList->isNullValue();
+      InstanceMethodList->isZeroValue() && ClassMethodList->isZeroValue();
 
   const ObjCCategoryDecl *Category =
       Interface->FindCategoryDeclaration(OCD->getIdentifier());
@@ -7623,9 +7623,9 @@ void CGObjCNonFragileABIMac::GenerateCategory(const ObjCCategoryImplDecl *OCD) {
     values.add(protocolList);
     values.add(propertyList);
     values.add(classPropertyList);
-    isEmptyCategory &= protocolList->isNullValue() &&
-                       propertyList->isNullValue() &&
-                       classPropertyList->isNullValue();
+    isEmptyCategory &= protocolList->isZeroValue() &&
+                       propertyList->isZeroValue() &&
+                       classPropertyList->isZeroValue();
   } else {
     values.addNullPointer(ObjCTypes.ProtocolListnfABIPtrTy);
     values.addNullPointer(ObjCTypes.PropertyListPtrTy);
@@ -7704,7 +7704,7 @@ llvm::Constant *CGObjCNonFragileABIMac::emitMethodList(
     Twine name, MethodListType kind, ArrayRef<const ObjCMethodDecl *> methods) {
   // Return null for empty list.
   if (methods.empty())
-    return llvm::Constant::getNullValue(ObjCTypes.MethodListnfABIPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.MethodListnfABIPtrTy);
 
   StringRef prefix;
   bool forProtocol;
@@ -7889,7 +7889,7 @@ CGObjCNonFragileABIMac::EmitIvarList(const ObjCImplementationDecl *ID) {
   if (ivars.empty()) {
     ivars.abandon();
     ivarList.abandon();
-    return llvm::Constant::getNullValue(ObjCTypes.IvarListnfABIPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.IvarListnfABIPtrTy);
   }
 
   auto ivarCount = ivars.size();
@@ -8051,7 +8051,7 @@ llvm::Constant *CGObjCNonFragileABIMac::EmitProtocolList(
   // Just return null for empty protocol lists
   auto Protocols = GetRuntimeProtocolList(begin, end);
   if (Protocols.empty())
-    return llvm::Constant::getNullValue(ObjCTypes.ProtocolListnfABIPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.ProtocolListnfABIPtrTy);
 
   SmallVector<llvm::Constant *, 16> ProtocolRefs;
   ProtocolRefs.reserve(Protocols.size());
@@ -8062,7 +8062,7 @@ llvm::Constant *CGObjCNonFragileABIMac::EmitProtocolList(
   // If all of the protocols in the protocol list are objc_non_runtime_protocol
   // just return null
   if (ProtocolRefs.size() == 0)
-    return llvm::Constant::getNullValue(ObjCTypes.ProtocolListnfABIPtrTy);
+    return llvm::Constant::getZeroValue(ObjCTypes.ProtocolListnfABIPtrTy);
 
   // FIXME: We shouldn't need to do this lookup here, should we?
   SmallString<256> TmpName;

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1719,12 +1719,12 @@ llvm::Function *CGOpenMPRuntime::emitThreadPrivateVarDefinition(
     // Copying constructor for the threadprivate variable.
     // Must be NULL - reserved by runtime, but currently it requires that this
     // parameter is always NULL. Otherwise it fires assertion.
-    CopyCtor = llvm::Constant::getNullValue(CGM.DefaultPtrTy);
+    CopyCtor = llvm::Constant::getZeroValue(CGM.DefaultPtrTy);
     if (Ctor == nullptr) {
-      Ctor = llvm::Constant::getNullValue(CGM.DefaultPtrTy);
+      Ctor = llvm::Constant::getZeroValue(CGM.DefaultPtrTy);
     }
     if (Dtor == nullptr) {
-      Dtor = llvm::Constant::getNullValue(CGM.DefaultPtrTy);
+      Dtor = llvm::Constant::getZeroValue(CGM.DefaultPtrTy);
     }
     if (!CGF) {
       auto *InitFunctionTy =
@@ -8970,7 +8970,7 @@ private:
           //   &p[0], &p[3], /*size=*/0, RETURN_PARAM
           UseDeviceDataCombinedInfo.Pointers.push_back(Ptr);
           UseDeviceDataCombinedInfo.Sizes.push_back(
-              llvm::Constant::getNullValue(CGF.Int64Ty));
+              llvm::Constant::getZeroValue(CGF.Int64Ty));
           OpenMPOffloadMappingFlags Flags =
               OpenMPOffloadMappingFlags::OMP_MAP_RETURN_PARAM;
           if (HasUdpFbNullify)
@@ -10252,12 +10252,12 @@ public:
         CombinedInfo.Types.push_back(
             OpenMPOffloadMappingFlags::OMP_MAP_LITERAL);
         // Use zero size for pointer literals (just passing the pointer value)
-        CombinedInfo.Sizes.push_back(llvm::Constant::getNullValue(CGF.Int64Ty));
+        CombinedInfo.Sizes.push_back(llvm::Constant::getZeroValue(CGF.Int64Ty));
       } else {
         // Pointers are implicitly mapped with a zero size and no flags
         // (other than first map that is added for all implicit maps).
         CombinedInfo.Types.push_back(OpenMPOffloadMappingFlags::OMP_MAP_NONE);
-        CombinedInfo.Sizes.push_back(llvm::Constant::getNullValue(CGF.Int64Ty));
+        CombinedInfo.Sizes.push_back(llvm::Constant::getZeroValue(CGF.Int64Ty));
       }
       auto I = FirstPrivateDecls.find(VD);
       if (I != FirstPrivateDecls.end())
@@ -10278,7 +10278,7 @@ public:
         // Treat as a literal value (pass the pointer value itself)
         CombinedInfo.Pointers.push_back(CV);
         // Use zero size for pointer literals
-        CombinedInfo.Sizes.push_back(llvm::Constant::getNullValue(CGF.Int64Ty));
+        CombinedInfo.Sizes.push_back(llvm::Constant::getZeroValue(CGF.Int64Ty));
         CombinedInfo.Types.push_back(
             OpenMPOffloadMappingFlags::OMP_MAP_LITERAL);
       } else {
@@ -10649,7 +10649,7 @@ emitTargetCallFallback(CGOpenMPRuntime *OMPRuntime, llvm::Function *OutlinedFn,
     }
     llvm::SmallVector<llvm::Value *, 16> Args(CapturedVars.begin(),
                                               CapturedVars.end());
-    Args.push_back(llvm::Constant::getNullValue(CGF.Builder.getPtrTy()));
+    Args.push_back(llvm::Constant::getZeroValue(CGF.Builder.getPtrTy()));
     OMPRuntime->emitOutlinedFunctionCall(CGF, D.getBeginLoc(), OutlinedFn,
                                          Args);
   }
@@ -10890,7 +10890,7 @@ static void emitTargetCallKernelLaunch(
 
   // Append a null entry for the implicit dyn_ptr argument.
   using OpenMPOffloadMappingFlags = llvm::omp::OpenMPOffloadMappingFlags;
-  auto *NullPtr = llvm::Constant::getNullValue(CGF.Builder.getPtrTy());
+  auto *NullPtr = llvm::Constant::getZeroValue(CGF.Builder.getPtrTy());
   CombinedInfo.BasePointers.push_back(NullPtr);
   CombinedInfo.Pointers.push_back(NullPtr);
   CombinedInfo.DevicePointers.push_back(
@@ -11814,10 +11814,10 @@ void CGOpenMPRuntime::emitTargetDataStandAloneCall(
       break;
     }
     if (HasNowait) {
-      OffloadingArgs.push_back(llvm::Constant::getNullValue(CGF.Int32Ty));
-      OffloadingArgs.push_back(llvm::Constant::getNullValue(CGF.VoidPtrTy));
-      OffloadingArgs.push_back(llvm::Constant::getNullValue(CGF.Int32Ty));
-      OffloadingArgs.push_back(llvm::Constant::getNullValue(CGF.VoidPtrTy));
+      OffloadingArgs.push_back(llvm::Constant::getZeroValue(CGF.Int32Ty));
+      OffloadingArgs.push_back(llvm::Constant::getZeroValue(CGF.VoidPtrTy));
+      OffloadingArgs.push_back(llvm::Constant::getZeroValue(CGF.Int32Ty));
+      OffloadingArgs.push_back(llvm::Constant::getZeroValue(CGF.VoidPtrTy));
     }
     CGF.EmitRuntimeCall(
         OMPBuilder.getOrCreateRuntimeFunction(CGM.getModule(), RTLFn),
@@ -12427,7 +12427,7 @@ static llvm::Value *getAllocatorVal(CodeGenFunction &CGF,
                                         Allocator->getExprLoc());
   } else {
     // If no allocator specified, it defaults to the null allocator.
-    AllocVal = llvm::Constant::getNullValue(
+    AllocVal = llvm::Constant::getZeroValue(
         CGF.CGM.getTypes().ConvertType(CGF.getContext().VoidPtrTy));
   }
   return AllocVal;
@@ -12789,7 +12789,7 @@ Address CGOpenMPRuntime::emitLastprivateConditionalInit(CodeGenFunction &CGF,
   LValue FiredLVal =
       CGF.EmitLValueForField(BaseLVal, FiredField);
   CGF.EmitStoreOfScalar(
-      llvm::ConstantInt::getNullValue(CGF.ConvertTypeForMem(C.CharTy)),
+      llvm::ConstantInt::getZeroValue(CGF.ConvertTypeForMem(C.CharTy)),
       FiredLVal);
   return CGF.EmitLValueForField(BaseLVal, VDField).getAddress();
 }

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -1376,7 +1376,7 @@ void CGOpenMPRuntimeGPU::emitCriticalRegion(
       CGF.getContext().getIntTypeForBitwidth(/*DestWidth=*/32, /*Signed=*/0);
   Address Counter = CGF.CreateMemTemp(Int32Ty, "critical_counter");
   LValue CounterLVal = CGF.MakeAddrLValue(Counter, Int32Ty);
-  CGF.EmitStoreOfScalar(llvm::Constant::getNullValue(CGM.Int32Ty), CounterLVal,
+  CGF.EmitStoreOfScalar(llvm::Constant::getZeroValue(CGM.Int32Ty), CounterLVal,
                         /*isInit=*/true);
 
   // Block checks if loop counter exceeds upper bound.

--- a/clang/lib/CodeGen/CGPointerAuth.cpp
+++ b/clang/lib/CodeGen/CGPointerAuth.cpp
@@ -444,7 +444,7 @@ CodeGenModule::getConstantSignedPointer(llvm::Constant *Pointer, unsigned Key,
     assert(StorageAddress->getType() == DefaultPtrTy);
     AddressDiscriminator = StorageAddress;
   } else {
-    AddressDiscriminator = llvm::Constant::getNullValue(DefaultPtrTy);
+    AddressDiscriminator = llvm::Constant::getZeroValue(DefaultPtrTy);
   }
 
   llvm::ConstantInt *IntegerDiscriminator;
@@ -458,7 +458,7 @@ CodeGenModule::getConstantSignedPointer(llvm::Constant *Pointer, unsigned Key,
   return llvm::ConstantPtrAuth::get(
       Pointer, llvm::ConstantInt::get(Int32Ty, Key), IntegerDiscriminator,
       AddressDiscriminator,
-      /*DeactivationSymbol=*/llvm::Constant::getNullValue(DefaultPtrTy));
+      /*DeactivationSymbol=*/llvm::Constant::getZeroValue(DefaultPtrTy));
 }
 
 /// Does a given PointerAuthScheme require us to sign a value

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -6573,7 +6573,7 @@ convertToComplexValue(CodeGenFunction &CGF, RValue Val, QualType SrcType,
     llvm::Value *ScalarVal = CGF.EmitScalarConversion(
         Val.getScalarVal(), SrcType, DestElementType, Loc);
     ComplexVal = CodeGenFunction::ComplexPairTy(
-        ScalarVal, llvm::Constant::getNullValue(ScalarVal->getType()));
+        ScalarVal, llvm::Constant::getZeroValue(ScalarVal->getType()));
   } else {
     assert(Val.isComplex() && "Must be a scalar or complex.");
     QualType SrcElementType = SrcType->castAs<ComplexType>()->getElementType();

--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -111,7 +111,7 @@ static RValue PerformReturnAdjustment(CodeGenFunction &CGF,
 
     llvm::PHINode *PHI = CGF.Builder.CreatePHI(ReturnValue->getType(), 2);
     PHI->addIncoming(ReturnValue, AdjustNotNull);
-    PHI->addIncoming(llvm::Constant::getNullValue(ReturnValue->getType()),
+    PHI->addIncoming(llvm::Constant::getZeroValue(ReturnValue->getType()),
                      AdjustNull);
     ReturnValue = PHI;
   }
@@ -670,7 +670,7 @@ void CodeGenVTables::addRelativeComponent(ConstantArrayBuilder &builder,
                                           bool vtableHasLocalLinkage,
                                           bool isCompleteDtor) const {
   // No need to get the offset of a nullptr.
-  if (component->isNullValue())
+  if (component->isZeroValue())
     return builder.add(llvm::ConstantInt::get(CGM.Int32Ty, 0));
 
   auto *globalVal =
@@ -809,7 +809,7 @@ void CodeGenVTables::addVTableComponent(ConstantArrayBuilder &builder,
         if (IsThunk)
           nextVTableThunkIndex++;
         return builder.add(
-            llvm::ConstantExpr::getNullValue(CGM.GlobalsInt8PtrTy));
+            llvm::ConstantExpr::getZeroValue(CGM.GlobalsInt8PtrTy));
       }
       // Method is acceptable, continue processing as usual.
     }
@@ -898,7 +898,7 @@ void CodeGenVTables::addVTableComponent(ConstantArrayBuilder &builder,
 
   case VTableComponent::CK_UnusedFunctionPointer:
     if (RelativeCXXABIVTables)
-      return builder.add(llvm::ConstantExpr::getNullValue(CGM.Int32Ty));
+      return builder.add(llvm::ConstantExpr::getZeroValue(CGM.Int32Ty));
     else
       return builder.addNullPointer(CGM.GlobalsInt8PtrTy);
   }
@@ -1104,7 +1104,7 @@ llvm::GlobalVariable::LinkageTypes
 CodeGenModule::getVTableLinkage(const CXXRecordDecl *RD) {
   if (!RD->isExternallyVisible())
     return llvm::GlobalVariable::InternalLinkage;
-  
+
   // In windows, the linkage of vtable is not related to modules.
   bool IsInNamedModule = !getTarget().getCXXABI().isMicrosoft() &&
         RD->isInNamedModule();

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2624,7 +2624,7 @@ void CodeGenFunction::EmitVariablyModifiedType(QualType type) {
             auto CheckOrdinal = SanitizerKind::SO_VLABound;
             auto CheckHandler = SanitizerHandler::VLABoundNotPositive;
             SanitizerDebugLocation SanScope(this, {CheckOrdinal}, CheckHandler);
-            llvm::Value *Zero = llvm::Constant::getNullValue(size->getType());
+            llvm::Value *Zero = llvm::Constant::getZeroValue(size->getType());
             clang::QualType SEType = sizeExpr->getType();
             llvm::Value *CheckCondition =
                 SEType->isSignedIntegerType()

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -981,7 +981,7 @@ public:
   void pushCleanupAndDeferDeactivation(CleanupKind Kind, As... A) {
     // Placeholder dominating IP for this cleanup.
     llvm::Instruction *DominatingIP =
-        Builder.CreateFlagLoad(llvm::Constant::getNullValue(Int8PtrTy));
+        Builder.CreateFlagLoad(llvm::Constant::getZeroValue(Int8PtrTy));
     EHStack.pushCleanup<T>(Kind, A...);
     DeferredDeactivationCleanupStack.push_back(
         {EHStack.stable_begin(), DominatingIP});

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1102,7 +1102,7 @@ void CodeGenModule::Release() {
     // compilation unit can be associated.
     auto *GV = new llvm::GlobalVariable(
         getModule(), Int8Ty, false, llvm::GlobalValue::ExternalLinkage,
-        llvm::Constant::getNullValue(Int8Ty),
+        llvm::Constant::getZeroValue(Int8Ty),
         "__hip_cuid_" + getContext().getCUIDHash());
     getSanitizerMetadata()->disableSanitizerForGlobal(GV);
     addCompilerUsedGlobal(GV);
@@ -6435,7 +6435,7 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
     // non-zero null pointers. In this case they should have weak linkage
     // since common linkage must have zero initializer and must not have
     // explicit section therefore cannot have non-zero initial value.
-    if (!GV->getInitializer()->isNullValue())
+    if (!GV->getInitializer()->isZeroValue())
       GV->setLinkage(llvm::GlobalVariable::WeakAnyLinkage);
   }
 
@@ -8311,7 +8311,7 @@ llvm::Constant *CodeGenModule::GetAddrOfRTTIDescriptor(QualType Ty,
   // FIXME: should we even be calling this method if RTTI is disabled
   // and it's not for EH?
   if (!shouldEmitRTTI(ForEH))
-    return llvm::Constant::getNullValue(GlobalsInt8PtrTy);
+    return llvm::Constant::getZeroValue(GlobalsInt8PtrTy);
 
   if (ForEH && Ty->isObjCObjectPointerType() &&
       LangOpts.ObjCRuntime.isGNUFamily())

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -916,7 +916,7 @@ static llvm::Constant *pointerAuthResignConstant(
     return nullptr;
 
   assert(CPA->getKey()->getZExtValue() == CurAuthInfo.getKey() &&
-         CPA->getAddrDiscriminator()->isNullValue() &&
+         CPA->getAddrDiscriminator()->isZeroValue() &&
          CPA->getDiscriminator() == CurAuthInfo.getDiscriminator() &&
          "unexpected key or discriminators");
 
@@ -1313,7 +1313,7 @@ ItaniumCXXABI::EmitMemberPointerComparison(CodeGenFunction &CGF,
   // This condition, together with the assumption that L.ptr == R.ptr,
   // tests whether the pointers are both null.  ARM imposes an extra
   // condition.
-  llvm::Value *Zero = llvm::Constant::getNullValue(LPtr->getType());
+  llvm::Value *Zero = llvm::Constant::getZeroValue(LPtr->getType());
   llvm::Value *EqZero = Builder.CreateICmp(Eq, LPtr, Zero, "cmp.ptr.null");
 
   // This condition tests whether L.adj == R.adj.  If this isn't
@@ -1511,7 +1511,8 @@ void ItaniumCXXABI::emitThrow(CodeGenFunction &CGF, const CXXThrowExpr *E) {
     Dtor = CGM.getAddrOfCXXStructor(GlobalDecl(DtorD, Dtor_Complete));
     Dtor = CGM.getFunctionPointer(Dtor, DtorTy);
   }
-  if (!Dtor) Dtor = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+  if (!Dtor)
+    Dtor = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
 
   llvm::Value *args[] = { ExceptionPtr, TypeInfo, Dtor };
   CGF.EmitNoreturnRuntimeCallOrInvoke(getThrowFn(CGM), args);
@@ -1823,7 +1824,7 @@ llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
     llvm::PHINode *PHI = CGF.Builder.CreatePHI(AdjustedThisPtr->getType(), 2);
     PHI->addIncoming(AdjustedThisPtr, PostCastAuthSuccess);
     llvm::Value *NullValue =
-        llvm::Constant::getNullValue(AdjustedThisPtr->getType());
+        llvm::Constant::getZeroValue(AdjustedThisPtr->getType());
     PHI->addIncoming(NullValue, NonNullBlock);
     AdjustedThisPtr = PHI;
   }
@@ -2993,7 +2994,7 @@ static void emitGlobalDtorWithCXAAtExit(CodeGenFunction &CGF,
     // __attribute__((destructor)) in a constructor function. Using null here is
     // okay because this argument is just passed back to the destructor
     // function.
-    addr = llvm::Constant::getNullValue(CGF.Int8PtrTy);
+    addr = llvm::Constant::getZeroValue(CGF.Int8PtrTy);
 
   llvm::Value *args[] = {dtorCallee, addr, handle};
   CGF.EmitNounwindRuntimeCall(atexit, args);
@@ -5311,7 +5312,7 @@ void XLCXXABI::registerGlobalDtor(CodeGenFunction &CGF, const VarDecl &D,
 
     // Register above __dtor with atexit().
     // First param is flags and must be 0, second param is function ptr
-    llvm::Value *NV = llvm::Constant::getNullValue(CGM.IntTy);
+    llvm::Value *NV = llvm::Constant::getZeroValue(CGM.IntTy);
     CGF.EmitNounwindRuntimeCall(AtExit, {NV, DtorStub});
 
     // Cannot unregister TLS __dtor so done

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -588,8 +588,8 @@ public:
     if (!isImageRelative())
       return PtrVal;
 
-    if (PtrVal->isNullValue())
-      return llvm::Constant::getNullValue(CGM.IntTy);
+    if (PtrVal->isZeroValue())
+      return llvm::Constant::getZeroValue(CGM.IntTy);
 
     llvm::Constant *ImageBaseAsInt =
         llvm::ConstantExpr::getPtrToInt(getImageBase(), CGM.IntPtrTy);
@@ -1014,7 +1014,7 @@ static llvm::CallBase *emitRTtypeidCall(CodeGenFunction &CGF,
 
 void MicrosoftCXXABI::EmitBadTypeidCall(CodeGenFunction &CGF) {
   llvm::CallBase *Call =
-      emitRTtypeidCall(CGF, llvm::Constant::getNullValue(CGM.VoidPtrTy));
+      emitRTtypeidCall(CGF, llvm::Constant::getZeroValue(CGM.VoidPtrTy));
   Call->setDoesNotReturn();
   CGF.Builder.CreateUnreachable();
 }
@@ -2872,7 +2872,7 @@ GetNullMemberPointerFields(const MemberPointerType *MPT,
   MSInheritanceModel Inheritance = RD->getMSInheritanceModel();
   if (MPT->isMemberFunctionPointer()) {
     // FunctionPointerOrVirtualThunk
-    fields.push_back(llvm::Constant::getNullValue(CGM.VoidPtrTy));
+    fields.push_back(llvm::Constant::getZeroValue(CGM.VoidPtrTy));
   } else {
     if (RD->nullFieldOffsetIsZero())
       fields.push_back(getZeroInt());  // FieldOffset
@@ -3111,7 +3111,7 @@ MicrosoftCXXABI::EmitMemberPointerComparison(CodeGenFunction &CGF,
   // Check if the first field is 0 if this is a function pointer.
   if (MPT->isMemberFunctionPointer()) {
     // (l1 == r1 && ...) || l0 == 0
-    llvm::Value *Zero = llvm::Constant::getNullValue(L0->getType());
+    llvm::Value *Zero = llvm::Constant::getZeroValue(L0->getType());
     llvm::Value *IsZero = Builder.CreateICmp(Eq, L0, Zero, "memptr.cmp.iszero");
     Res = Builder.CreateBinOp(Or, Res, IsZero);
   }
@@ -3129,7 +3129,7 @@ MicrosoftCXXABI::EmitMemberPointerIsNotNull(CodeGenFunction &CGF,
   llvm::SmallVector<llvm::Constant *, 4> fields;
   // We only need one field for member functions.
   if (MPT->isMemberFunctionPointer())
-    fields.push_back(llvm::Constant::getNullValue(CGM.VoidPtrTy));
+    fields.push_back(llvm::Constant::getZeroValue(CGM.VoidPtrTy));
   else
     GetNullMemberPointerFields(MPT, fields);
   assert(!fields.empty());
@@ -3158,12 +3158,12 @@ bool MicrosoftCXXABI::MemberPointerConstantIsNull(const MemberPointerType *MPT,
   if (MPT->isMemberFunctionPointer()) {
     llvm::Constant *FirstField = Val->getType()->isStructTy() ?
       Val->getAggregateElement(0U) : Val;
-    return FirstField->isNullValue();
+    return FirstField->isZeroValue();
   }
 
   // If it's not a function pointer and it's zero initializable, we can easily
   // check zero.
-  if (isZeroInitializable(MPT) && Val->isNullValue())
+  if (isZeroInitializable(MPT) && Val->isZeroValue())
     return true;
 
   // Otherwise, break down all the fields for comparison.  Hopefully these
@@ -3872,7 +3872,7 @@ MSRTTIBuilder::getBaseClassArray(SmallVectorImpl<MSRTTIClass> &Classes) {
   for (MSRTTIClass &Class : Classes)
     BaseClassArrayData.push_back(
         ABI.getImageRelativeConstant(getBaseClassDescriptor(Class)));
-  BaseClassArrayData.push_back(llvm::Constant::getNullValue(PtrType));
+  BaseClassArrayData.push_back(llvm::Constant::getZeroValue(PtrType));
   BCA->setInitializer(llvm::ConstantArray::get(ArrType, BaseClassArrayData));
   return BCA;
 }
@@ -4278,7 +4278,7 @@ llvm::Constant *MicrosoftCXXABI::getCatchableType(QualType T,
     else
       CopyCtor = CGM.getAddrOfCXXStructor(GlobalDecl(CD, Ctor_Complete));
   } else {
-    CopyCtor = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+    CopyCtor = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
   }
   CopyCtor = getImageRelativeConstant(CopyCtor);
 
@@ -4481,14 +4481,14 @@ llvm::GlobalVariable *MicrosoftCXXABI::getThrowInfo(QualType T) {
 
   // The cleanup-function (a destructor) must be called when the exception
   // object's lifetime ends.
-  llvm::Constant *CleanupFn = llvm::Constant::getNullValue(CGM.Int8PtrTy);
+  llvm::Constant *CleanupFn = llvm::Constant::getZeroValue(CGM.Int8PtrTy);
   if (const CXXRecordDecl *RD = T->getAsCXXRecordDecl())
     if (CXXDestructorDecl *DtorD = RD->getDestructor())
       if (!DtorD->isTrivial())
         CleanupFn = CGM.getAddrOfCXXStructor(GlobalDecl(DtorD, Dtor_Complete));
   // This is unused as far as we can tell, initialize it to null.
   llvm::Constant *ForwardCompat =
-      getImageRelativeConstant(llvm::Constant::getNullValue(CGM.Int8PtrTy));
+      getImageRelativeConstant(llvm::Constant::getZeroValue(CGM.Int8PtrTy));
   llvm::Constant *PointerToCatchableTypes = getImageRelativeConstant(CTA);
   llvm::StructType *TIType = getThrowInfoType();
   llvm::Constant *Fields[] = {

--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -1911,7 +1911,7 @@ CodeGenFunction::EmitAArch64CompareBuiltinExpr(Value *Op, llvm::Type *Ty,
     Op = Builder.CreateBitCast(Op, Ty);
   }
 
-  Constant *zero = Constant::getNullValue(Op->getType());
+  Constant *zero = Constant::getZeroValue(Op->getType());
 
   if (CmpInst::isFPPredicate(Pred)) {
     if (Pred == CmpInst::FCMP_OEQ)
@@ -2873,7 +2873,7 @@ static llvm::Value *MVEImmediateShr(CGBuilderTy &Builder, llvm::Value *V,
     // simply emit a zero vector. A signed shift of the full lane size does the
     // same thing as shifting by one bit fewer.
     if (Unsigned)
-      return llvm::Constant::getNullValue(V->getType());
+      return llvm::Constant::getZeroValue(V->getType());
     else
       --Shift;
   }
@@ -3914,7 +3914,7 @@ Value *CodeGenFunction::EmitSVEReinterpret(Value *Val, llvm::Type *Ty) {
 
 static void InsertExplicitZeroOperand(CGBuilderTy &Builder, llvm::Type *Ty,
                                       SmallVectorImpl<Value *> &Ops) {
-  auto *SplatZero = Constant::getNullValue(Ty);
+  auto *SplatZero = Constant::getZeroValue(Ty);
   Ops.insert(Ops.begin(), SplatZero);
 }
 
@@ -4102,7 +4102,7 @@ Value *CodeGenFunction::EmitAArch64SVEBuiltinExpr(unsigned BuiltinID,
     // Predicated intrinsics with _z suffix need a select w/ zeroinitializer.
     if (TypeFlags.getMergeType() == SVETypeFlags::MergeZero) {
       llvm::Type *OpndTy = Ops[1]->getType();
-      auto *SplatZero = Constant::getNullValue(OpndTy);
+      auto *SplatZero = Constant::getZeroValue(OpndTy);
       Ops[1] = Builder.CreateSelect(Ops[0], Ops[1], SplatZero);
     }
 
@@ -4221,7 +4221,7 @@ Value *CodeGenFunction::EmitAArch64SVEBuiltinExpr(unsigned BuiltinID,
   case SVE::BI__builtin_sve_svdup_n_b32:
   case SVE::BI__builtin_sve_svdup_n_b64: {
     Value *CmpNE =
-        Builder.CreateICmpNE(Ops[0], Constant::getNullValue(Ops[0]->getType()));
+        Builder.CreateICmpNE(Ops[0], Constant::getZeroValue(Ops[0]->getType()));
     llvm::ScalableVectorType *OverloadedTy = getSVEType(TypeFlags);
     Value *Dup = EmitSVEDupX(CmpNE, OverloadedTy);
     return EmitSVEPredicateCast(Dup, cast<llvm::ScalableVectorType>(Ty));
@@ -5689,7 +5689,7 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     Ops[1] = Builder.CreateBitCast(Ops[1], Int64Ty);
     Ops[0] = Builder.CreateAnd(Ops[0], Ops[1]);
     Ops[0] = Builder.CreateICmp(ICmpInst::ICMP_NE, Ops[0],
-                                llvm::Constant::getNullValue(Int64Ty));
+                                llvm::Constant::getZeroValue(Int64Ty));
     return Builder.CreateSExt(Ops[0], Int64Ty, "vtstd");
   }
   case NEON::BI__builtin_neon_vset_lane_i8:

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -196,7 +196,7 @@ Value *CodeGenFunction::EmitPPCBuiltinCpu(unsigned BuiltinID,
   Value *TheCall = Builder.CreateCall(F, {Op0}, "cpu_supports");
   Value *Mask =
       Builder.CreateAnd(TheCall, llvm::ConstantInt::get(Int32Ty, BitMask));
-  return Builder.CreateICmpNE(Mask, llvm::Constant::getNullValue(Int32Ty));
+  return Builder.CreateICmpNE(Mask, llvm::Constant::getZeroValue(Int32Ty));
 #undef PPC_FAWORD_HWCAP
 #undef PPC_FAWORD_HWCAP2
 #undef PPC_FAWORD_CPUID
@@ -402,7 +402,8 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     Op0 = IsLE ? HiLd : LoLd;
     Op1 = IsLE ? LoLd : HiLd;
     Value *AllElts = Builder.CreateCall(Vperm, {Op0, Op1, Mask1}, "shuffle1");
-    Constant *Zero = llvm::Constant::getNullValue(IsLE ? ResTy : AllElts->getType());
+    Constant *Zero =
+        llvm::Constant::getZeroValue(IsLE ? ResTy : AllElts->getType());
 
     if (IsLE) {
       SmallVector<int, 16> Consts;

--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -132,7 +132,7 @@ emitRVVPseudoUnaryBuiltin(CodeGenFunction *CGF, const CallExpr *E,
       Ops.insert(Ops.begin(), llvm::PoisonValue::get(ResultType));
   }
   auto ElemTy = cast<llvm::VectorType>(ResultType)->getElementType();
-  Ops.insert(Ops.begin() + 2, llvm::Constant::getNullValue(ElemTy));
+  Ops.insert(Ops.begin() + 2, llvm::Constant::getZeroValue(ElemTy));
   if (IsMasked) {
     Ops.push_back(ConstantInt::get(Ops.back()->getType(), PolicyAttrs));
     // maskedoff, op1, op2, mask, vl, policy
@@ -233,7 +233,7 @@ emitRVVPseudoVWCVTBuiltin(CodeGenFunction *CGF, const CallExpr *E,
       Ops.insert(Ops.begin(), llvm::PoisonValue::get(ResultType));
   }
   auto ElemTy = cast<llvm::VectorType>(Ops[1]->getType())->getElementType();
-  Ops.insert(Ops.begin() + 2, llvm::Constant::getNullValue(ElemTy));
+  Ops.insert(Ops.begin() + 2, llvm::Constant::getZeroValue(ElemTy));
   if (IsMasked) {
     Ops.push_back(ConstantInt::get(Ops.back()->getType(), PolicyAttrs));
     // maskedoff, op1, op2, mask, vl, policy
@@ -263,7 +263,7 @@ emitRVVPseudoVNCVTBuiltin(CodeGenFunction *CGF, const CallExpr *E,
       Ops.insert(Ops.begin(), llvm::PoisonValue::get(ResultType));
   }
   Ops.insert(Ops.begin() + 2,
-             llvm::Constant::getNullValue(Ops.back()->getType()));
+             llvm::Constant::getZeroValue(Ops.back()->getType()));
   if (IsMasked) {
     Ops.push_back(ConstantInt::get(Ops.back()->getType(), PolicyAttrs));
     // maskedoff, op1, xlen, mask, vl

--- a/clang/lib/CodeGen/TargetBuiltins/WebAssembly.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/WebAssembly.cpp
@@ -282,7 +282,7 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   case WebAssembly::BI__builtin_wasm_abs_i64x2: {
     Value *Vec = EmitScalarExpr(E->getArg(0));
     Value *Neg = Builder.CreateNeg(Vec, "neg");
-    Constant *Zero = llvm::Constant::getNullValue(Vec->getType());
+    Constant *Zero = llvm::Constant::getZeroValue(Vec->getType());
     Value *ICmp = Builder.CreateICmpSLT(Vec, Zero, "abscond");
     return Builder.CreateSelect(ICmp, Neg, Vec, "abs");
   }
@@ -422,7 +422,7 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
     llvm::Type *TruncT = SrcT->getWithNewType(Builder.getInt32Ty());
     Function *Callee = CGM.getIntrinsic(IntNo, {TruncT, SrcT});
     Value *Trunc = Builder.CreateCall(Callee, Vec);
-    Value *Splat = Constant::getNullValue(TruncT);
+    Value *Splat = Constant::getZeroValue(TruncT);
     return Builder.CreateShuffleVector(Trunc, Splat, {0, 1, 2, 3});
   }
   case WebAssembly::BI__builtin_wasm_shuffle_i8x16: {

--- a/clang/lib/CodeGen/TargetBuiltins/X86.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/X86.cpp
@@ -251,7 +251,7 @@ static Value *EmitX86vpcom(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
     Pred = ICmpInst::ICMP_NE;
     break;
   case 0x6:
-    return llvm::Constant::getNullValue(Ty); // FALSE
+    return llvm::Constant::getZeroValue(Ty); // FALSE
   case 0x7:
     return llvm::Constant::getAllOnesValue(Ty); // TRUE
   default:
@@ -306,7 +306,7 @@ static Value *EmitX86MaskedCompareResult(CodeGenFunction &CGF, Value *Cmp,
     for (unsigned i = NumElts; i != 8; ++i)
       Indices[i] = i % NumElts + NumElts;
     Cmp = CGF.Builder.CreateShuffleVector(
-        Cmp, llvm::Constant::getNullValue(Cmp->getType()), Indices);
+        Cmp, llvm::Constant::getZeroValue(Cmp->getType()), Indices);
   }
 
   return CGF.Builder.CreateBitCast(Cmp,
@@ -323,7 +323,7 @@ static Value *EmitX86MaskedCompare(CodeGenFunction &CGF, unsigned CC,
   Value *Cmp;
 
   if (CC == 3) {
-    Cmp = Constant::getNullValue(
+    Cmp = Constant::getZeroValue(
         llvm::FixedVectorType::get(CGF.Builder.getInt1Ty(), NumElts));
   } else if (CC == 7) {
     Cmp = Constant::getAllOnesValue(
@@ -350,7 +350,7 @@ static Value *EmitX86MaskedCompare(CodeGenFunction &CGF, unsigned CC,
 }
 
 static Value *EmitX86ConvertToMask(CodeGenFunction &CGF, Value *In) {
-  Value *Zero = Constant::getNullValue(In->getType());
+  Value *Zero = Constant::getZeroValue(In->getType());
   return EmitX86MaskedCompare(CGF, 1, true, { In, Zero });
 }
 
@@ -476,7 +476,7 @@ static Value *EmitX86FMAExpr(CodeGenFunction &CGF, const CallExpr *E,
   case clang::X86::BI__builtin_ia32_vfmaddsubph512_maskz:
   case clang::X86::BI__builtin_ia32_vfmaddsubps512_maskz:
   case clang::X86::BI__builtin_ia32_vfmaddsubpd512_maskz:
-    MaskFalseVal = Constant::getNullValue(Ops[0]->getType());
+    MaskFalseVal = Constant::getZeroValue(Ops[0]->getType());
     break;
   case clang::X86::BI__builtin_ia32_vfmsubph512_mask3:
   case clang::X86::BI__builtin_ia32_vfmaddph512_mask3:
@@ -544,8 +544,8 @@ static Value *EmitScalarFMAExpr(CodeGenFunction &CGF, const CallExpr *E,
   }
   // If we have more than 3 arguments, we need to do masking.
   if (Ops.size() > 3) {
-    Value *PassThru = ZeroMask ? Constant::getNullValue(Res->getType())
-                               : Ops[PTIdx];
+    Value *PassThru =
+        ZeroMask ? Constant::getZeroValue(Res->getType()) : Ops[PTIdx];
 
     // If we negated the accumulator and the its the PassThru value we need to
     // bypass the negate. Conveniently Upper should be the same thing in this
@@ -986,7 +986,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     // IR optimizer and backend.
     // TODO: If we had a "freeze" IR instruction to generate a fixed undef
     // value, we should use that here instead of a zero.
-    return llvm::Constant::getNullValue(ConvertType(E->getType()));
+    return llvm::Constant::getZeroValue(ConvertType(E->getType()));
   case X86::BI__builtin_ia32_vec_ext_v4hi:
   case X86::BI__builtin_ia32_vec_ext_v16qi:
   case X86::BI__builtin_ia32_vec_ext_v8hi:
@@ -1818,14 +1818,14 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     // If palignr is shifting the pair of vectors more than the size of two
     // lanes, emit zero.
     if (ShiftVal >= 32)
-      return llvm::Constant::getNullValue(ConvertType(E->getType()));
+      return llvm::Constant::getZeroValue(ConvertType(E->getType()));
 
     // If palignr is shifting the pair of input vectors more than one lane,
     // but less than two lanes, convert to shifting in zeroes.
     if (ShiftVal > 16) {
       ShiftVal -= 16;
       Ops[1] = Ops[0];
-      Ops[0] = llvm::Constant::getNullValue(Ops[0]->getType());
+      Ops[0] = llvm::Constant::getZeroValue(Ops[0]->getType());
     }
 
     int Indices[64];
@@ -1937,7 +1937,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     auto *VecTy = cast<llvm::FixedVectorType>(Ops[0]->getType());
     // Builtin type is vXi8.
     unsigned NumElts = VecTy->getNumElements();
-    Value *Zero = llvm::Constant::getNullValue(VecTy);
+    Value *Zero = llvm::Constant::getZeroValue(VecTy);
 
     // If pslldq is shifting the vector more than 15 bytes, emit zero.
     if (ShiftVal >= 16)
@@ -1963,7 +1963,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     auto *VecTy = cast<llvm::FixedVectorType>(Ops[0]->getType());
     // Builtin type is vXi8.
     unsigned NumElts = VecTy->getNumElements();
-    Value *Zero = llvm::Constant::getNullValue(VecTy);
+    Value *Zero = llvm::Constant::getZeroValue(VecTy);
 
     // If psrldq is shifting the vector more than 15 bytes, emit zero.
     if (ShiftVal >= 16)
@@ -1990,7 +1990,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     unsigned NumElts = Ops[0]->getType()->getIntegerBitWidth();
 
     if (ShiftVal >= NumElts)
-      return llvm::Constant::getNullValue(Ops[0]->getType());
+      return llvm::Constant::getZeroValue(Ops[0]->getType());
 
     Value *In = getMaskVecValue(*this, Ops[0], NumElts);
 
@@ -1998,7 +1998,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     for (unsigned i = 0; i != NumElts; ++i)
       Indices[i] = NumElts + i - ShiftVal;
 
-    Value *Zero = llvm::Constant::getNullValue(In->getType());
+    Value *Zero = llvm::Constant::getZeroValue(In->getType());
     Value *SV = Builder.CreateShuffleVector(
         Zero, In, ArrayRef(Indices, NumElts), "kshiftl");
     return Builder.CreateBitCast(SV, Ops[0]->getType());
@@ -2011,7 +2011,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     unsigned NumElts = Ops[0]->getType()->getIntegerBitWidth();
 
     if (ShiftVal >= NumElts)
-      return llvm::Constant::getNullValue(Ops[0]->getType());
+      return llvm::Constant::getZeroValue(Ops[0]->getType());
 
     Value *In = getMaskVecValue(*this, Ops[0], NumElts);
 
@@ -2019,7 +2019,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     for (unsigned i = 0; i != NumElts; ++i)
       Indices[i] = i + ShiftVal;
 
-    Value *Zero = llvm::Constant::getNullValue(In->getType());
+    Value *Zero = llvm::Constant::getZeroValue(In->getType());
     Value *SV = Builder.CreateShuffleVector(
         In, Zero, ArrayRef(Indices, NumElts), "kshiftr");
     return Builder.CreateBitCast(SV, Ops[0]->getType());
@@ -2153,7 +2153,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
   case X86::BI__builtin_ia32_kortestzsi:
   case X86::BI__builtin_ia32_kortestzdi: {
     Value *Or = EmitX86MaskLogic(*this, Instruction::Or, Ops);
-    Value *C = llvm::Constant::getNullValue(Ops[0]->getType());
+    Value *C = llvm::Constant::getZeroValue(Ops[0]->getType());
     Value *Cmp = Builder.CreateICmpEQ(Or, C);
     return Builder.CreateZExt(Cmp, ConvertType(E->getType()));
   }
@@ -3133,7 +3133,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     Builder.CreateBr(End);
 
     Builder.SetInsertPoint(Error);
-    Constant *Zero = llvm::Constant::getNullValue(Out->getType());
+    Constant *Zero = llvm::Constant::getZeroValue(Out->getType());
     Builder.CreateDefaultAlignedStore(Zero, Ops[0]);
     Builder.CreateBr(End);
 
@@ -3194,7 +3194,7 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
 
     Builder.SetInsertPoint(Error);
     for (int i = 0; i != 8; ++i) {
-      Constant *Zero = llvm::Constant::getNullValue(Ty);
+      Constant *Zero = llvm::Constant::getZeroValue(Ty);
       Value *Ptr = Builder.CreateConstGEP1_32(Ty, Ops[0], i);
       Builder.CreateAlignedStore(Zero, Ptr, Align(16));
     }

--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -473,8 +473,8 @@ bool IRForTarget::RewriteObjCConstString(llvm::GlobalVariable *ns_str,
   if (cstr)
     string_array = dyn_cast<ConstantDataSequential>(cstr->getInitializer());
 
-  Constant *alloc_arg = Constant::getNullValue(i8_ptr_ty);
-  Constant *bytes_arg = cstr ? cstr : Constant::getNullValue(i8_ptr_ty);
+  Constant *alloc_arg = Constant::getZeroValue(i8_ptr_ty);
+  Constant *bytes_arg = cstr ? cstr : Constant::getZeroValue(i8_ptr_ty);
   Constant *numBytes_arg = ConstantInt::get(
       m_intptr_ty, cstr ? (string_array->getNumElements() - 1) * string_array->getElementByteSize() : 0, false);
  int encoding_flags = 0;
@@ -1271,7 +1271,7 @@ static bool isGuardVariableRef(Value *V) {
 }
 
 void IRForTarget::TurnGuardLoadIntoZero(llvm::Instruction *guard_load) {
-  Constant *zero(Constant::getNullValue(guard_load->getType()));
+  Constant *zero(Constant::getZeroValue(guard_load->getType()));
   guard_load->replaceAllUsesWith(zero);
   guard_load->eraseFromParent();
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/InjectPointerSigningFixups.cpp
@@ -208,7 +208,7 @@ Error InjectPointerSigningFixupCode(llvm::Module &M,
       StructType::get(Ctx, {Int32Ty, FixupFn->getType(), UInt8PtrTy});
   Constant *PtrFixupCtor =
       ConstantStruct::get(CtorType, {ConstantInt::get(Int32Ty, 0), FixupFn,
-                                     Constant::getNullValue(UInt8PtrTy)});
+                                     Constant::getZeroValue(UInt8PtrTy)});
 
   const char *LLVMGlobalCtorsName = "llvm.global_ctors";
   GlobalVariable *OldCtorList = M.getNamedGlobal(LLVMGlobalCtorsName);

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -568,7 +568,7 @@ val set_module_identifier : llmodule -> string -> unit
 val get_module_flag : llmodule -> string -> llmetadata option
 
 (** [add_module_flag m b k v] Add a module-level flag b, with key [k] and
-    value [v] to the flags metadata of module [m]. It will create the 
+    value [v] to the flags metadata of module [m]. It will create the
     module-level flags named metadata if it doesn't already exist. *)
 val add_module_flag : llmodule -> ModuleFlagBehavior.t ->
                         string -> llmetadata -> unit
@@ -885,7 +885,7 @@ val indices : llvalue -> int array
 val is_constant : llvalue -> bool
 
 (** [const_null ty] returns the constant null (zero) of the type [ty].
-    See the method [llvm::Constant::getNullValue]. *)
+    See the method [llvm::Constant::getZeroValue]. *)
 val const_null : lltype -> llvalue
 
 (** [const_all_ones ty] returns the constant '-1' of the integer or vector type
@@ -905,7 +905,7 @@ val undef : lltype -> llvalue
 val poison : lltype -> llvalue
 
 (** [is_null v] returns [true] if the value [v] is the null (zero) value.
-    See the method [llvm::Constant::isNullValue]. *)
+    See the method [llvm::Constant::isZeroValue]. *)
 val is_null : llvalue -> bool
 
 (** [is_undef v] returns [true] if the value [v] is an undefined value, [false]

--- a/llvm/docs/MergeFunctions.rst
+++ b/llvm/docs/MergeFunctions.rst
@@ -561,7 +561,7 @@ Steps below are for the case when types are equal, or case when constants are
 bitcastable:
 
 3. One of constants is a "*null*" value. Return the result of
-``cmpFlags(L->isNullValue, R->isNullValue)`` comparison.
+``cmpFlags(L->isZeroValue, R->isZeroValue)`` comparison.
 
 4. Compare value IDs, and return result if it is not 0:
 

--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -3161,7 +3161,7 @@ Deleting Instructions
     AllocaInst* instToReplace = ...;
     BasicBlock::iterator ii(instToReplace);
 
-    ReplaceInstWithValue(ii, Constant::getNullValue(PointerType::getUnqual(Type::Int32Ty)));
+    ReplaceInstWithValue(ii, Constant::getZeroValue(PointerType::getUnqual(Type::Int32Ty)));
 
 * ``ReplaceInstWithInst``
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -75,18 +75,16 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to LLVM infrastructure
 
-* Removed ``Constant::isZeroValue``. It was functionally identical to
-  ``Constant::isNullValue`` for all types except floating-point negative
-  zero. All callers should use ``isNullValue`` instead. ``isZeroValue``
-  will be reintroduced in the future with bitwise-all-zeros semantics
-  to support non-zero null pointers.
-
 * Added support for specifying the null pointer bit representation per
   address space in `DataLayout`. Pointer specifications (`p`) accept new
   flags: `z` (null is all-zeros) and `o` (null is all-ones). Address
   spaces without an explicit flag default to all-zeros. See the
   `DataLayout` section of the
   [LangRef](https://llvm.org/docs/LangRef.html#data-layout) for details.
+
+* Renamed `isNullValue` and `getNullValue` to `isZeroValue` and `getZeroValue`.
+  A variant of null value check will be introduced back after the semantics of
+  `ConstantPointerNull` is changed.
 
 * Removed TypePromoteFloat legalization from SelectionDAG
 

--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl05.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl05.rst
@@ -775,7 +775,7 @@ insertion position to it.
         NamedValues.erase(VarName);
 
       // for expr always returns 0.0.
-      return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+      return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
     }
 
 The final code handles various cleanups: now that we have the "NextVar"

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/toy.cpp
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/toy.cpp
@@ -982,7 +982,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/toy.cpp
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/toy.cpp
@@ -982,7 +982,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/toy.cpp
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/toy.cpp
@@ -982,7 +982,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/toy.cpp
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/toy.cpp
@@ -965,7 +965,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/Chapter5/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter5/toy.cpp
@@ -773,7 +773,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Function *PrototypeAST::codegen() {

--- a/llvm/examples/Kaleidoscope/Chapter6/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter6/toy.cpp
@@ -885,7 +885,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Function *PrototypeAST::codegen() {

--- a/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
@@ -998,7 +998,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
@@ -986,7 +986,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/Chapter9/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter9/toy.cpp
@@ -1158,7 +1158,7 @@ Value *ForExprAST::codegen() {
     NamedValues.erase(VarName);
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(*TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(*TheContext));
 }
 
 Value *VarExprAST::codegen() {

--- a/llvm/examples/Kaleidoscope/MCJIT/cached/toy-jit.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/cached/toy-jit.cpp
@@ -44,18 +44,24 @@ enum Token {
   tok_eof = -1,
 
   // commands
-  tok_def = -2, tok_extern = -3,
+  tok_def = -2,
+  tok_extern = -3,
 
   // primary
-  tok_identifier = -4, tok_number = -5,
-  
+  tok_identifier = -4,
+  tok_number = -5,
+
   // control
-  tok_if = -6, tok_then = -7, tok_else = -8,
-  tok_for = -9, tok_in = -10,
-  
+  tok_if = -6,
+  tok_then = -7,
+  tok_else = -8,
+  tok_for = -9,
+  tok_in = -10,
+
   // operators
-  tok_binary = -11, tok_unary = -12,
-  
+  tok_binary = -11,
+  tok_unary = -12,
+
   // var definition
   tok_var = -13
 };
@@ -104,11 +110,11 @@ static int gettok() {
     // Comment until end of line.
     do LastChar = getchar();
     while (LastChar != EOF && LastChar != '\n' && LastChar != '\r');
-    
+
     if (LastChar != EOF)
       return gettok();
   }
-  
+
   // Check for end of file.  Don't eat the EOF.
   if (LastChar == EOF)
     return tok_eof;
@@ -152,8 +158,8 @@ class UnaryExprAST : public ExprAST {
   char Opcode;
   ExprAST *Operand;
 public:
-  UnaryExprAST(char opcode, ExprAST *operand) 
-    : Opcode(opcode), Operand(operand) {}
+  UnaryExprAST(char opcode, ExprAST *operand)
+      : Opcode(opcode), Operand(operand) {}
   virtual Value *Codegen();
 };
 
@@ -162,8 +168,8 @@ class BinaryExprAST : public ExprAST {
   char Op;
   ExprAST *LHS, *RHS;
 public:
-  BinaryExprAST(char op, ExprAST *lhs, ExprAST *rhs) 
-    : Op(op), LHS(lhs), RHS(rhs) {}
+  BinaryExprAST(char op, ExprAST *lhs, ExprAST *rhs)
+      : Op(op), LHS(lhs), RHS(rhs) {}
   virtual Value *Codegen();
 };
 
@@ -205,7 +211,7 @@ public:
   VarExprAST(const std::vector<std::pair<std::string, ExprAST*> > &varnames,
              ExprAST *body)
   : VarNames(varnames), Body(body) {}
-  
+
   virtual Value *Codegen();
 };
 
@@ -220,19 +226,19 @@ public:
   PrototypeAST(const std::string &name, const std::vector<std::string> &args,
                bool isoperator = false, unsigned prec = 0)
   : Name(name), Args(args), isOperator(isoperator), Precedence(prec) {}
-  
+
   bool isUnaryOp() const { return isOperator && Args.size() == 1; }
   bool isBinaryOp() const { return isOperator && Args.size() == 2; }
-  
+
   char getOperatorName() const {
     assert(isUnaryOp() || isBinaryOp());
     return Name[Name.size()-1];
   }
-  
+
   unsigned getBinaryPrecedence() const { return Precedence; }
-  
+
   Function *Codegen();
-  
+
   void CreateArgumentAllocas(Function *F);
 };
 
@@ -243,7 +249,7 @@ class FunctionAST {
 public:
   FunctionAST(PrototypeAST *proto, ExprAST *body)
     : Proto(proto), Body(body) {}
-  
+
   Function *Codegen();
 };
 
@@ -267,7 +273,7 @@ static std::map<char, int> BinopPrecedence;
 static int GetTokPrecedence() {
   if (!isascii(CurTok))
     return -1;
-  
+
   // Make sure it's a declared binop.
   int TokPrec = BinopPrecedence[CurTok];
   if (TokPrec <= 0) return -1;
@@ -286,12 +292,12 @@ static ExprAST *ParseExpression();
 ///   ::= identifier '(' expression* ')'
 static ExprAST *ParseIdentifierExpr() {
   std::string IdName = IdentifierStr;
-  
+
   getNextToken();  // eat identifier.
-  
+
   if (CurTok != '(') // Simple variable ref.
     return new VariableExprAST(IdName);
-  
+
   // Call.
   getNextToken();  // eat (
   std::vector<ExprAST*> Args;
@@ -311,7 +317,7 @@ static ExprAST *ParseIdentifierExpr() {
 
   // Eat the ')'.
   getNextToken();
-  
+
   return new CallExprAST(IdName, Args);
 }
 
@@ -327,7 +333,7 @@ static ExprAST *ParseParenExpr() {
   getNextToken();  // eat (.
   ExprAST *V = ParseExpression();
   if (!V) return 0;
-  
+
   if (CurTok != ')')
     return Error("expected ')'");
   getNextToken();  // eat ).
@@ -337,26 +343,26 @@ static ExprAST *ParseParenExpr() {
 /// ifexpr ::= 'if' expression 'then' expression 'else' expression
 static ExprAST *ParseIfExpr() {
   getNextToken();  // eat the if.
-  
+
   // condition.
   ExprAST *Cond = ParseExpression();
   if (!Cond) return 0;
-  
+
   if (CurTok != tok_then)
     return Error("expected then");
   getNextToken();  // eat the then
-  
+
   ExprAST *Then = ParseExpression();
   if (Then == 0) return 0;
-  
+
   if (CurTok != tok_else)
     return Error("expected else");
-  
+
   getNextToken();
-  
+
   ExprAST *Else = ParseExpression();
   if (!Else) return 0;
-  
+
   return new IfExprAST(Cond, Then, Else);
 }
 
@@ -366,24 +372,23 @@ static ExprAST *ParseForExpr() {
 
   if (CurTok != tok_identifier)
     return Error("expected identifier after for");
-  
+
   std::string IdName = IdentifierStr;
   getNextToken();  // eat identifier.
-  
+
   if (CurTok != '=')
     return Error("expected '=' after for");
   getNextToken();  // eat '='.
-  
-  
+
   ExprAST *Start = ParseExpression();
   if (Start == 0) return 0;
   if (CurTok != ',')
     return Error("expected ',' after for start value");
   getNextToken();
-  
+
   ExprAST *End = ParseExpression();
   if (End == 0) return 0;
-  
+
   // The step value is optional.
   ExprAST *Step = 0;
   if (CurTok == ',') {
@@ -391,18 +396,18 @@ static ExprAST *ParseForExpr() {
     Step = ParseExpression();
     if (Step == 0) return 0;
   }
-  
+
   if (CurTok != tok_in)
     return Error("expected 'in' after for");
   getNextToken();  // eat 'in'.
-  
+
   ExprAST *Body = ParseExpression();
   if (Body == 0) return 0;
 
   return new ForExprAST(IdName, Start, End, Step, Body);
 }
 
-/// varexpr ::= 'var' identifier ('=' expression)? 
+/// varexpr ::= 'var' identifier ('=' expression)?
 //                    (',' identifier ('=' expression)?)* 'in' expression
 static ExprAST *ParseVarExpr() {
   getNextToken();  // eat the var.
@@ -412,7 +417,7 @@ static ExprAST *ParseVarExpr() {
   // At least one variable name is required.
   if (CurTok != tok_identifier)
     return Error("expected identifier after var");
-  
+
   while (1) {
     std::string Name = IdentifierStr;
     getNextToken();  // eat identifier.
@@ -421,29 +426,29 @@ static ExprAST *ParseVarExpr() {
     ExprAST *Init = 0;
     if (CurTok == '=') {
       getNextToken(); // eat the '='.
-      
+
       Init = ParseExpression();
       if (Init == 0) return 0;
     }
-    
+
     VarNames.push_back(std::make_pair(Name, Init));
-    
+
     // End of var list, exit loop.
     if (CurTok != ',') break;
     getNextToken(); // eat the ','.
-    
+
     if (CurTok != tok_identifier)
       return Error("expected identifier list after var");
   }
-  
+
   // At this point, we have to have 'in'.
   if (CurTok != tok_in)
     return Error("expected 'in' keyword after 'var'");
   getNextToken();  // eat 'in'.
-  
+
   ExprAST *Body = ParseExpression();
   if (Body == 0) return 0;
-  
+
   return new VarExprAST(VarNames, Body);
 }
 
@@ -473,7 +478,7 @@ static ExprAST *ParseUnary() {
   // If the current token is not an operator, it must be a primary expr.
   if (!isascii(CurTok) || CurTok == '(' || CurTok == ',')
     return ParsePrimary();
-  
+
   // If this is a unary operator, read it.
   int Opc = CurTok;
   getNextToken();
@@ -488,20 +493,20 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
   // If this is a binop, find its precedence.
   while (1) {
     int TokPrec = GetTokPrecedence();
-    
+
     // If this is a binop that binds at least as tightly as the current binop,
     // consume it, otherwise we are done.
     if (TokPrec < ExprPrec)
       return LHS;
-    
+
     // Okay, we know this is a binop.
     int BinOp = CurTok;
     getNextToken();  // eat binop
-    
+
     // Parse the unary expression after the binary operator.
     ExprAST *RHS = ParseUnary();
     if (!RHS) return 0;
-    
+
     // If BinOp binds less tightly with RHS than the operator after RHS, let
     // the pending operator take RHS as its LHS.
     int NextPrec = GetTokPrecedence();
@@ -509,7 +514,7 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
       RHS = ParseBinOpRHS(TokPrec+1, RHS);
       if (RHS == 0) return 0;
     }
-    
+
     // Merge LHS/RHS.
     LHS = new BinaryExprAST(BinOp, LHS, RHS);
   }
@@ -521,7 +526,7 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
 static ExprAST *ParseExpression() {
   ExprAST *LHS = ParseUnary();
   if (!LHS) return 0;
-  
+
   return ParseBinOpRHS(0, LHS);
 }
 
@@ -531,10 +536,10 @@ static ExprAST *ParseExpression() {
 ///   ::= unary LETTER (id)
 static PrototypeAST *ParsePrototype() {
   std::string FnName;
-  
+
   unsigned Kind = 0; // 0 = identifier, 1 = unary, 2 = binary.
   unsigned BinaryPrecedence = 30;
-  
+
   switch (CurTok) {
   default:
     return ErrorP("Expected function name in prototype");
@@ -560,7 +565,7 @@ static PrototypeAST *ParsePrototype() {
     FnName += (char)CurTok;
     Kind = 2;
     getNextToken();
-    
+
     // Read the precedence if present.
     if (CurTok == tok_number) {
       if (NumVal < 1 || NumVal > 100)
@@ -570,23 +575,23 @@ static PrototypeAST *ParsePrototype() {
     }
     break;
   }
-  
+
   if (CurTok != '(')
     return ErrorP("Expected '(' in prototype");
-  
+
   std::vector<std::string> ArgNames;
   while (getNextToken() == tok_identifier)
     ArgNames.push_back(IdentifierStr);
   if (CurTok != ')')
     return ErrorP("Expected ')' in prototype");
-  
+
   // success.
   getNextToken();  // eat ')'.
-  
+
   // Verify right number of names for operator.
   if (Kind && ArgNames.size() != Kind)
     return ErrorP("Invalid number of operands for operator");
-  
+
   return new PrototypeAST(FnName, ArgNames, Kind != 0, BinaryPrecedence);
 }
 
@@ -661,7 +666,7 @@ Value *UnaryExprAST::Codegen() {
 #endif
   if (F == 0)
     return ErrorV("Unknown unary operator");
-  
+
   return Builder.CreateCall(F, OperandV, "unop");
 }
 
@@ -686,11 +691,11 @@ Value *BinaryExprAST::Codegen() {
     Builder.CreateStore(Val, Variable);
     return Val;
   }
-  
+
   Value *L = LHS->Codegen();
   Value *R = RHS->Codegen();
   if (L == 0 || R == 0) return 0;
-  
+
   switch (Op) {
   case '+': return Builder.CreateFAdd(L, R, "addtmp");
   case '-': return Builder.CreateFSub(L, R, "subtmp");
@@ -702,12 +707,12 @@ Value *BinaryExprAST::Codegen() {
     return Builder.CreateUIToFP(L, Type::getDoubleTy(TheContext), "booltmp");
   default: break;
   }
-  
+
   // If it wasn't a builtin binary operator, it must be a user defined one. Emit
   // a call to it.
   Function *F = TheModule->getFunction(std::string("binary")+Op);
   assert(F && "binary operator not found!");
-  
+
   Value *Ops[] = { L, R };
   return Builder.CreateCall(F, Ops, "binop");
 }
@@ -717,10 +722,10 @@ Value *CallExprAST::Codegen() {
   Function *CalleeF = TheModule->getFunction(Callee);
   if (CalleeF == 0) {
     char error_str[64];
-    sprintf(error_str, "Unknown function referenced %s", Callee.c_str()); 
+    sprintf(error_str, "Unknown function referenced %s", Callee.c_str());
     return ErrorV(error_str);
   }
-  
+
   // If argument mismatch error.
   if (CalleeF->arg_size() != Args.size())
     return ErrorV("Incorrect # arguments passed");
@@ -730,20 +735,20 @@ Value *CallExprAST::Codegen() {
     ArgsV.push_back(Args[i]->Codegen());
     if (ArgsV.back() == 0) return 0;
   }
-  
+
   return Builder.CreateCall(CalleeF, ArgsV, "calltmp");
 }
 
 Value *IfExprAST::Codegen() {
   Value *CondV = Cond->Codegen();
   if (CondV == 0) return 0;
-  
+
   // Convert condition to a bool by comparing equal to 0.0.
   CondV = Builder.CreateFCmpONE(
       CondV, ConstantFP::get(TheContext, APFloat(0.0)), "ifcond");
 
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
-  
+
   // Create blocks for the then and else cases.  Insert the 'then' block at the
   // end of the function.
   BasicBlock *ThenBB = BasicBlock::Create(TheContext, "then", TheFunction);
@@ -751,28 +756,28 @@ Value *IfExprAST::Codegen() {
   BasicBlock *MergeBB = BasicBlock::Create(TheContext, "ifcont");
 
   Builder.CreateCondBr(CondV, ThenBB, ElseBB);
-  
+
   // Emit then value.
   Builder.SetInsertPoint(ThenBB);
-  
+
   Value *ThenV = Then->Codegen();
   if (ThenV == 0) return 0;
-  
+
   Builder.CreateBr(MergeBB);
   // Codegen of 'Then' can change the current block, update ThenBB for the PHI.
   ThenBB = Builder.GetInsertBlock();
-  
+
   // Emit else block.
   TheFunction->insert(TheFunction->end(), ElseBB);
   Builder.SetInsertPoint(ElseBB);
-  
+
   Value *ElseV = Else->Codegen();
   if (ElseV == 0) return 0;
-  
+
   Builder.CreateBr(MergeBB);
   // Codegen of 'Else' can change the current block, update ElseBB for the PHI.
   ElseBB = Builder.GetInsertBlock();
-  
+
   // Emit merge block.
   TheFunction->insert(TheFunction->end(), MergeBB);
   Builder.SetInsertPoint(MergeBB);
@@ -790,7 +795,7 @@ Value *ForExprAST::Codegen() {
   //   start = startexpr
   //   store start -> var
   //   goto loop
-  // loop: 
+  // loop:
   //   ...
   //   bodyexpr
   //   ...
@@ -803,19 +808,19 @@ Value *ForExprAST::Codegen() {
   //   store nextvar -> var
   //   br endcond, loop, endloop
   // outloop:
-  
+
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
 
   // Create an alloca for the variable in the entry block.
   AllocaInst *Alloca = CreateEntryBlockAlloca(TheFunction, VarName);
-  
+
   // Emit the start code first, without 'variable' in scope.
   Value *StartVal = Start->Codegen();
   if (StartVal == 0) return 0;
-  
+
   // Store the value into the alloca.
   Builder.CreateStore(StartVal, Alloca);
-  
+
   // Make the new basic block for the loop header, inserting after current
   // block.
   BasicBlock *LoopBB = BasicBlock::Create(TheContext, "loop", TheFunction);
@@ -825,18 +830,18 @@ Value *ForExprAST::Codegen() {
 
   // Start insertion in LoopBB.
   Builder.SetInsertPoint(LoopBB);
-  
+
   // Within the loop, the variable is defined equal to the PHI node.  If it
   // shadows an existing variable, we have to restore it, so save it now.
   AllocaInst *OldVal = NamedValues[VarName];
   NamedValues[VarName] = Alloca;
-  
+
   // Emit the body of the loop.  This, like any other expr, can change the
   // current BB.  Note that we ignore the value computed by the body, but don't
   // allow an error.
   if (Body->Codegen() == 0)
     return 0;
-  
+
   // Emit the step value.
   Value *StepVal;
   if (Step) {
@@ -846,17 +851,17 @@ Value *ForExprAST::Codegen() {
     // If not specified, use 1.0.
     StepVal = ConstantFP::get(TheContext, APFloat(1.0));
   }
-  
+
   // Compute the end condition.
   Value *EndCond = End->Codegen();
   if (EndCond == 0) return EndCond;
-  
+
   // Reload, increment, and restore the alloca.  This handles the case where
   // the body of the loop mutates the variable.
   Value *CurVar = Builder.CreateLoad(Alloca, VarName.c_str());
   Value *NextVar = Builder.CreateFAdd(CurVar, StepVal, "nextvar");
   Builder.CreateStore(NextVar, Alloca);
-  
+
   // Convert condition to a bool by comparing equal to 0.0.
   EndCond = Builder.CreateFCmpONE(
       EndCond, ConstantFP::get(TheContext, APFloat(0.0)), "loopcond");
@@ -867,31 +872,30 @@ Value *ForExprAST::Codegen() {
 
   // Insert the conditional branch into the end of LoopEndBB.
   Builder.CreateCondBr(EndCond, LoopBB, AfterBB);
-  
+
   // Any new code will be inserted in AfterBB.
   Builder.SetInsertPoint(AfterBB);
-  
+
   // Restore the unshadowed variable.
   if (OldVal)
     NamedValues[VarName] = OldVal;
   else
     NamedValues.erase(VarName);
 
-  
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {
   std::vector<AllocaInst *> OldBindings;
-  
+
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
 
   // Register all variables and emit their initializer.
   for (unsigned i = 0, e = VarNames.size(); i != e; ++i) {
     const std::string &VarName = VarNames[i].first;
     ExprAST *Init = VarNames[i].second;
-    
+
     // Emit the initializer before adding the variable to scope, this prevents
     // the initializer from referencing the variable itself, and permits stuff
     // like this:
@@ -904,22 +908,22 @@ Value *VarExprAST::Codegen() {
     } else { // If not specified, use 0.0.
       InitVal = ConstantFP::get(TheContext, APFloat(0.0));
     }
-    
+
     AllocaInst *Alloca = CreateEntryBlockAlloca(TheFunction, VarName);
     Builder.CreateStore(InitVal, Alloca);
 
     // Remember the old variable binding so that we can restore the binding when
     // we unrecurse.
     OldBindings.push_back(NamedValues[VarName]);
-    
+
     // Remember this binding.
     NamedValues[VarName] = Alloca;
   }
-  
+
   // Codegen the body, now that all vars are in scope.
   Value *BodyVal = Body->Codegen();
   if (BodyVal == 0) return 0;
-  
+
   // Pop all our variables from scope.
   for (unsigned i = 0, e = VarNames.size(); i != e; ++i)
     NamedValues[VarNames[i].first] = OldBindings[i];
@@ -958,7 +962,7 @@ Function *PrototypeAST::Codegen() {
   for (Function::arg_iterator AI = F->arg_begin(); Idx != Args.size();
        ++AI, ++Idx)
     AI->setName(Args[Idx]);
-    
+
   return F;
 }
 
@@ -980,7 +984,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F) {
 
 Function *FunctionAST::Codegen() {
   NamedValues.clear();
-  
+
   Function *TheFunction = Proto->Codegen();
   if (TheFunction == 0)
     return 0;
@@ -992,7 +996,7 @@ Function *FunctionAST::Codegen() {
   // Create a new basic block to start insertion into.
   BasicBlock *BB = BasicBlock::Create(TheContext, "entry", TheFunction);
   Builder.SetInsertPoint(BB);
-  
+
   // Add all arguments to the symbol table and create their allocas.
   Proto->CreateArgumentAllocas(TheFunction);
 
@@ -1008,7 +1012,7 @@ Function *FunctionAST::Codegen() {
 
     return TheFunction;
   }
-  
+
   // Error reading body, remove function.
   TheFunction->eraseFromParent();
 
@@ -1093,21 +1097,18 @@ static void MainLoop() {
 //===----------------------------------------------------------------------===//
 
 /// putchard - putchar that takes a double and returns 0.
-extern "C" 
-double putchard(double X) {
+extern "C" double putchard(double X) {
   putchar((char)X);
   return 0;
 }
 
 /// printd - printf that takes a double prints it as "%f\n", returning 0.
-extern "C" 
-double printd(double X) {
+extern "C" double printd(double X) {
   printf("%f", X);
   return 0;
 }
 
-extern "C" 
-double printlf() {
+extern "C" double printlf() {
   printf("\n");
   return 0;
 }

--- a/llvm/examples/Kaleidoscope/MCJIT/cached/toy.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/cached/toy.cpp
@@ -1243,7 +1243,7 @@ Value *ForExprAST::Codegen() {
 
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {

--- a/llvm/examples/Kaleidoscope/MCJIT/complete/toy.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/complete/toy.cpp
@@ -1321,7 +1321,7 @@ Value *ForExprAST::Codegen() {
 
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {

--- a/llvm/examples/Kaleidoscope/MCJIT/initial/toy.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/initial/toy.cpp
@@ -1101,7 +1101,7 @@ Value *ForExprAST::Codegen() {
 
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {

--- a/llvm/examples/Kaleidoscope/MCJIT/lazy/toy-jit.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/lazy/toy-jit.cpp
@@ -89,11 +89,11 @@ static int gettok() {
     // Comment until end of line.
     do LastChar = getchar();
     while (LastChar != EOF && LastChar != '\n' && LastChar != '\r');
-    
+
     if (LastChar != EOF)
       return gettok();
   }
-  
+
   // Check for end of file.  Don't eat the EOF.
   if (LastChar == EOF)
     return tok_eof;
@@ -137,8 +137,8 @@ class UnaryExprAST : public ExprAST {
   char Opcode;
   ExprAST *Operand;
 public:
-  UnaryExprAST(char opcode, ExprAST *operand) 
-    : Opcode(opcode), Operand(operand) {}
+  UnaryExprAST(char opcode, ExprAST *operand)
+      : Opcode(opcode), Operand(operand) {}
   virtual Value *Codegen();
 };
 
@@ -147,8 +147,8 @@ class BinaryExprAST : public ExprAST {
   char Op;
   ExprAST *LHS, *RHS;
 public:
-  BinaryExprAST(char op, ExprAST *lhs, ExprAST *rhs) 
-    : Op(op), LHS(lhs), RHS(rhs) {}
+  BinaryExprAST(char op, ExprAST *lhs, ExprAST *rhs)
+      : Op(op), LHS(lhs), RHS(rhs) {}
   virtual Value *Codegen();
 };
 
@@ -190,7 +190,7 @@ public:
   VarExprAST(const std::vector<std::pair<std::string, ExprAST*> > &varnames,
              ExprAST *body)
   : VarNames(varnames), Body(body) {}
-  
+
   virtual Value *Codegen();
 };
 
@@ -205,19 +205,19 @@ public:
   PrototypeAST(const std::string &name, const std::vector<std::string> &args,
                bool isoperator = false, unsigned prec = 0)
   : Name(name), Args(args), isOperator(isoperator), Precedence(prec) {}
-  
+
   bool isUnaryOp() const { return isOperator && Args.size() == 1; }
   bool isBinaryOp() const { return isOperator && Args.size() == 2; }
-  
+
   char getOperatorName() const {
     assert(isUnaryOp() || isBinaryOp());
     return Name[Name.size()-1];
   }
-  
+
   unsigned getBinaryPrecedence() const { return Precedence; }
-  
+
   Function *Codegen();
-  
+
   void CreateArgumentAllocas(Function *F);
 };
 
@@ -228,7 +228,7 @@ class FunctionAST {
 public:
   FunctionAST(PrototypeAST *proto, ExprAST *body)
     : Proto(proto), Body(body) {}
-  
+
   Function *Codegen();
 };
 
@@ -252,7 +252,7 @@ static std::map<char, int> BinopPrecedence;
 static int GetTokPrecedence() {
   if (!isascii(CurTok))
     return -1;
-  
+
   // Make sure it's a declared binop.
   int TokPrec = BinopPrecedence[CurTok];
   if (TokPrec <= 0) return -1;
@@ -271,12 +271,12 @@ static ExprAST *ParseExpression();
 ///   ::= identifier '(' expression* ')'
 static ExprAST *ParseIdentifierExpr() {
   std::string IdName = IdentifierStr;
-  
+
   getNextToken();  // eat identifier.
-  
+
   if (CurTok != '(') // Simple variable ref.
     return new VariableExprAST(IdName);
-  
+
   // Call.
   getNextToken();  // eat (
   std::vector<ExprAST*> Args;
@@ -296,7 +296,7 @@ static ExprAST *ParseIdentifierExpr() {
 
   // Eat the ')'.
   getNextToken();
-  
+
   return new CallExprAST(IdName, Args);
 }
 
@@ -312,7 +312,7 @@ static ExprAST *ParseParenExpr() {
   getNextToken();  // eat (.
   ExprAST *V = ParseExpression();
   if (!V) return 0;
-  
+
   if (CurTok != ')')
     return Error("expected ')'");
   getNextToken();  // eat ).
@@ -322,26 +322,26 @@ static ExprAST *ParseParenExpr() {
 /// ifexpr ::= 'if' expression 'then' expression 'else' expression
 static ExprAST *ParseIfExpr() {
   getNextToken();  // eat the if.
-  
+
   // condition.
   ExprAST *Cond = ParseExpression();
   if (!Cond) return 0;
-  
+
   if (CurTok != tok_then)
     return Error("expected then");
   getNextToken();  // eat the then
-  
+
   ExprAST *Then = ParseExpression();
   if (Then == 0) return 0;
-  
+
   if (CurTok != tok_else)
     return Error("expected else");
-  
+
   getNextToken();
-  
+
   ExprAST *Else = ParseExpression();
   if (!Else) return 0;
-  
+
   return new IfExprAST(Cond, Then, Else);
 }
 
@@ -351,24 +351,23 @@ static ExprAST *ParseForExpr() {
 
   if (CurTok != tok_identifier)
     return Error("expected identifier after for");
-  
+
   std::string IdName = IdentifierStr;
   getNextToken();  // eat identifier.
-  
+
   if (CurTok != '=')
     return Error("expected '=' after for");
   getNextToken();  // eat '='.
-  
-  
+
   ExprAST *Start = ParseExpression();
   if (Start == 0) return 0;
   if (CurTok != ',')
     return Error("expected ',' after for start value");
   getNextToken();
-  
+
   ExprAST *End = ParseExpression();
   if (End == 0) return 0;
-  
+
   // The step value is optional.
   ExprAST *Step = 0;
   if (CurTok == ',') {
@@ -376,18 +375,18 @@ static ExprAST *ParseForExpr() {
     Step = ParseExpression();
     if (Step == 0) return 0;
   }
-  
+
   if (CurTok != tok_in)
     return Error("expected 'in' after for");
   getNextToken();  // eat 'in'.
-  
+
   ExprAST *Body = ParseExpression();
   if (Body == 0) return 0;
 
   return new ForExprAST(IdName, Start, End, Step, Body);
 }
 
-/// varexpr ::= 'var' identifier ('=' expression)? 
+/// varexpr ::= 'var' identifier ('=' expression)?
 //                    (',' identifier ('=' expression)?)* 'in' expression
 static ExprAST *ParseVarExpr() {
   getNextToken();  // eat the var.
@@ -397,7 +396,7 @@ static ExprAST *ParseVarExpr() {
   // At least one variable name is required.
   if (CurTok != tok_identifier)
     return Error("expected identifier after var");
-  
+
   while (1) {
     std::string Name = IdentifierStr;
     getNextToken();  // eat identifier.
@@ -406,29 +405,29 @@ static ExprAST *ParseVarExpr() {
     ExprAST *Init = 0;
     if (CurTok == '=') {
       getNextToken(); // eat the '='.
-      
+
       Init = ParseExpression();
       if (Init == 0) return 0;
     }
-    
+
     VarNames.push_back(std::make_pair(Name, Init));
-    
+
     // End of var list, exit loop.
     if (CurTok != ',') break;
     getNextToken(); // eat the ','.
-    
+
     if (CurTok != tok_identifier)
       return Error("expected identifier list after var");
   }
-  
+
   // At this point, we have to have 'in'.
   if (CurTok != tok_in)
     return Error("expected 'in' keyword after 'var'");
   getNextToken();  // eat 'in'.
-  
+
   ExprAST *Body = ParseExpression();
   if (Body == 0) return 0;
-  
+
   return new VarExprAST(VarNames, Body);
 }
 
@@ -458,7 +457,7 @@ static ExprAST *ParseUnary() {
   // If the current token is not an operator, it must be a primary expr.
   if (!isascii(CurTok) || CurTok == '(' || CurTok == ',')
     return ParsePrimary();
-  
+
   // If this is a unary operator, read it.
   int Opc = CurTok;
   getNextToken();
@@ -473,20 +472,20 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
   // If this is a binop, find its precedence.
   while (1) {
     int TokPrec = GetTokPrecedence();
-    
+
     // If this is a binop that binds at least as tightly as the current binop,
     // consume it, otherwise we are done.
     if (TokPrec < ExprPrec)
       return LHS;
-    
+
     // Okay, we know this is a binop.
     int BinOp = CurTok;
     getNextToken();  // eat binop
-    
+
     // Parse the unary expression after the binary operator.
     ExprAST *RHS = ParseUnary();
     if (!RHS) return 0;
-    
+
     // If BinOp binds less tightly with RHS than the operator after RHS, let
     // the pending operator take RHS as its LHS.
     int NextPrec = GetTokPrecedence();
@@ -494,7 +493,7 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
       RHS = ParseBinOpRHS(TokPrec+1, RHS);
       if (RHS == 0) return 0;
     }
-    
+
     // Merge LHS/RHS.
     LHS = new BinaryExprAST(BinOp, LHS, RHS);
   }
@@ -506,7 +505,7 @@ static ExprAST *ParseBinOpRHS(int ExprPrec, ExprAST *LHS) {
 static ExprAST *ParseExpression() {
   ExprAST *LHS = ParseUnary();
   if (!LHS) return 0;
-  
+
   return ParseBinOpRHS(0, LHS);
 }
 
@@ -516,10 +515,10 @@ static ExprAST *ParseExpression() {
 ///   ::= unary LETTER (id)
 static PrototypeAST *ParsePrototype() {
   std::string FnName;
-  
+
   unsigned Kind = 0; // 0 = identifier, 1 = unary, 2 = binary.
   unsigned BinaryPrecedence = 30;
-  
+
   switch (CurTok) {
   default:
     return ErrorP("Expected function name in prototype");
@@ -545,7 +544,7 @@ static PrototypeAST *ParsePrototype() {
     FnName += (char)CurTok;
     Kind = 2;
     getNextToken();
-    
+
     // Read the precedence if present.
     if (CurTok == tok_number) {
       if (NumVal < 1 || NumVal > 100)
@@ -555,23 +554,23 @@ static PrototypeAST *ParsePrototype() {
     }
     break;
   }
-  
+
   if (CurTok != '(')
     return ErrorP("Expected '(' in prototype");
-  
+
   std::vector<std::string> ArgNames;
   while (getNextToken() == tok_identifier)
     ArgNames.push_back(IdentifierStr);
   if (CurTok != ')')
     return ErrorP("Expected ')' in prototype");
-  
+
   // success.
   getNextToken();  // eat ')'.
-  
+
   // Verify right number of names for operator.
   if (Kind && ArgNames.size() != Kind)
     return ErrorP("Invalid number of operands for operator");
-  
+
   return new PrototypeAST(FnName, ArgNames, Kind != 0, BinaryPrecedence);
 }
 
@@ -646,7 +645,7 @@ Value *UnaryExprAST::Codegen() {
 #endif
   if (F == 0)
     return ErrorV("Unknown unary operator");
-  
+
   return Builder.CreateCall(F, OperandV, "unop");
 }
 
@@ -668,11 +667,11 @@ Value *BinaryExprAST::Codegen() {
     Builder.CreateStore(Val, Variable);
     return Val;
   }
-  
+
   Value *L = LHS->Codegen();
   Value *R = RHS->Codegen();
   if (L == 0 || R == 0) return 0;
-  
+
   switch (Op) {
   case '+': return Builder.CreateFAdd(L, R, "addtmp");
   case '-': return Builder.CreateFSub(L, R, "subtmp");
@@ -684,12 +683,12 @@ Value *BinaryExprAST::Codegen() {
     return Builder.CreateUIToFP(L, Type::getDoubleTy(TheContext), "booltmp");
   default: break;
   }
-  
+
   // If it wasn't a builtin binary operator, it must be a user defined one. Emit
   // a call to it.
   Function *F = TheModule->getFunction(std::string("binary")+Op);
   assert(F && "binary operator not found!");
-  
+
   Value *Ops[] = { L, R };
   return Builder.CreateCall(F, Ops, "binop");
 }
@@ -699,10 +698,10 @@ Value *CallExprAST::Codegen() {
   Function *CalleeF = TheModule->getFunction(Callee);
   if (CalleeF == 0) {
     char error_str[64];
-    sprintf(error_str, "Unknown function referenced %s", Callee.c_str()); 
+    sprintf(error_str, "Unknown function referenced %s", Callee.c_str());
     return ErrorV(error_str);
   }
-  
+
   // If argument mismatch error.
   if (CalleeF->arg_size() != Args.size())
     return ErrorV("Incorrect # arguments passed");
@@ -712,20 +711,20 @@ Value *CallExprAST::Codegen() {
     ArgsV.push_back(Args[i]->Codegen());
     if (ArgsV.back() == 0) return 0;
   }
-  
+
   return Builder.CreateCall(CalleeF, ArgsV, "calltmp");
 }
 
 Value *IfExprAST::Codegen() {
   Value *CondV = Cond->Codegen();
   if (CondV == 0) return 0;
-  
+
   // Convert condition to a bool by comparing equal to 0.0.
   CondV = Builder.CreateFCmpONE(
       CondV, ConstantFP::get(TheContext, APFloat(0.0)), "ifcond");
 
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
-  
+
   // Create blocks for the then and else cases.  Insert the 'then' block at the
   // end of the function.
   BasicBlock *ThenBB = BasicBlock::Create(TheContext, "then", TheFunction);
@@ -733,28 +732,28 @@ Value *IfExprAST::Codegen() {
   BasicBlock *MergeBB = BasicBlock::Create(TheContext, "ifcont");
 
   Builder.CreateCondBr(CondV, ThenBB, ElseBB);
-  
+
   // Emit then value.
   Builder.SetInsertPoint(ThenBB);
-  
+
   Value *ThenV = Then->Codegen();
   if (ThenV == 0) return 0;
-  
+
   Builder.CreateBr(MergeBB);
   // Codegen of 'Then' can change the current block, update ThenBB for the PHI.
   ThenBB = Builder.GetInsertBlock();
-  
+
   // Emit else block.
   TheFunction->insert(TheFunction->end(), ElseBB);
   Builder.SetInsertPoint(ElseBB);
-  
+
   Value *ElseV = Else->Codegen();
   if (ElseV == 0) return 0;
-  
+
   Builder.CreateBr(MergeBB);
   // Codegen of 'Else' can change the current block, update ElseBB for the PHI.
   ElseBB = Builder.GetInsertBlock();
-  
+
   // Emit merge block.
   TheFunction->insert(TheFunction->end(), MergeBB);
   Builder.SetInsertPoint(MergeBB);
@@ -772,7 +771,7 @@ Value *ForExprAST::Codegen() {
   //   start = startexpr
   //   store start -> var
   //   goto loop
-  // loop: 
+  // loop:
   //   ...
   //   bodyexpr
   //   ...
@@ -785,19 +784,19 @@ Value *ForExprAST::Codegen() {
   //   store nextvar -> var
   //   br endcond, loop, endloop
   // outloop:
-  
+
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
 
   // Create an alloca for the variable in the entry block.
   AllocaInst *Alloca = CreateEntryBlockAlloca(TheFunction, VarName);
-  
+
   // Emit the start code first, without 'variable' in scope.
   Value *StartVal = Start->Codegen();
   if (StartVal == 0) return 0;
-  
+
   // Store the value into the alloca.
   Builder.CreateStore(StartVal, Alloca);
-  
+
   // Make the new basic block for the loop header, inserting after current
   // block.
   BasicBlock *LoopBB = BasicBlock::Create(TheContext, "loop", TheFunction);
@@ -807,18 +806,18 @@ Value *ForExprAST::Codegen() {
 
   // Start insertion in LoopBB.
   Builder.SetInsertPoint(LoopBB);
-  
+
   // Within the loop, the variable is defined equal to the PHI node.  If it
   // shadows an existing variable, we have to restore it, so save it now.
   AllocaInst *OldVal = NamedValues[VarName];
   NamedValues[VarName] = Alloca;
-  
+
   // Emit the body of the loop.  This, like any other expr, can change the
   // current BB.  Note that we ignore the value computed by the body, but don't
   // allow an error.
   if (Body->Codegen() == 0)
     return 0;
-  
+
   // Emit the step value.
   Value *StepVal;
   if (Step) {
@@ -828,17 +827,17 @@ Value *ForExprAST::Codegen() {
     // If not specified, use 1.0.
     StepVal = ConstantFP::get(TheContext, APFloat(1.0));
   }
-  
+
   // Compute the end condition.
   Value *EndCond = End->Codegen();
   if (EndCond == 0) return EndCond;
-  
+
   // Reload, increment, and restore the alloca.  This handles the case where
   // the body of the loop mutates the variable.
   Value *CurVar = Builder.CreateLoad(Alloca, VarName.c_str());
   Value *NextVar = Builder.CreateFAdd(CurVar, StepVal, "nextvar");
   Builder.CreateStore(NextVar, Alloca);
-  
+
   // Convert condition to a bool by comparing equal to 0.0.
   EndCond = Builder.CreateFCmpONE(
       EndCond, ConstantFP::get(TheContext, APFloat(0.0)), "loopcond");
@@ -849,31 +848,30 @@ Value *ForExprAST::Codegen() {
 
   // Insert the conditional branch into the end of LoopEndBB.
   Builder.CreateCondBr(EndCond, LoopBB, AfterBB);
-  
+
   // Any new code will be inserted in AfterBB.
   Builder.SetInsertPoint(AfterBB);
-  
+
   // Restore the unshadowed variable.
   if (OldVal)
     NamedValues[VarName] = OldVal;
   else
     NamedValues.erase(VarName);
 
-  
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {
   std::vector<AllocaInst *> OldBindings;
-  
+
   Function *TheFunction = Builder.GetInsertBlock()->getParent();
 
   // Register all variables and emit their initializer.
   for (unsigned i = 0, e = VarNames.size(); i != e; ++i) {
     const std::string &VarName = VarNames[i].first;
     ExprAST *Init = VarNames[i].second;
-    
+
     // Emit the initializer before adding the variable to scope, this prevents
     // the initializer from referencing the variable itself, and permits stuff
     // like this:
@@ -886,22 +884,22 @@ Value *VarExprAST::Codegen() {
     } else { // If not specified, use 0.0.
       InitVal = ConstantFP::get(TheContext, APFloat(0.0));
     }
-    
+
     AllocaInst *Alloca = CreateEntryBlockAlloca(TheFunction, VarName);
     Builder.CreateStore(InitVal, Alloca);
 
     // Remember the old variable binding so that we can restore the binding when
     // we unrecurse.
     OldBindings.push_back(NamedValues[VarName]);
-    
+
     // Remember this binding.
     NamedValues[VarName] = Alloca;
   }
-  
+
   // Codegen the body, now that all vars are in scope.
   Value *BodyVal = Body->Codegen();
   if (BodyVal == 0) return 0;
-  
+
   // Pop all our variables from scope.
   for (unsigned i = 0, e = VarNames.size(); i != e; ++i)
     NamedValues[VarNames[i].first] = OldBindings[i];
@@ -940,7 +938,7 @@ Function *PrototypeAST::Codegen() {
   for (Function::arg_iterator AI = F->arg_begin(); Idx != Args.size();
        ++AI, ++Idx)
     AI->setName(Args[Idx]);
-    
+
   return F;
 }
 
@@ -962,7 +960,7 @@ void PrototypeAST::CreateArgumentAllocas(Function *F) {
 
 Function *FunctionAST::Codegen() {
   NamedValues.clear();
-  
+
   Function *TheFunction = Proto->Codegen();
   if (TheFunction == 0)
     return 0;
@@ -974,7 +972,7 @@ Function *FunctionAST::Codegen() {
   // Create a new basic block to start insertion into.
   BasicBlock *BB = BasicBlock::Create(TheContext, "entry", TheFunction);
   Builder.SetInsertPoint(BB);
-  
+
   // Add all arguments to the symbol table and create their allocas.
   Proto->CreateArgumentAllocas(TheFunction);
 
@@ -990,7 +988,7 @@ Function *FunctionAST::Codegen() {
 
     return TheFunction;
   }
-  
+
   // Error reading body, remove function.
   TheFunction->eraseFromParent();
 
@@ -1077,21 +1075,18 @@ static void MainLoop() {
 //===----------------------------------------------------------------------===//
 
 /// putchard - putchar that takes a double and returns 0.
-extern "C" 
-double putchard(double X) {
+extern "C" double putchard(double X) {
   putchar((char)X);
   return 0;
 }
 
 /// printd - printf that takes a double prints it as "%f\n", returning 0.
-extern "C" 
-double printd(double X) {
+extern "C" double printd(double X) {
   printf("%f", X);
   return 0;
 }
 
-extern "C" 
-double printlf() {
+extern "C" double printlf() {
   printf("\n");
   return 0;
 }

--- a/llvm/examples/Kaleidoscope/MCJIT/lazy/toy.cpp
+++ b/llvm/examples/Kaleidoscope/MCJIT/lazy/toy.cpp
@@ -1141,7 +1141,7 @@ Value *ForExprAST::Codegen() {
 
 
   // for expr always returns 0.0.
-  return Constant::getNullValue(Type::getDoubleTy(TheContext));
+  return Constant::getZeroValue(Type::getDoubleTy(TheContext));
 }
 
 Value *VarExprAST::Codegen() {

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2357,7 +2357,7 @@ LLVM_C_ABI int LLVMGetNumOperands(LLVMValueRef Val);
 /**
  * Obtain a constant value referring to the null instance of a type.
  *
- * @see llvm::Constant::getNullValue()
+ * @see llvm::Constant::getZeroValue()
  */
 LLVM_C_ABI LLVMValueRef LLVMConstNull(LLVMTypeRef Ty); /* all zeroes */
 
@@ -2388,7 +2388,7 @@ LLVM_C_ABI LLVMValueRef LLVMGetPoison(LLVMTypeRef Ty);
 /**
  * Determine whether a value instance is null.
  *
- * @see llvm::Constant::isNullValue()
+ * @see llvm::Constant::isZeroValue()
  */
 LLVM_C_ABI LLVMBool LLVMIsNull(LLVMValueRef Val);
 

--- a/llvm/include/llvm/Analysis/SparsePropagation.h
+++ b/llvm/include/llvm/Analysis/SparsePropagation.h
@@ -326,7 +326,7 @@ void SparseSolver<LatticeKey, LatticeVal, KeyInfo>::getFeasibleSuccessors(
     }
 
     // Constant condition variables mean the branch can only go a single way
-    Succs[C->isNullValue()] = true;
+    Succs[C->isZeroValue()] = true;
     return;
   }
 

--- a/llvm/include/llvm/IR/Constant.h
+++ b/llvm/include/llvm/IR/Constant.h
@@ -51,8 +51,8 @@ public:
   void operator=(const Constant &) = delete;
   Constant(const Constant &) = delete;
 
-  /// Return true if this is the value that would be returned by getNullValue.
-  LLVM_ABI bool isNullValue() const;
+  /// Return true if this is a all-zero constant.
+  LLVM_ABI bool isZeroValue() const;
 
   /// Returns true if the value is one.
   LLVM_ABI bool isOneValue() const;
@@ -187,7 +187,8 @@ public:
   ///
   LLVM_ABI void handleOperandChange(Value *, Value *);
 
-  LLVM_ABI static Constant *getNullValue(Type *Ty);
+  /// Constructor to create a '0' constant of arbitrary type.
+  LLVM_ABI static Constant *getZeroValue(Type *Ty);
 
   /// @returns the value for an integer or vector of integer constant of the
   /// given type that has all its bits set to true.

--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -1242,7 +1242,7 @@ public:
 
   /// Whether there is any non-null address discriminator.
   bool hasAddressDiscriminator() const {
-    return !getAddrDiscriminator()->isNullValue();
+    return !getAddrDiscriminator()->isZeroValue();
   }
 
   Constant *getDeactivationSymbol() const {

--- a/llvm/include/llvm/IR/FixedPointBuilder.h
+++ b/llvm/include/llvm/IR/FixedPointBuilder.h
@@ -52,7 +52,7 @@ template <class IRBuilderTy> class FixedPointBuilder {
       // numbers, right shifting rounds towards negative infinity. In this case,
       // we can just round up before shifting.
       if (DstIsInteger && SrcIsSigned) {
-        Value *Zero = Constant::getNullValue(Result->getType());
+        Value *Zero = Constant::getZeroValue(Result->getType());
         Value *IsNegative = B.CreateICmpSLT(Result, Zero);
         Value *LowBits = ConstantInt::get(
             B.getContext(), APInt::getLowBitsSet(ResultWidth, SrcScale));
@@ -212,7 +212,7 @@ public:
     // When saturating unsigned-with-padding using signed operations, we may
     // get negative values. Emit an extra clamp to zero.
     if (DstSema.isSaturated() && DstSema.hasUnsignedPadding()) {
-      Constant *Zero = Constant::getNullValue(Result->getType());
+      Constant *Zero = Constant::getZeroValue(Result->getType());
       Result =
           B.CreateSelect(B.CreateICmpSLT(Result, Zero), Zero, Result, "satmin");
     }
@@ -270,7 +270,7 @@ public:
     // Subtraction can end up below 0 for padded unsigned operations, so emit
     // an extra clamp in that case.
     if (CommonSema.isSaturated() && CommonSema.hasUnsignedPadding()) {
-      Constant *Zero = Constant::getNullValue(Result->getType());
+      Constant *Zero = Constant::getZeroValue(Result->getType());
       Result =
           B.CreateSelect(B.CreateICmpSLT(Result, Zero), Zero, Result, "satmin");
     }

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1778,7 +1778,7 @@ public:
                           Instruction *MDFrom = nullptr) {
     assert(Cond2->getType()->isIntOrIntVectorTy(1));
     return CreateSelect(Cond1, Cond2,
-                        ConstantInt::getNullValue(Cond2->getType()), Name,
+                        ConstantInt::getZeroValue(Cond2->getType()), Name,
                         MDFrom);
   }
 
@@ -1835,7 +1835,7 @@ public:
       std::optional<fp::ExceptionBehavior> Except = std::nullopt);
 
   Value *CreateNeg(Value *V, const Twine &Name = "", bool HasNSW = false) {
-    return CreateSub(Constant::getNullValue(V->getType()), V, Name,
+    return CreateSub(Constant::getZeroValue(V->getType()), V, Name,
                      /*HasNUW=*/0, HasNSW);
   }
 
@@ -2693,17 +2693,17 @@ public:
 
   /// Return a boolean value testing if \p Arg == 0.
   Value *CreateIsNull(Value *Arg, const Twine &Name = "") {
-    return CreateICmpEQ(Arg, Constant::getNullValue(Arg->getType()), Name);
+    return CreateICmpEQ(Arg, Constant::getZeroValue(Arg->getType()), Name);
   }
 
   /// Return a boolean value testing if \p Arg != 0.
   Value *CreateIsNotNull(Value *Arg, const Twine &Name = "") {
-    return CreateICmpNE(Arg, Constant::getNullValue(Arg->getType()), Name);
+    return CreateICmpNE(Arg, Constant::getZeroValue(Arg->getType()), Name);
   }
 
   /// Return a boolean value testing if \p Arg < 0.
   Value *CreateIsNeg(Value *Arg, const Twine &Name = "") {
-    return CreateICmpSLT(Arg, ConstantInt::getNullValue(Arg->getType()), Name);
+    return CreateICmpSLT(Arg, ConstantInt::getZeroValue(Arg->getType()), Name);
   }
 
   /// Return a boolean value testing if \p Arg > -1.

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -581,7 +581,7 @@ struct is_zero {
   template <typename ITy> bool match(ITy *V) const {
     auto *C = dyn_cast<Constant>(V);
     // FIXME: this should be able to do something for scalable vectors
-    return C && (C->isNullValue() || cst_pred_ty<is_zero_int>().match(C));
+    return C && (C->isZeroValue() || cst_pred_ty<is_zero_int>().match(C));
   }
 };
 /// Match any null constant or a vector with all elements equal to 0.
@@ -2282,7 +2282,7 @@ template <typename LHS_t, typename RHS_t> struct ICmpLike_match {
     // trunc nuw x to i1 is equivalent to icmp ne x, 0
     if (V->getType()->isIntOrIntVectorTy(1) &&
         PatternMatch::match(V, m_NUWTrunc(m_Value(A))) && L.match(A) &&
-        R.match(ConstantInt::getNullValue(A->getType()))) {
+        R.match(ConstantInt::getZeroValue(A->getType()))) {
       Pred = ICmpInst::ICMP_NE;
       return true;
     }
@@ -3325,7 +3325,7 @@ struct LogicalOp_match {
 
       if (Opcode == Instruction::And) {
         auto *C = dyn_cast<Constant>(FVal);
-        if (C && C->isNullValue())
+        if (C && C->isZeroValue())
           return (L.match(Cond) && R.match(TVal)) ||
                  (Commutable && L.match(TVal) && R.match(Cond));
       } else {

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -314,7 +314,7 @@ public:
         case Instruction::FSub: // 0.0 - X (doesn't simplify, but it is safe)
         case Instruction::FDiv: // 0.0 / X (doesn't simplify, but it is safe)
         case Instruction::FRem: // 0.0 % X = 0
-          SafeC = Constant::getNullValue(EltTy);
+          SafeC = Constant::getZeroValue(EltTy);
           break;
         default:
           llvm_unreachable("Expected to find identity constant for opcode");

--- a/llvm/include/llvm/Transforms/Utils/Evaluator.h
+++ b/llvm/include/llvm/Transforms/Utils/Evaluator.h
@@ -90,7 +90,7 @@ public:
       // silly, e.g. storing the address of the alloca somewhere and using it
       // later.  Since this is undefined, we'll just make it be null.
       if (!Tmp->use_empty())
-        Tmp->replaceAllUsesWith(Constant::getNullValue(Tmp->getType()));
+        Tmp->replaceAllUsesWith(Constant::getZeroValue(Tmp->getType()));
   }
 
   /// Evaluate a call to function F, returning true if successful, false if we

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -821,7 +821,7 @@ computeUnlikelySuccessors(const BasicBlock *BB, Loop *L,
           CI->getPredicate(), CmpLHSConst, CmpConst, DL);
       // If the result means we don't branch to the block then that block is
       // unlikely.
-      if (Result && ((Result->isNullValue() && B == BI->getSuccessor(0)) ||
+      if (Result && ((Result->isZeroValue() && B == BI->getSuccessor(0)) ||
                      (Result->isOneValue() && B == BI->getSuccessor(1))))
         UnlikelyBlocks.insert(B);
     }

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -707,15 +707,15 @@ Constant *FoldReinterpretLoadFromConst(Constant *C, Type *LoadTy,
                                   DL.getTypeSizeInBits(LoadTy).getFixedValue());
     if (Constant *Res =
             FoldReinterpretLoadFromConst(C, MapTy, OrigLoadTy, Offset, DL)) {
-      if (Res->isNullValue() && !LoadTy->isX86_AMXTy())
+      if (Res->isZeroValue() && !LoadTy->isX86_AMXTy())
         // Materializing a zero can be done trivially without a bitcast
-        return Constant::getNullValue(LoadTy);
+        return Constant::getZeroValue(LoadTy);
       Type *CastTy = LoadTy->isPtrOrPtrVectorTy() ? DL.getIntPtrType(LoadTy) : LoadTy;
       Res = FoldBitCast(Res, CastTy, DL);
       if (LoadTy->isPtrOrPtrVectorTy()) {
         // For vector of pointer, we needed to first convert to a vector of integer, then do vector inttoptr
-        if (Res->isNullValue() && !LoadTy->isX86_AMXTy())
-          return Constant::getNullValue(LoadTy);
+        if (Res->isZeroValue() && !LoadTy->isX86_AMXTy())
+          return Constant::getZeroValue(LoadTy);
         if (DL.isNonIntegralPointerType(LoadTy->getScalarType()))
           // Be careful not to replace a load of an addrspace value with an inttoptr here
           return nullptr;
@@ -912,8 +912,8 @@ Constant *llvm::ConstantFoldLoadFromUniformValue(Constant *C, Type *Ty,
   // uniform.
   if (!DL.typeSizeEqualsStoreSize(C->getType()))
     return nullptr;
-  if (C->isNullValue() && !Ty->isX86_AMXTy())
-    return Constant::getNullValue(Ty);
+  if (C->isZeroValue() && !Ty->isX86_AMXTy())
+    return Constant::getZeroValue(Ty);
   if (C->isAllOnesValue() &&
       (Ty->isIntOrIntVectorTy() || Ty->isByteOrByteVectorTy() ||
        Ty->isFPOrFPVectorTy()))
@@ -1093,7 +1093,7 @@ Constant *SymbolicallyEvaluateGEP(const GEPOperator *GEP,
     }
   }
 
-  if ((Ptr->isNullValue() || BaseIntVal != 0) &&
+  if ((Ptr->isZeroValue() || BaseIntVal != 0) &&
       !DL.mustNotIntroduceIntToPtr(Ptr->getType())) {
 
     // If the index size is smaller than the pointer size, add to the low
@@ -1343,14 +1343,14 @@ Constant *llvm::ConstantFoldCompareInstOperands(
   // ConstantExpr::getCompare cannot do this, because it doesn't have DL
   // around to know if bit truncation is happening.
   if (auto *CE0 = dyn_cast<ConstantExpr>(Ops0)) {
-    if (Ops1->isNullValue()) {
+    if (Ops1->isZeroValue()) {
       if (CE0->getOpcode() == Instruction::IntToPtr) {
         Type *IntPtrTy = DL.getIntPtrType(CE0->getType());
         // Convert the integer value to the right size to ensure we get the
         // proper extension or truncation.
         if (Constant *C = ConstantFoldIntegerCast(CE0->getOperand(0), IntPtrTy,
                                                   /*IsSigned*/ false, DL)) {
-          Constant *Null = Constant::getNullValue(C->getType());
+          Constant *Null = Constant::getZeroValue(C->getType());
           return ConstantFoldCompareInstOperands(Predicate, C, Null, DL, TLI);
         }
       }
@@ -1362,7 +1362,7 @@ Constant *llvm::ConstantFoldCompareInstOperands(
         Type *AddrTy = DL.getAddressType(CE0->getOperand(0)->getType());
         if (CE0->getType() == AddrTy) {
           Constant *C = CE0->getOperand(0);
-          Constant *Null = Constant::getNullValue(C->getType());
+          Constant *Null = Constant::getZeroValue(C->getType());
           return ConstantFoldCompareInstOperands(Predicate, C, Null, DL, TLI);
         }
       }
@@ -1649,7 +1649,7 @@ Constant *llvm::ConstantFoldCastOperand(unsigned Opcode, Constant *C,
         APInt BaseOffset(BitWidth, 0);
         auto *Base = cast<Constant>(GEP->stripAndAccumulateConstantOffsets(
             DL, BaseOffset, /*AllowNonInbounds=*/true));
-        if (Base->isNullValue()) {
+        if (Base->isZeroValue()) {
           FoldedValue = ConstantInt::get(CE->getContext(), BaseOffset);
         } else {
           // ptrtoint/ptrtoaddr (gep i8, Ptr, (sub 0, V))
@@ -1661,7 +1661,7 @@ Constant *llvm::ConstantFoldCastOperand(unsigned Opcode, Constant *C,
             Type *IntIdxTy = DL.getIndexType(Ptr->getType());
             if (Sub && Sub->getType() == IntIdxTy &&
                 Sub->getOpcode() == Instruction::Sub &&
-                Sub->getOperand(0)->isNullValue())
+                Sub->getOperand(0)->isZeroValue())
               FoldedValue = ConstantExpr::getSub(
                   ConstantExpr::getCast(Opcode, Ptr, IntIdxTy),
                   Sub->getOperand(1));
@@ -2327,18 +2327,18 @@ Constant *constantFoldVectorReduce(Intrinsic::ID IID, Constant *Op) {
     case Intrinsic::vector_reduce_umax:
       return SplatVal;
     case Intrinsic::vector_reduce_add:
-      if (SplatVal->isNullValue())
+      if (SplatVal->isZeroValue())
         return SplatVal;
       break;
     case Intrinsic::vector_reduce_mul:
-      if (SplatVal->isNullValue() || SplatVal->isOneValue())
+      if (SplatVal->isZeroValue() || SplatVal->isOneValue())
         return SplatVal;
       break;
     case Intrinsic::vector_reduce_xor:
-      if (SplatVal->isNullValue())
+      if (SplatVal->isZeroValue())
         return SplatVal;
       if (OpVT->getElementCount().isKnownMultipleOf(2))
-        return Constant::getNullValue(OpVT->getElementType());
+        return Constant::getZeroValue(OpVT->getElementType());
       break;
     }
   }
@@ -2561,7 +2561,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
         IntrinsicID == Intrinsic::fptoui_sat ||
         IntrinsicID == Intrinsic::fptosi_sat ||
         IntrinsicID == Intrinsic::canonicalize)
-      return Constant::getNullValue(Ty);
+      return Constant::getZeroValue(Ty);
     if (IntrinsicID == Intrinsic::bswap ||
         IntrinsicID == Intrinsic::bitreverse ||
         IntrinsicID == Intrinsic::launder_invariant_group ||
@@ -3265,7 +3265,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       break;
 
     case Intrinsic::wasm_anytrue:
-      return Op->isNullValue() ? ConstantInt::get(Ty, 0)
+      return Op->isZeroValue() ? ConstantInt::get(Ty, 0)
                                : ConstantInt::get(Ty, 1);
 
     case Intrinsic::wasm_alltrue:
@@ -3274,7 +3274,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       for (unsigned I = 0; I != E; ++I) {
         Constant *Elt = Op->getAggregateElement(I);
         // Return false as soon as we find a non-true element.
-        if (Elt && Elt->isNullValue())
+        if (Elt && Elt->isZeroValue())
           return ConstantInt::get(Ty, 0);
         // Bail as soon as we find an element we cannot prove to be true.
         if (!Elt || !isa<ConstantInt>(Elt))
@@ -3798,7 +3798,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       // X - undef -> { 0, false }
       // undef - X -> { 0, false }
       if (!C0 || !C1)
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
       [[fallthrough]];
     case Intrinsic::uadd_with_overflow:
     case Intrinsic::sadd_with_overflow:
@@ -3808,7 +3808,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
         return ConstantStruct::get(
             cast<StructType>(Ty),
             {Constant::getAllOnesValue(Ty->getStructElementType(0)),
-             Constant::getNullValue(Ty->getStructElementType(1))});
+             Constant::getZeroValue(Ty->getStructElementType(1))});
       }
       [[fallthrough]];
     case Intrinsic::smul_with_overflow:
@@ -3816,7 +3816,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       // undef * X -> { 0, false }
       // X * undef -> { 0, false }
       if (!C0 || !C1)
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
 
       APInt Res;
       bool Overflow;
@@ -3862,7 +3862,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       if (!C0 && !C1)
         return UndefValue::get(Ty);
       if (!C0 || !C1)
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
       if (IntrinsicID == Intrinsic::usub_sat)
         return ConstantInt::get(Ty, C0->usub_sat(*C1));
       else
@@ -3875,7 +3875,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       if (C1->isOne() && (!C0 || C0->isZero()))
         return PoisonValue::get(Ty);
       if (!C0)
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
       if (IntrinsicID == Intrinsic::cttz)
         return ConstantInt::get(Ty, C0->countr_zero());
       else
@@ -3891,7 +3891,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
 
       // Undef operand with no poison min --> 0 (sign bit must be clear)
       if (!C0)
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
 
       return ConstantInt::get(Ty, C0->abs());
     case Intrinsic::amdgcn_wave_reduce_umin:
@@ -3971,7 +3971,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       Constant *Elt = Operands[0]->getAggregateElement(I);
       if (!Elt)
         return nullptr;
-      if (isa<UndefValue>(Elt) || Elt->isNullValue())
+      if (isa<UndefValue>(Elt) || Elt->isZeroValue())
         continue;
       return ConstantInt::get(Ty, I);
     }
@@ -4182,7 +4182,7 @@ static Constant *ConstantFoldScalarCall3(StringRef Name,
     // undef * C -> 0
     // C * undef -> 0
     if (!C0 || !C1)
-      return Constant::getNullValue(Ty);
+      return Constant::getZeroValue(Ty);
 
     // This code performs rounding towards negative infinity in case the result
     // cannot be represented exactly for the given scale. Targets that do care
@@ -4300,7 +4300,7 @@ static Constant *ConstantFoldFixedVectorCall(
         else
           return nullptr;
       }
-      if (MaskElt->isNullValue()) {
+      if (MaskElt->isZeroValue()) {
         if (!PassthruElt)
           return nullptr;
         NewElements.push_back(PassthruElt);
@@ -4489,7 +4489,7 @@ static Constant *ConstantFoldScalableVectorCall(
   switch (IntrinsicID) {
   case Intrinsic::aarch64_sve_convert_from_svbool: {
     Constant *Src = Operands[0];
-    if (!Src->isNullValue())
+    if (!Src->isZeroValue())
       break;
 
     return ConstantInt::getFalse(SVTy);
@@ -4498,7 +4498,7 @@ static Constant *ConstantFoldScalableVectorCall(
     auto *Op0 = dyn_cast<ConstantInt>(Operands[0]);
     auto *Op1 = dyn_cast<ConstantInt>(Operands[1]);
     if (Op0 && Op1 && Op0->getValue().uge(Op1->getValue()))
-      return ConstantVector::getNullValue(SVTy);
+      return ConstantVector::getZeroValue(SVTy);
     break;
   }
   case Intrinsic::vector_interleave2:
@@ -4564,7 +4564,7 @@ ConstantFoldScalarFrexpCall(Constant *Op, Type *IntTy) {
   // using undef.
   Constant *Result1 = FrexpMant.isFinite()
                           ? ConstantInt::getSigned(IntTy, FrexpExp)
-                          : ConstantInt::getNullValue(IntTy);
+                          : ConstantInt::getZeroValue(IntTy);
   return {Result0, Result1};
 }
 

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -417,7 +417,7 @@ bool GlobalsAAResult::AnalyzeIndirectGlobalMemory(GlobalVariable *GV) {
 
   // If the initializer is a valid pointer, bail.
   if (Constant *C = GV->getInitializer())
-    if (!C->isNullValue())
+    if (!C->isZeroValue())
       return false;
 
   // Walk the user list of the global.  If we find anything other than a direct

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1388,7 +1388,7 @@ InductionDescriptor::InductionDescriptor(Value *Start, InductionKind K,
 
 InductionDescriptor
 InductionDescriptor::getCanonicalIntInduction(Type *Ty, ScalarEvolution &SE) {
-  return InductionDescriptor(Constant::getNullValue(Ty), IK_IntInduction,
+  return InductionDescriptor(Constant::getZeroValue(Ty), IK_IntInduction,
                              SE.getOne(Ty));
 }
 

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2613,7 +2613,7 @@ bool CallAnalyzer::visitSelectInst(SelectInst &SI) {
 
   // Select condition is a constant.
   Value *SelectedV = CondC->isAllOnesValue()  ? TrueVal
-                     : (CondC->isNullValue()) ? FalseVal
+                     : (CondC->isZeroValue()) ? FalseVal
                                               : nullptr;
   if (!SelectedV) {
     // Condition is a vector constant that is not all 1s or all 0s.  If all

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -610,7 +610,7 @@ static Value *simplifyAddInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
 
   // If two operands are negative, return 0.
   if (isKnownNegation(Op0, Op1))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X + (Y - X) -> Y
   // (Y - X) + X -> Y
@@ -724,7 +724,7 @@ static Value *simplifyByDomEq(unsigned Opcode, Value *Op0, Value *Op1,
     case Instruction::Xor:
     case Instruction::URem:
     case Instruction::SRem:
-      return Constant::getNullValue(Ty);
+      return Constant::getZeroValue(Ty);
 
     case Instruction::SDiv:
     case Instruction::UDiv:
@@ -764,20 +764,20 @@ static Value *simplifySubInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
 
   // X - X -> 0
   if (Op0 == Op1)
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // Is this a negation?
   if (match(Op0, m_Zero())) {
     // 0 - X -> 0 if the sub is NUW.
     if (IsNUW)
-      return Constant::getNullValue(Op0->getType());
+      return Constant::getZeroValue(Op0->getType());
 
     KnownBits Known = computeKnownBits(Op1, Q);
     if (Known.Zero.isMaxSignedValue()) {
       // Op1 is either 0 or the minimum signed value. If the sub is NSW, then
       // Op1 must be 0 because negating the minimum signed value is undefined.
       if (IsNSW)
-        return Constant::getNullValue(Op0->getType());
+        return Constant::getZeroValue(Op0->getType());
 
       // 0 - X -> X if X is 0 or the minimum signed value.
       return Op1;
@@ -908,7 +908,7 @@ static Value *simplifyMulInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
   // X * undef -> 0
   // X * 0 -> 0
   if (Q.isUndefValue(Op1) || match(Op1, m_Zero()))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X * 1 -> X
   if (match(Op1, m_One()))
@@ -926,7 +926,7 @@ static Value *simplifyMulInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
     // mul i1 nsw is a special-case because -1 * -1 is poison (+1 is not
     // representable). All other cases reduce to 0, so just return 0.
     if (IsNSW)
-      return ConstantInt::getNullValue(Op0->getType());
+      return ConstantInt::getZeroValue(Op0->getType());
 
     // Treat "mul i1" as "and i1".
     if (MaxRecurse)
@@ -1070,17 +1070,17 @@ static Value *simplifyDivRem(Instruction::BinaryOps Opcode, Value *Op0,
   // undef / X -> 0
   // undef % X -> 0
   if (Q.isUndefValue(Op0))
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
 
   // 0 / X -> 0
   // 0 % X -> 0
   if (match(Op0, m_Zero()))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X / X -> 1
   // X % X -> 0
   if (Op0 == Op1)
-    return IsDiv ? ConstantInt::get(Ty, 1) : Constant::getNullValue(Ty);
+    return IsDiv ? ConstantInt::get(Ty, 1) : Constant::getZeroValue(Ty);
 
   KnownBits Known = computeKnownBits(Op1, Q);
   // X / 0 -> poison
@@ -1097,7 +1097,7 @@ static Value *simplifyDivRem(Instruction::BinaryOps Opcode, Value *Op0,
   // or remainder-by-zero, so assume the divisor is 1.
   //   e.g. 1, zext (i8 X), sdiv X (Y and 1)
   if (Known.countMinLeadingZeros() == Known.getBitWidth() - 1)
-    return IsDiv ? Op0 : Constant::getNullValue(Ty);
+    return IsDiv ? Op0 : Constant::getZeroValue(Ty);
 
   // If X * Y does not overflow, then:
   //   X * Y / Y -> X
@@ -1111,12 +1111,12 @@ static Value *simplifyDivRem(Instruction::BinaryOps Opcode, Value *Op0,
         (!IsSigned && Q.IIQ.hasNoUnsignedWrap(Mul)) ||
         (IsSigned && match(X, m_SDiv(m_Value(), m_Specific(Op1)))) ||
         (!IsSigned && match(X, m_UDiv(m_Value(), m_Specific(Op1))))) {
-      return IsDiv ? X : Constant::getNullValue(Op0->getType());
+      return IsDiv ? X : Constant::getZeroValue(Op0->getType());
     }
   }
 
   if (isDivZero(Op0, Op1, Q, MaxRecurse, IsSigned))
-    return IsDiv ? Constant::getNullValue(Op0->getType()) : Op0;
+    return IsDiv ? Constant::getZeroValue(Op0->getType()) : Op0;
 
   if (Value *V = simplifyByDomEq(Opcode, Op0, Op1, Q, MaxRecurse))
     return V;
@@ -1186,7 +1186,7 @@ static Value *simplifyRem(Instruction::BinaryOps Opcode, Value *Op0, Value *Op1,
          match(Op0, m_NSWShl(m_Specific(Op1), m_Value()))) ||
         (Opcode == Instruction::URem &&
          match(Op0, m_NUWShl(m_Specific(Op1), m_Value()))))
-      return Constant::getNullValue(Op0->getType());
+      return Constant::getZeroValue(Op0->getType());
 
     const APInt *C0;
     if (match(Op1, m_APInt(C0))) {
@@ -1201,7 +1201,7 @@ static Value *simplifyRem(Instruction::BinaryOps Opcode, Value *Op0, Value *Op1,
                       m_NUWMul(m_Value(), m_CheckedInt([C0](const APInt &C) {
                                  return C.urem(*C0).isZero();
                                }))))
-        return Constant::getNullValue(Op0->getType());
+        return Constant::getZeroValue(Op0->getType());
     }
   }
   return nullptr;
@@ -1243,11 +1243,11 @@ static Value *simplifySRemInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
   // srem Op0, (sext i1 X) --> srem Op0, -1 --> 0
   Value *X;
   if (match(Op1, m_SExt(m_Value(X))) && X->getType()->isIntOrIntVectorTy(1))
-    return ConstantInt::getNullValue(Op0->getType());
+    return ConstantInt::getZeroValue(Op0->getType());
 
   // If the two operands are negated, return 0.
   if (isKnownNegation(Op0, Op1))
-    return ConstantInt::getNullValue(Op0->getType());
+    return ConstantInt::getZeroValue(Op0->getType());
 
   return simplifyRem(Instruction::SRem, Op0, Op1, Q, MaxRecurse);
 }
@@ -1311,7 +1311,7 @@ static Value *simplifyShift(Instruction::BinaryOps Opcode, Value *Op0,
 
   // 0 shift by X -> 0
   if (match(Op0, m_Zero()))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X shift by 0 -> X
   // Shift-by-sign-extended bool must be shift-by-0 because shift-by-all-ones
@@ -1378,12 +1378,12 @@ static Value *simplifyRightShift(Instruction::BinaryOps Opcode, Value *Op0,
 
   // X >> X -> 0
   if (Op0 == Op1)
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // undef >> X -> 0
   // undef >> X -> undef (if it's exact)
   if (Q.isUndefValue(Op0))
-    return IsExact ? Op0 : Constant::getNullValue(Op0->getType());
+    return IsExact ? Op0 : Constant::getZeroValue(Op0->getType());
 
   // The low bit cannot be shifted out of an exact shift if it is set.
   // TODO: Generalize by counting trailing zeros (see fold for exact division).
@@ -1408,7 +1408,7 @@ static Value *simplifyShlInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
   // undef << X -> 0
   // undef << X -> undef if (if it's NSW/NUW)
   if (Q.isUndefValue(Op0))
-    return IsNSW || IsNUW ? Op0 : Constant::getNullValue(Ty);
+    return IsNSW || IsNUW ? Op0 : Constant::getZeroValue(Ty);
 
   // (X >> A) << A -> X
   Value *X;
@@ -1427,7 +1427,7 @@ static Value *simplifyShlInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
   // produce poison is 0, and "0 << (bitwidth-1) --> 0".
   if (IsNSW && IsNUW &&
       match(Op1, m_SpecificInt(Ty->getScalarSizeInBits() - 1)))
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
 
   return nullptr;
 }
@@ -2008,7 +2008,7 @@ static Value *simplifyLogicOfAddSub(Value *Op0, Value *Op1,
       // (X + C) | (~C - X) --> (X + C) | ~(X + C) --> -1
       // (X + C) ^ (~C - X) --> (X + C) ^ ~(X + C) --> -1
       Type *Ty = Op0->getType();
-      return Opcode == Instruction::And ? ConstantInt::getNullValue(Ty)
+      return Opcode == Instruction::And ? ConstantInt::getZeroValue(Ty)
                                         : ConstantInt::getAllOnesValue(Ty);
     }
   }
@@ -2021,7 +2021,7 @@ static Value *simplifyAndCommutative(Value *Op0, Value *Op1,
                                      unsigned MaxRecurse) {
   // ~A & A =  0
   if (match(Op0, m_Not(m_Specific(Op1))))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // (A | ?) & A = A
   if (match(Op0, m_c_Or(m_Specific(Op1), m_Value())))
@@ -2048,7 +2048,7 @@ static Value *simplifyAndCommutative(Value *Op0, Value *Op1,
   // (A - 1) & A --> 0 (if A is a power-of-2 or 0)
   if (match(Op0, m_Add(m_Specific(Op1), m_AllOnes())) &&
       isKnownToBeAPowerOfTwo(Op1, Q.DL, /*OrZero*/ true, Q.AC, Q.CxtI, Q.DT))
-    return Constant::getNullValue(Op1->getType());
+    return Constant::getZeroValue(Op1->getType());
 
   // (x << N) & ((x << M) - 1) --> 0, where x is known to be a power of 2 and
   // M <= N.
@@ -2057,7 +2057,7 @@ static Value *simplifyAndCommutative(Value *Op0, Value *Op1,
       match(Op1, m_Add(m_Shl(m_Specific(X), m_APInt(Shift2)), m_AllOnes())) &&
       isKnownToBeAPowerOfTwo(X, Q.DL, /*OrZero*/ true, Q.AC, Q.CxtI) &&
       Shift1->uge(*Shift2))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   if (Value *V =
           simplifyAndOrWithICmpEq(Instruction::And, Op0, Op1, Q, MaxRecurse))
@@ -2079,7 +2079,7 @@ static Value *simplifyAndInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
 
   // X & undef -> 0
   if (Q.isUndefValue(Op1))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X & X = X
   if (Op0 == Op1)
@@ -2087,7 +2087,7 @@ static Value *simplifyAndInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
 
   // X & 0 = 0
   if (match(Op1, m_Zero()))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // X & -1 = X
   if (match(Op1, m_AllOnes()))
@@ -2129,7 +2129,7 @@ static Value *simplifyAndInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
     KnownBits Known = computeKnownBits(Shift, Q);
     // Use getActiveBits() to make use of the additional power of two knowledge
     if (PowerC->getActiveBits() >= Known.getMaxValue().getActiveBits())
-      return ConstantInt::getNullValue(Op1->getType());
+      return ConstantInt::getZeroValue(Op1->getType());
   }
 
   if (Value *V = simplifyAndOrOfCmps(Q, Op0, Op1, true))
@@ -2213,14 +2213,14 @@ static Value *simplifyAndInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
                          m_CombineAnd(m_BinOp(Or),
                                       m_c_Or(m_Deferred(X), m_Value(Y))))) &&
       match(Op1, m_c_Xor(m_Specific(Or), m_Specific(Y))))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   const APInt *C1;
   Value *A;
   // (A ^ C) & (A ^ ~C) -> 0
   if (match(Op0, m_Xor(m_Value(A), m_APInt(C1))) &&
       match(Op1, m_Xor(m_Specific(A), m_SpecificInt(~*C1))))
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   if (Op0->getType()->isIntOrIntVectorTy(1)) {
     if (std::optional<bool> Implied = isImpliedCondition(Op0, Op1, Q.DL)) {
@@ -2546,7 +2546,7 @@ static Value *simplifyXorInst(Value *Op0, Value *Op1, const SimplifyQuery &Q,
 
   // A ^ A = 0
   if (Op0 == Op1)
-    return Constant::getNullValue(Op0->getType());
+    return Constant::getZeroValue(Op0->getType());
 
   // A ^ ~A  =  ~A ^ A  =  -1
   if (match(Op0, m_Not(m_Specific(Op1))) || match(Op1, m_Not(m_Specific(Op0))))
@@ -3384,14 +3384,14 @@ static Value *simplifyICmpWithBinOp(CmpPredicate Pred, Value *LHS, Value *RHS,
     // icmp (X+Y), X -> icmp Y, 0 for equalities or if there is no overflow.
     if ((A == RHS || B == RHS) && NoLHSWrapProblem)
       if (Value *V = simplifyICmpInst(Pred, A == RHS ? B : A,
-                                      Constant::getNullValue(RHS->getType()), Q,
+                                      Constant::getZeroValue(RHS->getType()), Q,
                                       MaxRecurse - 1))
         return V;
 
     // icmp X, (X+Y) -> icmp 0, Y for equalities or if there is no overflow.
     if ((C == LHS || D == LHS) && NoRHSWrapProblem)
       if (Value *V =
-              simplifyICmpInst(Pred, Constant::getNullValue(LHS->getType()),
+              simplifyICmpInst(Pred, Constant::getZeroValue(LHS->getType()),
                                C == LHS ? D : C, Q, MaxRecurse - 1))
         return V;
 
@@ -3970,7 +3970,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
 
         // Otherwise the upper bits of LHS are zero while RHS has a non-zero bit
         // there.  Use this to work out the result of the comparison.
-        if (AnyEq->isNullValue()) {
+        if (AnyEq->isZeroValue()) {
           switch (Pred) {
           default:
             llvm_unreachable("Unknown ICmp predicate!");
@@ -3978,7 +3978,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
           case ICmpInst::ICMP_EQ:
           case ICmpInst::ICMP_UGT:
           case ICmpInst::ICMP_UGE:
-            return Constant::getNullValue(ITy);
+            return Constant::getZeroValue(ITy);
 
           case ICmpInst::ICMP_NE:
           case ICmpInst::ICMP_ULT:
@@ -3990,12 +3990,12 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
           case ICmpInst::ICMP_SGT:
           case ICmpInst::ICMP_SGE:
             return ConstantFoldCompareInstOperands(
-                ICmpInst::ICMP_SLT, C, Constant::getNullValue(C->getType()),
+                ICmpInst::ICMP_SLT, C, Constant::getZeroValue(C->getType()),
                 Q.DL);
           case ICmpInst::ICMP_SLT:
           case ICmpInst::ICMP_SLE:
             return ConstantFoldCompareInstOperands(
-                ICmpInst::ICMP_SGE, C, Constant::getNullValue(C->getType()),
+                ICmpInst::ICMP_SGE, C, Constant::getZeroValue(C->getType()),
                 Q.DL);
           }
         }
@@ -4047,12 +4047,12 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
 
         // Otherwise the upper bits of LHS are all equal, while RHS has varying
         // bits there.  Use this to work out the result of the comparison.
-        if (AnyEq->isNullValue()) {
+        if (AnyEq->isZeroValue()) {
           switch (Pred) {
           default:
             llvm_unreachable("Unknown ICmp predicate!");
           case ICmpInst::ICMP_EQ:
-            return Constant::getNullValue(ITy);
+            return Constant::getZeroValue(ITy);
           case ICmpInst::ICMP_NE:
             return Constant::getAllOnesValue(ITy);
 
@@ -4061,12 +4061,12 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
           case ICmpInst::ICMP_SGT:
           case ICmpInst::ICMP_SGE:
             return ConstantFoldCompareInstOperands(
-                ICmpInst::ICMP_SLT, C, Constant::getNullValue(C->getType()),
+                ICmpInst::ICMP_SLT, C, Constant::getZeroValue(C->getType()),
                 Q.DL);
           case ICmpInst::ICMP_SLT:
           case ICmpInst::ICMP_SLE:
             return ConstantFoldCompareInstOperands(
-                ICmpInst::ICMP_SGE, C, Constant::getNullValue(C->getType()),
+                ICmpInst::ICMP_SGE, C, Constant::getZeroValue(C->getType()),
                 Q.DL);
 
           // If LHS is non-negative then LHS <u RHS.  If LHS is negative then
@@ -4076,7 +4076,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
             // Comparison is true iff the LHS <s 0.
             if (MaxRecurse)
               if (Value *V = simplifyICmpInst(ICmpInst::ICMP_SLT, SrcOp,
-                                              Constant::getNullValue(SrcTy), Q,
+                                              Constant::getZeroValue(SrcTy), Q,
                                               MaxRecurse - 1))
                 return V;
             break;
@@ -4085,7 +4085,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
             // Comparison is true iff the LHS >=s 0.
             if (MaxRecurse)
               if (Value *V = simplifyICmpInst(ICmpInst::ICMP_SGE, SrcOp,
-                                              Constant::getNullValue(SrcTy), Q,
+                                              Constant::getZeroValue(SrcTy), Q,
                                               MaxRecurse - 1))
                 return V;
             break;
@@ -4495,7 +4495,7 @@ static Value *simplifyWithOpsReplaced(Value *V,
       if ((Opcode == Instruction::Sub || Opcode == Instruction::Xor) &&
           NewOps[0] == NewOps[1] &&
           any_of(Ops, [=](const auto &Rep) { return NewOps[0] == Rep.second; }))
-        return Constant::getNullValue(I->getType());
+        return Constant::getZeroValue(I->getType());
 
       // If we are substituting an absorber constant into a binop and extra
       // poison can't leak if we remove the select -- because both operands of
@@ -6028,7 +6028,7 @@ simplifyFSubInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   if (FMF.noNaNs()) {
     // fsub nnan x, x ==> 0.0
     if (Op0 == Op1)
-      return Constant::getNullValue(Op0->getType());
+      return Constant::getZeroValue(Op0->getType());
 
     // With nnan: {+/-}Inf - X --> {+/-}Inf
     if (match(Op0, m_Inf()))
@@ -6797,20 +6797,20 @@ static Value *simplifySVEIntReduction(Intrinsic::ID IID, Type *ReturnType,
   case Intrinsic::aarch64_sve_saddv:
   case Intrinsic::aarch64_sve_uaddv:
   case Intrinsic::aarch64_sve_umaxv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isNullValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isZeroValue()))
       return ConstantInt::get(ReturnType, 0);
     break;
   case Intrinsic::aarch64_sve_andv:
   case Intrinsic::aarch64_sve_uminv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isAllOnesValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isAllOnesValue()))
       return ConstantInt::get(ReturnType, APInt::getMaxValue(Width));
     break;
   case Intrinsic::aarch64_sve_smaxv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isMinSignedValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isMinSignedValue()))
       return ConstantInt::get(ReturnType, APInt::getSignedMinValue(Width));
     break;
   case Intrinsic::aarch64_sve_sminv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isMaxSignedValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isMaxSignedValue()))
       return ConstantInt::get(ReturnType, APInt::getSignedMaxValue(Width));
     break;
   }
@@ -6889,14 +6889,14 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     if (match(Op0, m_LShr(m_Negative(), m_Value(X))))
       return X;
     if (match(Op0, m_AShr(m_Negative(), m_Value())))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     break;
   }
   case Intrinsic::ptrmask: {
     // NOTE: We can't apply this simplifications based on the value of Op1
     // because we need to preserve provenance.
     if (Q.isUndefValue(Op0) || match(Op0, m_Zero()))
-      return Constant::getNullValue(Op0->getType());
+      return Constant::getZeroValue(Op0->getType());
 
     assert(Op1->getType()->getScalarSizeInBits() ==
                Q.DL.getIndexTypeSizeInBits(Op0->getType()) &&
@@ -6992,7 +6992,7 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     // Fold to a constant if the relationship between operands can be
     // established with certainty
     if (isICmpTrue(CmpInst::ICMP_EQ, Op0, Op1, Q, RecursionLimit))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
 
     ICmpInst::Predicate PredGT =
         IID == Intrinsic::scmp ? ICmpInst::ICMP_SGT : ICmpInst::ICMP_UGT;
@@ -7012,7 +7012,7 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     // X - undef -> { 0, false }
     // undef - X -> { 0, false }
     if (Op0 == Op1 || Q.isUndefValue(Op0) || Q.isUndefValue(Op1))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     break;
   case Intrinsic::uadd_with_overflow:
   case Intrinsic::sadd_with_overflow:
@@ -7022,7 +7022,7 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
       return ConstantStruct::get(
           cast<StructType>(ReturnType),
           {Constant::getAllOnesValue(ReturnType->getStructElementType(0)),
-           Constant::getNullValue(ReturnType->getStructElementType(1))});
+           Constant::getZeroValue(ReturnType->getStructElementType(1))});
     }
     break;
   case Intrinsic::umul_with_overflow:
@@ -7030,11 +7030,11 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     // 0 * X -> { 0, false }
     // X * 0 -> { 0, false }
     if (match(Op0, m_Zero()) || match(Op1, m_Zero()))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     // undef * X -> { 0, false }
     // X * undef -> { 0, false }
     if (Q.isUndefValue(Op0) || Q.isUndefValue(Op1))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     break;
   case Intrinsic::uadd_sat:
     // sat(MAX + X) -> MAX
@@ -7060,12 +7060,12 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
   case Intrinsic::usub_sat:
     // sat(0 - X) -> 0, sat(X - MAX) -> 0
     if (match(Op0, m_Zero()) || match(Op1, m_AllOnes()))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     [[fallthrough]];
   case Intrinsic::ssub_sat:
     // X - X -> 0, X - undef -> 0, undef - X -> 0
     if (Op0 == Op1 || Q.isUndefValue(Op0) || Q.isUndefValue(Op1))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
     // X - 0 -> X
     if (match(Op1, m_Zero()))
       return Op0;
@@ -7290,7 +7290,7 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
 
     // Rotating zero by anything is zero.
     if (match(Op0, m_Zero()) && match(Op1, m_Zero()))
-      return ConstantInt::getNullValue(F->getReturnType());
+      return ConstantInt::getZeroValue(F->getReturnType());
 
     // Rotating -1 by anything is -1.
     if (match(Op0, m_AllOnes()) && match(Op1, m_AllOnes()))
@@ -7327,11 +7327,11 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
 
     // X * 0 -> 0
     if (match(Op1, m_Zero()))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
 
     // X * undef -> 0
     if (Q.isUndefValue(Op1))
-      return Constant::getNullValue(ReturnType);
+      return Constant::getZeroValue(ReturnType);
 
     // X * (1 << Scale) -> X
     APInt ScaledOne =

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -863,14 +863,14 @@ void LazyValueInfoImpl::intersectAssumeOrGuardBlockValueConstantRange(
         switch (RK.AttrKind) {
         case Attribute::NonNull:
           BBLV = BBLV.intersect(ValueLatticeElement::getNot(
-              Constant::getNullValue(RK.WasOn->getType())));
+              Constant::getZeroValue(RK.WasOn->getType())));
           break;
 
         case Attribute::Dereferenceable:
           if (auto *CI = dyn_cast<ConstantInt>(RK.IRArgValue);
               CI && !CI->isZero())
             BBLV = BBLV.intersect(ValueLatticeElement::getNot(
-                Constant::getNullValue(RK.WasOn->getType())));
+                Constant::getZeroValue(RK.WasOn->getType())));
           break;
 
         default:
@@ -1465,7 +1465,7 @@ std::optional<ValueLatticeElement> LazyValueInfoImpl::getValueFromICmpCondition(
     match(X, m_PtrToIntSameSize(DL, m_Value(X)));
     match(Y, m_PtrToIntSameSize(DL, m_Value(Y)));
     if ((X == LHS && Y == RHS) || (X == RHS && Y == LHS)) {
-      Constant *NullVal = Constant::getNullValue(Val->getType());
+      Constant *NullVal = Constant::getZeroValue(Val->getType());
       if (EdgePred == ICmpInst::ICMP_EQ)
         return ValueLatticeElement::get(NullVal);
       return ValueLatticeElement::getNot(NullVal);
@@ -1488,11 +1488,11 @@ ValueLatticeElement LazyValueInfoImpl::getValueFromTrunc(Value *Val,
   if (Trunc->hasNoUnsignedWrap()) {
     if (IsTrueDest)
       return ValueLatticeElement::get(ConstantInt::get(Ty, 1));
-    return ValueLatticeElement::get(Constant::getNullValue(Ty));
+    return ValueLatticeElement::get(Constant::getZeroValue(Ty));
   }
 
   if (IsTrueDest)
-    return ValueLatticeElement::getNot(Constant::getNullValue(Ty));
+    return ValueLatticeElement::getNot(Constant::getZeroValue(Ty));
   return ValueLatticeElement::getNot(Constant::getAllOnesValue(Ty));
 }
 
@@ -2080,13 +2080,13 @@ static Constant *getPredicateResult(CmpInst::Predicate Pred, Constant *C,
       // !C1 == C -> false iff C1 == C.
       Constant *Res = ConstantFoldCompareInstOperands(
           ICmpInst::ICMP_NE, Val.getNotConstant(), C, DL);
-      if (Res && Res->isNullValue())
+      if (Res && Res->isZeroValue())
         return ConstantInt::getFalse(ResTy);
     } else if (Pred == ICmpInst::ICMP_NE) {
       // !C1 != C -> true iff C1 == C.
       Constant *Res = ConstantFoldCompareInstOperands(
           ICmpInst::ICMP_NE, Val.getNotConstant(), C, DL);
-      if (Res && Res->isNullValue())
+      if (Res && Res->isZeroValue())
         return ConstantInt::getTrue(ResTy);
     }
     return nullptr;
@@ -2115,7 +2115,7 @@ Constant *LazyValueInfo::getPredicateAt(CmpInst::Predicate Pred, Value *V,
   // return it quickly. But this is only a fastpath, and falling
   // through would still be correct.
   const DataLayout &DL = CxtI->getDataLayout();
-  if (V->getType()->isPointerTy() && C->isNullValue() &&
+  if (V->getType()->isPointerTy() && C->isZeroValue() &&
       isKnownNonZero(V->stripPointerCastsSameRepresentation(), DL)) {
     Type *ResTy = CmpInst::makeCmpResultType(C->getType());
     if (Pred == ICmpInst::ICMP_EQ)

--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -553,7 +553,7 @@ static bool isZero(Value *V, const DataLayout &DL, DominatorTree *DT,
   if (!C)
     return false;
 
-  if (C->isNullValue())
+  if (C->isZeroValue())
     return true;
 
   // For a vector, KnownZero will only be true if all values are zero, so check

--- a/llvm/lib/Analysis/Local.cpp
+++ b/llvm/lib/Analysis/Local.cpp
@@ -41,7 +41,7 @@ Value *llvm::emitGEPOffset(IRBuilderBase *Builder, const DataLayout &DL,
        ++i, ++GTI) {
     Value *Op = *i;
     if (Constant *OpC = dyn_cast<Constant>(Op)) {
-      if (OpC->isNullValue())
+      if (OpC->isZeroValue())
         continue;
 
       // Handle a struct index, which adds its field offset to the pointer.
@@ -75,5 +75,5 @@ Value *llvm::emitGEPOffset(IRBuilderBase *Builder, const DataLayout &DL,
     }
     AddOffset(Op);
   }
-  return Result ? Result : Constant::getNullValue(IntIdxTy);
+  return Result ? Result : Constant::getZeroValue(IntIdxTy);
 }

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -439,7 +439,7 @@ Constant *llvm::getInitialValueOfAllocation(const Value *V,
   if ((AK & AllocFnKind::Uninitialized) != AllocFnKind::Unknown)
     return UndefValue::get(Ty);
   if ((AK & AllocFnKind::Zeroed) != AllocFnKind::Unknown)
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
 
   return nullptr;
 }
@@ -713,7 +713,7 @@ Value *llvm::lowerObjectSizeCall(
     return nullptr;
 
   return MaxVal ? Constant::getAllOnesValue(ResultType)
-                : Constant::getNullValue(ResultType);
+                : Constant::getZeroValue(ResultType);
 }
 
 STATISTIC(ObjectVisitorArgument,

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -152,7 +152,7 @@ static bool CanProveNotTakenFirstIteration(const BasicBlock *ExitBlock,
   if (!SimpleCst)
     return false;
   if (ExitBlock == BI->getSuccessor(0))
-    return SimpleCst->isNullValue();
+    return SimpleCst->isZeroValue();
   assert(ExitBlock == BI->getSuccessor(1) && "implied by above");
   return SimpleCst->isAllOnesValue();
 }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -9805,7 +9805,7 @@ ScalarEvolution::ExitLimit ScalarEvolution::computeShiftCompareExitLimit(
   assert(Result->getType()->isIntegerTy(1) &&
          "Otherwise cannot be an operand to a branch instruction");
 
-  if (Result->isNullValue()) {
+  if (Result->isZeroValue()) {
     unsigned BitWidth = getTypeSizeInBits(RHS->getType());
     const SCEV *UpperBound =
         getConstant(getEffectiveSCEVType(RHS->getType()), BitWidth);

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1724,7 +1724,7 @@ static void computeKnownBitsFromOperator(const Operator *I,
 
       // Handle case when index is zero.
       Constant *CIndex = dyn_cast<Constant>(Index);
-      if (CIndex && CIndex->isNullValue())
+      if (CIndex && CIndex->isZeroValue())
         continue;
 
       if (StructType *STy = GTI.getStructTypeOrNull()) {
@@ -3121,7 +3121,7 @@ static bool isNonZeroSub(const APInt &DemandedElts, const SimplifyQuery &Q,
 
   // TODO: Move this case into isKnownNonEqual().
   if (auto *C = dyn_cast<Constant>(X))
-    if (C->isNullValue() && isKnownNonZero(Y, DemandedElts, Q, Depth))
+    if (C->isZeroValue() && isKnownNonZero(Y, DemandedElts, Q, Depth))
       return true;
 
   return ::isKnownNonEqual(X, Y, DemandedElts, Q, Depth);
@@ -3697,7 +3697,7 @@ bool isKnownNonZero(const Value *V, const APInt &DemandedElts,
 #endif
 
   if (auto *C = dyn_cast<Constant>(V)) {
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return false;
     if (isa<ConstantInt>(C))
       // Must be non-zero due to null test above.
@@ -3710,7 +3710,7 @@ bool isKnownNonZero(const Value *V, const APInt &DemandedElts,
         if (!DemandedElts[i])
           continue;
         Constant *Elt = C->getAggregateElement(i);
-        if (!Elt || Elt->isNullValue())
+        if (!Elt || Elt->isZeroValue())
           return false;
         if (!isa<PoisonValue>(Elt) && !isa<ConstantInt>(Elt))
           return false;
@@ -4464,7 +4464,7 @@ static unsigned ComputeNumSignBitsImpl(const Value *V,
 
       // Handle NEG.
       if (const auto *CLHS = dyn_cast<Constant>(U->getOperand(0)))
-        if (CLHS->isNullValue()) {
+        if (CLHS->isZeroValue()) {
           KnownBits Known(TyBits);
           computeKnownBits(U->getOperand(1), DemandedElts, Known, Q, Depth + 1);
           // If the input is known to be 0 or 1, the output is 0/-1, which is
@@ -6415,8 +6415,8 @@ Value *llvm::isBytewiseValue(Value *V, const DataLayout &DL) {
   }
 
   // Handle 'null' ConstantArrayZero etc.
-  if (C->isNullValue())
-    return Constant::getNullValue(Type::getInt8Ty(Ctx));
+  if (C->isZeroValue())
+    return Constant::getZeroValue(Type::getInt8Ty(Ctx));
 
   // Constant floating-point values can be handled as integer values if the
   // corresponding integer value is "byteable".  An important case is 0.0.
@@ -6692,7 +6692,7 @@ bool llvm::getConstantDataArrayInfo(const Value *V,
   ConstantDataArray *Array = nullptr;
   ArrayType *ArrayTy = nullptr;
 
-  if (GV->getInitializer()->isNullValue()) {
+  if (GV->getInitializer()->isZeroValue()) {
     Type *GVTy = GV->getValueType();
     uint64_t SizeInBytes = DL.getTypeStoreSize(GVTy).getFixedValue();
     uint64_t Length = SizeInBytes / ElementSizeInBytes;
@@ -8728,7 +8728,7 @@ bool llvm::isKnownNegation(const Value *X, const Value *Y, bool NeedNSW,
       return false;
 
     auto *Zero = cast<Constant>(BO->getOperand(0));
-    if (!AllowPoison && !Zero->isNullValue())
+    if (!AllowPoison && !Zero->isZeroValue())
       return false;
 
     return true;

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -345,7 +345,7 @@ Value *llvm::findScalarElement(Value *V, unsigned EltNo) {
   Value *Val; Constant *C;
   if (match(V, m_Add(m_Value(Val), m_Constant(C))))
     if (Constant *Elt = C->getAggregateElement(EltNo))
-      if (Elt->isNullValue())
+      if (Elt->isZeroValue())
         return findScalarElement(Val, EltNo);
 
   // If the vector is a splat then we can trivially find the scalar element.
@@ -1259,7 +1259,7 @@ bool llvm::maskIsAllZeroOrUndef(Value *Mask) {
   auto *ConstMask = dyn_cast<Constant>(Mask);
   if (!ConstMask)
     return false;
-  if (ConstMask->isNullValue() || isa<UndefValue>(ConstMask))
+  if (ConstMask->isZeroValue() || isa<UndefValue>(ConstMask))
     return true;
   if (isa<ScalableVectorType>(ConstMask->getType()))
     return false;
@@ -1268,7 +1268,7 @@ bool llvm::maskIsAllZeroOrUndef(Value *Mask) {
            E = cast<FixedVectorType>(ConstMask->getType())->getNumElements();
        I != E; ++I) {
     if (auto *MaskElt = ConstMask->getAggregateElement(I))
-      if (MaskElt->isNullValue() || isa<UndefValue>(MaskElt))
+      if (MaskElt->isZeroValue() || isa<UndefValue>(MaskElt))
         continue;
     return false;
   }
@@ -1340,7 +1340,7 @@ APInt llvm::possiblyDemandedEltsInMask(Value *Mask) {
   APInt DemandedElts = APInt::getAllOnes(VWidth);
   if (auto *CV = dyn_cast<ConstantVector>(Mask))
     for (unsigned i = 0; i < VWidth; i++)
-      if (CV->getAggregateElement(i)->isNullValue())
+      if (CV->getAggregateElement(i)->isZeroValue())
         DemandedElts.clearBit(i);
   return DemandedElts;
 }

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6829,12 +6829,12 @@ bool LLParser::convertValIDToValue(Type *Ty, ValID &ID, Value *&V,
     if (auto *TETy = dyn_cast<TargetExtType>(Ty))
       if (!TETy->hasProperty(TargetExtType::HasZeroInit))
         return error(ID.Loc, "invalid type for null constant");
-    V = Constant::getNullValue(Ty);
+    V = Constant::getZeroValue(Ty);
     return false;
   case ValID::t_None:
     if (!Ty->isTokenTy())
       return error(ID.Loc, "invalid type for none constant");
-    V = Constant::getNullValue(Ty);
+    V = Constant::getZeroValue(Ty);
     return false;
   case ValID::t_Poison:
     // FIXME: LabelTy should not be a first-class type.
@@ -6910,7 +6910,7 @@ bool LLParser::parseConstantValue(Type *Ty, Constant *&C) {
     return false;
   }
   case ValID::t_Null:
-    C = Constant::getNullValue(Ty);
+    C = Constant::getZeroValue(Ty);
     return false;
   default:
     return error(Loc, "expected a constant value");

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -3349,7 +3349,7 @@ Error BitcodeReader::parseConstants() {
       if (auto *TETy = dyn_cast<TargetExtType>(CurTy))
         if (!TETy->hasProperty(TargetExtType::HasZeroInit))
           return error("Invalid type for a constant null value");
-      V = Constant::getNullValue(CurTy);
+      V = Constant::getZeroValue(CurTy);
       break;
     case bitc::CST_CODE_INTEGER:   // INTEGER: [intval]
       if (!CurTy->isIntOrIntVectorTy() || Record.empty())

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -2874,7 +2874,7 @@ void ModuleBitcodeWriter::writeConstants(unsigned FirstVal, unsigned LastVal,
     const Constant *C = cast<Constant>(V);
     unsigned Code = -1U;
     unsigned AbbrevToUse = 0;
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Code = bitc::CST_CODE_NULL;
     } else if (isa<PoisonValue>(C)) {
       Code = bitc::CST_CODE_POISON;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3653,7 +3653,7 @@ void AsmPrinter::preprocessXXStructorList(const DataLayout &DL,
   // Gather the structors in a form that's convenient for sorting by priority.
   for (Value *O : cast<ConstantArray>(List)->operands()) {
     auto *CS = cast<ConstantStruct>(O);
-    if (CS->getOperand(1)->isNullValue())
+    if (CS->getOperand(1)->isZeroValue())
       break; // Found a null terminator, skip the rest.
     ConstantInt *Priority = dyn_cast<ConstantInt>(CS->getOperand(0));
     if (!Priority)
@@ -3662,7 +3662,7 @@ void AsmPrinter::preprocessXXStructorList(const DataLayout &DL,
     Structor &S = Structors.back();
     S.Priority = Priority->getLimitedValue(65535);
     S.Func = CS->getOperand(1);
-    if (!CS->getOperand(2)->isNullValue()) {
+    if (!CS->getOperand(2)->isZeroValue()) {
       if (TM.getTargetTriple().isOSAIX()) {
         CS->getContext().emitError(
             "associated data of XXStructor list is not yet supported on AIX");
@@ -3861,7 +3861,7 @@ const MCExpr *AsmPrinter::lowerConstant(const Constant *CV,
                                         uint64_t Offset) {
   MCContext &Ctx = OutContext;
 
-  if (CV->isNullValue() || isa<UndefValue>(CV))
+  if (CV->isZeroValue() || isa<UndefValue>(CV))
     return MCConstantExpr::create(0, Ctx);
 
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(CV))

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -671,7 +671,7 @@ bool AtomicExpandImpl::expandAtomicLoadToCmpXchg(LoadInst *LI) {
 
   Value *Addr = LI->getPointerOperand();
   Type *Ty = LI->getType();
-  Constant *DummyVal = Constant::getNullValue(Ty);
+  Constant *DummyVal = Constant::getZeroValue(Ty);
 
   Value *Pair = Builder.CreateAtomicCmpXchg(
       Addr, DummyVal, DummyVal, LI->getAlign(), Order,
@@ -945,7 +945,7 @@ static PartwordMaskValues createMaskInstrs(IRBuilderBase &Builder,
   } else {
     // If the alignment is high enough, the LSB are known 0.
     PMV.AlignedAddr = Addr;
-    PtrLSB = ConstantInt::getNullValue(IntTy);
+    PtrLSB = ConstantInt::getZeroValue(IntTy);
   }
 
   if (DL.isLittleEndian()) {

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -1848,7 +1848,7 @@ bool CodeGenPrepare::unfoldPowerOf2Test(CmpInst *Cmp) {
         (Pred == CmpInst::ICMP_ULT || Pred == CmpInst::ICMP_EQ)
             ? CmpInst::ICMP_EQ
             : CmpInst::ICMP_NE;
-    NewCmp = Builder.CreateICmp(NewPred, And, ConstantInt::getNullValue(OpTy));
+    NewCmp = Builder.CreateICmp(NewPred, And, ConstantInt::getZeroValue(OpTy));
   } else {
     // ctpop(x) == 1 -> (x ^ (x - 1)) u> (x - 1)
     // ctpop(x) != 1 -> (x ^ (x - 1)) u<= (x - 1)
@@ -2243,7 +2243,7 @@ static bool foldURemOfLoopIncrement(Instruction *Rem, const DataLayout *DL,
   Value *RemAdd = Builder.CreateNUWAdd(NewRem, ConstantInt::get(Ty, 1));
   Value *RemCmp = Builder.CreateICmp(ICmpInst::ICMP_EQ, RemAdd, RemAmt);
   Value *RemSel =
-      Builder.CreateSelect(RemCmp, Constant::getNullValue(Ty), RemAdd);
+      Builder.CreateSelect(RemCmp, Constant::getZeroValue(Ty), RemAdd);
 
   NewRem->addIncoming(Start, L->getLoopPreheader());
   NewRem->addIncoming(RemSel, L->getLoopLatch());
@@ -2636,7 +2636,7 @@ static bool despeculateCountZeros(IntrinsicInst *CountZeros,
 
   // Replace the unconditional branch that was created by the first split with
   // a compare against zero and a conditional branch.
-  Value *Zero = Constant::getNullValue(Ty);
+  Value *Zero = Constant::getZeroValue(Ty);
   // Avoid introducing branch on poison. This also replaces the ctz operand.
   if (!isGuaranteedNotToBeUndefOrPoison(Op))
     Op = Builder.CreateFreeze(Op, Op->getName() + ".fr");
@@ -4291,7 +4291,7 @@ private:
     }
     assert(CommonType && "At least one non-null value must be!");
     for (auto *V : NullValue)
-      Map[V] = Constant::getNullValue(CommonType);
+      Map[V] = Constant::getZeroValue(CommonType);
     return true;
   }
 
@@ -6072,7 +6072,7 @@ bool CodeGenPrepare::optimizeMemoryInst(Instruction *MemoryInst, Value *Addr,
 
     if (!ResultPtr && !AddrMode.BaseReg && !AddrMode.Scale &&
         !AddrMode.BaseOffs) {
-      SunkAddr = Constant::getNullValue(Addr->getType());
+      SunkAddr = Constant::getZeroValue(Addr->getType());
     } else if (!ResultPtr) {
       return Modified;
     } else {
@@ -6249,7 +6249,7 @@ bool CodeGenPrepare::optimizeMemoryInst(Instruction *MemoryInst, Value *Addr,
     }
 
     if (!Result)
-      SunkAddr = Constant::getNullValue(Addr->getType());
+      SunkAddr = Constant::getZeroValue(Addr->getType());
     else
       SunkAddr = Builder.CreateIntToPtr(Result, Addr->getType(), "sunkaddr");
   }
@@ -6364,7 +6364,7 @@ bool CodeGenPrepare::optimizeGatherScatterInst(Instruction *MemoryInst,
       auto *SecondTy = GetElementPtrInst::getIndexedType(
           SourceTy, ArrayRef(Ops).drop_front());
       NewAddr =
-          Builder.CreateGEP(SecondTy, NewAddr, Constant::getNullValue(IndexTy));
+          Builder.CreateGEP(SecondTy, NewAddr, Constant::getZeroValue(IndexTy));
     } else {
       Value *Base = Ops[0];
       Value *Index = Ops[FinalIndex];
@@ -6373,7 +6373,7 @@ bool CodeGenPrepare::optimizeGatherScatterInst(Instruction *MemoryInst,
       if (Ops.size() != 2) {
         // Replace the last index with 0.
         Ops[FinalIndex] =
-            Constant::getNullValue(Ops[FinalIndex]->getType()->getScalarType());
+            Constant::getZeroValue(Ops[FinalIndex]->getType()->getScalarType());
         Base = Builder.CreateGEP(SourceTy, Base, ArrayRef(Ops).drop_front());
         SourceTy = GetElementPtrInst::getIndexedType(
             SourceTy, ArrayRef(Ops).drop_front());
@@ -6405,7 +6405,7 @@ bool CodeGenPrepare::optimizeGatherScatterInst(Instruction *MemoryInst,
              Intrinsic::masked_scatter);
       ScalarTy = MemoryInst->getOperand(0)->getType()->getScalarType();
     }
-    NewAddr = Builder.CreateGEP(ScalarTy, V, Constant::getNullValue(IndexTy));
+    NewAddr = Builder.CreateGEP(ScalarTy, V, Constant::getZeroValue(IndexTy));
   } else {
     // Constant, SelectionDAGBuilder knows to check if its a splat.
     return false;
@@ -6525,12 +6525,12 @@ bool CodeGenPrepare::optimizeMulWithOverflow(Instruction *I, bool IsSigned,
     Value *XorRHS = Builder.CreateXor(HiRHS, SignLoRHS);
     Value *Or = Builder.CreateOr(XorLHS, XorRHS, "or.lhs.rhs");
     IsAnyBitTrue = Builder.CreateCmp(ICmpInst::ICMP_NE, Or,
-                                     ConstantInt::getNullValue(Or->getType()));
+                                     ConstantInt::getZeroValue(Or->getType()));
   } else {
     Value *CmpLHS = Builder.CreateCmp(ICmpInst::ICMP_NE, HiLHS,
-                                      ConstantInt::getNullValue(LegalTy));
+                                      ConstantInt::getZeroValue(LegalTy));
     Value *CmpRHS = Builder.CreateCmp(ICmpInst::ICMP_NE, HiRHS,
-                                      ConstantInt::getNullValue(LegalTy));
+                                      ConstantInt::getZeroValue(LegalTy));
     IsAnyBitTrue = Builder.CreateOr(CmpLHS, CmpRHS, "or.lhs.rhs");
   }
   Builder.CreateCondBr(IsAnyBitTrue, OverflowBB, NoOverflowBB);

--- a/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
+++ b/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
@@ -2431,13 +2431,13 @@ void ComplexDeinterleavingGraph::processReductionSingle(
 
   Value *NewInit = nullptr;
   if (auto *C = dyn_cast<Constant>(Init)) {
-    if (C->isNullValue())
-      NewInit = Constant::getNullValue(NewVTy);
+    if (C->isZeroValue())
+      NewInit = Constant::getZeroValue(NewVTy);
   }
 
   if (!NewInit)
     NewInit =
-        Builder.CreateVectorInterleave({Init, Constant::getNullValue(VTy)});
+        Builder.CreateVectorInterleave({Init, Constant::getZeroValue(VTy)});
 
   NewPHI->addIncoming(NewInit, Incoming);
   NewPHI->addIncoming(OperationReplacement, BackEdge);

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -5784,7 +5784,7 @@ bool CombinerHelper::matchUDivOrURemByConst(MachineInstr &MI) const {
   if (Opcode == TargetOpcode::G_UDIV &&
       MI.getFlag(MachineInstr::MIFlag::IsExact)) {
     return matchUnaryPredicate(
-        MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+        MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
   }
 
   auto *RHSDef = MRI.getVRegDef(RHS);
@@ -5808,7 +5808,7 @@ bool CombinerHelper::matchUDivOrURemByConst(MachineInstr &MI) const {
   }
 
   return matchUnaryPredicate(
-      MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+      MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
 }
 
 void CombinerHelper::applyUDivOrURemByConst(MachineInstr &MI) const {
@@ -5842,7 +5842,7 @@ bool CombinerHelper::matchSDivOrSRemByConst(MachineInstr &MI) const {
   if (Opcode == TargetOpcode::G_SDIV &&
       MI.getFlag(MachineInstr::MIFlag::IsExact)) {
     return matchUnaryPredicate(
-        MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+        MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
   }
 
   auto *RHSDef = MRI.getVRegDef(RHS);
@@ -5862,7 +5862,7 @@ bool CombinerHelper::matchSDivOrSRemByConst(MachineInstr &MI) const {
   }
 
   return matchUnaryPredicate(
-      MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+      MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
 }
 
 void CombinerHelper::applySDivOrSRemByConst(MachineInstr &MI) const {

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -362,8 +362,8 @@ bool IRTranslator::translateCompare(const User &U,
   if (CmpInst::isIntPredicate(Pred))
     MIRBuilder.buildICmp(Pred, Res, Op0, Op1, Flags);
   else if (Pred == CmpInst::FCMP_FALSE)
-    MIRBuilder.buildCopy(
-        Res, getOrCreateVReg(*Constant::getNullValue(U.getType())));
+    MIRBuilder.buildCopy(Res,
+                         getOrCreateVReg(*Constant::getZeroValue(U.getType())));
   else if (Pred == CmpInst::FCMP_TRUE)
     MIRBuilder.buildCopy(
         Res, getOrCreateVReg(*Constant::getAllOnesValue(U.getType())));
@@ -577,7 +577,7 @@ bool IRTranslator::shouldEmitAsBranches(
   if (Cases[0].CmpRHS == Cases[1].CmpRHS &&
       Cases[0].PredInfo.Pred == Cases[1].PredInfo.Pred &&
       isa<Constant>(Cases[0].CmpRHS) &&
-      cast<Constant>(Cases[0].CmpRHS)->isNullValue()) {
+      cast<Constant>(Cases[0].CmpRHS)->isZeroValue()) {
     if (Cases[0].PredInfo.Pred == CmpInst::ICMP_EQ &&
         Cases[0].TrueBB == Cases[1].ThisBB)
       return false;

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1549,7 +1549,7 @@ bool llvm::isNullOrNullSplat(const MachineInstr &MI,
   case TargetOpcode::G_IMPLICIT_DEF:
     return AllowUndefs;
   case TargetOpcode::G_CONSTANT:
-    return MI.getOperand(1).getCImm()->isNullValue();
+    return MI.getOperand(1).getCImm()->isZeroValue();
   case TargetOpcode::G_FCONSTANT: {
     const ConstantFP *FPImm = MI.getOperand(1).getFPImm();
     return FPImm->isZero() && !FPImm->isNegative();

--- a/llvm/lib/CodeGen/InterleavedAccessPass.cpp
+++ b/llvm/lib/CodeGen/InterleavedAccessPass.cpp
@@ -572,7 +572,7 @@ static void getGapMask(const Constant &MaskConst, unsigned Factor,
     bool AllZero = true;
     for (unsigned Idx = 0U; Idx < LeafMaskLen; ++Idx) {
       Constant *C = MaskConst.getAggregateElement(F + Idx * Factor);
-      if (!C->isNullValue()) {
+      if (!C->isZeroValue()) {
         AllZero = false;
         break;
       }
@@ -594,7 +594,7 @@ static std::pair<Value *, APInt> getMask(Value *WideMask, unsigned Factor,
       // Check if all the intrinsic arguments are the same, except those that
       // are zeros, which we mark as gaps in the gap mask.
       for (auto [Idx, Arg] : enumerate(IMI->args())) {
-        if (auto *C = dyn_cast<Constant>(Arg); C && C->isNullValue()) {
+        if (auto *C = dyn_cast<Constant>(Arg); C && C->isZeroValue()) {
           GapMask.clearBit(Idx);
           continue;
         }

--- a/llvm/lib/CodeGen/IntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/IntrinsicLowering.cpp
@@ -282,7 +282,7 @@ void IntrinsicLowering::LowerIntrinsicCall(CallInst *CI) {
                "save" : "restore") << " intrinsic.\n";
     Warned = true;
     if (Callee->getIntrinsicID() == Intrinsic::stacksave)
-      CI->replaceAllUsesWith(Constant::getNullValue(CI->getType()));
+      CI->replaceAllUsesWith(Constant::getZeroValue(CI->getType()));
     break;
   }
 

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -555,13 +555,13 @@ static bool expandProtectedFieldPtr(Function &Intr) {
       // pointer.
       if (auto *CI = dyn_cast<ICmpInst>(U.getUser())) {
         if (auto *Op = dyn_cast<Constant>(CI->getOperand(0))) {
-          if (Op->isNullValue()) {
+          if (Op->isZeroValue()) {
             CI->setOperand(1, Pointer);
             continue;
           }
         }
         if (auto *Op = dyn_cast<Constant>(CI->getOperand(1))) {
-          if (Op->isNullValue()) {
+          if (Op->isZeroValue()) {
             CI->setOperand(0, Pointer);
             continue;
           }

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23069,7 +23069,7 @@ bool DAGCombiner::tryStoreMergeOfConstants(
       if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(StoredVal))
         IsElementZero = C->isZero();
       else if (ConstantFPSDNode *C = dyn_cast<ConstantFPSDNode>(StoredVal))
-        IsElementZero = C->getConstantFPValue()->isNullValue();
+        IsElementZero = C->getConstantFPValue()->isZeroValue();
       else if (ISD::isBuildVectorAllZeros(StoredVal.getNode()))
         IsElementZero = true;
       if (IsElementZero) {

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -288,9 +288,9 @@ Register FastISel::materializeConstant(const Value *V, MVT VT) {
     // Translate this as an integer zero so that it can be
     // local-CSE'd with actual integer zeros.
     Reg =
-        getRegForValue(Constant::getNullValue(DL.getIntPtrType(V->getType())));
+        getRegForValue(Constant::getZeroValue(DL.getIntPtrType(V->getType())));
   else if (const auto *CF = dyn_cast<ConstantFP>(V)) {
-    if (CF->isNullValue())
+    if (CF->isZeroValue())
       Reg = fastMaterializeFloatZero(CF);
     else
       // Try to emit the constant directly.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1961,13 +1961,13 @@ SDValue SelectionDAGBuilder::getValueImpl(const Value *V) {
       return getValue(NC->getGlobalValue());
 
     if (VT == MVT::aarch64svcount) {
-      assert(C->isNullValue() && "Can only zero this target type!");
+      assert(C->isZeroValue() && "Can only zero this target type!");
       return DAG.getNode(ISD::BITCAST, getCurSDLoc(), VT,
                          DAG.getConstant(0, getCurSDLoc(), MVT::nxv16i1));
     }
 
     if (VT.isRISCVVectorTuple()) {
-      assert(C->isNullValue() && "Can only zero this target type!");
+      assert(C->isZeroValue() && "Can only zero this target type!");
       return DAG.getNode(
           ISD::BITCAST, getCurSDLoc(), VT,
           DAG.getNode(
@@ -2780,10 +2780,9 @@ SelectionDAGBuilder::ShouldEmitAsBranches(const std::vector<CaseBlock> &Cases) {
 
   // Handle: (X != null) | (Y != null) --> (X|Y) != 0
   // Handle: (X == null) & (Y == null) --> (X|Y) == 0
-  if (Cases[0].CmpRHS == Cases[1].CmpRHS &&
-      Cases[0].CC == Cases[1].CC &&
+  if (Cases[0].CmpRHS == Cases[1].CmpRHS && Cases[0].CC == Cases[1].CC &&
       isa<Constant>(Cases[0].CmpRHS) &&
-      cast<Constant>(Cases[0].CmpRHS)->isNullValue()) {
+      cast<Constant>(Cases[0].CmpRHS)->isZeroValue()) {
     if (Cases[0].CC == ISD::SETEQ && Cases[0].TrueBB == Cases[1].ThisBB)
       return false;
     if (Cases[0].CC == ISD::SETNE && Cases[0].FalseBB == Cases[1].ThisBB)

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -1427,7 +1427,7 @@ static void mapWasmLandingPadIndex(MachineBasicBlock *MBB,
   // this information.
   bool IsSingleCatchAllClause =
       CPI->arg_size() == 1 &&
-      cast<Constant>(CPI->getArgOperand(0))->isNullValue();
+      cast<Constant>(CPI->getArgOperand(0))->isZeroValue();
   // cathchpads for longjmp use an empty type list, e.g. catchpad within %0 []
   // and they don't need LSDA info
   bool IsCatchLongjmp = CPI->arg_size() == 0;

--- a/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
+++ b/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
@@ -152,7 +152,7 @@ Constant *ShadowStackGCLoweringImpl::GetFrameMap(Function &F) {
   SmallVector<Constant *, 16> Metadata;
   for (unsigned I = 0; I != Roots.size(); ++I) {
     Constant *C = cast<Constant>(Roots[I].first->getArgOperand(1));
-    if (!C->isNullValue())
+    if (!C->isZeroValue())
       NumMeta = I + 1;
     Metadata.push_back(C);
   }
@@ -248,9 +248,9 @@ bool ShadowStackGCLoweringImpl::doInitialization(Module &M) {
     // linkage!
     Head = new GlobalVariable(
         M, StackEntryPtrTy, false, GlobalValue::LinkOnceAnyLinkage,
-        Constant::getNullValue(StackEntryPtrTy), "llvm_gc_root_chain");
+        Constant::getZeroValue(StackEntryPtrTy), "llvm_gc_root_chain");
   } else if (Head->hasExternalLinkage() && Head->isDeclaration()) {
-    Head->setInitializer(Constant::getNullValue(StackEntryPtrTy));
+    Head->setInitializer(Constant::getZeroValue(StackEntryPtrTy));
     Head->setLinkage(GlobalValue::LinkOnceAnyLinkage);
   }
 
@@ -259,7 +259,7 @@ bool ShadowStackGCLoweringImpl::doInitialization(Module &M) {
 
 bool ShadowStackGCLoweringImpl::IsNullValue(Value *V) {
   if (Constant *C = dyn_cast<Constant>(V))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/CodeGen/WasmEHPrepare.cpp
+++ b/llvm/lib/CodeGen/WasmEHPrepare.cpp
@@ -291,7 +291,7 @@ bool WasmEHPrepareImpl::prepareEHPads(Function &F) {
     // In case of a single catch (...), we don't need to emit a personalify
     // function call
     if (CPI->arg_size() == 1 &&
-        cast<Constant>(CPI->getArgOperand(0))->isNullValue())
+        cast<Constant>(CPI->getArgOperand(0))->isZeroValue())
       prepareEHPad(BB, false);
     else
       prepareEHPad(BB, true, Index++);

--- a/llvm/lib/CodeGen/WinEHPrepare.cpp
+++ b/llvm/lib/CodeGen/WinEHPrepare.cpp
@@ -163,7 +163,7 @@ static void addTryBlockMapEntry(WinEHFuncInfo &FuncInfo, int TryLow,
   for (const CatchPadInst *CPI : Handlers) {
     WinEHHandlerType HT;
     Constant *TypeInfo = cast<Constant>(CPI->getArgOperand(0));
-    if (TypeInfo->isNullValue())
+    if (TypeInfo->isZeroValue())
       HT.TypeDescriptor = nullptr;
     else
       HT.TypeDescriptor = cast<GlobalVariable>(TypeInfo->stripPointerCasts());
@@ -517,7 +517,7 @@ static void calculateSEHStateNumbers(WinEHFuncInfo &FuncInfo,
     const Constant *FilterOrNull =
         cast<Constant>(CatchPad->getArgOperand(0)->stripPointerCasts());
     const Function *Filter = dyn_cast<Function>(FilterOrNull);
-    assert((Filter || FilterOrNull->isNullValue()) &&
+    assert((Filter || FilterOrNull->isZeroValue()) &&
            "unexpected filter value");
     int TryState = addSEHExcept(FuncInfo, ParentState, Filter, CatchPadBB);
 

--- a/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -384,7 +384,7 @@ void ExecutionEngine::runStaticConstructorsDestructors(Module &module,
     if (!CS) continue;
 
     Constant *FP = CS->getOperand(1);
-    if (FP->isNullValue())
+    if (FP->isZeroValue())
       continue;  // Found a sentinel value, ignore.
 
     // Strip off constant expression casts.
@@ -890,9 +890,9 @@ GenericValue ExecutionEngine::getConstantValue(const Constant *C) {
   }
 
   if (auto *TETy = dyn_cast<TargetExtType>(C->getType())) {
-    assert(TETy->hasProperty(TargetExtType::HasZeroInit) && C->isNullValue() &&
+    assert(TETy->hasProperty(TargetExtType::HasZeroInit) && C->isZeroValue() &&
            "TargetExtType only supports null constant value");
-    C = Constant::getNullValue(TETy->getLayoutType());
+    C = Constant::getZeroValue(TETy->getLayoutType());
   }
 
   // Otherwise, we have a simple constant.

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -185,7 +185,7 @@ Error ReOptimizeLayer::reoptimizeIfCallFrequent(ReOptimizeLayer &Parent,
     Type *I64Ty = Type::getInt64Ty(M.getContext());
     GlobalVariable *Counter = new GlobalVariable(
         M, I64Ty, false, GlobalValue::InternalLinkage,
-        Constant::getNullValue(I64Ty), "__orc_reopt_counter");
+        Constant::getZeroValue(I64Ty), "__orc_reopt_counter");
     for (auto &F : M) {
       if (F.isDeclaration())
         continue;

--- a/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
@@ -492,7 +492,7 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP,
   Builder.CreateCondBr(KindCond, IfKindBB, IfEndBB);
   Builder.SetInsertPoint(IfKindBB);
   auto *FnCond = Builder.CreateICmpEQ(
-      Size, ConstantInt::getNullValue(Type::getInt64Ty(C)));
+      Size, ConstantInt::getZeroValue(Type::getInt64Ty(C)));
   Builder.CreateCondBr(FnCond, IfThenBB, IfElseBB);
 
   // Create kernel registration code.

--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -70,7 +70,7 @@ offloading::getOffloadingEntryInitializer(Module &M, object::OffloadKind Kind,
 
   // Construct the offloading entry.
   Constant *EntryData[] = {
-      ConstantExpr::getNullValue(Int64Ty),
+      ConstantExpr::getZeroValue(Int64Ty),
       ConstantInt::get(Int16Ty, 1),
       ConstantInt::get(Int16Ty, Kind),
       ConstantInt::get(Int32Ty, Flags),
@@ -79,7 +79,7 @@ offloading::getOffloadingEntryInitializer(Module &M, object::OffloadKind Kind,
       ConstantInt::get(Int64Ty, Size),
       ConstantInt::get(Int64Ty, Data),
       AuxAddr ? ConstantExpr::getPointerBitCastOrAddrSpaceCast(AuxAddr, PtrTy)
-              : ConstantExpr::getNullValue(PtrTy)};
+              : ConstantExpr::getZeroValue(PtrTy)};
   Constant *EntryInitializer = ConstantStruct::get(getEntryTy(M), EntryData);
   return {EntryInitializer, Str};
 }

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -635,7 +635,7 @@ void OpenMPIRBuilder::getKernelArgsVector(TargetKernelArgs &KernelArgs,
   Value *PointerNum = Builder.getInt32(KernelArgs.NumTargetItems);
   auto Int32Ty = Type::getInt32Ty(Builder.getContext());
   constexpr size_t MaxDim = 3;
-  Value *ZeroArray = Constant::getNullValue(ArrayType::get(Int32Ty, MaxDim));
+  Value *ZeroArray = Constant::getZeroValue(ArrayType::get(Int32Ty, MaxDim));
 
   Value *HasNoWaitFlag = Builder.getInt64(KernelArgs.HasNoWait);
 
@@ -1098,7 +1098,7 @@ Constant *OpenMPIRBuilder::getOrCreateIdent(Constant *SrcLocStr,
   Constant *&Ident =
       IdentMap[{SrcLocStr, uint64_t(LocFlags) << 31 | Reserve2Flags}];
   if (!Ident) {
-    Constant *I32Null = ConstantInt::getNullValue(Int32);
+    Constant *I32Null = ConstantInt::getZeroValue(Int32);
     Constant *IdentData[] = {I32Null,
                              ConstantInt::get(Int32, uint32_t(LocFlags)),
                              ConstantInt::get(Int32, Reserve2Flags),
@@ -1631,7 +1631,7 @@ static void targetParallelCallback(
   if (isGenericKernel(*OuterFn))
     WrapperFn = createTargetParallelWrapper(OMPIRBuilder, OutlinedFn);
   else
-    WrapperFn = Constant::getNullValue(PtrTy);
+    WrapperFn = Constant::getZeroValue(PtrTy);
 
   // Build kmpc_parallel_60 call
   Value *Parallel60CallArgs[] = {
@@ -1730,7 +1730,7 @@ hostParallelCallback(OpenMPIRBuilder *OMPIRBuilder, Function &OutlinedFn,
   // If there are no arguments, pass a null pointer.
   auto PtrTy = OMPIRBuilder->VoidPtr;
   if (IfCondition && NumCapturedVars == 0) {
-    Value *NullPtrValue = Constant::getNullValue(PtrTy);
+    Value *NullPtrValue = Constant::getZeroValue(PtrTy);
     RealArgs.push_back(NullPtrValue);
   }
 
@@ -2150,7 +2150,7 @@ void OpenMPIRBuilder::emitTaskyieldImpl(const LocationDescription &Loc) {
   uint32_t SrcLocStrSize;
   Constant *SrcLocStr = getOrCreateSrcLocStr(Loc, SrcLocStrSize);
   Value *Ident = getOrCreateIdent(SrcLocStr, SrcLocStrSize);
-  Constant *I32Null = ConstantInt::getNullValue(Int32);
+  Constant *I32Null = ConstantInt::getZeroValue(Int32);
   Value *Args[] = {Ident, getOrCreateThreadID(Ident), I32Null};
 
   createRuntimeFunctionCall(
@@ -2240,7 +2240,7 @@ Expected<Value *> OpenMPIRBuilder::createTaskDuplicationFunction(
     Type *PrivatesTy, int32_t PrivatesIndex, TaskDupCallbackTy DupCB) {
   unsigned ProgramAddressSpace = M.getDataLayout().getProgramAddressSpace();
   if (!DupCB)
-    return Constant::getNullValue(
+    return Constant::getZeroValue(
         PointerType::get(Builder.getContext(), ProgramAddressSpace));
 
   // From OpenMP Runtime p_task_dup_t:
@@ -3520,7 +3520,7 @@ Expected<Function *> OpenMPIRBuilder::emitInterWarpCopyFunction(
         CntAddr = Builder.CreateAddrSpaceCast(CntAddr, Builder.getPtrTy(),
                                               CntAddr->getName() + ".ascast");
         Builder.restoreIP(CodeGenIP);
-        Builder.CreateStore(Constant::getNullValue(Builder.getInt32Ty()),
+        Builder.CreateStore(Constant::getZeroValue(Builder.getInt32Ty()),
                             CntAddr,
                             /*Volatile=*/false);
         PrecondBB = BasicBlock::Create(Ctx, "precond");
@@ -6167,7 +6167,7 @@ static void workshareLoopTargetCallback(
   if (OutlinedFnCallInstruction->arg_size() > 1)
     LoopBodyArg = OutlinedFnCallInstruction->getArgOperand(1);
   else
-    LoopBodyArg = Constant::getNullValue(Builder.getPtrTy());
+    LoopBodyArg = Constant::getZeroValue(Builder.getPtrTy());
   OutlinedFnCallInstruction->eraseFromParent();
 
   createTargetLoopWorkshareCall(OMPIRBuilder, LoopType, Preheader, Ident,
@@ -8383,7 +8383,7 @@ Constant *OpenMPIRBuilder::createOutlinedFunctionID(Function *OutlinedFn,
 
   return new GlobalVariable(
       M, Builder.getInt8Ty(), /*isConstant=*/true, GlobalValue::WeakAnyLinkage,
-      Constant::getNullValue(Builder.getInt8Ty()), EntryFnIDName);
+      Constant::getZeroValue(Builder.getInt8Ty()), EntryFnIDName);
 }
 
 Constant *OpenMPIRBuilder::createTargetRegionEntryAddr(Function *OutlinedFn,
@@ -8395,7 +8395,7 @@ Constant *OpenMPIRBuilder::createTargetRegionEntryAddr(Function *OutlinedFn,
          "Named kernel already exists?");
   return new GlobalVariable(
       M, Builder.getInt8Ty(), /*isConstant=*/true, GlobalValue::InternalLinkage,
-      Constant::getNullValue(Builder.getInt8Ty()), EntryFnName);
+      Constant::getZeroValue(Builder.getInt8Ty()), EntryFnName);
 }
 
 Error OpenMPIRBuilder::emitTargetRegionFunction(
@@ -8498,10 +8498,10 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createTargetData(
       auto TaskBodyCB = [&](Value *, Value *,
                             IRBuilderBase::InsertPoint) -> Error {
         if (Info.HasNoWait) {
-          OffloadingArgs.append({llvm::Constant::getNullValue(Int32),
-                                 llvm::Constant::getNullValue(VoidPtr),
-                                 llvm::Constant::getNullValue(Int32),
-                                 llvm::Constant::getNullValue(VoidPtr)});
+          OffloadingArgs.append({llvm::Constant::getZeroValue(Int32),
+                                 llvm::Constant::getZeroValue(VoidPtr),
+                                 llvm::Constant::getZeroValue(Int32),
+                                 llvm::Constant::getZeroValue(VoidPtr)});
         }
 
         createRuntimeFunctionCall(getOrCreateRuntimeFunctionPtr(*MapperFunc),
@@ -9615,7 +9615,7 @@ static void emitTargetCall(
     // Ensure the host fallback has the same dyn_ptr ABI as the device.
     SmallVector<Value *> FallbackArgs(Args.begin(), Args.end());
     FallbackArgs.push_back(
-        Constant::getNullValue(PointerType::getUnqual(Builder.getContext())));
+        Constant::getZeroValue(PointerType::getUnqual(Builder.getContext())));
     OMPBuilder.createRuntimeFunctionCall(OutlinedFn, FallbackArgs);
     return Builder.saveIP();
   };
@@ -9874,7 +9874,7 @@ GlobalVariable *OpenMPIRBuilder::getOrCreateInternalVariable(
                        ? GlobalValue::InternalLinkage
                        : GlobalValue::CommonLinkage;
     auto *GV = new GlobalVariable(M, Ty, /*IsConstant=*/false, Linkage,
-                                  Constant::getNullValue(Ty), Elem.first(),
+                                  Constant::getZeroValue(Ty), Elem.first(),
                                   /*InsertBefore=*/nullptr,
                                   GlobalValue::NotThreadLocal, AddressSpaceVal);
     const llvm::Align TypeAlign = DL.getABITypeAlign(Ty);
@@ -9895,7 +9895,7 @@ Value *OpenMPIRBuilder::getOMPCriticalRegionLock(StringRef CriticalName) {
 Value *OpenMPIRBuilder::getSizeInBytes(Value *BasePtr) {
   LLVMContext &Ctx = Builder.getContext();
   Value *Null =
-      Constant::getNullValue(PointerType::getUnqual(BasePtr->getContext()));
+      Constant::getZeroValue(PointerType::getUnqual(BasePtr->getContext()));
   Value *SizeGep =
       Builder.CreateGEP(BasePtr->getType(), Null, Builder.getInt32(1));
   Value *SizePtrToInt = Builder.CreatePtrToInt(SizeGep, Type::getInt64Ty(Ctx));
@@ -9957,7 +9957,7 @@ void OpenMPIRBuilder::emitMapperCall(const LocationDescription &Loc,
       Builder.CreateInBoundsGEP(ArrI64Ty, MapperAllocas.ArgSizes,
                                 {Builder.getInt32(0), Builder.getInt32(0)});
   Value *NullPtr =
-      Constant::getNullValue(PointerType::getUnqual(Int8Ptr->getContext()));
+      Constant::getZeroValue(PointerType::getUnqual(Int8Ptr->getContext()));
   createRuntimeFunctionCall(MapperFunc, {SrcLocInfo, Builder.getInt64(DeviceID),
                                          Builder.getInt32(NumOperands),
                                          ArgsBaseGEP, ArgsGEP, ArgSizesGEP,
@@ -10245,7 +10245,7 @@ Expected<Function *> OpenMPIRBuilder::emitUserDefinedMapper(
     Value *CurSizeArg = Info->Sizes[I];
     Value *CurNameArg = Info->Names.size()
                             ? Info->Names[I]
-                            : Constant::getNullValue(Builder.getPtrTy());
+                            : Constant::getZeroValue(Builder.getPtrTy());
 
     // Extract the MEMBER_OF field from the map type.
     Value *OriMapType = Builder.getInt64(
@@ -10488,7 +10488,7 @@ Error OpenMPIRBuilder::emitOffloadingArrays(
     Info.EmitDebug = true;
   } else {
     Info.RTArgs.MapNamesArray =
-        Constant::getNullValue(PointerType::getUnqual(Builder.getContext()));
+        Constant::getZeroValue(PointerType::getUnqual(Builder.getContext()));
     Info.EmitDebug = false;
   }
 
@@ -11745,7 +11745,7 @@ void OpenMPIRBuilder::createOffloadEntriesAndInfoMetadata(
   if (Config.hasRequiresFlags() && !Config.isTargetDevice())
     offloading::emitOffloadingEntry(
         M, object::OffloadKind::OFK_OpenMP,
-        Constant::getNullValue(PointerType::getUnqual(M.getContext())),
+        Constant::getZeroValue(PointerType::getUnqual(M.getContext())),
         ".requires", /*Size=*/0,
         OffloadEntriesInfoManager::OMPTargetGlobalRegisterRequires,
         Config.getRequiresFlags());

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -338,7 +338,7 @@ void InstModificationIRStrategy::mutate(Instruction &Inst,
     // constant 0.
     Value *Operand = Inst.getOperand(0);
     if (Constant *C = dyn_cast<Constant>(Operand)) {
-      if (!C->isNullValue()) {
+      if (!C->isZeroValue()) {
         ShuffleItems = {0, 1};
       }
     }

--- a/llvm/lib/IR/AbstractCallSite.cpp
+++ b/llvm/lib/IR/AbstractCallSite.cpp
@@ -144,7 +144,7 @@ AbstractCallSite::AbstractCallSite(const Use *U)
   assert(VarArgFlagAsCM->getType()->isIntegerTy(1) &&
          "Malformed !callback metadata var-arg flag");
 
-  if (VarArgFlagAsCM->getValue()->isNullValue())
+  if (VarArgFlagAsCM->getValue()->isZeroValue())
     return;
 
   // Add all variadic arguments at the end.

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1716,11 +1716,11 @@ static void writeConstantInternal(raw_ostream &Out, const Constant *CV,
 
     // ptrauth (ptr CST, i32 KEY[, i64 DISC[, ptr ADDRDISC[, ptr DS]?]?]?)
     unsigned NumOpsToWrite = 2;
-    if (!CPA->getOperand(2)->isNullValue())
+    if (!CPA->getOperand(2)->isZeroValue())
       NumOpsToWrite = 3;
-    if (!CPA->getOperand(3)->isNullValue())
+    if (!CPA->getOperand(3)->isZeroValue())
       NumOpsToWrite = 4;
-    if (!CPA->getOperand(4)->isNullValue())
+    if (!CPA->getOperand(4)->isZeroValue())
       NumOpsToWrite = 5;
 
     ListSeparator LS;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1961,7 +1961,7 @@ static Value *upgradeX86PSLLDQIntrinsics(IRBuilder<> &Builder, Value *Op,
   Op = Builder.CreateBitCast(Op, VecTy, "cast");
 
   // We'll be shuffling in zeroes.
-  Value *Res = Constant::getNullValue(VecTy);
+  Value *Res = Constant::getZeroValue(VecTy);
 
   // If shift is less than 16, emit a shuffle to move the bytes. Otherwise,
   // we'll just return the zero vector.
@@ -1995,7 +1995,7 @@ static Value *upgradeX86PSRLDQIntrinsics(IRBuilder<> &Builder, Value *Op,
   Op = Builder.CreateBitCast(Op, VecTy, "cast");
 
   // We'll be shuffling in zeroes.
-  Value *Res = Constant::getNullValue(VecTy);
+  Value *Res = Constant::getZeroValue(VecTy);
 
   // If shift is less than 16, emit a shuffle to move the bytes. Otherwise,
   // we'll just return the zero vector.
@@ -2084,14 +2084,14 @@ static Value *upgradeX86ALIGNIntrinsics(IRBuilder<> &Builder, Value *Op0,
   // If palignr is shifting the pair of vectors more than the size of two
   // lanes, emit zero.
   if (ShiftVal >= 32)
-    return llvm::Constant::getNullValue(Op0->getType());
+    return llvm::Constant::getZeroValue(Op0->getType());
 
   // If palignr is shifting the pair of input vectors more than one lane,
   // but less than two lanes, convert to shifting in zeroes.
   if (ShiftVal > 16) {
     ShiftVal -= 16;
     Op1 = Op0;
-    Op0 = llvm::Constant::getNullValue(Op0->getType());
+    Op0 = llvm::Constant::getZeroValue(Op0->getType());
   }
 
   int Indices[64];
@@ -2239,7 +2239,7 @@ static Value *upgradeX86vpcom(IRBuilder<> &Builder, CallBase &CI, unsigned Imm,
     Pred = ICmpInst::ICMP_NE;
     break;
   case 0x6:
-    return Constant::getNullValue(Ty); // FALSE
+    return Constant::getZeroValue(Ty); // FALSE
   case 0x7:
     return Constant::getAllOnesValue(Ty); // TRUE
   default:
@@ -2378,9 +2378,8 @@ static Value *applyX86MaskOn1BitsVec(IRBuilder<> &Builder, Value *Vec,
       Indices[i] = i;
     for (unsigned i = NumElts; i != 8; ++i)
       Indices[i] = NumElts + i % NumElts;
-    Vec = Builder.CreateShuffleVector(Vec,
-                                      Constant::getNullValue(Vec->getType()),
-                                      Indices);
+    Vec = Builder.CreateShuffleVector(
+        Vec, Constant::getZeroValue(Vec->getType()), Indices);
   }
   return Builder.CreateBitCast(Vec, Builder.getIntNTy(std::max(NumElts, 8U)));
 }
@@ -2392,7 +2391,7 @@ static Value *upgradeMaskedCompare(IRBuilder<> &Builder, CallBase &CI,
 
   Value *Cmp;
   if (CC == 3) {
-    Cmp = Constant::getNullValue(
+    Cmp = Constant::getZeroValue(
         FixedVectorType::get(Builder.getInt1Ty(), NumElts));
   } else if (CC == 7) {
     Cmp = Constant::getAllOnesValue(
@@ -2703,7 +2702,7 @@ static Value *upgradeNVVMIntrinsicCall(StringRef Name, CallBase *CI,
     Value *Arg = CI->getArgOperand(0);
     Value *Neg = Builder.CreateNeg(Arg, "neg");
     Value *Cmp = Builder.CreateICmpSGE(
-        Arg, llvm::Constant::getNullValue(Arg->getType()), "abs.cond");
+        Arg, llvm::Constant::getZeroValue(Arg->getType()), "abs.cond");
     Rep = Builder.CreateSelect(Cmp, Arg, Neg, "abs");
   } else if (Name == "abs.bf16" || Name == "abs.bf16x2") {
     Type *Ty = (Name == "abs.bf16")
@@ -2959,7 +2958,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     Value *Mask = CI->getArgOperand(2);
     Rep = Builder.CreateAnd(Op0, Op1);
     llvm::Type *Ty = Op0->getType();
-    Value *Zero = llvm::Constant::getNullValue(Ty);
+    Value *Zero = llvm::Constant::getZeroValue(Ty);
     ICmpInst::Predicate Pred = Name.starts_with("avx512.ptestm")
                                    ? ICmpInst::ICMP_NE
                                    : ICmpInst::ICMP_EQ;
@@ -3027,7 +3026,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     if (Name[14] == 'c')
       C = ConstantInt::getAllOnesValue(Builder.getInt16Ty());
     else
-      C = ConstantInt::getNullValue(Builder.getInt16Ty());
+      C = ConstantInt::getZeroValue(Builder.getInt16Ty());
     Rep = Builder.CreateICmpEQ(Rep, C);
     Rep = Builder.CreateZExt(Rep, Builder.getInt32Ty());
   } else if (Name == "sse.add.ss" || Name == "sse2.add.sd" ||
@@ -3138,7 +3137,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
              Name.starts_with("avx512.cvtd2mask.") ||
              Name.starts_with("avx512.cvtq2mask.")) {
     Value *Op = CI->getArgOperand(0);
-    Value *Zero = llvm::Constant::getNullValue(Op->getType());
+    Value *Zero = llvm::Constant::getZeroValue(Op->getType());
     Rep = Builder.CreateICmp(ICmpInst::ICMP_SLT, Op, Zero);
     Rep = applyX86MaskOn1BitsVec(Builder, Rep, nullptr);
   } else if (Name == "ssse3.pabs.b.128" || Name == "ssse3.pabs.w.128" ||
@@ -3444,7 +3443,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     ElementCount EC = cast<VectorType>(CI->getType())->getElementCount();
     Type *MaskTy = VectorType::get(Type::getInt32Ty(C), EC);
     SmallVector<int, 8> M;
-    ShuffleVectorInst::getShuffleMask(Constant::getNullValue(MaskTy), M);
+    ShuffleVectorInst::getShuffleMask(Constant::getZeroValue(MaskTy), M);
     Rep = Builder.CreateShuffleVector(Op, M);
 
     if (CI->arg_size() == 3)
@@ -4163,7 +4162,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
 
     Rep = Builder.CreateIntrinsic(Intrinsic::fma, Ops[0]->getType(), Ops);
 
-    Rep = Builder.CreateInsertElement(Constant::getNullValue(CI->getType()),
+    Rep = Builder.CreateInsertElement(Constant::getZeroValue(CI->getType()),
                                       Rep, (uint64_t)0);
   } else if (Name.starts_with("avx512.mask.vfmadd.s") ||
              Name.starts_with("avx512.maskz.vfmadd.s") ||
@@ -4206,7 +4205,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       Rep = Builder.CreateFMA(A, B, C);
     }
 
-    Value *PassThru = IsMaskZ   ? Constant::getNullValue(Rep->getType())
+    Value *PassThru = IsMaskZ   ? Constant::getZeroValue(Rep->getType())
                       : IsMask3 ? C
                                 : A;
 
@@ -4259,7 +4258,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       Rep = Builder.CreateFMA(A, B, C);
     }
 
-    Value *PassThru = IsMaskZ   ? llvm::Constant::getNullValue(CI->getType())
+    Value *PassThru = IsMaskZ   ? llvm::Constant::getZeroValue(CI->getType())
                       : IsMask3 ? CI->getArgOperand(2)
                                 : CI->getArgOperand(0);
 
@@ -4328,7 +4327,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       Rep = Builder.CreateShuffleVector(Even, Odd, Idxs);
     }
 
-    Value *PassThru = IsMaskZ   ? llvm::Constant::getNullValue(CI->getType())
+    Value *PassThru = IsMaskZ   ? llvm::Constant::getZeroValue(CI->getType())
                       : IsMask3 ? CI->getArgOperand(2)
                                 : CI->getArgOperand(0);
 
@@ -4934,7 +4933,7 @@ static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
     if (CI->arg_size() == 4) {
       auto *Offset = dyn_cast_or_null<Constant>(CI->getArgOperand(1));
       // Nonzero offset dbg.values get dropped without a replacement.
-      if (!Offset || !Offset->isNullValue())
+      if (!Offset || !Offset->isZeroValue())
         return;
       VarOp = 2;
       ExprOp = 3;
@@ -5264,7 +5263,7 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     assert(CI->arg_size() == 4);
     // Drop nonzero offsets instead of attempting to upgrade them.
     if (auto *Offset = dyn_cast_or_null<Constant>(CI->getArgOperand(1)))
-      if (Offset->isNullValue()) {
+      if (Offset->isZeroValue()) {
         NewCall = Builder.CreateCall(
             NewFn,
             {CI->getArgOperand(0), CI->getArgOperand(2), CI->getArgOperand(3)});
@@ -5785,13 +5784,14 @@ MDNode *llvm::UpgradeTBAANode(MDNode &MD) {
     // Create a MDNode <ScalarType, ScalarType, offset 0, const>
     Metadata *Elts2[] = {ScalarType, ScalarType,
                          ConstantAsMetadata::get(
-                             Constant::getNullValue(Type::getInt64Ty(Context))),
+                             Constant::getZeroValue(Type::getInt64Ty(Context))),
                          MD.getOperand(2)};
     return MDNode::get(Context, Elts2);
   }
   // Create a MDNode <MD, MD, offset 0>
-  Metadata *Elts[] = {&MD, &MD, ConstantAsMetadata::get(Constant::getNullValue(
-                                    Type::getInt64Ty(Context)))};
+  Metadata *Elts[] = {&MD, &MD,
+                      ConstantAsMetadata::get(
+                          Constant::getZeroValue(Type::getInt64Ty(Context)))};
   return MDNode::get(Context, Elts);
 }
 

--- a/llvm/lib/IR/ConstantFold.cpp
+++ b/llvm/lib/IR/ConstantFold.cpp
@@ -171,13 +171,13 @@ Constant *llvm::ConstantFoldCastInstruction(unsigned opc, Constant *V,
     // [us]itofp(undef) = 0, because the result value is bounded.
     if (opc == Instruction::ZExt || opc == Instruction::SExt ||
         opc == Instruction::UIToFP || opc == Instruction::SIToFP)
-      return Constant::getNullValue(DestTy);
+      return Constant::getZeroValue(DestTy);
     return UndefValue::get(DestTy);
   }
 
-  if (V->isNullValue() && !DestTy->isX86_AMXTy() &&
+  if (V->isZeroValue() && !DestTy->isX86_AMXTy() &&
       opc != Instruction::AddrSpaceCast)
-    return Constant::getNullValue(DestTy);
+    return Constant::getZeroValue(DestTy);
 
   // If the cast operand is a constant expression, there's a few things we can
   // do to try to simplify it.
@@ -295,7 +295,8 @@ Constant *llvm::ConstantFoldCastInstruction(unsigned opc, Constant *V,
 Constant *llvm::ConstantFoldSelectInstruction(Constant *Cond,
                                               Constant *V1, Constant *V2) {
   // Check for i1 and vector true/false conditions.
-  if (Cond->isNullValue()) return V2;
+  if (Cond->isZeroValue())
+    return V2;
   if (Cond->isAllOnesValue()) return V1;
 
   // If the condition is a vector constant, fold the result elementwise.
@@ -318,7 +319,7 @@ Constant *llvm::ConstantFoldSelectInstruction(Constant *Cond,
         V = isa<UndefValue>(V1Element) ? V1Element : V2Element;
       } else {
         if (!isa<ConstantInt>(Cond)) break;
-        V = Cond->isNullValue() ? V2Element : V1Element;
+        V = Cond->isZeroValue() ? V2Element : V1Element;
       }
       Result.push_back(V);
     }
@@ -442,7 +443,7 @@ Constant *llvm::ConstantFoldInsertElementInstruction(Constant *Val,
 
   // Inserting null into all zeros is still all zeros.
   // TODO: This is true for undef and poison splats too.
-  if (isa<ConstantAggregateZero>(Val) && Elt->isNullValue())
+  if (isa<ConstantAggregateZero>(Val) && Elt->isZeroValue())
     return Val;
 
   ConstantInt *CIdx = dyn_cast<ConstantInt>(Idx);
@@ -498,7 +499,8 @@ Constant *llvm::ConstantFoldShuffleVectorInstruction(Constant *V1, Constant *V2,
 
     // For scalable vectors, make sure this doesn't fold back into a
     // shufflevector.
-    if (!MaskEltCount.isScalable() || Elt->isNullValue() || isa<UndefValue>(Elt))
+    if (!MaskEltCount.isScalable() || Elt->isZeroValue() ||
+        isa<UndefValue>(Elt))
       return ConstantVector::getSplat(MaskEltCount, Elt);
   }
 
@@ -668,7 +670,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
       if (isa<UndefValue>(C1) && isa<UndefValue>(C2))
         // Handle undef ^ undef -> 0 special case. This is a common
         // idiom (misuse).
-        return Constant::getNullValue(C1->getType());
+        return Constant::getZeroValue(C1->getType());
       [[fallthrough]];
     case Instruction::Add:
     case Instruction::Sub:
@@ -676,7 +678,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
     case Instruction::And:
       if (isa<UndefValue>(C1) && isa<UndefValue>(C2)) // undef & undef -> undef
         return C1;
-      return Constant::getNullValue(C1->getType());   // undef & X -> 0
+      return Constant::getZeroValue(C1->getType()); // undef & X -> 0
     case Instruction::Mul: {
       // undef * undef -> undef
       if (isa<UndefValue>(C1) && isa<UndefValue>(C2))
@@ -688,7 +690,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
           return UndefValue::get(C1->getType());
 
       // X * undef -> 0       otherwise
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     }
     case Instruction::SDiv:
     case Instruction::UDiv:
@@ -697,7 +699,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
       if (match(C2, m_CombineOr(m_Undef(), m_Zero())))
         return PoisonValue::get(C2->getType());
       // undef / X -> 0       otherwise
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     case Instruction::URem:
     case Instruction::SRem:
       // X % undef -> poison
@@ -705,7 +707,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
       if (match(C2, m_CombineOr(m_Undef(), m_Zero())))
         return PoisonValue::get(C2->getType());
       // undef % X -> 0       otherwise
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     case Instruction::Or:                          // X | undef -> -1
       if (isa<UndefValue>(C1) && isa<UndefValue>(C2)) // undef | undef -> undef
         return C1;
@@ -715,20 +717,20 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
       if (isa<UndefValue>(C2))
         return PoisonValue::get(C2->getType());
       // undef >>l X -> 0
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     case Instruction::AShr:
       // X >>a undef -> poison
       if (isa<UndefValue>(C2))
         return PoisonValue::get(C2->getType());
       // TODO: undef >>a X -> poison if the shift is exact
       // undef >>a X -> 0
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     case Instruction::Shl:
       // X << undef -> undef
       if (isa<UndefValue>(C2))
         return PoisonValue::get(C2->getType());
       // undef << X -> 0
-      return Constant::getNullValue(C1->getType());
+      return Constant::getZeroValue(C1->getType());
     case Instruction::FSub:
       // -0.0 - undef --> undef (consistent with "fneg undef")
       if (match(C1, m_NegZeroFP()) && isa<UndefValue>(C2))
@@ -772,7 +774,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
     case Instruction::URem:
     case Instruction::SRem:
       if (CI2->isOne())
-        return Constant::getNullValue(CI2->getType());        // X % 1 == 0
+        return Constant::getZeroValue(CI2->getType()); // X % 1 == 0
       if (CI2->isZero())
         return PoisonValue::get(CI2->getType());              // X % 0 == poison
       break;
@@ -813,7 +815,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
 
             // If checking bits we know are clear, return zero.
             if ((CI2->getValue() & BitsNotSet) == CI2->getValue())
-              return Constant::getNullValue(CI2->getType());
+              return Constant::getZeroValue(CI2->getType());
           }
         }
       }
@@ -910,7 +912,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
   if (auto *VTy = dyn_cast<VectorType>(C1->getType())) {
     // Fast path for splatted constants.
     if (Constant *C2Splat = C2->getSplatValue()) {
-      if (Instruction::isIntDivRem(Opcode) && C2Splat->isNullValue())
+      if (Instruction::isIntDivRem(Opcode) && C2Splat->isZeroValue())
         return PoisonValue::get(VTy);
       if (Constant *C1Splat = C1->getSplatValue()) {
         Constant *Res =
@@ -1143,7 +1145,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
 
   // Fold FCMP_FALSE/FCMP_TRUE unconditionally.
   if (Predicate == FCmpInst::FCMP_FALSE)
-    return Constant::getNullValue(ResultTy);
+    return Constant::getZeroValue(ResultTy);
 
   if (Predicate == FCmpInst::FCMP_TRUE)
     return Constant::getAllOnesValue(ResultTy);
@@ -1170,7 +1172,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
     return ConstantInt::get(ResultTy, CmpInst::isUnordered(Predicate));
   }
 
-  if (C2->isNullValue()) {
+  if (C2->isZeroValue()) {
     // The caller is expected to commute the operands if the constant expression
     // is C2.
     // C1 >= 0 --> true
@@ -1178,7 +1180,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
       return Constant::getAllOnesValue(ResultTy);
     // C1 < 0 --> false
     if (Predicate == ICmpInst::ICMP_ULT)
-      return Constant::getNullValue(ResultTy);
+      return Constant::getZeroValue(ResultTy);
   }
 
   // If the comparison is a comparison between two i1's, simplify it.
@@ -1335,7 +1337,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
       return ConstantInt::get(ResultTy, Result);
 
     if ((!isa<ConstantExpr>(C1) && isa<ConstantExpr>(C2)) ||
-        (C1->isNullValue() && !C2->isNullValue())) {
+        (C1->isZeroValue() && !C2->isZeroValue())) {
       // If C2 is a constant expr and C1 isn't, flip them around and fold the
       // other way if possible.
       // Also, if C1 is null and C2 isn't, flip them around.
@@ -1367,7 +1369,7 @@ Constant *llvm::ConstantFoldGetElementPtr(Type *PointeeTy, Constant *C,
 
     return all_of(Idxs, [](Value *Idx) {
       Constant *IdxC = cast<Constant>(Idx);
-      return IdxC->isNullValue() || isa<UndefValue>(IdxC);
+      return IdxC->isZeroValue() || isa<UndefValue>(IdxC);
     });
   };
   if (IsNoOp())

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -68,10 +68,10 @@ bool Constant::isNegativeZeroValue() const {
     return false;
 
   // Otherwise, just use +0.0.
-  return isNullValue();
+  return isZeroValue();
 }
 
-bool Constant::isNullValue() const {
+bool Constant::isZeroValue() const {
   // 0 is null.
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(this))
     return CI->isZero();
@@ -386,8 +386,7 @@ bool Constant::containsConstantExpression() const {
   return false;
 }
 
-/// Constructor to create a '0' constant of arbitrary type.
-Constant *Constant::getNullValue(Type *Ty) {
+Constant *Constant::getZeroValue(Type *Ty) {
   switch (Ty->getTypeID()) {
   case Type::ByteTyID:
     return ConstantByte::get(Ty, 0);
@@ -1261,12 +1260,12 @@ void ConstantFP::destroyConstantImpl() {
 
 Constant *ConstantAggregateZero::getSequentialElement() const {
   if (auto *AT = dyn_cast<ArrayType>(getType()))
-    return Constant::getNullValue(AT->getElementType());
-  return Constant::getNullValue(cast<VectorType>(getType())->getElementType());
+    return Constant::getZeroValue(AT->getElementType());
+  return Constant::getZeroValue(cast<VectorType>(getType())->getElementType());
 }
 
 Constant *ConstantAggregateZero::getStructElement(unsigned Elt) const {
-  return Constant::getNullValue(getType()->getStructElementType(Elt));
+  return Constant::getZeroValue(getType()->getStructElementType(Elt));
 }
 
 Constant *ConstantAggregateZero::getElementValue(Constant *C) const {
@@ -1488,7 +1487,7 @@ Constant *ConstantArray::getImpl(ArrayType *Ty, ArrayRef<Constant*> V) {
   if (isa<UndefValue>(C) && rangeOnlyContains(V.begin(), V.end(), C))
     return UndefValue::get(Ty);
 
-  if (C->isNullValue() && rangeOnlyContains(V.begin(), V.end(), C))
+  if (C->isZeroValue() && rangeOnlyContains(V.begin(), V.end(), C))
     return ConstantAggregateZero::get(Ty);
 
   // Check to see if all of the elements are ConstantFP or ConstantInt or
@@ -1540,11 +1539,11 @@ Constant *ConstantStruct::get(StructType *ST, ArrayRef<Constant*> V) {
   if (!V.empty()) {
     isUndef = isa<UndefValue>(V[0]);
     isPoison = isa<PoisonValue>(V[0]);
-    isZero = V[0]->isNullValue();
+    isZero = V[0]->isZeroValue();
     // PoisonValue inherits UndefValue, so its check is not necessary.
     if (isUndef || isZero) {
       for (Constant *C : V) {
-        if (!C->isNullValue())
+        if (!C->isZeroValue())
           isZero = false;
         if (!isa<PoisonValue>(C))
           isPoison = false;
@@ -1585,7 +1584,7 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
   // If this is an all-undef or all-zero vector, return a
   // ConstantAggregateZero or UndefValue.
   Constant *C = V[0];
-  bool isZero = C->isNullValue();
+  bool isZero = C->isZeroValue();
   bool isUndef = isa<UndefValue>(C);
   bool isPoison = isa<PoisonValue>(C);
   bool isSplatFP = UseConstantFPForFixedLengthSplat && isa<ConstantFP>(C);
@@ -1630,7 +1629,7 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
 Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
   if (!EC.isScalable()) {
     // Maintain special handling of zero.
-    if (!V->isNullValue()) {
+    if (!V->isZeroValue()) {
       if (UseConstantIntForFixedLengthSplat && isa<ConstantInt>(V))
         return ConstantInt::get(V->getContext(), EC,
                                 cast<ConstantInt>(V)->getValue());
@@ -1653,7 +1652,7 @@ Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
   }
 
   // Maintain special handling of zero.
-  if (!V->isNullValue()) {
+  if (!V->isZeroValue()) {
     if (UseConstantIntForScalableSplat && isa<ConstantInt>(V))
       return ConstantInt::get(V->getContext(), EC,
                               cast<ConstantInt>(V)->getValue());
@@ -1667,7 +1666,7 @@ Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
 
   Type *VTy = VectorType::get(V->getType(), EC);
 
-  if (V->isNullValue())
+  if (V->isZeroValue())
     return ConstantAggregateZero::get(VTy);
   if (isa<PoisonValue>(V))
     return PoisonValue::get(VTy);
@@ -1877,7 +1876,7 @@ Constant *Constant::getSplatValue(bool AllowPoison) const {
   if (isa<PoisonValue>(this))
     return PoisonValue::get(cast<VectorType>(getType())->getElementType());
   if (isa<ConstantAggregateZero>(this))
-    return getNullValue(cast<VectorType>(getType())->getElementType());
+    return getZeroValue(cast<VectorType>(getType())->getElementType());
   if (auto *CI = dyn_cast<ConstantInt>(this))
     return ConstantInt::get(getContext(), CI->getValue());
   if (auto *CB = dyn_cast<ConstantByte>(this))
@@ -2163,7 +2162,7 @@ Value *DSOLocalEquivalent::handleOperandChangeImpl(Value *From, Value *To) {
 
   // If the argument is replaced with a null value, just replace this constant
   // with a null value.
-  if (cast<Constant>(To)->isNullValue())
+  if (cast<Constant>(To)->isZeroValue())
     return To;
 
   // The replacement could be a bitcast or an alias to another function. We can
@@ -2307,7 +2306,7 @@ bool ConstantPtrAuth::isKnownCompatibleWith(const Value *Key,
                                             const DataLayout &DL) const {
   // This function may only be validly called to analyze a ptrauth operation
   // with no deactivation symbol, so if we have one it isn't compatible.
-  if (!getDeactivationSymbol()->isNullValue())
+  if (!getDeactivationSymbol()->isZeroValue())
     return false;
 
   // If the keys are different, there's no chance for this to be compatible.
@@ -2329,7 +2328,7 @@ bool ConstantPtrAuth::isKnownCompatibleWith(const Value *Key,
   const Value *AddrDiscriminator = nullptr;
 
   // This constant may or may not have an integer discriminator (instead of 0).
-  if (!getDiscriminator()->isNullValue()) {
+  if (!getDiscriminator()->isZeroValue()) {
     // If it does, there's an implicit blend.  We need to have a matching blend
     // intrinsic in the provided full discriminator.
     if (!match(Discriminator,
@@ -2671,7 +2670,7 @@ Constant *ConstantExpr::getSizeOf(Type* Ty) {
   // Note that a non-inbounds gep is used, as null isn't within any object.
   Constant *GEPIdx = ConstantInt::get(Type::getInt32Ty(Ty->getContext()), 1);
   Constant *GEP = getGetElementPtr(
-      Ty, Constant::getNullValue(PointerType::getUnqual(Ty->getContext())),
+      Ty, Constant::getZeroValue(PointerType::getUnqual(Ty->getContext())),
       GEPIdx);
   return getPtrToInt(GEP,
                      Type::getInt64Ty(Ty->getContext()));
@@ -2682,7 +2681,7 @@ Constant *ConstantExpr::getAlignOf(Type* Ty) {
   // Note that a non-inbounds gep is used, as null isn't within any object.
   Type *AligningTy = StructType::get(Type::getInt1Ty(Ty->getContext()), Ty);
   Constant *NullPtr =
-      Constant::getNullValue(PointerType::getUnqual(AligningTy->getContext()));
+      Constant::getZeroValue(PointerType::getUnqual(AligningTy->getContext()));
   Constant *Zero = ConstantInt::get(Type::getInt64Ty(Ty->getContext()), 0);
   Constant *One = ConstantInt::get(Type::getInt32Ty(Ty->getContext()), 1);
   Constant *Indices[2] = {Zero, One};
@@ -2860,7 +2859,7 @@ Constant *ConstantExpr::getExactLogBase2(Constant *C) {
       return nullptr;
     // Note that log2(iN undef) is *NOT* iN undef, because log2(iN undef) u< N.
     if (isa<UndefValue>(Elt)) {
-      Elts.push_back(Constant::getNullValue(Ty->getScalarType()));
+      Elts.push_back(Constant::getZeroValue(Ty->getScalarType()));
       continue;
     }
     if (!match(Elt, m_APInt(IVal)) || !IVal->isPowerOf2())
@@ -2881,7 +2880,7 @@ Constant *ConstantExpr::getBinOpIdentity(unsigned Opcode, Type *Ty,
       case Instruction::Add: // X + 0 = X
       case Instruction::Or:  // X | 0 = X
       case Instruction::Xor: // X ^ 0 = X
-        return Constant::getNullValue(Ty);
+        return Constant::getZeroValue(Ty);
       case Instruction::Mul: // X * 1 = X
         return ConstantInt::get(Ty, 1);
       case Instruction::And: // X & -1 = X
@@ -2905,7 +2904,7 @@ Constant *ConstantExpr::getBinOpIdentity(unsigned Opcode, Type *Ty,
     case Instruction::LShr: // X >>u 0 = X
     case Instruction::AShr: // X >> 0 = X
     case Instruction::FSub: // X - 0.0 = X
-      return Constant::getNullValue(Ty);
+      return Constant::getZeroValue(Ty);
     case Instruction::SDiv: // X / 1 = X
     case Instruction::UDiv: // X /u 1 = X
       return ConstantInt::get(Ty, 1);
@@ -2919,7 +2918,7 @@ Constant *ConstantExpr::getBinOpIdentity(unsigned Opcode, Type *Ty,
 Constant *ConstantExpr::getIntrinsicIdentity(Intrinsic::ID ID, Type *Ty) {
   switch (ID) {
   case Intrinsic::umax:
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
   case Intrinsic::umin:
     return Constant::getAllOnesValue(Ty);
   case Intrinsic::smax:
@@ -2953,7 +2952,7 @@ Constant *ConstantExpr::getBinOpAbsorber(unsigned Opcode, Type *Ty,
 
   case Instruction::And: // 0 & X = 0
   case Instruction::Mul: // 0 * X = 0
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
   }
 
   // AllowLHSConstant must be set.
@@ -2970,7 +2969,7 @@ Constant *ConstantExpr::getBinOpAbsorber(unsigned Opcode, Type *Ty,
   case Instruction::UDiv: // 0 /u X = 0
   case Instruction::URem: // 0 %u X = 0
   case Instruction::SRem: // 0 %s X = 0
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
   }
 }
 
@@ -3598,7 +3597,7 @@ Value *ConstantArray::handleOperandChangeImpl(Value *From, Value *To) {
     AllSame &= Val == ToC;
   }
 
-  if (AllSame && ToC->isNullValue())
+  if (AllSame && ToC->isZeroValue())
     return ConstantAggregateZero::get(getType());
 
   if (AllSame && isa<UndefValue>(ToC))
@@ -3638,7 +3637,7 @@ Value *ConstantStruct::handleOperandChangeImpl(Value *From, Value *To) {
     AllSame &= Val == ToC;
   }
 
-  if (AllSame && ToC->isNullValue())
+  if (AllSame && ToC->isZeroValue())
     return ConstantAggregateZero::get(getType());
 
   if (AllSame && isa<UndefValue>(ToC))

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1269,7 +1269,7 @@ int LLVMGetNumOperands(LLVMValueRef Val) {
 /*--.. Operations on constants of any type .................................--*/
 
 LLVMValueRef LLVMConstNull(LLVMTypeRef Ty) {
-  return wrap(Constant::getNullValue(unwrap(Ty)));
+  return wrap(Constant::getZeroValue(unwrap(Ty)));
 }
 
 LLVMValueRef LLVMConstAllOnes(LLVMTypeRef Ty) {
@@ -1290,7 +1290,7 @@ LLVMBool LLVMIsConstant(LLVMValueRef Ty) {
 
 LLVMBool LLVMIsNull(LLVMValueRef Val) {
   if (Constant *C = dyn_cast<Constant>(unwrap(Val)))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 
@@ -3627,7 +3627,7 @@ LLVMValueRef LLVMBuildCleanupPad(LLVMBuilderRef B, LLVMValueRef ParentPad,
                                  const char *Name) {
   if (ParentPad == nullptr) {
     Type *Ty = Type::getTokenTy(unwrap(B)->getContext());
-    ParentPad = wrap(Constant::getNullValue(Ty));
+    ParentPad = wrap(Constant::getZeroValue(Ty));
   }
   return wrap(unwrap(B)->CreateCleanupPad(
       unwrap(ParentPad), ArrayRef(unwrap(Args), NumArgs), Name));
@@ -3642,7 +3642,7 @@ LLVMValueRef LLVMBuildCatchSwitch(LLVMBuilderRef B, LLVMValueRef ParentPad,
                                   unsigned NumHandlers, const char *Name) {
   if (ParentPad == nullptr) {
     Type *Ty = Type::getTokenTy(unwrap(B)->getContext());
-    ParentPad = wrap(Constant::getNullValue(Ty));
+    ParentPad = wrap(Constant::getZeroValue(Ty));
   }
   return wrap(unwrap(B)->CreateCatchSwitch(unwrap(ParentPad), unwrap(UnwindBB),
                                            NumHandlers, Name));

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2375,7 +2375,7 @@ static void setAssignmentTrackingModuleFlag(Module &M) {
 
 static bool getAssignmentTrackingModuleFlag(const Module &M) {
   Metadata *Value = M.getModuleFlag(AssignmentTrackingModuleFlag);
-  return Value && !cast<ConstantAsMetadata>(Value)->getValue()->isNullValue();
+  return Value && !cast<ConstantAsMetadata>(Value)->getValue()->isZeroValue();
 }
 
 bool llvm::isAssignmentTrackingEnabled(const Module &M) {

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -1907,7 +1907,7 @@ Constant *ShuffleVectorInst::convertShuffleMaskForBitcode(ArrayRef<int> Mask,
     assert(all_equal(Mask) && "Unexpected shuffle");
     Type *VecTy = VectorType::get(Int32Ty, Mask.size(), true);
     if (Mask[0] == 0)
-      return Constant::getNullValue(VecTy);
+      return Constant::getZeroValue(VecTy);
     return PoisonValue::get(VecTy);
   }
   SmallVector<Constant *, 16> MaskConst;

--- a/llvm/lib/IR/SafepointIRVerifier.cpp
+++ b/llvm/lib/IR/SafepointIRVerifier.cpp
@@ -368,7 +368,7 @@ static enum BaseType getBaseType(const Value *Val) {
     if (isa<Constant>(V)) {
       // We found at least one base pointer which is non-null, so this derived
       // pointer is not exclusively derived from null.
-      if (V != Constant::getNullValue(V->getType()))
+      if (V != Constant::getZeroValue(V->getType()))
         isExclusivelyDerivedFromNull = false;
       // Continue processing the remaining values to make sure it's exclusively
       // constant.

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -121,7 +121,7 @@ public:
     Type *Ty = C->getType();
     Hashes.emplace_back(hashType(Ty));
 
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Hashes.emplace_back(static_cast<stable_hash>('N'));
       return stable_hash_combine(Hashes);
     }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -896,7 +896,7 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
     // If the global has common linkage, it must have a zero initializer and
     // cannot be constant.
     if (GV.hasCommonLinkage()) {
-      Check(GV.getInitializer()->isNullValue(),
+      Check(GV.getInitializer()->isZeroValue(),
             "'common' global must have a zero initializer!", &GV);
       Check(!GV.isConstant(), "'common' global may not be marked constant!",
             &GV);
@@ -2850,7 +2850,7 @@ void Verifier::visitConstantPtrAuth(const ConstantPtrAuth *CPA) {
         "signed ptrauth constant deactivation symbol must be a pointer");
 
   Check(isa<GlobalValue>(CPA->getDeactivationSymbol()) ||
-            CPA->getDeactivationSymbol()->isNullValue(),
+            CPA->getDeactivationSymbol()->isZeroValue(),
         "signed ptrauth constant deactivation symbol must be a global value "
         "or null");
 }

--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -382,7 +382,7 @@ Register AArch64FastISel::materializeInt(const ConstantInt *CI, MVT VT) {
 Register AArch64FastISel::materializeFP(const ConstantFP *CFP, MVT VT) {
   // Positive zero (+0.0) has to be materialized with a fmov from the zero
   // register, because the immediate version of fmov cannot encode zero.
-  if (CFP->isNullValue())
+  if (CFP->isZeroValue())
     return fastMaterializeFloatZero(CFP);
 
   if (VT != MVT::f32 && VT != MVT::f64)
@@ -553,7 +553,7 @@ Register AArch64FastISel::fastMaterializeConstant(const Constant *C) {
 }
 
 Register AArch64FastISel::fastMaterializeFloatZero(const ConstantFP *CFP) {
-  assert(CFP->isNullValue() &&
+  assert(CFP->isZeroValue() &&
          "Floating-point constant is not a positive zero.");
   MVT VT;
   if (!isTypeLegal(CFP->getType(), VT))
@@ -1216,7 +1216,7 @@ Register AArch64FastISel::emitAddSub(bool UseAdd, MVT RetVT, const Value *LHS,
       ResultReg = emitAddSub_ri(UseAdd, RetVT, LHSReg, Imm, SetFlags,
                                 WantResult);
   } else if (const auto *C = dyn_cast<Constant>(RHS))
-    if (C->isNullValue())
+    if (C->isZeroValue())
       ResultReg = emitAddSub_ri(UseAdd, RetVT, LHSReg, 0, SetFlags, WantResult);
 
   if (ResultReg)
@@ -2290,10 +2290,10 @@ bool AArch64FastISel::emitCompareAndBranch(const CondBrInst *BI) {
     return false;
   case CmpInst::ICMP_EQ:
   case CmpInst::ICMP_NE:
-    if (isa<Constant>(LHS) && cast<Constant>(LHS)->isNullValue())
+    if (isa<Constant>(LHS) && cast<Constant>(LHS)->isZeroValue())
       std::swap(LHS, RHS);
 
-    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isNullValue())
+    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isZeroValue())
       return false;
 
     if (const auto *AI = dyn_cast<BinaryOperator>(LHS))
@@ -2319,7 +2319,7 @@ bool AArch64FastISel::emitCompareAndBranch(const CondBrInst *BI) {
     break;
   case CmpInst::ICMP_SLT:
   case CmpInst::ICMP_SGE:
-    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isNullValue())
+    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isZeroValue())
       return false;
 
     TestBit = BW - 1;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -33398,7 +33398,7 @@ Value *AArch64TargetLowering::createComplexDeinterleavingIR(
     Value *Accumulator) const {
   VectorType *Ty = cast<VectorType>(InputA->getType());
   if (Accumulator == nullptr)
-    Accumulator = Constant::getNullValue(Ty);
+    Accumulator = Constant::getZeroValue(Ty);
   bool IsScalable = Ty->isScalableTy();
   bool IsInt = Ty->getElementType()->isIntegerTy();
 

--- a/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
@@ -342,7 +342,7 @@ static bool shouldConvertImpl(const Constant *Cst) {
   // instances of Cst.
   // Ideally, we could promote this into a global and rematerialize the constant
   // when it was a bad idea.
-  if (Cst->isNullValue())
+  if (Cst->isZeroValue())
     return false;
 
   // Globals cannot be or contain scalable vectors.

--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -226,9 +226,9 @@ public:
       if (Offset > LastOffset)
         emitZeroes(IRB, LastOffset, Offset - LastOffset);
 
-      Value *Store1 = I1 == Out.end() ? Constant::getNullValue(IRB.getInt64Ty())
+      Value *Store1 = I1 == Out.end() ? Constant::getZeroValue(IRB.getInt64Ty())
                                       : I1->second;
-      Value *Store2 = I2 == Out.end() ? Constant::getNullValue(IRB.getInt64Ty())
+      Value *Store2 = I2 == Out.end() ? Constant::getZeroValue(IRB.getInt64Ty())
                                       : I2->second;
       emitPair(IRB, Offset, Store1, Store2);
       LastOffset = Offset + 16;
@@ -479,7 +479,7 @@ Instruction *AArch64StackTagging::insertBaseTaggedPointer(
   IRBuilder<> IRB(&PrologueBB->front());
   Instruction *Base =
       IRB.CreateIntrinsic(Intrinsic::aarch64_irg_sp, {},
-                          {Constant::getNullValue(IRB.getInt64Ty())});
+                          {Constant::getZeroValue(IRB.getInt64Ty())});
   Base->setName("basetag");
   const Triple &TargetTriple = M.getTargetTriple();
   // This ABI will make it into Android API level 35.
@@ -585,7 +585,7 @@ bool AArch64StackTagging::runOnFunction(Function &Fn) {
     IRBuilder<> IRB(Info.AI->getNextNode());
     Instruction *TagPCall =
         IRB.CreateIntrinsic(Intrinsic::aarch64_tagp, {Info.AI->getType()},
-                            {Constant::getNullValue(Info.AI->getType()), Base,
+                            {Constant::getZeroValue(Info.AI->getType()), Base,
                              ConstantInt::get(IRB.getInt64Ty(), Tag)});
     if (Info.AI->hasName())
       TagPCall->setName(Info.AI->getName() + ".tag");

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1880,7 +1880,7 @@ simplifySVEIntrinsic(InstCombiner &IC, IntrinsicInst &II,
 
     if (IInfo.inactiveLanesAreUnused()) {
       if (IInfo.resultIsZeroInitialized())
-        IC.replaceInstUsesWith(II, Constant::getNullValue(II.getType()));
+        IC.replaceInstUsesWith(II, Constant::getZeroValue(II.getType()));
 
       return IC.eraseInstFromFunction(II);
     }
@@ -2124,7 +2124,7 @@ static std::optional<Instruction *> instCombineSVECmpNE(InstCombiner &IC,
 
   // If all bits are zero bail early with an empty predicate
   if (PredicateBits == 0) {
-    auto *PFalse = Constant::getNullValue(II.getType());
+    auto *PFalse = Constant::getZeroValue(II.getType());
     PFalse->takeName(&II);
     return IC.replaceInstUsesWith(II, PFalse);
   }
@@ -2187,7 +2187,7 @@ static std::optional<Instruction *> instCombineSVELast(InstCombiner &IC,
   }
 
   auto *C = dyn_cast<Constant>(Pg);
-  if (IsAfter && C && C->isNullValue()) {
+  if (IsAfter && C && C->isZeroValue()) {
     // The intrinsic is extracting lane 0 so use an extract instead.
     auto *IdxTy = Type::getInt64Ty(II.getContext());
     auto *Extract = ExtractElementInst::Create(Vec, ConstantInt::get(IdxTy, 0));

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -5676,7 +5676,7 @@ AArch64InstructionSelector::emitConstantVector(Register Dst, Constant *CV,
   assert((DstSize == 64 || DstSize == 128) &&
          "Unexpected vector constant size");
 
-  if (CV->isNullValue()) {
+  if (CV->isZeroValue()) {
     if (DstSize == 128) {
       auto Mov =
           MIRBuilder.buildInstr(AArch64::MOVIv2d_ns, {Dst}, {}).addImm(0);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1210,7 +1210,7 @@ static Value *getSign32(Value *V, IRBuilder<> &Builder, const DataLayout DL) {
   if (Known.isNegative())
     return Constant::getAllOnesValue(V->getType());
   if (Known.isNonNegative())
-    return Constant::getNullValue(V->getType());
+    return Constant::getZeroValue(V->getType());
   return Builder.CreateAShr(V, Builder.getInt32(31));
 }
 
@@ -1565,7 +1565,7 @@ bool AMDGPUCodeGenPrepareImpl::visitLoadInst(LoadInst &I) {
       ConstantInt *Lower =
         mdconst::extract<ConstantInt>(Range->getOperand(0));
 
-      if (Lower->isNullValue()) {
+      if (Lower->isZeroValue()) {
         WidenLoad->setMetadata(LLVMContext::MD_range, nullptr);
       } else {
         Metadata *LowAndHigh[] = {

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -441,7 +441,7 @@ static APInt trimTrailingZerosInVector(InstCombiner &IC, Value *UseV,
       break;
 
     if (auto *ConstElt = dyn_cast<Constant>(Elt)) {
-      if (!ConstElt->isNullValue() && !isa<UndefValue>(Elt))
+      if (!ConstElt->isZeroValue() && !isa<UndefValue>(Elt))
         break;
     } else {
       break;
@@ -936,7 +936,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     // llvm.amdgcn.class(undef, mask) -> mask != 0
     if (IC.getSimplifyQuery().isUndefValue(Src0)) {
       Value *CmpMask = IC.Builder.CreateICmpNE(
-          Src1, ConstantInt::getNullValue(Src1->getType()));
+          Src1, ConstantInt::getZeroValue(Src1->getType()));
       return IC.replaceInstUsesWith(II, CmpMask);
     }
     break;
@@ -1003,7 +1003,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       return IC.replaceInstUsesWith(II, PoisonValue::get(Ty));
 
     if(IC.getSimplifyQuery().isUndefValue(Arg))
-      return IC.replaceInstUsesWith(II, Constant::getNullValue(Ty));
+      return IC.replaceInstUsesWith(II, Constant::getZeroValue(Ty));
 
     ConstantInt *CArg = dyn_cast<ConstantInt>(II.getArgOperand(0));
     if (!CArg)
@@ -1034,7 +1034,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     if (CWidth) {
       Width = CWidth->getZExtValue();
       if ((Width & (IntSize - 1)) == 0) {
-        return IC.replaceInstUsesWith(II, ConstantInt::getNullValue(Ty));
+        return IC.replaceInstUsesWith(II, ConstantInt::getZeroValue(Ty));
       }
 
       // Hardware ignores high bits, so remove those.
@@ -1304,7 +1304,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       if (auto *CSrc1 = dyn_cast<Constant>(Src1)) {
         Constant *CCmp = ConstantFoldCompareInstOperands(
             (ICmpInst::Predicate)CCVal, CSrc0, CSrc1, DL);
-        if (CCmp && CCmp->isNullValue()) {
+        if (CCmp && CCmp->isZeroValue()) {
           return IC.replaceInstUsesWith(
               II, IC.Builder.CreateSExt(CCmp, II.getType()));
         }
@@ -1349,7 +1349,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
          (match(Src1, PatternMatch::m_AllOnes()) &&
           match(Src0, m_SExt(PatternMatch::m_Value(ExtSrc))))) &&
         ExtSrc->getType()->isIntegerTy(1)) {
-      IC.replaceOperand(II, 1, ConstantInt::getNullValue(Src1->getType()));
+      IC.replaceOperand(II, 1, ConstantInt::getZeroValue(Src1->getType()));
       IC.replaceOperand(II, 2,
                         ConstantInt::get(CC->getType(), CmpInst::ICMP_NE));
       return &II;
@@ -1457,7 +1457,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     if (auto *Src = dyn_cast<ConstantInt>(Arg)) {
       if (Src->isZero()) {
         // amdgcn.ballot(i1 0) is zero.
-        return IC.replaceInstUsesWith(II, Constant::getNullValue(II.getType()));
+        return IC.replaceInstUsesWith(II, Constant::getZeroValue(II.getType()));
       }
     }
     if (ST->isWave32() && II.getType()->getIntegerBitWidth() == 64) {
@@ -1525,7 +1525,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     auto *BC = cast<ConstantInt>(II.getArgOperand(5));
     auto *RM = cast<ConstantInt>(II.getArgOperand(3));
     auto *BM = cast<ConstantInt>(II.getArgOperand(4));
-    if (BC->isNullValue() || RM->getZExtValue() != 0xF ||
+    if (BC->isZeroValue() || RM->getZExtValue() != 0xF ||
         BM->getZExtValue() != 0xF || isa<PoisonValue>(Old))
       break;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -1224,8 +1224,8 @@ public:
 Constant *FatPtrConstMaterializer::materializeBufferFatPtrConst(Constant *C) {
   Type *SrcTy = C->getType();
   auto *NewTy = dyn_cast<StructType>(TypeMap->remapType(SrcTy));
-  if (C->isNullValue())
-    return ConstantAggregateZero::getNullValue(NewTy);
+  if (C->isZeroValue())
+    return ConstantAggregateZero::getZeroValue(NewTy);
   if (isa<PoisonValue>(C)) {
     return ConstantStruct::get(NewTy,
                                {PoisonValue::get(NewTy->getElementType(0)),
@@ -2037,13 +2037,13 @@ PtrParts SplitPtrStructs::visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
   auto *ResTy = cast<StructType>(I.getType());
   Type *RsrcTy = ResTy->getElementType(0);
   Type *OffTy = ResTy->getElementType(1);
-  Value *ZeroOff = Constant::getNullValue(OffTy);
+  Value *ZeroOff = Constant::getZeroValue(OffTy);
 
   // Special case for null pointers, undef, and poison, which can be created by
   // address space propagation.
   auto *InConst = dyn_cast<Constant>(In);
-  if (InConst && InConst->isNullValue()) {
-    Value *NullRsrc = Constant::getNullValue(RsrcTy);
+  if (InConst && InConst->isZeroValue()) {
+    Value *NullRsrc = Constant::getZeroValue(RsrcTy);
     SplitUsers.insert(&I);
     return {NullRsrc, ZeroOff};
   }
@@ -2246,7 +2246,7 @@ PtrParts SplitPtrStructs::visitIntrinsicInst(IntrinsicInst &I) {
                                       {Base, Stride, NumRecords, Flags});
     copyMetadata(Rsrc, &I);
     Rsrc->takeName(&I);
-    Value *Zero = Constant::getNullValue(OffType);
+    Value *Zero = Constant::getZeroValue(OffType);
     SplitUsers.insert(&I);
     return {Rsrc, Zero};
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -342,7 +342,7 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
       if (!Remainder)
         continue;
       Remainder->replaceAllUsesWith(
-          Constant::getNullValue(Remainder->getType()));
+          Constant::getZeroValue(Remainder->getType()));
       MadeChange = true;
     }
   } else if (HasUniformWorkGroupSize) { // Pre-V5.

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.h
@@ -53,7 +53,7 @@ static inline const MCExpr *lowerAddrSpaceCast(const Constant *CV,
   if (CE && CE->getOpcode() == Instruction::AddrSpaceCast) {
     auto *Op = CE->getOperand(0);
     auto SrcAddr = Op->getType()->getPointerAddressSpace();
-    if (Op->isNullValue() && AMDGPU::getNullPointerValue(SrcAddr) == 0) {
+    if (Op->isZeroValue() && AMDGPU::getNullPointerValue(SrcAddr) == 0) {
       auto DstAddr = CE->getType()->getPointerAddressSpace();
       return MCConstantExpr::create(AMDGPU::getNullPointerValue(DstAddr),
                                     OutContext);

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -654,7 +654,7 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     Type *AccessTy = Inst->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
     if (Constant *CI = dyn_cast<Constant>(Index)) {
-      if (CI->isNullValue() && AccessSize == VecStoreSize) {
+      if (CI->isZeroValue() && AccessSize == VecStoreSize) {
         Inst->replaceAllUsesWith(
             Builder.CreateBitPreservingCastChain(DL, CurVal, AccessTy));
         return nullptr;
@@ -732,7 +732,7 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     Type *AccessTy = Val->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
     if (Constant *CI = dyn_cast<Constant>(Index))
-      if (CI->isNullValue() && AccessSize == VecStoreSize)
+      if (CI->isZeroValue() && AccessSize == VecStoreSize)
         return Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
 
     // Storing a subvector.
@@ -1659,7 +1659,7 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(
   TID = Builder.CreateAdd(TID, TIdZ);
 
   LLVMContext &Context = Mod->getContext();
-  Value *Indices[] = {Constant::getNullValue(Type::getInt32Ty(Context)), TID};
+  Value *Indices[] = {Constant::getZeroValue(Type::getInt32Ty(Context)), TID};
 
   Value *Offset = Builder.CreateInBoundsGEP(GVTy, GV, Indices);
   AA.Alloca->mutateType(Offset->getType());
@@ -1677,10 +1677,10 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(
 
         Type *NewTy = LHS->getType()->getWithNewType(NewPtrTy);
         if (isa<ConstantPointerNull, ConstantAggregateZero>(LHS))
-          CI->setOperand(0, Constant::getNullValue(NewTy));
+          CI->setOperand(0, Constant::getZeroValue(NewTy));
 
         if (isa<ConstantPointerNull, ConstantAggregateZero>(RHS))
-          CI->setOperand(1, Constant::getNullValue(NewTy));
+          CI->setOperand(1, Constant::getZeroValue(NewTy));
 
         continue;
       }
@@ -1698,15 +1698,15 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(
       // Adjust the types of any constant operands.
       if (SelectInst *SI = dyn_cast<SelectInst>(V)) {
         if (isa<ConstantPointerNull, ConstantAggregateZero>(SI->getOperand(1)))
-          SI->setOperand(1, Constant::getNullValue(NewTy));
+          SI->setOperand(1, Constant::getZeroValue(NewTy));
 
         if (isa<ConstantPointerNull, ConstantAggregateZero>(SI->getOperand(2)))
-          SI->setOperand(2, Constant::getNullValue(NewTy));
+          SI->setOperand(2, Constant::getZeroValue(NewTy));
       } else if (PHINode *Phi = dyn_cast<PHINode>(V)) {
         for (unsigned I = 0, E = Phi->getNumIncomingValues(); I != E; ++I) {
           if (isa<ConstantPointerNull, ConstantAggregateZero>(
                   Phi->getIncomingValue(I)))
-            Phi->setIncomingValue(I, Constant::getNullValue(NewTy));
+            Phi->setIncomingValue(I, Constant::getZeroValue(NewTy));
         }
       }
 

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -20107,7 +20107,7 @@ SITargetLowering::shouldExpandAtomicRMWInIR(const AtomicRMWInst *RMW) const {
         // Atomic sub/or/xor do not work over PCI express, but atomic add
         // does. InstCombine transforms these with 0 to or, so undo that.
         if (const Constant *ConstVal = dyn_cast<Constant>(RMW->getValOperand());
-            ConstVal && ConstVal->isNullValue())
+            ConstVal && ConstVal->isZeroValue())
           return AtomicExpansionKind::CustomExpand;
       }
 
@@ -20678,7 +20678,7 @@ void SITargetLowering::emitExpandAtomicRMW(AtomicRMWInst *AI) const {
   if (Op == AtomicRMWInst::Sub || Op == AtomicRMWInst::Or ||
       Op == AtomicRMWInst::Xor) {
     if (const auto *ConstVal = dyn_cast<Constant>(AI->getValOperand());
-        ConstVal && ConstVal->isNullValue()) {
+        ConstVal && ConstVal->isZeroValue()) {
       // atomicrmw or %ptr, 0 -> atomicrmw add %ptr, 0
       AI->setOperation(AtomicRMWInst::Add);
 

--- a/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
+++ b/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
@@ -396,7 +396,7 @@ static void collectElements(Constant *Init,
   unsigned ArrSize = ArrayTy->getNumElements();
   if (isa<ConstantAggregateZero>(Init)) {
     for (unsigned I = 0; I < ArrSize; ++I)
-      Elements.push_back(Constant::getNullValue(ArrayTy->getElementType()));
+      Elements.push_back(Constant::getZeroValue(ArrayTy->getElementType()));
     return;
   }
 

--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -280,7 +280,7 @@ static Value *expandVecReduceAdd(CallInst *Orig, Intrinsic::ID IntrinsicId) {
   // Handle the initial start value for floating-point addition.
   if (IsFAdd) {
     Constant *StartValue = dyn_cast<Constant>(Orig->getOperand(0));
-    if (StartValue && !StartValue->isNullValue())
+    if (StartValue && !StartValue->isZeroValue())
       Sum = Builder.CreateFAdd(Sum, StartValue);
   }
 
@@ -1025,7 +1025,7 @@ static Value *expandSignIntrinsic(CallInst *Orig) {
   Type *Ty = X->getType();
   Type *ScalarTy = Ty->getScalarType();
   Type *RetTy = Orig->getType();
-  Constant *Zero = Constant::getNullValue(Ty);
+  Constant *Zero = Constant::getZeroValue(Ty);
 
   IRBuilder<> Builder(Orig);
 

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -630,7 +630,7 @@ public:
 
       // Copy coordinates and offsets into Args.
       extractElementsIntoArgs(IRB, Args, 2, Coords, 3);
-      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
+      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isZeroValue())
         extractElementsIntoArgs(IRB, Args, 5, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
@@ -944,7 +944,7 @@ public:
 
       auto ZeroOrUndef = [&](Type *Ty) {
         return MMDI.ValidatorVersion < VersionTuple(1, 6)
-                   ? Constant::getNullValue(Ty)
+                   ? Constant::getZeroValue(Ty)
                    : UndefValue::get(Ty);
       };
 

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -279,7 +279,7 @@ static void createTextureLoad(IntrinsicInst *II, LoadInst *LI,
         FixedVectorType::get(Builder.getInt32Ty(), VecTy->getNumElements());
   else
     OffsetTy = Builder.getInt32Ty();
-  Value *Offsets = Constant::getNullValue(OffsetTy);
+  Value *Offsets = Constant::getZeroValue(OffsetTy);
 
   Value *V =
       Builder.CreateIntrinsic(ContainedType, Intrinsic::dx_resource_load_level,

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
@@ -2019,7 +2019,7 @@ void DXILBitcodeWriter::writeConstants(unsigned FirstVal, unsigned LastVal,
     const Constant *C = cast<Constant>(V);
     unsigned Code = -1U;
     unsigned AbbrevToUse = 0;
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Code = bitc::CST_CODE_NULL;
     } else if (isa<UndefValue>(C)) {
       Code = bitc::CST_CODE_UNDEF;

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -1148,7 +1148,7 @@ HexagonTargetLowering::LowerConstantPool(SDValue Op, SelectionDAG &DAG) const {
       assert(isPowerOf2_32(VecLen) &&
              "conversion only supported for pow2 VectorSize");
       for (unsigned i = 0; i < VecLen; ++i)
-        NewConst.push_back(IRB.getInt8(CV->getOperand(i)->isNullValue()));
+        NewConst.push_back(IRB.getInt8(CV->getOperand(i)->isZeroValue()));
 
       CVal = ConstantVector::get(NewConst);
       isVTi1Type = true;

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -1412,7 +1412,7 @@ auto AlignVectors::realignStoreGroup(IRBuilderBase &Builder,
     ByteSpan VSection =
         VSpan.section(Index * ScLen, ScLen).shift(-Index * ScLen);
     Value *Undef = UndefValue::get(SecTy);
-    Value *Zero = Constant::getNullValue(SecTy);
+    Value *Zero = Constant::getZeroValue(SecTy);
     Value *AccumV = Undef;
     Value *AccumM = Zero;
     for (ByteSpan::Block &S : VSection) {
@@ -2984,7 +2984,7 @@ auto HvxIdioms::processFxpMulChopped(IRBuilderBase &Builder, Instruction &In,
 
   // Add the optional rounding to the proper word.
   if (Op.RoundAt.has_value()) {
-    Value *Zero = Constant::getNullValue(WordX[0]->getType());
+    Value *Zero = Constant::getZeroValue(WordX[0]->getType());
     SmallVector<Value *> RoundV(WordP.size(), Zero);
     RoundV[*Op.RoundAt / 32] =
         ConstantInt::get(HvxWordTy, 1ull << (*Op.RoundAt % 32));
@@ -3064,7 +3064,7 @@ auto HvxIdioms::createAddCarry(IRBuilderBase &Builder, Value *X, Value *Y,
     } else {
       AddCarry = HVC.HST.getIntrinsicId(Hexagon::V6_vaddcarry);
       if (CarryIn == nullptr)
-        CarryIn = Constant::getNullValue(HVC.getBoolTy(HVC.length(VecTy)));
+        CarryIn = Constant::getZeroValue(HVC.getBoolTy(HVC.length(VecTy)));
       Args.push_back(CarryIn);
     }
     Value *Ret = HVC.createHvxIntrinsic(Builder, AddCarry,
@@ -3212,7 +3212,7 @@ auto HvxIdioms::createMulLong(IRBuilderBase &Builder, ArrayRef<Value *> WordX,
     }
   }
 
-  Value *Zero = Constant::getNullValue(WordX[0]->getType());
+  Value *Zero = Constant::getZeroValue(WordX[0]->getType());
 
   auto pop_back_or_zero = [Zero](auto &Vector) -> Value * {
     if (Vector.empty())
@@ -3349,7 +3349,7 @@ auto HexagonVectorCombine::getConstInt(int Val, unsigned Width) const
 
 auto HexagonVectorCombine::isZero(const Value *Val) const -> bool {
   if (auto *C = dyn_cast<Constant>(Val))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1022,7 +1022,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
           (GVar->getAddressSpace() == ADDRESS_SPACE_CONST)) {
         const Constant *Initializer = GVar->getInitializer();
         // 'undef' is treated as there is no value specified.
-        if (!Initializer->isNullValue() && !isa<UndefValue>(Initializer)) {
+        if (!Initializer->isZeroValue() && !isa<UndefValue>(Initializer)) {
           O << " = ";
           printScalarConstant(Initializer, O);
         }
@@ -1030,7 +1030,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
         // The frontend adds zero-initializer to device and constant variables
         // that don't have an initial value, and UndefValue to shared
         // variables, so skip warning for this case.
-        if (!GVar->getInitializer()->isNullValue() &&
+        if (!GVar->getInitializer()->isZeroValue() &&
             !isa<UndefValue>(GVar->getInitializer())) {
           report_fatal_error("initial value of '" + GVar->getName() +
                              "' is not allowed in addrspace(" +
@@ -1056,7 +1056,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
            (GVar->getAddressSpace() == ADDRESS_SPACE_CONST)) &&
           GVar->hasInitializer()) {
         const Constant *Initializer = GVar->getInitializer();
-        if (!isa<UndefValue>(Initializer) && !Initializer->isNullValue()) {
+        if (!isa<UndefValue>(Initializer) && !Initializer->isZeroValue()) {
           AggBuffer aggBuffer(ElementSize, *this);
           bufferAggregateConstant(Initializer, &aggBuffer);
           if (aggBuffer.numSymbols()) {
@@ -1626,7 +1626,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
                                    AggBuffer *AggBuffer) {
   const DataLayout &DL = getDataLayout();
   int AllocSize = DL.getTypeAllocSize(CPV->getType());
-  if (isa<UndefValue>(CPV) || CPV->isNullValue()) {
+  if (isa<UndefValue>(CPV) || CPV->isZeroValue()) {
     // Non-zero Bytes indicates that we need to zero-fill everything. Otherwise,
     // only the space allocated by CPV.
     AggBuffer->addZeros(Bytes ? Bytes : AllocSize);
@@ -1819,7 +1819,7 @@ void NVPTXAsmPrinter::bufferAggregateConstVec(const ConstantVector *CV,
 
     // Optionally pad with zeros.
     if (NumPaddingZeros)
-      SubCVElems.append(NumPaddingZeros, ConstantInt::getNullValue(ElemTy));
+      SubCVElems.append(NumPaddingZeros, ConstantInt::getZeroValue(ElemTy));
 
     auto SubCV = ConstantVector::get(SubCVElems);
     Type *Int8Ty = IntegerType::get(SubCV->getContext(), 8);
@@ -1860,7 +1860,7 @@ NVPTXAsmPrinter::lowerConstantForGV(const Constant *CV,
                                     bool ProcessingGeneric) const {
   MCContext &Ctx = OutContext;
 
-  if (CV->isNullValue() || isa<UndefValue>(CV))
+  if (CV->isZeroValue() || isa<UndefValue>(CV))
     return MCConstantExpr::create(0, Ctx);
 
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(CV))

--- a/llvm/lib/Target/NVPTX/NVPTXCtorDtorLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXCtorDtorLowering.cpp
@@ -109,7 +109,7 @@ static void createInitOrFiniCalls(Function &F, bool IsCtor) {
         auto *GV = new GlobalVariable(
             M, PointerType::get(C, 0),
             /*isConstant=*/false, GlobalValue::WeakAnyLinkage,
-            Constant::getNullValue(PointerType::get(C, 0)),
+            Constant::getZeroValue(PointerType::get(C, 0)),
             IsCtor ? "__init_array_start" : "__fini_array_start",
             /*InsertBefore=*/nullptr, GlobalVariable::NotThreadLocal,
             /*AddressSpace=*/llvm::ADDRESS_SPACE_GLOBAL);
@@ -122,7 +122,7 @@ static void createInitOrFiniCalls(Function &F, bool IsCtor) {
         auto *GV = new GlobalVariable(
             M, PointerType::get(C, 0),
             /*isConstant=*/false, GlobalValue::WeakAnyLinkage,
-            Constant::getNullValue(PointerType::get(C, 0)),
+            Constant::getZeroValue(PointerType::get(C, 0)),
             IsCtor ? "__init_array_end" : "__fini_array_end",
             /*InsertBefore=*/nullptr, GlobalVariable::NotThreadLocal,
             /*AddressSpace=*/llvm::ADDRESS_SPACE_GLOBAL);

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -3599,7 +3599,7 @@ SDValue NVPTXTargetLowering::LowerVAARG(SDValue Op, SelectionDAG &DAG) const {
   Tmp1 = DAG.getStore(VAListLoad.getValue(1), DL, Tmp1, Tmp2,
                       MachinePointerInfo(V));
 
-  const Value *SrcV = Constant::getNullValue(
+  const Value *SrcV = Constant::getZeroValue(
       PointerType::get(*DAG.getContext(), ADDRESS_SPACE_LOCAL));
 
   // Load the actual argument out of the pointer VAList

--- a/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
@@ -96,7 +96,7 @@ class PPCBoolRetToInt : public FunctionPass {
     if (auto *P = dyn_cast<PHINode>(V)) {
       // Temporarily set the operands to 0. We'll fix this later in
       // runOnUse.
-      Value *Zero = Constant::getNullValue(IntTy);
+      Value *Zero = Constant::getZeroValue(IntTy);
       PHINode *Q =
         PHINode::Create(IntTy, P->getNumIncomingValues(), P->getName(), P->getIterator());
       for (unsigned I = 0; I < P->getNumOperands(); ++I)

--- a/llvm/lib/Target/SPIRV/SPIRVCtorDtorLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCtorDtorLowering.cpp
@@ -109,7 +109,7 @@ void createInitOrFiniCalls(Function &F, bool IsCtor) {
     auto *GV = new GlobalVariable(
         M, PointerType::getUnqual(C),
         /*isConstant=*/false, GlobalValue::WeakAnyLinkage,
-        Constant::getNullValue(PointerType::getUnqual(C)), Name,
+        Constant::getZeroValue(PointerType::getUnqual(C)), Name,
         /*InsertBefore=*/nullptr, GlobalVariable::NotThreadLocal,
         /*AddressSpace=*/SPIRV_GLOBAL_AS);
     GV->setVisibility(GlobalVariable::ProtectedVisibility);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -1806,7 +1806,7 @@ Instruction *SPIRVEmitIntrinsics::visitSwitchInst(SwitchInst &I) {
   // it will be removed after IR translation pass
   B.SetInsertPoint(ParentBB);
   IndirectBrInst *BrI = B.CreateIndirectBr(
-      Constant::getNullValue(PointerType::getUnqual(ParentBB->getContext())),
+      Constant::getZeroValue(PointerType::getUnqual(ParentBB->getContext())),
       BBCases.size());
   for (BasicBlock *BBCase : BBCases)
     BrI->addDestination(BBCase);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -581,7 +581,7 @@ Register SPIRVGlobalRegistry::getOrCreateCompositeOrNull(
   if (Register R = find(CA, CurMF); R.isValid())
     return R;
 
-  bool IsNull = Val->isNullValue() && ZeroAsNull;
+  bool IsNull = Val->isZeroValue() && ZeroAsNull;
   Register ElemReg;
   if (!IsNull)
     ElemReg =

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1739,9 +1739,9 @@ bool SPIRVInstructionSelector::selectPopCount(Register ResVReg,
                                               SPIRVTypeInst ResType,
                                               MachineInstr &I,
                                               unsigned Opcode) const {
-  // Vulkan restricts OpBitCount to 32-bit integers or vectors of 32-bit 
-  // integers unless VK_KHR_maintenance9 is enabled. Until VK_KHR_maintaince9 
-  // is core we will not generate OpBitCount with any other types when 
+  // Vulkan restricts OpBitCount to 32-bit integers or vectors of 32-bit
+  // integers unless VK_KHR_maintenance9 is enabled. Until VK_KHR_maintaince9
+  // is core we will not generate OpBitCount with any other types when
   // targeting Vulkan.
   if (!STI.getTargetTriple().isVulkanOS())
     return selectUnOp(ResVReg, ResType, I, Opcode);
@@ -2176,7 +2176,7 @@ SPIRVInstructionSelector::getOrCreateMemSetGlobal(MachineInstr &I) const {
       ArrayType::get(IntegerType::get(CurFunction.getContext(), 8), Num);
   GlobalVariable *GV = new GlobalVariable(*CurFunction.getParent(), LLVMArrTy,
                                           true, GlobalValue::InternalLinkage,
-                                          Constant::getNullValue(LLVMArrTy));
+                                          Constant::getZeroValue(LLVMArrTy));
 
   Type *ValTy = Type::getInt8Ty(I.getMF()->getFunction().getContext());
   Type *ArrTy = ArrayType::get(ValTy, Num);

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
@@ -158,7 +158,7 @@ Constant *SPIRVLegalizeZeroSizeArraysImpl::legalizeConstant(Constant *C) {
   if (isa<UndefValue>(C))
     return PoisonValue::get(NewTy);
   if (isa<ConstantAggregateZero>(C))
-    return Constant::getNullValue(NewTy);
+    return Constant::getZeroValue(NewTy);
   if (ConstantArray *CA = dyn_cast<ConstantArray>(C)) {
     SmallVector<Constant *, 8> Elems;
     for (Use &U : CA->operands())

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -99,7 +99,7 @@ addConstantsToTrack(MachineFunction &MF, SPIRVGlobalRegistry *GR,
             if (SrcMI && (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT ||
                           SrcMI->getOpcode() == TargetOpcode::G_IMPLICIT_DEF))
               TargetExtConstTypes[SrcMI] = Const->getType();
-            if (Const->isNullValue()) {
+            if (Const->isZeroValue()) {
               MachineBasicBlock &DepMBB = MF.front();
               MachineIRBuilder MIB(DepMBB, DepMBB.getFirstNonPHI());
               SPIRVTypeInst ExtType = GR->getOrCreateSPIRVType(

--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -527,7 +527,7 @@ addFunctionTypeMutation(NamedMDNode *NMD,
   transform(ChangedTys, std::back_inserter(MDArgs), [=, &Ctx](auto &&CTy) {
     return MDNode::get(
         Ctx, {ConstantAsMetadata::get(ConstantInt::get(I32Ty, CTy.first, true)),
-              ValueAsMetadata::get(Constant::getNullValue(CTy.second))});
+              ValueAsMetadata::get(Constant::getZeroValue(CTy.second))});
   });
   if (!AsmConstraints.empty())
     MDArgs.push_back(MDNode::get(Ctx, MDString::get(Ctx, AsmConstraints)));

--- a/llvm/lib/Target/TargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/TargetLoweringObjectFile.cpp
@@ -68,7 +68,7 @@ unsigned TargetLoweringObjectFile::getCallSiteEncoding() const {
 
 static bool isNullOrUndef(const Constant *C) {
   // Check that the constant isn't all zeros or undefs.
-  if (C->isNullValue() || isa<UndefValue>(C))
+  if (C->isZeroValue() || isa<UndefValue>(C))
     return true;
   if (!isa<ConstantAggregate>(C))
     return false;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRegStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRegStackify.cpp
@@ -114,12 +114,12 @@ static void convertImplicitDefToConstZero(MachineInstr *MI,
     MI->addOperand(MachineOperand::CreateImm(0));
   } else if (RegClass == &WebAssembly::F32RegClass) {
     MI->setDesc(TII->get(WebAssembly::CONST_F32));
-    auto *Val = cast<ConstantFP>(Constant::getNullValue(
+    auto *Val = cast<ConstantFP>(Constant::getZeroValue(
         Type::getFloatTy(MF.getFunction().getContext())));
     MI->addOperand(MachineOperand::CreateFPImm(Val));
   } else if (RegClass == &WebAssembly::F64RegClass) {
     MI->setDesc(TII->get(WebAssembly::CONST_F64));
-    auto *Val = cast<ConstantFP>(Constant::getNullValue(
+    auto *Val = cast<ConstantFP>(Constant::getZeroValue(
         Type::getDoubleTy(MF.getFunction().getContext())));
     MI->addOperand(MachineOperand::CreateFPImm(Val));
   } else if (RegClass == &WebAssembly::V128RegClass) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetTransformInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetTransformInfo.cpp
@@ -604,7 +604,7 @@ static Value *simplifyWasmSwizzle(const IntrinsicInst &II,
 
   auto *V1 = II.getArgOperand(0);
   auto *V2 =
-      AnyOutOfBounds ? Constant::getNullValue(VecTy) : PoisonValue::get(VecTy);
+      AnyOutOfBounds ? Constant::getZeroValue(VecTy) : PoisonValue::get(VecTy);
 
   return Builder.CreateShuffleVector(V1, V2, ArrayRef(Indexes, NumElts));
 }

--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -657,7 +657,7 @@ bool X86FastISel::X86FastEmitStore(EVT VT, const Value *Val,
                                    MachineMemOperand *MMO, bool Aligned) {
   // Handle 'null' like i32/i64 0.
   if (isa<ConstantPointerNull>(Val))
-    Val = Constant::getNullValue(DL.getIntPtrType(Val->getContext()));
+    Val = Constant::getZeroValue(DL.getIntPtrType(Val->getContext()));
 
   // If this is a store of a simple constant, fold the constant into the store.
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(Val)) {
@@ -1408,7 +1408,7 @@ bool X86FastISel::X86FastEmitCompare(const Value *Op0, const Value *Op1, EVT VT,
 
   // Handle 'null' like i32/i64 0.
   if (isa<ConstantPointerNull>(Op1))
-    Op1 = Constant::getNullValue(DL.getIntPtrType(Op0->getContext()));
+    Op1 = Constant::getZeroValue(DL.getIntPtrType(Op0->getContext()));
 
   // We have two options: compare with register or immediate.  If the RHS of
   // the compare is an immediate that we can fold into this compare, use
@@ -1485,7 +1485,7 @@ bool X86FastISel::X86SelectCmp(const Instruction *I) {
   // %x again on the RHS.
   if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
     const auto *RHSC = dyn_cast<ConstantFP>(RHS);
-    if (RHSC && RHSC->isNullValue())
+    if (RHSC && RHSC->isZeroValue())
       RHS = LHS;
   }
 
@@ -1673,7 +1673,7 @@ bool X86FastISel::X86SelectBranch(const Instruction *I) {
       // use %x again on the RHS.
       if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
         const auto *CmpRHSC = dyn_cast<ConstantFP>(CmpRHS);
-        if (CmpRHSC && CmpRHSC->isNullValue())
+        if (CmpRHSC && CmpRHSC->isZeroValue())
           CmpRHS = CmpLHS;
       }
 
@@ -2186,7 +2186,7 @@ bool X86FastISel::X86FastEmitSSESelect(MVT RetVT, const Instruction *I) {
   // %x again on the RHS.
   if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
     const auto *CmpRHSC = dyn_cast<ConstantFP>(CmpRHS);
-    if (CmpRHSC && CmpRHSC->isNullValue())
+    if (CmpRHSC && CmpRHSC->isZeroValue())
       CmpRHS = CmpLHS;
   }
 
@@ -3766,7 +3766,7 @@ Register X86FastISel::X86MaterializeInt(const ConstantInt *CI, MVT VT) {
 }
 
 Register X86FastISel::X86MaterializeFP(const ConstantFP *CFP, MVT VT) {
-  if (CFP->isNullValue())
+  if (CFP->isZeroValue())
     return fastMaterializeFloatZero(CFP);
 
   // Can't handle alternate code models yet.

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -20142,7 +20142,7 @@ static SDValue GetTLSADDR(SelectionDAG &DAG, GlobalAddressSDNode *GA,
   const X86Subtarget &Subtarget = DAG.getSubtarget<X86Subtarget>();
   unsigned Seg = Subtarget.is64Bit() ? X86AS::FS : X86AS::GS;
 
-  Value *Ptr = Constant::getNullValue(PointerType::get(*DAG.getContext(), Seg));
+  Value *Ptr = Constant::getZeroValue(PointerType::get(*DAG.getContext(), Seg));
   SDValue Offset =
       DAG.getLoad(PtrVT, dl, DAG.getEntryNode(), DAG.getIntPtrConstant(0, dl),
                   MachinePointerInfo(Ptr));
@@ -20215,7 +20215,7 @@ static SDValue LowerToTLSExecModel(GlobalAddressSDNode *GA, SelectionDAG &DAG,
   SDLoc dl(GA);
 
   // Get the Thread Pointer, which is %gs:0 (32-bit) or %fs:0 (64-bit).
-  Value *Ptr = Constant::getNullValue(
+  Value *Ptr = Constant::getZeroValue(
       PointerType::get(*DAG.getContext(), is64Bit ? X86AS::FS : X86AS::GS));
 
   SDValue ThreadPointer =
@@ -20360,7 +20360,7 @@ X86TargetLowering::LowerGlobalTLSAddress(SDValue Op, SelectionDAG &DAG) const {
     // Get the Thread Pointer, which is %fs:__tls_array (32-bit) or
     // %gs:0x58 (64-bit). On MinGW, __tls_array is not available, so directly
     // use its literal value of 0x2C.
-    Value *Ptr = Constant::getNullValue(
+    Value *Ptr = Constant::getZeroValue(
         Subtarget.is64Bit() ? PointerType::get(*DAG.getContext(), X86AS::GS)
                             : PointerType::get(*DAG.getContext(), X86AS::FS));
 
@@ -27958,7 +27958,7 @@ SDValue X86TargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
       SDLoc dl(Op);
       EVT PtrVT = Op.getValueType();
       // Get the Thread Pointer, which is %gs:0 (32-bit) or %fs:0 (64-bit).
-      Value *Ptr = Constant::getNullValue(PointerType::get(
+      Value *Ptr = Constant::getZeroValue(PointerType::get(
           *DAG.getContext(), Subtarget.is64Bit() ? X86AS::FS : X86AS::GS));
       return DAG.getLoad(PtrVT, dl, DAG.getEntryNode(),
                          DAG.getIntPtrConstant(0, dl), MachinePointerInfo(Ptr));
@@ -43280,7 +43280,7 @@ static SDValue combineTargetShuffle(SDValue N, const SDLoc &DL,
         // Create a vector constant - scalar constant followed by zeros.
         EVT ScalarVT = N0.getOperand(0).getValueType();
         Type *ScalarTy = ScalarVT.getTypeForEVT(*DAG.getContext());
-        Constant *Zero = ConstantInt::getNullValue(ScalarTy);
+        Constant *Zero = ConstantInt::getZeroValue(ScalarTy);
         SmallVector<Constant *, 32> ConstantVec(NumElts, Zero);
         ConstantVec[0] = const_cast<ConstantInt *>(C->getConstantIntValue());
 

--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -31,7 +31,7 @@ static Constant *getNegativeIsTrueBoolVec(Constant *V, const DataLayout &DL) {
   VectorType *IntTy = VectorType::getInteger(cast<VectorType>(V->getType()));
   V = ConstantExpr::getBitCast(V, IntTy);
   V = ConstantFoldCompareInstOperands(CmpInst::ICMP_SGT,
-                                      Constant::getNullValue(IntTy), V, DL);
+                                      Constant::getZeroValue(IntTy), V, DL);
   assert(V && "Vector must be foldable");
   return V;
 }
@@ -58,7 +58,7 @@ static Value *getBoolVecFromMask(Value *Mask, const DataLayout &DL) {
 static Instruction *simplifyX86MaskedLoad(IntrinsicInst &II, InstCombiner &IC) {
   Value *Ptr = II.getOperand(0);
   Value *Mask = II.getOperand(1);
-  Constant *ZeroVec = Constant::getNullValue(II.getType());
+  Constant *ZeroVec = Constant::getZeroValue(II.getType());
 
   // Zero Mask - masked load instruction creates a zero vector.
   if (isa<ConstantAggregateZero>(Mask))
@@ -401,7 +401,7 @@ static Value *simplifyX86varShift(const IntrinsicInst &II,
         ConstantVec.push_back(UndefValue::get(SVT));
       } else {
         assert(LogicalShift && "Logical shift expected");
-        ConstantVec.push_back(ConstantInt::getNullValue(SVT));
+        ConstantVec.push_back(ConstantInt::getZeroValue(SVT));
       }
     }
     return ConstantVector::get(ConstantVec);
@@ -615,7 +615,7 @@ static Value *simplifyX86movmsk(const IntrinsicInst &II,
 
   // movmsk(undef) -> zero as we must ensure the upper bits are zero.
   if (isa<UndefValue>(Arg))
-    return Constant::getNullValue(ResTy);
+    return Constant::getZeroValue(ResTy);
 
   // Preserve previous behavior and give up.
   // TODO: treat as <8 x i8>.
@@ -721,7 +721,7 @@ static Value *simplifyTernarylogic(const IntrinsicInst &II,
   uint8_t Imm = ArgImm->getValue().getZExtValue();
   switch (Imm) {
   case 0x0:
-    Res = {Constant::getNullValue(Ty), 0};
+    Res = {Constant::getZeroValue(Ty), 0};
     break;
   case 0x1:
     if (ABCIsConst)
@@ -2061,7 +2061,7 @@ static Value *simplifyX86pshufb(const IntrinsicInst &II,
   }
 
   auto V1 = II.getArgOperand(0);
-  auto V2 = Constant::getNullValue(VecTy);
+  auto V2 = Constant::getZeroValue(VecTy);
   return Builder.CreateShuffleVector(V1, V2, ArrayRef(Indexes, NumElts));
 }
 
@@ -2262,7 +2262,7 @@ X86TTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::x86_bmi_pext_32:
   case Intrinsic::x86_bmi_pext_64:
     if (auto *MaskC = dyn_cast<ConstantInt>(II.getArgOperand(1))) {
-      if (MaskC->isNullValue()) {
+      if (MaskC->isZeroValue()) {
         return IC.replaceInstUsesWith(II, ConstantInt::get(II.getType(), 0));
       }
       if (MaskC->isAllOnesValue()) {
@@ -2306,7 +2306,7 @@ X86TTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::x86_bmi_pdep_32:
   case Intrinsic::x86_bmi_pdep_64:
     if (auto *MaskC = dyn_cast<ConstantInt>(II.getArgOperand(1))) {
-      if (MaskC->isNullValue()) {
+      if (MaskC->isZeroValue()) {
         return IC.replaceInstUsesWith(II, ConstantInt::get(II.getType(), 0));
       }
       if (MaskC->isAllOnesValue()) {
@@ -3238,7 +3238,7 @@ std::optional<Value *> X86TTIImpl::simplifyDemandedUseBitsIntrinsic(
     APInt DemandedElts = DemandedMask.zextOrTrunc(ArgWidth);
     Type *VTy = II.getType();
     if (DemandedElts.isZero()) {
-      return ConstantInt::getNullValue(VTy);
+      return ConstantInt::getZeroValue(VTy);
     }
 
     // We know that the upper bits are set to zero.

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -8420,7 +8420,7 @@ MachineInstr *X86InstrInfo::foldMemoryOperandImpl(
     }
 
     const Constant *C =
-        IsAllOnes ? Constant::getAllOnesValue(Ty) : Constant::getNullValue(Ty);
+        IsAllOnes ? Constant::getAllOnesValue(Ty) : Constant::getZeroValue(Ty);
     unsigned CPI = MCP.getConstantPoolIndex(C, Alignment);
 
     // Create operands to load from the constant pool entry.

--- a/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
@@ -210,7 +210,7 @@ Value *X86LowerAMXIntrinsics::createTileLoadStoreLoops(
     // %vec.phi.row = phi <256 x i32> [ zeroinitializer, %entry ], [ %ResVec,
     // %tileload.scalarize.rows.latch ]
     B.SetInsertPoint(RowLoopHeader->getTerminator());
-    Value *VecZero = Constant::getNullValue(V256I32Ty);
+    Value *VecZero = Constant::getZeroValue(V256I32Ty);
     PHINode *VecCPhiRowLoop = B.CreatePHI(V256I32Ty, 2, "vec.phi.row");
     VecCPhiRowLoop->addIncoming(VecZero, Start);
 
@@ -339,7 +339,7 @@ X86LowerAMXIntrinsics::createTileDPLoops(BasicBlock *Start, BasicBlock *End,
   B.SetInsertPoint(RowLoopHeader->getTerminator());
   PHINode *VecCPhiRowLoop = B.CreatePHI(V256I32Ty, 2, "vec.c.phi.row");
   VecCPhiRowLoop->addIncoming(VecC, Start);
-  Value *VecZero = Constant::getNullValue(V256I32Ty);
+  Value *VecZero = Constant::getZeroValue(V256I32Ty);
   PHINode *VecDPhiRowLoop = B.CreatePHI(V256I32Ty, 2, "vec.d.phi.row");
   VecDPhiRowLoop->addIncoming(VecZero, Start);
 
@@ -455,7 +455,7 @@ X86LowerAMXIntrinsics::createTileDPLoops(BasicBlock *Start, BasicBlock *End,
     Value *SubVecA = B.CreateBitCast(EltA, V2I16Ty);
     Value *EltB = B.CreateExtractElement(VecB, IdxB);
     Value *SubVecB = B.CreateBitCast(EltB, V2I16Ty);
-    Value *ZeroV2I16 = Constant::getNullValue(V2I16Ty);
+    Value *ZeroV2I16 = Constant::getZeroValue(V2I16Ty);
     int ShuffleMask[4] = {2, 0, 3, 1};
     auto ShuffleArray = ArrayRef(ShuffleMask);
     Value *AV2F32 = B.CreateBitCast(
@@ -576,7 +576,7 @@ bool X86LowerAMXIntrinsics::lowerTileLoadStore(Instruction *TileLoadStore) {
 bool X86LowerAMXIntrinsics::lowerTileZero(Instruction *TileZero) {
   IRBuilder<> Builder(TileZero);
   FixedVectorType *V256I32Ty = FixedVectorType::get(Builder.getInt32Ty(), 256);
-  Value *VecZero = Constant::getNullValue(V256I32Ty);
+  Value *VecZero = Constant::getZeroValue(V256I32Ty);
   for (Use &U : llvm::make_early_inc_range(TileZero->uses())) {
     Instruction *I = cast<Instruction>(U.getUser());
     Value *Vec;

--- a/llvm/lib/Target/X86/X86LowerAMXType.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXType.cpp
@@ -813,7 +813,7 @@ bool X86LowerAMXCast::optimizeAMXCastFromPhi(
       // might support const.
       if (isa<Constant>(IncValue)) {
         auto *IncConst = dyn_cast<Constant>(IncValue);
-        if (!isa<UndefValue>(IncValue) && !IncConst->isNullValue())
+        if (!isa<UndefValue>(IncValue) && !IncConst->isZeroValue())
           return false;
         Value *Row = nullptr, *Col = nullptr;
         std::tie(Row, Col) = getShape(OldPN);

--- a/llvm/lib/Target/X86/X86PartialReduction.cpp
+++ b/llvm/lib/Target/X86/X86PartialReduction.cpp
@@ -208,7 +208,7 @@ bool X86PartialReduction::tryMAddReplacement(Instruction *Op,
   // Concatenate zeroes to extend back to the original type.
   SmallVector<int, 32> ConcatMask(NumElts);
   std::iota(ConcatMask.begin(), ConcatMask.end(), 0);
-  Value *Zero = Constant::getNullValue(MAdd->getType());
+  Value *Zero = Constant::getZeroValue(MAdd->getType());
   Value *Concat = Builder.CreateShuffleVector(MAdd, Zero, ConcatMask);
 
   Mul->replaceAllUsesWith(Concat);
@@ -292,7 +292,7 @@ bool X86PartialReduction::trySADReplacement(Instruction *Op) {
     for (unsigned i = NumElts; i != 16; ++i)
       ConcatMask[i] = (i % NumElts) + NumElts;
 
-    Value *Zero = Constant::getNullValue(Op0->getType());
+    Value *Zero = Constant::getZeroValue(Op0->getType());
     Op0 = Builder.CreateShuffleVector(Op0, Zero, ConcatMask);
     Op1 = Builder.CreateShuffleVector(Op1, Zero, ConcatMask);
     NumElts = 16;
@@ -343,7 +343,7 @@ bool X86PartialReduction::trySADReplacement(Instruction *Op) {
     for (unsigned i = SubElts; i != NumElts; ++i)
       ConcatMask[i] = (i % SubElts) + SubElts;
 
-    Value *Zero = Constant::getNullValue(Ops[0]->getType());
+    Value *Zero = Constant::getZeroValue(Ops[0]->getType());
     Ops[0] = Builder.CreateShuffleVector(Ops[0], Zero, ConcatMask);
   }
 
@@ -360,7 +360,7 @@ static Value *matchAddReduction(const ExtractElementInst &EE,
   ReduceInOneBB = true;
   // Make sure we're extracting index 0.
   auto *Index = dyn_cast<ConstantInt>(EE.getIndexOperand());
-  if (!Index || !Index->isNullValue())
+  if (!Index || !Index->isZeroValue())
     return nullptr;
 
   const auto *BO = dyn_cast<BinaryOperator>(EE.getVectorOperand());

--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -5005,13 +5005,13 @@ InstructionCost X86TTIImpl::getScalarizationOverhead(
   if (Insert && !ForPoisonSrc) {
     // This is nearly identical to BaseT::getScalarizationOverhead(), except
     // it is passing nullptr to getVectorInstrCost() for Op0 (instead of
-    // Constant::getNullValue()), which makes the X86TTIImpl
+    // Constant::getZeroValue()), which makes the X86TTIImpl
     // getVectorInstrCost() return 0 instead of 1.
     for (unsigned I : seq(DemandedElts.getBitWidth())) {
       if (!DemandedElts[I])
         continue;
       Cost += getVectorInstrCost(Instruction::InsertElement, Ty, CostKind, I,
-                                 Constant::getNullValue(Ty),
+                                 Constant::getZeroValue(Ty),
                                  VL.empty() ? nullptr : VL[I],
                                  TTI::VectorInstrContext::None);
     }

--- a/llvm/lib/Target/X86/X86WinEHState.cpp
+++ b/llvm/lib/Target/X86/X86WinEHState.cpp
@@ -464,7 +464,7 @@ void WinEHStateFnPassImpl::linkExceptionRegistration(IRBuilder<> &Builder,
   // Handler = Handler
   Builder.CreateStore(Handler, Builder.CreateStructGEP(LinkTy, Link, 1));
   // Next = [fs:00]
-  Constant *FSZero = Constant::getNullValue(PointerType::get(C, X86AS::FS));
+  Constant *FSZero = Constant::getZeroValue(PointerType::get(C, X86AS::FS));
   Value *Next = Builder.CreateLoad(PointerType::getUnqual(C), FSZero);
   Builder.CreateStore(Next, Builder.CreateStructGEP(LinkTy, Link, 0));
   // [fs:00] = Link
@@ -484,7 +484,7 @@ void WinEHStateFnPassImpl::unlinkExceptionRegistration(IRBuilder<> &Builder) {
   // [fs:00] = Link->Next
   Value *Next = Builder.CreateLoad(PointerType::getUnqual(C),
                                    Builder.CreateStructGEP(LinkTy, Link, 0));
-  Constant *FSZero = Constant::getNullValue(PointerType::get(C, X86AS::FS));
+  Constant *FSZero = Constant::getZeroValue(PointerType::get(C, X86AS::FS));
   Builder.CreateStore(Next, FSZero);
 }
 

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -1898,7 +1898,7 @@ static bool foldMemChr(CallInst *Call, DomTreeUpdater *DTU,
 
   PHINode *PHI =
       PHINode::Create(Call->getType(), 2, Call->getName(), BBNext->begin());
-  PHI->addIncoming(Constant::getNullValue(Call->getType()), BB);
+  PHI->addIncoming(Constant::getZeroValue(Call->getType()), BB);
   PHI->addIncoming(FirstOccursLocation, BBSuccess);
 
   Call->replaceAllUsesWith(PHI);

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1674,7 +1674,7 @@ static void eliminateSwiftErrorArgument(Function &F, Argument &Arg,
   Arg.replaceAllUsesWith(Alloca);
 
   // Set an initial value in the alloca.  swifterror is always null on entry.
-  auto InitialValue = Constant::getNullValue(ValueTy);
+  auto InitialValue = Constant::getZeroValue(ValueTy);
   Builder.CreateStore(InitialValue, Alloca);
 
   // Find all the suspends in the function and save and restore around them.

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -393,8 +393,8 @@ Value *AA::getWithType(Value &V, Type &Ty) {
   if (isa<UndefValue>(V))
     return UndefValue::get(&Ty);
   if (auto *C = dyn_cast<Constant>(&V)) {
-    if (C->isNullValue() && !Ty.isPtrOrPtrVectorTy())
-      return Constant::getNullValue(&Ty);
+    if (C->isZeroValue() && !Ty.isPtrOrPtrVectorTy())
+      return Constant::getZeroValue(&Ty);
     if (C->getType()->isPointerTy() && Ty.isPointerTy())
       return ConstantExpr::getPointerCast(C, &Ty);
     if (C->getType()->getPrimitiveSizeInBits() >= Ty.getPrimitiveSizeInBits()) {
@@ -492,7 +492,7 @@ static bool getPotentialCopiesOfMemoryValue(
         NullOnly = false;
       else if (isa<UndefValue>(*V))
         /* No op */;
-      else if (isa<Constant>(*V) && cast<Constant>(*V)->isNullValue())
+      else if (isa<Constant>(*V) && cast<Constant>(*V)->isZeroValue())
         NullRequired = !IsExact;
       else
         NullOnly = false;

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -4035,7 +4035,7 @@ struct AANoAliasReturned final : AANoAliasImpl {
 
     auto CheckReturnValue = [&](Value &RV) -> bool {
       if (Constant *C = dyn_cast<Constant>(&RV))
-        if (C->isNullValue() || isa<UndefValue>(C))
+        if (C->isZeroValue() || isa<UndefValue>(C))
           return true;
 
       /// For now, we can only deduce noalias if we have call sites.
@@ -10048,7 +10048,7 @@ struct AAPotentialConstantValuesFloating : AAPotentialConstantValuesImpl {
     bool OnlyLeft = false, OnlyRight = false;
     if (C && *C && (*C)->isOneValue())
       OnlyLeft = true;
-    else if (C && *C && (*C)->isNullValue())
+    else if (C && *C && (*C)->isZeroValue())
       OnlyRight = true;
 
     bool LHSContainsUndef = false, RHSContainsUndef = false;

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1471,7 +1471,7 @@ static bool isFunctionMallocLike(Function *F, const SCCNodeSet &SCCNodes) {
     Value *RetVal = FlowsToReturn[i];
 
     if (Constant *C = dyn_cast<Constant>(RetVal)) {
-      if (!C->isNullValue() && !isa<UndefValue>(C))
+      if (!C->isZeroValue() && !isa<UndefValue>(C))
         return false;
 
       continue;

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -455,13 +455,13 @@ Constant *InstCostVisitor::visitSelectInst(SelectInst &I) {
   assert(LastVisited != KnownConstants.end() && "Invalid iterator!");
 
   if (I.getCondition() == LastVisited->first) {
-    Value *V = LastVisited->second->isNullValue() ? I.getFalseValue()
+    Value *V = LastVisited->second->isZeroValue() ? I.getFalseValue()
                                                   : I.getTrueValue();
     return findConstantFor(V);
   }
   if (Constant *Condition = findConstantFor(I.getCondition()))
     if ((I.getTrueValue() == LastVisited->first && Condition->isOneValue()) ||
-        (I.getFalseValue() == LastVisited->first && Condition->isNullValue()))
+        (I.getFalseValue() == LastVisited->first && Condition->isZeroValue()))
       return LastVisited->second;
   return nullptr;
 }
@@ -1203,7 +1203,7 @@ Constant *FunctionSpecializer::getCandidateConstant(Value *V) {
 
   // Don't specialize on (anything derived from) the address of a non-constant
   // global variable, unless explicitly enabled.
-  if (C && C->getType()->isPointerTy() && !C->isNullValue())
+  if (C && C->getType()->isPointerTy() && !C->isZeroValue())
     if (auto *GV = dyn_cast<GlobalVariable>(getUnderlyingObject(C));
         GV && !(GV->isConstant() || SpecializeOnAddress))
       return nullptr;

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1144,7 +1144,7 @@ optimizeOnceStoredGlobal(GlobalVariable *GV, Value *StoredOnceVal,
   // users of the loaded value (often calls and loads) that would trap if the
   // value was null.
   if (GV->getInitializer()->getType()->isPointerTy() &&
-      GV->getInitializer()->isNullValue() &&
+      GV->getInitializer()->isZeroValue() &&
       StoredOnceVal->getType()->isPointerTy() &&
       !NullPointerIsDefined(
           nullptr /* F */,
@@ -1217,7 +1217,7 @@ static bool TryToShrinkGlobalToBoolean(GlobalVariable *GV, Constant *OtherVal) {
   bool EmitOneOrZero = true;
   auto *CI = dyn_cast<ConstantInt>(OtherVal);
   if (CI && CI->getValue().getActiveBits() <= 64) {
-    IsOneZero = InitVal->isNullValue() && CI->isOne();
+    IsOneZero = InitVal->isZeroValue() && CI->isOne();
 
     auto *CIInit = dyn_cast<ConstantInt>(GV->getInitializer());
     if (CIInit && CIInit->getValue().getActiveBits() <= 64) {
@@ -2426,7 +2426,7 @@ static bool OptimizeEmptyGlobalAtExitDtors(Function *CXAAtExitFn, bool isCXX) {
       continue;
 
     // Just remove the call.
-    CI->replaceAllUsesWith(Constant::getNullValue(CI->getType()));
+    CI->replaceAllUsesWith(Constant::getZeroValue(CI->getType()));
     CI->eraseFromParent();
 
     if (isCXX)

--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1421,7 +1421,7 @@ void LowerTypeTestsModule::moveInitializerToModuleConstructor(
   IRBuilder<> IRB(WeakInitializerFn->getEntryBlock().getTerminator());
   GV->setConstant(false);
   IRB.CreateAlignedStore(GV->getInitializer(), GV, GV->getAlign());
-  GV->setInitializer(Constant::getNullValue(GV->getValueType()));
+  GV->setInitializer(Constant::getZeroValue(GV->getValueType()));
 }
 
 void LowerTypeTestsModule::findGlobalVariableUsersOf(
@@ -1465,9 +1465,9 @@ void LowerTypeTestsModule::replaceWeakDeclarationWithJumpTablePtr(
       InsertPt = PN->getIncomingBlock(U)->getTerminator();
     IRBuilder Builder(InsertPt);
     Value *ICmp = Builder.CreateICmp(CmpInst::ICMP_NE, F,
-                                     Constant::getNullValue(F->getType()));
-    Value *Select = Builder.CreateSelect(ICmp, JT,
-                                         Constant::getNullValue(F->getType()));
+                                     Constant::getZeroValue(F->getType()));
+    Value *Select =
+        Builder.CreateSelect(ICmp, JT, Constant::getZeroValue(F->getType()));
 
     if (auto *SI = dyn_cast<SelectInst>(Select))
       setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -4542,7 +4542,7 @@ struct AAKernelInfoFunction : AAKernelInfo {
 
     Instruction *IsDone =
         ICmpInst::Create(ICmpInst::ICmp, llvm::CmpInst::ICMP_EQ, WorkFn,
-                         Constant::getNullValue(VoidPtrTy), "worker.is_done",
+                         Constant::getZeroValue(VoidPtrTy), "worker.is_done",
                          StateMachineBeginBB);
     IsDone->setDebugLoc(DLoc);
     CondBrInst::Create(IsDone, StateMachineFinishedBB,
@@ -4554,7 +4554,7 @@ struct AAKernelInfoFunction : AAKernelInfo {
         ->setDebugLoc(DLoc);
 
     Value *ZeroArg =
-        Constant::getNullValue(ParallelRegionFnTy->getParamType(0));
+        Constant::getZeroValue(ParallelRegionFnTy->getParamType(0));
 
     const unsigned int WrapperFunctionArgNo = 6;
 

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1670,7 +1670,7 @@ bool DevirtModule::tryEvaluateFunctionsWithArgs(
     Evaluator Eval(M.getDataLayout(), nullptr);
     SmallVector<Constant *, 2> EvalArgs;
     EvalArgs.push_back(
-        Constant::getNullValue(Fn->getFunctionType()->getParamType(0)));
+        Constant::getZeroValue(Fn->getFunctionType()->getParamType(0)));
     for (unsigned I = 0; I != Args.size(); ++I) {
       auto *ArgTy =
           dyn_cast<IntegerType>(Fn->getFunctionType()->getParamType(I + 1));

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1743,7 +1743,7 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   // zext(A) + sext(A) --> 0 if A is i1
   if (match(&I, m_c_BinOp(m_ZExt(m_Value(A)), m_SExt(m_Deferred(A)))) &&
       A->getType()->isIntOrIntVectorTy(1))
-    return replaceInstUsesWith(I, Constant::getNullValue(I.getType()));
+    return replaceInstUsesWith(I, Constant::getZeroValue(I.getType()));
 
   // sext(A < B) + zext(A > B) => ucmp/scmp(A, B)
   CmpPredicate LTPred, GTPred;
@@ -2782,7 +2782,7 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
       // because of worklist visitation order. So ugly it is.
       bool OtherHandOfSubIsTrueVal = OtherHandOfSub == TrueVal;
       Value *NewSub = SubBuilder(OtherHandOfSubIsTrueVal ? FalseVal : TrueVal);
-      Constant *Zero = Constant::getNullValue(Ty);
+      Constant *Zero = Constant::getZeroValue(Ty);
       SelectInst *NewSel =
           SelectInst::Create(Cond, OtherHandOfSubIsTrueVal ? Zero : NewSub,
                              OtherHandOfSubIsTrueVal ? NewSub : Zero);
@@ -2914,7 +2914,7 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
     Value *IsNeg = Builder.CreateIsNeg(A);
     // Copy the nsw flags from the sub to the negate.
     Value *NegA = I.hasNoUnsignedWrap()
-                      ? Constant::getNullValue(A->getType())
+                      ? Constant::getZeroValue(A->getType())
                       : Builder.CreateNeg(A, "", I.hasNoSignedWrap());
     return SelectInst::Create(IsNeg, NegA, A);
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -587,7 +587,7 @@ static Value *foldLogOpOfMaskedICmps(Value *LHS, Value *RHS, bool IsAnd,
     // We can't use C as zero because we might actually handle
     //   (icmp ne (A & B), B) & (icmp ne (A & D), D)
     // with B and D, having a single bit set.
-    Value *Zero = Constant::getNullValue(A->getType());
+    Value *Zero = Constant::getZeroValue(A->getType());
     return Builder.CreateICmp(NewCC, NewAnd, Zero);
   }
   if (Mask & BMask_AllOnes) {
@@ -1826,7 +1826,7 @@ Instruction *InstCombinerImpl::foldCastedBitwiseLogic(BinaryOperator &I) {
       return nullptr;
 
     auto *ICmpL =
-        Builder.CreateICmpSLT(A, Constant::getNullValue(A->getType()));
+        Builder.CreateICmpSLT(A, Constant::getZeroValue(A->getType()));
     auto *ICmpR = cast<ZExtInst>(Op1)->getOperand(0);
     auto *BitwiseOp = Builder.CreateBinOp(LogicOpc, ICmpL, ICmpR);
 
@@ -2468,7 +2468,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
                     m_Value(Y)))) {
     Value *Cmp = Builder.CreateIsNull(Neg);
     return createSelectInstWithUnknownProfile(Cmp,
-                                              ConstantInt::getNullValue(Ty), Y);
+                                              ConstantInt::getZeroValue(Ty), Y);
   }
 
   // Canonicalize:
@@ -2629,7 +2629,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
       assert(BitNum >= 0 && "Expected demanded bits to handle impossible mask");
       Value *Cmp = Builder.CreateICmpEQ(X, ConstantInt::get(Ty, BitNum));
       return createSelectInstWithUnknownProfile(Cmp, ConstantInt::get(Ty, *C),
-                                                ConstantInt::getNullValue(Ty));
+                                                ConstantInt::getZeroValue(Ty));
     }
 
     Constant *C1, *C2;
@@ -2649,7 +2649,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
           Constant *CmpC = ConstantExpr::getSub(LshrC, Log2C1);
           Value *Cmp = Builder.CreateICmpEQ(X, CmpC);
           return createSelectInstWithUnknownProfile(
-              Cmp, ConstantInt::get(Ty, *C3), ConstantInt::getNullValue(Ty));
+              Cmp, ConstantInt::get(Ty, *C3), ConstantInt::getZeroValue(Ty));
         }
       }
 
@@ -2659,14 +2659,14 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
         Constant *Log2C1 = ConstantExpr::getExactLogBase2(C1);
         Constant *Cmp =
             ConstantFoldCompareInstOperands(ICmpInst::ICMP_ULT, Log2C3, C2, DL);
-        if (Cmp && Cmp->isNullValue()) {
+        if (Cmp && Cmp->isZeroValue()) {
           // iff C1,C3 is pow2 and Log2(C3) >= C2:
           // ((C1 >> X) << C2) & C3 -> X == (cttz(C1)+C2-cttz(C3)) ? C3 : 0
           Constant *ShlC = ConstantExpr::getAdd(C2, Log2C1);
           Constant *CmpC = ConstantExpr::getSub(ShlC, Log2C3);
           Value *Cmp = Builder.CreateICmpEQ(X, CmpC);
           return createSelectInstWithUnknownProfile(
-              Cmp, ConstantInt::get(Ty, *C3), ConstantInt::getNullValue(Ty));
+              Cmp, ConstantInt::get(Ty, *C3), ConstantInt::getZeroValue(Ty));
         }
       }
     }
@@ -2824,31 +2824,31 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
   Value *A, *B;
   if (match(&I, m_c_And(m_SExt(m_Value(A)), m_Value(B))) &&
       A->getType()->isIntOrIntVectorTy(1))
-    return createSelectInstWithUnknownProfile(A, B, Constant::getNullValue(Ty));
+    return createSelectInstWithUnknownProfile(A, B, Constant::getZeroValue(Ty));
 
   // Similarly, a 'not' of the bool translates to a swap of the select arms:
   // ~sext(A) & B / B & ~sext(A) --> A ? 0 : B
   if (match(&I, m_c_And(m_Not(m_SExt(m_Value(A))), m_Value(B))) &&
       A->getType()->isIntOrIntVectorTy(1))
-    return createSelectInstWithUnknownProfile(A, Constant::getNullValue(Ty), B);
+    return createSelectInstWithUnknownProfile(A, Constant::getZeroValue(Ty), B);
 
   // and(zext(A), B) -> A ? (B & 1) : 0
   if (match(&I, m_c_And(m_OneUse(m_ZExt(m_Value(A))), m_Value(B))) &&
       A->getType()->isIntOrIntVectorTy(1))
     return createSelectInstWithUnknownProfile(
         A, Builder.CreateAnd(B, ConstantInt::get(Ty, 1)),
-        Constant::getNullValue(Ty));
+        Constant::getZeroValue(Ty));
 
   // (-1 + A) & B --> A ? 0 : B where A is 0/1.
   if (match(&I, m_c_And(m_OneUse(m_Add(m_ZExtOrSelf(m_Value(A)), m_AllOnes())),
                         m_Value(B)))) {
     if (A->getType()->isIntOrIntVectorTy(1))
-      return createSelectInstWithUnknownProfile(A, Constant::getNullValue(Ty),
+      return createSelectInstWithUnknownProfile(A, Constant::getZeroValue(Ty),
                                                 B);
     if (computeKnownBits(A, &I).countMaxActiveBits() <= 1) {
       return createSelectInstWithUnknownProfile(
-          Builder.CreateICmpEQ(A, Constant::getNullValue(A->getType())), B,
-          Constant::getNullValue(Ty));
+          Builder.CreateICmpEQ(A, Constant::getZeroValue(A->getType())), B,
+          Constant::getZeroValue(Ty));
     }
   }
 
@@ -2859,7 +2859,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
       *C == X->getType()->getScalarSizeInBits() - 1) {
     Value *IsNeg = Builder.CreateIsNeg(X, "isneg");
     return createSelectInstWithUnknownProfile(IsNeg, Y,
-                                              ConstantInt::getNullValue(Ty));
+                                              ConstantInt::getZeroValue(Ty));
   }
   // If there's a 'not' of the shifted value, swap the select operands:
   // ~(iN X s>> (N-1)) & Y --> (X s< 0) ? 0 : Y -- with optional sext
@@ -2869,7 +2869,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
       *C == X->getType()->getScalarSizeInBits() - 1) {
     Value *IsNeg = Builder.CreateIsNeg(X, "isneg");
     return createSelectInstWithUnknownProfile(IsNeg,
-                                              ConstantInt::getNullValue(Ty), Y);
+                                              ConstantInt::getZeroValue(Ty), Y);
   }
 
   // (~x) & y  -->  ~(x | (~y))  iff that gets rid of inversions
@@ -3471,7 +3471,7 @@ Value *InstCombinerImpl::foldAndOrOfICmps(ICmpInst *LHS, ICmpInst *RHS,
       (!IsLogical || isGuaranteedNotToBePoison(RHS0))) {
     Value *NewOr = Builder.CreateOr(LHS0, RHS0);
     return Builder.CreateICmp(PredL, NewOr,
-                              Constant::getNullValue(NewOr->getType()));
+                              Constant::getZeroValue(NewOr->getType()));
   }
 
   // (icmp ne A, -1) | (icmp ne B, -1) --> (icmp ne (A&B), -1)
@@ -3707,7 +3707,7 @@ static bool matchSubIntegerPackFromVector(Value *V, Value *&Vec,
         const unsigned ConstIdx = ShuffleIdx - NumVecElts;
         auto *ConstElt =
             dyn_cast<ConstantInt>(ConstVec->getAggregateElement(ConstIdx));
-        if (!ConstElt || !ConstElt->isNullValue())
+        if (!ConstElt || !ConstElt->isZeroValue())
           return false;
         continue;
       }
@@ -3771,7 +3771,7 @@ static Instruction *foldIntegerPackFromVector(Instruction &I,
   }
 
   Value *MaskedVec = Builder.CreateShuffleVector(
-      LhsVec, Constant::getNullValue(LhsVec->getType()), ShuffleMask,
+      LhsVec, Constant::getZeroValue(LhsVec->getType()), ShuffleMask,
       I.getName() + ".v");
   return CastInst::Create(Instruction::BitCast, MaskedVec, I.getType());
 }
@@ -4652,11 +4652,11 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
     return Res;
 
   if (Value *V =
-          simplifyAndOrWithOpReplaced(Op0, Op1, Constant::getNullValue(Ty),
+          simplifyAndOrWithOpReplaced(Op0, Op1, Constant::getZeroValue(Ty),
                                       /*SimplifyOnly*/ false, *this))
     return BinaryOperator::CreateOr(V, Op1);
   if (Value *V =
-          simplifyAndOrWithOpReplaced(Op1, Op0, Constant::getNullValue(Ty),
+          simplifyAndOrWithOpReplaced(Op1, Op0, Constant::getZeroValue(Ty),
                                       /*SimplifyOnly*/ false, *this))
     return BinaryOperator::CreateOr(Op0, V);
 
@@ -4805,7 +4805,7 @@ Value *InstCombinerImpl::foldXorOfICmps(ICmpInst *LHS, ICmpInst *RHS,
       Value *And = Builder.CreateAnd(Xor, Pow2);
       return Builder.CreateICmp(PredL == PredR ? ICmpInst::ICMP_NE
                                                : ICmpInst::ICMP_EQ,
-                                And, ConstantInt::getNullValue(Xor->getType()));
+                                And, ConstantInt::getZeroValue(Xor->getType()));
     }
   }
 
@@ -4963,7 +4963,7 @@ static Instruction *canonicalizeAbs(BinaryOperator &Xor,
     // Copy the nsw flags from the add to the negate.
     auto *Add = cast<BinaryOperator>(Op0);
     Value *NegA = Add->hasNoUnsignedWrap()
-                      ? Constant::getNullValue(A->getType())
+                      ? Constant::getZeroValue(A->getType())
                       : Builder.CreateNeg(A, "", Add->hasNoSignedWrap());
     return SelectInst::Create(IsNeg, NegA, A);
   }
@@ -5410,7 +5410,7 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
                        m_AShr(m_Value(X), m_APIntAllowPoison(CA))))) &&
         *CA == X->getType()->getScalarSizeInBits() - 1 &&
         !match(C1, m_AllOnes())) {
-      assert(!C1->isNullValue() && "Unexpected xor with 0");
+      assert(!C1->isZeroValue() && "Unexpected xor with 0");
       Value *IsNotNeg = Builder.CreateIsNotNeg(X);
       return createSelectInstWithUnknownProfile(IsNotNeg, Op1,
                                                 Builder.CreateNot(Op1));

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -498,7 +498,7 @@ static Instruction *foldCttzCtlz(IntrinsicInst &II, InstCombinerImpl &IC) {
     // If zero is poison, then the input can be assumed to be "true", so the
     // instruction simplifies to "false".
     assert(match(Op1, m_One()) && "Expected ctlz/cttz operand to be 0 or 1");
-    return IC.replaceInstUsesWith(II, ConstantInt::getNullValue(II.getType()));
+    return IC.replaceInstUsesWith(II, ConstantInt::getZeroValue(II.getType()));
   }
 
   // If ctlz/cttz is only used as a shift amount, set is_zero_poison to true.
@@ -711,7 +711,7 @@ static Instruction *foldCtpop(IntrinsicInst &II, InstCombinerImpl &IC) {
   if (IC.isKnownToBeAPowerOfTwo(Op0, /* OrZero */ true))
     return CastInst::Create(Instruction::ZExt,
                             IC.Builder.CreateICmp(ICmpInst::ICMP_NE, Op0,
-                                                  Constant::getNullValue(Ty)),
+                                                  Constant::getZeroValue(Ty)),
                             Ty);
 
   // Add range attribute since known bits can't completely reflect what we know.
@@ -815,7 +815,7 @@ static Instruction *simplifyNeonTbl(IntrinsicInst &II, InstCombiner &IC,
       } else {
         // Otherwise, choose some element from the dummy vector of zeroes (we'll
         // always choose the first).
-        SourceOperand = Constant::getNullValue(SourceTy);
+        SourceOperand = Constant::getZeroValue(SourceTy);
         SourceOperandElementIndex = 0;
       }
     } else {
@@ -2089,7 +2089,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (match(I1, m_One())) {
       assert(II->getType()->getScalarSizeInBits() != 1 &&
              "Expected simplify of umin with max constant");
-      Value *Zero = Constant::getNullValue(I0->getType());
+      Value *Zero = Constant::getZeroValue(I0->getType());
       Value *Cmp = Builder.CreateICmpNE(I0, Zero);
       return CastInst::Create(Instruction::ZExt, Cmp, II->getType());
     }
@@ -2391,7 +2391,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       Type *Ty = II->getType();
       APInt SignBit = APInt::getSignMask(Ty->getScalarSizeInBits());
       return SelectInst::Create(X, ConstantInt::get(Ty, SignBit),
-                                ConstantInt::getNullValue(Ty));
+                                ConstantInt::getZeroValue(Ty));
     }
 
     if (Instruction *crossLogicOpFold =
@@ -3939,7 +3939,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
           cast<VectorType>(ReturnType)->isScalableTy() ? VScaleMin : 1;
       if (ExtractIdx * ScaleFactor >= ALMUpperBound->getZExtValue())
         return replaceInstUsesWith(CI,
-                                   ConstantVector::getNullValue(ReturnType));
+                                   ConstantVector::getZeroValue(ReturnType));
     }
 
     auto *DstTy = dyn_cast<VectorType>(ReturnType);
@@ -4299,7 +4299,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (match(II->getArgOperand(0), m_ExtractValue<0>(m_Value(X)))) {
       if (match(X, m_Intrinsic<Intrinsic::frexp>(m_Value()))) {
         X = Builder.CreateInsertValue(
-            X, Constant::getNullValue(II->getType()->getStructElementType(1)),
+            X, Constant::getZeroValue(II->getType()->getStructElementType(1)),
             1);
         return replaceInstUsesWith(*II, X);
       }
@@ -4314,7 +4314,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       return replaceInstUsesWith(
           *II, Builder.CreateIntrinsic(
                    II->getType(), Intrinsic::get_active_lane_mask,
-                   {Constant::getNullValue(OpTy),
+                   {Constant::getZeroValue(OpTy),
                     ConstantInt::get(OpTy, Op1->usub_sat(*Op0))}));
     }
     break;
@@ -4834,7 +4834,7 @@ Instruction *InstCombinerImpl::visitCallBase(CallBase &Call) {
       // CFG, just change the callee to a null pointer.
       cast<CallBase>(OldCall)->setCalledFunction(
           CalleeF->getFunctionType(),
-          Constant::getNullValue(CalleeF->getType()));
+          Constant::getZeroValue(CalleeF->getType()));
       return nullptr;
     }
   }
@@ -5205,7 +5205,7 @@ bool InstCombinerImpl::transformConstExprCastCall(CallBase &Call) {
   // If the function takes more arguments than the call was taking, add them
   // now.
   for (unsigned i = NumCommonArgs; i != FT->getNumParams(); ++i) {
-    Args.push_back(Constant::getNullValue(FT->getParamType(i)));
+    Args.push_back(Constant::getZeroValue(FT->getParamType(i)));
     ArgAttrs.push_back(AttributeSet());
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1028,7 +1028,7 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
     return &Trunc;
 
   if (DestWidth == 1) {
-    Value *Zero = Constant::getNullValue(SrcTy);
+    Value *Zero = Constant::getZeroValue(SrcTy);
 
     Value *X;
     const APInt *C1;
@@ -1081,7 +1081,7 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
     if (match(Src,
               m_OneUse(m_Intrinsic<Intrinsic::usub_sat>(m_One(), m_Value(X)))))
       return new ICmpInst(ICmpInst::ICMP_EQ, X,
-                          ConstantInt::getNullValue(SrcTy));
+                          ConstantInt::getZeroValue(SrcTy));
   }
 
   Value *A, *B;
@@ -1516,7 +1516,7 @@ Instruction *InstCombinerImpl::visitZExt(ZExtInst &Zext) {
 
   // zext nneg bool x -> 0
   if (SrcTy->isIntOrIntVectorTy(1) && Zext.hasNonNeg())
-    return replaceInstUsesWith(Zext, Constant::getNullValue(Zext.getType()));
+    return replaceInstUsesWith(Zext, Constant::getZeroValue(Zext.getType()));
 
   // Try to extend the entire expression tree to the wide destination type.
   unsigned BitsToClear;
@@ -1689,9 +1689,9 @@ Instruction *InstCombinerImpl::transformSExtICmp(ICmpInst *Cmp,
 
         // If the icmp tests for a known zero bit we can constant fold it.
         if (!Op1C->isZero() && Op1C->getValue() != KnownZeroMask) {
-          Value *V = Pred == ICmpInst::ICMP_NE ?
-                       ConstantInt::getAllOnesValue(Sext.getType()) :
-                       ConstantInt::getNullValue(Sext.getType());
+          Value *V = Pred == ICmpInst::ICMP_NE
+                         ? ConstantInt::getAllOnesValue(Sext.getType())
+                         : ConstantInt::getZeroValue(Sext.getType());
           return replaceInstUsesWith(Sext, V);
         }
 
@@ -2412,7 +2412,7 @@ static Instruction *foldFPtoI(Instruction &FI, InstCombiner &IC) {
   KnownFPClass FPClass = computeKnownFPClass(
       FI.getOperand(0), Mask, IC.getSimplifyQuery().getWithInstruction(&FI));
   if (FPClass.isKnownNever(Mask))
-    return IC.replaceInstUsesWith(FI, ConstantInt::getNullValue(FI.getType()));
+    return IC.replaceInstUsesWith(FI, ConstantInt::getZeroValue(FI.getType()));
 
   return nullptr;
 }
@@ -2522,7 +2522,7 @@ Value *InstCombinerImpl::foldPtrToIntOrAddrOfGEP(Type *IntTy, Value *Ptr) {
       Res->getType() == IntTy && IntTy == IdxTy) {
     // pass
   } else if (isa<ConstantPointerNull>(Ptr)) {
-    Res = Constant::getNullValue(IdxTy);
+    Res = Constant::getZeroValue(IdxTy);
   } else {
     return nullptr;
   }
@@ -2668,7 +2668,7 @@ optimizeVectorResizeWithIntegerBitCasts(Value *InVal, VectorType *DestTy,
     // If we're increasing the number of elements (rewriting an integer zext),
     // shuffle in all of the elements from InVal. Fill the rest of the result
     // elements with zeros from a constant zero.
-    V2 = Constant::getNullValue(SrcTy);
+    V2 = Constant::getZeroValue(SrcTy);
     // Use first elt from V2 when indicating zero in the shuffle mask.
     uint32_t NullElt = SrcElts;
     // Extend with null values in the "most significant bits" by adding elements
@@ -2717,7 +2717,7 @@ static bool collectInsertionElements(Value *V, unsigned Shift,
   if (V->getType() == VecEltTy) {
     // Inserting null doesn't actually insert any elements.
     if (Constant *C = dyn_cast<Constant>(V))
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return true;
 
     unsigned ElementIndex = getTypeSizeIndex(Shift, VecEltTy);
@@ -2836,7 +2836,7 @@ static Value *optimizeIntegerToVectorInsertions(BitCastInst &CI,
   // If we succeeded, we know that all of the element are specified by Elements
   // or are zero if Elements has a null entry.  Recast this as a set of
   // insertions.
-  Value *Result = Constant::getNullValue(CI.getType());
+  Value *Result = Constant::getZeroValue(CI.getType());
   for (unsigned i = 0, e = Elements.size(); i != e; ++i) {
     if (!Elements[i]) continue;  // Unset element.
 
@@ -3252,9 +3252,8 @@ Instruction *InstCombinerImpl::visitBitCast(BitCastInst &CI) {
       // If our destination is not a vector, then make this a straight
       // scalar-scalar cast.
       if (!DestTy->isVectorTy()) {
-        Value *Elem =
-          Builder.CreateExtractElement(Src,
-                     Constant::getNullValue(Type::getInt32Ty(CI.getContext())));
+        Value *Elem = Builder.CreateExtractElement(
+            Src, Constant::getZeroValue(Type::getInt32Ty(CI.getContext())));
         return CastInst::Create(Instruction::BitCast, Elem, DestTy);
       }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -524,7 +524,7 @@ static Value *rewriteGEPAsOffset(Value *Start, Value *Base, GEPNoWrapFlags NW,
       Base->getContext(), DL.getIndexTypeSizeInBits(Start->getType()));
 
   DenseMap<Value *, Value *> NewInsts;
-  NewInsts[Base] = ConstantInt::getNullValue(IndexType);
+  NewInsts[Base] = ConstantInt::getZeroValue(IndexType);
 
   // Create the new PHI nodes, without adding any incoming values.
   for (Value *Val : Explored) {
@@ -689,11 +689,11 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
     Value *Offset =
         EmitGEPOffsets(Base.LHSGEPs, Base.LHSNW, IdxTy, /*RewriteGEPs=*/true);
     return NewICmp(Base.LHSNW, Offset,
-                   Constant::getNullValue(Offset->getType()));
+                   Constant::getZeroValue(Offset->getType()));
   }
 
   if (GEPLHS->isInBounds() && ICmpInst::isEquality(Cond) &&
-      isa<Constant>(RHS) && cast<Constant>(RHS)->isNullValue() &&
+      isa<Constant>(RHS) && cast<Constant>(RHS)->isZeroValue() &&
       !NullPointerIsDefined(I.getFunction(),
                             RHS->getType()->getPointerAddressSpace())) {
     // For most address spaces, an allocation can't be placed at null, but null
@@ -990,7 +990,7 @@ Instruction *InstCombinerImpl::foldICmpShrConstConst(ICmpInst &I, Value *A,
                    ConstantInt::get(A->getType(), AP2.logBase2()));
 
   if (AP1 == AP2)
-    return getICmp(I.ICMP_EQ, A, ConstantInt::getNullValue(A->getType()));
+    return getICmp(I.ICMP_EQ, A, ConstantInt::getZeroValue(A->getType()));
 
   int Shift;
   if (IsAShr && AP1.isNegative())
@@ -1041,7 +1041,7 @@ Instruction *InstCombinerImpl::foldICmpShlConstConst(ICmpInst &I, Value *A,
         ConstantInt::get(A->getType(), AP2.getBitWidth() - AP2TrailingZeros));
 
   if (AP1 == AP2)
-    return getICmp(I.ICMP_EQ, A, ConstantInt::getNullValue(A->getType()));
+    return getICmp(I.ICMP_EQ, A, ConstantInt::getZeroValue(A->getType()));
 
   // Get the distance between the lowest bits that are set.
   int Shift = AP1.countr_zero() - AP2TrailingZeros;
@@ -1195,7 +1195,7 @@ Instruction *InstCombinerImpl::foldSignBitTest(ICmpInst &I) {
   return ICmpInst::Create(Instruction::ICmp,
                           Pred == ICmpInst::ICMP_EQ ? ICmpInst::ICMP_SGE
                                                     : ICmpInst::ICMP_SLT,
-                          X, ConstantInt::getNullValue(XTy));
+                          X, ConstantInt::getZeroValue(XTy));
 }
 
 // Handle  icmp pred X, 0
@@ -1279,7 +1279,7 @@ Instruction *InstCombinerImpl::foldICmpWithZero(ICmpInst &Cmp) {
   if (ICmpInst::isEquality(Pred))
     if (Value *Stripped = stripNullTest(Cmp.getOperand(0)))
       return new ICmpInst(Pred, Stripped,
-                          Constant::getNullValue(Stripped->getType()));
+                          Constant::getZeroValue(Stripped->getType()));
 
   return nullptr;
 }
@@ -1308,7 +1308,7 @@ Instruction *InstCombinerImpl::foldIsMultipleOfAPowerOfTwo(ICmpInst &Cmp) {
 
   // Create new icmp eq (num & mask), 0
   auto *NewAnd = Builder.CreateAnd(Num, *Mask);
-  auto *Zero = Constant::getNullValue(Num->getType());
+  auto *Zero = Constant::getZeroValue(Num->getType());
 
   return new ICmpInst(Pred, NewAnd, Zero);
 }
@@ -1524,7 +1524,7 @@ Instruction *InstCombinerImpl::foldICmpTruncConstant(ICmpInst &Cmp,
       match(X, m_Shr(m_Value(ShOp), m_ConstantInt(ShAmt))) &&
       DstBits == SrcBits - ShAmt) {
     return TrueIfSigned ? new ICmpInst(ICmpInst::ICMP_SLT, ShOp,
-                                       ConstantInt::getNullValue(SrcTy))
+                                       ConstantInt::getZeroValue(SrcTy))
                         : new ICmpInst(ICmpInst::ICMP_SGT, ShOp,
                                        ConstantInt::getAllOnesValue(SrcTy));
   }
@@ -1623,7 +1623,7 @@ Instruction *InstCombinerImpl::foldICmpXorConstant(ICmpInst &Cmp,
                           ConstantInt::getAllOnesValue(X->getType()));
     else
       return new ICmpInst(ICmpInst::ICMP_SLT, X,
-                          ConstantInt::getNullValue(X->getType()));
+                          ConstantInt::getZeroValue(X->getType()));
   }
 
   if (Xor->hasOneUse()) {
@@ -1815,7 +1815,7 @@ Instruction *InstCombinerImpl::foldICmpAndConstConst(ICmpInst &Cmp,
     // Restrict this fold to single-use 'and' (PR10267).
     // Replace (and X, (1 << size(X)-1) != 0) with X s< 0
     if (C2->isSignMask()) {
-      Constant *Zero = Constant::getNullValue(X->getType());
+      Constant *Zero = Constant::getZeroValue(X->getType());
       auto NewPred = isICMP_NE ? ICmpInst::ICMP_SLT : ICmpInst::ICMP_SGE;
       return new ICmpInst(NewPred, X, Zero);
     }
@@ -1941,7 +1941,7 @@ Instruction *InstCombinerImpl::foldICmpAndConstant(ICmpInst &Cmp,
     if (match(And->getOperand(0), m_Add(m_Value(X), m_AllOnes())) &&
         match(And->getOperand(1), m_Not(m_Specific(X)))) {
       auto NewPred = TrueIfNeg ? CmpInst::ICMP_EQ : CmpInst::ICMP_NE;
-      return new ICmpInst(NewPred, X, ConstantInt::getNullValue(X->getType()));
+      return new ICmpInst(NewPred, X, ConstantInt::getZeroValue(X->getType()));
     }
     // (X & -X) <  0 --> X == MinSignedC
     // (X & -X) > -1 --> X != MinSignedC
@@ -1999,7 +1999,7 @@ Instruction *InstCombinerImpl::foldICmpAndConstant(ICmpInst &Cmp,
       match(And, m_OneUse(m_c_And(m_OneUse(m_Shl(m_AllOnes(), m_Value(X))),
                                   m_Value(Y))))) {
     Value *LShr = Builder.CreateLShr(Y, X);
-    return new ICmpInst(Pred, LShr, Constant::getNullValue(LShr->getType()));
+    return new ICmpInst(Pred, LShr, Constant::getZeroValue(LShr->getType()));
   }
 
   // (icmp eq/ne (and (add A, Addend), Msk), C)
@@ -2144,7 +2144,7 @@ Instruction *InstCombinerImpl::foldICmpOrConstant(ICmpInst &Cmp,
     // X | OrC s>= C --> X s>= 0 iff OrC s>= C s>= 0
     case ICmpInst::ICMP_SGE:
       if (OrC->sge(C))
-        return new ICmpInst(Pred, X, ConstantInt::getNullValue(X->getType()));
+        return new ICmpInst(Pred, X, ConstantInt::getZeroValue(X->getType()));
       break;
     // X | OrC s<= C --> X s< 0 iff OrC s> C s>= 0
     case ICmpInst::ICMP_SLE:
@@ -2152,7 +2152,7 @@ Instruction *InstCombinerImpl::foldICmpOrConstant(ICmpInst &Cmp,
     case ICmpInst::ICMP_SGT:
       if (OrC->sgt(C))
         return new ICmpInst(ICmpInst::getFlippedStrictnessPredicate(Pred), X,
-                            ConstantInt::getNullValue(X->getType()));
+                            ConstantInt::getZeroValue(X->getType()));
       break;
     default:
       break;
@@ -2167,9 +2167,9 @@ Instruction *InstCombinerImpl::foldICmpOrConstant(ICmpInst &Cmp,
     // Simplify icmp eq (or (ptrtoint P), (ptrtoint Q)), 0
     // -> and (icmp eq P, null), (icmp eq Q, null).
     Value *CmpP =
-        Builder.CreateICmp(Pred, P, ConstantInt::getNullValue(P->getType()));
+        Builder.CreateICmp(Pred, P, ConstantInt::getZeroValue(P->getType()));
     Value *CmpQ =
-        Builder.CreateICmp(Pred, Q, ConstantInt::getNullValue(Q->getType()));
+        Builder.CreateICmp(Pred, Q, ConstantInt::getZeroValue(Q->getType()));
     auto BOpc = Pred == CmpInst::ICMP_EQ ? Instruction::And : Instruction::Or;
     return BinaryOperator::Create(BOpc, CmpP, CmpQ);
   }
@@ -2193,7 +2193,7 @@ Instruction *InstCombinerImpl::foldICmpMulConstant(ICmpInst &Cmp,
   // X * X != 0 --> X != 0
   if (Cmp.isEquality() && C.isZero() && X == Mul->getOperand(1) &&
       (Mul->hasNoUnsignedWrap() || Mul->hasNoSignedWrap()))
-    return new ICmpInst(Pred, X, ConstantInt::getNullValue(MulTy));
+    return new ICmpInst(Pred, X, ConstantInt::getZeroValue(MulTy));
 
   const APInt *MulC;
   if (!match(Mul->getOperand(1), m_APInt(MulC)))
@@ -2206,7 +2206,7 @@ Instruction *InstCombinerImpl::foldICmpMulConstant(ICmpInst &Cmp,
   if (isSignTest(Pred, C) && Mul->hasNoSignedWrap()) {
     if (MulC->isNegative())
       Pred = ICmpInst::getSwappedPredicate(Pred);
-    return new ICmpInst(Pred, X, ConstantInt::getNullValue(MulTy));
+    return new ICmpInst(Pred, X, ConstantInt::getZeroValue(MulTy));
   }
 
   if (MulC->isZero())
@@ -2437,7 +2437,7 @@ Instruction *InstCombinerImpl::foldICmpShlConstant(ICmpInst &Cmp,
         APInt::getOneBitSet(TypeBits, TypeBits - ShiftAmt->getZExtValue() - 1));
     Value *And = Builder.CreateAnd(X, Mask, Shl->getName() + ".mask");
     return new ICmpInst(TrueIfSigned ? ICmpInst::ICMP_NE : ICmpInst::ICMP_EQ,
-                        And, Constant::getNullValue(ShType));
+                        And, Constant::getZeroValue(ShType));
   }
 
   // Simplify 'shl' inequality test into 'and' equality test.
@@ -2448,7 +2448,7 @@ Instruction *InstCombinerImpl::foldICmpShlConstant(ICmpInst &Cmp,
       Value *And = Builder.CreateAnd(X, (~C).lshr(ShiftAmt->getZExtValue()));
       return new ICmpInst(Pred == ICmpInst::ICMP_ULE ? ICmpInst::ICMP_EQ
                                                      : ICmpInst::ICMP_NE,
-                          And, Constant::getNullValue(ShType));
+                          And, Constant::getZeroValue(ShType));
     }
     // (X l<< C2) u</u>= C1 iff C1 is power of two -> X & (-C1 l>> C2) ==/!= 0
     if (C.isPowerOf2() &&
@@ -2457,7 +2457,7 @@ Instruction *InstCombinerImpl::foldICmpShlConstant(ICmpInst &Cmp,
           Builder.CreateAnd(X, (~(C - 1)).lshr(ShiftAmt->getZExtValue()));
       return new ICmpInst(Pred == ICmpInst::ICMP_ULT ? ICmpInst::ICMP_EQ
                                                      : ICmpInst::ICMP_NE,
-                          And, Constant::getNullValue(ShType));
+                          And, Constant::getZeroValue(ShType));
     }
   }
 
@@ -2525,7 +2525,7 @@ Instruction *InstCombinerImpl::foldICmpShrConstant(ICmpInst &Cmp,
         isSignBitCheck(Pred, C, TrueIfSigned))
       return new ICmpInst(TrueIfSigned ? CmpInst::ICMP_EQ : CmpInst::ICMP_NE,
                           Shr->getOperand(1),
-                          ConstantInt::getNullValue(X->getType()));
+                          ConstantInt::getZeroValue(X->getType()));
 
     // If the shifted constant is a power-of-2, test the shift amount directly:
     // (ShiftValC >> Y) >u C --> X <u (LZ(C) - LZ(ShiftValC))
@@ -2604,7 +2604,7 @@ Instruction *InstCombinerImpl::foldICmpShrConstant(ICmpInst &Cmp,
     if (C.getBitWidth() > 2 && C.getNumSignBits() <= ShAmtVal) {
       if (Pred == CmpInst::ICMP_UGT) {
         return new ICmpInst(CmpInst::ICMP_SLT, X,
-                            ConstantInt::getNullValue(ShrTy));
+                            ConstantInt::getZeroValue(ShrTy));
       }
       if (Pred == CmpInst::ICMP_ULT) {
         return new ICmpInst(CmpInst::ICMP_SGT, X,
@@ -2687,7 +2687,7 @@ Instruction *InstCombinerImpl::foldICmpSRemConstant(ICmpInst &Cmp,
     Type *Ty = SRem->getType();
     if (Pred == ICmpInst::ICMP_UGT)
       return new ICmpInst(ICmpInst::ICMP_SLT, SRem,
-                          ConstantInt::getNullValue(Ty));
+                          ConstantInt::getZeroValue(Ty));
     return new ICmpInst(ICmpInst::ICMP_SGT, SRem,
                         ConstantInt::getAllOnesValue(Ty));
   }
@@ -2729,7 +2729,7 @@ Instruction *InstCombinerImpl::foldICmpSRemConstant(ICmpInst &Cmp,
   // bit is set. Example:
   // (i8 X % 32) s> 0 --> (X & 159) s> 0
   if (Pred == ICmpInst::ICMP_SGT)
-    return new ICmpInst(ICmpInst::ICMP_SGT, And, ConstantInt::getNullValue(Ty));
+    return new ICmpInst(ICmpInst::ICMP_SGT, And, ConstantInt::getZeroValue(Ty));
 
   // For 'is negative?' check that the sign-bit is set and at least 1 masked
   // bit is set. Example:
@@ -3418,7 +3418,7 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
       if ((Pred == ICmpInst::ICMP_EQ || Pred == ICmpInst::ICMP_SLT ||
            Pred == ICmpInst::ICMP_NE || Pred == ICmpInst::ICMP_SGT) &&
           match(Op1, m_Zero()))
-        return new ICmpInst(Pred, X, ConstantInt::getNullValue(X->getType()));
+        return new ICmpInst(Pred, X, ConstantInt::getZeroValue(X->getType()));
 
       // icmp slt (bitcast (sitofp X)), 1 --> icmp slt X, 1
       if (Pred == ICmpInst::ICMP_SLT && match(Op1, m_One()))
@@ -3435,7 +3435,7 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
     // icmp ne (bitcast (uitofp X)), 0 --> icmp ne X, 0
     if (match(BCSrcOp, m_UIToFP(m_Value(X))))
       if (Cmp.isEquality() && match(Op1, m_Zero()))
-        return new ICmpInst(Pred, X, ConstantInt::getNullValue(X->getType()));
+        return new ICmpInst(Pred, X, ConstantInt::getZeroValue(X->getType()));
 
     const APInt *C;
     bool TrueIfSigned;
@@ -3459,7 +3459,7 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
           Value *NewBitcast = Builder.CreateBitCast(X, NewType);
           if (TrueIfSigned)
             return new ICmpInst(ICmpInst::ICMP_SLT, NewBitcast,
-                                ConstantInt::getNullValue(NewType));
+                                ConstantInt::getZeroValue(NewType));
           else
             return new ICmpInst(ICmpInst::ICMP_SGT, NewBitcast,
                                 ConstantInt::getAllOnesValue(NewType));
@@ -3498,7 +3498,7 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
     if (Value *NotBCSrcOp =
             getFreelyInverted(BCSrcOp, BCSrcOp->hasOneUse(), &Builder)) {
       Value *Cast = Builder.CreateBitCast(NotBCSrcOp, DstType);
-      return new ICmpInst(Pred, Cast, ConstantInt::getNullValue(DstType));
+      return new ICmpInst(Pred, Cast, ConstantInt::getZeroValue(DstType));
     }
   }
 
@@ -3511,7 +3511,7 @@ Instruction *InstCombinerImpl::foldICmpBitCast(ICmpInst &Cmp) {
     if (auto *VecTy = dyn_cast<FixedVectorType>(X->getType())) {
       Type *NewType = Builder.getIntNTy(VecTy->getPrimitiveSizeInBits());
       Value *NewCast = Builder.CreateBitCast(X, NewType);
-      return new ICmpInst(Pred, NewCast, ConstantInt::getNullValue(NewType));
+      return new ICmpInst(Pred, NewCast, ConstantInt::getZeroValue(NewType));
     }
   }
 
@@ -3614,7 +3614,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpEqualityWithConstant(
       if (match(BOp1, m_APInt(BOC)) && BOC->sgt(1) && BOC->isPowerOf2()) {
         Value *NewRem = Builder.CreateURem(BOp0, BOp1, BO->getName());
         return new ICmpInst(Pred, NewRem,
-                            Constant::getNullValue(BO->getType()));
+                            Constant::getZeroValue(BO->getType()));
       }
     }
     break;
@@ -3636,7 +3636,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpEqualityWithConstant(
         // (add nuw A, B) != 0 -> (or A, B) != 0
         if (match(BO, m_NUWAdd(m_Value(), m_Value()))) {
           Value *Or = Builder.CreateOr(BOp0, BOp1);
-          return new ICmpInst(Pred, Or, Constant::getNullValue(BO->getType()));
+          return new ICmpInst(Pred, Or, Constant::getZeroValue(BO->getType()));
         }
         Value *Neg = Builder.CreateNeg(BOp1);
         Neg->takeName(BO);
@@ -3683,7 +3683,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpEqualityWithConstant(
               ? (match(TV, m_Zero()) && isKnownNonZero(FV, Q))
               : (match(FV, m_Zero()) && isKnownNonZero(TV, Q))) {
         Value *Cmp = Builder.CreateICmp(
-            Pred, Other, Constant::getNullValue(Other->getType()));
+            Pred, Other, Constant::getZeroValue(Other->getType()));
         return BinaryOperator::Create(
             Pred == ICmpInst::ICMP_EQ ? Instruction::And : Instruction::Or, Cmp,
             Cond);
@@ -3706,7 +3706,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpEqualityWithConstant(
                : (match(TV, m_Zero()) && isKnownNonZero(FV, Q)))) {
         Value *NotCond = Builder.CreateNot(Cond);
         Value *Cmp = Builder.CreateICmp(
-            Pred, Other, Constant::getNullValue(Other->getType()));
+            Pred, Other, Constant::getZeroValue(Other->getType()));
         return BinaryOperator::Create(
             Pred == ICmpInst::ICMP_EQ ? Instruction::And : Instruction::Or, Cmp,
             NotCond);
@@ -3723,7 +3723,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpEqualityWithConstant(
       //    if Y * C never-overflow && OneUse:
       //      -> Y * C eq/ne X
       if (C.isZero())
-        return new ICmpInst(Pred, BOp0, Constant::getNullValue(BO->getType()));
+        return new ICmpInst(Pred, BOp0, Constant::getZeroValue(BO->getType()));
       else if (C.isOne())
         return new ICmpInst(Pred, BOp0, BOp1);
       else if (BO->hasOneUse()) {
@@ -3779,7 +3779,7 @@ static Instruction *foldCtpopPow2Test(ICmpInst &I, IntrinsicInst *CtpopLhs,
           (Pred == ICmpInst::ICMP_EQ || Pred == ICmpInst::ICMP_ULT)
               ? ICmpInst::ICMP_EQ
               : ICmpInst::ICMP_NE,
-          And, Constant::getNullValue(Op->getType()));
+          And, Constant::getZeroValue(Op->getType()));
     }
   }
 
@@ -3816,7 +3816,7 @@ Instruction *InstCombinerImpl::foldICmpEqIntrinsicWithConstant(
     // ctz(A) == bitwidth(A)  ->  A == 0 and likewise for !=
     if (C == BitWidth)
       return new ICmpInst(Pred, II->getArgOperand(0),
-                          ConstantInt::getNullValue(Ty));
+                          ConstantInt::getZeroValue(Ty));
 
     // ctz(A) == C -> A & Mask1 == Mask2, where Mask2 only has bit C set
     // and Mask1 has bits 0..C+1 set. Similar for ctl, but for high bits.
@@ -3841,7 +3841,7 @@ Instruction *InstCombinerImpl::foldICmpEqIntrinsicWithConstant(
     bool IsZero = C.isZero();
     if (IsZero || C == BitWidth)
       return new ICmpInst(Pred, II->getArgOperand(0),
-                          IsZero ? Constant::getNullValue(Ty)
+                          IsZero ? Constant::getZeroValue(Ty)
                                  : Constant::getAllOnesValue(Ty));
 
     break;
@@ -3867,7 +3867,7 @@ Instruction *InstCombinerImpl::foldICmpEqIntrinsicWithConstant(
     // umax(a, b) == 0  ->  (a | b) == 0
     if (C.isZero() && II->hasOneUse()) {
       Value *Or = Builder.CreateOr(II->getArgOperand(0), II->getArgOperand(1));
-      return new ICmpInst(Pred, Or, Constant::getNullValue(Ty));
+      return new ICmpInst(Pred, Or, Constant::getZeroValue(Ty));
     }
     break;
   }
@@ -4254,7 +4254,7 @@ Instruction *InstCombinerImpl::foldICmpIntrinsicWithConstant(ICmpInst &Cmp,
       APInt Mask = APInt::getLowBitsSet(BitWidth, C.getLimitedValue() + 1);
       return CmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_EQ,
                              Builder.CreateAnd(II->getArgOperand(0), Mask),
-                             ConstantInt::getNullValue(Ty));
+                             ConstantInt::getZeroValue(Ty));
     }
 
     // cttz(0bXXXXXXXX) < 3 -> 0bXXXXXXXX & 0b00000111 != 0
@@ -4262,7 +4262,7 @@ Instruction *InstCombinerImpl::foldICmpIntrinsicWithConstant(ICmpInst &Cmp,
       APInt Mask = APInt::getLowBitsSet(BitWidth, C.getLimitedValue());
       return CmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_NE,
                              Builder.CreateAnd(II->getArgOperand(0), Mask),
-                             ConstantInt::getNullValue(Ty));
+                             ConstantInt::getZeroValue(Ty));
     }
     break;
   }
@@ -4328,11 +4328,11 @@ Instruction *InstCombinerImpl::foldICmpInstWithConstantNotInt(ICmpInst &I) {
   switch (LHSI->getOpcode()) {
   case Instruction::IntToPtr:
     // icmp pred inttoptr(X), null -> icmp pred X, 0
-    if (RHSC->isNullValue() &&
+    if (RHSC->isZeroValue() &&
         DL.getIntPtrType(RHSC->getType()) == LHSI->getOperand(0)->getType())
       return new ICmpInst(
           I.getPredicate(), LHSI->getOperand(0),
-          Constant::getNullValue(LHSI->getOperand(0)->getType()));
+          Constant::getZeroValue(LHSI->getOperand(0)->getType()));
     break;
 
   case Instruction::Load:
@@ -4840,7 +4840,7 @@ foldShiftIntoShiftInAnotherHandOfAndInICmp(ICmpInst &I, const SimplifyQuery SQ,
                                     : NewShAmt;
       // If it's edge-case shift (by 0 or by WidestBitWidth-1) we can fold.
       if (NewShAmtSplat &&
-          (NewShAmtSplat->isNullValue() ||
+          (NewShAmtSplat->isZeroValue() ||
            NewShAmtSplat->getUniqueInteger() == WidestBitWidth - 1))
         return true;
       // We consider *min* leading zeros so a single outlier
@@ -4886,7 +4886,7 @@ foldShiftIntoShiftInAnotherHandOfAndInICmp(ICmpInst &I, const SimplifyQuery SQ,
                   : Builder.CreateShl(X, NewShAmt);
   Value *T1 = Builder.CreateAnd(T0, Y);
   return Builder.CreateICmp(I.getPredicate(), T1,
-                            Constant::getNullValue(WidestTy));
+                            Constant::getZeroValue(WidestTy));
 }
 
 /// Fold
@@ -4977,7 +4977,7 @@ static Instruction *foldICmpXNegX(ICmpInst &I,
     // else for equality-comparisons just keep the predicate.
 
     return ICmpInst::Create(Instruction::ICmp, Pred, X,
-                            Constant::getNullValue(X->getType()), I.getName());
+                            Constant::getZeroValue(X->getType()), I.getName());
   }
 
   // A value is not equal to its negation unless that value is 0 or
@@ -4989,7 +4989,7 @@ static Instruction *foldICmpXNegX(ICmpInst &I,
     Constant *MaxSignedVal =
         ConstantInt::get(Ty, APInt::getSignedMaxValue(BitWidth));
     Value *And = Builder.CreateAnd(X, MaxSignedVal);
-    Constant *Zero = Constant::getNullValue(Ty);
+    Constant *Zero = Constant::getZeroValue(Ty);
     return CmpInst::Create(Instruction::ICmp, Pred, And, Zero);
   }
 
@@ -5029,7 +5029,7 @@ static Instruction *foldICmpAndXX(ICmpInst &I, const SimplifyQuery &Q,
     // icmp (X & Y) eq/ne Y --> (~X & Y) eq/ne 0 if X  is freely invertible.
     if (auto *NotA = IC.getFreelyInverted(A, A->hasOneUse(), &IC.Builder))
       return new ICmpInst(Pred, IC.Builder.CreateAnd(Op1, NotA),
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
   }
 
   if (!ICmpInst::isSigned(Pred))
@@ -5047,13 +5047,13 @@ static Instruction *foldICmpAndXX(ICmpInst &I, const SimplifyQuery &Q,
     // (X & PosY) s<= X --> X s>= 0
     // (X & PosY) s> X --> X s< 0
     return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Op1,
-                        Constant::getNullValue(Op1->getType()));
+                        Constant::getZeroValue(Op1->getType()));
 
   if (isKnownNegative(Op1, IC.getSimplifyQuery().getWithInstruction(&I)))
     // (NegX & Y) s<= NegX --> Y s< 0
     // (NegX & Y) s> NegX --> Y s>= 0
     return new ICmpInst(ICmpInst::getFlippedStrictnessPredicate(Pred), A,
-                        Constant::getNullValue(A->getType()));
+                        Constant::getZeroValue(A->getType()));
 
   return nullptr;
 }
@@ -5084,7 +5084,7 @@ static Instruction *foldICmpOrXX(ICmpInst &I, const SimplifyQuery &Q,
     if (Value *NotOp1 = IC.getFreelyInverted(
             Op1, !isa<Constant>(Op1) && !Op1->hasNUsesOrMore(3), &IC.Builder))
       return new ICmpInst(Pred, IC.Builder.CreateAnd(A, NotOp1),
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     // icmp (X | Y) eq/ne Y --> (~X | Y) eq/ne -1 if X  is freely invertible.
     if (Value *NotA = IC.getFreelyInverted(A, A->hasOneUse(), &IC.Builder))
       return new ICmpInst(Pred, IC.Builder.CreateOr(Op1, NotA),
@@ -5130,7 +5130,7 @@ static Instruction *foldICmpXorXX(ICmpInst &I, const SimplifyQuery &Q,
       NewPred = ICmpInst::ICMP_SGE;
       break;
     }
-    Constant *Const = Constant::getNullValue(Op0->getType());
+    Constant *Const = Constant::getZeroValue(Op0->getType());
     return new ICmpInst(NewPred, Op0, Const);
   }
 
@@ -5223,7 +5223,7 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
         match(BO, m_Add(m_Specific(Op1), m_SpecificIntAllowPoison(*C)))) {
       CmpInst::Predicate NewPred =
           Pred == ICmpInst::ICMP_ULT ? ICmpInst::ICMP_NE : ICmpInst::ICMP_EQ;
-      Constant *Zero = ConstantInt::getNullValue(Op1->getType());
+      Constant *Zero = ConstantInt::getZeroValue(Op1->getType());
       return new ICmpInst(NewPred, Op1, Zero);
     }
 
@@ -5232,7 +5232,7 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
         match(BO, m_Add(m_Specific(Op0), m_SpecificIntAllowPoison(*C)))) {
       CmpInst::Predicate NewPred =
           Pred == ICmpInst::ICMP_UGT ? ICmpInst::ICMP_NE : ICmpInst::ICMP_EQ;
-      Constant *Zero = ConstantInt::getNullValue(Op1->getType());
+      Constant *Zero = ConstantInt::getZeroValue(Op1->getType());
       return new ICmpInst(NewPred, Op0, Zero);
     }
   }
@@ -5273,12 +5273,12 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
   // icmp (A+B), B -> icmp A, 0 for equalities or if there is no overflow.
   if ((A == Op1 || B == Op1) && NoOp0WrapProblem)
     return new ICmpInst(Pred, A == Op1 ? B : A,
-                        Constant::getNullValue(Op1->getType()));
+                        Constant::getZeroValue(Op1->getType()));
 
   // icmp C, (C+D) -> icmp 0, D for equalities or if there is no overflow.
   // icmp D, (C+D) -> icmp 0, C for equalities or if there is no overflow.
   if ((C == Op0 || D == Op0) && NoOp1WrapProblem)
-    return new ICmpInst(Pred, Constant::getNullValue(Op0->getType()),
+    return new ICmpInst(Pred, Constant::getZeroValue(Op0->getType()),
                         C == Op0 ? D : C);
 
   // icmp (A+B), (A+D) -> icmp B, D for equalities or if there is no overflow.
@@ -5421,10 +5421,10 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
 
   // icmp (A-B), A -> icmp 0, B for equalities or if there is no overflow.
   if (A == Op1 && NoOp0WrapProblem)
-    return new ICmpInst(Pred, Constant::getNullValue(Op1->getType()), B);
+    return new ICmpInst(Pred, Constant::getZeroValue(Op1->getType()), B);
   // icmp C, (C-D) -> icmp D, 0 for equalities or if there is no overflow.
   if (C == Op0 && NoOp1WrapProblem)
-    return new ICmpInst(Pred, D, Constant::getNullValue(Op0->getType()));
+    return new ICmpInst(Pred, D, Constant::getZeroValue(Op0->getType()));
 
   // Convert sub-with-unsigned-overflow comparisons into a comparison of args.
   // (A - B) u>/u<= A --> B u>/u<= A
@@ -5484,11 +5484,11 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
                                              SQ.getWithInstruction(&I));
           if (LessThan && match(LessThan, m_One()))
             return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Z,
-                                Constant::getNullValue(Z->getType()));
+                                Constant::getZeroValue(Z->getType()));
           Value *GreaterThan = simplifyICmpInst(ICmpInst::ICMP_SGT, X, Y,
                                                 SQ.getWithInstruction(&I));
           if (GreaterThan && match(GreaterThan, m_One()))
-            return new ICmpInst(Pred, Z, Constant::getNullValue(Z->getType()));
+            return new ICmpInst(Pred, Z, Constant::getZeroValue(Z->getType()));
         }
       } else {
         bool NonZero;
@@ -5496,7 +5496,7 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
           // If X != Y, fold (X *nw Z) eq/ne (Y *nw Z) -> Z eq/ne 0
           if (((Op0HasNSW && Op1HasNSW) || (Op0HasNUW && Op1HasNUW)) &&
               isKnownNonEqual(X, Y, SQ))
-            return new ICmpInst(Pred, Z, Constant::getNullValue(Z->getType()));
+            return new ICmpInst(Pred, Z, Constant::getZeroValue(Z->getType()));
 
           KnownBits ZKnown = computeKnownBits(Z, &I);
           // if Z % 2 != 0
@@ -5544,7 +5544,7 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     case ICmpInst::ICMP_SLT:
     case ICmpInst::ICMP_SLE:
       return new ICmpInst(ICmpInst::ICMP_SLT, SRem->getOperand(1),
-                          Constant::getNullValue(SRem->getType()));
+                          Constant::getZeroValue(SRem->getType()));
     }
   }
 
@@ -5632,7 +5632,7 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     auto BitwiseAnd = m_c_And(m_Value(), LSubOne);
 
     if (match(BO0, BitwiseAnd) && Pred == ICmpInst::ICMP_ULT) {
-      auto *Zero = Constant::getNullValue(BO0->getType());
+      auto *Zero = Constant::getZeroValue(BO0->getType());
       return new ICmpInst(ICmpInst::ICMP_NE, Op1, Zero);
     }
   }
@@ -5643,10 +5643,10 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
   if (!ICmpInst::isSigned(Pred)) {
     if (match(Op0, m_Shl(m_Specific(Op1), m_One())))
       return new ICmpInst(ICmpInst::getSignedPredicate(Pred), Op1,
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     else if (match(Op1, m_Shl(m_Specific(Op0), m_One())))
       return new ICmpInst(ICmpInst::getSignedPredicate(Pred),
-                          Constant::getNullValue(Op0->getType()), Op0);
+                          Constant::getZeroValue(Op0->getType()), Op0);
   }
 
   if (Value *V = foldMultiplicationOverflowCheck(I))
@@ -6066,7 +6066,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
   if (match(Op0, m_Xor(m_Value(A), m_Value(B)))) {
     if (A == Op1 || B == Op1) { // (A^B) == A  ->  B == 0
       Value *OtherVal = A == Op1 ? B : A;
-      return new ICmpInst(Pred, OtherVal, Constant::getNullValue(A->getType()));
+      return new ICmpInst(Pred, OtherVal, Constant::getZeroValue(A->getType()));
     }
 
     if (match(Op1, m_Xor(m_Value(C), m_Value(D)))) {
@@ -6094,7 +6094,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
   if (match(Op1, m_Xor(m_Value(A), m_Value(B))) && (A == Op0 || B == Op0)) {
     // A == (A^B)  ->  B == 0
     Value *OtherVal = A == Op0 ? B : A;
-    return new ICmpInst(Pred, OtherVal, Constant::getNullValue(A->getType()));
+    return new ICmpInst(Pred, OtherVal, Constant::getZeroValue(A->getType()));
   }
 
   // (X&Z) == (Y&Z) -> (X^Y) & Z == 0
@@ -6138,7 +6138,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
         // Build (X^Y) & Z
         Op1 = Builder.CreateXor(X, Y);
         Op1 = Builder.CreateAnd(Op1, Z);
-        return new ICmpInst(Pred, Op1, Constant::getNullValue(Op1->getType()));
+        return new ICmpInst(Pred, Op1, Constant::getZeroValue(Op1->getType()));
       }
     }
   }
@@ -6152,7 +6152,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
         match(Op1, m_OneUse(m_Or(m_Value(Y), m_Specific(C))))) {
       Value *Xor = Builder.CreateXor(X, Y);
       Value *And = Builder.CreateAnd(Xor, ConstantExpr::getNot(C));
-      return new ICmpInst(Pred, And, Constant::getNullValue(And->getType()));
+      return new ICmpInst(Pred, And, Constant::getZeroValue(And->getType()));
     }
   }
 
@@ -6197,7 +6197,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
       APInt AndVal = APInt::getLowBitsSet(TypeBits, TypeBits - ShAmt);
       Value *And =
           Builder.CreateAnd(Xor, Builder.getInt(AndVal), I.getName() + ".mask");
-      return new ICmpInst(Pred, And, Constant::getNullValue(Cst1->getType()));
+      return new ICmpInst(Pred, And, Constant::getZeroValue(Cst1->getType()));
     }
   }
 
@@ -6251,12 +6251,12 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
   if (match(Op0, m_c_And(m_Specific(Op1), m_Value())) &&
       isKnownToBeAPowerOfTwo(Op1, /* OrZero */ false, &I))
     return new ICmpInst(CmpInst::getInversePredicate(Pred), Op0,
-                        ConstantInt::getNullValue(Op0->getType()));
+                        ConstantInt::getZeroValue(Op0->getType()));
 
   if (match(Op1, m_c_And(m_Specific(Op0), m_Value())) &&
       isKnownToBeAPowerOfTwo(Op0, /* OrZero */ false, &I))
     return new ICmpInst(CmpInst::getInversePredicate(Pred), Op1,
-                        ConstantInt::getNullValue(Op1->getType()));
+                        ConstantInt::getZeroValue(Op1->getType()));
 
   // Canonicalize:
   // icmp eq/ne X, OneUse(rotate-right(X))
@@ -6299,7 +6299,7 @@ Instruction *InstCombinerImpl::foldICmpEquality(ICmpInst &I) {
       //    -> (icmp eq/ne (and X, P2), P2)
       return new ICmpInst(Pred, Builder.CreateAnd(B, A),
                           *IsZero ? A
-                                  : ConstantInt::getNullValue(A->getType()));
+                                  : ConstantInt::getZeroValue(A->getType()));
   }
 
   if (auto *Res = foldICmpEqualityWithOffset(
@@ -6376,7 +6376,7 @@ Instruction *InstCombinerImpl::foldICmpWithZextOrSext(ICmpInst &ICmp) {
       if (ICmp.isEquality() && X->getType()->isIntOrIntVectorTy(1) &&
           Y->getType()->isIntOrIntVectorTy(1))
         return new ICmpInst(ICmp.getPredicate(), Builder.CreateOr(X, Y),
-                            Constant::getNullValue(X->getType()));
+                            Constant::getZeroValue(X->getType()));
 
       // If we have mismatched casts and zext has the nneg flag, we can
       //  treat the "zext nneg" as "sext". Otherwise, we cannot fold and quit.
@@ -6461,7 +6461,7 @@ Instruction *InstCombinerImpl::foldICmpWithZextOrSext(ICmpInst &ICmp) {
   // Is source op negative?
   // icmp ugt (sext X), C --> icmp slt X, 0
   assert(ICmp.getPredicate() == ICmpInst::ICMP_UGT && "ICmp should be folded!");
-  return new ICmpInst(CmpInst::ICMP_SLT, X, Constant::getNullValue(SrcTy));
+  return new ICmpInst(CmpInst::ICMP_SLT, X, Constant::getZeroValue(SrcTy));
 }
 
 /// Handle icmp (cast x), (cast or constant).
@@ -7010,7 +7010,7 @@ Instruction *InstCombinerImpl::foldICmpUsingKnownBits(ICmpInst &I) {
         // exceeds the log2 of C.
         if (Op0Known.countMinTrailingZeros() >= CmpC->ceilLogBase2())
           return new ICmpInst(ICmpInst::ICMP_EQ, Op0,
-                              Constant::getNullValue(Op1->getType()));
+                              Constant::getZeroValue(Op1->getType()));
       }
       break;
     }
@@ -7027,7 +7027,7 @@ Instruction *InstCombinerImpl::foldICmpUsingKnownBits(ICmpInst &I) {
         // exceeds the log2 of C.
         if (Op0Known.countMinTrailingZeros() >= CmpC->getActiveBits())
           return new ICmpInst(ICmpInst::ICMP_NE, Op0,
-                              Constant::getNullValue(Op1->getType()));
+                              Constant::getZeroValue(Op1->getType()));
       }
       break;
     }
@@ -7099,7 +7099,7 @@ Instruction *InstCombinerImpl::foldICmpUsingKnownBits(ICmpInst &I) {
     if (Op1Known.isConstant() && Op1Known.getConstant().isPowerOf2() &&
         (Op0Known & Op1Known) == Op0Known)
       return new ICmpInst(CmpInst::getInversePredicate(Pred), Op0,
-                          ConstantInt::getNullValue(Op1->getType()));
+                          ConstantInt::getZeroValue(Op1->getType()));
     break;
   }
   case ICmpInst::ICMP_SGE:
@@ -7165,7 +7165,7 @@ Instruction *InstCombinerImpl::foldICmpUsingBoolRange(ICmpInst &I) {
     bool HasOneUse = ExtI->hasOneUse() && ExtI->getOperand(0)->hasOneUse();
     auto CreateRangeCheck = [&] {
       Value *CmpV1 =
-          Builder.CreateICmp(Pred1, X, Constant::getNullValue(X->getType()));
+          Builder.CreateICmp(Pred1, X, Constant::getZeroValue(X->getType()));
       Value *CmpV2 = Builder.CreateICmp(
           Pred1, X, ConstantInt::getSigned(X->getType(), IsSExt ? -1 : 1));
       return BinaryOperator::Create(
@@ -7386,7 +7386,7 @@ static Instruction *foldICmpWithHighBitMask(ICmpInst &Cmp,
     return nullptr;
 
   Value *NewX = Builder.CreateLShr(X, Y, X->getName() + ".highbits");
-  Constant *Zero = Constant::getNullValue(NewX->getType());
+  Constant *Zero = Constant::getZeroValue(NewX->getType());
   return CmpInst::Create(Instruction::ICmp, NewPred, NewX, Zero);
 }
 
@@ -7638,7 +7638,7 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
     Constant *C;
     if (match(Op0, m_Intrinsic<Intrinsic::abs>(m_Value(X), m_Constant(C))) &&
         match(Op1, m_Specific(X))) {
-      Value *NullValue = Constant::getNullValue(X->getType());
+      Value *NullValue = Constant::getZeroValue(X->getType());
       Value *AllOnesValue = Constant::getAllOnesValue(X->getType());
       const APInt SMin =
           APInt::getSignedMinValue(X->getType()->getScalarSizeInBits());
@@ -7683,13 +7683,13 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
   {
     if (match(Op0, m_UDiv(m_Specific(Op1), m_CheckedInt(CheckUGT1)))) {
       return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Op1,
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     }
 
     if (!ICmpInst::isUnsigned(Pred) &&
         match(Op0, m_SDiv(m_Specific(Op1), m_CheckedInt(CheckUGT1)))) {
       return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Op1,
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     }
   }
 
@@ -7698,13 +7698,13 @@ Instruction *InstCombinerImpl::foldICmpCommutative(CmpPredicate Pred,
   {
     if (match(Op0, m_LShr(m_Specific(Op1), m_CheckedInt(CheckNE0)))) {
       return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Op1,
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     }
 
     if ((Pred == CmpInst::ICMP_SLT || Pred == CmpInst::ICMP_SGE) &&
         match(Op0, m_AShr(m_Specific(Op1), m_CheckedInt(CheckNE0)))) {
       return new ICmpInst(ICmpInst::getSwappedPredicate(Pred), Op1,
-                          Constant::getNullValue(Op1->getType()));
+                          Constant::getZeroValue(Op1->getType()));
     }
   }
 
@@ -7830,7 +7830,7 @@ Instruction *InstCombinerImpl::visitICmpInst(ICmpInst &I) {
       match(Op1, m_Not(m_Specific(X)))) {
     if (C->isNonNegative())
       return new ICmpInst(ICmpInst::ICMP_SLT, X,
-                          Constant::getNullValue(X->getType()));
+                          Constant::getZeroValue(X->getType()));
     return new ICmpInst(ICmpInst::ICMP_UGT, X,
                         ConstantInt::get(X->getType(), ~*C));
   }
@@ -7854,7 +7854,7 @@ Instruction *InstCombinerImpl::visitICmpInst(ICmpInst &I) {
   if (match(Op1, m_APInt(C))) {
     // For i32: x >u 2147483647 -> x <s 0  -> true if sign bit set
     if (Pred == ICmpInst::ICMP_UGT && C->isMaxSignedValue()) {
-      Constant *Zero = Constant::getNullValue(Op0->getType());
+      Constant *Zero = Constant::getZeroValue(Op0->getType());
       return new ICmpInst(ICmpInst::ICMP_SLT, Op0, Zero);
     }
 
@@ -8057,7 +8057,7 @@ Instruction *InstCombinerImpl::visitICmpInst(ICmpInst &I) {
         if ((ExtOpc == Instruction::ZExt && ShiftOpc == Instruction::LShr) ||
             (ExtOpc == Instruction::SExt && ShiftOpc == Instruction::AShr)) {
           Value *SLTZero =
-              Builder.CreateICmpSLT(X, Constant::getNullValue(X->getType()));
+              Builder.CreateICmpSLT(X, Constant::getZeroValue(X->getType()));
           Value *Cmp = Builder.CreateICmp(Pred, SLTZero, Y, I.getName());
           return replaceInstUsesWith(I, Cmp);
         }
@@ -8402,20 +8402,20 @@ Instruction *InstCombinerImpl::foldCmpSelectOfConstants(CmpInst &I) {
   if (!Res00 || !Res01 || !Res10 || !Res11)
     return nullptr;
 
-  if ((!Res00->isNullValue() && !Res00->isAllOnesValue()) ||
-      (!Res01->isNullValue() && !Res01->isAllOnesValue()) ||
-      (!Res10->isNullValue() && !Res10->isAllOnesValue()) ||
-      (!Res11->isNullValue() && !Res11->isAllOnesValue()))
+  if ((!Res00->isZeroValue() && !Res00->isAllOnesValue()) ||
+      (!Res01->isZeroValue() && !Res01->isAllOnesValue()) ||
+      (!Res10->isZeroValue() && !Res10->isAllOnesValue()) ||
+      (!Res11->isZeroValue() && !Res11->isAllOnesValue()))
     return nullptr;
 
   std::bitset<4> Table;
-  if (!Res00->isNullValue())
+  if (!Res00->isZeroValue())
     Table.set(0);
-  if (!Res01->isNullValue())
+  if (!Res01->isZeroValue())
     Table.set(1);
-  if (!Res10->isNullValue())
+  if (!Res10->isZeroValue())
     Table.set(2);
-  if (!Res11->isNullValue())
+  if (!Res11->isZeroValue())
     Table.set(3);
 
   Value *Res = createLogicFromTable(Table, C1, C2, Builder,
@@ -9038,7 +9038,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     case FCmpInst::FCMP_UNE: // True if unordered or not equal
       // Canonicalize these to be 'fcmp uno %X, 0.0'.
       I.setPredicate(FCmpInst::FCMP_UNO);
-      I.setOperand(1, Constant::getNullValue(OpType));
+      I.setOperand(1, Constant::getZeroValue(OpType));
       return &I;
 
     case FCmpInst::FCMP_ORD: // True if ordered (no nans)
@@ -9047,7 +9047,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     case FCmpInst::FCMP_OLE: // True if ordered and less than or equal
       // Canonicalize these to be 'fcmp ord %X, 0.0'.
       I.setPredicate(FCmpInst::FCMP_ORD);
-      I.setOperand(1, Constant::getNullValue(OpType));
+      I.setOperand(1, Constant::getZeroValue(OpType));
       return &I;
     }
   }
@@ -9165,7 +9165,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
       Type *IntTy = X->getType();
       const APInt &SignMask = ~APInt::getSignMask(IntTy->getScalarSizeInBits());
       Value *MaskX = Builder.CreateAnd(X, ConstantInt::get(IntTy, SignMask));
-      return new ICmpInst(IntPred, MaskX, ConstantInt::getNullValue(IntTy));
+      return new ICmpInst(IntPred, MaskX, ConstantInt::getZeroValue(IntTy));
     }
   }
 
@@ -9315,7 +9315,7 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     if (Pred == FCmpInst::FCMP_OLT) {
       Value *IntX = Builder.CreateBitCast(X, IntType);
       return new ICmpInst(ICmpInst::ICMP_SLT, IntX,
-                          ConstantInt::getNullValue(IntType));
+                          ConstantInt::getZeroValue(IntType));
     }
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -500,10 +500,10 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
   // Y * (zext bool X) --> X ? Y : 0
   if (match(Op0, m_ZExt(m_Value(X))) && X->getType()->isIntOrIntVectorTy(1))
     return createSelectInstWithUnknownProfile(X, Op1,
-                                              ConstantInt::getNullValue(Ty));
+                                              ConstantInt::getZeroValue(Ty));
   if (match(Op1, m_ZExt(m_Value(X))) && X->getType()->isIntOrIntVectorTy(1))
     return createSelectInstWithUnknownProfile(X, Op0,
-                                              ConstantInt::getNullValue(Ty));
+                                              ConstantInt::getZeroValue(Ty));
 
   // mul (sext X), Y -> select X, -Y, 0
   // mul Y, (sext X) -> select X, -Y, 0
@@ -511,7 +511,7 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
       X->getType()->isIntOrIntVectorTy(1))
     return createSelectInstWithUnknownProfile(
         X, Builder.CreateNeg(Y, "", I.hasNoSignedWrap()),
-        ConstantInt::getNullValue(Op0->getType()));
+        ConstantInt::getZeroValue(Op0->getType()));
 
   Constant *ImmC;
   if (match(Op1, m_ImmConstant(ImmC))) {
@@ -519,7 +519,7 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
     if (match(Op0, m_SExt(m_Value(X))) && X->getType()->isIntOrIntVectorTy(1)) {
       Constant *NegC = ConstantExpr::getNeg(ImmC);
       return createSelectInstWithUnknownProfile(X, NegC,
-                                                ConstantInt::getNullValue(Ty));
+                                                ConstantInt::getZeroValue(Ty));
     }
 
     // (ashr i32 X, 31) * C --> (X < 0) ? -C : 0
@@ -529,7 +529,7 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
       Constant *NegC = ConstantExpr::getNeg(ImmC);
       Value *IsNeg = Builder.CreateIsNeg(X, "isneg");
       return createSelectInstWithUnknownProfile(IsNeg, NegC,
-                                                ConstantInt::getNullValue(Ty));
+                                                ConstantInt::getZeroValue(Ty));
     }
   }
 
@@ -541,14 +541,14 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
       *C == C->getBitWidth() - 1) {
     Value *IsNeg = Builder.CreateIsNeg(X, "isneg");
     return createSelectInstWithUnknownProfile(IsNeg, Y,
-                                              ConstantInt::getNullValue(Ty));
+                                              ConstantInt::getZeroValue(Ty));
   }
 
   // (and X, 1) * Y --> (trunc X) ? Y : 0
   if (match(&I, m_c_BinOp(m_OneUse(m_And(m_Value(X), m_One())), m_Value(Y)))) {
     Value *Tr = Builder.CreateTrunc(X, CmpInst::makeCmpResultType(Ty));
     return createSelectInstWithUnknownProfile(Tr, Y,
-                                              ConstantInt::getNullValue(Ty));
+                                              ConstantInt::getZeroValue(Ty));
   }
 
   // ((ashr X, 31) | 1) * X --> abs(X)
@@ -1297,7 +1297,7 @@ Instruction *InstCombinerImpl::commonIDivRemTransforms(BinaryOperator &I) {
     unsigned NumElts = VTy->getNumElements();
     for (unsigned i = 0; i != NumElts; ++i) {
       Constant *Elt = Op1C->getAggregateElement(i);
-      if (Elt && (Elt->isNullValue() || isa<UndefValue>(Elt)))
+      if (Elt && (Elt->isZeroValue() || isa<UndefValue>(Elt)))
         return replaceInstUsesWith(I, PoisonValue::get(Ty));
     }
   }
@@ -2343,7 +2343,7 @@ static Instruction *simplifyIRemMulShl(BinaryOperator &I,
   //      if (rem Y, Z) == 0
   //          -> 0
   if (RemYZ.isZero() && BO0NoWrap)
-    return IC.replaceInstUsesWith(I, ConstantInt::getNullValue(I.getType()));
+    return IC.replaceInstUsesWith(I, ConstantInt::getZeroValue(I.getType()));
 
   // Helper function to emit either (RemSimplificationC << X) or
   // (RemSimplificationC * X) depending on whether we matched Op0/Op1 as
@@ -2478,7 +2478,7 @@ Instruction *InstCombinerImpl::visitURem(BinaryOperator &I) {
     Value *Cmp =
         Builder.CreateICmpEQ(FrozenOp0, ConstantInt::getAllOnesValue(Ty));
     return createSelectInstWithUnknownProfile(
-        Cmp, ConstantInt::getNullValue(Ty), FrozenOp0);
+        Cmp, ConstantInt::getZeroValue(Ty), FrozenOp0);
   }
 
   // For "(X + 1) % Op1" and if (X u< Op1) => (X + 1) == Op1 ? 0 : X + 1 .
@@ -2491,7 +2491,7 @@ Instruction *InstCombinerImpl::visitURem(BinaryOperator &I) {
         FrozenOp0 = Builder.CreateFreeze(Op0, Op0->getName() + ".frozen");
       Value *Cmp = Builder.CreateICmpEQ(FrozenOp0, Op1);
       return createSelectInstWithUnknownProfile(
-          Cmp, ConstantInt::getNullValue(Ty), FrozenOp0);
+          Cmp, ConstantInt::getZeroValue(Ty), FrozenOp0);
     }
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1386,7 +1386,7 @@ static Value *foldDependentIVs(PHINode &PN, IRBuilderBase &Builder) {
   auto *BO = dyn_cast<BinaryOperator>(IvNext);
   Constant *Identity =
       BO ? ConstantExpr::getBinOpIdentity(BO->getOpcode(), Iv2Start->getType())
-         : Constant::getNullValue(Iv2Start->getType());
+         : Constant::getZeroValue(Iv2Start->getType());
   if (Iv2Start != Identity)
     return nullptr;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -891,7 +891,7 @@ static Value *foldSelectICmpAndBinOp(Value *CondVal, Value *TrueVal,
   auto *IdentityC =
       ConstantExpr::getBinOpIdentity(BinOp->getOpcode(), BinOp->getType(),
                                      /*AllowRHSConstant*/ true);
-  if (IdentityC == nullptr || !IdentityC->isNullValue())
+  if (IdentityC == nullptr || !IdentityC->isZeroValue())
     return nullptr;
 
   unsigned C2Log = C2->logBase2();
@@ -942,7 +942,7 @@ static Instruction *foldSetClearBits(SelectInst &Sel,
   // Cond ? (X & ~C) : (X | C) --> (X & ~C) | (Cond ? 0 : C)
   if (match(T, m_And(m_Value(X), m_APInt(NotC))) &&
       match(F, m_OneUse(m_Or(m_Specific(X), m_APInt(C)))) && *NotC == ~(*C)) {
-    Constant *Zero = ConstantInt::getNullValue(Ty);
+    Constant *Zero = ConstantInt::getZeroValue(Ty);
     Constant *OrC = ConstantInt::get(Ty, *C);
     Value *NewSel = Builder.CreateSelect(Cond, Zero, OrC, "masksel", &Sel);
     return BinaryOperator::CreateOr(T, NewSel);
@@ -951,7 +951,7 @@ static Instruction *foldSetClearBits(SelectInst &Sel,
   // Cond ? (X | C) : (X & ~C) --> (X & ~C) | (Cond ? C : 0)
   if (match(F, m_And(m_Value(X), m_APInt(NotC))) &&
       match(T, m_OneUse(m_Or(m_Specific(X), m_APInt(C)))) && *NotC == ~(*C)) {
-    Constant *Zero = ConstantInt::getNullValue(Ty);
+    Constant *Zero = ConstantInt::getZeroValue(Ty);
     Constant *OrC = ConstantInt::get(Ty, *C);
     Value *NewSel = Builder.CreateSelect(Cond, OrC, Zero, "masksel", &Sel);
     return BinaryOperator::CreateOr(F, NewSel);
@@ -1124,7 +1124,7 @@ canonicalizeSaturatedSubtractSigned(const ICmpInst *ICI, const Value *TrueVal,
       match(TrueVal, m_MaxSignedValue()) &&
       match(FalseVal, m_Neg(m_Specific(CmpLHS)))) {
     return Builder.CreateBinaryIntrinsic(
-        Intrinsic::ssub_sat, ConstantInt::getNullValue(CmpLHS->getType()),
+        Intrinsic::ssub_sat, ConstantInt::getZeroValue(CmpLHS->getType()),
         CmpLHS);
   }
 
@@ -1872,7 +1872,7 @@ static Value *canonicalizeClampLike(SelectInst &Sel0, ICmpInst &Cmp0,
   // it should either be the X itself, or an addition of some constant to X.
   Constant *C1;
   if (Cmp00 == X)
-    C1 = ConstantInt::getNullValue(X->getType());
+    C1 = ConstantInt::getZeroValue(X->getType());
   else if (!match(Cmp00,
                   m_Add(m_Specific(X),
                         m_CombineAnd(m_AnyIntegralConstant(), m_Constant(C1)))))
@@ -2713,7 +2713,7 @@ static Instruction *canonicalizeSelectToShuffle(SelectInst &SI) {
     if (Elt->isOneValue()) {
       // If the select condition element is true, choose from the 1st vector.
       Mask.push_back(i);
-    } else if (Elt->isNullValue()) {
+    } else if (Elt->isZeroValue()) {
       // If the select condition element is false, choose from the 2nd vector.
       Mask.push_back(i + NumElts);
     } else if (isa<UndefValue>(Elt)) {
@@ -4778,7 +4778,7 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
       return nullptr;
     Type *ElementType = Gep->getSourceElementType();
     Value *NewT = Idx;
-    Value *NewF = Constant::getNullValue(Idx->getType());
+    Value *NewF = Constant::getZeroValue(Idx->getType());
     if (Swap)
       std::swap(NewT, NewF);
     Value *NewSI =

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -751,7 +751,7 @@ static Value *foldShiftedShift(BinaryOperator *InnerShift, unsigned OuterShAmt,
   if (IsInnerShl == IsOuterShl) {
     // If this is an oversized composite shift, then unsigned shifts get 0.
     if (InnerShAmt + OuterShAmt >= TypeWidth)
-      return Constant::getNullValue(ShType);
+      return Constant::getZeroValue(ShType);
 
     return NewInnerShift(InnerShAmt + OuterShAmt);
   }
@@ -1364,7 +1364,7 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
     if (match(Op0, m_ZExt(m_Value(X))) && X->getType()->isIntOrIntVectorTy(1)) {
       auto *NewC = Builder.CreateShl(ConstantInt::get(Ty, 1), C1);
       return createSelectInstWithUnknownProfile(X, NewC,
-                                                ConstantInt::getNullValue(Ty));
+                                                ConstantInt::getZeroValue(Ty));
     }
   }
 
@@ -1558,7 +1558,7 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
       if (SrcTyBitWidth == 1) {
         auto *NewC = ConstantInt::get(
             Ty, APInt::getLowBitsSet(BitWidth, BitWidth - ShAmtC));
-        return SelectInst::Create(X, NewC, ConstantInt::getNullValue(Ty));
+        return SelectInst::Create(X, NewC, ConstantInt::getZeroValue(Ty));
       }
 
       if ((!Ty->isIntegerTy() || shouldChangeType(Ty, X->getType())) &&

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -108,7 +108,7 @@ static Value *simplifyShiftSelectingPackedElement(Instruction *I,
   IRBuilderBase::InsertPointGuard Guard(IC.Builder);
   IC.Builder.SetInsertPoint(I);
   Value *ShrAmtZ =
-      IC.Builder.CreateICmpEQ(ShrAmt, Constant::getNullValue(ShrAmt->getType()),
+      IC.Builder.CreateICmpEQ(ShrAmt, Constant::getZeroValue(ShrAmt->getType()),
                               ShrAmt->getName() + ".z");
   // There is no existing !prof metadata we can derive the !prof metadata for
   // this select.
@@ -1049,7 +1049,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         if (DemandedMask.isSubsetOf(Known.Zero) &&
             !match(I->getOperand(1), m_Zero()))
           return replaceOperand(
-              *I, 1, Constant::getNullValue(I->getOperand(1)->getType()));
+              *I, 1, Constant::getZeroValue(I->getOperand(1)->getType()));
 
         // Mask in demanded space does nothing.
         // NOTE: We may have attributes associated with the return value of the
@@ -1820,8 +1820,8 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       for (unsigned i = 0; i < VWidth; i++) {
         Constant *CElt = CV->getAggregateElement(i);
 
-        // isNullValue() always returns false when called on a ConstantExpr.
-        if (CElt->isNullValue())
+        // isZeroValue() always returns false when called on a ConstantExpr.
+        if (CElt->isZeroValue())
           DemandedLHS.clearBit(i);
         else if (CElt->isOneValue())
           DemandedRHS.clearBit(i);
@@ -1915,7 +1915,7 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       if (auto *CMask = dyn_cast<Constant>(II->getOperand(1))) {
         for (unsigned i = 0; i < VWidth; i++) {
           if (Constant *CElt = CMask->getAggregateElement(i)) {
-            if (CElt->isNullValue())
+            if (CElt->isZeroValue())
               DemandedPtrs.clearBit(i);
             else if (CElt->isAllOnesValue())
               DemandedPassThrough.clearBit(i);
@@ -2029,7 +2029,7 @@ static Constant *getFPClassConstant(Type *Ty, FPClassTest Mask,
     return PoisonValue::get(Ty);
 
   if (Mask == fcPosZero)
-    return Constant::getNullValue(Ty);
+    return Constant::getZeroValue(Ty);
 
   // TODO: Support aggregate types that are allowed by FPMathOperator.
   if (Ty->isAggregateType())

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -288,7 +288,7 @@ Value *InstCombinerImpl::EmitGEPOffsets(ArrayRef<GEPOperator *> GEPs,
   if (OneUseSum)
     Sum = Add(Sum, OneUseSum);
   if (!Sum)
-    return Constant::getNullValue(IdxTy);
+    return Constant::getZeroValue(IdxTy);
   return Sum;
 }
 
@@ -897,7 +897,7 @@ Instruction *InstCombinerImpl::tryFoldInstWithCtpopWithNot(Instruction *I) {
   if (Opc == Instruction::ICmp && !cast<ICmpInst>(I)->isEquality()) {
     Constant *Cmp =
         ConstantFoldCompareInstOperands(ICmpInst::ICMP_UGT, C, BitWidthC, DL);
-    if (!Cmp || !Cmp->isNullValue())
+    if (!Cmp || !Cmp->isZeroValue())
       return nullptr;
   }
 
@@ -1737,7 +1737,7 @@ Instruction *InstCombinerImpl::foldBinopOfSextBoolToSelect(BinaryOperator &BO) {
 
   // bo (sext i1 X), C --> select X, (bo -1, C), (bo 0, C)
   Constant *Ones = ConstantInt::getAllOnesValue(BO.getType());
-  Constant *Zero = ConstantInt::getNullValue(BO.getType());
+  Constant *Zero = ConstantInt::getZeroValue(BO.getType());
   Value *TVal = Builder.CreateBinOp(BO.getOpcode(), Ones, C);
   Value *FVal = Builder.CreateBinOp(BO.getOpcode(), Zero, C);
   return createSelectInstWithUnknownProfile(X, TVal, FVal);
@@ -1758,7 +1758,7 @@ static Value *simplifyOperationIntoSelectOperand(Instruction &I, SelectInst *SI,
       // Pass
     } else if (match(Op, m_ZExt(m_Specific(SI->getCondition())))) {
       V = IsTrueArm ? ConstantInt::get(Op->getType(), 1)
-                    : ConstantInt::getNullValue(Op->getType());
+                    : ConstantInt::getZeroValue(Op->getType());
     } else {
       V = Op;
     }
@@ -2975,7 +2975,7 @@ Instruction *InstCombinerImpl::visitGEPOfGEP(GetElementPtrInst &GEP,
   // Don't create GEPs with more than one non-zero index.
   unsigned NumNonZeroIndices = count_if(Indices, [](Value *Idx) {
     auto *C = dyn_cast<Constant>(Idx);
-    return !C || !C->isNullValue();
+    return !C || !C->isZeroValue();
   });
   if (NumNonZeroIndices > 1)
     return nullptr;
@@ -3370,7 +3370,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
     Type *EltTy = GTI.getIndexedType();
     if (EltTy->isSized() && DL.getTypeAllocSize(EltTy).isZero())
       if (!isa<Constant>(*I) || !match(I->get(), m_Zero())) {
-        *I = Constant::getNullValue(NewIndexType);
+        *I = Constant::getZeroValue(NewIndexType);
         MadeChange = true;
       }
 
@@ -3412,7 +3412,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 
   // Strip trailing zero indices.
   auto *LastIdx = dyn_cast<Constant>(Indices.back());
-  if (LastIdx && LastIdx->isNullValue() && !LastIdx->getType()->isVectorTy()) {
+  if (LastIdx && LastIdx->isZeroValue() && !LastIdx->getType()->isVectorTy()) {
     return replaceInstUsesWith(
         GEP, Builder.CreateGEP(GEP.getSourceElementType(), PtrOp,
                                drop_end(Indices), "", GEP.getNoWrapFlags()));
@@ -3420,7 +3420,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 
   // Strip leading zero indices.
   auto *FirstIdx = dyn_cast<Constant>(Indices.front());
-  if (FirstIdx && FirstIdx->isNullValue() &&
+  if (FirstIdx && FirstIdx->isZeroValue() &&
       !FirstIdx->getType()->isVectorTy()) {
     gep_type_iterator GTI = gep_type_begin(GEP);
     ++GTI;
@@ -3462,7 +3462,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
   for (auto [IdxNum, Idx] : enumerate(Indices)) {
     // Ignore one leading zero index.
     auto *C = dyn_cast<Constant>(Idx);
-    if (C && C->isNullValue() && IdxNum == 0)
+    if (C && C->isZeroValue() && IdxNum == 0)
       continue;
 
     if (!SeenNonZeroIndex) {
@@ -3477,7 +3477,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
                           GEP.getName() + ".split", GEP.getNoWrapFlags());
 
     SmallVector<Value *> BackIndices;
-    BackIndices.push_back(Constant::getNullValue(NewScalarIndexTy));
+    BackIndices.push_back(Constant::getZeroValue(NewScalarIndexTy));
     append_range(BackIndices, drop_begin(Indices, IdxNum));
     return GetElementPtrInst::Create(
         GetElementPtrInst::getIndexedType(GEPEltType, FrontIndices), FrontGEP,
@@ -3923,7 +3923,7 @@ Instruction *InstCombinerImpl::visitAllocSite(Instruction &MI) {
   if (Init) {
     if (isa<UndefValue>(Init))
       KnowInitUndef = true;
-    else if (Init->isNullValue())
+    else if (Init->isZeroValue())
       KnowInitZero = true;
   }
   // The various sanitizers don't actually return undef memory, but rather
@@ -3991,7 +3991,7 @@ Instruction *InstCombinerImpl::visitAllocSite(Instruction &MI) {
         if (isa<LoadInst>(I)) {
           assert(KnowInitZero || KnowInitUndef);
           Replace = KnowInitUndef ? UndefValue::get(I->getType())
-                                  : Constant::getNullValue(I->getType());
+                                  : Constant::getZeroValue(I->getType());
         } else
           Replace = PoisonValue::get(I->getType());
         replaceInstUsesWith(*I, Replace);
@@ -4890,7 +4890,7 @@ static bool isCatchAll(EHPersonality Personality, Constant *TypeInfo) {
   case EHPersonality::Wasm_CXX:
   case EHPersonality::XL_CXX:
   case EHPersonality::ZOS_CXX:
-    return TypeInfo->isNullValue();
+    return TypeInfo->isZeroValue();
   }
   llvm_unreachable("invalid enum");
 }
@@ -4971,7 +4971,7 @@ Instruction *InstCombinerImpl::visitLandingPadInst(LandingPadInst &LI) {
         // Not an empty filter - it contains at least one null typeinfo.
         assert(NumTypeInfos > 0 && "Should have handled empty filter already!");
         Constant *TypeInfo =
-          Constant::getNullValue(FilterType->getElementType());
+            Constant::getZeroValue(FilterType->getElementType());
         // If this typeinfo is a catch-all then the filter can never match.
         if (isCatchAll(Personality, TypeInfo)) {
           // Throw the filter away.
@@ -5147,7 +5147,7 @@ Instruction *InstCombinerImpl::visitLandingPadInst(LandingPadInst &LI) {
         // LFilter iff LFilter contains a zero.
         assert(FElts > 0 && "Should have eliminated the empty filter earlier!");
         for (unsigned l = 0; l != LElts; ++l)
-          if (LArray->getOperand(l)->isNullValue()) {
+          if (LArray->getOperand(l)->isZeroValue()) {
             // LFilter contains a zero - discard it.
             NewClauses.erase(J);
             MakeNewInstruction = true;
@@ -5458,7 +5458,7 @@ Instruction *InstCombinerImpl::visitFreeze(FreezeInst &I) {
       return BestValue;
     };
 
-    Value *NullValue = Constant::getNullValue(Ty);
+    Value *NullValue = Constant::getZeroValue(Ty);
     Value *BestValue = nullptr;
     for (auto *U : I.users()) {
       Value *V = NullValue;
@@ -5499,7 +5499,7 @@ Instruction *InstCombinerImpl::visitFreeze(FreezeInst &I) {
     if (!VTy)
       return nullptr;
     unsigned NumElts = VTy->getNumElements();
-    Constant *BestValue = Constant::getNullValue(VTy->getScalarType());
+    Constant *BestValue = Constant::getZeroValue(VTy->getScalarType());
     for (unsigned i = 0; i != NumElts; ++i) {
       Constant *EltC = C->getAggregateElement(i);
       if (EltC && !match(EltC, m_Undef())) {

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2653,7 +2653,7 @@ void ModuleAddressSanitizer::instrumentGlobals(IRBuilder<> &IRB,
 
     StructType *NewTy = StructType::get(Ty, RightRedZoneTy);
     Constant *NewInitializer = ConstantStruct::get(
-        NewTy, G->getInitializer(), Constant::getNullValue(RightRedZoneTy));
+        NewTy, G->getInitializer(), Constant::getZeroValue(RightRedZoneTy));
 
     // Create a new global variable with enough space for a redzone.
     GlobalValue::LinkageTypes Linkage = G->getLinkage();
@@ -2687,7 +2687,7 @@ void ModuleAddressSanitizer::instrumentGlobals(IRBuilder<> &IRB,
     G->eraseFromParent();
     NewGlobals[i] = NewGlobal;
 
-    Constant *ODRIndicator = Constant::getNullValue(IntptrTy);
+    Constant *ODRIndicator = Constant::getZeroValue(IntptrTy);
     GlobalValue *InstrumentedGlobal = NewGlobal;
 
     bool CanUsePrivateAliases =
@@ -2708,7 +2708,7 @@ void ModuleAddressSanitizer::instrumentGlobals(IRBuilder<> &IRB,
       // symbol __odr_asan_XXX to detect ODR violation.
       auto *ODRIndicatorSym =
           new GlobalVariable(M, IRB.getInt8Ty(), false, Linkage,
-                             Constant::getNullValue(IRB.getInt8Ty()),
+                             Constant::getZeroValue(IRB.getInt8Ty()),
                              kODRGenPrefix + NameForGlobal, nullptr,
                              NewGlobal->getThreadLocalMode());
 
@@ -2727,7 +2727,7 @@ void ModuleAddressSanitizer::instrumentGlobals(IRBuilder<> &IRB,
         ConstantExpr::getPointerCast(Name, IntptrTy),
         ConstantExpr::getPointerCast(getOrCreateModuleName(), IntptrTy),
         ConstantInt::get(IntptrTy, MD.IsDynInit),
-        Constant::getNullValue(IntptrTy), ODRIndicator);
+        Constant::getZeroValue(IntptrTy), ODRIndicator);
 
     LLVM_DEBUG(dbgs() << "NEW GLOBAL: " << *NewGlobal << "\n");
 
@@ -3413,7 +3413,7 @@ void FunctionStackPoisoner::createDynamicAllocasInitStorage() {
   BasicBlock &FirstBB = *F.begin();
   IRBuilder<> IRB(dyn_cast<Instruction>(FirstBB.begin()));
   DynamicAllocaLayout = IRB.CreateAlloca(IntptrTy, nullptr);
-  IRB.CreateStore(Constant::getNullValue(IntptrTy), DynamicAllocaLayout);
+  IRB.CreateStore(Constant::getZeroValue(IntptrTy), DynamicAllocaLayout);
   DynamicAllocaLayout->setAlignment(Align(32));
 }
 
@@ -3641,7 +3641,7 @@ void FunctionStackPoisoner::processStaticAllocas() {
           kAsanOptionDetectUseAfterReturn, IRB.getInt32Ty());
       Value *UseAfterReturnIsEnabled = IRB.CreateICmpNE(
           IRB.CreateLoad(IRB.getInt32Ty(), OptionDetectUseAfterReturn),
-          Constant::getNullValue(IRB.getInt32Ty()));
+          Constant::getZeroValue(IRB.getInt32Ty()));
       Instruction *Term =
           SplitBlockAndInsertIfThen(UseAfterReturnIsEnabled, InsBefore, false);
       IRBuilder<> IRBIf(Term);
@@ -3665,7 +3665,7 @@ void FunctionStackPoisoner::processStaticAllocas() {
     }
     FakeStackPtr = IRB.CreateIntToPtr(FakeStackInt, PtrTy);
     Value *NoFakeStack =
-        IRB.CreateICmpEQ(FakeStackInt, Constant::getNullValue(IntptrTy));
+        IRB.CreateICmpEQ(FakeStackInt, Constant::getZeroValue(IntptrTy));
     Instruction *Term =
         SplitBlockAndInsertIfThen(NoFakeStack, InsBefore, false);
     IRBuilder<> IRBIf(Term);
@@ -3680,8 +3680,8 @@ void FunctionStackPoisoner::processStaticAllocas() {
   } else {
     // void *FakeStack = nullptr;
     // void *LocalStackBase = alloca(LocalStackSize);
-    FakeStackInt = Constant::getNullValue(IntptrTy);
-    FakeStackPtr = Constant::getNullValue(PtrTy);
+    FakeStackInt = Constant::getZeroValue(IntptrTy);
+    FakeStackPtr = Constant::getZeroValue(PtrTy);
     LocalStackBase =
         DoDynamicAlloca ? createAllocaForLayout(IRB, L, true) : StaticAlloca;
     LocalStackBaseAlloca = LocalStackBase;
@@ -3772,7 +3772,7 @@ void FunctionStackPoisoner::processStaticAllocas() {
       // else
       //     <This is not a fake stack; unpoison the redzones>
       Value *Cmp =
-          IRBRet.CreateICmpNE(FakeStackInt, Constant::getNullValue(IntptrTy));
+          IRBRet.CreateICmpNE(FakeStackInt, Constant::getZeroValue(IntptrTy));
       Instruction *ThenTerm, *ElseTerm;
       SplitBlockAndInsertIfThenElse(Cmp, Ret, &ThenTerm, &ElseTerm);
 
@@ -3788,7 +3788,7 @@ void FunctionStackPoisoner::processStaticAllocas() {
             ConstantInt::get(IntptrTy, ClassSize - ASan.LongSize / 8));
         Value *SavedFlagPtr = IRBPoison.CreateLoad(IntptrTy, SavedFlagPtrPtr);
         IRBPoison.CreateStore(
-            Constant::getNullValue(IRBPoison.getInt8Ty()),
+            Constant::getZeroValue(IRBPoison.getInt8Ty()),
             IRBPoison.CreateIntToPtr(SavedFlagPtr, IRBPoison.getPtrTy()));
       } else {
         // For larger frames call __asan_stack_free_*.
@@ -3833,7 +3833,7 @@ void FunctionStackPoisoner::handleDynamicAllocaCall(AllocaInst *AI) {
   const Align Alignment = std::max(Align(kAllocaRzSize), AI->getAlign());
   const uint64_t AllocaRedzoneMask = kAllocaRzSize - 1;
 
-  Value *Zero = Constant::getNullValue(IntptrTy);
+  Value *Zero = Constant::getZeroValue(IntptrTy);
   Value *AllocaRzSize = ConstantInt::get(IntptrTy, kAllocaRzSize);
   Value *AllocaRzMask = ConstantInt::get(IntptrTy, AllocaRedzoneMask);
 

--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -2077,7 +2077,7 @@ Value *DFSanFunction::combineOrigins(const std::vector<Value *> &Shadows,
   for (size_t I = 0; I != Size; ++I) {
     Value *OpOrigin = Origins[I];
     Constant *ConstOpOrigin = dyn_cast<Constant>(OpOrigin);
-    if (ConstOpOrigin && ConstOpOrigin->isNullValue())
+    if (ConstOpOrigin && ConstOpOrigin->isZeroValue())
       continue;
     if (!Origin) {
       Origin = OpOrigin;
@@ -2363,7 +2363,7 @@ DFSanFunction::loadShadowOrigin(Value *Addr, uint64_t Size, Align InstAlignment,
     if (ClTrackOrigins == 2) {
       IRBuilder<> IRB(Pos->getParent(), Pos);
       auto *ConstantShadow = dyn_cast<Constant>(PrimitiveShadow);
-      if (!ConstantShadow || !ConstantShadow->isNullValue())
+      if (!ConstantShadow || !ConstantShadow->isZeroValue())
         Origin = updateOriginIfTainted(PrimitiveShadow, Origin, IRB);
     }
   }
@@ -2552,7 +2552,7 @@ void DFSanFunction::storeOrigin(BasicBlock::iterator Pos, Value *Addr,
   Value *CollapsedShadow = collapseToPrimitiveShadow(Shadow, Pos);
   IRBuilder<> IRB(Pos->getParent(), Pos);
   if (auto *ConstantShadow = dyn_cast<Constant>(CollapsedShadow)) {
-    if (!ConstantShadow->isNullValue())
+    if (!ConstantShadow->isZeroValue())
       paintOrigin(IRB, updateOrigin(Origin, IRB), StoreOriginAddr, Size,
                   OriginAlignment);
     return;

--- a/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
@@ -897,7 +897,7 @@ bool GCOVProfiler::emitProfileNotes(
         ArrayType *CounterTy = ArrayType::get(Type::getInt64Ty(*Ctx), Measured);
         GlobalVariable *Counters = new GlobalVariable(
             *M, CounterTy, false, GlobalValue::InternalLinkage,
-            Constant::getNullValue(CounterTy), "__llvm_gcov_ctr");
+            Constant::getZeroValue(CounterTy), "__llvm_gcov_ctr");
         const llvm::Triple &Triple = M->getTargetTriple();
         if (Triple.getObjectFormat() == llvm::Triple::XCOFF)
           Counters->setSection("__llvm_gcov_ctr_section");
@@ -1343,7 +1343,7 @@ Function *GCOVProfiler::insertReset(
   for (const auto &I : CountersBySP) {
     GlobalVariable *GV = I.first;
     auto *GVTy = cast<ArrayType>(GV->getValueType());
-    Builder.CreateMemSet(GV, Constant::getNullValue(Type::getInt8Ty(C)),
+    Builder.CreateMemSet(GV, Constant::getZeroValue(Type::getInt8Ty(C)),
                          GVTy->getNumElements() *
                              GVTy->getElementType()->getScalarSizeInBits() / 8,
                          GV->getAlign());

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -630,7 +630,7 @@ void HWAddressSanitizer::createHwasanNote() {
   // always create start and stop symbols.
   auto *Dummy = new GlobalVariable(
       M, Int8Arr0Ty, /*isConstantGlobal*/ true, GlobalVariable::PrivateLinkage,
-      Constant::getNullValue(Int8Arr0Ty), "hwasan.dummy.global");
+      Constant::getZeroValue(Int8Arr0Ty), "hwasan.dummy.global");
   Dummy->setSection("hwasan_globals");
   Dummy->setComdat(NoteComdat);
   Dummy->setMetadata(LLVMContext::MD_associated,
@@ -1908,7 +1908,7 @@ void HWAddressSanitizer::instrumentPersonalityFunctions() {
         HwasanPersonalityWrapper,
         {ThunkFn->getArg(0), ThunkFn->getArg(1), ThunkFn->getArg(2),
          ThunkFn->getArg(3), ThunkFn->getArg(4),
-         P.first ? P.first : Constant::getNullValue(PtrTy),
+         P.first ? P.first : Constant::getZeroValue(PtrTy),
          UnwindGetGR.getCallee(), UnwindGetCFA.getCallee()});
     WrapperCall->setTailCall();
     IRB.CreateRet(WrapperCall);

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1094,7 +1094,7 @@ GlobalVariable *InstrLowerer::getOrCreateBiasVar(StringRef VarName) {
   // is being used. Runtime has a weak external reference that is used
   // to check whether that's the case or not.
   Bias = new GlobalVariable(M, Int64Ty, false, GlobalValue::LinkOnceODRLinkage,
-                            Constant::getNullValue(Int64Ty), VarName);
+                            Constant::getZeroValue(Int64Ty), VarName);
   Bias->setVisibility(GlobalVariable::HiddenVisibility);
   // A definition that's weak (linkonce_odr) without being in a COMDAT
   // section wouldn't lead to link errors, but it would lead to a dead
@@ -1175,7 +1175,7 @@ void InstrLowerer::lowerCover(InstrProfCoverInst *CoverInstruction) {
 
 void InstrLowerer::lowerTimestamp(
     InstrProfTimestampInst *TimestampInstruction) {
-  assert(TimestampInstruction->getIndex()->isNullValue() &&
+  assert(TimestampInstruction->getIndex()->isZeroValue() &&
          "timestamp probes are always the first probe for a function");
   auto &Ctx = M.getContext();
   auto *TimestampAddr = getCounterAddress(TimestampInstruction);
@@ -1204,7 +1204,7 @@ void InstrLowerer::lowerIncrement(InstrProfIncrementInst *Inc) {
         ConstantPointerNull::get(PointerType::getUnqual(M.getContext()));
     Builder.CreateCall(Callee, {CastAddr, Uniform, Inc->getStep()});
   } else if (Options.Atomic || AtomicCounterUpdateAll ||
-             (Inc->getIndex()->isNullValue() && AtomicFirstCounter)) {
+             (Inc->getIndex()->isZeroValue() && AtomicFirstCounter)) {
     Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getStep(),
                             MaybeAlign(), AtomicOrdering::Monotonic);
   } else {
@@ -1638,7 +1638,7 @@ InstrLowerer::createRegionBitmaps(InstrProfMCDCBitmapInstBase *Inc,
   uint64_t NumBytes = Inc->getNumBitmapBytes();
   auto *BitmapTy = ArrayType::get(Type::getInt8Ty(M.getContext()), NumBytes);
   auto GV = new GlobalVariable(M, BitmapTy, false, Linkage,
-                               Constant::getNullValue(BitmapTy), Name);
+                               Constant::getZeroValue(BitmapTy), Name);
   GV->setAlignment(Align(1));
   return GV;
 }
@@ -1677,7 +1677,7 @@ InstrLowerer::createRegionCounters(InstrProfCntrInstBase *Inc, StringRef Name,
   } else {
     auto *CounterTy = ArrayType::get(Type::getInt64Ty(Ctx), NumCounters);
     GV = new GlobalVariable(M, CounterTy, false, Linkage,
-                            Constant::getNullValue(CounterTy), Name);
+                            Constant::getZeroValue(CounterTy), Name);
     GV->setAlignment(Align(8));
   }
   return GV;
@@ -1786,7 +1786,7 @@ void InstrLowerer::createDataVariable(InstrProfCntrInstBase *Inc) {
       !needsRuntimeRegistrationOfSectionRange(TT)) {
     ArrayType *ValuesTy = ArrayType::get(Type::getInt64Ty(Ctx), NS);
     auto *ValuesVar = new GlobalVariable(
-        M, ValuesTy, false, Linkage, Constant::getNullValue(ValuesTy),
+        M, ValuesTy, false, Linkage, Constant::getZeroValue(ValuesTy),
         getVarName(Inc, getInstrProfValuesVarPrefix(), Renamed));
     ValuesVar->setVisibility(Visibility);
     setGlobalVariableLargeSection(TT, *ValuesVar);
@@ -1938,7 +1938,7 @@ void InstrLowerer::emitVNodes() {
   ArrayType *VNodesTy = ArrayType::get(VNodeTy, NumCounters);
   auto *VNodesVar = new GlobalVariable(
       M, VNodesTy, false, GlobalValue::PrivateLinkage,
-      Constant::getNullValue(VNodesTy), getInstrProfVNodesVarName());
+      Constant::getZeroValue(VNodesTy), getInstrProfVNodesVarName());
   setGlobalVariableLargeSection(TT, *VNodesVar);
   VNodesVar->setSection(
       getInstrProfSectionName(IPSK_vnodes, TT.getObjectFormat()));

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1372,7 +1372,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // ZExt cannot convert between vector and scalar
     Value *ConvertedShadow = convertShadowToScalar(Shadow, IRB);
     if (auto *ConstantShadow = dyn_cast<Constant>(ConvertedShadow)) {
-      if (!ClCheckConstantShadow || ConstantShadow->isNullValue()) {
+      if (!ClCheckConstantShadow || ConstantShadow->isZeroValue()) {
         // Origin is not needed: value is initialized or const shadow is
         // ignored.
         return;
@@ -1535,7 +1535,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       Value *ConvertedShadow = ShadowData.Shadow;
 
       if (auto *ConstantShadow = dyn_cast<Constant>(ConvertedShadow)) {
-        if (!ClCheckConstantShadow || ConstantShadow->isNullValue()) {
+        if (!ClCheckConstantShadow || ConstantShadow->isZeroValue()) {
           // Skip, value is initialized or const shadow is ignored.
           continue;
         }
@@ -1942,11 +1942,11 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
     // TODO: Support callbacs with vectors of addresses.
     unsigned NumElements = cast<FixedVectorType>(VectTy)->getNumElements();
-    Value *ShadowPtrs = ConstantInt::getNullValue(
+    Value *ShadowPtrs = ConstantInt::getZeroValue(
         FixedVectorType::get(IRB.getPtrTy(), NumElements));
     Value *OriginPtrs = nullptr;
     if (MS.TrackOrigins)
-      OriginPtrs = ConstantInt::getNullValue(
+      OriginPtrs = ConstantInt::getZeroValue(
           FixedVectorType::get(IRB.getPtrTy(), NumElements));
     for (unsigned i = 0; i < NumElements; ++i) {
       Value *OneAddr =
@@ -2019,7 +2019,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     Type *ShadowTy = getShadowTy(OrigTy);
     if (!ShadowTy)
       return nullptr;
-    return Constant::getNullValue(ShadowTy);
+    return Constant::getZeroValue(ShadowTy);
   }
 
   /// Create a clean shadow value for a given value.
@@ -2056,7 +2056,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   }
 
   /// Create a clean (zero) origin.
-  Value *getCleanOrigin() { return Constant::getNullValue(MS.OriginTy); }
+  Value *getCleanOrigin() { return Constant::getZeroValue(MS.OriginTy); }
 
   /// Get the shadow value for a given Value.
   ///
@@ -2123,7 +2123,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
             if (!PropagateShadow || Overflow) {
               // ParamTLS overflow.
               EntryIRB.CreateMemSet(
-                  CpShadowPtr, Constant::getNullValue(EntryIRB.getInt8Ty()),
+                  CpShadowPtr, Constant::getZeroValue(EntryIRB.getInt8Ty()),
                   Size, ArgAlign);
             } else {
               Value *Base = getShadowPtrForArgument(EntryIRB, ArgOffset);
@@ -2474,7 +2474,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // * there is a defined 1 bit in C
     // * C is fully defined
     // Si = !(C & ~Sc) && Sc
-    Value *Zero = Constant::getNullValue(Sc->getType());
+    Value *Zero = Constant::getZeroValue(Sc->getType());
     Value *MinusOne = Constant::getAllOnesValue(Sc->getType());
     Value *LHS = IRB.CreateICmpNE(Sc, Zero);
     Value *RHS =
@@ -2759,7 +2759,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         } else {
           Constant *ConstOrigin = dyn_cast<Constant>(OpOrigin);
           // No point in adding something that might result in 0 origin value.
-          if (!ConstOrigin || !ConstOrigin->isNullValue()) {
+          if (!ConstOrigin || !ConstOrigin->isZeroValue()) {
             Value *Cond = MSV->convertToBool(OpShadow, IRB);
             Origin = IRB.CreateSelect(Cond, OpOrigin, Origin);
           }
@@ -3201,7 +3201,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       return;
     }
 
-    if ((constOp->isNullValue() &&
+    if ((constOp->isZeroValue() &&
          (pre == CmpInst::ICMP_SLT || pre == CmpInst::ICMP_SGE)) ||
         (constOp->isAllOnesValue() &&
          (pre == CmpInst::ICMP_SGT || pre == CmpInst::ICMP_SLE))) {
@@ -3550,7 +3550,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
     // If zero poison is requested, mix in with the shadow
     Constant *IsZeroPoison = cast<Constant>(I.getOperand(1));
-    if (!IsZeroPoison->isNullValue()) {
+    if (!IsZeroPoison->isZeroValue()) {
       Value *BoolZeroPoison = IRB.CreateIsNull(Src, "_mscz_bzp");
       OutputShadow = IRB.CreateOr(OutputShadow, BoolZeroPoison, "_mscz_bs");
     }
@@ -3776,7 +3776,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       Type *EltTy = cast<VectorType>(ResultShadow->getType())->getElementType();
       for (int i = 0; i < NumUsedElements; ++i) {
         ResultShadow = IRB.CreateInsertElement(
-            ResultShadow, ConstantInt::getNullValue(EltTy),
+            ResultShadow, ConstantInt::getZeroValue(EltTy),
             ConstantInt::get(IRB.getInt32Ty(), i));
       }
       setShadow(&I, ResultShadow);
@@ -3914,9 +3914,9 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       S2 = IRB.CreateBitCast(S2, T);
     }
     Value *S1_ext =
-        IRB.CreateSExt(IRB.CreateICmpNE(S1, Constant::getNullValue(T)), T);
+        IRB.CreateSExt(IRB.CreateICmpNE(S1, Constant::getZeroValue(T)), T);
     Value *S2_ext =
-        IRB.CreateSExt(IRB.CreateICmpNE(S2, Constant::getNullValue(T)), T);
+        IRB.CreateSExt(IRB.CreateICmpNE(S2, Constant::getZeroValue(T)), T);
     if (MMXEltSizeInBits) {
       S1_ext = IRB.CreateBitCast(S1_ext, getMMXVectorTy(64));
       S2_ext = IRB.CreateBitCast(S2_ext, getMMXVectorTy(64));
@@ -3949,13 +3949,13 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         cast<FixedVectorType>(S->getType())->getNumElements();
 
     S = IRB.CreateSelect(createDppMask(Width, SrcMask), S,
-                         Constant::getNullValue(S->getType()));
+                         Constant::getZeroValue(S->getType()));
     Value *SElem = IRB.CreateOrReduce(S);
     Value *IsClean = IRB.CreateIsNull(SElem, "_msdpp");
     Value *DstMaskV = createDppMask(Width, DstMask);
 
     return IRB.CreateSelect(
-        IsClean, Constant::getNullValue(DstMaskV->getType()), DstMaskV);
+        IsClean, Constant::getZeroValue(DstMaskV->getType()), DstMaskV);
   }
 
   // See `Intel Intrinsics Guide` for `_dp_p*` instructions.
@@ -4043,7 +4043,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     auto *Shadow1 = getShadow(&I, 1);
     Value *S = IRB.CreateOr(Shadow0, Shadow1);
     S = IRB.CreateBitCast(S, ResTy);
-    S = IRB.CreateSExt(IRB.CreateICmpNE(S, Constant::getNullValue(ResTy)),
+    S = IRB.CreateSExt(IRB.CreateICmpNE(S, Constant::getZeroValue(ResTy)),
                        ResTy);
     S = IRB.CreateLShr(S, ZeroBitsPerResultElement);
     S = IRB.CreateBitCast(S, getShadowTy(&I));
@@ -4202,7 +4202,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // Compute <4 x i1>, then extend back to <4 x i32>.
     Value *OutShadow = IRB.CreateSExt(
         IRB.CreateICmpNE(Horizontal,
-                         Constant::getNullValue(Horizontal->getType())),
+                         Constant::getZeroValue(Horizontal->getType())),
         ImplicitReturnType);
 
     // Cast it back to the required fake return type (if MMX: <1 x i64>; for
@@ -4249,7 +4249,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     auto *Shadow1 = getShadow(&I, 1);
     Value *S0 = IRB.CreateOr(Shadow0, Shadow1);
     Value *S = IRB.CreateSExt(
-        IRB.CreateICmpNE(S0, Constant::getNullValue(ResTy)), ResTy);
+        IRB.CreateICmpNE(S0, Constant::getZeroValue(ResTy)), ResTy);
     setShadow(&I, S);
     setOriginForNaryOp(I);
   }
@@ -4446,7 +4446,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     if (ClCheckAccessAddress) {
       insertCheckShadowOf(Mask, &I);
       Value *MaskedPtrShadow = IRB.CreateSelect(
-          Mask, getShadow(Ptrs), Constant::getNullValue((PtrsShadowTy)),
+          Mask, getShadow(Ptrs), Constant::getZeroValue((PtrsShadowTy)),
           "_msmaskedptrs");
       insertCheckShadow(MaskedPtrShadow, getOrigin(Ptrs), &I);
     }
@@ -4483,7 +4483,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     if (ClCheckAccessAddress) {
       insertCheckShadowOf(Mask, &I);
       Value *MaskedPtrShadow = IRB.CreateSelect(
-          Mask, getShadow(Ptrs), Constant::getNullValue((PtrsShadowTy)),
+          Mask, getShadow(Ptrs), Constant::getZeroValue((PtrsShadowTy)),
           "_msmaskedptrs");
       insertCheckShadow(MaskedPtrShadow, getOrigin(Ptrs), &I);
     }
@@ -4965,7 +4965,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     Value *Shadow0 = getShadow(&I, 0);
     Value *Shadow1 = getShadow(&I, 1);
     Value *Or = IRB.CreateOr(Shadow0, Shadow1);
-    Value *NZ = IRB.CreateICmpNE(Or, Constant::getNullValue(Or->getType()));
+    Value *NZ = IRB.CreateICmpNE(Or, Constant::getZeroValue(Or->getType()));
     Value *Scalar = convertShadowToScalar(NZ, IRB);
     Value *Shadow = IRB.CreateZExt(Scalar, getShadowTy(&I));
 
@@ -7512,7 +7512,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
                                  /*isStore*/ false);
           if (!PropagateShadow) {
             Store = IRB.CreateMemSet(ArgShadowBase,
-                                     Constant::getNullValue(IRB.getInt8Ty()),
+                                     Constant::getZeroValue(IRB.getInt8Ty()),
                                      Size, Alignment);
           } else {
             Store = IRB.CreateMemCpy(ArgShadowBase, Alignment, AShadowPtr,
@@ -7538,7 +7538,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
           Store = IRB.CreateAlignedStore(ArgShadow, ArgShadowBase,
                                          kShadowTLSAlignment);
           Constant *Cst = dyn_cast<Constant>(ArgShadow);
-          if (MS.TrackOrigins && !(Cst && Cst->isNullValue())) {
+          if (MS.TrackOrigins && !(Cst && Cst->isZeroValue())) {
             IRB.CreateStore(getOrigin(A),
                             getOriginPtrForArgument(IRB, ArgOffset));
           }
@@ -7931,7 +7931,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       if (Size <= 32)
         IRB.CreateAlignedStore(getCleanShadow(ElemTy), ShadowPtr, Align(1));
       else
-        IRB.CreateMemSet(ShadowPtr, ConstantInt::getNullValue(IRB.getInt8Ty()),
+        IRB.CreateMemSet(ShadowPtr, ConstantInt::getZeroValue(IRB.getInt8Ty()),
                          SizeVal, Align(1));
     }
   }
@@ -8077,7 +8077,7 @@ struct VarArgHelperBase : public VarArgHelper {
       return;
     Value *TailSize =
         ConstantInt::getSigned(IRB.getInt32Ty(), kParamTLSSize - BaseOffset);
-    IRB.CreateMemSet(ShadowBase, ConstantInt::getNullValue(IRB.getInt8Ty()),
+    IRB.CreateMemSet(ShadowBase, ConstantInt::getZeroValue(IRB.getInt8Ty()),
                      TailSize, Align(8));
   }
 
@@ -8088,7 +8088,7 @@ struct VarArgHelperBase : public VarArgHelper {
     auto [ShadowPtr, OriginPtr] = MSV.getShadowOriginPtr(
         VAListTag, IRB, IRB.getInt8Ty(), Alignment, /*isStore*/ true);
     // Unpoison the whole __va_list_tag.
-    IRB.CreateMemSet(ShadowPtr, Constant::getNullValue(IRB.getInt8Ty()),
+    IRB.CreateMemSet(ShadowPtr, Constant::getZeroValue(IRB.getInt8Ty()),
                      VAListTagSize, Alignment, false);
   }
 
@@ -8270,7 +8270,7 @@ struct VarArgAMD64Helper : public VarArgHelperBase {
           ConstantInt::get(MS.IntptrTy, AMD64FpEndOffset), VAArgOverflowSize);
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -8462,7 +8462,7 @@ struct VarArgAArch64Helper : public VarArgHelperBase {
           ConstantInt::get(MS.IntptrTy, AArch64VAEndOffset), VAArgOverflowSize);
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -8674,7 +8674,7 @@ struct VarArgPowerPC64Helper : public VarArgHelperBase {
 
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -8810,7 +8810,7 @@ struct VarArgPowerPC32Helper : public VarArgHelperBase {
 
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -8858,7 +8858,7 @@ struct VarArgPowerPC32Helper : public VarArgHelperBase {
         FPSaveArea = IRB.CreateIntToPtr(FPSaveArea, MS.PtrTy);
         // We fill fp shadow with zeroes as uninitialized fp args should have
         // been found during call base check
-        IRB.CreateMemSet(FPSaveArea, ConstantInt::getNullValue(IRB.getInt8Ty()),
+        IRB.CreateMemSet(FPSaveArea, ConstantInt::getZeroValue(IRB.getInt8Ty()),
                          ConstantInt::get(MS.IntptrTy, 32), Alignment);
       }
 
@@ -9146,7 +9146,7 @@ struct VarArgSystemZHelper : public VarArgHelperBase {
                         VAArgOverflowSize);
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -9249,7 +9249,7 @@ struct VarArgI386Helper : public VarArgHelperBase {
       // va_arg_tls somewhere in the function entry block.
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(
@@ -9334,7 +9334,7 @@ struct VarArgGenericHelper : public VarArgHelperBase {
       // va_arg_tls somewhere in the function entry block.
       VAArgTLSCopy = IRB.CreateAlloca(Type::getInt8Ty(*MS.C), CopySize);
       VAArgTLSCopy->setAlignment(kShadowTLSAlignment);
-      IRB.CreateMemSet(VAArgTLSCopy, Constant::getNullValue(IRB.getInt8Ty()),
+      IRB.CreateMemSet(VAArgTLSCopy, Constant::getZeroValue(IRB.getInt8Ty()),
                        CopySize, kShadowTLSAlignment, false);
 
       Value *SrcSize = IRB.CreateBinaryIntrinsic(

--- a/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
@@ -138,9 +138,9 @@ CtxInstrumentationLowerer::CtxInstrumentationLowerer(Module &M,
 #undef _VOLATILE_PTRDECL
 #undef _MUTEXDECL
 
-#define _PTRDECL(_, __) Constant::getNullValue(PointerTy),
+#define _PTRDECL(_, __) Constant::getZeroValue(PointerTy),
 #define _VOLATILE_PTRDECL(_, __) _PTRDECL(_, __)
-#define _MUTEXDECL(_) Constant::getNullValue(SanitizerMutexType),
+#define _MUTEXDECL(_) Constant::getZeroValue(SanitizerMutexType),
 #define _CONTEXT_ROOT                                                          \
   Constant::getIntegerValue(                                                   \
       PointerTy,                                                               \
@@ -302,7 +302,7 @@ bool CtxInstrumentationLowerer::lowerFunction(Function &F) {
       TheRootFunctionData = new GlobalVariable(
           M, FunctionDataTy, false, GlobalVariable::InternalLinkage,
           HasMusttail ? CannotBeRootInitializer
-                      : Constant::getNullValue(FunctionDataTy));
+                      : Constant::getZeroValue(FunctionDataTy));
 
       if (ContextRootSet.contains(&F)) {
         Context = Builder.CreateCall(

--- a/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
@@ -530,7 +530,7 @@ bool ModuleSanitizerCoverage::instrumentModule() {
         M.getOrInsertGlobal(SanCovCallbackGateName, Int64Ty));
     SanCovCallbackGate->setSection(
         getSectionName(SanCovCallbackGateSectionName));
-    SanCovCallbackGate->setInitializer(Constant::getNullValue(Int64Ty));
+    SanCovCallbackGate->setInitializer(Constant::getZeroValue(Int64Ty));
     SanCovCallbackGate->setLinkage(GlobalVariable::LinkOnceAnyLinkage);
     SanCovCallbackGate->setVisibility(GlobalVariable::HiddenVisibility);
     appendToCompilerUsed(M, SanCovCallbackGate);
@@ -774,7 +774,7 @@ GlobalVariable *ModuleSanitizerCoverage::CreateFunctionLocalArrayInSection(
   ArrayType *ArrayTy = ArrayType::get(Ty, NumElements);
   auto Array = new GlobalVariable(
       *CurModule, ArrayTy, false, GlobalVariable::PrivateLinkage,
-      Constant::getNullValue(ArrayTy), "__sancov_gen_");
+      Constant::getZeroValue(ArrayTy), "__sancov_gen_");
 
   if (TargetTriple.supportsCOMDAT() &&
       (F.hasComdat() || TargetTriple.isOSBinFormatELF() || !F.isInterposable()))
@@ -815,7 +815,7 @@ ModuleSanitizerCoverage::CreatePCArray(Function &F,
     } else {
       PCs.push_back((Constant *)IRB.CreatePointerCast(
           BlockAddress::get(AllBlocks[i]), PtrTy));
-      PCs.push_back(Constant::getNullValue(PtrTy));
+      PCs.push_back(Constant::getZeroValue(PtrTy));
     }
   }
   auto *PCArray =
@@ -1176,7 +1176,7 @@ void ModuleSanitizerCoverage::InjectCoverageAtBlock(Function &F, BasicBlock &BB,
       // Check stack depth.  If it's the deepest so far, record it.
       auto FrameAddrPtr = IRB.CreateIntrinsic(
           Intrinsic::frameaddress, IRB.getPtrTy(DL.getAllocaAddrSpace()),
-          {Constant::getNullValue(Int32Ty)});
+          {Constant::getZeroValue(Int32Ty)});
       auto FrameAddrInt = IRB.CreatePtrToInt(FrameAddrPtr, IntptrTy);
       auto LowestStack = IRB.CreateLoad(IntptrTy, SanCovLowestStack);
       auto IsStackLower = IRB.CreateICmpULT(FrameAddrInt, LowestStack);
@@ -1241,7 +1241,7 @@ void ModuleSanitizerCoverage::createFunctionControlFlow(Function &F) {
           (Constant *)IRB.CreatePointerCast(BlockAddress::get(SuccBB), PtrTy));
     }
 
-    CFs.push_back((Constant *)Constant::getNullValue(PtrTy));
+    CFs.push_back((Constant *)Constant::getZeroValue(PtrTy));
 
     for (auto &Inst : BB) {
       if (CallBase *CB = dyn_cast<CallBase>(&Inst)) {
@@ -1257,7 +1257,7 @@ void ModuleSanitizerCoverage::createFunctionControlFlow(Function &F) {
       }
     }
 
-    CFs.push_back((Constant *)Constant::getNullValue(PtrTy));
+    CFs.push_back((Constant *)Constant::getZeroValue(PtrTy));
   }
 
   FunctionCFsArray = CreateFunctionLocalArrayInSection(CFs.size(), F, PtrTy,

--- a/llvm/lib/Transforms/Instrumentation/TypeSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/TypeSanitizer.cpp
@@ -625,7 +625,7 @@ bool TypeSanitizer::instrumentWithShadowUpdate(
   if (TBAAMD)
     TDGV = TypeDescriptors[TBAAMD];
   else
-    TDGV = Constant::getNullValue(IRB.getPtrTy());
+    TDGV = Constant::getZeroValue(IRB.getPtrTy());
 
   Value *TD = IRB.CreateBitCast(TDGV, IRB.getPtrTy());
 

--- a/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
+++ b/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
@@ -168,7 +168,7 @@ static void addConditions(CallBase &CB, const ConditionsTy &Conditions) {
     Constant *ConstVal = cast<Constant>(Cond.first->getOperand(1));
     if (Cond.second == ICmpInst::ICMP_EQ)
       setConstantInArgument(CB, Arg, ConstVal);
-    else if (ConstVal->getType()->isPointerTy() && ConstVal->isNullValue()) {
+    else if (ConstVal->getType()->isPointerTy() && ConstVal->isZeroValue()) {
       assert(Cond.second == ICmpInst::ICMP_NE);
       addNonNullAttribute(CB, Arg);
     }

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -780,7 +780,7 @@ ConstraintInfo::getConstraint(CmpInst::Predicate Pred, Value *Op0, Value *Op1,
 ConstraintTy ConstraintInfo::getConstraintForSolving(CmpInst::Predicate Pred,
                                                      Value *Op0,
                                                      Value *Op1) const {
-  Constant *NullC = Constant::getNullValue(Op0->getType());
+  Constant *NullC = Constant::getZeroValue(Op0->getType());
   // Handle trivially true compares directly to avoid adding V UGE 0 constraints
   // for all variables in the unsigned system.
   if ((Pred == CmpInst::ICMP_ULE && Op0 == NullC) ||

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -226,7 +226,7 @@ static Value *getValueOnEdge(LazyValueInfo *LVI, Value *Incoming,
     if (Constant *C = LVI->getConstantOnEdge(Condition, From, To, CxtI)) {
       if (C->isOneValue())
         return SI->getTrueValue();
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return SI->getFalseValue();
     }
   }
@@ -832,7 +832,7 @@ static bool expandUDivOrURem(BinaryOperator *Instr, const ConstantRange &XCR,
   // X u/ Y -> 0  iff X u< Y
   // X u% Y -> X  iff X u< Y
   if (XCR.icmp(ICmpInst::ICMP_ULT, YCR)) {
-    Instr->replaceAllUsesWith(IsRem ? X : Constant::getNullValue(Ty));
+    Instr->replaceAllUsesWith(IsRem ? X : Constant::getZeroValue(Ty));
     Instr->eraseFromParent();
     ++NumUDivURemsNarrowedExpanded;
     return true;

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -2256,7 +2256,7 @@ bool DSEState::tryFoldIntoCalloc(MemoryDef *Def, const Value *DefUO) {
     // TODO: Could handle zero store to small allocation as well.
     return false;
   Constant *StoredConstant = dyn_cast<Constant>(MemSet->getValue());
-  if (!StoredConstant || !StoredConstant->isNullValue())
+  if (!StoredConstant || !StoredConstant->isZeroValue())
     return false;
 
   if (!isRemovable(DefI))

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -1250,7 +1250,7 @@ Value *EarlyCSE::getMatchingValue(LoadValue &InVal, ParseMemoryInst &MemInst,
         !isSameMemGeneration(InVal.Generation, CurrentGeneration, InVal.DefInst,
                              MemInst.get()))
       return nullptr;
-    return Constant::getNullValue(MemInst.getValueType());
+    return Constant::getZeroValue(MemInst.getValueType());
   }
   if (InVal.MatchingId != MemInst.getMatchingId())
     return nullptr;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2094,7 +2094,7 @@ bool GVNPass::processAssumeIntrinsic(AssumeInst *IntrinsicI) {
       // this code is not reachable.  FIXME: We could insert unreachable
       // instruction directly because we can modify the CFG.
       auto *NewS =
-          new StoreInst(PoisonValue::get(Int8Ty), Constant::getNullValue(PtrTy),
+          new StoreInst(PoisonValue::get(Int8Ty), Constant::getZeroValue(PtrTy),
                         IntrinsicI->getIterator());
       if (MSSAU) {
         const MemoryUseOrDef *FirstNonDom = nullptr;

--- a/llvm/lib/Transforms/Scalar/GuardWidening.cpp
+++ b/llvm/lib/Transforms/Scalar/GuardWidening.cpp
@@ -819,7 +819,7 @@ bool GuardWideningImpl::parseRangeChecks(
   auto &DL = IC->getDataLayout();
 
   GuardWideningImpl::RangeCheck Check(
-      CmpLHS, cast<ConstantInt>(ConstantInt::getNullValue(CmpRHS->getType())),
+      CmpLHS, cast<ConstantInt>(ConstantInt::getZeroValue(CmpRHS->getType())),
       CmpRHS, IC);
 
   if (!isKnownNonNegative(Check.getLength(), DL))

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1680,7 +1680,7 @@ bool IndVarSimplify::optimizeLoopExits(Loop *L, SCEVExpander &Rewriter) {
       // If already constant, nothing to do. However, if this is an
       // unconditional exit, we can still replace header phis with their
       // preheader value.
-      if (!L->contains(BI->getSuccessor(CI->isNullValue())))
+      if (!L->contains(BI->getSuccessor(CI->isZeroValue())))
         replaceLoopPHINodesWithPreheaderValues(LI, L, DeadInsts, *SE);
       return true;
     }

--- a/llvm/lib/Transforms/Scalar/InferAlignment.cpp
+++ b/llvm/lib/Transforms/Scalar/InferAlignment.cpp
@@ -47,7 +47,7 @@ static bool tryToImproveAlign(
   if (match(I, m_And(m_PtrToIntOrAddr(m_Value(PtrOp)), m_APInt(Const)))) {
     Align ActualAlign = Fn(PtrOp, Align(1), Align(1));
     if (Const->ult(ActualAlign.value())) {
-      I->replaceAllUsesWith(Constant::getNullValue(I->getType()));
+      I->replaceAllUsesWith(Constant::getZeroValue(I->getType()));
       return true;
     }
     if (Const->uge(
@@ -59,7 +59,7 @@ static bool tryToImproveAlign(
   if (match(I, m_Trunc(m_PtrToIntOrAddr(m_Value(PtrOp))))) {
     Align ActualAlign = Fn(PtrOp, Align(1), Align(1));
     if (Log2(ActualAlign) >= I->getType()->getScalarSizeInBits()) {
-      I->replaceAllUsesWith(Constant::getNullValue(I->getType()));
+      I->replaceAllUsesWith(Constant::getZeroValue(I->getType()));
       return true;
     }
   }

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1361,7 +1361,7 @@ bool MemCpyOptPass::processMemSetMemCpyDependence(MemCpyInst *MemCpy,
   Value *Ule = Builder.CreateICmpULE(DestSize, SrcSize);
   Value *SizeDiff = Builder.CreateSub(DestSize, SrcSize);
   Value *MemsetLen = Builder.CreateSelect(
-      Ule, ConstantInt::getNullValue(DestSize->getType()), SizeDiff);
+      Ule, ConstantInt::getZeroValue(DestSize->getType()), SizeDiff);
   // FIXME (#167968): we could explore estimating the branch_weights based on
   // value profiling data about the 2 sizes.
   if (auto *SI = dyn_cast<SelectInst>(MemsetLen))
@@ -1782,7 +1782,7 @@ static bool isZeroSize(Value *Size) {
       Size = Res;
   // Treat undef/poison size like zero.
   if (auto *C = dyn_cast<Constant>(Size))
-    return isa<UndefValue>(C) || C->isNullValue();
+    return isa<UndefValue>(C) || C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -3756,7 +3756,7 @@ void NewGVN::deleteInstructionsInBlock(BasicBlock *BB) {
   Type *Int8Ty = Type::getInt8Ty(BB->getContext());
   new StoreInst(
       PoisonValue::get(Int8Ty),
-      Constant::getNullValue(PointerType::getUnqual(BB->getContext())),
+      Constant::getZeroValue(PointerType::getUnqual(BB->getContext())),
       BB->getTerminator()->getIterator());
 }
 

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -297,7 +297,7 @@ static BinaryOperator *LowerNegateToMultiply(Instruction *Neg) {
 
   BinaryOperator *Res =
       CreateMul(Neg->getOperand(OpNo), NegOne, "", Neg->getIterator(), Neg);
-  Neg->setOperand(OpNo, Constant::getNullValue(Ty)); // Drop use of op.
+  Neg->setOperand(OpNo, Constant::getZeroValue(Ty)); // Drop use of op.
   Res->takeName(Neg);
   Neg->replaceAllUsesWith(Res);
   Res->setDebugLoc(Neg->getDebugLoc());
@@ -966,7 +966,7 @@ static BinaryOperator *convertOrWithNoCommonBitsToAdd(Instruction *Or) {
 /// Return true if we should break up this subtract of X-Y into (X + -Y).
 static bool ShouldBreakUpSubtract(Instruction *Sub) {
   // If this is a negation, we can't split it up!
-  if (match(Sub, m_Neg(m_Value())) || match(Sub, m_FNeg(m_Value()))) 
+  if (match(Sub, m_Neg(m_Value())) || match(Sub, m_FNeg(m_Value())))
     return false;
 
   // Don't breakup X - undef.
@@ -1004,8 +1004,8 @@ static BinaryOperator *BreakUpSubtract(Instruction *Sub,
   Value *NegVal = NegateValue(Sub->getOperand(1), Sub, ToRedo);
   BinaryOperator *New =
       CreateAdd(Sub->getOperand(0), NegVal, "", Sub->getIterator(), Sub);
-  Sub->setOperand(0, Constant::getNullValue(Sub->getType())); // Drop use of op.
-  Sub->setOperand(1, Constant::getNullValue(Sub->getType())); // Drop use of op.
+  Sub->setOperand(0, Constant::getZeroValue(Sub->getType())); // Drop use of op.
+  Sub->setOperand(1, Constant::getZeroValue(Sub->getType())); // Drop use of op.
   New->takeName(Sub);
 
   // Everyone now refers to the add instruction.
@@ -1194,7 +1194,7 @@ static Value *OptimizeAndOrXor(unsigned Opcode,
       unsigned FoundX = FindInOperandList(Ops, i, X);
       if (FoundX != i) {
         if (Opcode == Instruction::And)   // ...&X&~X = 0
-          return Constant::getNullValue(X->getType());
+          return Constant::getZeroValue(X->getType());
 
         if (Opcode == Instruction::Or)    // ...|X|~X = -1
           return Constant::getAllOnesValue(X->getType());
@@ -1216,7 +1216,7 @@ static Value *OptimizeAndOrXor(unsigned Opcode,
       // Drop pairs of values for Xor.
       assert(Opcode == Instruction::Xor);
       if (e == 2)
-        return Constant::getNullValue(Ops[0].Op->getType());
+        return Constant::getZeroValue(Ops[0].Op->getType());
 
       // Y ^ X^X -> Y
       Ops.erase(Ops.begin()+i, Ops.begin()+i+2);
@@ -1550,7 +1550,7 @@ Value *ReassociatePass::OptimizeAdd(Instruction *I,
     // Remove X and -X from the operand list.
     if (Ops.size() == 2 &&
         (match(TheOp, m_Neg(m_Value())) || match(TheOp, m_FNeg(m_Value()))))
-      return Constant::getNullValue(X->getType());
+      return Constant::getZeroValue(X->getType());
 
     // Remove X and ~X from the operand list.
     if (Ops.size() == 2 && match(TheOp, m_Not(m_Value())))

--- a/llvm/lib/Transforms/Scalar/Reg2Mem.cpp
+++ b/llvm/lib/Transforms/Scalar/Reg2Mem.cpp
@@ -64,7 +64,7 @@ static bool runPass(Function &F) {
   while (isa<AllocaInst>(I)) ++I;
 
   CastInst *AllocaInsertionPoint = new BitCastInst(
-      Constant::getNullValue(Type::getInt32Ty(F.getContext())),
+      Constant::getZeroValue(Type::getInt32Ty(F.getContext())),
       Type::getInt32Ty(F.getContext()), "reg2mem alloca point", I);
 
   // Find the escaped instructions. But don't create stack slots for

--- a/llvm/lib/Transforms/Scalar/ScalarizeMaskedMemIntrin.cpp
+++ b/llvm/lib/Transforms/Scalar/ScalarizeMaskedMemIntrin.cpp
@@ -182,7 +182,7 @@ static void scalarizeMaskedLoad(const DataLayout &DL, bool HasBranchDivergence,
 
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Gep = Builder.CreateConstInBoundsGEP1_32(EltTy, Ptr, Idx);
       LoadInst *Load = Builder.CreateAlignedLoad(EltTy, Gep, AdjustedAlignVal);
@@ -348,7 +348,7 @@ static void scalarizeMaskedStore(const DataLayout &DL, bool HasBranchDivergence,
 
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt = Builder.CreateExtractElement(Src, Idx);
       Value *Gep = Builder.CreateConstInBoundsGEP1_32(EltTy, Ptr, Idx);
@@ -492,7 +492,7 @@ static void scalarizeMaskedGather(const DataLayout &DL,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Ptr = Builder.CreateExtractElement(Ptrs, Idx, "Ptr" + Twine(Idx));
       LoadInst *Load =
@@ -630,7 +630,7 @@ static void scalarizeMaskedScatter(const DataLayout &DL,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt =
           Builder.CreateExtractElement(Src, Idx, "Elt" + Twine(Idx));
@@ -739,7 +739,7 @@ static void scalarizeMaskedExpandLoad(const DataLayout &DL,
     SmallVector<int, 16> ShuffleMask(VectorWidth, PoisonMaskElem);
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
       Value *InsertElt;
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue()) {
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue()) {
         InsertElt = PoisonValue::get(EltTy);
         ShuffleMask[Idx] = Idx + VectorWidth;
       } else {
@@ -869,7 +869,7 @@ static void scalarizeMaskedCompressStore(const DataLayout &DL,
   if (isConstantIntVector(Mask)) {
     unsigned MemIndex = 0;
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt =
           Builder.CreateExtractElement(Src, Idx, "Elt" + Twine(Idx));
@@ -1000,7 +1000,7 @@ static void scalarizeMaskedVectorHistogram(const DataLayout &DL, CallInst *CI,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Ptr = Builder.CreateExtractElement(Ptrs, Idx, "Ptr" + Twine(Idx));
       LoadInst *Load = Builder.CreateLoad(EltTy, Ptr, "Load" + Twine(Idx));

--- a/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
+++ b/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
@@ -813,7 +813,7 @@ ConstantOffsetExtractor::distributeCastsAndCloneChain(unsigned ChainIndex) {
 Value *ConstantOffsetExtractor::removeConstOffset(unsigned ChainIndex) {
   if (ChainIndex == 0) {
     assert(isa<ConstantInt>(UserChain[ChainIndex]));
-    return ConstantInt::getNullValue(UserChain[ChainIndex]->getType());
+    return ConstantInt::getZeroValue(UserChain[ChainIndex]->getType());
   }
 
   BinaryOperator *BO = cast<BinaryOperator>(UserChain[ChainIndex]);

--- a/llvm/lib/Transforms/Utils/AMDGPUEmitPrintf.cpp
+++ b/llvm/lib/Transforms/Utils/AMDGPUEmitPrintf.cpp
@@ -118,7 +118,7 @@ static Value *getStrlenWithNull(IRBuilder<> &Builder, Value *Str) {
   // Emit an early return for when the pointer is null.
   Builder.SetInsertPoint(Prev);
   auto CmpNull =
-      Builder.CreateICmpEQ(Str, Constant::getNullValue(Str->getType()));
+      Builder.CreateICmpEQ(Str, Constant::getZeroValue(Str->getType()));
   Builder.CreateCondBr(CmpNull, Join, While);
 
   // Entry to the while loop.

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1655,7 +1655,7 @@ void CodeExtractor::emitFunctionBody(
     Value *RewriteVal;
     if (StructValues.contains(inputs[i])) {
       Value *Idx[2];
-      Idx[0] = Constant::getNullValue(Type::getInt32Ty(header->getContext()));
+      Idx[0] = Constant::getZeroValue(Type::getInt32Ty(header->getContext()));
       Idx[1] = ConstantInt::get(Type::getInt32Ty(header->getContext()), aggIdx);
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           StructArgTy, AggArg, Idx, "gep_" + inputs[i]->getName(), newFuncRoot);
@@ -1824,7 +1824,7 @@ void CodeExtractor::emitFunctionBody(
       assert(AggArg && "Number of aggregate output arguments should match "
                        "the number of defined values");
       Value *Idx[2];
-      Idx[0] = Constant::getNullValue(Type::getInt32Ty(Context));
+      Idx[0] = Constant::getZeroValue(Type::getInt32Ty(Context));
       Idx[1] = ConstantInt::get(Type::getInt32Ty(Context), AggIdx);
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           StructArgTy, AggArg, Idx, "gep_" + Output->getName(), InsertPt);
@@ -1914,7 +1914,7 @@ CallInst *CodeExtractor::emitReplacerCall(
         continue;
 
       Value *Idx[2];
-      Idx[0] = Constant::getNullValue(Type::getInt32Ty(Context));
+      Idx[0] = Constant::getZeroValue(Type::getInt32Ty(Context));
       Idx[1] = ConstantInt::get(Type::getInt32Ty(Context), AggIdx);
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           StructArgTy, Struct, Idx, "gep_" + input->getName());
@@ -1958,7 +1958,7 @@ CallInst *CodeExtractor::emitReplacerCall(
     Value *Output = nullptr;
     if (StructValues.contains(outputs[i])) {
       Value *Idx[2];
-      Idx[0] = Constant::getNullValue(Type::getInt32Ty(Context));
+      Idx[0] = Constant::getZeroValue(Type::getInt32Ty(Context));
       Idx[1] = ConstantInt::get(Type::getInt32Ty(Context), AggIdx);
       GetElementPtrInst *GEP = GetElementPtrInst::Create(
           StructArgTy, Struct, Idx, "gep_reload_" + outputs[i]->getName());
@@ -1977,7 +1977,7 @@ CallInst *CodeExtractor::emitReplacerCall(
 
   // Now we can emit a switch statement using the call as a value.
   SwitchInst *TheSwitch =
-      SwitchInst::Create(Constant::getNullValue(Type::getInt16Ty(Context)),
+      SwitchInst::Create(Constant::getZeroValue(Type::getInt16Ty(Context)),
                          codeReplacer, 0, codeReplacer);
   for (auto P : enumerate(ExtractedFuncRetVals)) {
     BasicBlock *OldTarget = P.value();
@@ -2008,7 +2008,7 @@ CallInst *CodeExtractor::emitReplacerCall(
     } else {
       // Otherwise we must have code extracted an unwind or something, just
       // return whatever we want.
-      ReturnInst::Create(Context, Constant::getNullValue(OldFnRetTy),
+      ReturnInst::Create(Context, Constant::getZeroValue(OldFnRetTy),
                          TheSwitch->getIterator());
     }
 

--- a/llvm/lib/Transforms/Utils/Evaluator.cpp
+++ b/llvm/lib/Transforms/Utils/Evaluator.cpp
@@ -386,9 +386,9 @@ bool Evaluator::EvaluateBlock(BasicBlock::iterator CurInst, BasicBlock *&NextBB,
           Constant *Val = getVal(MSI->getValue());
           // Avoid the byte-per-byte scan if we're memseting a zeroinitializer
           // to zero.
-          if (!Val->isNullValue() || MutatedMemory.contains(GV) ||
+          if (!Val->isZeroValue() || MutatedMemory.contains(GV) ||
               !GV->hasDefinitiveInitializer() ||
-              !GV->getInitializer()->isNullValue()) {
+              !GV->getInitializer()->isZeroValue()) {
             APInt Len = LenC->getValue();
             if (Len.ugt(64 * 1024)) {
               LLVM_DEBUG(dbgs() << "Not evaluating large memset of size "

--- a/llvm/lib/Transforms/Utils/FunctionComparator.cpp
+++ b/llvm/lib/Transforms/Utils/FunctionComparator.cpp
@@ -347,11 +347,11 @@ int FunctionComparator::cmpConstants(const Constant *L,
 
   // OK, types are bitcastable, now check constant contents.
 
-  if (L->isNullValue() && R->isNullValue())
+  if (L->isZeroValue() && R->isZeroValue())
     return TypesRes;
-  if (L->isNullValue() && !R->isNullValue())
+  if (L->isZeroValue() && !R->isZeroValue())
     return 1;
-  if (!L->isNullValue() && R->isNullValue())
+  if (!L->isZeroValue() && R->isZeroValue())
     return -1;
 
   auto GlobalValueL = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(L));

--- a/llvm/lib/Transforms/Utils/FunctionImportUtils.cpp
+++ b/llvm/lib/Transforms/Utils/FunctionImportUtils.cpp
@@ -301,7 +301,7 @@ void FunctionImportGlobalProcessing::processGlobalForThinLTO(GlobalValue &GV) {
         // ignore them when computing import. We do not export references
         // of writeonly object. See computeImportForReferencedGlobals
         if (ImportIndex.isWriteOnly(GVS))
-          V->setInitializer(Constant::getNullValue(V->getValueType()));
+          V->setInitializer(Constant::getZeroValue(V->getValueType()));
       }
     }
   }

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -513,7 +513,7 @@ bool llvm::wouldInstructionBeTriviallyDead(const Instruction *I,
   if (auto *Call = dyn_cast<CallBase>(I)) {
     if (Value *FreedOp = getFreedOperand(Call, TLI))
       if (Constant *C = dyn_cast<Constant>(FreedOp))
-        return C->isNullValue() || isa<UndefValue>(C);
+        return C->isZeroValue() || isa<UndefValue>(C);
     if (isMathLibCallNoop(Call, TLI))
       return true;
   }

--- a/llvm/lib/Transforms/Utils/LowerGlobalDtors.cpp
+++ b/llvm/lib/Transforms/Utils/LowerGlobalDtors.cpp
@@ -109,7 +109,7 @@ static bool runImpl(Module &M) {
     uint16_t PriorityValue = Priority->getLimitedValue(UINT16_MAX);
 
     Constant *DtorFunc = CS->getOperand(1);
-    if (DtorFunc->isNullValue())
+    if (DtorFunc->isZeroValue())
       break; // Found a null terminator, skip the rest.
 
     Constant *Associated = CS->getOperand(2);
@@ -180,7 +180,7 @@ static bool runImpl(Module &M) {
                                       : Twine()) +
               (AtThisPriority.size() > 1 ? Twine("$") + Twine(ThisId)
                                          : Twine()) +
-              (!Associated->isNullValue() ? (Twine(".") + Associated->getName())
+              (!Associated->isZeroValue() ? (Twine(".") + Associated->getName())
                                           : Twine()),
           &M);
       BasicBlock *BB = BasicBlock::Create(C, "body", CallDtors);
@@ -198,7 +198,7 @@ static bool runImpl(Module &M) {
                                       : Twine()) +
               (AtThisPriority.size() > 1 ? Twine("$") + Twine(ThisId)
                                          : Twine()) +
-              (!Associated->isNullValue() ? (Twine(".") + Associated->getName())
+              (!Associated->isZeroValue() ? (Twine(".") + Associated->getName())
                                           : Twine()),
           &M);
       BasicBlock *EntryBB = BasicBlock::Create(C, "entry", RegisterCallDtors);
@@ -209,7 +209,7 @@ static bool runImpl(Module &M) {
       Value *Args[] = {CallDtors, Null, DsoHandle};
       Value *Res = CallInst::Create(AtExit, Args, "call", EntryBB);
       Value *Cmp = new ICmpInst(EntryBB, ICmpInst::ICMP_NE, Res,
-                                Constant::getNullValue(Res->getType()));
+                                Constant::getZeroValue(Res->getType()));
       CondBrInst::Create(Cmp, FailBB, RetBB, EntryBB);
 
       // If `__cxa_atexit` hits out-of-memory, trap, so that we don't misbehave.

--- a/llvm/lib/Transforms/Utils/MemoryTaggingSupport.cpp
+++ b/llvm/lib/Transforms/Utils/MemoryTaggingSupport.cpp
@@ -253,7 +253,7 @@ Value *getFP(IRBuilder<> &IRB) {
   return IRB.CreatePtrToInt(
       IRB.CreateIntrinsic(Intrinsic::frameaddress,
                           IRB.getPtrTy(M->getDataLayout().getAllocaAddrSpace()),
-                          {Constant::getNullValue(IRB.getInt32Ty())}),
+                          {Constant::getZeroValue(IRB.getInt32Ty())}),
       IRB.getIntPtrTy(M->getDataLayout()));
 }
 

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -55,7 +55,7 @@ static void appendToGlobalArray(StringRef ArrayName, Module &M, Function *F,
   CSVals[0] = IRB.getInt32(Priority);
   CSVals[1] = F;
   CSVals[2] = Data ? ConstantExpr::getPointerCast(Data, IRB.getPtrTy())
-                   : Constant::getNullValue(IRB.getPtrTy());
+                   : Constant::getZeroValue(IRB.getPtrTy());
   Constant *RuntimeCtorInit =
       ConstantStruct::get(EltTy, ArrayRef(CSVals, EltTy->getNumElements()));
 

--- a/llvm/lib/Transforms/Utils/PredicateInfo.cpp
+++ b/llvm/lib/Transforms/Utils/PredicateInfo.cpp
@@ -744,7 +744,7 @@ std::optional<PredicateConstraint> PredicateBase::getConstraint() const {
 
     if (match(Condition, m_NUWTrunc(m_Specific(RenamedOp)))) {
       return {{TrueEdge ? CmpInst::ICMP_NE : CmpInst::ICMP_EQ,
-               ConstantInt::getNullValue(RenamedOp->getType())}};
+               ConstantInt::getZeroValue(RenamedOp->getType())}};
     }
 
     CmpInst *Cmp = dyn_cast<CmpInst>(Condition);

--- a/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
+++ b/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
@@ -490,7 +490,7 @@ static void addAssumeNonNull(AssumptionCache *AC, LoadInst *LI) {
   Function *AssumeIntrinsic =
       Intrinsic::getOrInsertDeclaration(LI->getModule(), Intrinsic::assume);
   ICmpInst *LoadNotNull = new ICmpInst(ICmpInst::ICMP_NE, LI,
-                                       Constant::getNullValue(LI->getType()));
+                                       Constant::getZeroValue(LI->getType()));
   LoadNotNull->insertAfter(LI->getIterator());
   CallInst *CI = CallInst::Create(AssumeIntrinsic, {LoadNotNull});
   CI->insertAfter(LoadNotNull->getIterator());

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -491,7 +491,7 @@ static void inferAttribute(Function *F, unsigned AttrIndex,
   }
   // Infer nonnull attribute.
   if (Val.isNotConstant() && Val.getNotConstant()->getType()->isPointerTy() &&
-      Val.getNotConstant()->isNullValue() &&
+      Val.getNotConstant()->isZeroValue() &&
       !F->hasAttributeAtIndex(AttrIndex, Attribute::NonNull)) {
     F->addAttributeAtIndex(AttrIndex,
                            Attribute::get(F->getContext(), Attribute::NonNull));
@@ -616,7 +616,7 @@ private:
   bool markNotConstant(ValueLatticeElement &IV, Value *V, Constant *C);
 
   bool markNotNull(ValueLatticeElement &IV, Value *V) {
-    return markNotConstant(IV, V, Constant::getNullValue(V->getType()));
+    return markNotConstant(IV, V, Constant::getZeroValue(V->getType()));
   }
 
   /// markConstantRange - Mark the object as constant range with \p CR. If the
@@ -972,7 +972,7 @@ public:
         return ValueLatticeElement::getRange(*Range);
     }
     if (A->hasNonNullAttr())
-      return ValueLatticeElement::getNot(Constant::getNullValue(A->getType()));
+      return ValueLatticeElement::getNot(Constant::getZeroValue(A->getType()));
     // Assume nothing about the incoming arguments without attributes.
     return ValueLatticeElement::getOverdefined();
   }
@@ -1811,7 +1811,7 @@ void SCCPInstVisitor::visitGetElementPtrInst(GetElementPtrInst &I) {
     return;
 
   // gep inbounds/nuw of non-null is non-null.
-  if (PtrState.isNotConstant() && PtrState.getNotConstant()->isNullValue()) {
+  if (PtrState.isNotConstant() && PtrState.getNotConstant()->isZeroValue()) {
     if (I.hasNoUnsignedWrap() ||
         (I.isInBounds() &&
          !NullPointerIsDefined(I.getFunction(), I.getAddressSpace())))

--- a/llvm/lib/Transforms/Utils/SanitizerStats.cpp
+++ b/llvm/lib/Transforms/Utils/SanitizerStats.cpp
@@ -48,7 +48,7 @@ void SanitizerStatReport::create(IRBuilder<> &B, SanitizerStatKind SK) {
 
   Inits.push_back(ConstantArray::get(
       StatTy,
-      {Constant::getNullValue(PtrTy),
+      {Constant::getZeroValue(PtrTy),
        ConstantExpr::getIntToPtr(
            ConstantInt::get(IntPtrTy, uint64_t(SK) << (IntPtrTy->getBitWidth() -
                                                        kSanitizerStatKindBits)),
@@ -82,7 +82,7 @@ void SanitizerStatReport::finish() {
   auto NewModuleStatsGV = new GlobalVariable(
       *M, makeModuleStatsTy(), false, GlobalValue::InternalLinkage,
       ConstantStruct::getAnon(
-          {Constant::getNullValue(Int8PtrTy),
+          {Constant::getZeroValue(Int8PtrTy),
            ConstantInt::get(Int32Ty, Inits.size()),
            ConstantArray::get(makeModuleStatsArrayTy(), Inits)}));
   ModuleStatsGV->replaceAllUsesWith(NewModuleStatsGV);

--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -243,7 +243,7 @@ Value *SCEVExpander::InsertNoopCastOfTo(Value *V, Type *Ty) {
   if (Op == Instruction::IntToPtr) {
     auto *PtrTy = cast<PointerType>(Ty);
     if (DL.isNonIntegralPointerType(PtrTy))
-      return Builder.CreatePtrAdd(Constant::getNullValue(PtrTy), V, "scevgep");
+      return Builder.CreatePtrAdd(Constant::getZeroValue(PtrTy), V, "scevgep");
   }
   // Short-circuit unnecessary bitcasts.
   if (Op == Instruction::BitCast) {
@@ -666,7 +666,7 @@ Value *SCEVExpander::visitMulExpr(SCEVUseT<const SCEVMulExpr *> S) {
       Prod = ExpandOpBinPowN();
     } else if (I->second->isAllOnesValue()) {
       // Instead of doing a multiply by negative one, just do a negate.
-      Prod = InsertBinop(Instruction::Sub, Constant::getNullValue(Ty), Prod,
+      Prod = InsertBinop(Instruction::Sub, Constant::getZeroValue(Ty), Prod,
                          SCEV::FlagAnyWrap, /*IsSafeToHoist*/ true);
       ++I;
     } else {
@@ -1416,7 +1416,7 @@ Value *SCEVExpander::visitAddRecExpr(SCEVUseT<const SCEVAddRecExpr *> S) {
         rememberInstruction(Add);
         CanonicalIV->addIncoming(Add, HP);
       } else {
-        CanonicalIV->addIncoming(Constant::getNullValue(Ty), HP);
+        CanonicalIV->addIncoming(Constant::getZeroValue(Ty), HP);
       }
     }
   }
@@ -1698,8 +1698,9 @@ Value *SCEVExpander::expand(SCEVUse S) {
       if (auto *NNI = dyn_cast<PossiblyNonNegInst>(I)) {
         auto *Src = NNI->getOperand(0);
         if (isImpliedByDomCondition(ICmpInst::ICMP_SGE, Src,
-                                    Constant::getNullValue(Src->getType()), I,
-                                    DL).value_or(false))
+                                    Constant::getZeroValue(Src->getType()), I,
+                                    DL)
+                .value_or(false))
           NNI->setNonNeg(true);
       }
     }

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -343,7 +343,7 @@ isSelectInRoleOfConjunctionOrDisjunction(const SelectInst *SI) {
   return ((isa<ConstantInt>(SI->getTrueValue()) &&
            (dyn_cast<ConstantInt>(SI->getTrueValue())->isOne())) ||
           (isa<ConstantInt>(SI->getFalseValue()) &&
-           (dyn_cast<ConstantInt>(SI->getFalseValue())->isNullValue())));
+           (dyn_cast<ConstantInt>(SI->getFalseValue())->isZeroValue())));
 }
 
 } // end anonymous namespace
@@ -5983,11 +5983,11 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
     NewBI = Builder.CreateCondBr(Cmp, Dest, OtherDest);
   }
   // If NumCases overflowed, then all possible values jump to the successor.
-  else if (NumCases->isNullValue() && !Cases->empty()) {
+  else if (NumCases->isZeroValue() && !Cases->empty()) {
     NewBI = Builder.CreateBr(Dest);
   } else {
     Value *Sub = SI->getCondition();
-    if (!Offset->isNullValue())
+    if (!Offset->isZeroValue())
       Sub = Builder.CreateAdd(Sub, Offset, Sub->getName() + ".off");
     Value *Cmp = Builder.CreateICmpULT(Sub, NumCases, "switch");
     NewBI = Builder.CreateCondBr(Cmp, Dest, OtherDest);
@@ -6308,7 +6308,7 @@ constantFold(Instruction *I, const DataLayout &DL,
       return nullptr;
     if (A->isAllOnesValue())
       return lookupConstant(Select->getTrueValue(), ConstantPool);
-    if (A->isNullValue())
+    if (A->isZeroValue())
       return lookupConstant(Select->getFalseValue(), ConstantPool);
     return nullptr;
   }
@@ -6587,11 +6587,11 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
       // Check if cases with the same result can cover all number
       // in touched bits.
       if (BitMask.popcount() == Log2_32(CaseCount)) {
-        if (!MinCaseVal->isNullValue())
+        if (!MinCaseVal->isZeroValue())
           Condition = Builder.CreateSub(Condition, MinCaseVal);
         Value *And = Builder.CreateAnd(Condition, ~BitMask, "switch.and");
         Value *Cmp = Builder.CreateICmpEQ(
-            And, Constant::getNullValue(And->getType()), "switch.selectcmp");
+            And, Constant::getZeroValue(And->getType()), "switch.selectcmp");
         Value *Ret =
             Builder.CreateSelect(Cmp, ResultVector[0].first, DefaultResult);
         if (auto *SI = dyn_cast<SelectInst>(Ret); SI && HasBranchWeights) {
@@ -7091,7 +7091,7 @@ static bool shouldUseSwitchConditionAsTableIndex(
     ConstantInt &MinCaseVal, const ConstantInt &MaxCaseVal,
     bool HasDefaultResults, const SmallVector<Type *> &ResultTypes,
     const DataLayout &DL, const TargetTransformInfo &TTI) {
-  if (MinCaseVal.isNullValue())
+  if (MinCaseVal.isZeroValue())
     return true;
   if (MinCaseVal.isNegative() ||
       MaxCaseVal.getLimitedValue() == std::numeric_limits<uint64_t>::max() ||
@@ -8688,7 +8688,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
   if (I->use_empty())
     return false;
 
-  if (C->isNullValue() || isa<UndefValue>(C)) {
+  if (C->isZeroValue() || isa<UndefValue>(C)) {
     // Only look at the first use we can handle, avoid hurting compile time with
     // long uselists
     auto FindUse = llvm::find_if(I->uses(), [](auto &U) {
@@ -8764,7 +8764,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
       if (isa<UndefValue>(C) && HasNoUndefAttr)
         return true;
       // Return null to a nonnull+noundef return value is undefined.
-      if (C->isNullValue() && HasNoUndefAttr &&
+      if (C->isZeroValue() && HasNoUndefAttr &&
           Ret->getFunction()->hasRetAttribute(Attribute::NonNull)) {
         return !PtrValueMayBeModified;
       }
@@ -8791,7 +8791,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
     }
 
     if (auto *CB = dyn_cast<CallBase>(User)) {
-      if (C->isNullValue() && NullPointerIsDefined(CB->getFunction()))
+      if (C->isZeroValue() && NullPointerIsDefined(CB->getFunction()))
         return false;
       // A call to null is undefined.
       if (CB->getCalledOperand() == I)

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -255,7 +255,7 @@ static bool isOnlyUsedInComparisonWithZero(Value *V) {
   for (User *U : V->users()) {
     if (ICmpInst *IC = dyn_cast<ICmpInst>(U))
       if (Constant *C = dyn_cast<Constant>(IC->getOperand(1)))
-        if (C->isNullValue())
+        if (C->isZeroValue())
           continue;
     // Unknown instruction.
     return false;
@@ -480,7 +480,7 @@ static Value* memChrToCharCompare(CallInst *CI, Value *NBytes,
     Cmp = B.CreateLogicalAnd(And, Cmp);
   }
 
-  Value *NullPtr = Constant::getNullValue(CI->getType());
+  Value *NullPtr = Constant::getZeroValue(CI->getType());
   return B.CreateSelect(Cmp, Src, NullPtr);
 }
 
@@ -517,7 +517,7 @@ Value *LibCallSimplifier::optimizeStrChr(CallInst *CI, IRBuilderBase &B) {
   }
 
   if (CharC->isZero()) {
-    Value *NullPtr = Constant::getNullValue(CI->getType());
+    Value *NullPtr = Constant::getZeroValue(CI->getType());
     if (isOnlyUsedInEqualityComparison(CI, NullPtr))
       // Pre-empt the transformation to strlen below and fold
       // strchr(A, '\0') == null to false.
@@ -540,7 +540,7 @@ Value *LibCallSimplifier::optimizeStrChr(CallInst *CI, IRBuilderBase &B) {
                  ? Str.size()
                  : Str.find(CharC->getSExtValue());
   if (I == StringRef::npos) // Didn't find the char.  strchr returns null.
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   // strchr(s+n,c)  -> gep(s+n+i,c)
   return B.CreateInBoundsGEP(B.getInt8Ty(), SrcStr, B.getInt64(I), "strchr");
@@ -1088,13 +1088,13 @@ Value *LibCallSimplifier::optimizeStrPBrk(CallInst *CI, IRBuilderBase &B) {
   // strpbrk(s, "") -> nullptr
   // strpbrk("", s) -> nullptr
   if ((HasS1 && S1.empty()) || (HasS2 && S2.empty()))
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   // Constant folding.
   if (HasS1 && HasS2) {
     size_t I = S1.find_first_of(S2);
     if (I == StringRef::npos) // No match.
-      return Constant::getNullValue(CI->getType());
+      return Constant::getZeroValue(CI->getType());
 
     return B.CreateInBoundsGEP(B.getInt8Ty(), CI->getArgOperand(0),
                                B.getInt64(I), "strpbrk");
@@ -1127,7 +1127,7 @@ Value *LibCallSimplifier::optimizeStrSpn(CallInst *CI, IRBuilderBase &B) {
   // strspn(s, "") -> 0
   // strspn("", s) -> 0
   if ((HasS1 && S1.empty()) || (HasS2 && S2.empty()))
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   // Constant folding.
   if (HasS1 && HasS2) {
@@ -1147,7 +1147,7 @@ Value *LibCallSimplifier::optimizeStrCSpn(CallInst *CI, IRBuilderBase &B) {
 
   // strcspn("", s) -> 0
   if (HasS1 && S1.empty())
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   // Constant folding.
   if (HasS1 && HasS2) {
@@ -1182,7 +1182,7 @@ Value *LibCallSimplifier::optimizeStrStr(CallInst *CI, IRBuilderBase &B) {
       ICmpInst *Old = cast<ICmpInst>(U);
       Value *Cmp =
           B.CreateICmp(Old->getPredicate(), StrNCmp,
-                       ConstantInt::getNullValue(StrNCmp->getType()), "cmp");
+                       ConstantInt::getZeroValue(StrNCmp->getType()), "cmp");
       replaceAllUsesWith(Old, Cmp);
     }
     return CI;
@@ -1202,7 +1202,7 @@ Value *LibCallSimplifier::optimizeStrStr(CallInst *CI, IRBuilderBase &B) {
     size_t Offset = SearchStr.find(ToFindStr);
 
     if (Offset == StringRef::npos) // strstr("foo", "bar") -> null
-      return Constant::getNullValue(CI->getType());
+      return Constant::getZeroValue(CI->getType());
 
     // strstr("abcd", "bc") -> gep((char*)"abcd", 1)
     return B.CreateConstInBoundsGEP1_64(B.getInt8Ty(), CI->getArgOperand(0),
@@ -1224,7 +1224,7 @@ Value *LibCallSimplifier::optimizeMemRChr(CallInst *CI, IRBuilderBase &B) {
   annotateNonNullAndDereferenceable(CI, 0, Size, DL);
   Value *CharVal = CI->getArgOperand(1);
   ConstantInt *LenC = dyn_cast<ConstantInt>(Size);
-  Value *NullPtr = Constant::getNullValue(CI->getType());
+  Value *NullPtr = Constant::getZeroValue(CI->getType());
 
   if (LenC) {
     if (LenC->isZero())
@@ -1319,7 +1319,7 @@ Value *LibCallSimplifier::optimizeMemChr(CallInst *CI, IRBuilderBase &B) {
   Value *CharVal = CI->getArgOperand(1);
   ConstantInt *CharC = dyn_cast<ConstantInt>(CharVal);
   ConstantInt *LenC = dyn_cast<ConstantInt>(Size);
-  Value *NullPtr = Constant::getNullValue(CI->getType());
+  Value *NullPtr = Constant::getZeroValue(CI->getType());
 
   // memchr(x, y, 0) -> null
   if (LenC) {
@@ -1505,7 +1505,7 @@ static Value *optimizeMemCmpVarSize(CallInst *CI, Value *LHS, Value *RHS,
                                     Value *Size, bool StrNCmp,
                                     IRBuilderBase &B, const DataLayout &DL) {
   if (LHS == RHS) // memcmp(s,s,x) -> 0
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   StringRef LStr, RStr;
   if (!getConstantStringInfo(LHS, LStr, /*TrimAtNul=*/false) ||
@@ -1547,7 +1547,7 @@ static Value *optimizeMemCmpConstantSize(CallInst *CI, Value *LHS, Value *RHS,
                                          uint64_t Len, IRBuilderBase &B,
                                          const DataLayout &DL) {
   if (Len == 0) // memcmp(s1,s2,0) -> 0
-    return Constant::getNullValue(CI->getType());
+    return Constant::getZeroValue(CI->getType());
 
   // memcmp(S1,S2,1) -> *(unsigned char*)LHS - *(unsigned char*)RHS
   if (Len == 1) {
@@ -1654,8 +1654,8 @@ Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
     return Dst;
   // memccpy(d, s, c, 0) -> nullptr
   if (N) {
-    if (N->isNullValue())
-      return Constant::getNullValue(CI->getType());
+    if (N->isZeroValue())
+      return Constant::getZeroValue(CI->getType());
     if (!getConstantStringInfo(Src, SrcStr, /*TrimAtNul=*/false) ||
         // TODO: Handle zeroinitializer.
         !StopChar)
@@ -1670,7 +1670,7 @@ Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
     if (N->getZExtValue() <= SrcStr.size()) {
       copyFlags(*CI, B.CreateMemCpy(Dst, Align(1), Src, Align(1),
                                     CI->getArgOperand(3)));
-      return Constant::getNullValue(CI->getType());
+      return Constant::getZeroValue(CI->getType());
     }
     return nullptr;
   }
@@ -1681,7 +1681,7 @@ Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
   copyFlags(*CI, B.CreateMemCpy(Dst, Align(1), Src, Align(1), NewN));
   return Pos + 1 <= N->getZExtValue()
              ? B.CreateInBoundsGEP(B.getInt8Ty(), Dst, NewN)
-             : Constant::getNullValue(CI->getType());
+             : Constant::getZeroValue(CI->getType());
 }
 
 Value *LibCallSimplifier::optimizeMemPCpy(CallInst *CI, IRBuilderBase &B) {
@@ -3217,7 +3217,7 @@ Value *LibCallSimplifier::optimizeFFS(CallInst *CI, IRBuilderBase &B) {
   V = B.CreateAdd(V, ConstantInt::get(V->getType(), 1));
   V = B.CreateIntCast(V, RetType, false);
 
-  Value *Cond = B.CreateICmpNE(Op, Constant::getNullValue(ArgType));
+  Value *Cond = B.CreateICmpNE(Op, Constant::getZeroValue(ArgType));
   return B.CreateSelect(Cond, V, ConstantInt::get(RetType, 0));
 }
 

--- a/llvm/lib/Transforms/Utils/VNCoercion.cpp
+++ b/llvm/lib/Transforms/Utils/VNCoercion.cpp
@@ -61,7 +61,7 @@ bool VNCoercion::canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
     // an array w/null.  Despite non-integral pointers not generally having a
     // specific bit pattern, we do assume null is zero.
     if (auto *CI = dyn_cast<Constant>(StoredVal))
-      return CI->isNullValue();
+      return CI->isZeroValue();
     return false;
   } else if (StoredNI && LoadNI &&
              StoredTy->getPointerAddressSpace() !=

--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -537,7 +537,7 @@ Value *Mapper::mapValue(const Value *V) {
   if (isa<ConstantAggregateZero>(C))
     return getVM()[V] = ConstantAggregateZero::get(NewTy);
   if (isa<ConstantTargetNone>(C))
-    return getVM()[V] = Constant::getNullValue(NewTy);
+    return getVM()[V] = Constant::getZeroValue(NewTy);
   assert(isa<ConstantPointerNull>(C));
   return getVM()[V] = ConstantPointerNull::get(cast<PointerType>(NewTy));
 }
@@ -1135,7 +1135,7 @@ void Mapper::mapAppendingVariable(GlobalVariable &GV, GlobalVariable *OldGV,
       auto *S = cast<ConstantStruct>(V);
       auto *E1 = cast<Constant>(mapValue(S->getOperand(0)));
       auto *E2 = cast<Constant>(mapValue(S->getOperand(1)));
-      Constant *Null = Constant::getNullValue(VoidPtrTy);
+      Constant *Null = Constant::getZeroValue(VoidPtrTy);
       NewV = ConstantStruct::get(cast<StructType>(EltTy), E1, E2, Null);
     } else {
       NewV = cast_or_null<Constant>(mapValue(V));

--- a/llvm/lib/Transforms/Vectorize/LoopIdiomVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopIdiomVectorize.cpp
@@ -513,7 +513,7 @@ Value *LoopIdiomVectorize::createMaskedFindMismatch(
   VectorIndexPhi->addIncoming(ExtStart, VectorLoopPreheaderBlock);
   Type *VectorLoadType =
       ScalableVectorType::get(Builder.getInt8Ty(), ByteCompareVF);
-  Value *Passthru = ConstantInt::getNullValue(VectorLoadType);
+  Value *Passthru = ConstantInt::getZeroValue(VectorLoadType);
 
   Value *VectorLhsGep =
       Builder.CreateGEP(LoadType, PtrA, VectorIndexPhi, "", GEPA->isInBounds());
@@ -1210,7 +1210,7 @@ Value *LoopIdiomVectorize::expandFindFirstByte(
   // Other common arguments.
   BasicBlock *Preheader = CurLoop->getLoopPreheader();
   LLVMContext &Ctx = Preheader->getContext();
-  Value *Passthru = ConstantInt::getNullValue(CharVTy);
+  Value *Passthru = ConstantInt::getZeroValue(CharVTy);
 
   // Split block in the original loop preheader.
   // SPH is the new preheader to the old scalar loop.
@@ -1283,7 +1283,7 @@ Value *LoopIdiomVectorize::expandFindFirstByte(
       Builder.CreatePtrToInt(SearchStart, I64Ty, "search_start_int");
   Value *ISearchEnd =
       Builder.CreatePtrToInt(SearchEnd, I64Ty, "search_end_int");
-  Value *SearchIdxInit = Constant::getNullValue(I64Ty);
+  Value *SearchIdxInit = Constant::getZeroValue(I64Ty);
   Value *SearchTripCount =
       Builder.CreateZExt(Builder.CreatePtrDiff(CharTy, SearchEnd, SearchStart,
                                                "search_trip_count"),
@@ -1292,7 +1292,7 @@ Value *LoopIdiomVectorize::expandFindFirstByte(
       Builder.CreatePtrToInt(NeedleStart, I64Ty, "needle_start_int");
   Value *INeedleEnd =
       Builder.CreatePtrToInt(NeedleEnd, I64Ty, "needle_end_int");
-  Value *NeedleIdxInit = Constant::getNullValue(I64Ty);
+  Value *NeedleIdxInit = Constant::getZeroValue(I64Ty);
   Value *NeedleTripCount =
       Builder.CreateZExt(Builder.CreatePtrDiff(CharTy, NeedleEnd, NeedleStart,
                                                "needle_trip_count"),
@@ -1334,7 +1334,7 @@ Value *LoopIdiomVectorize::expandFindFirstByte(
   Value *Search = Builder.CreateGEP(CharTy, SearchStart, SearchIdx, "psearch");
   Value *LoadSearch = Builder.CreateMaskedLoad(
       CharVTy, Search, Align(1), PredSearch, Passthru, "search_load_vec");
-  Value *MatchInit = Constant::getNullValue(PredVTy);
+  Value *MatchInit = Constant::getZeroValue(PredVTy);
   Builder.CreateBr(BB2);
   DTU.applyUpdates({{DominatorTree::Insert, BB1, BB2}});
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -722,7 +722,7 @@ void LoopVectorizationLegality::addInductionPhi(
   if (ID.getKind() == InductionDescriptor::IK_IntInduction &&
       ID.getConstIntStepValue() && ID.getConstIntStepValue()->isOne() &&
       isa<Constant>(ID.getStartValue()) &&
-      cast<Constant>(ID.getStartValue())->isNullValue()) {
+      cast<Constant>(ID.getStartValue())->isZeroValue()) {
 
     // Use the phi node with the widest type as induction. Use the last
     // one if there are multiple (no good reason for doing this other

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -11764,7 +11764,7 @@ class InstructionsCompatibilityAnalysis {
           // rather than trying to gather it.
           Operands[0][Idx] = I->getOperand(0);
           Operands[1][Idx] = ConstantInt::get(I->getType(), 1);
-          Operands[2][Idx] = ConstantInt::getNullValue(I->getType());
+          Operands[2][Idx] = ConstantInt::getZeroValue(I->getType());
           continue;
         }
         auto [Op, ConvertedOps] = convertTo(I, S);
@@ -11795,7 +11795,7 @@ class InstructionsCompatibilityAnalysis {
         auto *GEP = dyn_cast<GetElementPtrInst>(V);
         if (!GEP) {
           Operands[0][Idx] = V;
-          Operands[1][Idx] = ConstantInt::getNullValue(Ty);
+          Operands[1][Idx] = ConstantInt::getZeroValue(Ty);
           continue;
         }
         Operands[0][Idx] = GEP->getPointerOperand();
@@ -15596,7 +15596,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
         ExtraCost += GetNodeMinBWAffectedCost(*E, E->getVectorFactor()) +
                      GetNodeMinBWAffectedCost(*E2, E2->getVectorFactor());
       }
-      V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+      V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
       V2 = getAllOnesValue(*R.DL, getWidenedType(ScalarTy, CommonVF));
     } else if (!V1 && P2.isNull()) {
       // Shuffle single entry node.
@@ -15623,7 +15623,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
         std::iota(CommonMask.begin(), CommonMask.end(), 0);
       }
       ExtraCost += GetNodeMinBWAffectedCost(*E, CommonVF);
-      V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+      V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
       // Not identity/broadcast? Try to see if the original vector is better.
       if (!E->ReorderIndices.empty() && CommonVF == E->ReorderIndices.size() &&
           CommonVF == CommonMask.size() &&
@@ -15668,7 +15668,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
         CommonVF = VF;
       }
       ExtraCost += GetValueMinBWAffectedCost(V1);
-      V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+      V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
       ExtraCost += GetNodeMinBWAffectedCost(
           *E2, std::min(CommonVF, E2->getVectorFactor()));
       V2 = getAllOnesValue(*R.DL, getWidenedType(ScalarTy, CommonVF));
@@ -15697,7 +15697,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
       }
       ExtraCost += GetNodeMinBWAffectedCost(
           *E1, std::min(CommonVF, E1->getVectorFactor()));
-      V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+      V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
       ExtraCost += GetValueMinBWAffectedCost(V2);
       V2 = getAllOnesValue(*R.DL, getWidenedType(ScalarTy, CommonVF));
     } else {
@@ -15712,17 +15712,17 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
       ExtraCost +=
           GetValueMinBWAffectedCost(V1) + GetValueMinBWAffectedCost(V2);
       if (V1->getType() != V2->getType()) {
-        V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+        V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
         V2 = getAllOnesValue(*R.DL, getWidenedType(ScalarTy, CommonVF));
       } else {
         if (cast<VectorType>(V1->getType())->getElementType() != ScalarTy)
-          V1 = Constant::getNullValue(getWidenedType(ScalarTy, CommonVF));
+          V1 = Constant::getZeroValue(getWidenedType(ScalarTy, CommonVF));
         if (cast<VectorType>(V2->getType())->getElementType() != ScalarTy)
           V2 = getAllOnesValue(*R.DL, getWidenedType(ScalarTy, CommonVF));
       }
     }
     InVectors.front() =
-        Constant::getNullValue(getWidenedType(ScalarTy, CommonMask.size()));
+        Constant::getZeroValue(getWidenedType(ScalarTy, CommonMask.size()));
     if (InVectors.size() == 2)
       InVectors.pop_back();
     return ExtraCost + BaseShuffleAnalysis::createShuffle<InstructionCost>(
@@ -15854,7 +15854,7 @@ public:
     if (NumParts != 1 && UniqueBases.size() != 1) {
       UseVecBaseAsInput = true;
       VecBase =
-          Constant::getNullValue(getWidenedType(ScalarTy, CommonMask.size()));
+          Constant::getZeroValue(getWidenedType(ScalarTy, CommonMask.size()));
     }
     return VecBase;
   }
@@ -15985,7 +15985,7 @@ public:
                 Value *Root = nullptr) {
     Cost += getBuildVectorCost(VL, Root);
     if (!Root) {
-      // FIXME: Need to find a way to avoid use of getNullValue here.
+      // FIXME: Need to find a way to avoid use of getZeroValue here.
       SmallVector<Constant *> Vals;
       unsigned VF = VL.size();
       if (MaskVF != 0)
@@ -16001,7 +16001,7 @@ public:
           Vals.push_back(UndefValue::get(ScalarTy));
           continue;
         }
-        Vals.push_back(Constant::getNullValue(ScalarTy));
+        Vals.push_back(Constant::getZeroValue(ScalarTy));
       }
       if (auto *VecTy = dyn_cast<FixedVectorType>(VLScalarTy)) {
         assert(SLPReVec && "FixedVectorType is not expected.");
@@ -24270,7 +24270,7 @@ Value *BoUpSLP::vectorizeTree(
       // Replace conditions of the poisoning logical ops with the non-poison
       // constant value.
       for (SelectInst *SI : LogicalOpSelects)
-        SI->setCondition(Constant::getNullValue(SI->getCondition()->getType()));
+        SI->setCondition(Constant::getZeroValue(SI->getCondition()->getType()));
     }
   }
   // Retain to-be-deleted instructions for some debug-info bookkeeping and alias
@@ -27761,7 +27761,7 @@ class HorizontalReduction {
       if (UseSelect && OpTy == CmpInst::makeCmpResultType(OpTy))
         return Builder.CreateSelectWithUnknownProfile(
             LHS, RHS,
-            ConstantInt::getNullValue(CmpInst::makeCmpResultType(OpTy)),
+            ConstantInt::getZeroValue(CmpInst::makeCmpResultType(OpTy)),
             DEBUG_TYPE, Name);
       unsigned RdxOpcode = RecurrenceDescriptor::getOpcode(Kind);
       return Builder.CreateBinOp((Instruction::BinaryOps)RdxOpcode, LHS, RHS,
@@ -29419,7 +29419,7 @@ private:
           LLVM_DEBUG(dbgs()
                      << "SLP: Xor " << Cnt << "of " << Vec << ". (HorRdx)\n");
           if (Cnt % 2 == 0)
-            Vec = Constant::getNullValue(Vec->getType());
+            Vec = Constant::getZeroValue(Vec->getType());
           break;
         }
         case RecurKind::FAdd: {
@@ -29573,7 +29573,7 @@ private:
       LLVM_DEBUG(dbgs() << "SLP: Xor " << Cnt << "of " << VectorizedValue
                         << ". (HorRdx)\n");
       if (Cnt % 2 == 0)
-        return Constant::getNullValue(VectorizedValue->getType());
+        return Constant::getZeroValue(VectorizedValue->getType());
       return VectorizedValue;
     }
     case RecurKind::FAdd: {
@@ -29685,7 +29685,7 @@ private:
       if (NeedShuffle)
         VectorizedValue = Builder.CreateShuffleVector(
             VectorizedValue,
-            ConstantVector::getNullValue(VectorizedValue->getType()), Mask);
+            ConstantVector::getZeroValue(VectorizedValue->getType()), Mask);
       return VectorizedValue;
     }
     case RecurKind::FAdd: {

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -657,7 +657,7 @@ Value *VPInstruction::generate(VPTransformState &State) {
     Value *Sub = Builder.CreateSub(ScalarTC, VFxUF);
     Value *Cmp =
         Builder.CreateICmp(CmpInst::Predicate::ICMP_UGT, ScalarTC, VFxUF);
-    Value *Zero = ConstantInt::getNullValue(ScalarTC->getType());
+    Value *Zero = ConstantInt::getZeroValue(ScalarTC->getType());
     return Builder.CreateSelect(Cmp, Sub, Zero);
   }
   case VPInstruction::ExplicitVectorLength: {
@@ -2593,7 +2593,7 @@ void VPScalarIVStepsRecipe::execute(VPTransformState &State) {
   unsigned EndLane = FirstLaneOnly ? 1 : State.VF.getKnownMinValue();
   assert(!State.Lane && "replicate regions must be dissolved before ::execute");
   Value *StartIdx0 = getStartIndex() ? State.get(getStartIndex(), true)
-                                     : Constant::getNullValue(BaseIVTy);
+                                     : Constant::getZeroValue(BaseIVTy);
 
   for (unsigned Lane = 0; Lane < EndLane; ++Lane) {
     // It is okay if the induction variable type cannot hold the lane number,

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1317,7 +1317,7 @@ static VPIRValue *tryToFoldLiveIns(VPSingleDefRecipe &R,
     switch (Opcode) {
     case VPInstruction::LogicalAnd:
       return Folder.FoldSelect(Ops[0], Ops[1],
-                               ConstantInt::getNullValue(Ops[1]->getType()));
+                               ConstantInt::getZeroValue(Ops[1]->getType()));
     case VPInstruction::Not:
       return Folder.FoldBinOp(Instruction::BinaryOps::Xor, Ops[0],
                               Constant::getAllOnesValue(Ops[0]->getType()));

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1673,7 +1673,7 @@ bool VectorCombine::foldSelectsFromBitcast(Instruction &I) {
 
     Builder.SetInsertPoint(InsertPt);
     Value *VecSel =
-        Builder.CreateSelect(Cond, SrcVec, Constant::getNullValue(SrcVecTy));
+        Builder.CreateSelect(Cond, SrcVec, Constant::getZeroValue(SrcVecTy));
     Value *NewBC = Builder.CreateBitCast(VecSel, DstVecTy);
 
     // Replace each scalar select with an extract from the new bitcast.
@@ -4718,7 +4718,7 @@ bool VectorCombine::foldICmpEqZeroVectorReduce(Instruction &I) {
   Type *Ty = XTy->getScalarType();
   Value *NewReduce = Builder.CreateIntrinsic(Ty, II->getIntrinsicID(), {X});
   Value *NewCmp =
-      Builder.CreateICmp(Pred, NewReduce, ConstantInt::getNullValue(Ty));
+      Builder.CreateICmp(Pred, NewReduce, ConstantInt::getZeroValue(Ty));
   replaceValue(I, *NewCmp);
   return true;
 }

--- a/llvm/tools/llubi/lib/Context.cpp
+++ b/llvm/tools/llubi/lib/Context.cpp
@@ -58,7 +58,7 @@ AnyValue Context::getConstantValueImpl(Constant *C) {
     return AnyValue::getPoisonValue(*this, C->getType());
 
   if (isa<ConstantAggregateZero>(C))
-    return AnyValue::getNullValue(*this, C->getType());
+    return AnyValue::getZeroValue(*this, C->getType());
 
   if (isa<ConstantPointerNull>(C))
     return Pointer::null(C->getType()->getPointerAddressSpace(), DL);

--- a/llvm/tools/llubi/lib/Library.cpp
+++ b/llvm/tools/llubi/lib/Library.cpp
@@ -87,7 +87,7 @@ AnyValue Library::executeMalloc(StringRef Name, Type *Type,
       Executor.reportError() << "Insufficient heap space.";
       return AnyValue::poison();
     }
-    return AnyValue::getNullValue(Ctx, Type);
+    return AnyValue::getZeroValue(Ctx, Type);
   }
 
   return Ctx.deriveFromMemoryObject(Obj);
@@ -108,14 +108,14 @@ AnyValue Library::executeCalloc(StringRef Name, Type *Type,
   bool Overflow = false;
   const APInt AllocSize = Count.umul_ov(Size, Overflow);
   if (Overflow)
-    return AnyValue::getNullValue(Ctx, Type);
+    return AnyValue::getZeroValue(Ctx, Type);
 
   const IntrusiveRefCntPtr<MemoryObject> Obj =
       Ctx.allocate(AllocSize.getLimitedValue(), getMaxAlign(DL), Name, 0,
                    MemInitKind::Zeroed, AllocKind);
 
   if (!Obj)
-    return AnyValue::getNullValue(Ctx, Type);
+    return AnyValue::getZeroValue(Ctx, Type);
 
   return Ctx.deriveFromMemoryObject(Obj);
 }

--- a/llvm/tools/llubi/lib/Value.cpp
+++ b/llvm/tools/llubi/lib/Value.cpp
@@ -248,7 +248,7 @@ AnyValue AnyValue::getPoisonValue(Context &Ctx, Type *Ty) {
   }
   llvm_unreachable("Unsupported type");
 }
-AnyValue AnyValue::getNullValue(Context &Ctx, Type *Ty) {
+AnyValue AnyValue::getZeroValue(Context &Ctx, Type *Ty) {
   if (Ty->isIntegerTy())
     return AnyValue(APInt::getZero(Ty->getIntegerBitWidth()));
   if (Ty->isFloatingPointTy())
@@ -258,18 +258,18 @@ AnyValue AnyValue::getNullValue(Context &Ctx, Type *Ty) {
   if (auto *VecTy = dyn_cast<VectorType>(Ty)) {
     uint32_t NumElements = Ctx.getEVL(VecTy->getElementCount());
     return AnyValue(std::vector<AnyValue>(
-        NumElements, getNullValue(Ctx, VecTy->getElementType())));
+        NumElements, getZeroValue(Ctx, VecTy->getElementType())));
   }
   if (auto *ArrTy = dyn_cast<ArrayType>(Ty)) {
     uint64_t NumElements = ArrTy->getNumElements();
     return AnyValue(std::vector<AnyValue>(
-        NumElements, getNullValue(Ctx, ArrTy->getElementType())));
+        NumElements, getZeroValue(Ctx, ArrTy->getElementType())));
   }
   if (auto *StructTy = dyn_cast<StructType>(Ty)) {
     std::vector<AnyValue> Elements;
     Elements.reserve(StructTy->getNumElements());
     for (uint32_t I = 0, E = StructTy->getNumElements(); I != E; ++I)
-      Elements.push_back(getNullValue(Ctx, StructTy->getElementType(I)));
+      Elements.push_back(getZeroValue(Ctx, StructTy->getElementType(I)));
     return AnyValue(std::move(Elements));
   }
   llvm_unreachable("Unsupported type");

--- a/llvm/tools/llubi/lib/Value.h
+++ b/llvm/tools/llubi/lib/Value.h
@@ -143,7 +143,7 @@ public:
   static AnyValue poison() { return AnyValue(PoisonTag{}); }
   static AnyValue boolean(bool Val) { return AnyValue(APInt(1, Val)); }
   static AnyValue getPoisonValue(Context &Ctx, Type *Ty);
-  static AnyValue getNullValue(Context &Ctx, Type *Ty);
+  static AnyValue getZeroValue(Context &Ctx, Type *Ty);
   static AnyValue getVectorSplat(const AnyValue &Scalar, size_t NumElements);
 
   bool isNone() const { return Kind == StorageKind::None; }

--- a/llvm/tools/llubi/llubi.cpp
+++ b/llvm/tools/llubi/llubi.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
            "all arguments.\n";
     Args.reserve(EntryFn->arg_size());
     for (Argument &Arg : EntryFn->args())
-      Args.push_back(ubi::AnyValue::getNullValue(Ctx, Arg.getType()));
+      Args.push_back(ubi::AnyValue::getZeroValue(Ctx, Arg.getType()));
   }
 
   ubi::EventHandler NoopHandler;

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -622,7 +622,7 @@ uint64_t ReducerWorkItem::computeMIRComplexityScore() const {
 // for more reduced.
 static unsigned classifyReductivePower(const Value *V) {
   if (auto *C = dyn_cast<ConstantData>(V)) {
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return 0;
     if (C->isOneValue())
       return 1;

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -52,7 +52,7 @@ static bool isOne(Use &Op) {
 
 static bool isZero(Use &Op) {
   auto *C = dyn_cast<Constant>(Op);
-  return C && C->isNullValue();
+  return C && C->isZeroValue();
 }
 
 static bool isZeroOrOneFP(Value *Op) {
@@ -147,7 +147,7 @@ void llvm::reduceOperandsZeroDeltaPass(Oracle &O, ReducerWorkItem &WorkItem) {
     }
 
     // Don't replace existing zeroes.
-    return isZero(Op) ? nullptr : Constant::getNullValue(Op->getType());
+    return isZero(Op) ? nullptr : Constant::getZeroValue(Op->getType());
   };
   extractOperandsFromModule(O, WorkItem, ReduceValue);
 }

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
@@ -62,7 +62,7 @@ static int classifyReductivePower(Value *V) {
   if (auto *C = dyn_cast<ConstantData>(V)) {
     if (isa<UndefValue>(V))
       return -2;
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return 7;
     if (C->isOneValue())
       return 6;

--- a/llvm/tools/llvm-reduce/deltas/Utils.cpp
+++ b/llvm/tools/llvm-reduce/deltas/Utils.cpp
@@ -35,7 +35,7 @@ Value *llvm::getDefaultValue(Type *T) {
     return PoisonValue::get(TET);
   }
 
-  return Constant::getNullValue(T);
+  return Constant::getZeroValue(T);
 }
 
 bool llvm::hasAliasUse(Function &F) {

--- a/llvm/tools/llvm-stress/llvm-stress.cpp
+++ b/llvm/tools/llvm-stress/llvm-stress.cpp
@@ -215,7 +215,7 @@ protected:
     if (Tp->isIntegerTy()) {
       if (getRandom() & 1)
         return ConstantInt::getAllOnesValue(Tp);
-      return ConstantInt::getNullValue(Tp);
+      return ConstantInt::getZeroValue(Tp);
     } else if (Tp->isFloatingPointTy()) {
       if (getRandom() & 1)
         return ConstantFP::getAllOnesValue(Tp);
@@ -237,7 +237,7 @@ protected:
     if (Tp->isIntegerTy()) {
       if (getRandom() & 1)
         return ConstantInt::getAllOnesValue(Tp);
-      return ConstantInt::getNullValue(Tp);
+      return ConstantInt::getZeroValue(Tp);
     } else if (Tp->isFloatingPointTy()) {
       if (getRandom() & 1)
         return ConstantFP::getAllOnesValue(Tp);
@@ -411,7 +411,7 @@ struct ConstModifier: public Modifier {
                 return PT->push_back(ConstantVector::getAllOnesValue(Ty));
               break;
       case 1: if (Ty->isIntOrIntVectorTy())
-                return PT->push_back(ConstantVector::getNullValue(Ty));
+          return PT->push_back(ConstantVector::getZeroValue(Ty));
       }
     }
 

--- a/llvm/unittests/Analysis/LoadsTest.cpp
+++ b/llvm/unittests/Analysis/LoadsTest.cpp
@@ -123,7 +123,7 @@ define void @f(ptr %p1, ptr %p2, i64 %i, ptr addrspace(1) %p1as1) {
 
   Value *P1 = &*F->arg_begin();
   Value *P2 = F->getArg(1);
-  Value *NullPtr = Constant::getNullValue(P1->getType());
+  Value *NullPtr = Constant::getZeroValue(P1->getType());
   auto InstIter = F->front().begin();
   CallInst *UserOfY = cast<CallInst>(&*InstIter);
   Value *ConstDerefPtr = UserOfY->getArgOperand(0);

--- a/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
+++ b/llvm/unittests/Analysis/ScalarEvolutionTest.cpp
@@ -83,7 +83,7 @@ TEST_F(ScalarEvolutionsTest, SCEVUnknownRAUW) {
   ReturnInst::Create(Context, nullptr, BB);
 
   Type *Ty = Type::getInt1Ty(Context);
-  Constant *Init = Constant::getNullValue(Ty);
+  Constant *Init = Constant::getZeroValue(Ty);
   Value *V0 = new GlobalVariable(M, Ty, false, GlobalValue::ExternalLinkage, Init, "V0");
   Value *V1 = new GlobalVariable(M, Ty, false, GlobalValue::ExternalLinkage, Init, "V1");
   Value *V2 = new GlobalVariable(M, Ty, false, GlobalValue::ExternalLinkage, Init, "V2");
@@ -137,7 +137,7 @@ TEST_F(ScalarEvolutionsTest, SimplifiedPHI) {
   ReturnInst::Create(Context, nullptr, ExitBB);
   auto *Ty = Type::getInt32Ty(Context);
   auto *PN = PHINode::Create(Ty, 2, "", LoopBB->begin());
-  PN->addIncoming(Constant::getNullValue(Ty), EntryBB);
+  PN->addIncoming(Constant::getZeroValue(Ty), EntryBB);
   PN->addIncoming(PoisonValue::get(Ty), LoopBB);
   ScalarEvolution SE = buildSE(*F);
   const SCEV *S1 = SE.getSCEV(PN);
@@ -676,7 +676,7 @@ TEST_F(ScalarEvolutionsTest, SCEVZeroExtendExpr) {
   Type *I64Ty = Type::getInt64Ty(Context);
   Type *I8Ty = Type::getInt8Ty(Context);
   Type *I8PtrTy = PointerType::getUnqual(Context);
-  Value *Accum = Constant::getNullValue(I8PtrTy);
+  Value *Accum = Constant::getZeroValue(I8PtrTy);
   int Iters = 20;
   for (int i = 0; i < Iters; i++) {
     BasicBlock *IncBB = BasicBlock::Create(Context, "for.inc", F, EndBB);
@@ -1738,9 +1738,9 @@ TEST_F(ScalarEvolutionsTest, ComplexityComparatorIsStrictWeakOrdering2) {
 
 TEST_F(ScalarEvolutionsTest, ComplexityComparatorIsStrictWeakOrdering3) {
   Type *Int64Ty = Type::getInt64Ty(Context);
-  Constant *Init = Constant::getNullValue(Int64Ty);
+  Constant *Init = Constant::getZeroValue(Int64Ty);
   Type *PtrTy = PointerType::get(Context, 0);
-  Constant *Null = Constant::getNullValue(PtrTy);
+  Constant *Null = Constant::getZeroValue(PtrTy);
   FunctionType *FTy = FunctionType::get(Type::getVoidTy(Context), {}, false);
 
   Value *V0 = new GlobalVariable(M, Int64Ty, false,

--- a/llvm/unittests/Analysis/ValueLatticeTest.cpp
+++ b/llvm/unittests/Analysis/ValueLatticeTest.cpp
@@ -109,9 +109,9 @@ TEST_F(ValueLatticeTest, getCompareIntegers) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV1, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV1, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLE, I1Ty, LV1, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV1, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV1, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV1, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV1, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV1, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV1, DL)->isZeroValue());
 
   auto LV2 =
       ValueLatticeElement::getRange({APInt(32, 10, true), APInt(32, 20, true)});
@@ -119,9 +119,9 @@ TEST_F(ValueLatticeTest, getCompareIntegers) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLE, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV2, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV2, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV2, DL)->isZeroValue());
 
   auto LV3 =
       ValueLatticeElement::getRange({APInt(32, 15, true), APInt(32, 19, true)});
@@ -155,9 +155,9 @@ TEST_F(ValueLatticeTest, getCompareFloat) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OEQ, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGE, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLE, I1Ty, LV2, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_ONE, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLT, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGT, I1Ty, LV2, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_ONE, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLT, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGT, I1Ty, LV2, DL)->isZeroValue());
 
   EXPECT_TRUE(
       LV1.mergeIn(ValueLatticeElement::get(ConstantFP::get(FloatTy, 2.2))));

--- a/llvm/unittests/AsmParser/AsmParserTest.cpp
+++ b/llvm/unittests/AsmParser/AsmParserTest.cpp
@@ -154,7 +154,7 @@ TEST(AsmParserTest, TypeAndConstantValueParsing) {
   ASSERT_TRUE(V);
   EXPECT_TRUE(V->getType()->isVectorTy());
   ASSERT_TRUE(isa<Constant>(V));
-  EXPECT_TRUE(cast<Constant>(V)->isNullValue());
+  EXPECT_TRUE(cast<Constant>(V)->isZeroValue());
 
   V = parseConstantValue("<4 x i32> poison", Error, M);
   ASSERT_TRUE(V);

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -2435,7 +2435,7 @@ TEST_F(OpenMPIRBuilderTest, StaticWorkshareLoopTarget) {
   EXPECT_EQ(ArgFunction->arg_size(), 1u);
   EXPECT_EQ(ArgFunction->getArg(0)->getType(), TripCount->getType());
   // Check that no variables except for loop counter are used in loop body
-  EXPECT_EQ(Constant::getNullValue(Builder.getPtrTy()),
+  EXPECT_EQ(Constant::getZeroValue(Builder.getPtrTy()),
             WorkshareLoopRuntimeCall->getArgOperand(2));
   // Check loop trip count argument
   EXPECT_EQ(TripCount, WorkshareLoopRuntimeCall->getArgOperand(3));
@@ -6613,8 +6613,8 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   LoadInst *Value = nullptr;
   StoreInst *TargetStore = nullptr;
   llvm::SmallVector<llvm::Value *, 2> CapturedArgs = {
-      Constant::getNullValue(PointerType::get(Ctx, 0)),
-      Constant::getNullValue(PointerType::get(Ctx, 0))};
+      Constant::getZeroValue(PointerType::get(Ctx, 0)),
+      Constant::getZeroValue(PointerType::get(Ctx, 0))};
 
   auto SimpleArgAccessorCB =
       [&](llvm::Argument &Arg, llvm::Value *Input, llvm::Value *&RetVal,
@@ -7018,7 +7018,7 @@ TEST_F(OpenMPIRBuilderTest, ConstantAllocaRaise) {
   LoadInst *Value = nullptr;
   StoreInst *TargetStore = nullptr;
   llvm::SmallVector<llvm::Value *, 1> CapturedArgs = {
-      Constant::getNullValue(PointerType::get(Ctx, 0))};
+      Constant::getZeroValue(PointerType::get(Ctx, 0))};
 
   auto SimpleArgAccessorCB =
       [&](llvm::Argument &Arg, llvm::Value *Input, llvm::Value *&RetVal,
@@ -7202,7 +7202,7 @@ TEST_F(OpenMPIRBuilderTest, DebugRecordLoc) {
   auto *Alloca = Builder.CreateAlloca(Builder.getInt32Ty());
 
   llvm::SmallVector<llvm::Value *, 1> CapturedArgs = {
-      Alloca, Constant::getNullValue(PointerType::get(Ctx, 0))};
+      Alloca, Constant::getZeroValue(PointerType::get(Ctx, 0))};
 
   auto SimpleArgAccessorCB =
       [&](llvm::Argument &Arg, llvm::Value *Input, llvm::Value *&RetVal,

--- a/llvm/unittests/IR/AsmWriterTest.cpp
+++ b/llvm/unittests/IR/AsmWriterTest.cpp
@@ -85,7 +85,7 @@ TEST(AsmWriterTest, PrintNullOperandBundle) {
   LLVMContext C;
   Type *Int32Ty = Type::getInt32Ty(C);
   FunctionType *FnTy = FunctionType::get(Int32Ty, Int32Ty, /*isVarArg=*/false);
-  Value *Callee = Constant::getNullValue(PointerType::getUnqual(C));
+  Value *Callee = Constant::getZeroValue(PointerType::getUnqual(C));
   Value *Args[] = {ConstantInt::get(Int32Ty, 42)};
   std::unique_ptr<BasicBlock> NormalDest(BasicBlock::Create(C));
   std::unique_ptr<BasicBlock> UnwindDest(BasicBlock::Create(C));

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -158,32 +158,32 @@ TEST(ConstantsTest, PointerCast) {
 
   // ptrtoint ptr to i64
   EXPECT_EQ(
-      Constant::getNullValue(Int64Ty),
-      ConstantExpr::getPointerCast(Constant::getNullValue(PtrTy), Int64Ty));
+      Constant::getZeroValue(Int64Ty),
+      ConstantExpr::getPointerCast(Constant::getZeroValue(PtrTy), Int64Ty));
 
   // bitcast ptr to ptr
-  EXPECT_EQ(Constant::getNullValue(PtrTy),
-            ConstantExpr::getPointerCast(Constant::getNullValue(PtrTy), PtrTy));
+  EXPECT_EQ(Constant::getZeroValue(PtrTy),
+            ConstantExpr::getPointerCast(Constant::getZeroValue(PtrTy), PtrTy));
 
   // ptrtoint <4 x ptr> to <4 x i64>
-  EXPECT_EQ(Constant::getNullValue(Int64VecTy),
-            ConstantExpr::getPointerCast(Constant::getNullValue(PtrVecTy),
+  EXPECT_EQ(Constant::getZeroValue(Int64VecTy),
+            ConstantExpr::getPointerCast(Constant::getZeroValue(PtrVecTy),
                                          Int64VecTy));
 
   // ptrtoint <vscale x 4 x ptr> to <vscale x 4 x i64>
-  EXPECT_EQ(Constant::getNullValue(Int64ScalableVecTy),
+  EXPECT_EQ(Constant::getZeroValue(Int64ScalableVecTy),
             ConstantExpr::getPointerCast(
-                Constant::getNullValue(PtrScalableVecTy), Int64ScalableVecTy));
+                Constant::getZeroValue(PtrScalableVecTy), Int64ScalableVecTy));
 
   // bitcast <4 x ptr> to <4 x ptr>
   EXPECT_EQ(
-      Constant::getNullValue(PtrVecTy),
-      ConstantExpr::getPointerCast(Constant::getNullValue(PtrVecTy), PtrVecTy));
+      Constant::getZeroValue(PtrVecTy),
+      ConstantExpr::getPointerCast(Constant::getZeroValue(PtrVecTy), PtrVecTy));
 
   // bitcast <vscale x 4 x ptr> to <vscale x 4 x ptr>
-  EXPECT_EQ(Constant::getNullValue(PtrScalableVecTy),
+  EXPECT_EQ(Constant::getZeroValue(PtrScalableVecTy),
             ConstantExpr::getPointerCast(
-                Constant::getNullValue(PtrScalableVecTy), PtrScalableVecTy));
+                Constant::getZeroValue(PtrScalableVecTy), PtrScalableVecTy));
 
   Type *Ptr1Ty = PointerType::get(C, 1);
   ConstantInt *K = ConstantInt::get(Type::getInt64Ty(C), 1234);
@@ -194,14 +194,14 @@ TEST(ConstantsTest, PointerCast) {
   EXPECT_NE(K, ConstantExpr::getAddrSpaceCast(
                    ConstantExpr::getIntToPtr(K, Ptr1Ty), PtrTy));
 
-  Constant *NullPtr0 = Constant::getNullValue(PtrTy);
-  Constant *NullPtr1 = Constant::getNullValue(Ptr1Ty);
+  Constant *NullPtr0 = Constant::getZeroValue(PtrTy);
+  Constant *NullPtr1 = Constant::getZeroValue(Ptr1Ty);
 
   // Make sure that addrspacecast of null is not folded away.
-  EXPECT_NE(Constant::getNullValue(PtrTy),
+  EXPECT_NE(Constant::getZeroValue(PtrTy),
             ConstantExpr::getAddrSpaceCast(NullPtr0, Ptr1Ty));
 
-  EXPECT_NE(Constant::getNullValue(Ptr1Ty),
+  EXPECT_NE(Constant::getZeroValue(Ptr1Ty),
             ConstantExpr::getAddrSpaceCast(NullPtr1, PtrTy));
 }
 
@@ -484,7 +484,7 @@ bool foldFuncPtrAndConstToNull(LLVMContext &Context, Module *TheModule,
 
   Constant *C = ConstantFoldBinaryInstruction(Instruction::And, TheConstantExpr,
                                               TheConstant);
-  bool Result = C && C->isNullValue();
+  bool Result = C && C->isZeroValue();
 
   if (!TheModule) {
     // If the Module exists then it will delete the Function.
@@ -571,12 +571,12 @@ TEST(ConstantsTest, FoldGlobalVariablePtr) {
   Constant *PtrToInt = ConstantExpr::getPtrToInt(Global.get(), IntType);
   ASSERT_TRUE(
       ConstantFoldBinaryInstruction(Instruction::And, PtrToInt, TheConstant)
-          ->isNullValue());
+          ->isZeroValue());
 
   Constant *PtrToAddr = ConstantExpr::getPtrToAddr(Global.get(), IntType);
   ASSERT_TRUE(
       ConstantFoldBinaryInstruction(Instruction::And, PtrToAddr, TheConstant)
-          ->isNullValue());
+          ->isZeroValue());
 }
 
 // Check that containsUndefOrPoisonElement and containsPoisonElement is working
@@ -755,7 +755,7 @@ TEST(ConstantsTest, GetSplatValueRoundTrip) {
 
     for (auto EC : {ScalableEC, FixedEC}) {
       for (auto *Ty : {FloatTy, Int32Ty, Int8Ty}) {
-        Constant *Zero = Constant::getNullValue(Ty);
+        Constant *Zero = Constant::getZeroValue(Ty);
         Constant *One = Constant::getAllOnesValue(Ty);
 
         for (auto *C : {Zero, One}) {

--- a/llvm/unittests/IR/DominatorTreeTest.cpp
+++ b/llvm/unittests/IR/DominatorTreeTest.cpp
@@ -1085,7 +1085,7 @@ TEST(DominatorTree, ValueDomination) {
                  [&](Function &F, DominatorTree *DT, PostDominatorTree *PDT) {
     Argument *A = F.getArg(0);
     GlobalValue *G = M->getNamedValue("foo");
-    Constant *C = ConstantInt::getNullValue(Type::getInt8Ty(Context));
+    Constant *C = ConstantInt::getZeroValue(Type::getInt8Ty(Context));
 
     Instruction *I = F.getEntryBlock().getTerminator();
     EXPECT_TRUE(DT->dominates(A, I));

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -247,10 +247,10 @@ TEST(InstructionsTest, CastInst) {
   Type *VScaleV2PtrTy = ScalableVectorType::get(PtrTy, 2);
   Type *VScaleV4PtrTy = ScalableVectorType::get(PtrTy, 4);
 
-  const Constant* c8 = Constant::getNullValue(V8x8Ty);
-  const Constant* c64 = Constant::getNullValue(V8x64Ty);
+  const Constant *c8 = Constant::getZeroValue(V8x8Ty);
+  const Constant *c64 = Constant::getZeroValue(V8x64Ty);
 
-  const Constant *v2ptr32 = Constant::getNullValue(V2PtrTy);
+  const Constant *v2ptr32 = Constant::getZeroValue(V2PtrTy);
 
   EXPECT_EQ(CastInst::Trunc, CastInst::getCastOpcode(c64, true, V8x8Ty, true));
   EXPECT_EQ(CastInst::SExt, CastInst::getCastOpcode(c8, true, V8x64Ty, true));
@@ -293,93 +293,93 @@ TEST(InstructionsTest, CastInst) {
   EXPECT_FALSE(CastInst::isBitCastable(V2Int64Ty, V2Int32Ty));
 
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V4PtrTy), V2PtrTy));
+                                     Constant::getZeroValue(V4PtrTy), V2PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V2PtrTy), V4PtrTy));
+                                     Constant::getZeroValue(V2PtrTy), V4PtrTy));
 
   EXPECT_FALSE(CastInst::castIsValid(
-      Instruction::AddrSpaceCast, Constant::getNullValue(V4PtrAS1Ty), V2PtrTy));
+      Instruction::AddrSpaceCast, Constant::getZeroValue(V4PtrAS1Ty), V2PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(
-      Instruction::AddrSpaceCast, Constant::getNullValue(V2PtrTy), V4PtrAS1Ty));
+      Instruction::AddrSpaceCast, Constant::getZeroValue(V2PtrTy), V4PtrAS1Ty));
 
   // Address space cast of fixed/scalable vectors of pointers to scalable/fixed
   // vector of pointers.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                     Constant::getZeroValue(VScaleV4PtrAS1Ty),
                                      V4PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(V4PtrTy),
+                                     Constant::getZeroValue(V4PtrTy),
                                      VScaleV4PtrAS1Ty));
   // Address space cast of scalable vectors of pointers to scalable vector of
   // pointers.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                     Constant::getZeroValue(VScaleV4PtrAS1Ty),
                                      VScaleV2PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV2PtrTy),
+                                     Constant::getZeroValue(VScaleV2PtrTy),
                                      VScaleV4PtrAS1Ty));
   EXPECT_TRUE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                    Constant::getNullValue(VScaleV4PtrTy),
+                                    Constant::getZeroValue(VScaleV4PtrTy),
                                     VScaleV4PtrAS1Ty));
   // Same number of lanes, different address space.
   EXPECT_TRUE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                    Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                    Constant::getZeroValue(VScaleV4PtrAS1Ty),
                                     VScaleV4PtrTy));
   // Same number of lanes, same address space.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV4PtrTy),
+                                     Constant::getZeroValue(VScaleV4PtrTy),
                                      VScaleV4PtrTy));
 
   // Bit casting fixed/scalable vector to scalable/fixed vectors.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V2Int32Ty),
+                                     Constant::getZeroValue(V2Int32Ty),
                                      VScaleV2Int32Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V2Int64Ty),
+                                     Constant::getZeroValue(V2Int64Ty),
                                      VScaleV2Int64Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V4Int16Ty),
+                                     Constant::getZeroValue(V4Int16Ty),
                                      VScaleV4Int16Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV2Int32Ty),
+                                     Constant::getZeroValue(VScaleV2Int32Ty),
                                      V2Int32Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV2Int64Ty),
+                                     Constant::getZeroValue(VScaleV2Int64Ty),
                                      V2Int64Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV4Int16Ty),
+                                     Constant::getZeroValue(VScaleV4Int16Ty),
                                      V4Int16Ty));
 
   // Bit casting scalable vectors to scalable vectors.
   EXPECT_TRUE(CastInst::castIsValid(Instruction::BitCast,
-                                    Constant::getNullValue(VScaleV4Int16Ty),
+                                    Constant::getZeroValue(VScaleV4Int16Ty),
                                     VScaleV2Int32Ty));
   EXPECT_TRUE(CastInst::castIsValid(Instruction::BitCast,
-                                    Constant::getNullValue(VScaleV2Int32Ty),
+                                    Constant::getZeroValue(VScaleV2Int32Ty),
                                     VScaleV4Int16Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV2Int64Ty),
+                                     Constant::getZeroValue(VScaleV2Int64Ty),
                                      VScaleV2Int32Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV2Int32Ty),
+                                     Constant::getZeroValue(VScaleV2Int32Ty),
                                      VScaleV2Int64Ty));
 
   // Bitcasting to/from <vscale x 1 x Ty>
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(VScaleV1Int16Ty),
+                                     Constant::getZeroValue(VScaleV1Int16Ty),
                                      V1Int16Ty));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V1Int16Ty),
+                                     Constant::getZeroValue(V1Int16Ty),
                                      VScaleV1Int16Ty));
 
   // Check that assertion is not hit when creating a cast with a vector of
   // pointers
   // First form
   BasicBlock *BB = BasicBlock::Create(C);
-  Constant *NullV2I32Ptr = Constant::getNullValue(V2PtrTy);
+  Constant *NullV2I32Ptr = Constant::getZeroValue(V2PtrTy);
   auto Inst1 = CastInst::CreatePointerCast(NullV2I32Ptr, V2Int32Ty, "foo", BB);
 
-  Constant *NullVScaleV2I32Ptr = Constant::getNullValue(VScaleV2PtrTy);
+  Constant *NullVScaleV2I32Ptr = Constant::getZeroValue(VScaleV2PtrTy);
   auto Inst1VScale = CastInst::CreatePointerCast(
       NullVScaleV2I32Ptr, VScaleV2Int32Ty, "foo.vscale", BB);
 
@@ -406,8 +406,8 @@ TEST(InstructionsTest, CastCAPI) {
 
   Type *PtrTy = PointerType::get(C, 0);
 
-  const Constant *C8 = Constant::getNullValue(Int8Ty);
-  const Constant *C64 = Constant::getNullValue(Int64Ty);
+  const Constant *C8 = Constant::getZeroValue(Int8Ty);
+  const Constant *C64 = Constant::getZeroValue(Int64Ty);
 
   EXPECT_EQ(LLVMBitCast,
             LLVMGetCastOpcode(wrap(C64), true, wrap(Int64Ty), true));
@@ -415,8 +415,8 @@ TEST(InstructionsTest, CastCAPI) {
   EXPECT_EQ(LLVMSExt, LLVMGetCastOpcode(wrap(C8), true, wrap(Int64Ty), true));
   EXPECT_EQ(LLVMZExt, LLVMGetCastOpcode(wrap(C8), false, wrap(Int64Ty), true));
 
-  const Constant *CF32 = Constant::getNullValue(FloatTy);
-  const Constant *CF64 = Constant::getNullValue(DoubleTy);
+  const Constant *CF32 = Constant::getZeroValue(FloatTy);
+  const Constant *CF64 = Constant::getZeroValue(DoubleTy);
 
   EXPECT_EQ(LLVMFPToUI,
             LLVMGetCastOpcode(wrap(CF32), true, wrap(Int8Ty), false));
@@ -430,7 +430,7 @@ TEST(InstructionsTest, CastCAPI) {
   EXPECT_EQ(LLVMFPExt,
             LLVMGetCastOpcode(wrap(CF32), true, wrap(DoubleTy), true));
 
-  const Constant *CPtr8 = Constant::getNullValue(PtrTy);
+  const Constant *CPtr8 = Constant::getZeroValue(PtrTy);
 
   EXPECT_EQ(LLVMPtrToInt,
             LLVMGetCastOpcode(wrap(CPtr8), true, wrap(Int8Ty), true));
@@ -438,8 +438,8 @@ TEST(InstructionsTest, CastCAPI) {
 
   Type *V8x8Ty = FixedVectorType::get(Int8Ty, 8);
   Type *V8x64Ty = FixedVectorType::get(Int64Ty, 8);
-  const Constant *CV8 = Constant::getNullValue(V8x8Ty);
-  const Constant *CV64 = Constant::getNullValue(V8x64Ty);
+  const Constant *CV8 = Constant::getZeroValue(V8x8Ty);
+  const Constant *CV64 = Constant::getZeroValue(V8x64Ty);
 
   EXPECT_EQ(LLVMTrunc, LLVMGetCastOpcode(wrap(CV64), true, wrap(V8x8Ty), true));
   EXPECT_EQ(LLVMSExt, LLVMGetCastOpcode(wrap(CV8), true, wrap(V8x64Ty), true));
@@ -447,7 +447,7 @@ TEST(InstructionsTest, CastCAPI) {
   Type *PtrAS1Ty = PointerType::get(C, 1);
   Type *V2PtrAS1Ty = FixedVectorType::get(PtrAS1Ty, 2);
   Type *V2PtrTy = FixedVectorType::get(PtrTy, 2);
-  const Constant *CV2Ptr = Constant::getNullValue(V2PtrTy);
+  const Constant *CV2Ptr = Constant::getZeroValue(V2PtrTy);
 
   EXPECT_EQ(LLVMAddrSpaceCast,
             LLVMGetCastOpcode(wrap(CV2Ptr), true, wrap(V2PtrAS1Ty), true));
@@ -724,7 +724,7 @@ TEST(InstructionsTest, CloneCall) {
   Type *Int32Ty = Type::getInt32Ty(C);
   Type *ArgTys[] = {Int32Ty, Int32Ty, Int32Ty};
   FunctionType *FnTy = FunctionType::get(Int32Ty, ArgTys, /*isVarArg=*/false);
-  Value *Callee = Constant::getNullValue(PointerType::getUnqual(C));
+  Value *Callee = Constant::getZeroValue(PointerType::getUnqual(C));
   Value *Args[] = {
     ConstantInt::get(Int32Ty, 1),
     ConstantInt::get(Int32Ty, 2),
@@ -758,7 +758,7 @@ TEST(InstructionsTest, AlterCallBundles) {
   LLVMContext C;
   Type *Int32Ty = Type::getInt32Ty(C);
   FunctionType *FnTy = FunctionType::get(Int32Ty, Int32Ty, /*isVarArg=*/false);
-  Value *Callee = Constant::getNullValue(PointerType::getUnqual(C));
+  Value *Callee = Constant::getZeroValue(PointerType::getUnqual(C));
   Value *Args[] = {ConstantInt::get(Int32Ty, 42)};
   OperandBundleDef OldBundle("before", UndefValue::get(Int32Ty));
   std::unique_ptr<CallInst> Call(
@@ -785,7 +785,7 @@ TEST(InstructionsTest, AlterInvokeBundles) {
   LLVMContext C;
   Type *Int32Ty = Type::getInt32Ty(C);
   FunctionType *FnTy = FunctionType::get(Int32Ty, Int32Ty, /*isVarArg=*/false);
-  Value *Callee = Constant::getNullValue(PointerType::getUnqual(C));
+  Value *Callee = Constant::getZeroValue(PointerType::getUnqual(C));
   Value *Args[] = {ConstantInt::get(Int32Ty, 42)};
   std::unique_ptr<BasicBlock> NormalDest(BasicBlock::Create(C));
   std::unique_ptr<BasicBlock> UnwindDest(BasicBlock::Create(C));
@@ -865,7 +865,7 @@ TEST_F(ModuleWithFunctionTest, DropPoisonGeneratingFlags) {
   }
 
   {
-    Value *GEPBase = Constant::getNullValue(B.getPtrTy());
+    Value *GEPBase = Constant::getZeroValue(B.getPtrTy());
     auto *GI = cast<GetElementPtrInst>(
         B.CreateInBoundsGEP(B.getInt8Ty(), GEPBase, Arg0));
     ASSERT_TRUE(GI->isInBounds());
@@ -1327,7 +1327,7 @@ TEST(InstructionsTest, ShuffleMaskQueries) {
   ShuffleVectorInst *Id13 =
       new ShuffleVectorInst(Constant::getAllOnesValue(VScaleV4Int32Ty),
                             UndefValue::get(VScaleV4Int32Ty),
-                            Constant::getNullValue(VScaleV4Int32Ty));
+                            Constant::getZeroValue(VScaleV4Int32Ty));
   int Index = 0;
   EXPECT_FALSE(Id13->isExtractSubvectorMask(Index));
   EXPECT_FALSE(Id13->changesLength());
@@ -1339,7 +1339,7 @@ TEST(InstructionsTest, ShuffleMaskQueries) {
   ShuffleVectorInst *Id14 =
       new ShuffleVectorInst(Constant::getAllOnesValue(VScaleV2Int32Ty),
                             UndefValue::get(VScaleV2Int32Ty),
-                            Constant::getNullValue(VScaleV4Int32Ty));
+                            Constant::getZeroValue(VScaleV4Int32Ty));
   EXPECT_TRUE(Id14->changesLength());
   EXPECT_TRUE(Id14->increasesLength());
   delete Id14;
@@ -1348,8 +1348,8 @@ TEST(InstructionsTest, ShuffleMaskQueries) {
   // don't crash.
   ShuffleVectorInst *Id15 =
       new ShuffleVectorInst(Constant::getAllOnesValue(VScaleV2Int32Ty),
-                            Constant::getNullValue(VScaleV2Int32Ty),
-                            Constant::getNullValue(VScaleV2Int32Ty));
+                            Constant::getZeroValue(VScaleV2Int32Ty),
+                            Constant::getZeroValue(VScaleV2Int32Ty));
   EXPECT_FALSE(Id15->isIdentityWithPadding());
   EXPECT_FALSE(Id15->isIdentityWithExtract());
   EXPECT_FALSE(Id15->isConcat());
@@ -1369,7 +1369,7 @@ TEST(InstructionsTest, ShuffleMaskIsReplicationMask) {
       for (int OpVF : seq_inclusive(VF, 2 * VF + 1)) {
         LLVMContext Ctx;
         Type *OpVFTy = FixedVectorType::get(IntegerType::getInt1Ty(Ctx), OpVF);
-        Value *Op = ConstantVector::getNullValue(OpVFTy);
+        Value *Op = ConstantVector::getZeroValue(OpVFTy);
         ShuffleVectorInst *SVI = new ShuffleVectorInst(Op, Op, ReplicatedMask);
         EXPECT_EQ(SVI->isReplicationMask(GuessedReplicationFactor, GuessedVF),
                   OpVF == VF);
@@ -1565,99 +1565,99 @@ TEST(InstructionsTest, FPCallIsFPMathOperator) {
   Type *ITy = Type::getInt32Ty(C);
   FunctionType *IFnTy = FunctionType::get(ITy, {});
   PointerType *PtrTy = PointerType::getUnqual(C);
-  Value *ICallee = Constant::getNullValue(PtrTy);
+  Value *ICallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> ICall(CallInst::Create(IFnTy, ICallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(ICall));
 
   Type *VITy = FixedVectorType::get(ITy, 2);
   FunctionType *VIFnTy = FunctionType::get(VITy, {});
-  Value *VICallee = Constant::getNullValue(PtrTy);
+  Value *VICallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> VICall(CallInst::Create(VIFnTy, VICallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(VICall));
 
   Type *AITy = ArrayType::get(ITy, 2);
   FunctionType *AIFnTy = FunctionType::get(AITy, {});
-  Value *AICallee = Constant::getNullValue(PtrTy);
+  Value *AICallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> AICall(CallInst::Create(AIFnTy, AICallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(AICall));
 
   Type *FTy = Type::getFloatTy(C);
   FunctionType *FFnTy = FunctionType::get(FTy, {});
-  Value *FCallee = Constant::getNullValue(PtrTy);
+  Value *FCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> FCall(CallInst::Create(FFnTy, FCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(FCall));
 
   Type *VFTy = FixedVectorType::get(FTy, 2);
   FunctionType *VFFnTy = FunctionType::get(VFTy, {});
-  Value *VFCallee = Constant::getNullValue(PtrTy);
+  Value *VFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> VFCall(CallInst::Create(VFFnTy, VFCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(VFCall));
 
   Type *AFTy = ArrayType::get(FTy, 2);
   FunctionType *AFFnTy = FunctionType::get(AFTy, {});
-  Value *AFCallee = Constant::getNullValue(PtrTy);
+  Value *AFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> AFCall(CallInst::Create(AFFnTy, AFCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(AFCall));
 
   Type *AVFTy = ArrayType::get(VFTy, 2);
   FunctionType *AVFFnTy = FunctionType::get(AVFTy, {});
-  Value *AVFCallee = Constant::getNullValue(PtrTy);
+  Value *AVFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> AVFCall(
       CallInst::Create(AVFFnTy, AVFCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(AVFCall));
 
   Type *StructITy = StructType::get(ITy, ITy);
   FunctionType *StructIFnTy = FunctionType::get(StructITy, {});
-  Value *StructICallee = Constant::getNullValue(PtrTy);
+  Value *StructICallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> StructICall(
       CallInst::Create(StructIFnTy, StructICallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(StructICall));
 
   Type *EmptyStructTy = StructType::get(C);
   FunctionType *EmptyStructFnTy = FunctionType::get(EmptyStructTy, {});
-  Value *EmptyStructCallee = Constant::getNullValue(PtrTy);
+  Value *EmptyStructCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> EmptyStructCall(
       CallInst::Create(EmptyStructFnTy, EmptyStructCallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(EmptyStructCall));
 
   Type *NamedStructFTy = StructType::create({FTy, FTy}, "AStruct");
   FunctionType *NamedStructFFnTy = FunctionType::get(NamedStructFTy, {});
-  Value *NamedStructFCallee = Constant::getNullValue(PtrTy);
+  Value *NamedStructFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> NamedStructFCall(
       CallInst::Create(NamedStructFFnTy, NamedStructFCallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(NamedStructFCall));
 
   Type *MixedStructTy = StructType::get(FTy, ITy);
   FunctionType *MixedStructFnTy = FunctionType::get(MixedStructTy, {});
-  Value *MixedStructCallee = Constant::getNullValue(PtrTy);
+  Value *MixedStructCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> MixedStructCall(
       CallInst::Create(MixedStructFnTy, MixedStructCallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(MixedStructCall));
 
   Type *StructFTy = StructType::get(FTy, FTy, FTy);
   FunctionType *StructFFnTy = FunctionType::get(StructFTy, {});
-  Value *StructFCallee = Constant::getNullValue(PtrTy);
+  Value *StructFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> StructFCall(
       CallInst::Create(StructFFnTy, StructFCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(StructFCall));
 
   Type *StructVFTy = StructType::get(VFTy, VFTy, VFTy, VFTy);
   FunctionType *StructVFFnTy = FunctionType::get(StructVFTy, {});
-  Value *StructVFCallee = Constant::getNullValue(PtrTy);
+  Value *StructVFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> StructVFCall(
       CallInst::Create(StructVFFnTy, StructVFCallee, {}, ""));
   EXPECT_TRUE(isa<FPMathOperator>(StructVFCall));
 
   Type *NestedStructFTy = StructType::get(StructFTy, StructFTy, StructFTy);
   FunctionType *NestedStructFFnTy = FunctionType::get(NestedStructFTy, {});
-  Value *NestedStructFCallee = Constant::getNullValue(PtrTy);
+  Value *NestedStructFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> NestedStructFCall(
       CallInst::Create(NestedStructFFnTy, NestedStructFCallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(NestedStructFCall));
 
   Type *AStructFTy = ArrayType::get(StructFTy, 5);
   FunctionType *AStructFFnTy = FunctionType::get(AStructFTy, {});
-  Value *AStructFCallee = Constant::getNullValue(PtrTy);
+  Value *AStructFCallee = Constant::getZeroValue(PtrTy);
   std::unique_ptr<CallInst> AStructFCall(
       CallInst::Create(AStructFFnTy, AStructFCallee, {}, ""));
   EXPECT_FALSE(isa<FPMathOperator>(AStructFCall));

--- a/llvm/unittests/IR/IntrinsicsTest.cpp
+++ b/llvm/unittests/IR/IntrinsicsTest.cpp
@@ -52,7 +52,7 @@ public:
     SmallVector<Value *, 4> ProcessedArgs;
     auto *Decl = Intrinsic::getOrInsertDeclaration(M.get(), ID);
     for (auto *Ty : Decl->getFunctionType()->params()) {
-      auto *Val = Constant::getNullValue(Ty);
+      auto *Val = Constant::getZeroValue(Ty);
       ProcessedArgs.push_back(Val);
     }
     return Builder.CreateCall(Decl, ProcessedArgs);
@@ -342,8 +342,8 @@ TEST_F(IntrinsicsTest, IRBuilderCreateIntrinsicVector) {
 
   Type *RetTy = FixedVectorType::get(Type::getInt32Ty(Context), 4);
   SmallVector<Value *, 2> Args;
-  Args.push_back(Constant::getNullValue(RetTy));
-  Args.push_back(Constant::getNullValue(RetTy));
+  Args.push_back(Constant::getZeroValue(RetTy));
+  Args.push_back(Constant::getZeroValue(RetTy));
 
   CallInst *CI = Builder.CreateIntrinsic(RetTy, Intrinsic::umax, Args);
 
@@ -360,7 +360,7 @@ TEST_F(IntrinsicsTest, IRBuilderCreateIntrinsicAddressSpace) {
 
   Type *RetTy = Type::getVoidTy(Context);
   SmallVector<Value *, 4> Args;
-  Args.push_back(Constant::getNullValue(
+  Args.push_back(Constant::getZeroValue(
       PointerType::get(Context, 1))); // ptr addrspace(1) null
   Args.push_back(ConstantInt::get(Type::getInt32Ty(Context), 0)); // rw
   Args.push_back(ConstantInt::get(Type::getInt32Ty(Context), 3)); // locality

--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -1540,7 +1540,7 @@ TEST_F(PatternMatchTest, UndefPoisonMix) {
   StructType *StTy = StructType::get(ScalarTy, ScalarTy);
   StructType *StTy2 = StructType::get(ScalarTy, StTy);
   StructType *StTy3 = StructType::get(StTy, ScalarTy);
-  Constant *Zero = ConstantInt::getNullValue(ScalarTy);
+  Constant *Zero = ConstantInt::getZeroValue(ScalarTy);
   UndefValue *U = UndefValue::get(ScalarTy);
   UndefValue *P = PoisonValue::get(ScalarTy);
 
@@ -1572,8 +1572,8 @@ TEST_F(PatternMatchTest, VectorUndefInt) {
   Constant *VectorUndef = UndefValue::get(VectorTy);
   Constant *ScalarPoison = PoisonValue::get(ScalarTy);
   Constant *VectorPoison = PoisonValue::get(VectorTy);
-  Constant *ScalarZero = Constant::getNullValue(ScalarTy);
-  Constant *VectorZero = Constant::getNullValue(VectorTy);
+  Constant *ScalarZero = Constant::getZeroValue(ScalarTy);
+  Constant *VectorZero = Constant::getZeroValue(VectorTy);
 
   SmallVector<Constant *, 4> Elems;
   Elems.push_back(ScalarUndef);
@@ -1663,8 +1663,8 @@ TEST_F(PatternMatchTest, VectorUndefFloat) {
   Constant *VectorUndef = UndefValue::get(VectorTy);
   Constant *ScalarPoison = PoisonValue::get(ScalarTy);
   Constant *VectorPoison = PoisonValue::get(VectorTy);
-  Constant *ScalarZero = Constant::getNullValue(ScalarTy);
-  Constant *VectorZero = Constant::getNullValue(VectorTy);
+  Constant *ScalarZero = Constant::getZeroValue(ScalarTy);
+  Constant *VectorZero = Constant::getZeroValue(VectorTy);
   Constant *ScalarPosInf = ConstantFP::getInfinity(ScalarTy, false);
   Constant *ScalarNegInf = ConstantFP::getInfinity(ScalarTy, true);
   Constant *ScalarNaN = ConstantFP::getNaN(ScalarTy, true);
@@ -1865,10 +1865,10 @@ TEST_F(PatternMatchTest, VectorUndefFloat) {
 
   CC = nullptr;
   EXPECT_TRUE(match(VectorZero, m_CheckedFp(CC, CheckTrue)));
-  EXPECT_TRUE(CC->isNullValue());
+  EXPECT_TRUE(CC->isZeroValue());
   CC = nullptr;
   EXPECT_TRUE(match(VectorZero, m_CheckedFp(CC, CheckNonNaN)));
-  EXPECT_TRUE(CC->isNullValue());
+  EXPECT_TRUE(CC->isZeroValue());
 
   // Splats with undef are never allowed.
   // Whether splats with poison can be matched depends on the matcher.
@@ -2434,7 +2434,7 @@ TEST_F(PatternMatchTest, VectorLogicalSelects) {
   Value *AllocaVec = IRB.CreateAlloca(v3i1);
   Value *Scalar = IRB.CreateLoad(i1, Alloca);
   Value *Vector = IRB.CreateLoad(v3i1, AllocaVec);
-  Constant *F = Constant::getNullValue(v3i1);
+  Constant *F = Constant::getZeroValue(v3i1);
   Constant *T = Constant::getAllOnesValue(v3i1);
 
   // select <3 x i1> Vector, <3 x i1> Vector, <3 x i1> <i1 0, i1 0, i1 0>
@@ -2463,7 +2463,7 @@ TEST_F(PatternMatchTest, NotForbidPoison) {
   Constant *ScalarUndef = UndefValue::get(ScalarTy);
   Constant *ScalarPoison = PoisonValue::get(ScalarTy);
   Constant *ScalarOnes = Constant::getAllOnesValue(ScalarTy);
-  Constant *VectorZero = Constant::getNullValue(VectorTy);
+  Constant *VectorZero = Constant::getZeroValue(VectorTy);
   Constant *VectorOnes = Constant::getAllOnesValue(VectorTy);
 
   SmallVector<Constant *, 3> MixedElemsUndef;
@@ -2616,7 +2616,7 @@ TYPED_TEST(MutableConstTest, FCmp) {
   typedef std::tuple_element_t<0, TypeParam> ValueType;
   typedef std::tuple_element_t<1, TypeParam> InstructionType;
 
-  Value *L = Constant::getNullValue(IRB.getFloatTy());
+  Value *L = Constant::getZeroValue(IRB.getFloatTy());
   Value *R = ConstantFP::getInfinity(IRB.getFloatTy(), true);
   FCmpInst::Predicate Pred = FCmpInst::FCMP_OGT;
 
@@ -2704,7 +2704,7 @@ TEST_F(PatternMatchTest, ConstExpr) {
 TEST_F(PatternMatchTest, PtrAdd) {
   Type *PtrTy = PointerType::getUnqual(Ctx);
   Type *IdxTy = Type::getInt64Ty(Ctx);
-  Constant *Null = Constant::getNullValue(PtrTy);
+  Constant *Null = Constant::getZeroValue(PtrTy);
   Constant *Offset = ConstantInt::get(IdxTy, 42);
   Value *PtrAdd = IRB.CreatePtrAdd(Null, Offset);
   Value *OtherGEP = IRB.CreateGEP(IdxTy, Null, Offset);

--- a/llvm/unittests/IR/ValueHandleTest.cpp
+++ b/llvm/unittests/IR/ValueHandleTest.cpp
@@ -324,7 +324,7 @@ TEST_F(ValueHandle, CallbackVH_DeletionCanRAUW) {
   private:
     void deleted() override {
       getValPtr()->replaceAllUsesWith(
-          Constant::getNullValue(Type::getInt32Ty(*Context)));
+          Constant::getZeroValue(Type::getInt32Ty(*Context)));
       setValPtr(nullptr);
     }
     void allUsesReplacedWith(Value *new_value) override {
@@ -340,12 +340,12 @@ TEST_F(ValueHandle, CallbackVH_DeletionCanRAUW) {
   RecoveringVH RVH(Context);
   RVH = RecoveringVH(Context, BitcastV.get());
   std::unique_ptr<BinaryOperator> BitcastUser(BinaryOperator::CreateAdd(
-      RVH, Constant::getNullValue(Type::getInt32Ty(Context))));
+      RVH, Constant::getZeroValue(Type::getInt32Ty(Context))));
   EXPECT_EQ(BitcastV.get(), BitcastUser->getOperand(0));
   BitcastV.reset();  // Would crash without the ValueHandler.
-  EXPECT_EQ(Constant::getNullValue(Type::getInt32Ty(Context)),
+  EXPECT_EQ(Constant::getZeroValue(Type::getInt32Ty(Context)),
             RVH.AURWArgument);
-  EXPECT_EQ(Constant::getNullValue(Type::getInt32Ty(Context)),
+  EXPECT_EQ(Constant::getZeroValue(Type::getInt32Ty(Context)),
             BitcastUser->getOperand(0));
 }
 

--- a/llvm/unittests/IR/ValueTest.cpp
+++ b/llvm/unittests/IR/ValueTest.cpp
@@ -344,7 +344,7 @@ TEST(GlobalTest, Initializer) {
   LLVMContext Ctx;
   Module M("test", Ctx);
   Type *Int8Ty = Type::getInt8Ty(Ctx);
-  Constant *Int8Null = Constant::getNullValue(Int8Ty);
+  Constant *Int8Null = Constant::getZeroValue(Int8Ty);
 
   GlobalVariable *GV = new GlobalVariable(
       M, Int8Ty, false, GlobalValue::ExternalLinkage, nullptr, "GV");

--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -1684,7 +1684,7 @@ TEST(SymtabTest, instr_prof_symtab_module_test) {
       PointerType::get(Ctx, M->getDataLayout().getDefaultGlobalsAddressSpace()),
       3);
   Constant *Int32TyNull =
-      llvm::ConstantExpr::getNullValue(PointerType::getUnqual(Ctx));
+      llvm::ConstantExpr::getZeroValue(PointerType::getUnqual(Ctx));
   SmallVector<llvm::Type *, 1> tys = {VTableArrayType};
   StructType *VTableType = llvm::StructType::get(Ctx, tys);
 

--- a/llvm/unittests/Target/X86/TernlogTest.cpp
+++ b/llvm/unittests/Target/X86/TernlogTest.cpp
@@ -119,7 +119,7 @@ struct TernTester {
 
       auto *C = dyn_cast<Constant>(V);
       assert(C);
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return 0;
       if (C->isAllOnesValue())
         return ((~uint64_t(0)) >> (ElemWidth % 64));

--- a/llvm/unittests/Transforms/Utils/CloningTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CloningTest.cpp
@@ -143,7 +143,7 @@ TEST_F(CloneInstruction, OverflowBits) {
 TEST_F(CloneInstruction, Inbounds) {
   V = new Argument(PointerType::get(context, 0));
 
-  Constant *Z = Constant::getNullValue(Type::getInt32Ty(context));
+  Constant *Z = Constant::getZeroValue(Type::getInt32Ty(context));
   std::vector<Value *> ops;
   ops.push_back(Z);
   GetElementPtrInst *GEP =

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -153,7 +153,7 @@ TEST(Local, ReplaceDbgDeclare) {
   auto *AI = dyn_cast<AllocaInst>(Inst);
   ASSERT_TRUE(AI);
 
-  Value *NewBase = Constant::getNullValue(PointerType::getUnqual(C));
+  Value *NewBase = Constant::getZeroValue(PointerType::getUnqual(C));
   DIBuilder DIB(*M);
   replaceDbgDeclare(AI, NewBase, DIB, DIExpression::ApplyOffset, 0);
 
@@ -1115,7 +1115,7 @@ TEST(Local, CanReplaceOperandWithVariable) {
   Type *PtrPtr = B.getPtrTy(0);
   Value *Alloca = B.CreateAlloca(PtrPtr, (unsigned)0);
   CallInst *GCRoot = B.CreateIntrinsic(
-      Intrinsic::gcroot, {Alloca, Constant::getNullValue(PtrPtr)});
+      Intrinsic::gcroot, {Alloca, Constant::getZeroValue(PtrPtr)});
   EXPECT_TRUE(canReplaceOperandWithVariable(GCRoot, 0)); // Alloca
   EXPECT_FALSE(canReplaceOperandWithVariable(GCRoot, 1));
   EXPECT_FALSE(canReplaceOperandWithVariable(GCRoot, 2));

--- a/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
@@ -943,7 +943,7 @@ TEST_F(ScalarEvolutionExpanderTest, ExpandNonIntegralPtrWithNullBase) {
     Value *Offset = &*F.arg_begin();
     auto *GEP = dyn_cast<GetElementPtrInst>(V);
     EXPECT_TRUE(GEP);
-    EXPECT_TRUE(cast<Constant>(GEP->getPointerOperand())->isNullValue());
+    EXPECT_TRUE(cast<Constant>(GEP->getPointerOperand())->isZeroValue());
     EXPECT_EQ(GEP->getNumOperands(), 2U);
     EXPECT_TRUE(match(
         GEP->getOperand(1),

--- a/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
@@ -433,7 +433,7 @@ TEST(ValueMapperTest, mapValueConstantTargetNoneToLayoutTypeNullValue) {
 
   // Check that ConstantTargetNone is mapped to '0' constant of its layout type.
   auto *OldConstant = ConstantTargetNone::get(OldTy);
-  auto *NewConstant = Constant::getNullValue(NewTy);
+  auto *NewConstant = Constant::getZeroValue(NewTy);
   EXPECT_EQ(NewConstant, Mapper.mapValue(*OldConstant));
 }
 

--- a/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanPatternMatchTest.cpp
@@ -71,7 +71,7 @@ TEST_F(VPPatternMatchTest, GetElementPtr) {
   VPValue *One = Plan.getOrAddLiveIn(ConstantInt::get(I64Ty, 1));
   VPValue *Two = Plan.getOrAddLiveIn(ConstantInt::get(I64Ty, 2));
   VPValue *Ptr =
-      Plan.getOrAddLiveIn(Constant::getNullValue(PointerType::get(C, 0)));
+      Plan.getOrAddLiveIn(Constant::getZeroValue(PointerType::get(C, 0)));
 
   VPInstruction *PtrAdd = Builder.createPtrAdd(Ptr, One);
   VPInstruction *WidePtrAdd = Builder.createWidePtrAdd(Ptr, Two);

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2206,7 +2206,7 @@ def LLVM_PoisonOp : LLVM_Op<"mlir.poison", [Pure, ConstantLike]>,
 
 def LLVM_ZeroOp
     : LLVM_Op<"mlir.zero", [Pure, ConstantLike]>,
-      LLVM_Builder<"$res = llvm::Constant::getNullValue($_resultType);">
+      LLVM_Builder<"$res = llvm::Constant::getZeroValue($_resultType);">
 {
   let summary = "Creates a zero-initialized value of LLVM dialect type.";
   let description = [{

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -7492,7 +7492,7 @@ convertOmpTarget(Operation &opInst, llvm::IRBuilderBase &builder,
 
     // Append a null entry for the implicit dyn_ptr argument so the argument
     // count sent to the runtime already includes it.
-    auto *nullPtr = llvm::Constant::getNullValue(builder.getPtrTy());
+    auto *nullPtr = llvm::Constant::getZeroValue(builder.getPtrTy());
     combinedInfos.BasePointers.push_back(nullPtr);
     combinedInfos.Pointers.push_back(nullPtr);
     combinedInfos.DevicePointers.push_back(

--- a/mlir/lib/Target/LLVMIR/Dialect/Ptr/PtrToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/Ptr/PtrToLLVMIRTranslation.cpp
@@ -196,7 +196,7 @@ translateTypeOffsetOp(TypeOffsetOp typeOffsetOp, llvm::IRBuilderBase &builder,
     return typeOffsetOp.emitError("Failed to translate the result type");
 
   // Use GEP with null pointer to compute type size/offset.
-  llvm::Value *nullPtr = llvm::Constant::getNullValue(builder.getPtrTy(0));
+  llvm::Value *nullPtr = llvm::Constant::getZeroValue(builder.getPtrTy(0));
   llvm::Value *offsetPtr =
       builder.CreateGEP(elementType, nullPtr, {builder.getInt32(1)});
   llvm::Value *offset = builder.CreatePtrToInt(offsetPtr, resultType);

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1616,7 +1616,7 @@ ModuleImport::convertGlobalCtorsAndDtors(llvm::GlobalVariable *globalVar) {
     Attribute dataAttr;
     if (gv)
       dataAttr = FlatSymbolRefAttr::get(context, gv->getName());
-    else if (data->isNullValue())
+    else if (data->isZeroValue())
       dataAttr = ZeroAttr::get(context);
     else
       return failure();

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -567,7 +567,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
   if (!attr || isa<UndefAttr>(attr))
     return llvm::UndefValue::get(llvmType);
   if (isa<ZeroAttr>(attr))
-    return llvm::Constant::getNullValue(llvmType);
+    return llvm::Constant::getZeroValue(llvmType);
   if (auto *structType = dyn_cast<::llvm::StructType>(llvmType)) {
     auto arrayAttr = dyn_cast<ArrayAttr>(attr);
     if (!arrayAttr) {
@@ -654,7 +654,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
           llvm::ElementCount::get(numElements, /*Scalable=*/isScalable), child);
     if (llvmType->isArrayTy()) {
       auto *arrayType = llvm::ArrayType::get(elementType, numElements);
-      if (child->isNullValue() && !elementType->isFPOrFPVectorTy()) {
+      if (child->isZeroValue() && !elementType->isFPOrFPVectorTy()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       }
       if (llvm::ConstantDataSequential::isElementTypeCompatible(elementType)) {
@@ -1433,7 +1433,7 @@ LogicalResult ModuleTranslation::convertGlobalsAndAliases() {
       llvm::Type *eltTy = llvm::StructType::get(
           builder.getInt32Ty(), builder.getPtrTy(), builder.getPtrTy());
       llvm::ArrayType *at = llvm::ArrayType::get(eltTy, 0);
-      llvm::Constant *zeroInit = llvm::Constant::getNullValue(at);
+      llvm::Constant *zeroInit = llvm::Constant::getZeroValue(at);
       (void)new llvm::GlobalVariable(
           *llvmModule, zeroInit->getType(), false,
           llvm::GlobalValue::AppendingLinkage, zeroInit,

--- a/polly/lib/CodeGen/IslExprBuilder.cpp
+++ b/polly/lib/CodeGen/IslExprBuilder.cpp
@@ -199,7 +199,7 @@ Value *IslExprBuilder::createOpUnary(__isl_take isl_ast_expr *Expr) {
     V = Builder.CreateSExt(V, MaxType);
 
   isl_ast_expr_free(Expr);
-  return createSub(ConstantInt::getNullValue(MaxType), V);
+  return createSub(ConstantInt::getZeroValue(MaxType), V);
 }
 
 Value *IslExprBuilder::createOpNAry(__isl_take isl_ast_expr *Expr) {

--- a/polly/lib/CodeGen/IslNodeBuilder.cpp
+++ b/polly/lib/CodeGen/IslNodeBuilder.cpp
@@ -1167,7 +1167,7 @@ Value *IslNodeBuilder::preloadInvariantLoad(const MemoryAccess &MA,
   }
 
   MergePHI->addIncoming(PreAccInst, ExecBB);
-  MergePHI->addIncoming(Constant::getNullValue(AccInstTy), CondBB);
+  MergePHI->addIncoming(Constant::getZeroValue(AccInstTy), CondBB);
 
   return PreloadVal;
 }

--- a/polly/lib/CodeGen/RuntimeDebugBuilder.cpp
+++ b/polly/lib/CodeGen/RuntimeDebugBuilder.cpp
@@ -157,5 +157,5 @@ void RuntimeDebugBuilder::createFlush(PollyIRBuilder &Builder) {
   // pointer, the type we point to does conceptually not matter. However, if
   // fflush is already declared in this translation unit, we use the very same
   // type to ensure that LLVM does not complain about mismatching types.
-  Builder.CreateCall(F, Constant::getNullValue(F->arg_begin()->getType()));
+  Builder.CreateCall(F, Constant::getZeroValue(F->arg_begin()->getType()));
 }

--- a/polly/lib/Support/SCEVValidator.cpp
+++ b/polly/lib/Support/SCEVValidator.cpp
@@ -427,7 +427,7 @@ public:
 
     auto *Divisor = SRem->getOperand(1);
     auto *CI = dyn_cast<ConstantInt>(Divisor);
-    if (!CI || CI->isNullValue())
+    if (!CI || CI->isZeroValue())
       return visitGenericInst(SRem, S);
 
     auto *Dividend = SRem->getOperand(0);

--- a/polly/lib/Transform/ZoneAlgo.cpp
+++ b/polly/lib/Transform/ZoneAlgo.cpp
@@ -436,8 +436,8 @@ isl::union_map ZoneAlgorithm::getWrittenValue(MemoryAccess *MA,
   if (auto *Memset = dyn_cast<MemSetInst>(AccInst)) {
     auto *WrittenConstant = dyn_cast<Constant>(Memset->getValue());
     Type *Ty = MA->getLatestScopArrayInfo()->getElementType();
-    if (WrittenConstant && WrittenConstant->isNullValue()) {
-      Constant *Zero = Constant::getNullValue(Ty);
+    if (WrittenConstant && WrittenConstant->isZeroValue()) {
+      Constant *Zero = Constant::getZeroValue(Ty);
       return makeNormalizedValInst(Zero, Stmt, L);
     }
   }


### PR DESCRIPTION
Currently, a "null value" in LLVM means a zero value. We are moving toward changing the semantics of `ConstantPointerNull` to represent a semantic null pointer instead of a zero-valued pointer. As a result, the meaning of "null value" will also change in the future.

This PR is a first step toward renaming the two widely used "null value" interfaces to "zero value". Semantic "null value" interfaces will be added back later together with the semantic changes to `ConstantPointerNull`.