### PR TITLE
[clang] correctly handle +/- features when matching modules

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -456,6 +456,26 @@ static bool checkCodegenOptions(const CodeGenOptions &CGOpts,
   return false;
 }
 
+static std::vector<std::string>
+accumulateFeaturesAsWritten(std::vector<std::string> FeaturesAsWritten) {
+  llvm::erase_if(FeaturesAsWritten, [](const std::string &S) {
+    return S.empty() || (S[0] != '+' && S[0] != '-');
+  });
+  llvm::stable_sort(FeaturesAsWritten,
+                    [](const std::string &A, const std::string &B) {
+                      return A.substr(1) < B.substr(1);
+                    });
+  auto NewRend =
+      std::unique(FeaturesAsWritten.rbegin(), FeaturesAsWritten.rend(),
+                  [](const std::string &A, const std::string &B) {
+                    return A.substr(1) == B.substr(1);
+                  });
+  // Because we are operating on reverse iterators, the duplicate elements
+  // are actually at the beginning.
+  FeaturesAsWritten.erase(FeaturesAsWritten.begin(), NewRend.base());
+  return FeaturesAsWritten;
+}
+
 /// Compare the given set of target options against an existing set of
 /// target options.
 ///
@@ -491,16 +511,12 @@ static bool checkTargetOptions(const TargetOptions &TargetOpts,
 #undef CHECK_TARGET_OPT
 
   // Compare feature sets.
-  SmallVector<StringRef, 4> ExistingFeatures(
-                                             ExistingTargetOpts.FeaturesAsWritten.begin(),
-                                             ExistingTargetOpts.FeaturesAsWritten.end());
-  SmallVector<StringRef, 4> ReadFeatures(TargetOpts.FeaturesAsWritten.begin(),
-                                         TargetOpts.FeaturesAsWritten.end());
-  llvm::sort(ExistingFeatures);
-  ExistingFeatures.erase(llvm::unique(ExistingFeatures),
-                         ExistingFeatures.end());
-  llvm::sort(ReadFeatures);
-  ReadFeatures.erase(llvm::unique(ReadFeatures), ReadFeatures.end());
+  // Alternatively, we could be diffing TargetOpts.Features, but that would
+  // clutter the output with implied features.
+  std::vector<std::string> ExistingFeatures =
+      accumulateFeaturesAsWritten(ExistingTargetOpts.FeaturesAsWritten);
+  std::vector<std::string> ReadFeatures =
+      accumulateFeaturesAsWritten(TargetOpts.FeaturesAsWritten);
 
   // We compute the set difference in both directions explicitly so that we can
   // diagnose the differences differently.

--- a/clang/test/Modules/merge-target-features.cpp
+++ b/clang/test/Modules/merge-target-features.cpp
@@ -19,6 +19,24 @@
 // RUN:   -target-cpu i386 -target-feature +sse2 -target-feature +sse2 \
 // RUN:   Inputs/merge-target-features/module.modulemap
 //
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -emit-module -fmodule-name=foo -o %t/foo-plusminus.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 -target-feature -sse2 \
+// RUN:   Inputs/merge-target-features/module.modulemap
+//
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -emit-module -fmodule-name=foo -o %t/foo-minusplus.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature -sse2 -target-feature +sse2 \
+// RUN:   Inputs/merge-target-features/module.modulemap
+//
 // RUN: not %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
 // RUN:   -iquote Inputs/merge-target-features \
 // RUN:   -fno-implicit-modules \
@@ -81,6 +99,55 @@
 // RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
 // RUN:   | FileCheck --allow-empty --check-prefix=DOUBLE %s
 // DOUBLE-NOT: error:
+//
+// RUN: not %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -fmodule-map-file=Inputs/merge-target-features/module.modulemap \
+// RUN:   -fmodule-file=%t/foo-plusminus.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 \
+// RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
+// RUN:   | FileCheck --allow-empty --check-prefix=PLUSMINUS %s
+// PLUSMINUS: error: precompiled file '{{.*}}foo-plusminus.pcm' was compiled with the target feature '-sse2' but the current translation unit is not
+// PLUSMINUS: error: {{.*}} configuration mismatch
+//
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -fmodule-map-file=Inputs/merge-target-features/module.modulemap \
+// RUN:   -fmodule-file=%t/foo-minusplus.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 \
+// RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
+// RUN:   | FileCheck --allow-empty --check-prefix=MINUSPLUS %s
+// MINUSPLUS-NOT: error:
+//
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -fmodule-map-file=Inputs/merge-target-features/module.modulemap \
+// RUN:   -fmodule-file=%t/foo.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 -target-feature invalid \
+// RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
+// RUN:   | FileCheck --allow-empty --check-prefix=IGNORED %s
+// IGNORED-NOT: error:
+//
+// RUN: %clang_cc1 -fmodules -x c++ -fmodules-cache-path=%t \
+// RUN:   -iquote Inputs/merge-target-features \
+// RUN:   -fno-implicit-modules \
+// RUN:   -fmodule-map-file-home-is-cwd \
+// RUN:   -fmodule-map-file=Inputs/merge-target-features/module.modulemap \
+// RUN:   -fmodule-file=%t/foo.pcm \
+// RUN:   -triple i386-unknown-unknown \
+// RUN:   -target-cpu i386 -target-feature +sse2 -target-feature x \
+// RUN:   -fsyntax-only merge-target-features.cpp 2>&1 \
+// RUN:   | FileCheck --allow-empty --check-prefix=IGNORED2 %s
+// IGNORED2-NOT: error:
 
 #include "foo.h"
 


### PR DESCRIPTION
By sorting and then comparing, we made +sse2 -sse2 equal to
-sse2 +sse2, where the former has sse2 disabled, and the latter
enabled. I verified this is actually the case by compiling the
following:

```
 #ifdef __SSE2__
  #error X
 #endif
```
