### PR TITLE
[NFC][Codegen] Remove dead switch cases

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/X86.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/X86.cpp
@@ -102,8 +102,6 @@ static Value *emitX86RoundImmediate(CodeGenFunction &CGF, Value *X,
     case 0b11:
       ID = Intrinsic::experimental_constrained_trunc;
       break;
-    default:
-      llvm_unreachable("Invalid rounding mode");
     }
 
     Function *F = CGF.CGM.getIntrinsic(ID, X->getType());
@@ -123,8 +121,6 @@ static Value *emitX86RoundImmediate(CodeGenFunction &CGF, Value *X,
   case 0b11:
     ID = Intrinsic::trunc;
     break;
-  default:
-    llvm_unreachable("Invalid rounding mode");
   }
 
   Function *F = CGF.CGM.getIntrinsic(ID, X->getType());


### PR DESCRIPTION
Static analysis flagged these cases as dead code b/c the `& RoundingMask` mask ensured that the other switch cases completely covered the results.