### PR TITLE
[RFC][NFCI][Constants] Add `Constant::isZeroValue`

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -82,11 +82,10 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to LLVM infrastructure
 
-* Removed ``Constant::isZeroValue``. It was functionally identical to
-  ``Constant::isNullValue`` for all types except floating-point negative
-  zero. All callers should use ``isNullValue`` instead. ``isZeroValue``
-  will be reintroduced in the future with bitwise-all-zeros semantics
-  to support non-zero null pointers.
+* `Constant::isNullValue` is now an alias of `Constant::isZeroValue`, as they
+  are functionally identical. `Constant::isNullValue` has been deprecated and
+  will be removed in a future release, to be reintroduced with updated semantics
+  once `ConstantPointerNull` changes.
 
 * Added support for specifying the null pointer bit representation per
   address space in `DataLayout`. Pointer specifications (`p`) accept new

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -2393,6 +2393,13 @@ LLVM_C_ABI LLVMValueRef LLVMGetPoison(LLVMTypeRef Ty);
 LLVM_C_ABI LLVMBool LLVMIsNull(LLVMValueRef Val);
 
 /**
+ * Determine whether a value instance is a zero value.
+ *
+ * @see llvm::Constant::isZeroValue()
+ */
+LLVM_C_ABI LLVMBool LLVMIsZeroValue(LLVMValueRef Val);
+
+/**
  * Obtain a constant that is a constant pointer pointing to NULL for a
  * specified type.
  */

--- a/llvm/include/llvm/Analysis/SparsePropagation.h
+++ b/llvm/include/llvm/Analysis/SparsePropagation.h
@@ -326,7 +326,7 @@ void SparseSolver<LatticeKey, LatticeVal, KeyInfo>::getFeasibleSuccessors(
     }
 
     // Constant condition variables mean the branch can only go a single way
-    Succs[C->isNullValue()] = true;
+    Succs[C->isZeroValue()] = true;
     return;
   }
 

--- a/llvm/include/llvm/IR/Constant.h
+++ b/llvm/include/llvm/IR/Constant.h
@@ -52,7 +52,11 @@ public:
   Constant(const Constant &) = delete;
 
   /// Return true if this is the value that would be returned by getNullValue.
-  LLVM_ABI bool isNullValue() const;
+  /// TODO: Remove this after the migration to isZeroValue is complete.
+  LLVM_ABI bool isNullValue() const { return isZeroValue(); }
+
+  /// Return true if the value is zero.
+  LLVM_ABI bool isZeroValue() const;
 
   /// Returns true if the value is one.
   LLVM_ABI bool isOneValue() const;

