### PR TITLE
[flang] Use __builtin_int for integer conversions

### DIFF
--- a/flang/include/flang/Evaluate/intrinsics.h
+++ b/flang/include/flang/Evaluate/intrinsics.h
@@ -115,15 +115,13 @@ public:
   static const inline std::string InvalidName{
       "(invalid intrinsic function call)"};
 
+  // Name of intrinsics used in various locations.
+  static inline const char *const BuiltinIntName{"__builtin_int"};
+
   llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   std::unique_ptr<Implementation> impl_;
-};
-
-class Intrinsics {
-public:
-  static inline const char *const BuiltinInt{"__builtin_int"};
 };
 
 // Check if an intrinsic explicitly allows its INTENT(OUT) arguments to be

--- a/flang/include/flang/Evaluate/intrinsics.h
+++ b/flang/include/flang/Evaluate/intrinsics.h
@@ -121,6 +121,11 @@ private:
   std::unique_ptr<Implementation> impl_;
 };
 
+class Intrinsics {
+public:
+  static inline const char *const BuiltinInt{"__builtin_int"};
+};
+
 // Check if an intrinsic explicitly allows its INTENT(OUT) arguments to be
 // allocatable coarrays.
 bool AcceptsIntentOutAllocatableCoarray(const std::string &);

