### PR TITLE
[compiler-rt][test] Disable create_thread_loop2 for lsan on Darwin

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/create_thread_loop2.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/create_thread_loop2.cpp
@@ -5,6 +5,9 @@
 // Crashes on Android.
 // UNSUPPORTED: android
 
+// Occasionally hangs on macOS using LSAN.
+// UNSUPPORTED: darwin && lsan
+
 #include <cstdint>
 #include <pthread.h>
 #include <stdlib.h>


### PR DESCRIPTION
create_thread_loop2 occasionally hangs on macOS till hitting timeout.
Disable the tests for LSAN on macOS.
