### PR TITLE
[VectorUtils] Fix -Wunused-variable

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -786,7 +786,8 @@ private:
   /// \returns the newly created interleave group.
   InterleaveGroup<Instruction> *
   createInterleaveGroup(Instruction *Instr, int Stride, Align Alignment) {
-    auto [It, Inserted] = InterleaveGroupMap.try_emplace(Instr);
+    [[maybe_unused]] auto [It, Inserted] =
+        InterleaveGroupMap.try_emplace(Instr);
     assert(Inserted && "Already in an interleaved access group");
     It->second = new InterleaveGroup<Instruction>(Instr, Stride, Alignment);
     InterleaveGroups.insert(It->second);


### PR DESCRIPTION
Inserted is only used inside an assert, so mark the structured binding `[[maybe_unused]]` to avoid a warning in non-asserts builds.