### PR TITLE
[libcxx] Include __utility/exchange.h in thread.h

### DIFF
--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -29,6 +29,7 @@
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_cvref.h>
+#include <__utility/exchange.h>
 #include <__utility/forward.h>
 #include <tuple>
 


### PR DESCRIPTION
Otherwise in generic-no-localization we get errors like the following:
```
error: declaration of '__exchange' must be imported from module 'std.utility.exchange'
```

Not exactly sure why 8af8a60d544afaeac4834bb78f6b55bc890fb5fd was able to pass CI in the first place, but this fixes the only known CI breakage.