### PR TITLE
[compiler-rt] Add MSVC CRT flags to ASan coverage test

### DIFF
--- a/compiler-rt/test/asan/TestCases/asan_and_llvm_coverage_test.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_and_llvm_coverage_test.cpp
@@ -1,4 +1,8 @@
-// RUN: %clangxx_asan -coverage -O0 %s -o %t
+// RUN: %clangxx_asan -coverage -O0 \
+// RUN:   %if target={{.*-windows-msvc.*}} %{ \
+// RUN:     -D_MT -D_DLL \
+// RUN:     -Wl,-nodefaultlib:libcmt,-defaultlib:msvcrt,-defaultlib:oldnames \
+// RUN:   %} %s -o %t
 // RUN: %env_asan_opts=check_initialization_order=1 %run %t 2>&1 | FileCheck %s
 
 #include <stdio.h>


### PR DESCRIPTION
The ASan coverage test also links clang_rt.profile because it uses
-coverage. On Windows MSVC, this can fail if the test is linked with the
static CRT but clang_rt.profile was built with the dynamic CRT.

For example, a profile runtime that uses /MD may reference DLL CRT symbols
such as __imp_* symbols. Add the same dynamic CRT flags directly to this
one test on Windows MSVC so it keeps linking when clang_rt.profile changes.