--- a/flang/lib/Evaluate/formatting.cpp
+++ b/flang/lib/Evaluate/formatting.cpp
@@ -510,7 +510,7 @@ llvm::raw_ostream &Convert<TO, FROMCAT>::AsFortran(llvm::raw_ostream &o) const {
   if constexpr (TO::category == TypeCategory::Character) {
     this->left().AsFortran(o << "achar(iachar(") << ')';
   } else if constexpr (TO::category == TypeCategory::Integer) {
-    this->left().AsFortran(o << "__builtin_int(");
+    this->left().AsFortran(o << Intrinsics::BuiltinInt << "(");
   } else if constexpr (TO::category == TypeCategory::Real) {
     this->left().AsFortran(o << "real(");
   } else if constexpr (TO::category == TypeCategory::Complex) {
@@ -828,10 +828,10 @@ llvm::raw_ostream &DescriptorInquiry::AsFortran(llvm::raw_ostream &o) const {
     o << "%STRIDE(";
     break;
   case Field::Rank:
-    o << "__builtin_int(rank(";
+    o << Intrinsics::BuiltinInt << "(rank(";
     break;
   case Field::Len:
-    o << "__builtin_int(";
+    o << Intrinsics::BuiltinInt << "(";
     break;
   }
   base_.AsFortran(o);

--- a/flang/lib/Evaluate/formatting.cpp
+++ b/flang/lib/Evaluate/formatting.cpp
@@ -510,7 +510,7 @@ llvm::raw_ostream &Convert<TO, FROMCAT>::AsFortran(llvm::raw_ostream &o) const {
   if constexpr (TO::category == TypeCategory::Character) {
     this->left().AsFortran(o << "achar(iachar(") << ')';
   } else if constexpr (TO::category == TypeCategory::Integer) {
-    this->left().AsFortran(o << "int(");
+    this->left().AsFortran(o << "__builtin_int(");
   } else if constexpr (TO::category == TypeCategory::Real) {
     this->left().AsFortran(o << "real(");
   } else if constexpr (TO::category == TypeCategory::Complex) {
@@ -828,10 +828,10 @@ llvm::raw_ostream &DescriptorInquiry::AsFortran(llvm::raw_ostream &o) const {
     o << "%STRIDE(";
     break;
   case Field::Rank:
-    o << "int(rank(";
+    o << "__builtin_int(rank(";
     break;
   case Field::Len:
-    o << "int(";
+    o << "__builtin_int(";
     break;
   }
   base_.AsFortran(o);

--- a/flang/lib/Evaluate/formatting.cpp
+++ b/flang/lib/Evaluate/formatting.cpp
@@ -510,7 +510,7 @@ llvm::raw_ostream &Convert<TO, FROMCAT>::AsFortran(llvm::raw_ostream &o) const {
   if constexpr (TO::category == TypeCategory::Character) {
     this->left().AsFortran(o << "achar(iachar(") << ')';
   } else if constexpr (TO::category == TypeCategory::Integer) {
-    this->left().AsFortran(o << Intrinsics::BuiltinInt << "(");
+    this->left().AsFortran(o << IntrinsicProcTable::BuiltinIntName << "(");
   } else if constexpr (TO::category == TypeCategory::Real) {
     this->left().AsFortran(o << "real(");
   } else if constexpr (TO::category == TypeCategory::Complex) {
@@ -828,10 +828,10 @@ llvm::raw_ostream &DescriptorInquiry::AsFortran(llvm::raw_ostream &o) const {
     o << "%STRIDE(";
     break;
   case Field::Rank:
-    o << Intrinsics::BuiltinInt << "(rank(";
+    o << IntrinsicProcTable::BuiltinIntName << "(rank(";
     break;
   case Field::Len:
-    o << Intrinsics::BuiltinInt << "(";
+    o << IntrinsicProcTable::BuiltinIntName << "(";
     break;
   }
   base_.AsFortran(o);

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1187,7 +1187,7 @@ static const std::pair<const char *, const char *> genericAlias[]{
     {"unsigned", "uint"}, // Sun vs gfortran names
     {"xor", "ieor"},
     {"__builtin_ieee_selected_real_kind", "selected_real_kind"},
-    {Intrinsics::BuiltinInt, "int"},
+    {IntrinsicProcTable::BuiltinIntName, "int"},
 };
 
 // The following table contains the intrinsic functions listed in

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1187,6 +1187,7 @@ static const std::pair<const char *, const char *> genericAlias[]{
     {"unsigned", "uint"}, // Sun vs gfortran names
     {"xor", "ieor"},
     {"__builtin_ieee_selected_real_kind", "selected_real_kind"},
+    {"__builtin_int", "int"},
 };
 
 // The following table contains the intrinsic functions listed in

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1187,7 +1187,7 @@ static const std::pair<const char *, const char *> genericAlias[]{
     {"unsigned", "uint"}, // Sun vs gfortran names
     {"xor", "ieor"},
     {"__builtin_ieee_selected_real_kind", "selected_real_kind"},
-    {"__builtin_int", "int"},
+    {Intrinsics::BuiltinInt, "int"},
 };
 
 // The following table contains the intrinsic functions listed in

--- a/flang/test/Evaluate/bug153031.f90
+++ b/flang/test/Evaluate/bug153031.f90
@@ -11,8 +11,8 @@ interface
 end interface
 type(t) :: x(10)
 allocate(x(1)%a(2))
-!CHECK: PRINT *, ubound(x(int(impure(1_4),kind=8))%a,dim=1_4)
+!CHECK: PRINT *, ubound(x(__builtin_int(impure(1_4),kind=8))%a,dim=1_4)
 print *, ubound(x(impure(1))%a, dim=1)
-!CHECK: PRINT *, int(size(x(int(pure(1_4),kind=8))%a,dim=1,kind=8)+lbound(x(int(pure(1_4),kind=8))%a,dim=1,kind=8)-1_8,kind=4)
+!CHECK: PRINT *, __builtin_int(size(x(__builtin_int(pure(1_4),kind=8))%a,dim=1,kind=8)+lbound(x(__builtin_int(pure(1_4),kind=8))%a,dim=1,kind=8)-1_8,kind=4)
 print *, ubound(x(pure(1))%a, dim=1)
 end

--- a/flang/test/Evaluate/bug188879.f90
+++ b/flang/test/Evaluate/bug188879.f90
@@ -1,0 +1,9 @@
+! RUN: %flang_fc1 -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! Ensure that integer conversions inserted by the frontend use __builtin_int.
+
+subroutine sub0 (n, int )
+  integer(kind=4) :: n
+  !CHECK: Subprogram scope: sub0
+  !CHECK:   int {{.*}}: ObjectEntity dummy type: INTEGER(4) shape: 1_8:__builtin_int(n,kind=8)
+  integer(kind=4) :: int(n)
+end subroutine

--- a/flang/test/Evaluate/elem-shape.f90
+++ b/flang/test/Evaluate/elem-shape.f90
@@ -5,7 +5,7 @@ module m
   subroutine sub(x,y)
     real :: x(:), y(:)
     optional x
-    !CHECK: PRINT *, int(size(y,dim=1,kind=8),kind=4)
+    !CHECK: PRINT *, __builtin_int(size(y,dim=1,kind=8),kind=4)
     print *, size(f(x,y))
   end
   elemental function f(x,y)

--- a/flang/test/Evaluate/fold-assumed-type-rank.f90
+++ b/flang/test/Evaluate/fold-assumed-type-rank.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
 subroutine sub3(ar_at)
   type(*) :: ar_at(..)
-!CHECK:  PRINT *, int(int(rank(ar_at),kind=8),kind=4)
+!CHECK:  PRINT *, __builtin_int(__builtin_int(rank(ar_at),kind=8),kind=4)
   print *, rank(ar_at)
 end

--- a/flang/test/Evaluate/rewrite-out_of_range.F90
+++ b/flang/test/Evaluate/rewrite-out_of_range.F90
@@ -178,14 +178,14 @@ end
 !CHECK:   PRINT *, " real", 2_4, "real", 8_4, .false._4
 !CHECK:   PRINT *, " real", 2_4, "real", 10_4, .false._4
 !CHECK-KIND16:   PRINT *, " real", 2_4, "real", 16_4, .false._4
-!CHECK:   PRINT *, " real", 3_4, "real", 2_4, blt(int(transfer(abs(x)-6.5536e4_3,0_2),kind=8)-1_8,32639_2)
+!CHECK:   PRINT *, " real", 3_4, "real", 2_4, blt(__builtin_int(transfer(abs(x)-6.5536e4_3,0_2),kind=8)-1_8,32639_2)
 !CHECK:   PRINT *, " real", 3_4, "real", 3_4, .false._4
 !CHECK:   PRINT *, " real", 3_4, "real", 4_4, .false._4
 !CHECK:   PRINT *, " real", 3_4, "real", 8_4, .false._4
 !CHECK:   PRINT *, " real", 3_4, "real", 10_4, .false._4
 !CHECK-KIND16:   PRINT *, " real", 3_4, "real", 16_4, .false._4
-!CHECK:   PRINT *, " real", 4_4, "real", 2_4, blt(int(transfer(abs(x)-6.5504e4_4,0_4),kind=8)-1_8,2139095039_4)
-!CHECK:   PRINT *, " real", 4_4, "real", 3_4, blt(int(transfer(abs(x)-3.3895313892515354759047080037148786688e38_4,0_4),kind=8)-1_8,2139095039_4)
+!CHECK:   PRINT *, " real", 4_4, "real", 2_4, blt(__builtin_int(transfer(abs(x)-6.5504e4_4,0_4),kind=8)-1_8,2139095039_4)
+!CHECK:   PRINT *, " real", 4_4, "real", 3_4, blt(__builtin_int(transfer(abs(x)-3.3895313892515354759047080037148786688e38_4,0_4),kind=8)-1_8,2139095039_4)
 !CHECK:   PRINT *, " real", 4_4, "real", 4_4, .false._4
 !CHECK:   PRINT *, " real", 4_4, "real", 8_4, .false._4
 !CHECK:   PRINT *, " real", 4_4, "real", 10_4, .false._4

--- a/flang/test/Evaluate/rewrite01.f90
+++ b/flang/test/Evaluate/rewrite01.f90
@@ -26,7 +26,7 @@ end function
 subroutine ubound_test(x, n, m)
   integer :: x(n, m)
   integer :: y(0:n, 0:m) ! UBOUND could be 0 if n or m are < 0
-  !CHECK: PRINT *, [INTEGER(4)::int(size(x,dim=1,kind=8),kind=4),int(size(x,dim=2,kind=8),kind=4)]
+  !CHECK: PRINT *, [INTEGER(4)::__builtin_int(size(x,dim=1,kind=8),kind=4),__builtin_int(size(x,dim=2,kind=8),kind=4)]
   print *, ubound(x)
   !CHECK: PRINT *, ubound(returns_array(n,m))
   print *, ubound(returns_array(n, m))
@@ -44,7 +44,7 @@ end subroutine
 
 subroutine size_test(x, n, m)
   integer :: x(n, m)
-  !CHECK: PRINT *, int(size(x,dim=1,kind=8)*size(x,dim=2,kind=8),kind=4)
+  !CHECK: PRINT *, __builtin_int(size(x,dim=1,kind=8)*size(x,dim=2,kind=8),kind=4)
   print *, size(x)
   !CHECK: PRINT *, size(returns_array(n,m))
   print *, size(returns_array(n, m))
@@ -65,7 +65,7 @@ subroutine shape_test(x, n, m)
   end interface
   procedure(foo), pointer :: pf
   integer :: x(n, m)
-  !CHECK: PRINT *, [INTEGER(4)::int(size(x,dim=1,kind=8),kind=4),int(size(x,dim=2,kind=8),kind=4)]
+  !CHECK: PRINT *, [INTEGER(4)::__builtin_int(size(x,dim=1,kind=8),kind=4),__builtin_int(size(x,dim=2,kind=8),kind=4)]
   print *, shape(x)
   !CHECK: PRINT *, shape(returns_array(n,m))
   print *, shape(returns_array(n, m))
@@ -126,7 +126,7 @@ subroutine len_test(a,b, c, d, e, n, m)
      end function mofun
   end interface
 
-  !CHECK: PRINT *, int(int(a%len,kind=8),kind=4)
+  !CHECK: PRINT *, __builtin_int(__builtin_int(a%len,kind=8),kind=4)
   print *, len(a)
   !CHECK: PRINT *, 5_4
   print *, len(a(1:5))
@@ -136,7 +136,7 @@ subroutine len_test(a,b, c, d, e, n, m)
   print *, len(b(a) // a)
   !CHECK: PRINT *, 10_4
   print *, len(c)
-  !CHECK: PRINT *, len(c(int(i,kind=8):int(j,kind=8)))
+  !CHECK: PRINT *, len(c(__builtin_int(i,kind=8):__builtin_int(j,kind=8)))
   print *, len(c(i:j))
   !CHECK: PRINT *, 5_4
   print *, len(c(1:5))
@@ -146,11 +146,11 @@ subroutine len_test(a,b, c, d, e, n, m)
   print *, len(d(c) // c)
   !CHECK: PRINT *, 0_4
   print *, len(a(10:4))
-  !CHECK: PRINT *, int(max(0_8,int(m,kind=8)-int(n,kind=8)+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(m,kind=8)-__builtin_int(n,kind=8)+1_8),kind=4)
   print *, len(a(n:m))
-  !CHECK: PRINT *, len(b(a(int(n,kind=8):int(m,kind=8))))
+  !CHECK: PRINT *, len(b(a(__builtin_int(n,kind=8):__builtin_int(m,kind=8))))
   print *, len(b(a(n:m)))
-  !CHECK: PRINT *, int(max(0_8,max(0_8,int(n,kind=8))-4_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,max(0_8,__builtin_int(n,kind=8))-4_8+1_8),kind=4)
   print *, len(e(4:))
   !CHECK: PRINT *, len(fun1(n-m))
   print *, len(fun1(n-m))
@@ -162,7 +162,7 @@ subroutine len_test(a,b, c, d, e, n, m)
   print *, len(trim(c))
   !CHECK: PRINT *, 40_4
   print *, len(repeat(c, 4))
-  !CHECK: PRINT *, len(repeat(c,int(i,kind=8)))
+  !CHECK: PRINT *, len(repeat(c,__builtin_int(i,kind=8)))
   print *, len(repeat(c, i))
 end subroutine len_test
 
@@ -237,7 +237,7 @@ subroutine array_ctor_implied_do_index(x, j)
   character(10) :: c
   !CHECK: PRINT *, size([INTEGER(4)::(x(1_8:i:1_8),INTEGER(8)::i=1_8,2_8,1_8)])
   print *, size([(x(1:i), integer(8)::i=1,2)])
-  !CHECK: PRINT *, int(2_8*max((j-1_8+1_8)/1_8,0_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(2_8*max((j-1_8+1_8)/1_8,0_8),kind=4)
   print *, size([(x(1:j), integer(8)::i=1,2)])
   !CHECK: PRINT *, len([(c(i:i),INTEGER(8)::i=1_8,4_8,1_8)])
   print *, len([(c(i:i), integer(8)::i = 1,4)])

--- a/flang/test/Evaluate/rewrite02.f90
+++ b/flang/test/Evaluate/rewrite02.f90
@@ -8,17 +8,17 @@ subroutine foo(j)
     character*4 sc, ac(1)
   end type
   type(t) st, at(1)
-  !CHECK: PRINT *, sc(1_8:int(j,kind=8))
+  !CHECK: PRINT *, sc(1_8:__builtin_int(j,kind=8))
   print *, sc(1:j)
-  !CHECK: PRINT *, ac(1_8)(1_8:int(j,kind=8))
+  !CHECK: PRINT *, ac(1_8)(1_8:__builtin_int(j,kind=8))
   print *, ac(1)(1:j)
-  !CHECK: PRINT *, st%sc(1_8:int(j,kind=8))
+  !CHECK: PRINT *, st%sc(1_8:__builtin_int(j,kind=8))
   print *, st%sc(1:j)
-  !CHECK: PRINT *, st%ac(1_8)(1_8:int(j,kind=8))
+  !CHECK: PRINT *, st%ac(1_8)(1_8:__builtin_int(j,kind=8))
   print *, st%ac(1)(1:j)
-  !CHECK: PRINT *, at(1_8)%sc(1_8:int(j,kind=8))
+  !CHECK: PRINT *, at(1_8)%sc(1_8:__builtin_int(j,kind=8))
   print *, at(1)%sc(1:j)
-  !CHECK: PRINT *, at(1_8)%ac(1_8)(1_8:int(j,kind=8))
+  !CHECK: PRINT *, at(1_8)%ac(1_8)(1_8:__builtin_int(j,kind=8))
   print *, at(1)%ac(1)(1:j)
   !CHECK: PRINT *, 1_4
   print *, sc(1:j)%kind
@@ -32,16 +32,16 @@ subroutine foo(j)
   print *, at(1)%sc(1:j)%kind
   !CHECK: PRINT *, 1_4
   print *, at(1)%ac(1)(1:j)%kind
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, sc(1:j)%len
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, ac(1)(1:j)%len
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, st%sc(1:j)%len
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, st%ac(1)(1:j)%len
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, at(1)%sc(1:j)%len
-  !CHECK: PRINT *, int(max(0_8,int(j,kind=8)-1_8+1_8),kind=4)
+  !CHECK: PRINT *, __builtin_int(max(0_8,__builtin_int(j,kind=8)-1_8+1_8),kind=4)
   print *, at(1)%ac(1)(1:j)%len
 end

--- a/flang/test/Evaluate/rewrite05.f90
+++ b/flang/test/Evaluate/rewrite05.f90
@@ -5,11 +5,11 @@ program main
   end type
   type(t) :: x
   call init(10)
-  !CHECK: PRINT *, [INTEGER(4)::int(lbound(x%component,dim=1,kind=8),kind=4)]
+  !CHECK: PRINT *, [INTEGER(4)::__builtin_int(lbound(x%component,dim=1,kind=8),kind=4)]
   print *, lbound(x%component)
-  !CHECK: PRINT *, [INTEGER(4)::int(size(x%component,dim=1,kind=8)+lbound(x%component,dim=1,kind=8)-1_8,kind=4)]
+  !CHECK: PRINT *, [INTEGER(4)::__builtin_int(size(x%component,dim=1,kind=8)+lbound(x%component,dim=1,kind=8)-1_8,kind=4)]
   print *, ubound(x%component)
-  !CHECK: PRINT *, int(size(x%component,dim=1,kind=8),kind=4)
+  !CHECK: PRINT *, __builtin_int(size(x%component,dim=1,kind=8),kind=4)
   print *, size(x%component)
   !CHECK: PRINT *, 4_8*size(x%component,dim=1,kind=8)
   print *, sizeof(x%component)

--- a/flang/test/Parser/OpenMP/doacross-clause.f90
+++ b/flang/test/Parser/OpenMP/doacross-clause.f90
@@ -19,7 +19,7 @@ end
 !UNPARSE:  DO i=1_4,10_4
 !UNPARSE:   DO j=1_4,10_4
 !UNPARSE: !$OMP ORDERED  DOACROSS(SOURCE)
-!UNPARSE:     x(int(i,kind=8),int(j,kind=8))=i+j
+!UNPARSE:     x(__builtin_int(i,kind=8),__builtin_int(j,kind=8))=i+j
 !UNPARSE:   END DO
 !UNPARSE:  END DO
 !UNPARSE: !$OMP END DO
@@ -53,7 +53,7 @@ end
 !UNPARSE:  DO i=1_4,10_4
 !UNPARSE:   DO j=1_4,10_4
 !UNPARSE: !$OMP ORDERED  DOACROSS(SINK: i+1_4, j-2_4) DOACROSS(SINK: i, j+3_4)
-!UNPARSE:     x(int(i,kind=8),int(j,kind=8))=i+j
+!UNPARSE:     x(__builtin_int(i,kind=8),__builtin_int(j,kind=8))=i+j
 !UNPARSE:   END DO
 !UNPARSE:  END DO
 !UNPARSE: !$OMP END DO

--- a/flang/test/Parser/OpenMP/loop-transformation-construct01.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct01.f90
@@ -41,15 +41,15 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | | | | | Scalar -> Expr = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | | | | Designator -> DataRef -> Name = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | Block
-!CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'y(int(i,kind=8))=5_4*y(int(i,kind=8))'
-!CHECK-PARSE-NEXT: | | | | | | | | | Variable = 'y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'y(__builtin_int(i,kind=8))=5_4*y(__builtin_int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | Variable = 'y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | DataRef -> Name = 'y'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Designator -> DataRef -> Name = 'i'
-!CHECK-PARSE-NEXT: | | | | | | | | | Expr = '5_4*y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | Expr = '5_4*y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | Multiply
-!CHECK-PARSE-NEXT: | | | | | | | | | | | Expr = 'y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | | | Expr = 'y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | DataRef -> Name = 'y'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'i'
@@ -74,7 +74,7 @@ end subroutine
 !CHECK-UNPARSE-NEXT: !$OMP DO
 !CHECK-UNPARSE-NEXT: !$OMP UNROLL PARTIAL(1_4)
 !CHECK-UNPARSE-NEXT:  DO i=1_4,i
-!CHECK-UNPARSE-NEXT:    y(int(i,kind=8))=5_4*y(int(i,kind=8))
+!CHECK-UNPARSE-NEXT:    y(__builtin_int(i,kind=8))=5_4*y(__builtin_int(i,kind=8))
 !CHECK-UNPARSE-NEXT:  END DO
 !CHECK-UNPARSE-NEXT: !$OMP END UNROLL
 !CHECK-UNPARSE-NEXT: !$OMP END DO

--- a/flang/test/Parser/OpenMP/loop-transformation-construct02.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct02.f90
@@ -50,15 +50,15 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | | | | | | | Scalar -> Expr = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Designator -> DataRef -> Name = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | | | Block
-!CHECK-PARSE-NEXT: | | | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'y(int(i,kind=8))=5_4*y(int(i,kind=8))'
-!CHECK-PARSE-NEXT: | | | | | | | | | | | Variable = 'y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'y(__builtin_int(i,kind=8))=5_4*y(__builtin_int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | | | Variable = 'y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | DataRef -> Name = 'y'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'i'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | | Designator -> DataRef -> Name = 'i'
-!CHECK-PARSE-NEXT: | | | | | | | | | | | Expr = '5_4*y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | | | Expr = '5_4*y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Multiply
-!CHECK-PARSE-NEXT: | | | | | | | | | | | | | Expr = 'y(int(i,kind=8))'
+!CHECK-PARSE-NEXT: | | | | | | | | | | | | | Expr = 'y(__builtin_int(i,kind=8))'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | | | DataRef -> Name = 'y'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'i'
@@ -88,7 +88,7 @@ end subroutine
 !CHECK-UNPARSE-NEXT: !$OMP UNROLL PARTIAL(1_4)
 !CHECK-UNPARSE-NEXT: !$OMP TILE
 !CHECK-UNPARSE-NEXT:  DO i=1_4,i
-!CHECK-UNPARSE-NEXT:    y(int(i,kind=8))=5_4*y(int(i,kind=8))
+!CHECK-UNPARSE-NEXT:    y(__builtin_int(i,kind=8))=5_4*y(__builtin_int(i,kind=8))
 !CHECK-UNPARSE-NEXT:  END DO
 !CHECK-UNPARSE-NEXT: !$OMP END TILE
 !CHECK-UNPARSE-NEXT: !$OMP END UNROLL

--- a/flang/test/Parser/OpenMP/loop-transformation-construct03.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct03.f90
@@ -45,15 +45,15 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | | | | | Scalar -> Expr = '10_4'
 !CHECK-PARSE-NEXT: | | | | | | | | | | LiteralConstant -> IntLiteralConstant = '10'
 !CHECK-PARSE-NEXT: | | | | | | | Block
-!CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(int(b,kind=8),2_8)=a(int(c,kind=8),1_8)'
-!CHECK-PARSE-NEXT: | | | | | | | | | Variable = 'a(int(b,kind=8),2_8)'
+!CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(__builtin_int(b,kind=8),2_8)=a(__builtin_int(c,kind=8),1_8)'
+!CHECK-PARSE-NEXT: | | | | | | | | | Variable = 'a(__builtin_int(b,kind=8),2_8)'
 !CHECK-PARSE-NEXT: | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | DataRef -> Name = 'a'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'b'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | Designator -> DataRef -> Name = 'b'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | SectionSubscript -> Integer -> Expr = '2_4'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!CHECK-PARSE-NEXT: | | | | | | | | | Expr = 'a(int(c,kind=8),1_8)'
+!CHECK-PARSE-NEXT: | | | | | | | | | Expr = 'a(__builtin_int(c,kind=8),1_8)'
 !CHECK-PARSE-NEXT: | | | | | | | | | | Designator -> DataRef -> ArrayElement
 !CHECK-PARSE-NEXT: | | | | | | | | | | | DataRef -> Name = 'a'
 !CHECK-PARSE-NEXT: | | | | | | | | | | | SectionSubscript -> Integer -> Expr = 'c'
@@ -71,7 +71,7 @@ end subroutine
 !CHECK-UNPARSE-NEXT: !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO  COLLAPSE(2_4) PRIVATE(b)
 !CHECK-UNPARSE-NEXT:  DO b=1_4,10_4
 !CHECK-UNPARSE-NEXT:   DO c=1_4,10_4
-!CHECK-UNPARSE-NEXT:     a(int(b,kind=8),2_8)=a(int(c,kind=8),1_8)
+!CHECK-UNPARSE-NEXT:     a(__builtin_int(b,kind=8),2_8)=a(__builtin_int(c,kind=8),1_8)
 !CHECK-UNPARSE-NEXT:   END DO
 !CHECK-UNPARSE-NEXT:  END DO
 !CHECK-UNPARSE-NEXT: END SUBROUTINE

--- a/flang/test/Parser/OpenMP/nontemporal-unparse.f90
+++ b/flang/test/Parser/OpenMP/nontemporal-unparse.f90
@@ -20,7 +20,7 @@ end program omp_simd
 !UNPARSE:  ALLOCATE(a(10_4))
 !UNPARSE: !$OMP SIMD NONTEMPORAL(a)
 !UNPARSE:  DO i=1_4,10_4
-!UNPARSE:    a(int(i,kind=8))=i
+!UNPARSE:    a(__builtin_int(i,kind=8))=i
 !UNPARSE:  END DO
 !UNPARSE: !$OMP END SIMD
 !UNPARSE: END PROGRAM OMP_SIMD
@@ -40,8 +40,8 @@ end program omp_simd
 !PARSE-TREE: | | | | | Scalar -> Expr = '10_4'
 !PARSE-TREE: | | | | | | LiteralConstant -> IntLiteralConstant = '10'
 !PARSE-TREE: | | | Block
-!PARSE-TREE: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(int(i,kind=8))=i'
-!PARSE-TREE: | | | | | Variable = 'a(int(i,kind=8))'
+!PARSE-TREE: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'a(__builtin_int(i,kind=8))=i'
+!PARSE-TREE: | | | | | Variable = 'a(__builtin_int(i,kind=8))'
 !PARSE-TREE: | | | | | | Designator -> DataRef -> ArrayElement
 !PARSE-TREE: | | | | | | | DataRef -> Name = 'a'
 !PARSE-TREE: | | | | | | | SectionSubscript -> Integer -> Expr = 'i'

--- a/flang/test/Parser/OpenMP/ordered-depend.f90
+++ b/flang/test/Parser/OpenMP/ordered-depend.f90
@@ -19,7 +19,7 @@ end
 !UNPARSE:  DO i=1_4,10_4
 !UNPARSE:   DO j=1_4,10_4
 !UNPARSE: !$OMP ORDERED  DEPEND(SOURCE)
-!UNPARSE:     x(int(i,kind=8),int(j,kind=8))=i+j
+!UNPARSE:     x(__builtin_int(i,kind=8),__builtin_int(j,kind=8))=i+j
 !UNPARSE:   END DO
 !UNPARSE:  END DO
 !UNPARSE: !$OMP END DO
@@ -53,7 +53,7 @@ end
 !UNPARSE:  DO i=1_4,10_4
 !UNPARSE:   DO j=1_4,10_4
 !UNPARSE: !$OMP ORDERED  DEPEND(SINK: i+1_4, j-2_4) DEPEND(SINK: i, j+3_4)
-!UNPARSE:     x(int(i,kind=8),int(j,kind=8))=i+j
+!UNPARSE:     x(__builtin_int(i,kind=8),__builtin_int(j,kind=8))=i+j
 !UNPARSE:   END DO
 !UNPARSE:  END DO
 !UNPARSE: !$OMP END DO

--- a/flang/test/Parser/cuf-sanity-unparse.CUF
+++ b/flang/test/Parser/cuf-sanity-unparse.CUF
@@ -36,9 +36,9 @@ include "cuf-sanity-common"
 !CHECK:   END DO
 !CHECK:   !$CUF KERNEL DO <<<*,*>>> REDUCE(+:x,y) REDUCE(*:z)
 !CHECK:   DO j=1_4,10_4
-!CHECK:    x=x+a(int(j,kind=8))
-!CHECK:    y=y+a(int(j,kind=8))
-!CHECK:    z=z*a(int(j,kind=8))
+!CHECK:    x=x+a(__builtin_int(j,kind=8))
+!CHECK:    y=y+a(__builtin_int(j,kind=8))
+!CHECK:    z=z*a(__builtin_int(j,kind=8))
 !CHECK:   END DO
 !CHECK:    CALL globalsub<<<1_4,2_4>>>()
 !CHECK:    CALL globalsub<<<1_4,2_4,3_4>>>()

--- a/flang/test/Semantics/array-constr-values.f90
+++ b/flang/test/Semantics/array-constr-values.f90
@@ -67,7 +67,7 @@ subroutine checkC7115()
   !ERROR: Implied DO index 'i' is active in a surrounding implied DO loop and may not have the same name
   real, dimension(100), parameter :: bad = [((88.8, i = 1, 10), i = 1, 10)]
 
-  !ERROR: Value of named constant 'bad2' ([INTEGER(4)::(int(j,kind=4),INTEGER(8)::j=1_8,1_8,0_8)]) cannot be computed as a constant value
+  !ERROR: Value of named constant 'bad2' ([INTEGER(4)::(__builtin_int(j,kind=4),INTEGER(8)::j=1_8,1_8,0_8)]) cannot be computed as a constant value
   !ERROR: The stride of an implied DO loop must not be zero
   integer, parameter :: bad2(*) = [(j, j=1,1,0)]
   integer, parameter, dimension(-1:0) :: negLower = (/343,512/)

--- a/flang/test/Semantics/bug124716.f90
+++ b/flang/test/Semantics/bug124716.f90
@@ -21,7 +21,7 @@ END SUBMODULE
 !interface
 !module subroutine sub1(n,arr)
 !integer(4),intent(in)::n
-!integer(4)::arr(1_8:int(n,kind=8))
+!integer(4)::arr(1_8:__builtin_int(n,kind=8))
 !end
 !end interface
 !end
@@ -31,6 +31,6 @@ END SUBMODULE
 !contains
 !module subroutine sub1(n,arr)
 !integer(4),intent(in)::n
-!integer(4)::arr(1_8:int(n,kind=8))
+!integer(4)::arr(1_8:__builtin_int(n,kind=8))
 !end
 !end

--- a/flang/test/Semantics/call03.f90
+++ b/flang/test/Semantics/call03.f90
@@ -296,16 +296,16 @@ module m01
     integer :: j(1)
     j(1) = 1
     !ERROR: Actual argument associated with INTENT(OUT) dummy argument 'x=' is not definable
-    !BECAUSE: Variable 'a(int(j,kind=8))' has a vector subscript
+    !BECAUSE: Variable 'a(__builtin_int(j,kind=8))' has a vector subscript
     call intentout_arr(a(j))
     !ERROR: Actual argument associated with INTENT(IN OUT) dummy argument 'x=' is not definable
-    !BECAUSE: Variable 'a(int(j,kind=8))' has a vector subscript
+    !BECAUSE: Variable 'a(__builtin_int(j,kind=8))' has a vector subscript
     call intentinout_arr(a(j))
     !WARNING: Actual argument associated with ASYNCHRONOUS dummy argument 'x=' is not definable [-Wundefinable-asynchronous-or-volatile-actual]
-    !BECAUSE: Variable 'a(int(j,kind=8))' has a vector subscript
+    !BECAUSE: Variable 'a(__builtin_int(j,kind=8))' has a vector subscript
     call asynchronous_arr(a(j))
     !WARNING: Actual argument associated with VOLATILE dummy argument 'x=' is not definable [-Wundefinable-asynchronous-or-volatile-actual]
-    !BECAUSE: Variable 'a(int(j,kind=8))' has a vector subscript
+    !BECAUSE: Variable 'a(__builtin_int(j,kind=8))' has a vector subscript
     call volatile_arr(a(j))
   end subroutine
 

--- a/flang/test/Semantics/call22.f90
+++ b/flang/test/Semantics/call22.f90
@@ -12,7 +12,7 @@ module m
   end function
   subroutine test
     real :: a(3) = [1, 2, 3]
-    !ERROR: Dimension 1 of actual argument (a) corresponding to dummy argument #1 ('a') has extent 3, but actual argument ([REAL(4)::(g(int(j,kind=4)),INTEGER(8)::j=1_8,2_8,1_8)]) corresponding to dummy argument #2 ('b') has extent 2
+    !ERROR: Dimension 1 of actual argument (a) corresponding to dummy argument #1 ('a') has extent 3, but actual argument ([REAL(4)::(g(__builtin_int(j,kind=4)),INTEGER(8)::j=1_8,2_8,1_8)]) corresponding to dummy argument #2 ('b') has extent 2
     print *, f(a, [(g(j), j=1, 2)])
   end subroutine
 end

--- a/flang/test/Semantics/data01.f90
+++ b/flang/test/Semantics/data01.f90
@@ -62,7 +62,7 @@ subroutine CheckValue
   !OK: constant array element
   data x / a(1) /
   !C886, C887
-  !ERROR: DATA statement value 'a(int(i,kind=8))' for 'y' is not a constant
+  !ERROR: DATA statement value 'a(__builtin_int(i,kind=8))' for 'y' is not a constant
   data y / a(i) /
   !ERROR: DATA statement value 'b(1_8)' for 'z' is not a constant
   data z / b(1) /

--- a/flang/test/Semantics/kinds03.f90
+++ b/flang/test/Semantics/kinds03.f90
@@ -6,7 +6,7 @@
   !REF: /MainProgram1/ipdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType9/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/ipdt/x ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/ipdt/x ObjectEntity INTEGER(__builtin_int(__builtin_int(k,kind=4),kind=8))
   integer(kind=k) :: x
  end type ipdt
  !DEF: /MainProgram1/rpdt DerivedType
@@ -15,7 +15,7 @@
   !REF: /MainProgram1/rpdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType13/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(__builtin_int(__builtin_int(k,kind=4),kind=8))
   real(kind=k) :: x
  end type rpdt
  !DEF: /MainProgram1/zpdt DerivedType
@@ -24,7 +24,7 @@
   !REF: /MainProgram1/zpdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType17/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(__builtin_int(__builtin_int(k,kind=4),kind=8))
   complex(kind=k) :: x
  end type zpdt
  !DEF: /MainProgram1/lpdt DerivedType
@@ -33,7 +33,7 @@
   !REF: /MainProgram1/lpdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType21/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/lpdt/x ObjectEntity LOGICAL(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/lpdt/x ObjectEntity LOGICAL(__builtin_int(__builtin_int(k,kind=4),kind=8))
   logical(kind=k) :: x
  end type lpdt
  !REF: /MainProgram1/ipdt

--- a/flang/test/Semantics/lshift.f90
+++ b/flang/test/Semantics/lshift.f90
@@ -12,7 +12,7 @@ end
 subroutine test_integer1()
   integer(1) :: i, j, k
   k = lshift(i, j)
-!CHECK: k=shiftl(i,int(j,kind=4))
+!CHECK: k=shiftl(i,__builtin_int(j,kind=4))
   print *, lshift(8_1, 2)
 !CHECK: PRINT *, 32_1
 end
@@ -20,7 +20,7 @@ end
 subroutine test_integer2()
   integer(2) :: i, j, k
   k = lshift(i, j)
-!CHECK: k=shiftl(i,int(j,kind=4))
+!CHECK: k=shiftl(i,__builtin_int(j,kind=4))
   print *, lshift(8_2, 2)
 !CHECK: PRINT *, 32_2
 end
@@ -36,7 +36,7 @@ end
 subroutine test_integer8()
   integer(8) :: i, j, k
   k = lshift(i, j)
-!CHECK: k=shiftl(i,int(j,kind=4))
+!CHECK: k=shiftl(i,__builtin_int(j,kind=4))
   print *, lshift(-16_8, 2)
 !CHECK: PRINT *, -64_8
 end
@@ -44,7 +44,7 @@ end
 subroutine test_integer16()
   integer(16) :: i, j, k
   k = lshift(i, j)
-!CHECK: k=shiftl(i,int(j,kind=4))
+!CHECK: k=shiftl(i,__builtin_int(j,kind=4))
   print *, lshift(8_16, 2)
 !CHECK: PRINT *, 32_16
 end

--- a/flang/test/Semantics/modfile03.f90
+++ b/flang/test/Semantics/modfile03.f90
@@ -219,7 +219,7 @@ end
 !contains
 !subroutine foo(x,a)
 !type(t),intent(in)::x
-!real(4)::a(1_8:int(m8a$foo(10_4),kind=8))
+!real(4)::a(1_8:__builtin_int(m8a$foo(10_4),kind=8))
 !end
 !end
 
@@ -268,6 +268,6 @@ end
 !contains
 !subroutine s(x,y)
 !class(t),intent(in)::x
-!real(4)::y(1_8:int(x%f(x%n),kind=8))
+!real(4)::y(1_8:__builtin_int(x%f(x%n),kind=8))
 !end
 !end

--- a/flang/test/Semantics/modfile17.f90
+++ b/flang/test/Semantics/modfile17.f90
@@ -91,21 +91,21 @@ end module
 !integer(2),kind::k2
 !integer(4),kind::k4
 !integer(8),kind::k8
-!integer(int(int(k1,kind=1),kind=8))::j1
-!integer(int(int(k2,kind=2),kind=8))::j2
-!integer(int(int(k4,kind=4),kind=8))::j4
+!integer(__builtin_int(__builtin_int(k1,kind=1),kind=8))::j1
+!integer(__builtin_int(__builtin_int(k2,kind=2),kind=8))::j2
+!integer(__builtin_int(__builtin_int(k4,kind=4),kind=8))::j4
 !integer(k8)::j8
 !end type
 !type::defaulted(n1,n2,n4,n8)
 !integer(1),kind::n1=1_4
-!integer(2),kind::n2=2_4*int(int(n1,kind=1),kind=4)
-!integer(4),kind::n4=2_4*int(int(n2,kind=2),kind=4)
-!integer(8),kind::n8=12_4-int(n4,kind=4)
-!type(capture(k1=int(n1,kind=1),k2=int(n2,kind=2),k4=int(n4,kind=4),k8=n8))::cap
+!integer(2),kind::n2=2_4*__builtin_int(__builtin_int(n1,kind=1),kind=4)
+!integer(4),kind::n4=2_4*__builtin_int(__builtin_int(n2,kind=2),kind=4)
+!integer(8),kind::n8=12_4-__builtin_int(n4,kind=4)
+!type(capture(k1=__builtin_int(n1,kind=1),k2=__builtin_int(n2,kind=2),k4=__builtin_int(n4,kind=4),k8=n8))::cap
 !end type
 !type,extends(defaulted)::extension(k5)
 !integer(4),kind::k5=4_4
-!integer(int(int(k5,kind=4),kind=8))::j5
+!integer(__builtin_int(__builtin_int(k5,kind=4),kind=8))::j5
 !end type
 !type(capture(k1=1_1,k2=1_2,k4=1_4,k8=1_8))::x1111
 !integer(1)::res01_1

--- a/flang/test/Semantics/modfile23.f90
+++ b/flang/test/Semantics/modfile23.f90
@@ -164,7 +164,7 @@ end
 !contains
 ! subroutine s1(x)
 !  use m1,only:i
-!  type(t5(l=int(i,kind=4)))::x
+!  type(t5(l=__builtin_int(i,kind=4)))::x
 ! end
 ! subroutine s2(x)
 !  use m1,only:i

--- a/flang/test/Semantics/modfile33.f90
+++ b/flang/test/Semantics/modfile33.f90
@@ -572,7 +572,7 @@ end
 !  real(4) :: x
 !  real(4) :: y(1_8:4_8, 1_8:n)
 !  real(4) :: z(1_8:2_8, 1_8:2_8, 1_8:2_8)
-!  real(4) :: a(1_8:int(int(4_8*size(y,dim=2,kind=8),kind=4),kind=8))
+!  real(4) :: a(1_8:__builtin_int(__builtin_int(4_8*size(y,dim=2,kind=8),kind=4),kind=8))
 !  real(4) :: b(1_8:add(y, z))
 ! end
 !end
@@ -608,7 +608,7 @@ end
 !module m7
 ! type :: t(k)
 !  integer(4), kind :: k
-!  real(int(int(k,kind=4),kind=8))::a
+!  real(__builtin_int(__builtin_int(k,kind=4),kind=8))::a
 ! end type
 ! interface
 !  pure function f1(x, y)

--- a/flang/test/Semantics/modfile39.f90
+++ b/flang/test/Semantics/modfile39.f90
@@ -40,7 +40,7 @@ end module
 !private::m1$m1$priv
 !contains
 !subroutine s(a)
-!real(4)::a(1_8:int(m1$m1$priv(1_4),kind=8))
+!real(4)::a(1_8:__builtin_int(m1$m1$priv(1_4),kind=8))
 !end
 !end
 

--- a/flang/test/Semantics/modfile48.f90
+++ b/flang/test/Semantics/modfile48.f90
@@ -12,7 +12,7 @@ end module
 !module m
 !type::t(k)
 !integer(4),kind::k
-!real(int(int(k,kind=4),kind=8))::x=real(0., kind=k)
+!real(__builtin_int(__builtin_int(k,kind=4),kind=8))::x=real(0., kind=k)
 !end type
 !intrinsic::real
 !end

--- a/flang/test/Semantics/modproc01.f90
+++ b/flang/test/Semantics/modproc01.f90
@@ -29,12 +29,12 @@ end module
 !CHECK:    pdt2, PUBLIC: DerivedType components: j2,a2
 !CHECK:    sm, PUBLIC size=4 offset=0: ObjectEntity type: INTEGER(4)
 !CHECK:    DerivedType scope: pdt1
-!CHECK:      a1, ALLOCATABLE: ObjectEntity type: TYPE(pdt2(int(k1,kind=4),int(l1,kind=4)))
+!CHECK:      a1, ALLOCATABLE: ObjectEntity type: TYPE(pdt2(__builtin_int(k1,kind=4),__builtin_int(l1,kind=4)))
 !CHECK:      k1: TypeParam type:INTEGER(4) Kind
 !CHECK:      l1: TypeParam type:INTEGER(4) Len
 !CHECK:    DerivedType scope: pdt2
-!CHECK:      a2: ObjectEntity type: TYPE(pdt1(k1=int(k2,kind=4),l1=int(l2,kind=4))) shape: 1_8:k2
-!CHECK:      j2: ObjectEntity type: INTEGER(int(int(k2,kind=4),kind=8))
+!CHECK:      a2: ObjectEntity type: TYPE(pdt1(k1=__builtin_int(k2,kind=4),l1=__builtin_int(l2,kind=4))) shape: 1_8:k2
+!CHECK:      j2: ObjectEntity type: INTEGER(__builtin_int(__builtin_int(k2,kind=4),kind=8))
 !CHECK:      k2: TypeParam type:INTEGER(4) Kind
 !CHECK:      l2: TypeParam type:INTEGER(4) Len
 !CHECK:    Subprogram scope: mf size=112 alignment=8
@@ -44,32 +44,32 @@ end module
 !CHECK:      str, INTENT(IN) size=24 offset=8: ObjectEntity dummy type: CHARACTER(n,1)
 !CHECK:      x1, INTENT(IN) size=40 offset=32: ObjectEntity dummy type: TYPE(pdt1(k1=1_4,l1=n))
 !CHECK:      DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=n)
-!CHECK:        a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=int(l1,kind=4)))
+!CHECK:        a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:        k1: TypeParam type:INTEGER(4) Kind init:1_4
 !CHECK:        l1: TypeParam type:INTEGER(4) Len init:n
-!CHECK:        DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=1_4,l2=int(l1,kind=4))
-!CHECK:          a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=1_4,l1=int(l2,kind=4))) shape: 1_8:1_8
+!CHECK:        DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=1_4,l2=__builtin_int(l1,kind=4))
+!CHECK:          a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=1_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:1_8
 !CHECK:          j2 size=1 offset=0: ObjectEntity type: INTEGER(1)
 !CHECK:          k2: TypeParam type:INTEGER(4) Kind init:1_4
-!CHECK:          l2: TypeParam type:INTEGER(4) Len init:int(l1,kind=4)
-!CHECK:          DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=int(l2,kind=4))
-!CHECK:            a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=int(l1,kind=4)))
+!CHECK:          l2: TypeParam type:INTEGER(4) Len init:__builtin_int(l1,kind=4)
+!CHECK:          DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=__builtin_int(l2,kind=4))
+!CHECK:            a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:            k1: TypeParam type:INTEGER(4) Kind init:1_4
-!CHECK:            l1: TypeParam type:INTEGER(4) Len init:int(l2,kind=4)
+!CHECK:            l1: TypeParam type:INTEGER(4) Len init:__builtin_int(l2,kind=4)
 !CHECK:      DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=n)
-!CHECK:        a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=int(l2,kind=4))) shape: 1_8:2_8
+!CHECK:        a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:2_8
 !CHECK:        j2 size=2 offset=0: ObjectEntity type: INTEGER(2)
 !CHECK:        k2: TypeParam type:INTEGER(4) Kind init:2_4
 !CHECK:        l2: TypeParam type:INTEGER(4) Len init:n
