### PR TITLE
[clang][AST][NFC] const-correctness improvements for member functions returing `ArrayRef`

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3214,7 +3214,7 @@ public:
   /// a CallExpr without going through the slower virtual child_iterator
   /// interface.  This provides efficient reverse iteration of the
   /// subexpressions.  This is currently used for CFG construction.
-  ArrayRef<Stmt *> getRawSubExprs() {
+  ArrayRef<Stmt *> getRawSubExprs() const {
     return {getTrailingStmts(), PREARGS_START + getNumPreArgs() + getNumArgs()};
   }
 
@@ -5349,8 +5349,6 @@ public:
     return reinterpret_cast<Expr * const *>(InitExprs.data());
   }
 
-  ArrayRef<Expr *> inits() { return {getInits(), getNumInits()}; }
-
   ArrayRef<Expr *> inits() const { return {getInits(), getNumInits()}; }
 
   const Expr *getInit(unsigned Init) const {
@@ -6123,7 +6121,11 @@ public:
 
   Expr **getExprs() { return reinterpret_cast<Expr **>(getTrailingObjects()); }
 
-  ArrayRef<Expr *> exprs() { return {getExprs(), getNumExprs()}; }
+  Expr *const *getExprs() const {
+    return reinterpret_cast<Expr *const *>(getTrailingObjects());
+  }
+
+  ArrayRef<Expr *> exprs() const { return {getExprs(), getNumExprs()}; }
 
   SourceLocation getLParenLoc() const { return LParenLoc; }
   SourceLocation getRParenLoc() const { return RParenLoc; }

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -5184,10 +5184,6 @@ public:
 
   ArrayRef<Expr *> getInitExprs() const { return getTrailingObjects(NumExprs); }
 
-  ArrayRef<Expr *> getUserSpecifiedInitExprs() {
-    return getTrailingObjects(NumUserSpecifiedExprs);
-  }
-
   ArrayRef<Expr *> getUserSpecifiedInitExprs() const {
     return getTrailingObjects(NumUserSpecifiedExprs);
   }

--- a/clang/include/clang/AST/OpenACCClause.h
+++ b/clang/include/clang/AST/OpenACCClause.h
@@ -455,11 +455,6 @@ public:
     return getExprs()[0];
   }
 
-  ArrayRef<Expr *> getVarList() {
-    assert(!HasConditionExpr.has_value() &&
-           "Condition Expr self clause asked about var list");
-    return getExprs();
-  }
   ArrayRef<Expr *> getVarList() const {
     assert(!HasConditionExpr.has_value() &&
            "Condition Expr self clause asked about var list");
@@ -559,9 +554,6 @@ public:
   SourceLocation getQueuesLoc() const { return QueuesLoc; }
   bool hasDevNumExpr() const { return getExprs()[0]; }
   Expr *getDevNumExpr() const { return getExprs()[0]; }
-  ArrayRef<Expr *> getQueueIdExprs() {
-    return OpenACCClauseWithExprs::getExprs().drop_front();
-  }
   ArrayRef<Expr *> getQueueIdExprs() const {
     return OpenACCClauseWithExprs::getExprs().drop_front();
   }
@@ -590,8 +582,6 @@ public:
   Create(const ASTContext &C, SourceLocation BeginLoc, SourceLocation LParenLoc,
          ArrayRef<Expr *> IntExprs, SourceLocation EndLoc);
 
-  ArrayRef<Expr *> getIntExprs() { return OpenACCClauseWithExprs::getExprs(); }
-
   ArrayRef<Expr *> getIntExprs() const {
     return OpenACCClauseWithExprs::getExprs();
   }
@@ -616,7 +606,6 @@ public:
                                    SourceLocation LParenLoc,
                                    ArrayRef<Expr *> SizeExprs,
                                    SourceLocation EndLoc);
-  ArrayRef<Expr *> getSizeExprs() { return OpenACCClauseWithExprs::getExprs(); }
 
   ArrayRef<Expr *> getSizeExprs() const {
     return OpenACCClauseWithExprs::getExprs();
@@ -827,7 +816,6 @@ protected:
 
 public:
   static bool classof(const OpenACCClause *C);
-  ArrayRef<Expr *> getVarList() { return getExprs(); }
   ArrayRef<Expr *> getVarList() const { return getExprs(); }
 };
 
@@ -870,11 +858,6 @@ public:
   }
   // Gets a list of 'made up' `VarDecl` objects that can be used by codegen to
   // ensure that we properly initialize each of these variables.
-  ArrayRef<OpenACCPrivateRecipe> getInitRecipes() {
-    return ArrayRef<OpenACCPrivateRecipe>{
-        getTrailingObjects<OpenACCPrivateRecipe>(), getExprs().size()};
-  }
-
   ArrayRef<OpenACCPrivateRecipe> getInitRecipes() const {
     return ArrayRef<OpenACCPrivateRecipe>{
         getTrailingObjects<OpenACCPrivateRecipe>(), getExprs().size()};
@@ -933,11 +916,6 @@ public:
 
   // Gets a list of 'made up' `VarDecl` objects that can be used by codegen to
   // ensure that we properly initialize each of these variables.
-  ArrayRef<OpenACCFirstPrivateRecipe> getInitRecipes() {
-    return ArrayRef<OpenACCFirstPrivateRecipe>{
-        getTrailingObjects<OpenACCFirstPrivateRecipe>(), getExprs().size()};
-  }
-
   ArrayRef<OpenACCFirstPrivateRecipe> getInitRecipes() const {
     return ArrayRef<OpenACCFirstPrivateRecipe>{
         getTrailingObjects<OpenACCFirstPrivateRecipe>(), getExprs().size()};
@@ -1364,11 +1342,6 @@ class OpenACCReductionClause final
 public:
   static bool classof(const OpenACCClause *C) {
     return C->getClauseKind() == OpenACCClauseKind::Reduction;
-  }
-
-  ArrayRef<OpenACCReductionRecipe> getRecipes() {
-    return ArrayRef<OpenACCReductionRecipe>{
-        getTrailingObjects<OpenACCReductionRecipe>(), getExprs().size()};
   }
 
   ArrayRef<OpenACCReductionRecipe> getRecipes() const {

--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -515,8 +515,6 @@ class OpenACCWaitConstruct final
 
   ArrayRef<Expr *> getExprs() const { return {getExprPtr(), NumExprs}; }
 
-  ArrayRef<Expr *> getExprs() { return {getExprPtr(), NumExprs}; }
-
 public:
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == OpenACCWaitConstructClass;
@@ -538,7 +536,6 @@ public:
 
   bool hasDevNumExpr() const { return getExprs()[0]; }
   Expr *getDevNumExpr() const { return getExprs()[0]; }
-  ArrayRef<Expr *> getQueueIdExprs() { return getExprs().drop_front(); }
   ArrayRef<Expr *> getQueueIdExprs() const { return getExprs().drop_front(); }
 
   child_range children() {


### PR DESCRIPTION
- Add const qualifiers to member functions.
- Drop non-const-qualified member functions whose const-qualified versions return same thing.