### PR TITLE
clang: Use Triple::isCompatibleWith to match OpenMP arguments

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1897,7 +1897,7 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOpenMPTargetArgs(
       llvm::Triple TT = normalizeOffloadTriple(A->getValue(0));
 
       // Passing device args: -Xopenmp-target=<triple> -opt=val.
-      if (TT.getTriple() == getTripleString())
+      if (TT.isCompatibleWith(getTriple()))
         Index = Args.getBaseArgs().MakeIndex(A->getValue(1));
       else
         continue;

--- a/clang/test/Driver/openmp-offload.c
+++ b/clang/test/Driver/openmp-offload.c
@@ -222,3 +222,14 @@
 // RUN:     --offload-arch=znver4 %s 2>&1 | FileCheck -check-prefix=CHK-CPU-ARCH-X %s
 // CHK-CPU-ARCH-X: "-cc1" "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-target-cpu" "x86-64"
 // CHK-CPU-ARCH-X: "-cc1" "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-target-cpu" "znver4"
+
+/// ###########################################################################
+
+/// Check thumbv7 triples are considered compatible with armv7 triples, thus forwarding -mcpu=cortex-a7
+/// FIXME: If these triples are swapped, there is an assert
+// RUN:   %clang -### -no-canonical-prefixes -fopenmp=libomp -fopenmp-targets=thumbv7-pc-linux-gnu -Xopenmp-target=armv7-pc-linux-gnu -mcpu=cortex-a7 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-COMPAT-TRIPLE %s
+
+// CHK-COMPAT-TRIPLE: clang{{.*}} "-cc1" "-triple" "armv7-pc-linux-gnu"
+// CHK-COMPAT-TRIPLE-SAME: "-target-cpu" "cortex-a7"
+// CHK-COMPAT-TRIPLE-SAME: "-fopenmp-is-target-device"


### PR DESCRIPTION
Previously this was performing an exact string comparison
of the triple. Use the triple predicate so that in the future
amdgpu triples without a subarch will be considered compatible
with triples that do. This preserves compatibility with existing
uses without a subarch.

Note that if you swap the triples, there's an assert in
buildCompilerRTBasename but this appears to be a pre-existing
issue I can reproduce without the patch (but I can't reproduce
on godbolt for some reason).