-!CHECK:        DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=2_4,l1=int(l2,kind=4))
-!CHECK:          a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=2_4,l2=int(l1,kind=4)))
+!CHECK:        DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))
+!CHECK:          a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=2_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:          k1: TypeParam type:INTEGER(4) Kind init:2_4
-!CHECK:          l1: TypeParam type:INTEGER(4) Len init:int(l2,kind=4)
-!CHECK:          DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=int(l1,kind=4))
-!CHECK:            a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=int(l2,kind=4))) shape: 1_8:2_8
+!CHECK:          l1: TypeParam type:INTEGER(4) Len init:__builtin_int(l2,kind=4)
+!CHECK:          DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=__builtin_int(l1,kind=4))
+!CHECK:            a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:2_8
 !CHECK:            j2 size=2 offset=0: ObjectEntity type: INTEGER(2)
 !CHECK:            k2: TypeParam type:INTEGER(4) Kind init:2_4
-!CHECK:            l2: TypeParam type:INTEGER(4) Len init:int(l1,kind=4)
+!CHECK:            l2: TypeParam type:INTEGER(4) Len init:__builtin_int(l1,kind=4)
 
 submodule(m) sm
  contains
@@ -92,32 +92,32 @@ end submodule
 !CHECK:        str, INTENT(IN) size=24 offset=8: ObjectEntity dummy type: CHARACTER(n,1)
 !CHECK:        x1, INTENT(IN) size=40 offset=32: ObjectEntity dummy type: TYPE(pdt1(k1=1_4,l1=n))
 !CHECK:        DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=n)
