### PR TITLE
[mlir][ABI] Add Test target + classification injection helper

### DIFF
--- a/mlir/include/mlir/ABI/Targets/Test/TestTarget.h
+++ b/mlir/include/mlir/ABI/Targets/Test/TestTarget.h
@@ -1,0 +1,98 @@
+//===- TestTarget.h - Predictable test ABI target --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the test ABI target, a predictable, dialect-agnostic
+// classifier used to exercise the MLIR ABIRewriteContext infrastructure
+// without depending on any real ABI.  See TestTarget.cpp for the rules
+// and the rationale.
+//
+// It also declares parseClassificationAttr, the helper used by the
+// classification-injection driver: tests can attach an arbitrary
+// FunctionClassification to a function via a plain mlir::DictionaryAttr,
+// and the rewriter pass reads it back through this parser.  This lets
+// tests verify rewriter output against any classification (including
+// shapes the test target itself doesn't produce) without needing a real
+// ABIInfo.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ABI_TARGETS_TEST_TESTTARGET_H
+#define MLIR_ABI_TARGETS_TEST_TESTTARGET_H
+
+#include "mlir/ABI/ABIRewriteContext.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/DataLayoutInterfaces.h"
+#include "llvm/Support/Error.h"
+
+namespace mlir {
+namespace abi {
+namespace test {
+
+/// Classify a function signature using the test target's predictable rules.
+///
+/// The rules approximate x86_64 SysV thresholds for reviewer familiarity
+/// (see TestTarget.cpp for the full list) but are not a substitute for
+/// testing against a real ABIInfo.  Real-ABI-shaped tests should use the
+/// classification-injection driver via `parseClassificationAttr` below.
+///
+/// \param argTypes   Argument types of the function.
+/// \param returnType Return type of the function.
+/// \param dl         DataLayout used for size and alignment queries.
+FunctionClassification classify(ArrayRef<Type> argTypes, Type returnType,
+                                const DataLayout &dl);
+
+/// Parse a `FunctionClassification` from a plain MLIR DictionaryAttr.
+///
+/// Schema (all keys are required unless marked optional):
+///
+///   {
+///     return = { kind = "<kind>", ...per-kind keys... },
+///     args   = [ { kind = "<kind>", ...per-kind keys... }, ... ]
+///   }
+///
+/// Per-arg/return dictionary keys:
+///   kind: StringAttr.  One of "direct", "extend", "indirect",
+///         "ignore", "expand".
+///
+/// For kind = "direct" (all optional):
+///   coerced_type:  TypeAttr.  ABI-coerced type, if different from the
+///                  original.
+///   can_flatten:   BoolAttr.  Defaults to true.
+///
+/// For kind = "extend" (coerced_type required, sign_extend optional):
+///   coerced_type:  TypeAttr.  Required; the extended integer type.
+///   sign_extend:   BoolAttr.  Defaults to false (zero-extend).
+///
+/// For kind = "indirect" (indirect_align required, byval optional):
+///   indirect_align: IntegerAttr.  Required; alignment of the pointed-to
+///                   object in bytes.
+///   byval:          BoolAttr.  Defaults to true.
+///
+/// For kind = "ignore" / "expand": no extra keys.
+///
+/// Future schema additions tracked in projects/daily_log.md (Step 0c
+/// field-mapping table).  When we add new fields to ArgClassification
+/// (e.g. direct_offset, extend_kind tristate, indirect_addr_space,
+/// indirect_realign), the corresponding optional keys go here.
+///
+/// Unknown keys cause a parse error (no silent ignore — keeps schema
+/// honest as it grows).
+///
+/// \param attr   The dictionary attribute to parse.
+/// \param emitError  Diagnostic sink for parse errors.
+/// \returns The parsed classification, or std::nullopt on error.
+std::optional<FunctionClassification>
+parseClassificationAttr(DictionaryAttr attr,
+                        function_ref<InFlightDiagnostic()> emitError);
+
+} // namespace test
+} // namespace abi
+} // namespace mlir
+
+#endif // MLIR_ABI_TARGETS_TEST_TESTTARGET_H

