### PR TITLE
[libc++] Add `optional<T&>(optional<U>...)` constraints for ctors shared with `optional<T>`

### DIFF
--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -966,7 +966,7 @@ private:
     }
 
     template <class>
-    _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_assign() {
+    _LIBCPP_HIDE_FROM_ABI static constexpr bool __enable_assign() {
       return false;
     }
   };

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -953,11 +953,35 @@ private:
     }
   };
 
+  template <class _QualUp>
+  struct _CheckOptionalLikeRefConstructor {
+    template <class>
+    _LIBCPP_HIDE_FROM_ABI static constexpr bool __enable_implicit() {
+      return !is_convertible_v<_QualUp, _Tp&>;
+    }
+
+    template <class>
+    _LIBCPP_HIDE_FROM_ABI static constexpr bool __enable_explicit() {
+      return is_convertible_v<_QualUp, _Tp&>;
+    }
+
+    template <class>
+    _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_assign() {
+      return false;
+    }
+  };
+
   template <class _Up, class _QualUp>
   using _CheckOptionalLikeCtor _LIBCPP_NODEBUG =
-      _If< _And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp> >::value,
-           _CheckOptionalLikeConstructor<_QualUp>,
-           __check_tuple_constructor_fail >;
+      _If<_And<is_lvalue_reference<_Tp>, // optional<T&>
+               _IsNotSame<__remove_cvref_t<_Tp>, optional<_Up>>,
+               _IsNotSame<_Tp&, _Up>,
+               is_constructible<_Tp&, _QualUp>>::value,
+          _CheckOptionalLikeRefConstructor<_QualUp>,
+          _If< _And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp> >::value, // optional<T>
+               _CheckOptionalLikeConstructor<_QualUp>,
+               __check_tuple_constructor_fail > >;
+
   template <class _Up, class _QualUp>
   using _CheckOptionalLikeAssign _LIBCPP_NODEBUG =
       _If< _And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp>, is_assignable<_Tp&, _QualUp> >::value,

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
@@ -182,6 +182,18 @@ constexpr bool test_ref() {
 
   static_assert(!std::is_constructible_v<std::optional<int>, const std::optional<ConstRValueOnly<int>>&&>);
 
+  // optional(const optional<U>&) !is_constructible_v<T&, const U&>.
+  static_assert(std::is_constructible_v<std::optional<int&>, const std::optional<ConstLValueOnly<int>>&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, const std::optional<LValueOnly<int>>&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, const std::optional<RValueOnly<int>>&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, const std::optional<ConstRValueOnly<int>>&>);
+
+  // optional(const optional<U>&&) !is_constructible_v<T&, const U>.
+  static_assert(std::is_constructible_v<std::optional<int&>, const std::optional<ConstLValueOnly<int>>&&>);
+  static_assert(std::is_constructible_v<std::optional<int&>, const std::optional<ConstRValueOnly<int>>&&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, const std::optional<LValueOnly<int>>&&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, const std::optional<RValueOnly<int>>&&>);
+
   return true;
 }
 #endif

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
@@ -174,6 +174,15 @@ constexpr bool test_ref() {
     ASSERT_NOT_NOEXCEPT(std::optional<const int&>(std::move(o1)));
   }
 
+  // optional(optional<U>&) !is_constructible_v<T&, U&>.
+  static_assert(std::is_constructible_v<std::optional<int&>, std::optional<LValueOnly<int>>&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, std::optional<RValueOnly<int>>&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, std::optional<ConstRValueOnly<int>>&>);
+
+  // optional(optional<U>&&) !is_constructible_v<T&, U>.
+  static_assert(std::is_constructible_v<std::optional<int&>, std::optional<RValueOnly<int>>&&>);
+  static_assert(!std::is_constructible_v<std::optional<int&>, std::optional<LValueOnly<int>>&&>);
+
   return true;
 }
 #endif

--- a/libcxx/test/std/utilities/optional/optional.object/optional_helper_types.h
+++ b/libcxx/test/std/utilities/optional/optional.object/optional_helper_types.h
@@ -79,6 +79,22 @@ struct LValueOnly {
 };
 
 template <typename T>
+struct ConstLValueOnly {
+  operator T&() & = delete;
+  operator T&() const&;
+  operator T&() &&      = delete;
+  operator T&() const&& = delete;
+};
+
+template <typename T>
+struct RValueOnly {
+  operator T&() &      = delete;
+  operator T&() const& = delete;
+  operator T&() &&;
+  operator T&() const&& = delete;
+};
+
+template <typename T>
 struct ConstRValueOnly {
   mutable T val{};
 


### PR DESCRIPTION
- Constraints were missing for some `optional<U>` constructors that were shared with `optional<T>`:
  - `const optional<U>&`
  - `optional<U>&&`
- Add some tests to verify the `is_constructible<...>` parts of the constraints for all four `optional<U>` constructors.
- As per the LLVM AI policy: Tests were created with assistance of AI. 