-!CHECK:          a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=int(l2,kind=4))) shape: 1_8:2_8
+!CHECK:          a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:2_8
 !CHECK:          j2 size=2 offset=0: ObjectEntity type: INTEGER(2)
 !CHECK:          k2: TypeParam type:INTEGER(4) Kind init:2_4
 !CHECK:          l2: TypeParam type:INTEGER(4) Len init:n
-!CHECK:          DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=2_4,l1=int(l2,kind=4))
-!CHECK:            a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=2_4,l2=int(l1,kind=4)))
+!CHECK:          DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))
+!CHECK:            a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=2_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:            k1: TypeParam type:INTEGER(4) Kind init:2_4
-!CHECK:            l1: TypeParam type:INTEGER(4) Len init:int(l2,kind=4)
-!CHECK:            DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=int(l1,kind=4))
-!CHECK:              a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=int(l2,kind=4))) shape: 1_8:2_8
+!CHECK:            l1: TypeParam type:INTEGER(4) Len init:__builtin_int(l2,kind=4)
+!CHECK:            DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=2_4,l2=__builtin_int(l1,kind=4))
+!CHECK:              a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=2_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:2_8
 !CHECK:              j2 size=2 offset=0: ObjectEntity type: INTEGER(2)
 !CHECK:              k2: TypeParam type:INTEGER(4) Kind init:2_4
