### PR TITLE
[llvm-profgen] Fix OpenCSD test and build issues

### DIFF
--- a/llvm/lib/ProfileData/CMakeLists.txt
+++ b/llvm/lib/ProfileData/CMakeLists.txt
@@ -51,12 +51,13 @@ set(LLVM_HAVE_OPENCSD OFF CACHE BOOL "Is OpenCSD available" FORCE)
 set(LLVM_OPENCSD_MIN_VERSION "1.5.4")
 
 if(NOT LLVM_ENABLE_OPENCSD STREQUAL "OFF")
-  find_library(OPENCSD_LIB NAMES opencsd_c_api opencsd)
-  find_path(OPENCSD_INCLUDE NAMES opencsd/ocsd_if_types.h)
+  find_library(OPENCSD_C_LIB NAMES opencsd_c_api_static opencsd_c_api HINTS ${OPENCSD_ROOT} PATH_SUFFIXES lib lib64)
+  find_library(OPENCSD_CPP_LIB NAMES opencsd_static opencsd HINTS ${OPENCSD_ROOT} PATH_SUFFIXES lib lib64)
+  find_path(OPENCSD_INCLUDE NAMES opencsd/ocsd_if_types.h HINTS ${OPENCSD_ROOT} PATH_SUFFIXES include)
 
   set(OPENCSD_VERSION "")
   set(OPENCSD_VERSION_OK OFF)
-  if(OPENCSD_LIB AND OPENCSD_INCLUDE)
+  if(OPENCSD_C_LIB AND OPENCSD_INCLUDE)
     # The header exposes an OCSD_VER_STRING macro of the form "M.m.p"
     # which we extract for a robust version comparison.
     file(READ "${OPENCSD_INCLUDE}/opencsd/ocsd_if_version.h" _opencsd_ver_h)
@@ -69,16 +70,19 @@ if(NOT LLVM_ENABLE_OPENCSD STREQUAL "OFF")
     endif()
   endif()
 
-  if(OPENCSD_LIB AND OPENCSD_INCLUDE AND OPENCSD_VERSION_OK)
+  if(OPENCSD_C_LIB AND OPENCSD_CPP_LIB AND OPENCSD_INCLUDE AND OPENCSD_VERSION_OK)
     target_compile_definitions(LLVMProfileData PRIVATE HAVE_OPENCSD)
+    if(WIN32)
+      target_compile_definitions(LLVMProfileData PRIVATE OCSD_USE_STATIC_C_API)
+    endif()
     target_include_directories(LLVMProfileData PRIVATE ${OPENCSD_INCLUDE})
-    target_link_libraries(LLVMProfileData PRIVATE ${OPENCSD_LIB})
+    target_link_libraries(LLVMProfileData PUBLIC ${OPENCSD_C_LIB} ${OPENCSD_CPP_LIB})
     message(STATUS "LLVMProfileData: OpenCSD support enabled (found ${OPENCSD_VERSION}).")
     set(LLVM_HAVE_OPENCSD ON CACHE BOOL "Is OpenCSD available" FORCE)
-  elseif(OPENCSD_LIB AND OPENCSD_INCLUDE)
+  elseif(OPENCSD_C_LIB AND OPENCSD_INCLUDE)
     if(LLVM_ENABLE_OPENCSD STREQUAL "FORCE_ON")
       message(FATAL_ERROR
-        "OpenCSD found at ${OPENCSD_LIB} but its version "
+        "OpenCSD found at ${OPENCSD_C_LIB} but its version "
         "(${OPENCSD_VERSION}) is older than the required "
         "${LLVM_OPENCSD_MIN_VERSION}. Install a newer OpenCSD or "
         "configure with -DLLVM_ENABLE_OPENCSD=OFF.")

--- a/llvm/test/tools/llvm-profgen/etm-arch.test
+++ b/llvm/test/tools/llvm-profgen/etm-arch.test
@@ -1,6 +1,6 @@
 ; REQUIRES: opencsd, arm-registered-target
 ; RUN: split-file %s %t
-; RUN: printf '\x80' > %t.etm
+; RUN: printf '\200' > %t.etm
 
 ; Test 1: ARM binary with Cortex-M attributes should pass.
 ; RUN: yaml2obj %t/arm-valid.yaml -o %t.arm.valid.bin

--- a/llvm/test/tools/llvm-profgen/etm-opencsd.test
+++ b/llvm/test/tools/llvm-profgen/etm-opencsd.test
@@ -2,7 +2,7 @@
 ; RUN: yaml2obj %S/Inputs/etm-opencsd.yaml -o %t.bin
 
 ; Verify ETM trace decoding using OpenCSD with inlined trace data.
-; RUN: printf "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x83\x01\x9a\x4f\x00\x00\x96\x81\x9a\xfc\xfe\xfa\xf8\xfd\xfd\xd6\xfd\xfd\xc1" > %t.trace
+; RUN: printf "\000\000\000\000\000\000\000\000\000\000\000\200\001\000\203\001\232\117\000\000\226\201\232\374\376\372\370\375\375\326\375\375\301" > %t.trace
 
 ; Run the generator to produce the output file.
 ; RUN: llvm-profgen --etm=%t.trace --binary=%t.bin --output=%t.prof --format=text
@@ -13,7 +13,7 @@
 ; RUN: ls %t2.prof
 
 ; Verify error handling when no synchronization header (0x80) is found.
-; RUN: printf "\x00\x00\x00" > %t.nosync
+; RUN: printf "\000\000\000" > %t.nosync
 ; RUN: not llvm-profgen --etm=%t.nosync --binary=%t.bin --output=%t3.prof 2>&1 | FileCheck %s --check-prefix=NOSYNC
 
 ; NOSYNC: error: No synchronization header (0x80) found in the bitstream.


### PR DESCRIPTION
1) Replace non-portable hex escapes in printf with POSIX-compliant octal escapes in etm tests to fix
failures on Mac.

2) Define OCSD_USE_STATIC_C_API when building
LLVMProfileData on Windows to prevent incorrect dllimport interpretation when linking against static OpenCSD libraries.

3) Update ProfileData to use the OPENCSD_ROOT hint when resolving dependency paths and to support linking both static libraries for OpenCSD.