### PR TITLE
[OpenMP] Fix -Wunused-variable

### DIFF
--- a/llvm/lib/Frontend/OpenMP/DirectiveNameParser.cpp
+++ b/llvm/lib/Frontend/OpenMP/DirectiveNameParser.cpp
@@ -61,7 +61,8 @@ DirectiveNameParser::insertTransition(State *From, StringRef Tok) {
   if (State *Next = From->next(Tok))
     return Next;
 
-  auto [Where, DidIt] = From->Transition->try_emplace(Tok, State());
+  [[maybe_unused]] auto [Where, DidIt] =
+      From->Transition->try_emplace(Tok, State());
   assert(DidIt && "Map insertion failed");
   return &Where->second;
 }


### PR DESCRIPTION
DidIt is only used inside an assert, so mark the structured binding `[[maybe_unused]]` to avoid a warning in non-asserts builds