### PR TITLE
[HIP] Defer zero-length array diagnostics in host device functions

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9058,7 +9058,9 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     }
   }
 
-  // zero sized static arrays are not allowed in HIP device functions
+  // Zero-sized static arrays are not allowed in HIP device functions. For
+  // host/device functions this is only a device-side issue if the function is
+  // actually emitted for the device, so defer the diagnostic until then.
   if (getLangOpts().HIP && LangOpts.CUDAIsDevice) {
     if (FunctionDecl *FD = getCurFunctionDecl();
         FD &&
@@ -9066,7 +9068,9 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
       if (const ConstantArrayType *ArrayT =
               getASTContext().getAsConstantArrayType(T);
           ArrayT && ArrayT->isZeroSize()) {
-        Diag(NewVD->getLocation(), diag::err_typecheck_zero_array_size) << 2;
+        CUDA().DiagIfDeviceCode(NewVD->getLocation(),
+                                diag::err_typecheck_zero_array_size)
+            << 2;
       }
     }
   }

--- a/clang/test/SemaCUDA/zero-length-array-deferred.cu
+++ b/clang/test/SemaCUDA/zero-length-array-deferred.cu
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 -fsyntax-only -x hip -fcuda-is-device -triple amdgcn \
+// RUN:   -verify %s
+// RUN: %clang_cc1 -fsyntax-only -x hip -fcuda-is-device -triple amdgcn \
+// RUN:   -verify=device-use -DDEVICE_USE %s
+
+#include "Inputs/cuda.h"
+
+static __host__ __device__ int host_only_hd_array() {
+  int arr[0] = {};
+  return sizeof(arr);
+}
+
+static constexpr __host__ __device__ int host_only_hd_constexpr_array() {
+  int arr[0] = {};
+  return sizeof(arr);
+}
+
+static __host__ __device__ int host_only_hd_lambda_array() {
+  auto lambda = [] {
+    int arr[0] = {};
+    return sizeof(arr);
+  };
+  return lambda();
+}
+
+static __host__ int host_caller() {
+  return host_only_hd_array() + host_only_hd_constexpr_array() +
+         host_only_hd_lambda_array();
+}
+
+void host_use() {
+  (void)host_caller();
+}
+
+// expected-no-diagnostics
+
+#ifdef DEVICE_USE
+static __host__ __device__ int device_used_hd_array() {
+  int arr[0] = {};
+  // device-use-error@-1 {{zero-length arrays}}
+  return sizeof(arr);
+}
+
+static constexpr __host__ __device__ int device_used_hd_constexpr_array() {
+  int arr[0] = {};
+  // device-use-error@-1 {{zero-length arrays}}
+  return sizeof(arr);
+}
+
+static __host__ __device__ int device_used_hd_lambda_array() {
+  auto lambda = [] {
+    int arr[0] = {};
+    // device-use-error@-1 {{zero-length arrays}}
+    return sizeof(arr);
+  };
+  return lambda();
+  // device-use-note@-1 {{called by 'device_used_hd_lambda_array'}}
+}
+
+__global__ void kernel(int *out) {
+  *out = device_used_hd_array();
+  // device-use-note@-1 {{called by 'kernel'}}
+  *out += device_used_hd_constexpr_array();
+  // device-use-note@-1 {{called by 'kernel'}}
+  *out += device_used_hd_lambda_array();
+  // device-use-note@-1 {{called by 'kernel'}}
+}
+#endif


### PR DESCRIPTION
Zero-length arrays are currently allowed in host compilation but rejected in HIP
device compilation. For a host/device function, Clang diagnosed this
immediately instead of deferring it, so C++ headers could become unusable by
HIP programs when a constexpr function or lambda contained a zero-length array.

Defer the diagnostic for host/device functions so it is only emitted when the
function is actually emitted on the device side.

