### PR TITLE
[CodeGen][test][NFC] Quote the llc `-passes` arg

### DIFF
--- a/llvm/test/CodeGen/X86/machinesink-debug-inv-0.mir
+++ b/llvm/test/CodeGen/X86/machinesink-debug-inv-0.mir
@@ -3,7 +3,7 @@
 # RUN: llc -mtriple=x86_64 -machine-sink-load-instrs-threshold=2 -run-pass=mir-debugify,machine-sink,mir-strip-debug %s -o - | FileCheck %s
 
 # RUN: llc -mtriple=x86_64 -machine-sink-load-instrs-threshold=2 -passes=machine-sink %s -o - | FileCheck %s
-# RUN: llc -mtriple=x86_64 -machine-sink-load-instrs-threshold=2 -passes=mir-debugify,function(machine-function(machine-sink)),mir-strip-debug %s -o - | FileCheck %s
+# RUN: llc -mtriple=x86_64 -machine-sink-load-instrs-threshold=2 -passes='mir-debugify,function(machine-function(machine-sink)),mir-strip-debug' %s -o - | FileCheck %s
 
 # Verify that machine-sink pass is debug invariant wrt to given input. Since
 # the pass examines MemOperands the IR is required for the original bug to


### PR DESCRIPTION
The arg `-passes=mir-debugify,function(machine-function(machine-sink)),mir-strip-debug` only works w/ the lit built in shell, it causes problems when using a shell to evaluate this command (e.g. `syntax error near unexpected token '('`)