-!CHECK:              l2: TypeParam type:INTEGER(4) Len init:int(l1,kind=4)
+!CHECK:              l2: TypeParam type:INTEGER(4) Len init:__builtin_int(l1,kind=4)
 !CHECK:        DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=n)
-!CHECK:          a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=int(l1,kind=4)))
+!CHECK:          a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:          k1: TypeParam type:INTEGER(4) Kind init:1_4
 !CHECK:          l1: TypeParam type:INTEGER(4) Len init:n
-!CHECK:          DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=1_4,l2=int(l1,kind=4))
-!CHECK:            a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=1_4,l1=int(l2,kind=4))) shape: 1_8:1_8
+!CHECK:          DerivedType scope: size=72 alignment=8 instantiation of pdt2(k2=1_4,l2=__builtin_int(l1,kind=4))
+!CHECK:            a2 size=64 offset=8: ObjectEntity type: TYPE(pdt1(k1=1_4,l1=__builtin_int(l2,kind=4))) shape: 1_8:1_8
 !CHECK:            j2 size=1 offset=0: ObjectEntity type: INTEGER(1)
 !CHECK:            k2: TypeParam type:INTEGER(4) Kind init:1_4
-!CHECK:            l2: TypeParam type:INTEGER(4) Len init:int(l1,kind=4)
-!CHECK:            DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=int(l2,kind=4))
-!CHECK:              a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=int(l1,kind=4)))
+!CHECK:            l2: TypeParam type:INTEGER(4) Len init:__builtin_int(l1,kind=4)
+!CHECK:            DerivedType scope: size=40 alignment=8 instantiation of pdt1(k1=1_4,l1=__builtin_int(l2,kind=4))
+!CHECK:              a1, ALLOCATABLE size=40 offset=0: ObjectEntity type: TYPE(pdt2(k2=1_4,l2=__builtin_int(l1,kind=4)))
 !CHECK:              k1: TypeParam type:INTEGER(4) Kind init:1_4
