### PR TITLE
[lldb] Add missing closing brace in IRForTarget

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -1396,7 +1396,7 @@ IRForTarget::UnfoldConstant(Constant *old_constant,
         } break;
         }
       } else {
-        return llvm::createStringErrorV("unhandled constant type \"{0\".",
+        return llvm::createStringErrorV("unhandled constant type \"{0}\".",
                                         PrintValue(constant));
       }
     } else if (Instruction *inst = llvm::dyn_cast<Instruction>(user)) {


### PR DESCRIPTION
Follow-up to 51d52c2a6cdc.