--- a/mlir/lib/ABI/CMakeLists.txt
+++ b/mlir/lib/ABI/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(MLIRABI
   ABITypeMapper.cpp
+  Targets/Test/TestTarget.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/ABI

--- a/mlir/lib/ABI/Targets/Test/TestTarget.cpp
+++ b/mlir/lib/ABI/Targets/Test/TestTarget.cpp
@@ -1,0 +1,260 @@
+//===- TestTarget.cpp - Predictable test ABI target ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// **NOT A REAL ABI TARGET.**
+//
+// This file implements a predictable, dialect-agnostic ABI classifier for
+// testing the MLIR ABIRewriteContext infrastructure.  The rules approximate
+// x86_64 SysV thresholds (Direct / Extend / Indirect / Ignore / Expand) so
+// the generated classifications are familiar to reviewers, but they are
+// NOT a substitute for testing against the real x86_64 ABIInfo.  Real
+// ABI targets live alongside the LLVM ABI library in `llvm/lib/ABI/Targets/`.
+//
+// Real-ABI-shaped tests use the classification-injection driver via
+// `parseClassificationAttr`, which lets tests construct any
+// FunctionClassification (including shapes the test target itself does
+// not produce) by attaching a DictionaryAttr to the function.
+//
+// Rules:
+//   - mlir::NoneType                           → Ignore
+//   - IntegerType with width < 32              → Extend (zero-extend by
+//                                                default; tests using the
+//                                                injection driver can
+//                                                override to signed)
+//   - IntegerType with width >= 32             → Direct
+//   - FloatType, VectorType, MemRefType        → Direct
+//   - Anything else with DataLayout size 0     → Ignore
+//   - Anything else with DataLayout size <= 16 → Direct (coerced to the
+//                                                same type — no actual
+//                                                coercion in the test
+//                                                target; PR C handles
+//                                                non-trivial coercion)
+//   - Anything else with DataLayout size > 16  → Indirect with byval=true
+//                                                (sret on returns) and
+//                                                alignment from
+//                                                DataLayout
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/Targets/Test/TestTarget.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/Support/Alignment.h"
+
+using namespace mlir;
+using namespace mlir::abi;
+using namespace mlir::abi::test;
+
+namespace {
+
+/// Indirect-vs-direct cutoff in bytes.  Chosen to match x86_64 SysV's
+/// 16-byte register-passing window for reviewer familiarity.
+constexpr uint64_t IndirectCutoffBytes = 16;
+
+/// Below this width (in bits) integers get an extension attribute.
+/// Chosen to match x86_64 SysV (32-bit register width) for reviewer
+/// familiarity.
+constexpr unsigned ExtendBelowBits = 32;
+
+ArgClassification classifyOne(Type type, const DataLayout &dl) {
+  if (isa<NoneType>(type))
+    return ArgClassification::getIgnore();
+
+  if (auto intTy = dyn_cast<IntegerType>(type)) {
+    if (intTy.getWidth() < ExtendBelowBits) {
+      Type i32Ty = IntegerType::get(type.getContext(), ExtendBelowBits);
+      return ArgClassification::getExtend(i32Ty, /*signExt=*/intTy.isSigned());
+    }
+    return ArgClassification::getDirect();
+  }
+
+  if (auto indexTy = dyn_cast<IndexType>(type)) {
+    llvm::TypeSize sizeInBits = dl.getTypeSizeInBits(indexTy);
+    if (sizeInBits.getFixedValue() < ExtendBelowBits) {
+      Type i32Ty = IntegerType::get(type.getContext(), ExtendBelowBits);
+      return ArgClassification::getExtend(i32Ty, /*signExt=*/true);
+    }
+    return ArgClassification::getDirect();
+  }
+
+  if (isa<FloatType, VectorType, MemRefType>(type))
+    return ArgClassification::getDirect();
+
+  // For dialect-specific types: query DataLayout via
+  // DataLayoutTypeInterface.  Types that don't implement the interface
+  // (e.g. dialect-specific void / unit-style sentinel types used as a
+  // function's "no return value" marker) are treated as Ignore so that
+  // the test target degrades gracefully rather than crashing on unknown
+  // types.
+  if (!isa<DataLayoutTypeInterface>(type))
+    return ArgClassification::getIgnore();
+
+  llvm::TypeSize sizeInBits = dl.getTypeSizeInBits(type);
+  if (sizeInBits.isZero())
+    return ArgClassification::getIgnore();
+
+  uint64_t sizeInBytes = (sizeInBits.getFixedValue() + 7) / 8;
+  if (sizeInBytes <= IndirectCutoffBytes)
+    return ArgClassification::getDirect();
+
+  uint64_t alignBytes = dl.getTypeABIAlignment(type);
+  return ArgClassification::getIndirect(llvm::Align(alignBytes),
+                                        /*byVal=*/true);
+}
+
+} // namespace
+
+FunctionClassification mlir::abi::test::classify(ArrayRef<Type> argTypes,
+                                                 Type returnType,
+                                                 const DataLayout &dl) {
+  FunctionClassification fc;
+  fc.returnInfo = classifyOne(returnType, dl);
+  fc.argInfos.reserve(argTypes.size());
+  for (Type t : argTypes)
+    fc.argInfos.push_back(classifyOne(t, dl));
+  return fc;
+}
+
+namespace {
+
+/// Set of dictionary keys this parser knows about.  Any key not in this
+/// set causes a parse error (no silent ignore).  Updated when new
+/// optional keys are added to the schema.
+constexpr StringRef knownArgKeys[] = {
+    "kind",        "coerced_type",   "sign_extend",
+    "can_flatten", "indirect_align", "byval",
+};
+
+bool isKnownArgKey(StringRef key) {
+  for (StringRef k : knownArgKeys)
+    if (k == key)
+      return true;
+  return false;
+}
+
+/// Parse a single ArgClassification dictionary.  Returns std::nullopt on
+/// any error (with the diagnostic emitted via \p emitError).
+std::optional<ArgClassification>
+parseOne(DictionaryAttr argDict, function_ref<InFlightDiagnostic()> emitError) {
+  StringAttr kindAttr = argDict.getAs<StringAttr>("kind");
+  if (!kindAttr) {
+    emitError() << "missing required 'kind' StringAttr";
+    return std::nullopt;
+  }
+
+  for (NamedAttribute na : argDict)
+    if (!isKnownArgKey(na.getName().getValue())) {
+      emitError() << "unknown key '" << na.getName().getValue()
+                  << "' in classification dictionary; allowed keys are "
+                  << "kind, coerced_type, sign_extend, can_flatten, "
+                  << "indirect_align, byval";
+      return std::nullopt;
+    }
+
+  StringRef kind = kindAttr.getValue();
+
+  if (kind == "direct") {
+    Type coerced;
+    if (auto t = argDict.getAs<TypeAttr>("coerced_type"))
+      coerced = t.getValue();
+    auto c = ArgClassification::getDirect(coerced);
+    if (auto cf = argDict.getAs<BoolAttr>("can_flatten"))
+      c.canFlatten = cf.getValue();
+    return c;
+  }
+
+  if (kind == "extend") {
+    auto coerced = argDict.getAs<TypeAttr>("coerced_type");
+    if (!coerced) {
+      emitError() << "kind='extend' requires 'coerced_type' TypeAttr";
+      return std::nullopt;
+    }
+    bool signExt = false;
+    if (auto se = argDict.getAs<BoolAttr>("sign_extend"))
+      signExt = se.getValue();
+    return ArgClassification::getExtend(coerced.getValue(), signExt);
+  }
+
+  if (kind == "indirect") {
+    auto align = argDict.getAs<IntegerAttr>("indirect_align");
+    if (!align) {
+      emitError() << "kind='indirect' requires 'indirect_align' IntegerAttr";
+      return std::nullopt;
+    }
+    if (align.getInt() <= 0 || !llvm::isPowerOf2_64(align.getInt())) {
+      emitError() << "'indirect_align' must be a positive power of 2; got "
+                  << align.getInt();
+      return std::nullopt;
+    }
+    bool byVal = true;
+    if (auto bv = argDict.getAs<BoolAttr>("byval"))
+      byVal = bv.getValue();
+    return ArgClassification::getIndirect(llvm::Align(align.getInt()), byVal);
+  }
+
+  if (kind == "ignore") {
+    return ArgClassification::getIgnore();
+  }
+
+  if (kind == "expand") {
+    ArgClassification c;
+    c.kind = ArgKind::Expand;
+    return c;
+  }
+
+  emitError() << "unknown kind='" << kind
+              << "'; expected one of direct, extend, indirect, ignore, expand";
+  return std::nullopt;
+}
+
+} // namespace
+
+std::optional<FunctionClassification> mlir::abi::test::parseClassificationAttr(
+    DictionaryAttr attr, function_ref<InFlightDiagnostic()> emitError) {
+  auto returnDict = attr.getAs<DictionaryAttr>("return");
+  if (!returnDict) {
+    emitError() << "missing required 'return' DictionaryAttr";
+    return std::nullopt;
+  }
+
+  auto argsArr = attr.getAs<ArrayAttr>("args");
+  if (!argsArr) {
+    emitError() << "missing required 'args' ArrayAttr";
+    return std::nullopt;
+  }
+
+  for (NamedAttribute na : attr) {
+    StringRef k = na.getName().getValue();
+    if (k != "return" && k != "args") {
+      emitError() << "unknown top-level key '" << k
+                  << "'; only 'return' and 'args' are allowed";
+      return std::nullopt;
+    }
+  }
+
+  FunctionClassification fc;
+
+  std::optional<ArgClassification> ret = parseOne(returnDict, emitError);
+  if (!ret)
+    return std::nullopt;
+  fc.returnInfo = *ret;
+
+  fc.argInfos.reserve(argsArr.size());
+  for (Attribute a : argsArr) {
+    auto d = dyn_cast<DictionaryAttr>(a);
+    if (!d) {
+      emitError() << "'args' entries must be DictionaryAttrs";
+      return std::nullopt;
+    }
+    std::optional<ArgClassification> ac = parseOne(d, emitError);
+    if (!ac)
+      return std::nullopt;
+    fc.argInfos.push_back(*ac);
+  }
+
+  return fc;
+}

--- a/mlir/unittests/ABI/CMakeLists.txt
+++ b/mlir/unittests/ABI/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_unittest(MLIRABITests
   ABIRewriteContextTest.cpp
   ABITypeMapperTest.cpp
+  TestTargetTest.cpp
 )
 
 mlir_target_link_libraries(MLIRABITests

--- a/mlir/unittests/ABI/TestTargetTest.cpp
+++ b/mlir/unittests/ABI/TestTargetTest.cpp
@@ -1,0 +1,327 @@
+//===- TestTargetTest.cpp - Unit tests for the test ABI target -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ABI/Targets/Test/TestTarget.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::abi;
+using namespace mlir::abi::test;
+
+namespace {
+
+class TestTargetClassifyTest : public ::testing::Test {
+protected:
+  TestTargetClassifyTest()
+      : module(ModuleOp::create(UnknownLoc::get(&context))), dl(*module) {
+    context.loadDialect<DLTIDialect>();
+  }
+
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module;
+  DataLayout dl;
+};
+
+TEST_F(TestTargetClassifyTest, IgnoresNoneType) {
+  auto noneTy = NoneType::get(&context);
+  FunctionClassification fc = classify({}, noneTy, dl);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Ignore);
+}
+
+TEST_F(TestTargetClassifyTest, ExtendsNarrowSignedInteger) {
+  auto i8 = IntegerType::get(&context, 8, IntegerType::Signed);
+  FunctionClassification fc = classify({i8}, NoneType::get(&context), dl);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Extend);
+  EXPECT_TRUE(fc.argInfos[0].signExtend);
+  auto coerced = dyn_cast<IntegerType>(fc.argInfos[0].coercedType);
+  ASSERT_TRUE(coerced);
+  EXPECT_EQ(coerced.getWidth(), 32u);
+}
+
+TEST_F(TestTargetClassifyTest, ExtendsNarrowSignlessIntegerAsZeroExt) {
+  auto i8 = IntegerType::get(&context, 8);
+  FunctionClassification fc = classify({i8}, NoneType::get(&context), dl);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Extend);
+  EXPECT_FALSE(fc.argInfos[0].signExtend);
+}
+
+TEST_F(TestTargetClassifyTest, RegisterSizedIntegerIsDirect) {
+  auto i32 = IntegerType::get(&context, 32);
+  auto i64 = IntegerType::get(&context, 64);
+  FunctionClassification fc = classify({i32, i64}, NoneType::get(&context), dl);
+  ASSERT_EQ(fc.argInfos.size(), 2u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+  EXPECT_EQ(fc.argInfos[1].kind, ArgKind::Direct);
+}
+
+TEST_F(TestTargetClassifyTest, IndexTypeIsDirect) {
+  // The default DataLayout reports IndexType as 64 bits, which is at or above
+  // the extension threshold and should classify as Direct.
+  auto idx = IndexType::get(&context);
+  FunctionClassification fc = classify({idx}, idx, dl);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Direct);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+}
+
+TEST_F(TestTargetClassifyTest, FloatIsDirect) {
+  auto f32 = Float32Type::get(&context);
+  FunctionClassification fc = classify({f32}, f32, dl);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Direct);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+}
+
+TEST_F(TestTargetClassifyTest, FunctionLevelReturnAndArgsClassifiedTogether) {
+  auto i32 = IntegerType::get(&context, 32);
+  auto f64 = Float64Type::get(&context);
+  FunctionClassification fc = classify({i32, f64}, i32, dl);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Direct);
+  ASSERT_EQ(fc.argInfos.size(), 2u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+  EXPECT_EQ(fc.argInfos[1].kind, ArgKind::Direct);
+}
+
+TEST_F(TestTargetClassifyTest,
+       TypeWithoutDataLayoutInterfaceClassifiedAsIgnore) {
+  // FunctionType does not implement DataLayoutTypeInterface.  The classifier
+  // must treat it as Ignore rather than crashing in dl.getTypeSizeInBits().
+  // This guards against the same crash for dialect-specific void / sentinel
+  // types (e.g. cir::VoidType) used as a function's "no return value" marker.
+  auto i32 = IntegerType::get(&context, 32);
+  auto fnTy = FunctionType::get(&context, {i32}, {i32});
+  FunctionClassification fc = classify({}, fnTy, dl);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Ignore);
+}
+
+class TestTargetParseTest : public ::testing::Test {
+protected:
+  TestTargetParseTest() : builder(&context) {
+    // Suppress diagnostic printing during tests; capture into lastError
+    // for assertions instead.
+    context.getDiagEngine().registerHandler([this](Diagnostic &diag) {
+      lastError = diag.str();
+      return success();
+    });
+  }
+
+  /// Convenience: parse and assert success, returning the result.
+  FunctionClassification parseOk(DictionaryAttr attr) {
+    auto loc = UnknownLoc::get(&context);
+    auto result =
+        parseClassificationAttr(attr, [&]() { return mlir::emitError(loc); });
+    EXPECT_TRUE(result.has_value())
+        << "parseClassificationAttr failed: " << lastError;
+    return result.value_or(FunctionClassification{});
+  }
+
+  /// Convenience: parse and assert failure with a substring match.
+  void parseError(DictionaryAttr attr, StringRef expectedSubstr) {
+    auto loc = UnknownLoc::get(&context);
+    lastError.clear();
+    auto result =
+        parseClassificationAttr(attr, [&]() { return mlir::emitError(loc); });
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(lastError.find(expectedSubstr.str()), std::string::npos)
+        << "expected error containing '" << expectedSubstr << "' but got '"
+        << lastError << "'";
+  }
+
+  DictionaryAttr makeArg(ArrayRef<NamedAttribute> entries) {
+    return DictionaryAttr::get(&context, entries);
+  }
+
+  MLIRContext context;
+  OpBuilder builder;
+  std::string lastError;
+};
+
+TEST_F(TestTargetParseTest, ParsesDirectReturnAndOneDirectArg) {
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({direct})),
+  });
+
+  auto fc = parseOk(attr);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Direct);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Direct);
+}
+
+TEST_F(TestTargetParseTest, ParsesExtendWithCoercedTypeAndSignExtend) {
+  auto i32 = IntegerType::get(&context, 32);
+  auto extend = makeArg({
+      builder.getNamedAttr("kind", builder.getStringAttr("extend")),
+      builder.getNamedAttr("coerced_type", TypeAttr::get(i32)),
+      builder.getNamedAttr("sign_extend", builder.getBoolAttr(true)),
+  });
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({extend})),
+  });
+
+  auto fc = parseOk(attr);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Extend);
+  EXPECT_TRUE(fc.argInfos[0].signExtend);
+  EXPECT_EQ(fc.argInfos[0].coercedType, i32);
+}
+
+TEST_F(TestTargetParseTest, ParsesIndirectWithAlignAndByval) {
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto indirect = makeArg({
+      builder.getNamedAttr("kind", builder.getStringAttr("indirect")),
+      builder.getNamedAttr("indirect_align", builder.getI64IntegerAttr(16)),
+      builder.getNamedAttr("byval", builder.getBoolAttr(false)),
+  });
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({indirect})),
+  });
+
+  auto fc = parseOk(attr);
+  ASSERT_EQ(fc.argInfos.size(), 1u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Indirect);
+  EXPECT_EQ(fc.argInfos[0].indirectAlign, llvm::Align(16));
+  EXPECT_FALSE(fc.argInfos[0].byVal);
+}
+
+TEST_F(TestTargetParseTest, ParsesIgnoreAndExpand) {
+  auto ignore =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("ignore"))});
+  auto expand =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("expand"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", ignore),
+      builder.getNamedAttr("args", builder.getArrayAttr({expand, ignore})),
+  });
+
+  auto fc = parseOk(attr);
+  EXPECT_EQ(fc.returnInfo.kind, ArgKind::Ignore);
+  ASSERT_EQ(fc.argInfos.size(), 2u);
+  EXPECT_EQ(fc.argInfos[0].kind, ArgKind::Expand);
+  EXPECT_EQ(fc.argInfos[1].kind, ArgKind::Ignore);
+}
+
+TEST_F(TestTargetParseTest, RejectsMissingReturn) {
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("args", builder.getArrayAttr({direct})),
+  });
+  parseError(attr, "missing required 'return'");
+}
+
+TEST_F(TestTargetParseTest, RejectsMissingArgs) {
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+  });
+  parseError(attr, "missing required 'args'");
+}
+
+TEST_F(TestTargetParseTest, RejectsUnknownTopLevelKey) {
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({})),
+      builder.getNamedAttr("future_field", builder.getStringAttr("hello")),
+  });
+  parseError(attr, "unknown top-level key 'future_field'");
+}
+
+TEST_F(TestTargetParseTest, RejectsUnknownArgKey) {
+  auto badArg = makeArg({
+      builder.getNamedAttr("kind", builder.getStringAttr("direct")),
+      builder.getNamedAttr("future_field", builder.getBoolAttr(true)),
+  });
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({badArg})),
+  });
+  parseError(attr, "unknown key 'future_field'");
+}
+
+TEST_F(TestTargetParseTest, RejectsExtendWithoutCoercedType) {
+  auto badExtend =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("extend"))});
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({badExtend})),
+  });
+  parseError(attr, "kind='extend' requires 'coerced_type'");
+}
+
+TEST_F(TestTargetParseTest, RejectsIndirectWithoutAlign) {
+  auto badIndirect = makeArg(
+      {builder.getNamedAttr("kind", builder.getStringAttr("indirect"))});
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({badIndirect})),
+  });
+  parseError(attr, "kind='indirect' requires 'indirect_align'");
+}
+
+TEST_F(TestTargetParseTest, RejectsIndirectWithNonPowerOfTwoAlign) {
+  auto badIndirect = makeArg({
+      builder.getNamedAttr("kind", builder.getStringAttr("indirect")),
+      builder.getNamedAttr("indirect_align", builder.getI64IntegerAttr(7)),
+  });
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({badIndirect})),
+  });
+  parseError(attr, "must be a positive power of 2");
+}
+
+TEST_F(TestTargetParseTest, RejectsUnknownKind) {
+  auto bad = makeArg(
+      {builder.getNamedAttr("kind", builder.getStringAttr("invalid_kind"))});
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({bad})),
+  });
+  parseError(attr, "unknown kind='invalid_kind'");
+}
+
+TEST_F(TestTargetParseTest, RejectsMissingKind) {
+  auto bad = makeArg({});
+  auto direct =
+      makeArg({builder.getNamedAttr("kind", builder.getStringAttr("direct"))});
+  auto attr = builder.getDictionaryAttr({
+      builder.getNamedAttr("return", direct),
+      builder.getNamedAttr("args", builder.getArrayAttr({bad})),
+  });
+  parseError(attr, "missing required 'kind'");
+}
+
+} // namespace