-!CHECK:              l1: TypeParam type:INTEGER(4) Len init:int(l2,kind=4)
+!CHECK:              l1: TypeParam type:INTEGER(4) Len init:__builtin_int(l2,kind=4)
 
 program test
   use m

--- a/flang/test/Semantics/pdt04.f90
+++ b/flang/test/Semantics/pdt04.f90
@@ -1,5 +1,5 @@
 !RUN: not %flang_fc1 %s 2>&1 | FileCheck %s
-!CHECK: error: KIND parameter expression (int(1_4/0_4,kind=8)) of intrinsic type CHARACTER did not resolve to a constant value
+!CHECK: error: KIND parameter expression (__builtin_int(1_4/0_4,kind=8)) of intrinsic type CHARACTER did not resolve to a constant value
 !CHECK: in the context: instantiation of parameterized derived type 'ty(j=1_4,k=0_4)'
 !CHECK: warning: INTEGER(4) division by zero
 program main

--- a/flang/test/Semantics/real10-x86-01.f90
+++ b/flang/test/Semantics/real10-x86-01.f90
@@ -7,7 +7,7 @@
   !REF: /MainProgram1/rpdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType3/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(__builtin_int(__builtin_int(k,kind=4),kind=8))
   real(kind=k) :: x
  end type rpdt
  !DEF: /MainProgram1/zpdt DerivedType
