### PR TITLE
[libc][semaphore] Zero-initialize rand_bytes to fix GCC warning

### DIFF
--- a/libc/src/semaphore/linux/named_semaphore.cpp
+++ b/libc/src/semaphore/linux/named_semaphore.cpp
@@ -61,7 +61,7 @@ constexpr int DEFAULT_OFLAGS = O_NOFOLLOW | O_CLOEXEC;
 
 ErrorOr<TmpPath> generate_tmp_path() {
   // fill out 8 random bytes.
-  cpp::array<uint8_t, RANDOM_SUFFIX_BYTES> rand_bytes;
+  cpp::array<uint8_t, RANDOM_SUFFIX_BYTES> rand_bytes{};
   auto ret = linux_syscalls::getrandom(rand_bytes.data(), rand_bytes.size(), 0);
   if (!ret.has_value())
     return Error(ret.error());


### PR DESCRIPTION
GCC 15 warns about `rand_bytes` being maybe uninitialized when passed to `getrandom`. Since `getrandom` writes to it, it doesn't strictly need initialization, but zero-initializing it satisfies the compiler and avoids the `-Werror=maybe-uninitialized` error.

Fix for https://github.com/llvm/llvm-project/pull/192278

Assisted by Gemini