### PR DESCRIPTION
First in a series of PRs splitting #192119 / #192124 per @andykaylor's review request to break them down by ArgKind and replace the C++ unit tests with `cir-opt`-driven `.cir` tests. This one is dialect-agnostic so it can land before the CIR side.

Two pieces:

1. A test ABI target at `mlir/lib/ABI/Targets/Test/`. Predictable rules approximating x86_64 SysV thresholds (Direct / Extend / Indirect / Ignore). The header and `.cpp` are both explicit that this is not a real ABI target — real ones live next to the LLVM ABI library.

2. A `parseClassificationAttr` helper that reads a plain `DictionaryAttr` and returns a `FunctionClassification`. Lets tests inject any classification (including shapes the test target itself doesn't produce) so rewriter behavior can be validated against real-ABI-shaped expectations without waiting for #194433. The schema is documented in the parser source comment; unknown keys cause a parse error so the schema stays honest as it grows.

The injection schema only covers fields that `mlir::abi::ArgClassification` currently has. Comparing it to `llvm::abi::ArgInfo` (in `llvm/include/llvm/ABI/FunctionInfo.h`) turned up ~5 missing concepts on the MLIR side: `direct_offset` (multi-eightbyte returns), `indirect_addr_space`, `indirect_realign`, an `extend_kind` tristate (we currently collapse to a single bool, losing the no-extend case), and function-level `calling_conv` / `num_required` for variadic. Those get added to the struct and the schema by whichever subsequent PR first needs them, rather than landing here as unused fields.

19 gtest cases for the classifier and parser (well-formed inputs, missing required keys, unknown-key rejection, alignment validation, kind validation). `ninja check-clang-cir-codegen` and `ninja check-clang-cir` both still pass at the previous baseline.

One thing to flag: the test target's automatic classifier never produces the `Expand` kind. That kind is only reachable through the injection driver. Fine for what this PR is for, but worth noting since it's the one ArgKind that doesn't get exercised by the test-target driver.