@@ -16,7 +16,7 @@
   !REF: /MainProgram1/zpdt/k
   integer, kind :: k
   !DEF: /MainProgram1/DerivedType4/k TypeParam INTEGER(4)
-  !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(int(int(k,kind=4),kind=8))
+  !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(__builtin_int(__builtin_int(k,kind=4),kind=8))
   complex(kind=k) :: x
  end type zpdt
  !REF: /MainProgram1/rpdt

--- a/flang/test/Semantics/rewrite03.f90
+++ b/flang/test/Semantics/rewrite03.f90
@@ -5,14 +5,14 @@
 program main
   real sf(1)
   integer :: j = 1
-!CHECK: sf(int(j,kind=8))=1._4
+!CHECK: sf(__builtin_int(j,kind=8))=1._4
   sf(j) = 1.
 end
 
 function func
   real sf(1)
   integer :: j = 1
-!CHECK: sf(int(j,kind=8))=2._4
+!CHECK: sf(__builtin_int(j,kind=8))=2._4
   sf(j) = 2.
   func = 0.
 end
@@ -20,7 +20,7 @@ end
 subroutine subr
   real sf(1)
   integer :: j = 1
-!CHECK: sf(int(j,kind=8))=3._4
+!CHECK: sf(__builtin_int(j,kind=8))=3._4
   sf(j) = 3.
 end
 
