### PR TITLE
[lldb] Add Policy infrastructure

### DIFF
--- a/lldb/include/lldb/Target/Policy.h
+++ b/lldb/include/lldb/Target/Policy.h
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TARGET_POLICY_H
+#define LLDB_TARGET_POLICY_H
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <cassert>
+
+namespace lldb_private {
+
+class Stream;
+
+/// Describes what view of the process a thread should see and what
+/// operations it is allowed to perform.
+///
+/// This replaces ad-hoc checks like CurrentThreadIsPrivateStateThread() with
+/// a unified, composable mechanism. Code consults the current policy on the
+/// per-thread PolicyStack instead of comparing host thread identities.
+///
+/// One motivating case is frame providers, which layer a public illusion on
+/// top of the private unwinder stack. The private state thread must see the
+/// raw unwinder frames, while public clients see the augmented view. Rather
+/// than checking thread identity at every callsite, the private state thread
+/// pushes Policy::PrivateState() and the rest follows from the policy.
+struct Policy {
+  /// What view of the process this thread sees.
+  enum class View {
+    Public,  ///< Provider-augmented frames, public state, public run lock.
+    Private, ///< Parent (unwinder) frames, private state, private run lock.
+  };
+
+  /// What operations this thread is allowed to perform.
+  /// Enforced at specific callsites, not by the policy itself.
+  struct Capabilities {
+    bool can_evaluate_expressions = true;
+    /// Whether expression evaluation may resume all threads to avoid
+    /// deadlocks (e.g. when a lock is held by another thread).
+    bool can_run_all_threads = true;
+    /// Whether the expression runner may fall back to running all threads
+    /// after a single-thread attempt times out.
+    bool can_try_all_threads = true;
+    bool can_run_breakpoint_actions = true;
+    bool can_load_frame_providers = true;
+    bool can_run_frame_recognizers = true;
+  };
+
+  View view = View::Public;
+  Capabilities capabilities;
+
+  static Policy PublicState() { return {}; }
+
+  static Policy PrivateState() {
+    Policy p;
+    p.view = View::Private;
+    p.capabilities.can_load_frame_providers = false;
+    p.capabilities.can_run_frame_recognizers = false;
+    return p;
+  }
+
+  static Policy PublicStateRunningExpression() {
+    Policy p;
+    p.capabilities.can_run_breakpoint_actions = false;
+    return p;
+  }
+
+  void Dump(Stream &s) const;
+};
+
+/// Per-thread policy stack.
+///
+/// The stack lives in thread_local storage. Each thread has its own stack,
+/// initialized with a default-constructed base entry that is never popped.
+/// RAII guards (Guard) push and pop policies.
+///
+/// For thread pool workers that don't inherit thread_local storage, the
+/// policy must be passed into the lambda and pushed onto the worker
+/// thread's stack when the task starts.
+class PolicyStack {
+public:
+  static PolicyStack &GetForCurrentThread() {
+    static thread_local PolicyStack s_stack;
+    return s_stack;
+  }
+
+  Policy Current() const { return m_stack.back(); }
+
+  void Push(Policy policy) { m_stack.push_back(std::move(policy)); }
+
+  void Pop() {
+    assert(!m_stack.empty() && "can't pop the last policy");
+    m_stack.pop_back();
+  }
+
+  void Dump(Stream &s) const;
+
+  /// RAII guard that pushes a policy on construction and pops on destruction.
+  class Guard {
+  public:
+    explicit Guard(Policy policy) { GetForCurrentThread().Push(policy); }
+    ~Guard() { GetForCurrentThread().Pop(); }
+
+    Guard(const Guard &) = delete;
+    Guard &operator=(const Guard &) = delete;
+  };
+
+private:
+  llvm::SmallVector<Policy> m_stack = {Policy{}};
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_TARGET_POLICY_H

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -31,6 +31,7 @@ add_lldb_library(lldbTarget
   OperatingSystem.cpp
   PathMappingList.cpp
   Platform.cpp
+  Policy.cpp
   Process.cpp
   ProcessTrace.cpp
   Queue.cpp

--- a/lldb/source/Target/Policy.cpp
+++ b/lldb/source/Target/Policy.cpp
@@ -1,0 +1,33 @@
+//===-- Policy.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/Policy.h"
+#include "lldb/Utility/Stream.h"
+
+using namespace lldb_private;
+
+void Policy::Dump(Stream &s) const {
+  s.Printf("view=%s", view == View::Public ? "public" : "private");
+  s.PutCString(", capabilities={");
+  s.Printf("eval_expr=%d", capabilities.can_evaluate_expressions);
+  s.Printf(" run_all=%d", capabilities.can_run_all_threads);
+  s.Printf(" try_all=%d", capabilities.can_try_all_threads);
+  s.Printf(" bp_actions=%d", capabilities.can_run_breakpoint_actions);
+  s.Printf(" frame_providers=%d", capabilities.can_load_frame_providers);
+  s.Printf(" frame_recognizers=%d", capabilities.can_run_frame_recognizers);
+  s.PutChar('}');
+}
+
+void PolicyStack::Dump(Stream &s) const {
+  s.Printf("PolicyStack depth=%zu\n", m_stack.size());
+  for (size_t i = 0; i < m_stack.size(); i++) {
+    s.Printf("  [%zu] ", i);
+    m_stack[i].Dump(s);
+    s.PutChar('\n');
+  }
+}

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -9,6 +9,7 @@ add_lldb_unittest(TargetTests
   MemoryTagMapTest.cpp
   ModuleCacheTest.cpp
   PathMappingListTest.cpp
+  PolicyTest.cpp
   RegisterFlagsTest.cpp
   RemoteAwarePlatformTest.cpp
   ScratchTypeSystemTest.cpp

--- a/lldb/unittests/Target/PolicyTest.cpp
+++ b/lldb/unittests/Target/PolicyTest.cpp
@@ -1,0 +1,154 @@
+//===-- PolicyTest.cpp ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/Policy.h"
+#include "lldb/Utility/StreamString.h"
+#include "gtest/gtest.h"
+
+#include <thread>
+
+using namespace lldb_private;
+
+TEST(PolicyTest, DefaultIsPublicWithAllCapabilities) {
+  Policy p;
+  EXPECT_EQ(p.view, Policy::View::Public);
+  EXPECT_TRUE(p.capabilities.can_evaluate_expressions);
+  EXPECT_TRUE(p.capabilities.can_run_all_threads);
+  EXPECT_TRUE(p.capabilities.can_try_all_threads);
+  EXPECT_TRUE(p.capabilities.can_run_breakpoint_actions);
+  EXPECT_TRUE(p.capabilities.can_load_frame_providers);
+  EXPECT_TRUE(p.capabilities.can_run_frame_recognizers);
+}
+
+TEST(PolicyTest, PublicState) {
+  Policy p = Policy::PublicState();
+  EXPECT_EQ(p.view, Policy::View::Public);
+  EXPECT_TRUE(p.capabilities.can_evaluate_expressions);
+  EXPECT_TRUE(p.capabilities.can_run_all_threads);
+  EXPECT_TRUE(p.capabilities.can_try_all_threads);
+  EXPECT_TRUE(p.capabilities.can_run_breakpoint_actions);
+  EXPECT_TRUE(p.capabilities.can_load_frame_providers);
+  EXPECT_TRUE(p.capabilities.can_run_frame_recognizers);
+}
+
+TEST(PolicyTest, PrivateState) {
+  Policy p = Policy::PrivateState();
+  EXPECT_EQ(p.view, Policy::View::Private);
+  EXPECT_TRUE(p.capabilities.can_evaluate_expressions);
+  EXPECT_TRUE(p.capabilities.can_run_all_threads);
+  EXPECT_TRUE(p.capabilities.can_try_all_threads);
+  EXPECT_TRUE(p.capabilities.can_run_breakpoint_actions);
+  EXPECT_FALSE(p.capabilities.can_load_frame_providers);
+  EXPECT_FALSE(p.capabilities.can_run_frame_recognizers);
+}
+
+TEST(PolicyTest, PublicStateRunningExpression) {
+  Policy p = Policy::PublicStateRunningExpression();
+  EXPECT_EQ(p.view, Policy::View::Public);
+  EXPECT_TRUE(p.capabilities.can_evaluate_expressions);
+  EXPECT_TRUE(p.capabilities.can_run_all_threads);
+  EXPECT_TRUE(p.capabilities.can_try_all_threads);
+  EXPECT_FALSE(p.capabilities.can_run_breakpoint_actions);
+  EXPECT_TRUE(p.capabilities.can_load_frame_providers);
+  EXPECT_TRUE(p.capabilities.can_run_frame_recognizers);
+}
+
+TEST(PolicyTest, StackDefaultIsPublicState) {
+  PolicyStack &stack = PolicyStack::GetForCurrentThread();
+  Policy current = stack.Current();
+  EXPECT_EQ(current.view, Policy::View::Public);
+  EXPECT_TRUE(current.capabilities.can_evaluate_expressions);
+  EXPECT_TRUE(current.capabilities.can_load_frame_providers);
+}
+
+TEST(PolicyTest, StackPushPop) {
+  PolicyStack &stack = PolicyStack::GetForCurrentThread();
+
+  stack.Push(Policy::PrivateState());
+  EXPECT_EQ(stack.Current().view, Policy::View::Private);
+  EXPECT_FALSE(stack.Current().capabilities.can_load_frame_providers);
+
+  stack.Push(Policy::PublicStateRunningExpression());
+  EXPECT_EQ(stack.Current().view, Policy::View::Public);
+  EXPECT_FALSE(stack.Current().capabilities.can_run_breakpoint_actions);
+
+  stack.Pop();
+  EXPECT_EQ(stack.Current().view, Policy::View::Private);
+
+  stack.Pop();
+  EXPECT_EQ(stack.Current().view, Policy::View::Public);
+}
+
+TEST(PolicyTest, GuardRAII) {
+  PolicyStack &stack = PolicyStack::GetForCurrentThread();
+  EXPECT_EQ(stack.Current().view, Policy::View::Public);
+
+  {
+    PolicyStack::Guard guard(Policy::PrivateState());
+    EXPECT_EQ(stack.Current().view, Policy::View::Private);
+    EXPECT_FALSE(stack.Current().capabilities.can_load_frame_providers);
+
+    {
+      PolicyStack::Guard inner(Policy::PublicStateRunningExpression());
+      EXPECT_EQ(stack.Current().view, Policy::View::Public);
+      EXPECT_FALSE(stack.Current().capabilities.can_run_breakpoint_actions);
+    }
+
+    EXPECT_EQ(stack.Current().view, Policy::View::Private);
+  }
+
+  EXPECT_EQ(stack.Current().view, Policy::View::Public);
+}
+
+TEST(PolicyTest, StackIsPerThread) {
+  PolicyStack &main_stack = PolicyStack::GetForCurrentThread();
+  main_stack.Push(Policy::PrivateState());
+
+  Policy::View other_thread_view;
+  std::thread t([&other_thread_view]() {
+    PolicyStack &stack = PolicyStack::GetForCurrentThread();
+    other_thread_view = stack.Current().view;
+  });
+  t.join();
+
+  EXPECT_EQ(main_stack.Current().view, Policy::View::Private);
+  EXPECT_EQ(other_thread_view, Policy::View::Public);
+
+  main_stack.Pop();
+}
+
+TEST(PolicyTest, DumpPublicState) {
+  StreamString s;
+  Policy::PublicState().Dump(s);
+  EXPECT_EQ(s.GetString(),
+            "view=public, capabilities={"
+            "eval_expr=1 run_all=1 try_all=1 "
+            "bp_actions=1 frame_providers=1 frame_recognizers=1}");
+}
+
+TEST(PolicyTest, DumpPrivateState) {
+  StreamString s;
+  Policy::PrivateState().Dump(s);
+  EXPECT_EQ(s.GetString(),
+            "view=private, capabilities={"
+            "eval_expr=1 run_all=1 try_all=1 "
+            "bp_actions=1 frame_providers=0 frame_recognizers=0}");
+}
+
+TEST(PolicyTest, DumpStack) {
+  PolicyStack &stack = PolicyStack::GetForCurrentThread();
+  stack.Push(Policy::PrivateState());
+
+  StreamString s;
+  stack.Dump(s);
+  EXPECT_NE(s.GetString().find("depth=2"), std::string::npos);
+  EXPECT_NE(s.GetString().find("[0] view=public"), std::string::npos);
+  EXPECT_NE(s.GetString().find("[1] view=private"), std::string::npos);
+
+  stack.Pop();
+}


### PR DESCRIPTION
Add a generic thread-local policy stack and a Policy struct that describes what view of the process a thread should see (private reality vs public illusion) and what operations it is allowed to perform.

This is the infrastructure for replacing ad-hoc host thread identity checks (CurrentThreadIsPrivateStateThread, IsOnThread, etc.) with a unified, composable mechanism. No behavioral changes yet -- adoption will follow in subsequent patches.

----

The following PRs are related to the Policy feature:
- #195762
- #195771
- #195774
- #195775

rdar://176223894