### PR TITLE
[PPC] Fix skipped base pointer expansion when using builtin setjmp.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -633,11 +633,12 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   if (!isPPC64 && (!isInt<32>(FrameSize) || !isInt<32>(NegFrameSize)))
     llvm_unreachable("Unhandled stack size!");
 
-  if (MFI.isFrameAddressTaken())
+  PPCFunctionInfo *FI = MF.getInfo<PPCFunctionInfo>();
+
+  if (MFI.isFrameAddressTaken() || FI->hasBuiltinSetJmp())
     replaceFPWithRealFP(MF);
 
   // Check if the link register (LR) must be saved.
-  PPCFunctionInfo *FI = MF.getInfo<PPCFunctionInfo>();
   bool MustSaveLR = FI->mustSaveLR();
   bool MustSaveTOC = FI->mustSaveTOC();
   const SmallVectorImpl<Register> &MustSaveCRs = FI->getMustSaveCRs();

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13449,6 +13449,8 @@ PPCTargetLowering::emitEHSjLjSetJmp(MachineInstr &MI,
 
   MachineFunction *MF = MBB->getParent();
   MachineRegisterInfo &MRI = MF->getRegInfo();
+  PPCFunctionInfo *FuncInfo = MF->getInfo<PPCFunctionInfo>();
+  FuncInfo->setHasBuiltinSetJmp();
 
   const BasicBlock *BB = MBB->getBasicBlock();
   MachineFunction::iterator I = ++MBB->getIterator();

--- a/llvm/lib/Target/PowerPC/PPCMachineFunctionInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCMachineFunctionInfo.h
@@ -155,6 +155,8 @@ private:
   bool AIXFuncUseTLSIEForLD = false;
   bool AIXFuncTLSModelOptInitDone = false;
 
+  bool HasBuiltinSJLJ_SetJmp = false;
+
 public:
   explicit PPCFunctionInfo(const Function &F, const TargetSubtargetInfo *STI);
 
@@ -181,6 +183,9 @@ public:
   void setROPProtectionHashSaveIndex(int Idx) {
     ROPProtectionHashSaveIndex = Idx;
   }
+
+  void setHasBuiltinSetJmp() { HasBuiltinSJLJ_SetJmp = true; }
+  bool hasBuiltinSetJmp() { return HasBuiltinSJLJ_SetJmp; }
 
   unsigned getMinReservedArea() const { return MinReservedArea; }
   void setMinReservedArea(unsigned size) { MinReservedArea = size; }

--- a/llvm/test/CodeGen/PowerPC/setjmp.ll
+++ b/llvm/test/CodeGen/PowerPC/setjmp.ll
@@ -1,0 +1,90 @@
+; RUN: llc < %s -mtriple=powerpc64le-unknown-linux-gnu -mcpu=pwr8 \
+; RUN:   -verify-machineinstrs | FileCheck --check-prefix=CHECK64 %s
+
+; RUN: llc < %s -mtriple=powerpc64le-unknown-linux-gnu -mcpu=pwr8 \
+; RUN:   -ppc-always-use-base-pointer -verify-machineinstrs | \
+; RUN: FileCheck --check-prefix=BP64 %s
+
+; RUN: llc < %s -mtriple=powerpc-unknown-linux-gnu -mcpu=pwr7 \
+; RUN:   -verify-machineinstrs | FileCheck --check-prefix=CHECK32 %s
+
+; RUN: llc < %s -mtriple=powerpc-unknown-linux-gnu -mcpu=pwr7 \
+; RUN:   -ppc-always-use-base-pointer -verify-machineinstrs | \
+; RUN: FileCheck --check-prefix=BP32 %s
+
+; RUN: llc < %s -mtriple=powerpc-unknown-linux-gnu -mcpu=pwr7 \
+; RUN:   -ppc-always-use-base-pointer -verify-machineinstrs \
+; RUN:   -relocation-model=pic | FileCheck --check-prefix=PIC32 %s
+
+@buf = internal global [5 x ptr] zeroinitializer, align 8
+
+declare i32 @llvm.eh.sjlj.setjmp(ptr) nounwind
+
+define i32 @setjmp_with_fp() nounwind #0 {
+  %r = call i32 @llvm.eh.sjlj.setjmp(ptr @buf)
+  ret i32 %r
+}
+
+; CHECK64-LABEL: setjmp_with_fp:
+; CHECK64:         addis [[SCRATCH:[0-9]+]], 2, buf@toc@ha
+; CHECK64:         addi [[BUF:[0-9]+]], [[SCRATCH]], buf@toc@l
+; CHECK64:         std 2, 24([[BUF]])
+; CHECK64:         std 31, 32([[BUF]])
+
+; BP64-LABEL: setjmp_with_fp:
+; BP64:         addis [[SCRATCH:[0-9]+]], 2, buf@toc@ha
+; BP64:         addi [[BUF:[0-9]+]], [[SCRATCH]], buf@toc@l
+; BP64:         std 2, 24([[BUF]])
+; BP64:         std 30, 32([[BUF]])
+
+; CHECK32-LABEL: setjmp_with_fp:
+; CHECK32:         lis [[SCRATCH:[0-9]+]], buf@ha
+; CHECK32:         la [[BUF:[0-9]+]], buf@l([[SCRATCH]])
+; CHECK32:         stw 31, 16([[BUF]])
+
+; BP32-LABEL: setjmp_with_fp:
+; BP32:         lis [[SCRATCH:[0-9]+]], buf@ha
+; BP32:         la [[BUF:[0-9]+]], buf@l([[SCRATCH]])
+; BP32:         stw 30, 16([[BUF]])
+
+; PIC32-LABEL: setjmp_with_fp:
+; PIC32:         lwz [[SCRATCH:[0-9]+]], .L0$poff-.L0$pb(30)
+; PIC32:         add 30, [[SCRATCH]], 30
+; PIC32:         lwz [[BUF:[0-9]+]], .LC0-.LTOC(30)
+; PIC32:         stw 29, 16([[BUF]])
+
+define i32 @setjmp_without_fp() nounwind #1 {
+  %r = call i32 @llvm.eh.sjlj.setjmp(ptr @buf)
+  ret i32 %r
+}
+
+; CHECK64-LABEL: setjmp_without_fp:
+; CHECK64:         addis [[SCRATCH:[0-9]+]], 2, buf@toc@ha
+; CHECK64:         addi [[BUF:[0-9]+]], [[SCRATCH]], buf@toc@l
+; CHECK64:         std 2, 24([[BUF]])
+; CHECK64:         std 1, 32([[BUF]])
+
+; BP64-LABEL: setjmp_without_fp:
+; BP64:         addis [[SCRATCH:[0-9]+]], 2, buf@toc@ha
+; BP64:         addi [[BUF:[0-9]+]], [[SCRATCH]], buf@toc@l
+; BP64:         std 2, 24([[BUF]])
+; BP64:         std 30, 32([[BUF]])
+
+; CHECK32-LABEL: setjmp_without_fp:
+; CHECK32:         lis [[SCRATCH:[0-9]+]], buf@ha
+; CHECK32:         la [[BUF:[0-9]+]], buf@l([[SCRATCH]])
+; CHECK32:         stw 1, 16(3)
+
+; BP32-LABEL: setjmp_without_fp:
+; BP32:         lis [[SCRATCH:[0-9]+]], buf@ha
+; BP32:         la [[BUF:[0-9]+]], buf@l([[SCRATCH]])
+; BP32:         stw 30, 16([[BUF]])
+
+; PIC32-LABEL: setjmp_without_fp:
+; PIC32:         lwz [[SCRATCH:[0-9]+]], .L1$poff-.L1$pb(30)
+; PIC32:         add 30, [[SCRATCH]], 30
+; PIC32:         lwz [[BUF:[0-9]+]], .LC0-.LTOC(30)
+; PIC32:         stw 29, 16([[BUF]])
+
+attributes #0 = { "frame-pointer"="all" }
+attributes #1 = { "frame-pointer"="none" }


### PR DESCRIPTION
When lowering the llvm.eh.sjlj.setjmp intrinsic we create an operand for the base pointer register with the expectation that we would later catch and expand that to the real physical register that we used for the base pointer (or a suitable alternative when we do not otherwise need a base pointer). The expansion would only happen when a frame had its address taken. This PR does the search and replace for BP and FP operands whenever we have an eh.sjlj.setjmp intrinsic also.