### PR TITLE
[MLIR][Transform] Don't error when a structurally inlinable call exists

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/Utils.cpp
+++ b/mlir/lib/Dialect/Transform/IR/Utils.cpp
@@ -143,7 +143,7 @@ transform::detail::mergeSymbolsInto(Operation *target,
       return;
 
     if (!inliner.isLegalToInline(call, callable, /*wouldBeCloned=*/false)) {
-      noInlineCalls.insert(callable);
+      noInlineCalls.insert(call.getOperation());
     }
     return;
   });
@@ -335,7 +335,7 @@ transform::detail::mergeSymbolsInto(Operation *target,
 
     if (!callable)
       return WalkResult::advance();
-    if (!noInlineCalls.contains(callable) &&
+    if (!noInlineCalls.contains(call.getOperation()) &&
         !inliner.isLegalToInline(call, callable, /*wouldBeCloned=*/false)) {
       InFlightDiagnostic diag =
           call->emitError()

--- a/mlir/lib/Dialect/Transform/IR/Utils.cpp
+++ b/mlir/lib/Dialect/Transform/IR/Utils.cpp
@@ -120,6 +120,34 @@ transform::detail::mergeSymbolsInto(Operation *target,
          "requires target to implement the 'SymbolTable' trait");
 
   SymbolTable targetSymbolTable(target);
+  InlinerInterface inliner(target->getContext());
+
+  // Collect all the functions that are called in `target` that cannot be
+  // inlined into `target`.
+  SmallPtrSet<Operation *, 1> noInlineCalls;
+  target->walk([&](CallOpInterface call) {
+    Operation *callable = nullptr;
+    CallInterfaceCallable callee = call.getCallableForCallee();
+    if (auto symRef = dyn_cast<SymbolRefAttr>(callee)) {
+      // Fall back to full resolution for nested symbols, the table is
+      // one-level only.
+      if (isa<FlatSymbolRefAttr>(symRef))
+        callable = targetSymbolTable.lookup(symRef.getLeafReference());
+      else
+        callable = SymbolTable::lookupNearestSymbolFrom(call, symRef);
+    } else if (auto value = dyn_cast<Value>(callee)) {
+      callable = value.getDefiningOp();
+    }
+
+    if (!callable)
+      return;
+
+    if (!inliner.isLegalToInline(call, callable, /*wouldBeCloned=*/false)) {
+      noInlineCalls.insert(callable);
+    }
+    return;
+  });
+
   SymbolTable otherSymbolTable(*other);
 
   // Step 1:
@@ -291,7 +319,6 @@ transform::detail::mergeSymbolsInto(Operation *target,
   if (preVerify.wasInterrupted())
     return failure();
 
-  InlinerInterface inliner(target->getContext());
   WalkResult inlineCheck = target->walk([&](CallOpInterface call) {
     Operation *callable = nullptr;
     CallInterfaceCallable callee = call.getCallableForCallee();
@@ -308,7 +335,8 @@ transform::detail::mergeSymbolsInto(Operation *target,
 
     if (!callable)
       return WalkResult::advance();
-    if (!inliner.isLegalToInline(call, callable, /*wouldBeCloned=*/false)) {
+    if (!noInlineCalls.contains(callable) &&
+        !inliner.isLegalToInline(call, callable, /*wouldBeCloned=*/false)) {
       InFlightDiagnostic diag =
           call->emitError()
           << "merged call is not legal to inline into its caller";

--- a/mlir/test/Dialect/Transform/inliner-legality.mlir
+++ b/mlir/test/Dialect/Transform/inliner-legality.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt %s --pass-pipeline='builtin.module(transform-interpreter)'
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.yield
+  }
+  
+  func.func @f() {
+    return
+  }
+
+  func.func @main() {
+    // This call is marked noinline, so it is illegal to inline.
+    // The fix ensures that this does not cause an error during symbol merging.
+    "test.conversion_call_op"() {callee = @f, noinline} : () -> ()
+    return
+  }
+}


### PR DESCRIPTION
Fixes bug introduced in https://github.com/llvm/llvm-project/pull/192956

Specifically transform-interpreter would crash if any op in the region it is applied to is marked as no-inline via the inliner interface. This is because the check added does a post processing to verify that all operations can be inlined [and there isn't an issue due to symbol merging]. However, it fails to account for the case where an operation was already not inlinable (and not an error introduced by the transform symbol merging).