--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -1248,7 +1248,7 @@ public:
 
   /// Whether there is any non-null address discriminator.
   bool hasAddressDiscriminator() const {
-    return !getAddrDiscriminator()->isNullValue();
+    return !getAddrDiscriminator()->isZeroValue();
   }
 
   Constant *getDeactivationSymbol() const {

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -581,7 +581,7 @@ struct is_zero {
   template <typename ITy> bool match(ITy *V) const {
     auto *C = dyn_cast<Constant>(V);
     // FIXME: this should be able to do something for scalable vectors
-    return C && (C->isNullValue() || cst_pred_ty<is_zero_int>().match(C));
+    return C && (C->isZeroValue() || cst_pred_ty<is_zero_int>().match(C));
   }
 };
 /// Match any null constant or a vector with all elements equal to 0.
@@ -3325,7 +3325,7 @@ struct LogicalOp_match {
 
       if (Opcode == Instruction::And) {
         auto *C = dyn_cast<Constant>(FVal);
-        if (C && C->isNullValue())
+        if (C && C->isZeroValue())
           return (L.match(Cond) && R.match(TVal)) ||
                  (Commutable && L.match(TVal) && R.match(Cond));
       } else {

--- a/llvm/lib/Analysis/BranchProbabilityInfo.cpp
+++ b/llvm/lib/Analysis/BranchProbabilityInfo.cpp
@@ -821,7 +821,7 @@ computeUnlikelySuccessors(const BasicBlock *BB, Loop *L,
           CI->getPredicate(), CmpLHSConst, CmpConst, DL);
       // If the result means we don't branch to the block then that block is
       // unlikely.
-      if (Result && ((Result->isNullValue() && B == BI->getSuccessor(0)) ||
+      if (Result && ((Result->isZeroValue() && B == BI->getSuccessor(0)) ||
                      (Result->isOneValue() && B == BI->getSuccessor(1))))
         UnlikelyBlocks.insert(B);
     }

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -707,14 +707,14 @@ Constant *FoldReinterpretLoadFromConst(Constant *C, Type *LoadTy,
                                   DL.getTypeSizeInBits(LoadTy).getFixedValue());
     if (Constant *Res =
             FoldReinterpretLoadFromConst(C, MapTy, OrigLoadTy, Offset, DL)) {
-      if (Res->isNullValue() && !LoadTy->isX86_AMXTy())
+      if (Res->isZeroValue() && !LoadTy->isX86_AMXTy())
         // Materializing a zero can be done trivially without a bitcast
         return Constant::getNullValue(LoadTy);
       Type *CastTy = LoadTy->isPtrOrPtrVectorTy() ? DL.getIntPtrType(LoadTy) : LoadTy;
       Res = FoldBitCast(Res, CastTy, DL);
       if (LoadTy->isPtrOrPtrVectorTy()) {
         // For vector of pointer, we needed to first convert to a vector of integer, then do vector inttoptr
-        if (Res->isNullValue() && !LoadTy->isX86_AMXTy())
+        if (Res->isZeroValue() && !LoadTy->isX86_AMXTy())
           return Constant::getNullValue(LoadTy);
         if (DL.isNonIntegralPointerType(LoadTy->getScalarType()))
           // Be careful not to replace a load of an addrspace value with an inttoptr here
@@ -912,7 +912,7 @@ Constant *llvm::ConstantFoldLoadFromUniformValue(Constant *C, Type *Ty,
   // uniform.
   if (!DL.typeSizeEqualsStoreSize(C->getType()))
     return nullptr;
-  if (C->isNullValue() && !Ty->isX86_AMXTy())
+  if (C->isZeroValue() && !Ty->isX86_AMXTy())
     return Constant::getNullValue(Ty);
   if (C->isAllOnesValue() &&
       (Ty->isIntOrIntVectorTy() || Ty->isByteOrByteVectorTy() ||
@@ -1093,7 +1093,7 @@ Constant *SymbolicallyEvaluateGEP(const GEPOperator *GEP,
     }
   }
 
-  if ((Ptr->isNullValue() || BaseIntVal != 0) &&
+  if ((Ptr->isZeroValue() || BaseIntVal != 0) &&
       !DL.mustNotIntroduceIntToPtr(Ptr->getType())) {
 
     // If the index size is smaller than the pointer size, add to the low
@@ -1343,7 +1343,7 @@ Constant *llvm::ConstantFoldCompareInstOperands(
   // ConstantExpr::getCompare cannot do this, because it doesn't have DL
   // around to know if bit truncation is happening.
   if (auto *CE0 = dyn_cast<ConstantExpr>(Ops0)) {
-    if (Ops1->isNullValue()) {
+    if (Ops1->isZeroValue()) {
       if (CE0->getOpcode() == Instruction::IntToPtr) {
         Type *IntPtrTy = DL.getIntPtrType(CE0->getType());
         // Convert the integer value to the right size to ensure we get the
@@ -1649,7 +1649,7 @@ Constant *llvm::ConstantFoldCastOperand(unsigned Opcode, Constant *C,
         APInt BaseOffset(BitWidth, 0);
         auto *Base = cast<Constant>(GEP->stripAndAccumulateConstantOffsets(
             DL, BaseOffset, /*AllowNonInbounds=*/true));
-        if (Base->isNullValue()) {
+        if (Base->isZeroValue()) {
           FoldedValue = ConstantInt::get(CE->getContext(), BaseOffset);
         } else {
           // ptrtoint/ptrtoaddr (gep i8, Ptr, (sub 0, V))
@@ -1661,7 +1661,7 @@ Constant *llvm::ConstantFoldCastOperand(unsigned Opcode, Constant *C,
             Type *IntIdxTy = DL.getIndexType(Ptr->getType());
             if (Sub && Sub->getType() == IntIdxTy &&
                 Sub->getOpcode() == Instruction::Sub &&
-                Sub->getOperand(0)->isNullValue())
+                Sub->getOperand(0)->isZeroValue())
               FoldedValue = ConstantExpr::getSub(
                   ConstantExpr::getCast(Opcode, Ptr, IntIdxTy),
                   Sub->getOperand(1));
@@ -2327,15 +2327,15 @@ Constant *constantFoldVectorReduce(Intrinsic::ID IID, Constant *Op) {
     case Intrinsic::vector_reduce_umax:
       return SplatVal;
     case Intrinsic::vector_reduce_add:
-      if (SplatVal->isNullValue())
+      if (SplatVal->isZeroValue())
         return SplatVal;
       break;
     case Intrinsic::vector_reduce_mul:
-      if (SplatVal->isNullValue() || SplatVal->isOneValue())
+      if (SplatVal->isZeroValue() || SplatVal->isOneValue())
         return SplatVal;
       break;
     case Intrinsic::vector_reduce_xor:
-      if (SplatVal->isNullValue())
+      if (SplatVal->isZeroValue())
         return SplatVal;
       if (OpVT->getElementCount().isKnownMultipleOf(2))
         return Constant::getNullValue(OpVT->getElementType());
@@ -3265,7 +3265,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       break;
 
     case Intrinsic::wasm_anytrue:
-      return Op->isNullValue() ? ConstantInt::get(Ty, 0)
+      return Op->isZeroValue() ? ConstantInt::get(Ty, 0)
                                : ConstantInt::get(Ty, 1);
 
     case Intrinsic::wasm_alltrue:
@@ -3274,7 +3274,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       for (unsigned I = 0; I != E; ++I) {
         Constant *Elt = Op->getAggregateElement(I);
         // Return false as soon as we find a non-true element.
-        if (Elt && Elt->isNullValue())
+        if (Elt && Elt->isZeroValue())
           return ConstantInt::get(Ty, 0);
         // Bail as soon as we find an element we cannot prove to be true.
         if (!Elt || !isa<ConstantInt>(Elt))
@@ -3971,7 +3971,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       Constant *Elt = Operands[0]->getAggregateElement(I);
       if (!Elt)
         return nullptr;
-      if (isa<UndefValue>(Elt) || Elt->isNullValue())
+      if (isa<UndefValue>(Elt) || Elt->isZeroValue())
         continue;
       return ConstantInt::get(Ty, I);
     }
@@ -4300,7 +4300,7 @@ static Constant *ConstantFoldFixedVectorCall(
         else
           return nullptr;
       }
-      if (MaskElt->isNullValue()) {
+      if (MaskElt->isZeroValue()) {
         if (!PassthruElt)
           return nullptr;
         NewElements.push_back(PassthruElt);
@@ -4489,7 +4489,7 @@ static Constant *ConstantFoldScalableVectorCall(
   switch (IntrinsicID) {
   case Intrinsic::aarch64_sve_convert_from_svbool: {
     Constant *Src = Operands[0];
-    if (!Src->isNullValue())
+    if (!Src->isZeroValue())
       break;
 
     return ConstantInt::getFalse(SVTy);

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -417,7 +417,7 @@ bool GlobalsAAResult::AnalyzeIndirectGlobalMemory(GlobalVariable *GV) {
 
   // If the initializer is a valid pointer, bail.
   if (Constant *C = GV->getInitializer())
-    if (!C->isNullValue())
+    if (!C->isZeroValue())
       return false;
 
   // Walk the user list of the global.  If we find anything other than a direct

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2613,7 +2613,7 @@ bool CallAnalyzer::visitSelectInst(SelectInst &SI) {
 
   // Select condition is a constant.
   Value *SelectedV = CondC->isAllOnesValue()  ? TrueVal
-                     : (CondC->isNullValue()) ? FalseVal
+                     : (CondC->isZeroValue()) ? FalseVal
                                               : nullptr;
   if (!SelectedV) {
     // Condition is a vector constant that is not all 1s or all 0s.  If all

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -3970,7 +3970,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
 
         // Otherwise the upper bits of LHS are zero while RHS has a non-zero bit
         // there.  Use this to work out the result of the comparison.
-        if (AnyEq->isNullValue()) {
+        if (AnyEq->isZeroValue()) {
           switch (Pred) {
           default:
             llvm_unreachable("Unknown ICmp predicate!");
@@ -4047,7 +4047,7 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
 
         // Otherwise the upper bits of LHS are all equal, while RHS has varying
         // bits there.  Use this to work out the result of the comparison.
-        if (AnyEq->isNullValue()) {
+        if (AnyEq->isZeroValue()) {
           switch (Pred) {
           default:
             llvm_unreachable("Unknown ICmp predicate!");
@@ -6795,20 +6795,20 @@ static Value *simplifySVEIntReduction(Intrinsic::ID IID, Type *ReturnType,
   case Intrinsic::aarch64_sve_saddv:
   case Intrinsic::aarch64_sve_uaddv:
   case Intrinsic::aarch64_sve_umaxv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isNullValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isZeroValue()))
       return ConstantInt::get(ReturnType, 0);
     break;
   case Intrinsic::aarch64_sve_andv:
   case Intrinsic::aarch64_sve_uminv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isAllOnesValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isAllOnesValue()))
       return ConstantInt::get(ReturnType, APInt::getMaxValue(Width));
     break;
   case Intrinsic::aarch64_sve_smaxv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isMinSignedValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isMinSignedValue()))
       return ConstantInt::get(ReturnType, APInt::getSignedMinValue(Width));
     break;
   case Intrinsic::aarch64_sve_sminv:
-    if ((C0 && C0->isNullValue()) || (C1 && C1->isMaxSignedValue()))
+    if ((C0 && C0->isZeroValue()) || (C1 && C1->isMaxSignedValue()))
       return ConstantInt::get(ReturnType, APInt::getSignedMaxValue(Width));
     break;
   }

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -2080,13 +2080,13 @@ static Constant *getPredicateResult(CmpInst::Predicate Pred, Constant *C,
       // !C1 == C -> false iff C1 == C.
       Constant *Res = ConstantFoldCompareInstOperands(
           ICmpInst::ICMP_NE, Val.getNotConstant(), C, DL);
-      if (Res && Res->isNullValue())
+      if (Res && Res->isZeroValue())
         return ConstantInt::getFalse(ResTy);
     } else if (Pred == ICmpInst::ICMP_NE) {
       // !C1 != C -> true iff C1 == C.
       Constant *Res = ConstantFoldCompareInstOperands(
           ICmpInst::ICMP_NE, Val.getNotConstant(), C, DL);
-      if (Res && Res->isNullValue())
+      if (Res && Res->isZeroValue())
         return ConstantInt::getTrue(ResTy);
     }
     return nullptr;
@@ -2115,7 +2115,7 @@ Constant *LazyValueInfo::getPredicateAt(CmpInst::Predicate Pred, Value *V,
   // return it quickly. But this is only a fastpath, and falling
   // through would still be correct.
   const DataLayout &DL = CxtI->getDataLayout();
-  if (V->getType()->isPointerTy() && C->isNullValue() &&
+  if (V->getType()->isPointerTy() && C->isZeroValue() &&
       isKnownNonZero(V->stripPointerCastsSameRepresentation(), DL)) {
     Type *ResTy = CmpInst::makeCmpResultType(C->getType());
     if (Pred == ICmpInst::ICMP_EQ)

--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -553,7 +553,7 @@ static bool isZero(Value *V, const DataLayout &DL, DominatorTree *DT,
   if (!C)
     return false;
 
-  if (C->isNullValue())
+  if (C->isZeroValue())
     return true;
 
   // For a vector, KnownZero will only be true if all values are zero, so check

--- a/llvm/lib/Analysis/Local.cpp
+++ b/llvm/lib/Analysis/Local.cpp
@@ -41,7 +41,7 @@ Value *llvm::emitGEPOffset(IRBuilderBase *Builder, const DataLayout &DL,
        ++i, ++GTI) {
     Value *Op = *i;
     if (Constant *OpC = dyn_cast<Constant>(Op)) {
-      if (OpC->isNullValue())
+      if (OpC->isZeroValue())
         continue;
 
       // Handle a struct index, which adds its field offset to the pointer.

--- a/llvm/lib/Analysis/MustExecute.cpp
+++ b/llvm/lib/Analysis/MustExecute.cpp
@@ -152,7 +152,7 @@ static bool CanProveNotTakenFirstIteration(const BasicBlock *ExitBlock,
   if (!SimpleCst)
     return false;
   if (ExitBlock == BI->getSuccessor(0))
-    return SimpleCst->isNullValue();
+    return SimpleCst->isZeroValue();
   assert(ExitBlock == BI->getSuccessor(1) && "implied by above");
   return SimpleCst->isAllOnesValue();
 }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -9789,7 +9789,7 @@ ScalarEvolution::ExitLimit ScalarEvolution::computeShiftCompareExitLimit(
   assert(Result->getType()->isIntegerTy(1) &&
          "Otherwise cannot be an operand to a branch instruction");
 
-  if (Result->isNullValue()) {
+  if (Result->isZeroValue()) {
     unsigned BitWidth = getTypeSizeInBits(RHS->getType());
     const SCEV *UpperBound =
         getConstant(getEffectiveSCEVType(RHS->getType()), BitWidth);

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1720,7 +1720,7 @@ static void computeKnownBitsFromOperator(const Operator *I,
 
       // Handle case when index is zero.
       Constant *CIndex = dyn_cast<Constant>(Index);
-      if (CIndex && CIndex->isNullValue())
+      if (CIndex && CIndex->isZeroValue())
         continue;
 
       if (StructType *STy = GTI.getStructTypeOrNull()) {
@@ -3117,7 +3117,7 @@ static bool isNonZeroSub(const APInt &DemandedElts, const SimplifyQuery &Q,
 
   // TODO: Move this case into isKnownNonEqual().
   if (auto *C = dyn_cast<Constant>(X))
-    if (C->isNullValue() && isKnownNonZero(Y, DemandedElts, Q, Depth))
+    if (C->isZeroValue() && isKnownNonZero(Y, DemandedElts, Q, Depth))
       return true;
 
   return ::isKnownNonEqual(X, Y, DemandedElts, Q, Depth);
@@ -3693,7 +3693,7 @@ bool isKnownNonZero(const Value *V, const APInt &DemandedElts,
 #endif
 
   if (auto *C = dyn_cast<Constant>(V)) {
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return false;
     if (isa<ConstantInt>(C))
       // Must be non-zero due to null test above.
@@ -3706,7 +3706,7 @@ bool isKnownNonZero(const Value *V, const APInt &DemandedElts,
         if (!DemandedElts[i])
           continue;
         Constant *Elt = C->getAggregateElement(i);
-        if (!Elt || Elt->isNullValue())
+        if (!Elt || Elt->isZeroValue())
           return false;
         if (!isa<PoisonValue>(Elt) && !isa<ConstantInt>(Elt))
           return false;
@@ -4460,7 +4460,7 @@ static unsigned ComputeNumSignBitsImpl(const Value *V,
 
       // Handle NEG.
       if (const auto *CLHS = dyn_cast<Constant>(U->getOperand(0)))
-        if (CLHS->isNullValue()) {
+        if (CLHS->isZeroValue()) {
           KnownBits Known(TyBits);
           computeKnownBits(U->getOperand(1), DemandedElts, Known, Q, Depth + 1);
           // If the input is known to be 0 or 1, the output is 0/-1, which is
@@ -6411,7 +6411,7 @@ Value *llvm::isBytewiseValue(Value *V, const DataLayout &DL) {
   }
 
   // Handle 'null' ConstantArrayZero etc.
-  if (C->isNullValue())
+  if (C->isZeroValue())
     return Constant::getNullValue(Type::getInt8Ty(Ctx));
 
   // Constant floating-point values can be handled as integer values if the
@@ -6688,7 +6688,7 @@ bool llvm::getConstantDataArrayInfo(const Value *V,
   ConstantDataArray *Array = nullptr;
   ArrayType *ArrayTy = nullptr;
 
-  if (GV->getInitializer()->isNullValue()) {
+  if (GV->getInitializer()->isZeroValue()) {
     Type *GVTy = GV->getValueType();
     uint64_t SizeInBytes = DL.getTypeStoreSize(GVTy).getFixedValue();
     uint64_t Length = SizeInBytes / ElementSizeInBytes;
@@ -8710,7 +8710,7 @@ bool llvm::isKnownNegation(const Value *X, const Value *Y, bool NeedNSW,
       return false;
 
     auto *Zero = cast<Constant>(BO->getOperand(0));
-    if (!AllowPoison && !Zero->isNullValue())
+    if (!AllowPoison && !Zero->isZeroValue())
       return false;
 
     return true;

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -345,7 +345,7 @@ Value *llvm::findScalarElement(Value *V, unsigned EltNo) {
   Value *Val; Constant *C;
   if (match(V, m_Add(m_Value(Val), m_Constant(C))))
     if (Constant *Elt = C->getAggregateElement(EltNo))
-      if (Elt->isNullValue())
+      if (Elt->isZeroValue())
         return findScalarElement(Val, EltNo);
 
   // If the vector is a splat then we can trivially find the scalar element.
@@ -1259,7 +1259,7 @@ bool llvm::maskIsAllZeroOrUndef(Value *Mask) {
   auto *ConstMask = dyn_cast<Constant>(Mask);
   if (!ConstMask)
     return false;
-  if (ConstMask->isNullValue() || isa<UndefValue>(ConstMask))
+  if (ConstMask->isZeroValue() || isa<UndefValue>(ConstMask))
     return true;
   if (isa<ScalableVectorType>(ConstMask->getType()))
     return false;
@@ -1268,7 +1268,7 @@ bool llvm::maskIsAllZeroOrUndef(Value *Mask) {
            E = cast<FixedVectorType>(ConstMask->getType())->getNumElements();
        I != E; ++I) {
     if (auto *MaskElt = ConstMask->getAggregateElement(I))
-      if (MaskElt->isNullValue() || isa<UndefValue>(MaskElt))
+      if (MaskElt->isZeroValue() || isa<UndefValue>(MaskElt))
         continue;
     return false;
   }
@@ -1340,7 +1340,7 @@ APInt llvm::possiblyDemandedEltsInMask(Value *Mask) {
   APInt DemandedElts = APInt::getAllOnes(VWidth);
   if (auto *CV = dyn_cast<ConstantVector>(Mask))
     for (unsigned i = 0; i < VWidth; i++)
-      if (CV->getAggregateElement(i)->isNullValue())
+      if (CV->getAggregateElement(i)->isZeroValue())
         DemandedElts.clearBit(i);
   return DemandedElts;
 }

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -2917,7 +2917,7 @@ void ModuleBitcodeWriter::writeConstants(unsigned FirstVal, unsigned LastVal,
     const Constant *C = cast<Constant>(V);
     unsigned Code = -1U;
     unsigned AbbrevToUse = 0;
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Code = bitc::CST_CODE_NULL;
     } else if (isa<PoisonValue>(C)) {
       Code = bitc::CST_CODE_POISON;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3640,7 +3640,7 @@ void AsmPrinter::preprocessXXStructorList(const DataLayout &DL,
   // Gather the structors in a form that's convenient for sorting by priority.
   for (Value *O : cast<ConstantArray>(List)->operands()) {
     auto *CS = cast<ConstantStruct>(O);
-    if (CS->getOperand(1)->isNullValue())
+    if (CS->getOperand(1)->isZeroValue())
       break; // Found a null terminator, skip the rest.
     ConstantInt *Priority = dyn_cast<ConstantInt>(CS->getOperand(0));
     if (!Priority)
@@ -3649,7 +3649,7 @@ void AsmPrinter::preprocessXXStructorList(const DataLayout &DL,
     Structor &S = Structors.back();
     S.Priority = Priority->getLimitedValue(65535);
     S.Func = CS->getOperand(1);
-    if (!CS->getOperand(2)->isNullValue()) {
+    if (!CS->getOperand(2)->isZeroValue()) {
       if (TM.getTargetTriple().isOSAIX()) {
         CS->getContext().emitError(
             "associated data of XXStructor list is not yet supported on AIX");
@@ -3848,7 +3848,7 @@ const MCExpr *AsmPrinter::lowerConstant(const Constant *CV,
                                         uint64_t Offset) {
   MCContext &Ctx = OutContext;
 
-  if (CV->isNullValue() || isa<UndefValue>(CV))
+  if (CV->isZeroValue() || isa<UndefValue>(CV))
     return MCConstantExpr::create(0, Ctx);
 
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(CV))

--- a/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
+++ b/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
@@ -2431,7 +2431,7 @@ void ComplexDeinterleavingGraph::processReductionSingle(
 
   Value *NewInit = nullptr;
   if (auto *C = dyn_cast<Constant>(Init)) {
-    if (C->isNullValue())
+    if (C->isZeroValue())
       NewInit = Constant::getNullValue(NewVTy);
   }
 

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -5784,7 +5784,7 @@ bool CombinerHelper::matchUDivOrURemByConst(MachineInstr &MI) const {
   if (Opcode == TargetOpcode::G_UDIV &&
       MI.getFlag(MachineInstr::MIFlag::IsExact)) {
     return matchUnaryPredicate(
-        MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+        MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
   }
 
   auto *RHSDef = MRI.getVRegDef(RHS);
@@ -5808,7 +5808,7 @@ bool CombinerHelper::matchUDivOrURemByConst(MachineInstr &MI) const {
   }
 
   return matchUnaryPredicate(
-      MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+      MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
 }
 
 void CombinerHelper::applyUDivOrURemByConst(MachineInstr &MI) const {
@@ -5842,7 +5842,7 @@ bool CombinerHelper::matchSDivOrSRemByConst(MachineInstr &MI) const {
   if (Opcode == TargetOpcode::G_SDIV &&
       MI.getFlag(MachineInstr::MIFlag::IsExact)) {
     return matchUnaryPredicate(
-        MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+        MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
   }
 
   auto *RHSDef = MRI.getVRegDef(RHS);
@@ -5862,7 +5862,7 @@ bool CombinerHelper::matchSDivOrSRemByConst(MachineInstr &MI) const {
   }
 
   return matchUnaryPredicate(
-      MRI, RHS, [](const Constant *C) { return C && !C->isNullValue(); });
+      MRI, RHS, [](const Constant *C) { return C && !C->isZeroValue(); });
 }
 
 void CombinerHelper::applySDivOrSRemByConst(MachineInstr &MI) const {

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -582,7 +582,7 @@ bool IRTranslator::shouldEmitAsBranches(
   if (Cases[0].CmpRHS == Cases[1].CmpRHS &&
       Cases[0].PredInfo.Pred == Cases[1].PredInfo.Pred &&
       isa<Constant>(Cases[0].CmpRHS) &&
-      cast<Constant>(Cases[0].CmpRHS)->isNullValue()) {
+      cast<Constant>(Cases[0].CmpRHS)->isZeroValue()) {
     if (Cases[0].PredInfo.Pred == CmpInst::ICMP_EQ &&
         Cases[0].TrueBB == Cases[1].ThisBB)
       return false;

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1550,7 +1550,7 @@ bool llvm::isNullOrNullSplat(const MachineInstr &MI,
   case TargetOpcode::G_IMPLICIT_DEF:
     return AllowUndefs;
   case TargetOpcode::G_CONSTANT:
-    return MI.getOperand(1).getCImm()->isNullValue();
+    return MI.getOperand(1).getCImm()->isZeroValue();
   case TargetOpcode::G_FCONSTANT: {
     const ConstantFP *FPImm = MI.getOperand(1).getFPImm();
     return FPImm->isZero() && !FPImm->isNegative();

--- a/llvm/lib/CodeGen/InterleavedAccessPass.cpp
+++ b/llvm/lib/CodeGen/InterleavedAccessPass.cpp
@@ -572,7 +572,7 @@ static void getGapMask(const Constant &MaskConst, unsigned Factor,
     bool AllZero = true;
     for (unsigned Idx = 0U; Idx < LeafMaskLen; ++Idx) {
       Constant *C = MaskConst.getAggregateElement(F + Idx * Factor);
-      if (!C->isNullValue()) {
+      if (!C->isZeroValue()) {
         AllZero = false;
         break;
       }
@@ -594,7 +594,7 @@ static std::pair<Value *, APInt> getMask(Value *WideMask, unsigned Factor,
       // Check if all the intrinsic arguments are the same, except those that
       // are zeros, which we mark as gaps in the gap mask.
       for (auto [Idx, Arg] : enumerate(IMI->args())) {
-        if (auto *C = dyn_cast<Constant>(Arg); C && C->isNullValue()) {
+        if (auto *C = dyn_cast<Constant>(Arg); C && C->isZeroValue()) {
           GapMask.clearBit(Idx);
           continue;
         }

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -555,13 +555,13 @@ static bool expandProtectedFieldPtr(Function &Intr) {
       // pointer.
       if (auto *CI = dyn_cast<ICmpInst>(U.getUser())) {
         if (auto *Op = dyn_cast<Constant>(CI->getOperand(0))) {
-          if (Op->isNullValue()) {
+          if (Op->isZeroValue()) {
             CI->setOperand(1, Pointer);
             continue;
           }
         }
         if (auto *Op = dyn_cast<Constant>(CI->getOperand(1))) {
-          if (Op->isNullValue()) {
+          if (Op->isZeroValue()) {
             CI->setOperand(0, Pointer);
             continue;
           }

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23072,7 +23072,7 @@ bool DAGCombiner::tryStoreMergeOfConstants(
       if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(StoredVal))
         IsElementZero = C->isZero();
       else if (ConstantFPSDNode *C = dyn_cast<ConstantFPSDNode>(StoredVal))
-        IsElementZero = C->getConstantFPValue()->isNullValue();
+        IsElementZero = C->getConstantFPValue()->isZeroValue();
       else if (ISD::isBuildVectorAllZeros(StoredVal.getNode()))
         IsElementZero = true;
       if (IsElementZero) {

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -290,7 +290,7 @@ Register FastISel::materializeConstant(const Value *V, MVT VT) {
     Reg =
         getRegForValue(Constant::getNullValue(DL.getIntPtrType(V->getType())));
   else if (const auto *CF = dyn_cast<ConstantFP>(V)) {
-    if (CF->isNullValue())
+    if (CF->isZeroValue())
       Reg = fastMaterializeFloatZero(CF);
     else
       // Try to emit the constant directly.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1962,13 +1962,13 @@ SDValue SelectionDAGBuilder::getValueImpl(const Value *V) {
       return getValue(NC->getGlobalValue());
 
     if (VT == MVT::aarch64svcount) {
-      assert(C->isNullValue() && "Can only zero this target type!");
+      assert(C->isZeroValue() && "Can only zero this target type!");
       return DAG.getNode(ISD::BITCAST, getCurSDLoc(), VT,
                          DAG.getConstant(0, getCurSDLoc(), MVT::nxv16i1));
     }
 
     if (VT.isRISCVVectorTuple()) {
-      assert(C->isNullValue() && "Can only zero this target type!");
+      assert(C->isZeroValue() && "Can only zero this target type!");
       return DAG.getNode(
           ISD::BITCAST, getCurSDLoc(), VT,
           DAG.getNode(
@@ -2781,10 +2781,9 @@ SelectionDAGBuilder::ShouldEmitAsBranches(const std::vector<CaseBlock> &Cases) {
 
   // Handle: (X != null) | (Y != null) --> (X|Y) != 0
   // Handle: (X == null) & (Y == null) --> (X|Y) == 0
-  if (Cases[0].CmpRHS == Cases[1].CmpRHS &&
-      Cases[0].CC == Cases[1].CC &&
+  if (Cases[0].CmpRHS == Cases[1].CmpRHS && Cases[0].CC == Cases[1].CC &&
       isa<Constant>(Cases[0].CmpRHS) &&
-      cast<Constant>(Cases[0].CmpRHS)->isNullValue()) {
+      cast<Constant>(Cases[0].CmpRHS)->isZeroValue()) {
     if (Cases[0].CC == ISD::SETEQ && Cases[0].TrueBB == Cases[1].ThisBB)
       return false;
     if (Cases[0].CC == ISD::SETNE && Cases[0].FalseBB == Cases[1].ThisBB)

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -1427,7 +1427,7 @@ static void mapWasmLandingPadIndex(MachineBasicBlock *MBB,
   // this information.
   bool IsSingleCatchAllClause =
       CPI->arg_size() == 1 &&
-      cast<Constant>(CPI->getArgOperand(0))->isNullValue();
+      cast<Constant>(CPI->getArgOperand(0))->isZeroValue();
   // cathchpads for longjmp use an empty type list, e.g. catchpad within %0 []
   // and they don't need LSDA info
   bool IsCatchLongjmp = CPI->arg_size() == 0;

--- a/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
+++ b/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
@@ -152,7 +152,7 @@ Constant *ShadowStackGCLoweringImpl::GetFrameMap(Function &F) {
   SmallVector<Constant *, 16> Metadata;
   for (unsigned I = 0; I != Roots.size(); ++I) {
     Constant *C = cast<Constant>(Roots[I].first->getArgOperand(1));
-    if (!C->isNullValue())
+    if (!C->isZeroValue())
       NumMeta = I + 1;
     Metadata.push_back(C);
   }
@@ -259,7 +259,7 @@ bool ShadowStackGCLoweringImpl::doInitialization(Module &M) {
 
 bool ShadowStackGCLoweringImpl::IsNullValue(Value *V) {
   if (Constant *C = dyn_cast<Constant>(V))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/CodeGen/WasmEHPrepare.cpp
+++ b/llvm/lib/CodeGen/WasmEHPrepare.cpp
@@ -291,7 +291,7 @@ bool WasmEHPrepareImpl::prepareEHPads(Function &F) {
     // In case of a single catch (...), we don't need to emit a personalify
     // function call
     if (CPI->arg_size() == 1 &&
-        cast<Constant>(CPI->getArgOperand(0))->isNullValue())
+        cast<Constant>(CPI->getArgOperand(0))->isZeroValue())
       prepareEHPad(BB, false);
     else
       prepareEHPad(BB, true, Index++);

--- a/llvm/lib/CodeGen/WinEHPrepare.cpp
+++ b/llvm/lib/CodeGen/WinEHPrepare.cpp
@@ -163,7 +163,7 @@ static void addTryBlockMapEntry(WinEHFuncInfo &FuncInfo, int TryLow,
   for (const CatchPadInst *CPI : Handlers) {
     WinEHHandlerType HT;
     Constant *TypeInfo = cast<Constant>(CPI->getArgOperand(0));
-    if (TypeInfo->isNullValue())
+    if (TypeInfo->isZeroValue())
       HT.TypeDescriptor = nullptr;
     else
       HT.TypeDescriptor = cast<GlobalVariable>(TypeInfo->stripPointerCasts());
@@ -517,7 +517,7 @@ static void calculateSEHStateNumbers(WinEHFuncInfo &FuncInfo,
     const Constant *FilterOrNull =
         cast<Constant>(CatchPad->getArgOperand(0)->stripPointerCasts());
     const Function *Filter = dyn_cast<Function>(FilterOrNull);
-    assert((Filter || FilterOrNull->isNullValue()) &&
+    assert((Filter || FilterOrNull->isZeroValue()) &&
            "unexpected filter value");
     int TryState = addSEHExcept(FuncInfo, ParentState, Filter, CatchPadBB);
 

--- a/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -384,7 +384,7 @@ void ExecutionEngine::runStaticConstructorsDestructors(Module &module,
     if (!CS) continue;
 
     Constant *FP = CS->getOperand(1);
-    if (FP->isNullValue())
+    if (FP->isZeroValue())
       continue;  // Found a sentinel value, ignore.
 
     // Strip off constant expression casts.
@@ -890,7 +890,7 @@ GenericValue ExecutionEngine::getConstantValue(const Constant *C) {
   }
 
   if (auto *TETy = dyn_cast<TargetExtType>(C->getType())) {
-    assert(TETy->hasProperty(TargetExtType::HasZeroInit) && C->isNullValue() &&
+    assert(TETy->hasProperty(TargetExtType::HasZeroInit) && C->isZeroValue() &&
            "TargetExtType only supports null constant value");
     C = Constant::getNullValue(TETy->getLayoutType());
   }

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -338,7 +338,7 @@ void InstModificationIRStrategy::mutate(Instruction &Inst,
     // constant 0.
     Value *Operand = Inst.getOperand(0);
     if (Constant *C = dyn_cast<Constant>(Operand)) {
-      if (!C->isNullValue()) {
+      if (!C->isZeroValue()) {
         ShuffleItems = {0, 1};
       }
     }

--- a/llvm/lib/IR/AbstractCallSite.cpp
+++ b/llvm/lib/IR/AbstractCallSite.cpp
@@ -144,7 +144,7 @@ AbstractCallSite::AbstractCallSite(const Use *U)
   assert(VarArgFlagAsCM->getType()->isIntegerTy(1) &&
          "Malformed !callback metadata var-arg flag");
 
-  if (VarArgFlagAsCM->getValue()->isNullValue())
+  if (VarArgFlagAsCM->getValue()->isZeroValue())
     return;
 
   // Add all variadic arguments at the end.

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1692,11 +1692,11 @@ static void writeConstantInternal(raw_ostream &Out, const Constant *CV,
 
     // ptrauth (ptr CST, i32 KEY[, i64 DISC[, ptr ADDRDISC[, ptr DS]?]?]?)
     unsigned NumOpsToWrite = 2;
-    if (!CPA->getOperand(2)->isNullValue())
+    if (!CPA->getOperand(2)->isZeroValue())
       NumOpsToWrite = 3;
-    if (!CPA->getOperand(3)->isNullValue())
+    if (!CPA->getOperand(3)->isZeroValue())
       NumOpsToWrite = 4;
-    if (!CPA->getOperand(4)->isNullValue())
+    if (!CPA->getOperand(4)->isZeroValue())
       NumOpsToWrite = 5;
 
     ListSeparator LS;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4934,7 +4934,7 @@ static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
     if (CI->arg_size() == 4) {
       auto *Offset = dyn_cast_or_null<Constant>(CI->getArgOperand(1));
       // Nonzero offset dbg.values get dropped without a replacement.
-      if (!Offset || !Offset->isNullValue())
+      if (!Offset || !Offset->isZeroValue())
         return;
       VarOp = 2;
       ExprOp = 3;
@@ -5264,7 +5264,7 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     assert(CI->arg_size() == 4);
     // Drop nonzero offsets instead of attempting to upgrade them.
     if (auto *Offset = dyn_cast_or_null<Constant>(CI->getArgOperand(1)))
-      if (Offset->isNullValue()) {
+      if (Offset->isZeroValue()) {
         NewCall = Builder.CreateCall(
             NewFn,
             {CI->getArgOperand(0), CI->getArgOperand(2), CI->getArgOperand(3)});

--- a/llvm/lib/IR/ConstantFold.cpp
+++ b/llvm/lib/IR/ConstantFold.cpp
@@ -175,7 +175,7 @@ Constant *llvm::ConstantFoldCastInstruction(unsigned opc, Constant *V,
     return UndefValue::get(DestTy);
   }
 
-  if (V->isNullValue() && !DestTy->isX86_AMXTy() &&
+  if (V->isZeroValue() && !DestTy->isX86_AMXTy() &&
       opc != Instruction::AddrSpaceCast)
     return Constant::getNullValue(DestTy);
 
@@ -295,7 +295,8 @@ Constant *llvm::ConstantFoldCastInstruction(unsigned opc, Constant *V,
 Constant *llvm::ConstantFoldSelectInstruction(Constant *Cond,
                                               Constant *V1, Constant *V2) {
   // Check for i1 and vector true/false conditions.
-  if (Cond->isNullValue()) return V2;
+  if (Cond->isZeroValue())
+    return V2;
   if (Cond->isAllOnesValue()) return V1;
 
   // If the condition is a vector constant, fold the result elementwise.
@@ -318,7 +319,7 @@ Constant *llvm::ConstantFoldSelectInstruction(Constant *Cond,
         V = isa<UndefValue>(V1Element) ? V1Element : V2Element;
       } else {
         if (!isa<ConstantInt>(Cond)) break;
-        V = Cond->isNullValue() ? V2Element : V1Element;
+        V = Cond->isZeroValue() ? V2Element : V1Element;
       }
       Result.push_back(V);
     }
@@ -442,7 +443,7 @@ Constant *llvm::ConstantFoldInsertElementInstruction(Constant *Val,
 
   // Inserting null into all zeros is still all zeros.
   // TODO: This is true for undef and poison splats too.
-  if (Val->isNullValue() && Elt->isNullValue())
+  if (Val->isZeroValue() && Elt->isZeroValue())
     return Val;
 
   ConstantInt *CIdx = dyn_cast<ConstantInt>(Idx);
@@ -498,7 +499,8 @@ Constant *llvm::ConstantFoldShuffleVectorInstruction(Constant *V1, Constant *V2,
 
     // For scalable vectors, make sure this doesn't fold back into a
     // shufflevector.
-    if (!MaskEltCount.isScalable() || Elt->isNullValue() || isa<UndefValue>(Elt))
+    if (!MaskEltCount.isScalable() || Elt->isZeroValue() ||
+        isa<UndefValue>(Elt))
       return ConstantVector::getSplat(MaskEltCount, Elt);
   }
 
@@ -910,7 +912,7 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode, Constant *C1,
   if (auto *VTy = dyn_cast<VectorType>(C1->getType())) {
     // Fast path for splatted constants.
     if (Constant *C2Splat = C2->getSplatValue()) {
-      if (Instruction::isIntDivRem(Opcode) && C2Splat->isNullValue())
+      if (Instruction::isIntDivRem(Opcode) && C2Splat->isZeroValue())
         return PoisonValue::get(VTy);
       if (Constant *C1Splat = C1->getSplatValue()) {
         Constant *Res =
@@ -1170,7 +1172,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
     return ConstantInt::get(ResultTy, CmpInst::isUnordered(Predicate));
   }
 
-  if (C2->isNullValue()) {
+  if (C2->isZeroValue()) {
     // The caller is expected to commute the operands if the constant expression
     // is C2.
     // C1 >= 0 --> true
@@ -1335,7 +1337,7 @@ Constant *llvm::ConstantFoldCompareInstruction(CmpInst::Predicate Predicate,
       return ConstantInt::get(ResultTy, Result);
 
     if ((!isa<ConstantExpr>(C1) && isa<ConstantExpr>(C2)) ||
-        (C1->isNullValue() && !C2->isNullValue())) {
+        (C1->isZeroValue() && !C2->isZeroValue())) {
       // If C2 is a constant expr and C1 isn't, flip them around and fold the
       // other way if possible.
       // Also, if C1 is null and C2 isn't, flip them around.
@@ -1367,7 +1369,7 @@ Constant *llvm::ConstantFoldGetElementPtr(Type *PointeeTy, Constant *C,
 
     return all_of(Idxs, [](Value *Idx) {
       Constant *IdxC = cast<Constant>(Idx);
-      return IdxC->isNullValue() || isa<UndefValue>(IdxC);
+      return IdxC->isZeroValue() || isa<UndefValue>(IdxC);
     });
   };
   if (IsNoOp())

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -84,10 +84,10 @@ bool Constant::isNegativeZeroValue() const {
     return false;
 
   // Otherwise, just use +0.0.
-  return isNullValue();
+  return isZeroValue();
 }
 
-bool Constant::isNullValue() const {
+bool Constant::isZeroValue() const {
   // 0 is null.
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(this))
     return CI->isZero();
@@ -1514,7 +1514,7 @@ Constant *ConstantArray::getImpl(ArrayType *Ty, ArrayRef<Constant*> V) {
   if (isa<UndefValue>(C) && rangeOnlyContains(V.begin(), V.end(), C))
     return UndefValue::get(Ty);
 
-  if (C->isNullValue() && rangeOnlyContains(V.begin(), V.end(), C))
+  if (C->isZeroValue() && rangeOnlyContains(V.begin(), V.end(), C))
     return ConstantAggregateZero::get(Ty);
 
   // Check to see if all of the elements are ConstantFP or ConstantInt or
@@ -1566,11 +1566,11 @@ Constant *ConstantStruct::get(StructType *ST, ArrayRef<Constant*> V) {
   if (!V.empty()) {
     isUndef = isa<UndefValue>(V[0]);
     isPoison = isa<PoisonValue>(V[0]);
-    isZero = V[0]->isNullValue();
+    isZero = V[0]->isZeroValue();
     // PoisonValue inherits UndefValue, so its check is not necessary.
     if (isUndef || isZero) {
       for (Constant *C : V) {
-        if (!C->isNullValue())
+        if (!C->isZeroValue())
           isZero = false;
         if (!isa<PoisonValue>(C))
           isPoison = false;
@@ -1611,7 +1611,7 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
   // If this is an all-undef or all-zero vector, return a
   // ConstantAggregateZero or UndefValue.
   Constant *C = V[0];
-  bool isZero = C->isNullValue();
+  bool isZero = C->isZeroValue();
   bool isUndef = isa<UndefValue>(C);
   bool isPoison = isa<PoisonValue>(C);
   bool isSplatFP = UseConstantFPForFixedLengthSplat && isa<ConstantFP>(C);
@@ -1667,7 +1667,7 @@ Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
 
   if (!EC.isScalable()) {
     // Maintain special handling of zero.
-    if (!V->isNullValue()) {
+    if (!V->isZeroValue()) {
       if (UseConstantIntForFixedLengthSplat && isa<ConstantInt>(V))
         return ConstantInt::get(V->getContext(), EC,
                                 cast<ConstantInt>(V)->getValue());
@@ -1691,7 +1691,7 @@ Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
   }
 
   // Maintain special handling of zero.
-  if (!V->isNullValue()) {
+  if (!V->isZeroValue()) {
     if (UseConstantIntForScalableSplat && isa<ConstantInt>(V))
       return ConstantInt::get(V->getContext(), EC,
                               cast<ConstantInt>(V)->getValue());
@@ -1706,7 +1706,7 @@ Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
 
   Type *VTy = VectorType::get(V->getType(), EC);
 
-  if (V->isNullValue())
+  if (V->isZeroValue())
     return ConstantAggregateZero::get(VTy);
   if (isa<PoisonValue>(V))
     return PoisonValue::get(VTy);
@@ -2210,7 +2210,7 @@ Value *DSOLocalEquivalent::handleOperandChangeImpl(Value *From, Value *To) {
 
   // If the argument is replaced with a null value, just replace this constant
   // with a null value.
-  if (cast<Constant>(To)->isNullValue())
+  if (cast<Constant>(To)->isZeroValue())
     return To;
 
   // The replacement could be a bitcast or an alias to another function. We can
@@ -2354,7 +2354,7 @@ bool ConstantPtrAuth::isKnownCompatibleWith(const Value *Key,
                                             const DataLayout &DL) const {
   // This function may only be validly called to analyze a ptrauth operation
   // with no deactivation symbol, so if we have one it isn't compatible.
-  if (!getDeactivationSymbol()->isNullValue())
+  if (!getDeactivationSymbol()->isZeroValue())
     return false;
 
   // If the keys are different, there's no chance for this to be compatible.
@@ -2376,7 +2376,7 @@ bool ConstantPtrAuth::isKnownCompatibleWith(const Value *Key,
   const Value *AddrDiscriminator = nullptr;
 
   // This constant may or may not have an integer discriminator (instead of 0).
-  if (!getDiscriminator()->isNullValue()) {
+  if (!getDiscriminator()->isZeroValue()) {
     // If it does, there's an implicit blend.  We need to have a matching blend
     // intrinsic in the provided full discriminator.
     if (!match(Discriminator,
@@ -3645,7 +3645,7 @@ Value *ConstantArray::handleOperandChangeImpl(Value *From, Value *To) {
     AllSame &= Val == ToC;
   }
 
-  if (AllSame && ToC->isNullValue())
+  if (AllSame && ToC->isZeroValue())
     return ConstantAggregateZero::get(getType());
 
   if (AllSame && isa<UndefValue>(ToC))
@@ -3685,7 +3685,7 @@ Value *ConstantStruct::handleOperandChangeImpl(Value *From, Value *To) {
     AllSame &= Val == ToC;
   }
 
-  if (AllSame && ToC->isNullValue())
+  if (AllSame && ToC->isZeroValue())
     return ConstantAggregateZero::get(getType());
 
   if (AllSame && isa<UndefValue>(ToC))

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1290,7 +1290,7 @@ LLVMBool LLVMIsConstant(LLVMValueRef Ty) {
 
 LLVMBool LLVMIsNull(LLVMValueRef Val) {
   if (Constant *C = dyn_cast<Constant>(unwrap(Val)))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2375,7 +2375,7 @@ static void setAssignmentTrackingModuleFlag(Module &M) {
 
 static bool getAssignmentTrackingModuleFlag(const Module &M) {
   Metadata *Value = M.getModuleFlag(AssignmentTrackingModuleFlag);
-  return Value && !cast<ConstantAsMetadata>(Value)->getValue()->isNullValue();
+  return Value && !cast<ConstantAsMetadata>(Value)->getValue()->isZeroValue();
 }
 
 bool llvm::isAssignmentTrackingEnabled(const Module &M) {

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -121,7 +121,7 @@ public:
     Type *Ty = C->getType();
     Hashes.emplace_back(hashType(Ty));
 
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Hashes.emplace_back(static_cast<stable_hash>('N'));
       return stable_hash_combine(Hashes);
     }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -897,7 +897,7 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
     // If the global has common linkage, it must have a zero initializer and
     // cannot be constant.
     if (GV.hasCommonLinkage()) {
-      Check(GV.getInitializer()->isNullValue(),
+      Check(GV.getInitializer()->isZeroValue(),
             "'common' global must have a zero initializer!", &GV);
       Check(!GV.isConstant(), "'common' global may not be marked constant!",
             &GV);
@@ -2864,7 +2864,7 @@ void Verifier::visitConstantPtrAuth(const ConstantPtrAuth *CPA) {
         "signed ptrauth constant deactivation symbol must be a pointer");
 
   Check(isa<GlobalValue>(CPA->getDeactivationSymbol()) ||
-            CPA->getDeactivationSymbol()->isNullValue(),
+            CPA->getDeactivationSymbol()->isZeroValue(),
         "signed ptrauth constant deactivation symbol must be a global value "
         "or null");
 }

--- a/llvm/lib/Target/AArch64/AArch64FastISel.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FastISel.cpp
@@ -382,7 +382,7 @@ Register AArch64FastISel::materializeInt(const ConstantInt *CI, MVT VT) {
 Register AArch64FastISel::materializeFP(const ConstantFP *CFP, MVT VT) {
   // Positive zero (+0.0) has to be materialized with a fmov from the zero
   // register, because the immediate version of fmov cannot encode zero.
-  if (CFP->isNullValue())
+  if (CFP->isZeroValue())
     return fastMaterializeFloatZero(CFP);
 
   if (VT != MVT::f32 && VT != MVT::f64)
@@ -555,7 +555,7 @@ Register AArch64FastISel::fastMaterializeConstant(const Constant *C) {
 }
 
 Register AArch64FastISel::fastMaterializeFloatZero(const ConstantFP *CFP) {
-  assert(CFP->isNullValue() &&
+  assert(CFP->isZeroValue() &&
          "Floating-point constant is not a positive zero.");
   MVT VT;
   if (!isTypeLegal(CFP->getType(), VT))
@@ -1218,7 +1218,7 @@ Register AArch64FastISel::emitAddSub(bool UseAdd, MVT RetVT, const Value *LHS,
       ResultReg = emitAddSub_ri(UseAdd, RetVT, LHSReg, Imm, SetFlags,
                                 WantResult);
   } else if (const auto *C = dyn_cast<Constant>(RHS))
-    if (C->isNullValue())
+    if (C->isZeroValue())
       ResultReg = emitAddSub_ri(UseAdd, RetVT, LHSReg, 0, SetFlags, WantResult);
 
   if (ResultReg)
@@ -2292,10 +2292,10 @@ bool AArch64FastISel::emitCompareAndBranch(const CondBrInst *BI) {
     return false;
   case CmpInst::ICMP_EQ:
   case CmpInst::ICMP_NE:
-    if (isa<Constant>(LHS) && cast<Constant>(LHS)->isNullValue())
+    if (isa<Constant>(LHS) && cast<Constant>(LHS)->isZeroValue())
       std::swap(LHS, RHS);
 
-    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isNullValue())
+    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isZeroValue())
       return false;
 
     if (const auto *AI = dyn_cast<BinaryOperator>(LHS))
@@ -2321,7 +2321,7 @@ bool AArch64FastISel::emitCompareAndBranch(const CondBrInst *BI) {
     break;
   case CmpInst::ICMP_SLT:
   case CmpInst::ICMP_SGE:
-    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isNullValue())
+    if (!isa<Constant>(RHS) || !cast<Constant>(RHS)->isZeroValue())
       return false;
 
     TestBit = BW - 1;

--- a/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
@@ -342,7 +342,7 @@ static bool shouldConvertImpl(const Constant *Cst) {
   // instances of Cst.
   // Ideally, we could promote this into a global and rematerialize the constant
   // when it was a bad idea.
-  if (Cst->isNullValue())
+  if (Cst->isZeroValue())
     return false;
 
   // Globals cannot be or contain scalable vectors.

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2187,7 +2187,7 @@ static std::optional<Instruction *> instCombineSVELast(InstCombiner &IC,
   }
 
   auto *C = dyn_cast<Constant>(Pg);
-  if (IsAfter && C && C->isNullValue()) {
+  if (IsAfter && C && C->isZeroValue()) {
     // The intrinsic is extracting lane 0 so use an extract instead.
     auto *IdxTy = Type::getInt64Ty(II.getContext());
     auto *Extract = ExtractElementInst::Create(Vec, ConstantInt::get(IdxTy, 0));

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -5676,7 +5676,7 @@ AArch64InstructionSelector::emitConstantVector(Register Dst, Constant *CV,
   assert((DstSize == 64 || DstSize == 128) &&
          "Unexpected vector constant size");
 
-  if (CV->isNullValue()) {
+  if (CV->isZeroValue()) {
     if (DstSize == 128) {
       auto Mov =
           MIRBuilder.buildInstr(AArch64::MOVIv2d_ns, {Dst}, {}).addImm(0);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1565,7 +1565,7 @@ bool AMDGPUCodeGenPrepareImpl::visitLoadInst(LoadInst &I) {
       ConstantInt *Lower =
         mdconst::extract<ConstantInt>(Range->getOperand(0));
 
-      if (Lower->isNullValue()) {
+      if (Lower->isZeroValue()) {
         WidenLoad->setMetadata(LLVMContext::MD_range, nullptr);
       } else {
         Metadata *LowAndHigh[] = {

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -441,7 +441,7 @@ static APInt trimTrailingZerosInVector(InstCombiner &IC, Value *UseV,
       break;
 
     if (auto *ConstElt = dyn_cast<Constant>(Elt)) {
-      if (!ConstElt->isNullValue() && !isa<UndefValue>(Elt))
+      if (!ConstElt->isZeroValue() && !isa<UndefValue>(Elt))
         break;
     } else {
       break;
@@ -1304,7 +1304,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       if (auto *CSrc1 = dyn_cast<Constant>(Src1)) {
         Constant *CCmp = ConstantFoldCompareInstOperands(
             (ICmpInst::Predicate)CCVal, CSrc0, CSrc1, DL);
-        if (CCmp && CCmp->isNullValue()) {
+        if (CCmp && CCmp->isZeroValue()) {
           return IC.replaceInstUsesWith(
               II, IC.Builder.CreateSExt(CCmp, II.getType()));
         }
@@ -1525,7 +1525,7 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     auto *BC = cast<ConstantInt>(II.getArgOperand(5));
     auto *RM = cast<ConstantInt>(II.getArgOperand(3));
     auto *BM = cast<ConstantInt>(II.getArgOperand(4));
-    if (BC->isNullValue() || RM->getZExtValue() != 0xF ||
+    if (BC->isZeroValue() || RM->getZExtValue() != 0xF ||
         BM->getZExtValue() != 0xF || isa<PoisonValue>(Old))
       break;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -1224,7 +1224,7 @@ public:
 Constant *FatPtrConstMaterializer::materializeBufferFatPtrConst(Constant *C) {
   Type *SrcTy = C->getType();
   auto *NewTy = dyn_cast<StructType>(TypeMap->remapType(SrcTy));
-  if (C->isNullValue())
+  if (C->isZeroValue())
     return ConstantAggregateZero::getNullValue(NewTy);
   if (isa<PoisonValue>(C)) {
     return ConstantStruct::get(NewTy,
@@ -2042,7 +2042,7 @@ PtrParts SplitPtrStructs::visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
   // Special case for null pointers, undef, and poison, which can be created by
   // address space propagation.
   auto *InConst = dyn_cast<Constant>(In);
-  if (InConst && InConst->isNullValue()) {
+  if (InConst && InConst->isZeroValue()) {
     Value *NullRsrc = Constant::getNullValue(RsrcTy);
     SplitUsers.insert(&I);
     return {NullRsrc, ZeroOff};

--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.h
@@ -53,7 +53,7 @@ static inline const MCExpr *lowerAddrSpaceCast(const Constant *CV,
   if (CE && CE->getOpcode() == Instruction::AddrSpaceCast) {
     auto *Op = CE->getOperand(0);
     auto SrcAddr = Op->getType()->getPointerAddressSpace();
-    if (Op->isNullValue() && AMDGPU::getNullPointerValue(SrcAddr) == 0) {
+    if (Op->isZeroValue() && AMDGPU::getNullPointerValue(SrcAddr) == 0) {
       auto DstAddr = CE->getType()->getPointerAddressSpace();
       return MCConstantExpr::create(AMDGPU::getNullPointerValue(DstAddr),
                                     OutContext);

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -654,7 +654,7 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     Type *AccessTy = Inst->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
     if (Constant *CI = dyn_cast<Constant>(Index)) {
-      if (CI->isNullValue() && AccessSize == VecStoreSize) {
+      if (CI->isZeroValue() && AccessSize == VecStoreSize) {
         Inst->replaceAllUsesWith(
             Builder.CreateBitPreservingCastChain(DL, CurVal, AccessTy));
         return nullptr;
@@ -732,7 +732,7 @@ static Value *promoteAllocaUserToVector(Instruction *Inst, const DataLayout &DL,
     Type *AccessTy = Val->getType();
     TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
     if (Constant *CI = dyn_cast<Constant>(Index))
-      if (CI->isNullValue() && AccessSize == VecStoreSize)
+      if (CI->isZeroValue() && AccessSize == VecStoreSize)
         return Builder.CreateBitPreservingCastChain(DL, Val, AA.Vector.Ty);
 
     // Storing a subvector.

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -20127,7 +20127,7 @@ SITargetLowering::shouldExpandAtomicRMWInIR(const AtomicRMWInst *RMW) const {
         // Atomic sub/or/xor do not work over PCI express, but atomic add
         // does. InstCombine transforms these with 0 to or, so undo that.
         if (const Constant *ConstVal = dyn_cast<Constant>(RMW->getValOperand());
-            ConstVal && ConstVal->isNullValue())
+            ConstVal && ConstVal->isZeroValue())
           return AtomicExpansionKind::CustomExpand;
       }
 
@@ -20698,7 +20698,7 @@ void SITargetLowering::emitExpandAtomicRMW(AtomicRMWInst *AI) const {
   if (Op == AtomicRMWInst::Sub || Op == AtomicRMWInst::Or ||
       Op == AtomicRMWInst::Xor) {
     if (const auto *ConstVal = dyn_cast<Constant>(AI->getValOperand());
-        ConstVal && ConstVal->isNullValue()) {
+        ConstVal && ConstVal->isZeroValue()) {
       // atomicrmw or %ptr, 0 -> atomicrmw add %ptr, 0
       AI->setOperation(AtomicRMWInst::Add);
 

--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -280,7 +280,7 @@ static Value *expandVecReduceAdd(CallInst *Orig, Intrinsic::ID IntrinsicId) {
   // Handle the initial start value for floating-point addition.
   if (IsFAdd) {
     Constant *StartValue = dyn_cast<Constant>(Orig->getOperand(0));
-    if (StartValue && !StartValue->isNullValue())
+    if (StartValue && !StartValue->isZeroValue())
       Sum = Builder.CreateFAdd(Sum, StartValue);
   }
 

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -630,7 +630,7 @@ public:
 
       // Copy coordinates and offsets into Args.
       extractElementsIntoArgs(IRB, Args, 2, Coords, 3);
-      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
+      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isZeroValue())
         extractElementsIntoArgs(IRB, Args, 5, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
@@ -2019,7 +2019,7 @@ void DXILBitcodeWriter::writeConstants(unsigned FirstVal, unsigned LastVal,
     const Constant *C = cast<Constant>(V);
     unsigned Code = -1U;
     unsigned AbbrevToUse = 0;
-    if (C->isNullValue()) {
+    if (C->isZeroValue()) {
       Code = bitc::CST_CODE_NULL;
     } else if (isa<UndefValue>(C)) {
       Code = bitc::CST_CODE_UNDEF;

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -1148,7 +1148,7 @@ HexagonTargetLowering::LowerConstantPool(SDValue Op, SelectionDAG &DAG) const {
       assert(isPowerOf2_32(VecLen) &&
              "conversion only supported for pow2 VectorSize");
       for (unsigned i = 0; i < VecLen; ++i)
-        NewConst.push_back(IRB.getInt8(CV->getOperand(i)->isNullValue()));
+        NewConst.push_back(IRB.getInt8(CV->getOperand(i)->isZeroValue()));
 
       CVal = ConstantVector::get(NewConst);
       isVTi1Type = true;

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -3349,7 +3349,7 @@ auto HexagonVectorCombine::getConstInt(int Val, unsigned Width) const
 
 auto HexagonVectorCombine::isZero(const Value *Val) const -> bool {
   if (auto *C = dyn_cast<Constant>(Val))
-    return C->isNullValue();
+    return C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1042,7 +1042,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
           (GVar->getAddressSpace() == ADDRESS_SPACE_CONST)) {
         const Constant *Initializer = GVar->getInitializer();
         // 'undef' is treated as there is no value specified.
-        if (!Initializer->isNullValue() && !isa<UndefValue>(Initializer)) {
+        if (!Initializer->isZeroValue() && !isa<UndefValue>(Initializer)) {
           O << " = ";
           printScalarConstant(Initializer, O);
         }
@@ -1050,7 +1050,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
         // The frontend adds zero-initializer to device and constant variables
         // that don't have an initial value, and UndefValue to shared
         // variables, so skip warning for this case.
-        if (!GVar->getInitializer()->isNullValue() &&
+        if (!GVar->getInitializer()->isZeroValue() &&
             !isa<UndefValue>(GVar->getInitializer())) {
           report_fatal_error("initial value of '" + GVar->getName() +
                              "' is not allowed in addrspace(" +
@@ -1076,7 +1076,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
            (GVar->getAddressSpace() == ADDRESS_SPACE_CONST)) &&
           GVar->hasInitializer()) {
         const Constant *Initializer = GVar->getInitializer();
-        if (!isa<UndefValue>(Initializer) && !Initializer->isNullValue()) {
+        if (!isa<UndefValue>(Initializer) && !Initializer->isZeroValue()) {
           AggBuffer aggBuffer(ElementSize, *this);
           bufferAggregateConstant(Initializer, &aggBuffer);
           if (aggBuffer.numSymbols()) {
@@ -1646,7 +1646,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
                                    AggBuffer *AggBuffer) {
   const DataLayout &DL = getDataLayout();
   int AllocSize = DL.getTypeAllocSize(CPV->getType());
-  if (isa<UndefValue>(CPV) || CPV->isNullValue()) {
+  if (isa<UndefValue>(CPV) || CPV->isZeroValue()) {
     // Non-zero Bytes indicates that we need to zero-fill everything. Otherwise,
     // only the space allocated by CPV.
     AggBuffer->addZeros(Bytes ? Bytes : AllocSize);
@@ -1880,7 +1880,7 @@ NVPTXAsmPrinter::lowerConstantForGV(const Constant *CV,
                                     bool ProcessingGeneric) const {
   MCContext &Ctx = OutContext;
 
-  if (CV->isNullValue() || isa<UndefValue>(CV))
+  if (CV->isZeroValue() || isa<UndefValue>(CV))
     return MCConstantExpr::create(0, Ctx);
 
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(CV))

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -581,7 +581,7 @@ Register SPIRVGlobalRegistry::getOrCreateCompositeOrNull(
   if (Register R = find(CA, CurMF); R.isValid())
     return R;
 
-  bool IsNull = Val->isNullValue() && ZeroAsNull;
+  bool IsNull = Val->isZeroValue() && ZeroAsNull;
   Register ElemReg;
   if (!IsNull)
     ElemReg =

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -99,7 +99,7 @@ addConstantsToTrack(MachineFunction &MF, SPIRVGlobalRegistry *GR,
             if (SrcMI && (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT ||
                           SrcMI->getOpcode() == TargetOpcode::G_IMPLICIT_DEF))
               TargetExtConstTypes[SrcMI] = Const->getType();
-            if (Const->isNullValue()) {
+            if (Const->isZeroValue()) {
               MachineBasicBlock &DepMBB = MF.front();
               MachineIRBuilder MIB(DepMBB, DepMBB.getFirstNonPHI());
               SPIRVTypeInst ExtType = GR->getOrCreateSPIRVType(

--- a/llvm/lib/Target/TargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/TargetLoweringObjectFile.cpp
@@ -68,7 +68,7 @@ unsigned TargetLoweringObjectFile::getCallSiteEncoding() const {
 
 static bool isNullOrUndef(const Constant *C) {
   // Check that the constant isn't all zeros or undefs.
-  if (C->isNullValue() || isa<UndefValue>(C))
+  if (C->isZeroValue() || isa<UndefValue>(C))
     return true;
   if (!isa<ConstantAggregate>(C))
     return false;

--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -1485,7 +1485,7 @@ bool X86FastISel::X86SelectCmp(const Instruction *I) {
   // %x again on the RHS.
   if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
     const auto *RHSC = dyn_cast<ConstantFP>(RHS);
-    if (RHSC && RHSC->isNullValue())
+    if (RHSC && RHSC->isZeroValue())
       RHS = LHS;
   }
 
@@ -1673,7 +1673,7 @@ bool X86FastISel::X86SelectBranch(const Instruction *I) {
       // use %x again on the RHS.
       if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
         const auto *CmpRHSC = dyn_cast<ConstantFP>(CmpRHS);
-        if (CmpRHSC && CmpRHSC->isNullValue())
+        if (CmpRHSC && CmpRHSC->isZeroValue())
           CmpRHS = CmpLHS;
       }
 
@@ -2186,7 +2186,7 @@ bool X86FastISel::X86FastEmitSSESelect(MVT RetVT, const Instruction *I) {
   // %x again on the RHS.
   if (Predicate == CmpInst::FCMP_ORD || Predicate == CmpInst::FCMP_UNO) {
     const auto *CmpRHSC = dyn_cast<ConstantFP>(CmpRHS);
-    if (CmpRHSC && CmpRHSC->isNullValue())
+    if (CmpRHSC && CmpRHSC->isZeroValue())
       CmpRHS = CmpLHS;
   }
 
@@ -3766,7 +3766,7 @@ Register X86FastISel::X86MaterializeInt(const ConstantInt *CI, MVT VT) {
 }
 
 Register X86FastISel::X86MaterializeFP(const ConstantFP *CFP, MVT VT) {
-  if (CFP->isNullValue())
+  if (CFP->isZeroValue())
     return fastMaterializeFloatZero(CFP);
 
   // Can't handle alternate code models yet.

--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -2262,7 +2262,7 @@ X86TTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::x86_bmi_pext_32:
   case Intrinsic::x86_bmi_pext_64:
     if (auto *MaskC = dyn_cast<ConstantInt>(II.getArgOperand(1))) {
-      if (MaskC->isNullValue()) {
+      if (MaskC->isZeroValue()) {
         return IC.replaceInstUsesWith(II, ConstantInt::get(II.getType(), 0));
       }
       if (MaskC->isAllOnesValue()) {
@@ -2306,7 +2306,7 @@ X86TTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   case Intrinsic::x86_bmi_pdep_32:
   case Intrinsic::x86_bmi_pdep_64:
     if (auto *MaskC = dyn_cast<ConstantInt>(II.getArgOperand(1))) {
-      if (MaskC->isNullValue()) {
+      if (MaskC->isZeroValue()) {
         return IC.replaceInstUsesWith(II, ConstantInt::get(II.getType(), 0));
       }
       if (MaskC->isAllOnesValue()) {

--- a/llvm/lib/Target/X86/X86LowerAMXType.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXType.cpp
@@ -813,7 +813,7 @@ bool X86LowerAMXCast::optimizeAMXCastFromPhi(
       // might support const.
       if (isa<Constant>(IncValue)) {
         auto *IncConst = dyn_cast<Constant>(IncValue);
-        if (!isa<UndefValue>(IncValue) && !IncConst->isNullValue())
+        if (!isa<UndefValue>(IncValue) && !IncConst->isZeroValue())
           return false;
         Value *Row = nullptr, *Col = nullptr;
         std::tie(Row, Col) = getShape(OldPN);

--- a/llvm/lib/Target/X86/X86PartialReduction.cpp
+++ b/llvm/lib/Target/X86/X86PartialReduction.cpp
@@ -360,7 +360,7 @@ static Value *matchAddReduction(const ExtractElementInst &EE,
   ReduceInOneBB = true;
   // Make sure we're extracting index 0.
   auto *Index = dyn_cast<ConstantInt>(EE.getIndexOperand());
-  if (!Index || !Index->isNullValue())
+  if (!Index || !Index->isZeroValue())
     return nullptr;
 
   const auto *BO = dyn_cast<BinaryOperator>(EE.getVectorOperand());

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -393,7 +393,7 @@ Value *AA::getWithType(Value &V, Type &Ty) {
   if (isa<UndefValue>(V))
     return UndefValue::get(&Ty);
   if (auto *C = dyn_cast<Constant>(&V)) {
-    if (C->isNullValue() && !Ty.isPtrOrPtrVectorTy())
+    if (C->isZeroValue() && !Ty.isPtrOrPtrVectorTy())
       return Constant::getNullValue(&Ty);
     if (C->getType()->isPointerTy() && Ty.isPointerTy())
       return ConstantExpr::getPointerCast(C, &Ty);
@@ -492,7 +492,7 @@ static bool getPotentialCopiesOfMemoryValue(
         NullOnly = false;
       else if (isa<UndefValue>(*V))
         /* No op */;
-      else if (isa<Constant>(*V) && cast<Constant>(*V)->isNullValue())
+      else if (isa<Constant>(*V) && cast<Constant>(*V)->isZeroValue())
         NullRequired = !IsExact;
       else
         NullOnly = false;

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -4038,7 +4038,7 @@ struct AANoAliasReturned final : AANoAliasImpl {
 
     auto CheckReturnValue = [&](Value &RV) -> bool {
       if (Constant *C = dyn_cast<Constant>(&RV))
-        if (C->isNullValue() || isa<UndefValue>(C))
+        if (C->isZeroValue() || isa<UndefValue>(C))
           return true;
 
       /// For now, we can only deduce noalias if we have call sites.
@@ -10051,7 +10051,7 @@ struct AAPotentialConstantValuesFloating : AAPotentialConstantValuesImpl {
     bool OnlyLeft = false, OnlyRight = false;
     if (C && *C && (*C)->isOneValue())
       OnlyLeft = true;
-    else if (C && *C && (*C)->isNullValue())
+    else if (C && *C && (*C)->isZeroValue())
       OnlyRight = true;
 
     bool LHSContainsUndef = false, RHSContainsUndef = false;

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1471,7 +1471,7 @@ static bool isFunctionMallocLike(Function *F, const SCCNodeSet &SCCNodes) {
     Value *RetVal = FlowsToReturn[i];
 
     if (Constant *C = dyn_cast<Constant>(RetVal)) {
-      if (!C->isNullValue() && !isa<UndefValue>(C))
+      if (!C->isZeroValue() && !isa<UndefValue>(C))
         return false;
 
       continue;

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -455,13 +455,13 @@ Constant *InstCostVisitor::visitSelectInst(SelectInst &I) {
   assert(LastVisited != KnownConstants.end() && "Invalid iterator!");
 
   if (I.getCondition() == LastVisited->first) {
-    Value *V = LastVisited->second->isNullValue() ? I.getFalseValue()
+    Value *V = LastVisited->second->isZeroValue() ? I.getFalseValue()
                                                   : I.getTrueValue();
     return findConstantFor(V);
   }
   if (Constant *Condition = findConstantFor(I.getCondition()))
     if ((I.getTrueValue() == LastVisited->first && Condition->isOneValue()) ||
-        (I.getFalseValue() == LastVisited->first && Condition->isNullValue()))
+        (I.getFalseValue() == LastVisited->first && Condition->isZeroValue()))
       return LastVisited->second;
   return nullptr;
 }
@@ -1203,7 +1203,7 @@ Constant *FunctionSpecializer::getCandidateConstant(Value *V) {
 
   // Don't specialize on (anything derived from) the address of a non-constant
   // global variable, unless explicitly enabled.
-  if (C && C->getType()->isPointerTy() && !C->isNullValue())
+  if (C && C->getType()->isPointerTy() && !C->isZeroValue())
     if (auto *GV = dyn_cast<GlobalVariable>(getUnderlyingObject(C));
         GV && !(GV->isConstant() || SpecializeOnAddress))
       return nullptr;

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1144,7 +1144,7 @@ optimizeOnceStoredGlobal(GlobalVariable *GV, Value *StoredOnceVal,
   // users of the loaded value (often calls and loads) that would trap if the
   // value was null.
   if (GV->getInitializer()->getType()->isPointerTy() &&
-      GV->getInitializer()->isNullValue() &&
+      GV->getInitializer()->isZeroValue() &&
       StoredOnceVal->getType()->isPointerTy() &&
       !NullPointerIsDefined(
           nullptr /* F */,
@@ -1217,7 +1217,7 @@ static bool TryToShrinkGlobalToBoolean(GlobalVariable *GV, Constant *OtherVal) {
   bool EmitOneOrZero = true;
   auto *CI = dyn_cast<ConstantInt>(OtherVal);
   if (CI && CI->getValue().getActiveBits() <= 64) {
-    IsOneZero = InitVal->isNullValue() && CI->isOne();
+    IsOneZero = InitVal->isZeroValue() && CI->isOne();
 
     auto *CIInit = dyn_cast<ConstantInt>(GV->getInitializer());
     if (CIInit && CIInit->getValue().getActiveBits() <= 64) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -2659,7 +2659,7 @@ Instruction *InstCombinerImpl::visitAnd(BinaryOperator &I) {
         Constant *Log2C1 = ConstantExpr::getExactLogBase2(C1);
         Constant *Cmp =
             ConstantFoldCompareInstOperands(ICmpInst::ICMP_ULT, Log2C3, C2, DL);
-        if (Cmp && Cmp->isNullValue()) {
+        if (Cmp && Cmp->isZeroValue()) {
           // iff C1,C3 is pow2 and Log2(C3) >= C2:
           // ((C1 >> X) << C2) & C3 -> X == (cttz(C1)+C2-cttz(C3)) ? C3 : 0
           Constant *ShlC = ConstantExpr::getAdd(C2, Log2C1);
@@ -3707,7 +3707,7 @@ static bool matchSubIntegerPackFromVector(Value *V, Value *&Vec,
         const unsigned ConstIdx = ShuffleIdx - NumVecElts;
         auto *ConstElt =
             dyn_cast<ConstantInt>(ConstVec->getAggregateElement(ConstIdx));
-        if (!ConstElt || !ConstElt->isNullValue())
+        if (!ConstElt || !ConstElt->isZeroValue())
           return false;
         continue;
       }
@@ -5410,7 +5410,7 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
                        m_AShr(m_Value(X), m_APIntAllowPoison(CA))))) &&
         *CA == X->getType()->getScalarSizeInBits() - 1 &&
         !match(C1, m_AllOnes())) {
-      assert(!C1->isNullValue() && "Unexpected xor with 0");
+      assert(!C1->isZeroValue() && "Unexpected xor with 0");
       Value *IsNotNeg = Builder.CreateIsNotNeg(X);
       return createSelectInstWithUnknownProfile(IsNotNeg, Op1,
                                                 Builder.CreateNot(Op1));

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2717,7 +2717,7 @@ static bool collectInsertionElements(Value *V, unsigned Shift,
   if (V->getType() == VecEltTy) {
     // Inserting null doesn't actually insert any elements.
     if (Constant *C = dyn_cast<Constant>(V))
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return true;
 
     unsigned ElementIndex = getTypeSizeIndex(Shift, VecEltTy);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -693,7 +693,7 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
   }
 
   if (GEPLHS->isInBounds() && ICmpInst::isEquality(Cond) &&
-      isa<Constant>(RHS) && cast<Constant>(RHS)->isNullValue() &&
+      isa<Constant>(RHS) && cast<Constant>(RHS)->isZeroValue() &&
       !NullPointerIsDefined(I.getFunction(),
                             RHS->getType()->getPointerAddressSpace())) {
     // For most address spaces, an allocation can't be placed at null, but null
@@ -4328,7 +4328,7 @@ Instruction *InstCombinerImpl::foldICmpInstWithConstantNotInt(ICmpInst &I) {
   switch (LHSI->getOpcode()) {
   case Instruction::IntToPtr:
     // icmp pred inttoptr(X), null -> icmp pred X, 0
-    if (RHSC->isNullValue() &&
+    if (RHSC->isZeroValue() &&
         DL.getIntPtrType(RHSC->getType()) == LHSI->getOperand(0)->getType())
       return new ICmpInst(
           I.getPredicate(), LHSI->getOperand(0),
@@ -4840,7 +4840,7 @@ foldShiftIntoShiftInAnotherHandOfAndInICmp(ICmpInst &I, const SimplifyQuery SQ,
                                     : NewShAmt;
       // If it's edge-case shift (by 0 or by WidestBitWidth-1) we can fold.
       if (NewShAmtSplat &&
-          (NewShAmtSplat->isNullValue() ||
+          (NewShAmtSplat->isZeroValue() ||
            NewShAmtSplat->getUniqueInteger() == WidestBitWidth - 1))
         return true;
       // We consider *min* leading zeros so a single outlier
@@ -8402,20 +8402,20 @@ Instruction *InstCombinerImpl::foldCmpSelectOfConstants(CmpInst &I) {
   if (!Res00 || !Res01 || !Res10 || !Res11)
     return nullptr;
 
-  if ((!Res00->isNullValue() && !Res00->isAllOnesValue()) ||
-      (!Res01->isNullValue() && !Res01->isAllOnesValue()) ||
-      (!Res10->isNullValue() && !Res10->isAllOnesValue()) ||
-      (!Res11->isNullValue() && !Res11->isAllOnesValue()))
+  if ((!Res00->isZeroValue() && !Res00->isAllOnesValue()) ||
+      (!Res01->isZeroValue() && !Res01->isAllOnesValue()) ||
+      (!Res10->isZeroValue() && !Res10->isAllOnesValue()) ||
+      (!Res11->isZeroValue() && !Res11->isAllOnesValue()))
     return nullptr;
 
   std::bitset<4> Table;
-  if (!Res00->isNullValue())
+  if (!Res00->isZeroValue())
     Table.set(0);
-  if (!Res01->isNullValue())
+  if (!Res01->isZeroValue())
     Table.set(1);
-  if (!Res10->isNullValue())
+  if (!Res10->isZeroValue())
     Table.set(2);
-  if (!Res11->isNullValue())
+  if (!Res11->isZeroValue())
     Table.set(3);
 
   Value *Res = createLogicFromTable(Table, C1, C2, Builder,

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1297,7 +1297,7 @@ Instruction *InstCombinerImpl::commonIDivRemTransforms(BinaryOperator &I) {
     unsigned NumElts = VTy->getNumElements();
     for (unsigned i = 0; i != NumElts; ++i) {
       Constant *Elt = Op1C->getAggregateElement(i);
-      if (Elt && (Elt->isNullValue() || isa<UndefValue>(Elt)))
+      if (Elt && (Elt->isZeroValue() || isa<UndefValue>(Elt)))
         return replaceInstUsesWith(I, PoisonValue::get(Ty));
     }
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -891,7 +891,7 @@ static Value *foldSelectICmpAndBinOp(Value *CondVal, Value *TrueVal,
   auto *IdentityC =
       ConstantExpr::getBinOpIdentity(BinOp->getOpcode(), BinOp->getType(),
                                      /*AllowRHSConstant*/ true);
-  if (IdentityC == nullptr || !IdentityC->isNullValue())
+  if (IdentityC == nullptr || !IdentityC->isZeroValue())
     return nullptr;
 
   unsigned C2Log = C2->logBase2();
@@ -2713,7 +2713,7 @@ static Instruction *canonicalizeSelectToShuffle(SelectInst &SI) {
     if (Elt->isOneValue()) {
       // If the select condition element is true, choose from the 1st vector.
       Mask.push_back(i);
-    } else if (Elt->isNullValue()) {
+    } else if (Elt->isZeroValue()) {
       // If the select condition element is false, choose from the 2nd vector.
       Mask.push_back(i + NumElts);
     } else if (isa<UndefValue>(Elt)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1820,8 +1820,8 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       for (unsigned i = 0; i < VWidth; i++) {
         Constant *CElt = CV->getAggregateElement(i);
 
-        // isNullValue() always returns false when called on a ConstantExpr.
-        if (CElt->isNullValue())
+        // isZeroValue() always returns false when called on a ConstantExpr.
+        if (CElt->isZeroValue())
           DemandedLHS.clearBit(i);
         else if (CElt->isOneValue())
           DemandedRHS.clearBit(i);
@@ -1915,7 +1915,7 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
       if (auto *CMask = dyn_cast<Constant>(II->getOperand(1))) {
         for (unsigned i = 0; i < VWidth; i++) {
           if (Constant *CElt = CMask->getAggregateElement(i)) {
-            if (CElt->isNullValue())
+            if (CElt->isZeroValue())
               DemandedPtrs.clearBit(i);
             else if (CElt->isAllOnesValue())
               DemandedPassThrough.clearBit(i);

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -897,7 +897,7 @@ Instruction *InstCombinerImpl::tryFoldInstWithCtpopWithNot(Instruction *I) {
   if (Opc == Instruction::ICmp && !cast<ICmpInst>(I)->isEquality()) {
     Constant *Cmp =
         ConstantFoldCompareInstOperands(ICmpInst::ICMP_UGT, C, BitWidthC, DL);
-    if (!Cmp || !Cmp->isNullValue())
+    if (!Cmp || !Cmp->isZeroValue())
       return nullptr;
   }
 
@@ -2975,7 +2975,7 @@ Instruction *InstCombinerImpl::visitGEPOfGEP(GetElementPtrInst &GEP,
   // Don't create GEPs with more than one non-zero index.
   unsigned NumNonZeroIndices = count_if(Indices, [](Value *Idx) {
     auto *C = dyn_cast<Constant>(Idx);
-    return !C || !C->isNullValue();
+    return !C || !C->isZeroValue();
   });
   if (NumNonZeroIndices > 1)
     return nullptr;
@@ -3412,7 +3412,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 
   // Strip trailing zero indices.
   auto *LastIdx = dyn_cast<Constant>(Indices.back());
-  if (LastIdx && LastIdx->isNullValue() && !LastIdx->getType()->isVectorTy()) {
+  if (LastIdx && LastIdx->isZeroValue() && !LastIdx->getType()->isVectorTy()) {
     return replaceInstUsesWith(
         GEP, Builder.CreateGEP(GEP.getSourceElementType(), PtrOp,
                                drop_end(Indices), "", GEP.getNoWrapFlags()));
@@ -3420,7 +3420,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 
   // Strip leading zero indices.
   auto *FirstIdx = dyn_cast<Constant>(Indices.front());
-  if (FirstIdx && FirstIdx->isNullValue() &&
+  if (FirstIdx && FirstIdx->isZeroValue() &&
       !FirstIdx->getType()->isVectorTy()) {
     gep_type_iterator GTI = gep_type_begin(GEP);
     ++GTI;
@@ -3462,7 +3462,7 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
   for (auto [IdxNum, Idx] : enumerate(Indices)) {
     // Ignore one leading zero index.
     auto *C = dyn_cast<Constant>(Idx);
-    if (C && C->isNullValue() && IdxNum == 0)
+    if (C && C->isZeroValue() && IdxNum == 0)
       continue;
 
     if (!SeenNonZeroIndex) {
@@ -3923,7 +3923,7 @@ Instruction *InstCombinerImpl::visitAllocSite(Instruction &MI) {
   if (Init) {
     if (isa<UndefValue>(Init))
       KnowInitUndef = true;
-    else if (Init->isNullValue())
+    else if (Init->isZeroValue())
       KnowInitZero = true;
   }
   // The various sanitizers don't actually return undef memory, but rather
@@ -4889,7 +4889,7 @@ static bool isCatchAll(EHPersonality Personality, Constant *TypeInfo) {
   case EHPersonality::Wasm_CXX:
   case EHPersonality::XL_CXX:
   case EHPersonality::ZOS_CXX:
-    return TypeInfo->isNullValue();
+    return TypeInfo->isZeroValue();
   }
   llvm_unreachable("invalid enum");
 }
@@ -5146,7 +5146,7 @@ Instruction *InstCombinerImpl::visitLandingPadInst(LandingPadInst &LI) {
         // LFilter iff LFilter contains a zero.
         assert(FElts > 0 && "Should have eliminated the empty filter earlier!");
         for (unsigned l = 0; l != LElts; ++l)
-          if (LArray->getOperand(l)->isNullValue()) {
+          if (LArray->getOperand(l)->isZeroValue()) {
             // LFilter contains a zero - discard it.
             NewClauses.erase(J);
             MakeNewInstruction = true;

--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -2077,7 +2077,7 @@ Value *DFSanFunction::combineOrigins(const std::vector<Value *> &Shadows,
   for (size_t I = 0; I != Size; ++I) {
     Value *OpOrigin = Origins[I];
     Constant *ConstOpOrigin = dyn_cast<Constant>(OpOrigin);
-    if (ConstOpOrigin && ConstOpOrigin->isNullValue())
+    if (ConstOpOrigin && ConstOpOrigin->isZeroValue())
       continue;
     if (!Origin) {
       Origin = OpOrigin;
@@ -2363,7 +2363,7 @@ DFSanFunction::loadShadowOrigin(Value *Addr, uint64_t Size, Align InstAlignment,
     if (ClTrackOrigins == 2) {
       IRBuilder<> IRB(Pos->getParent(), Pos);
       auto *ConstantShadow = dyn_cast<Constant>(PrimitiveShadow);
-      if (!ConstantShadow || !ConstantShadow->isNullValue())
+      if (!ConstantShadow || !ConstantShadow->isZeroValue())
         Origin = updateOriginIfTainted(PrimitiveShadow, Origin, IRB);
     }
   }
@@ -2552,7 +2552,7 @@ void DFSanFunction::storeOrigin(BasicBlock::iterator Pos, Value *Addr,
   Value *CollapsedShadow = collapseToPrimitiveShadow(Shadow, Pos);
   IRBuilder<> IRB(Pos->getParent(), Pos);
   if (auto *ConstantShadow = dyn_cast<Constant>(CollapsedShadow)) {
-    if (!ConstantShadow->isNullValue())
+    if (!ConstantShadow->isZeroValue())
       paintOrigin(IRB, updateOrigin(Origin, IRB), StoreOriginAddr, Size,
                   OriginAlignment);
     return;

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1175,7 +1175,7 @@ void InstrLowerer::lowerCover(InstrProfCoverInst *CoverInstruction) {
 
 void InstrLowerer::lowerTimestamp(
     InstrProfTimestampInst *TimestampInstruction) {
-  assert(TimestampInstruction->getIndex()->isNullValue() &&
+  assert(TimestampInstruction->getIndex()->isZeroValue() &&
          "timestamp probes are always the first probe for a function");
   auto &Ctx = M.getContext();
   auto *TimestampAddr = getCounterAddress(TimestampInstruction);
@@ -1204,7 +1204,7 @@ void InstrLowerer::lowerIncrement(InstrProfIncrementInst *Inc) {
         ConstantPointerNull::get(PointerType::getUnqual(M.getContext()));
     Builder.CreateCall(Callee, {CastAddr, Uniform, Inc->getStep()});
   } else if (Options.Atomic || AtomicCounterUpdateAll ||
-             (Inc->getIndex()->isNullValue() && AtomicFirstCounter)) {
+             (Inc->getIndex()->isZeroValue() && AtomicFirstCounter)) {
     Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getStep(),
                             MaybeAlign(), AtomicOrdering::Monotonic);
   } else {

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1372,7 +1372,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // ZExt cannot convert between vector and scalar
     Value *ConvertedShadow = convertShadowToScalar(Shadow, IRB);
     if (auto *ConstantShadow = dyn_cast<Constant>(ConvertedShadow)) {
-      if (!ClCheckConstantShadow || ConstantShadow->isNullValue()) {
+      if (!ClCheckConstantShadow || ConstantShadow->isZeroValue()) {
         // Origin is not needed: value is initialized or const shadow is
         // ignored.
         return;
@@ -1535,7 +1535,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       Value *ConvertedShadow = ShadowData.Shadow;
 
       if (auto *ConstantShadow = dyn_cast<Constant>(ConvertedShadow)) {
-        if (!ClCheckConstantShadow || ConstantShadow->isNullValue()) {
+        if (!ClCheckConstantShadow || ConstantShadow->isZeroValue()) {
           // Skip, value is initialized or const shadow is ignored.
           continue;
         }
@@ -2759,7 +2759,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         } else {
           Constant *ConstOrigin = dyn_cast<Constant>(OpOrigin);
           // No point in adding something that might result in 0 origin value.
-          if (!ConstOrigin || !ConstOrigin->isNullValue()) {
+          if (!ConstOrigin || !ConstOrigin->isZeroValue()) {
             Value *Cond = MSV->convertToBool(OpShadow, IRB);
             Origin = IRB.CreateSelect(Cond, OpOrigin, Origin);
           }
@@ -3201,7 +3201,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       return;
     }
 
-    if ((constOp->isNullValue() &&
+    if ((constOp->isZeroValue() &&
          (pre == CmpInst::ICMP_SLT || pre == CmpInst::ICMP_SGE)) ||
         (constOp->isAllOnesValue() &&
          (pre == CmpInst::ICMP_SGT || pre == CmpInst::ICMP_SLE))) {
@@ -3550,7 +3550,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
     // If zero poison is requested, mix in with the shadow
     Constant *IsZeroPoison = cast<Constant>(I.getOperand(1));
-    if (!IsZeroPoison->isNullValue()) {
+    if (!IsZeroPoison->isZeroValue()) {
       Value *BoolZeroPoison = IRB.CreateIsNull(Src, "_mscz_bzp");
       OutputShadow = IRB.CreateOr(OutputShadow, BoolZeroPoison, "_mscz_bs");
     }
@@ -7547,7 +7547,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
           Store = IRB.CreateAlignedStore(ArgShadow, ArgShadowBase,
                                          kShadowTLSAlignment);
           Constant *Cst = dyn_cast<Constant>(ArgShadow);
-          if (MS.TrackOrigins && !(Cst && Cst->isNullValue())) {
+          if (MS.TrackOrigins && !(Cst && Cst->isZeroValue())) {
             IRB.CreateStore(getOrigin(A),
                             getOriginPtrForArgument(IRB, ArgOffset));
           }

--- a/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
+++ b/llvm/lib/Transforms/Scalar/CallSiteSplitting.cpp
@@ -168,7 +168,7 @@ static void addConditions(CallBase &CB, const ConditionsTy &Conditions) {
     Constant *ConstVal = cast<Constant>(Cond.first->getOperand(1));
     if (Cond.second == ICmpInst::ICMP_EQ)
       setConstantInArgument(CB, Arg, ConstVal);
-    else if (ConstVal->getType()->isPointerTy() && ConstVal->isNullValue()) {
+    else if (ConstVal->getType()->isPointerTy() && ConstVal->isZeroValue()) {
       assert(Cond.second == ICmpInst::ICMP_NE);
       addNonNullAttribute(CB, Arg);
     }

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -226,7 +226,7 @@ static Value *getValueOnEdge(LazyValueInfo *LVI, Value *Incoming,
     if (Constant *C = LVI->getConstantOnEdge(Condition, From, To, CxtI)) {
       if (C->isOneValue())
         return SI->getTrueValue();
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return SI->getFalseValue();
     }
   }

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -2256,7 +2256,7 @@ bool DSEState::tryFoldIntoCalloc(MemoryDef *Def, const Value *DefUO) {
     // TODO: Could handle zero store to small allocation as well.
     return false;
   Constant *StoredConstant = dyn_cast<Constant>(MemSet->getValue());
-  if (!StoredConstant || !StoredConstant->isNullValue())
+  if (!StoredConstant || !StoredConstant->isZeroValue())
     return false;
 
   if (!isRemovable(DefI))

--- a/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/llvm/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1680,7 +1680,7 @@ bool IndVarSimplify::optimizeLoopExits(Loop *L, SCEVExpander &Rewriter) {
       // If already constant, nothing to do. However, if this is an
       // unconditional exit, we can still replace header phis with their
       // preheader value.
-      if (!L->contains(BI->getSuccessor(CI->isNullValue())))
+      if (!L->contains(BI->getSuccessor(CI->isZeroValue())))
         replaceLoopPHINodesWithPreheaderValues(LI, L, DeadInsts, *SE);
       return true;
     }

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1782,7 +1782,7 @@ static bool isZeroSize(Value *Size) {
       Size = Res;
   // Treat undef/poison size like zero.
   if (auto *C = dyn_cast<Constant>(Size))
-    return isa<UndefValue>(C) || C->isNullValue();
+    return isa<UndefValue>(C) || C->isZeroValue();
   return false;
 }
 

--- a/llvm/lib/Transforms/Scalar/ScalarizeMaskedMemIntrin.cpp
+++ b/llvm/lib/Transforms/Scalar/ScalarizeMaskedMemIntrin.cpp
@@ -182,7 +182,7 @@ static void scalarizeMaskedLoad(const DataLayout &DL, bool HasBranchDivergence,
 
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Gep = Builder.CreateConstInBoundsGEP1_32(EltTy, Ptr, Idx);
       LoadInst *Load = Builder.CreateAlignedLoad(EltTy, Gep, AdjustedAlignVal);
@@ -348,7 +348,7 @@ static void scalarizeMaskedStore(const DataLayout &DL, bool HasBranchDivergence,
 
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt = Builder.CreateExtractElement(Src, Idx);
       Value *Gep = Builder.CreateConstInBoundsGEP1_32(EltTy, Ptr, Idx);
@@ -492,7 +492,7 @@ static void scalarizeMaskedGather(const DataLayout &DL,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Ptr = Builder.CreateExtractElement(Ptrs, Idx, "Ptr" + Twine(Idx));
       LoadInst *Load =
@@ -630,7 +630,7 @@ static void scalarizeMaskedScatter(const DataLayout &DL,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt =
           Builder.CreateExtractElement(Src, Idx, "Elt" + Twine(Idx));
@@ -739,7 +739,7 @@ static void scalarizeMaskedExpandLoad(const DataLayout &DL,
     SmallVector<int, 16> ShuffleMask(VectorWidth, PoisonMaskElem);
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
       Value *InsertElt;
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue()) {
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue()) {
         InsertElt = PoisonValue::get(EltTy);
         ShuffleMask[Idx] = Idx + VectorWidth;
       } else {
@@ -869,7 +869,7 @@ static void scalarizeMaskedCompressStore(const DataLayout &DL,
   if (isConstantIntVector(Mask)) {
     unsigned MemIndex = 0;
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *OneElt =
           Builder.CreateExtractElement(Src, Idx, "Elt" + Twine(Idx));
@@ -1000,7 +1000,7 @@ static void scalarizeMaskedVectorHistogram(const DataLayout &DL, CallInst *CI,
   // Shorten the way if the mask is a vector of constants.
   if (isConstantIntVector(Mask)) {
     for (unsigned Idx = 0; Idx < VectorWidth; ++Idx) {
-      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isNullValue())
+      if (cast<Constant>(Mask)->getAggregateElement(Idx)->isZeroValue())
         continue;
       Value *Ptr = Builder.CreateExtractElement(Ptrs, Idx, "Ptr" + Twine(Idx));
       LoadInst *Load = Builder.CreateLoad(EltTy, Ptr, "Load" + Twine(Idx));

--- a/llvm/lib/Transforms/Utils/Evaluator.cpp
+++ b/llvm/lib/Transforms/Utils/Evaluator.cpp
@@ -386,9 +386,9 @@ bool Evaluator::EvaluateBlock(BasicBlock::iterator CurInst, BasicBlock *&NextBB,
           Constant *Val = getVal(MSI->getValue());
           // Avoid the byte-per-byte scan if we're memseting a zeroinitializer
           // to zero.
-          if (!Val->isNullValue() || MutatedMemory.contains(GV) ||
+          if (!Val->isZeroValue() || MutatedMemory.contains(GV) ||
               !GV->hasDefinitiveInitializer() ||
-              !GV->getInitializer()->isNullValue()) {
+              !GV->getInitializer()->isZeroValue()) {
             APInt Len = LenC->getValue();
             if (Len.ugt(64 * 1024)) {
               LLVM_DEBUG(dbgs() << "Not evaluating large memset of size "

--- a/llvm/lib/Transforms/Utils/FunctionComparator.cpp
+++ b/llvm/lib/Transforms/Utils/FunctionComparator.cpp
@@ -347,11 +347,11 @@ int FunctionComparator::cmpConstants(const Constant *L,
 
   // OK, types are bitcastable, now check constant contents.
 
-  if (L->isNullValue() && R->isNullValue())
+  if (L->isZeroValue() && R->isZeroValue())
     return TypesRes;
-  if (L->isNullValue() && !R->isNullValue())
+  if (L->isZeroValue() && !R->isZeroValue())
     return 1;
-  if (!L->isNullValue() && R->isNullValue())
+  if (!L->isZeroValue() && R->isZeroValue())
     return -1;
 
   auto GlobalValueL = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(L));

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -513,7 +513,7 @@ bool llvm::wouldInstructionBeTriviallyDead(const Instruction *I,
   if (auto *Call = dyn_cast<CallBase>(I)) {
     if (Value *FreedOp = getFreedOperand(Call, TLI))
       if (Constant *C = dyn_cast<Constant>(FreedOp))
-        return C->isNullValue() || isa<UndefValue>(C);
+        return C->isZeroValue() || isa<UndefValue>(C);
     if (isMathLibCallNoop(Call, TLI))
       return true;
   }

--- a/llvm/lib/Transforms/Utils/LowerGlobalDtors.cpp
+++ b/llvm/lib/Transforms/Utils/LowerGlobalDtors.cpp
@@ -109,7 +109,7 @@ static bool runImpl(Module &M) {
     uint16_t PriorityValue = Priority->getLimitedValue(UINT16_MAX);
 
     Constant *DtorFunc = CS->getOperand(1);
-    if (DtorFunc->isNullValue())
+    if (DtorFunc->isZeroValue())
       break; // Found a null terminator, skip the rest.
 
     Constant *Associated = CS->getOperand(2);
@@ -180,7 +180,7 @@ static bool runImpl(Module &M) {
                                       : Twine()) +
               (AtThisPriority.size() > 1 ? Twine("$") + Twine(ThisId)
                                          : Twine()) +
-              (!Associated->isNullValue() ? (Twine(".") + Associated->getName())
+              (!Associated->isZeroValue() ? (Twine(".") + Associated->getName())
                                           : Twine()),
           &M);
       BasicBlock *BB = BasicBlock::Create(C, "body", CallDtors);
@@ -198,7 +198,7 @@ static bool runImpl(Module &M) {
                                       : Twine()) +
               (AtThisPriority.size() > 1 ? Twine("$") + Twine(ThisId)
                                          : Twine()) +
-              (!Associated->isNullValue() ? (Twine(".") + Associated->getName())
+              (!Associated->isZeroValue() ? (Twine(".") + Associated->getName())
                                           : Twine()),
           &M);
       BasicBlock *EntryBB = BasicBlock::Create(C, "entry", RegisterCallDtors);

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -491,7 +491,7 @@ static void inferAttribute(Function *F, unsigned AttrIndex,
   }
   // Infer nonnull attribute.
   if (Val.isNotConstant() && Val.getNotConstant()->getType()->isPointerTy() &&
-      Val.getNotConstant()->isNullValue() &&
+      Val.getNotConstant()->isZeroValue() &&
       !F->hasAttributeAtIndex(AttrIndex, Attribute::NonNull)) {
     F->addAttributeAtIndex(AttrIndex,
                            Attribute::get(F->getContext(), Attribute::NonNull));
@@ -1811,7 +1811,7 @@ void SCCPInstVisitor::visitGetElementPtrInst(GetElementPtrInst &I) {
     return;
 
   // gep inbounds/nuw of non-null is non-null.
-  if (PtrState.isNotConstant() && PtrState.getNotConstant()->isNullValue()) {
+  if (PtrState.isNotConstant() && PtrState.getNotConstant()->isZeroValue()) {
     if (I.hasNoUnsignedWrap() ||
         (I.isInBounds() &&
          !NullPointerIsDefined(I.getFunction(), I.getAddressSpace())))

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -343,7 +343,7 @@ isSelectInRoleOfConjunctionOrDisjunction(const SelectInst *SI) {
   return ((isa<ConstantInt>(SI->getTrueValue()) &&
            (dyn_cast<ConstantInt>(SI->getTrueValue())->isOne())) ||
           (isa<ConstantInt>(SI->getFalseValue()) &&
-           (dyn_cast<ConstantInt>(SI->getFalseValue())->isNullValue())));
+           (dyn_cast<ConstantInt>(SI->getFalseValue())->isZeroValue())));
 }
 
 } // end anonymous namespace
@@ -5983,11 +5983,11 @@ bool SimplifyCFGOpt::turnSwitchRangeIntoICmp(SwitchInst *SI,
     NewBI = Builder.CreateCondBr(Cmp, Dest, OtherDest);
   }
   // If NumCases overflowed, then all possible values jump to the successor.
-  else if (NumCases->isNullValue() && !Cases->empty()) {
+  else if (NumCases->isZeroValue() && !Cases->empty()) {
     NewBI = Builder.CreateBr(Dest);
   } else {
     Value *Sub = SI->getCondition();
-    if (!Offset->isNullValue())
+    if (!Offset->isZeroValue())
       Sub = Builder.CreateAdd(Sub, Offset, Sub->getName() + ".off");
     Value *Cmp = Builder.CreateICmpULT(Sub, NumCases, "switch");
     NewBI = Builder.CreateCondBr(Cmp, Dest, OtherDest);
@@ -6308,7 +6308,7 @@ constantFold(Instruction *I, const DataLayout &DL,
       return nullptr;
     if (A->isAllOnesValue())
       return lookupConstant(Select->getTrueValue(), ConstantPool);
-    if (A->isNullValue())
+    if (A->isZeroValue())
       return lookupConstant(Select->getFalseValue(), ConstantPool);
     return nullptr;
   }
@@ -6587,7 +6587,7 @@ static Value *foldSwitchToSelect(const SwitchCaseResultVectorTy &ResultVector,
       // Check if cases with the same result can cover all number
       // in touched bits.
       if (BitMask.popcount() == Log2_32(CaseCount)) {
-        if (!MinCaseVal->isNullValue())
+        if (!MinCaseVal->isZeroValue())
           Condition = Builder.CreateSub(Condition, MinCaseVal);
         Value *And = Builder.CreateAnd(Condition, ~BitMask, "switch.and");
         Value *Cmp = Builder.CreateICmpEQ(
@@ -7091,7 +7091,7 @@ static bool shouldUseSwitchConditionAsTableIndex(
     ConstantInt &MinCaseVal, const ConstantInt &MaxCaseVal,
     bool HasDefaultResults, const SmallVector<Type *> &ResultTypes,
     const DataLayout &DL, const TargetTransformInfo &TTI) {
-  if (MinCaseVal.isNullValue())
+  if (MinCaseVal.isZeroValue())
     return true;
   if (MinCaseVal.isNegative() ||
       MaxCaseVal.getLimitedValue() == std::numeric_limits<uint64_t>::max() ||
@@ -8688,7 +8688,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
   if (I->use_empty())
     return false;
 
-  if (C->isNullValue() || isa<UndefValue>(C)) {
+  if (C->isZeroValue() || isa<UndefValue>(C)) {
     // Only look at the first use we can handle, avoid hurting compile time with
     // long uselists
     auto FindUse = llvm::find_if(I->uses(), [](auto &U) {
@@ -8764,7 +8764,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
       if (isa<UndefValue>(C) && HasNoUndefAttr)
         return true;
       // Return null to a nonnull+noundef return value is undefined.
-      if (C->isNullValue() && HasNoUndefAttr &&
+      if (C->isZeroValue() && HasNoUndefAttr &&
           Ret->getFunction()->hasRetAttribute(Attribute::NonNull)) {
         return !PtrValueMayBeModified;
       }
@@ -8791,7 +8791,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
     }
 
     if (auto *CB = dyn_cast<CallBase>(User)) {
-      if (C->isNullValue() && NullPointerIsDefined(CB->getFunction()))
+      if (C->isZeroValue() && NullPointerIsDefined(CB->getFunction()))
         return false;
       // A call to null is undefined.
       if (CB->getCalledOperand() == I)

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -255,7 +255,7 @@ static bool isOnlyUsedInComparisonWithZero(Value *V) {
   for (User *U : V->users()) {
     if (ICmpInst *IC = dyn_cast<ICmpInst>(U))
       if (Constant *C = dyn_cast<Constant>(IC->getOperand(1)))
-        if (C->isNullValue())
+        if (C->isZeroValue())
           continue;
     // Unknown instruction.
     return false;
@@ -1654,7 +1654,7 @@ Value *LibCallSimplifier::optimizeMemCCpy(CallInst *CI, IRBuilderBase &B) {
     return Dst;
   // memccpy(d, s, c, 0) -> nullptr
   if (N) {
-    if (N->isNullValue())
+    if (N->isZeroValue())
       return Constant::getNullValue(CI->getType());
     if (!getConstantStringInfo(Src, SrcStr, /*TrimAtNul=*/false) ||
         // TODO: Handle zeroinitializer.

--- a/llvm/lib/Transforms/Utils/VNCoercion.cpp
+++ b/llvm/lib/Transforms/Utils/VNCoercion.cpp
@@ -61,7 +61,7 @@ bool VNCoercion::canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
     // an array w/null.  Despite non-integral pointers not generally having a
     // specific bit pattern, we do assume null is zero.
     if (auto *CI = dyn_cast<Constant>(StoredVal))
-      return CI->isNullValue();
+      return CI->isZeroValue();
     return false;
   } else if (StoredNI && LoadNI &&
              StoredTy->getPointerAddressSpace() !=

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -722,7 +722,7 @@ void LoopVectorizationLegality::addInductionPhi(
   if (ID.getKind() == InductionDescriptor::IK_IntInduction &&
       ID.getConstIntStepValue() && ID.getConstIntStepValue()->isOne() &&
       isa<Constant>(ID.getStartValue()) &&
-      cast<Constant>(ID.getStartValue())->isNullValue()) {
+      cast<Constant>(ID.getStartValue())->isZeroValue()) {
 
     // Use the phi node with the widest type as induction. Use the last
     // one if there are multiple (no good reason for doing this other

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -622,7 +622,7 @@ uint64_t ReducerWorkItem::computeMIRComplexityScore() const {
 // for more reduced.
 static unsigned classifyReductivePower(const Value *V) {
   if (auto *C = dyn_cast<ConstantData>(V)) {
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return 0;
     if (C->isOneValue())
       return 1;

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -52,7 +52,7 @@ static bool isOne(Use &Op) {
 
 static bool isZero(Use &Op) {
   auto *C = dyn_cast<Constant>(Op);
-  return C && C->isNullValue();
+  return C && C->isZeroValue();
 }
 
 static bool isZeroOrOneFP(Value *Op) {

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsSkip.cpp
@@ -62,7 +62,7 @@ static int classifyReductivePower(Value *V) {
   if (auto *C = dyn_cast<ConstantData>(V)) {
     if (isa<UndefValue>(V))
       return -2;
-    if (C->isNullValue())
+    if (C->isZeroValue())
       return 7;
     if (C->isOneValue())
       return 6;

--- a/llvm/unittests/Analysis/ValueLatticeTest.cpp
+++ b/llvm/unittests/Analysis/ValueLatticeTest.cpp
@@ -109,9 +109,9 @@ TEST_F(ValueLatticeTest, getCompareIntegers) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV1, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV1, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLE, I1Ty, LV1, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV1, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV1, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV1, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV1, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV1, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV1, DL)->isZeroValue());
 
   auto LV2 =
       ValueLatticeElement::getRange({APInt(32, 10, true), APInt(32, 20, true)});
@@ -119,9 +119,9 @@ TEST_F(ValueLatticeTest, getCompareIntegers) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLT, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SLE, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_NE, I1Ty, LV2, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV2, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_EQ, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGE, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::ICMP_SGT, I1Ty, LV2, DL)->isZeroValue());
 
   auto LV3 =
       ValueLatticeElement::getRange({APInt(32, 15, true), APInt(32, 19, true)});
@@ -155,9 +155,9 @@ TEST_F(ValueLatticeTest, getCompareFloat) {
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OEQ, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGE, I1Ty, LV2, DL)->isOneValue());
   EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLE, I1Ty, LV2, DL)->isOneValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_ONE, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLT, I1Ty, LV2, DL)->isNullValue());
-  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGT, I1Ty, LV2, DL)->isNullValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_ONE, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OLT, I1Ty, LV2, DL)->isZeroValue());
+  EXPECT_TRUE(LV1.getCompare(CmpInst::FCMP_OGT, I1Ty, LV2, DL)->isZeroValue());
 
   EXPECT_TRUE(
       LV1.mergeIn(ValueLatticeElement::get(ConstantFP::get(FloatTy, 2.2))));

--- a/llvm/unittests/AsmParser/AsmParserTest.cpp
+++ b/llvm/unittests/AsmParser/AsmParserTest.cpp
@@ -154,7 +154,7 @@ TEST(AsmParserTest, TypeAndConstantValueParsing) {
   ASSERT_TRUE(V);
   EXPECT_TRUE(V->getType()->isVectorTy());
   ASSERT_TRUE(isa<Constant>(V));
-  EXPECT_TRUE(cast<Constant>(V)->isNullValue());
+  EXPECT_TRUE(cast<Constant>(V)->isZeroValue());
 
   V = parseConstantValue("<4 x i32> poison", Error, M);
   ASSERT_TRUE(V);

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -485,7 +485,7 @@ bool foldFuncPtrAndConstToNull(LLVMContext &Context, Module *TheModule,
 
   Constant *C = ConstantFoldBinaryInstruction(Instruction::And, TheConstantExpr,
                                               TheConstant);
-  bool Result = C && C->isNullValue();
+  bool Result = C && C->isZeroValue();
 
   if (!TheModule) {
     // If the Module exists then it will delete the Function.
@@ -572,12 +572,12 @@ TEST(ConstantsTest, FoldGlobalVariablePtr) {
   Constant *PtrToInt = ConstantExpr::getPtrToInt(Global.get(), IntType);
   ASSERT_TRUE(
       ConstantFoldBinaryInstruction(Instruction::And, PtrToInt, TheConstant)
-          ->isNullValue());
+          ->isZeroValue());
 
   Constant *PtrToAddr = ConstantExpr::getPtrToAddr(Global.get(), IntType);
   ASSERT_TRUE(
       ConstantFoldBinaryInstruction(Instruction::And, PtrToAddr, TheConstant)
-          ->isNullValue());
+          ->isZeroValue());
 }
 
 // Check that containsUndefOrPoisonElement and containsPoisonElement is working

--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -1865,10 +1865,10 @@ TEST_F(PatternMatchTest, VectorUndefFloat) {
 
   CC = nullptr;
   EXPECT_TRUE(match(VectorZero, m_CheckedFp(CC, CheckTrue)));
-  EXPECT_TRUE(CC->isNullValue());
+  EXPECT_TRUE(CC->isZeroValue());
   CC = nullptr;
   EXPECT_TRUE(match(VectorZero, m_CheckedFp(CC, CheckNonNaN)));
-  EXPECT_TRUE(CC->isNullValue());
+  EXPECT_TRUE(CC->isZeroValue());
 
   // Splats with undef are never allowed.
   // Whether splats with poison can be matched depends on the matcher.

--- a/llvm/unittests/Target/X86/TernlogTest.cpp
+++ b/llvm/unittests/Target/X86/TernlogTest.cpp
@@ -119,7 +119,7 @@ struct TernTester {
 
       auto *C = dyn_cast<Constant>(V);
       assert(C);
-      if (C->isNullValue())
+      if (C->isZeroValue())
         return 0;
       if (C->isAllOnesValue())
         return ((~uint64_t(0)) >> (ElemWidth % 64));

--- a/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ScalarEvolutionExpanderTest.cpp
@@ -943,7 +943,7 @@ TEST_F(ScalarEvolutionExpanderTest, ExpandNonIntegralPtrWithNullBase) {
     Value *Offset = &*F.arg_begin();
     auto *GEP = dyn_cast<GetElementPtrInst>(V);
     EXPECT_TRUE(GEP);
-    EXPECT_TRUE(cast<Constant>(GEP->getPointerOperand())->isNullValue());
+    EXPECT_TRUE(cast<Constant>(GEP->getPointerOperand())->isZeroValue());
     EXPECT_EQ(GEP->getNumOperands(), 2U);
     EXPECT_TRUE(match(
         GEP->getOperand(1),


### PR DESCRIPTION
The old `isZeroValue` was removed because it was functionally identical to `Constant::isNullValue`. Currently, a "null value" in LLVM means a zero value. We are moving toward changing the semantics of `ConstantPointerNull` to represent a semantic null pointer instead of a zero-valued pointer. As a result, the meaning of "null value" will also change in the future.

This PR series is the first step toward renaming the two widely used "null value" interfaces to "zero value". As the first PR in the series, this change adds a "new" `isZeroValue` alongside `isNullValue`, and makes `isNullValue` call `isZeroValue` directly. Then, all uses of `isNullValue` in LLVM are replaced with `isZeroValue`. Uses in other projects will be updated in separate PRs.

The plan is to eventually remove `isNullValue` after all uses have been migrated.