### PR TITLE
[clang] [NFC] Comment fix in ParseExpr.cpp

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -15,8 +15,8 @@
 /// In the C99 grammar, these unary operators bind tightest and are represented
 /// as the 'cast-expression' production.  Everything else is either a binary
 /// operator (e.g. '/') or a ternary operator ("?:").  The unary leaves are
-/// handled by ParseCastExpression, the higher level pieces are handled by
-/// ParseBinaryExpression.
+/// handled by ParseCastExpression, the higher level pieces are handled
+/// elsewhere.
 ///
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Update hanging reference of ParseBinaryExpression to ParseRHSOfBinaryExpression

Fixes #195747