### PR TITLE
[clang][test] Add missing `FileCheck` in Import/destructor/test.cpp

### DIFF
--- a/clang/test/Import/destructor/test.cpp
+++ b/clang/test/Import/destructor/test.cpp
@@ -1,10 +1,9 @@
-// RUN: clang-import-test -dump-ast -import %S/Inputs/F.cpp -expression %s
+// RUN: clang-import-test -dump-ast -import %S/Inputs/F.cpp -expression %s | FileCheck %s
 
 // Triggers the deserialization of B's destructor.
 B b1;
 
-// CHECK: CXXDestructorDecl
-
-// CHECK-NEXT: ~B 'void () noexcept' virtual
+// CHECK:      CXXDestructorDecl
+// CHECK-SAME: ~B
 // CHECK-SAME: 'void () noexcept'
 // CHECK-SAME: virtual


### PR DESCRIPTION
The test had `CHECK` directives that were never executed because the `RUN` line did not pipe output to `FileCheck`. This also replaces `CHECK-NEXT` with `CHECK-SAME` so the subsequent `CHECK-SAME` directives match the remaining destructor properties in order.