@@ -35,7 +35,7 @@ submodule(m) sm
   module procedure smp
     real sf(1)
     integer :: j = 1
-!CHECK: sf(int(j,kind=8))=4._4
+!CHECK: sf(__builtin_int(j,kind=8))=4._4
     sf(j) = 4.
   end
 end
@@ -44,7 +44,7 @@ subroutine block
   block
     real sf(1)
     integer :: j = 1
-!CHECK: sf(int(j,kind=8))=5._4
+!CHECK: sf(__builtin_int(j,kind=8))=5._4
     sf(j) = 5.
   end block
 end

--- a/flang/test/Semantics/rshift.f90
+++ b/flang/test/Semantics/rshift.f90
@@ -12,7 +12,7 @@ end
 subroutine test_integer1()
   integer(1) :: i, j, k
   k = rshift(i, j)
-!CHECK: k=shifta(i,int(j,kind=4))
+!CHECK: k=shifta(i,__builtin_int(j,kind=4))
   print *, rshift(8_1, 2)
 !CHECK: PRINT *, 2_1
 end
@@ -20,7 +20,7 @@ end
 subroutine test_integer2()
   integer(2) :: i, j, k
   k = rshift(i, j)
-!CHECK: k=shifta(i,int(j,kind=4))
+!CHECK: k=shifta(i,__builtin_int(j,kind=4))
   print *, rshift(8_2, 2)
 !CHECK: PRINT *, 2_2
 end
@@ -36,7 +36,7 @@ end
 subroutine test_integer8()
   integer(8) :: i, j, k
   k = rshift(i, j)
-!CHECK: k=shifta(i,int(j,kind=4))
+!CHECK: k=shifta(i,__builtin_int(j,kind=4))
   print *, rshift(-16_8, 2)
 !CHECK: PRINT *, -4_8
 end
@@ -44,7 +44,7 @@ end
 subroutine test_integer16()
   integer(16) :: i, j, k
   k = rshift(i, j)
-!CHECK: k=shifta(i,int(j,kind=4))
+!CHECK: k=shifta(i,__builtin_int(j,kind=4))
   print *, rshift(8_16, 2)
 !CHECK: PRINT *, 2_16
 end

--- a/flang/test/Semantics/symbol17.f90
+++ b/flang/test/Semantics/symbol17.f90
@@ -80,7 +80,7 @@ type(fwdpdt(kind(0))) function f2(n)
   !REF: /f2/fwdpdt/k
   integer, kind :: k
   !DEF: /f2/DerivedType2/k TypeParam INTEGER(4)
-  !DEF: /f2/fwdpdt/n ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
+  !DEF: /f2/fwdpdt/n ObjectEntity INTEGER(__builtin_int(__builtin_int(k,kind=4),kind=8))
   integer(kind=k) :: n
  end type
  !DEF: /f2/f2 ObjectEntity TYPE(fwdpdt(k=4_4))
@@ -100,7 +100,7 @@ subroutine s2 (q1)
   !REF: /s2/fwdpdt/k
   integer, kind :: k
   !DEF: /s2/DerivedType2/k TypeParam INTEGER(4)
-  !DEF: /s2/fwdpdt/n ObjectEntity INTEGER(int(int(k,kind=4),kind=8))
+  !DEF: /s2/fwdpdt/n ObjectEntity INTEGER(__builtin_int(__builtin_int(k,kind=4),kind=8))
   integer(kind=k) :: n
  end type
  !REF: /s2/q1

--- a/flang/test/Semantics/type-parameter-constant.f90
+++ b/flang/test/Semantics/type-parameter-constant.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 type A (p, r)
   integer, kind :: p, r
-  !ERROR: KIND parameter expression (int(selected_real_kind(six,twenty_three),kind=8)) of intrinsic type REAL did not resolve to a constant value
+  !ERROR: KIND parameter expression (__builtin_int(selected_real_kind(six,twenty_three),kind=8)) of intrinsic type REAL did not resolve to a constant value
   real (selected_real_kind(p, r)) :: data
 end type
    integer :: six = 6, twenty_three = 23


### PR DESCRIPTION
Frontend inserted conversions may conflict with variable names.
Avoid this for integer conversions by using `__builtin_int` instead
of `int`.

Fixes #188879
