### PR TITLE
[InlineOrder] Remove unused InlineHistoryMap

### DIFF
--- a/llvm/lib/Analysis/InlineOrder.cpp
+++ b/llvm/lib/Analysis/InlineOrder.cpp
@@ -264,7 +264,6 @@ public:
 private:
   SmallVector<CallBase *, 16> Heap;
   std::function<bool(const CallBase *L, const CallBase *R)> isLess;
-  DenseMap<CallBase *, int> InlineHistoryMap;
   DenseMap<const CallBase *, PriorityT> Priorities;
   FunctionAnalysisManager &FAM;
   const InlineParams &Params;


### PR DESCRIPTION
This patch removes InlineHistoryMap, an unused variable.  The last
use was removed by:

  commit 3af427539bc6b85a9fe3334b9a0b43d347ea29ac
  Author: Arthur Eubanks <aeubanks@google.com>
  Date:   Wed Apr 8 09:34:52 2026 -0700
