### PR TITLE
[NFC][SPIR-V] Rename vID register class to viID

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1462,7 +1462,7 @@ static bool generateGroupInst(const SPIRV::IncomingCall *Call,
     unsigned VecLen = Call->Arguments.size() - 1;
     VecReg = MRI->createGenericVirtualRegister(
         LLT::fixed_vector(VecLen, MRI->getType(ElemReg)));
-    MRI->setRegClass(VecReg, &SPIRV::vIDRegClass);
+    MRI->setRegClass(VecReg, &SPIRV::viIDRegClass);
     SPIRVTypeInst VecType =
         GR->getOrCreateSPIRVVectorType(ElemType, VecLen, MIRBuilder, true);
     GR->assignSPIRVTypeToVReg(VecType, VecReg, MIRBuilder.getMF());
@@ -2175,7 +2175,7 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
                             : 32;
     QueryResult = MIRBuilder.getMRI()->createGenericVirtualRegister(
         LLT::fixed_vector(NumActualRetComponents, Bitwidth));
-    MIRBuilder.getMRI()->setRegClass(QueryResult, &SPIRV::vIDRegClass);
+    MIRBuilder.getMRI()->setRegClass(QueryResult, &SPIRV::viIDRegClass);
     SPIRVTypeInst IntTy = GR->getOrCreateSPIRVIntegerType(Bitwidth, MIRBuilder);
     QueryResultType = GR->getOrCreateSPIRVVectorType(
         IntTy, NumActualRetComponents, MIRBuilder, true);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -2099,7 +2099,7 @@ SPIRVGlobalRegistry::getRegClass(SPIRVTypeInst SpvType) const {
       return &SPIRV::vfIDRegClass;
     if (ElemOpcode == SPIRV::OpTypePointer)
       return &SPIRV::vpIDRegClass;
-    return &SPIRV::vIDRegClass;
+    return &SPIRV::viIDRegClass;
   }
   }
   return &SPIRV::iIDRegClass;

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -177,7 +177,7 @@ SPIRVTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
   if (VT.isFloatingPoint())
     RC = VT.isVector() ? &SPIRV::vfIDRegClass : &SPIRV::fIDRegClass;
   else if (VT.isInteger())
-    RC = VT.isVector() ? &SPIRV::vIDRegClass : &SPIRV::iIDRegClass;
+    RC = VT.isVector() ? &SPIRV::viIDRegClass : &SPIRV::iIDRegClass;
   else
     RC = &SPIRV::iIDRegClass;
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -50,35 +50,35 @@ multiclass BinOpTypedGen<string name, bits<16> opCode, SDNode node, bit genF = 0
     if genF then
       def V: BinOpTyped<name, opCode, vfID, node>;
     else
-      def V: BinOpTyped<name, opCode, vID, node>;
+      def V: BinOpTyped<name, opCode, viID, node>;
   }
 }
 
 multiclass TernOpTypedGen<string name, bits<16> opCode, SDNode node, bit genP = 1, bit genI = 1, bit genF = 0, bit genV = 0> {
   if genP then {
     def SPSCond: TernOpTyped<name, opCode, iID, pID, node>;
-    def SPVCond: TernOpTyped<name, opCode, vID, pID, node>;
+    def SPVCond: TernOpTyped<name, opCode, viID, pID, node>;
   }
   if genI then {
     def SISCond: TernOpTyped<name, opCode, iID, iID, node>;
-    def SIVCond: TernOpTyped<name, opCode, vID, iID, node>;
+    def SIVCond: TernOpTyped<name, opCode, viID, iID, node>;
   }
   if genF then {
     def SFSCond: TernOpTyped<name, opCode, iID, fID, node>;
-    def SFVCond: TernOpTyped<name, opCode, vID, fID, node>;
+    def SFVCond: TernOpTyped<name, opCode, viID, fID, node>;
   }
   if genV then {
     if genP then {
       def VPSCond: TernOpTyped<name, opCode, iID, vpID, node>;
-      def VPVCond: TernOpTyped<name, opCode, vID, vpID, node>;
+      def VPVCond: TernOpTyped<name, opCode, viID, vpID, node>;
     }
     if genI then {
-      def VISCond: TernOpTyped<name, opCode, iID, vID, node>;
-      def VIVCond: TernOpTyped<name, opCode, vID, vID, node>;
+      def VISCond: TernOpTyped<name, opCode, iID, viID, node>;
+      def VIVCond: TernOpTyped<name, opCode, viID, viID, node>;
     }
     if genF then {
       def VFSCond: TernOpTyped<name, opCode, iID, vfID, node>;
-      def VFVCond: TernOpTyped<name, opCode, vID, vfID, node>;
+      def VFVCond: TernOpTyped<name, opCode, viID, vfID, node>;
     }
   }
 }

--- a/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
@@ -29,14 +29,14 @@ let Namespace = "SPIRV" in {
   def ID0 : Register<"ID0">;
   def fID0 : Register<"fID0">;
   def pID0 : Register<"pID0">;
-  def vID0 : Register<"vID0">;
+  def viID0 : Register<"viID0">;
   def vfID0 : Register<"vfID0">;
   def vpID0 : Register<"vpID0">;
 
   def iID : RegisterClass<"SPIRV", [i64], 64, (add ID0)>;
   def fID : RegisterClass<"SPIRV", [f64], 64, (add fID0)>;
   def pID : RegisterClass<"SPIRV", [p64], 64, (add pID0)>;
-  def vID : RegisterClass<"SPIRV", [v2i64], 64, (add vID0)>;
+  def viID : RegisterClass<"SPIRV", [v2i64], 64, (add viID0)>;
   def vfID : RegisterClass<"SPIRV", [v2f64], 64, (add vfID0)>;
   def vpID : RegisterClass<"SPIRV", [v2p64], 64, (add vpID0)>;
   
@@ -44,7 +44,7 @@ let Namespace = "SPIRV" in {
       "SPIRV",
       [i64, f64, p64, v2i64, v2f64, v2p64],
       64,
-      (add iID, fID, pID, vID, vfID, vpID)>;
+      (add iID, fID, pID, viID, vfID, vpID)>;
 
   // A few instructions like OpName can take ids from both type and non-type
   // instructions, so we need a super-class to allow for both to count as valid


### PR DESCRIPTION
Rename the v2i64 register and its class from vID/vID0 to viID/viID0 so it follows the same `v<element-kind>ID` convention as vfID (v2f64) and vpID (v2p64) for better consistency