### PR TITLE
[ValueTracking] Fix incorrect FMF propagation from select to fcmp

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8865,12 +8865,11 @@ llvm::getFlippedStrictnessPredicateAndConstant(CmpPredicate Pred, Constant *C) {
   return std::make_pair(NewPred, NewC);
 }
 
-static SelectPatternResult matchSelectPattern(CmpInst::Predicate Pred,
-                                              FastMathFlags FMF,
-                                              Value *CmpLHS, Value *CmpRHS,
-                                              Value *TrueVal, Value *FalseVal,
-                                              Value *&LHS, Value *&RHS,
-                                              unsigned Depth) {
+static SelectPatternResult
+matchSelectPattern(CmpInst::Predicate Pred, FastMathFlags FMF,
+                   FastMathFlags CmpFMF, Value *CmpLHS, Value *CmpRHS,
+                   Value *TrueVal, Value *FalseVal, Value *&LHS, Value *&RHS,
+                   unsigned Depth) {
   bool HasMismatchedZeros = false;
   if (CmpInst::isFPPredicate(Pred)) {
     // IEEE-754 ignores the sign of 0.0 in comparisons. So if the select has one
@@ -8922,14 +8921,21 @@ static SelectPatternResult matchSelectPattern(CmpInst::Predicate Pred,
   SelectPatternNaNBehavior NaNBehavior = SPNB_NA;
   bool Ordered = false;
 
+  auto NaNFMFFor = [&](const Value *Op) {
+    FastMathFlags Res = CmpFMF;
+    if ((Op == TrueVal || Op == FalseVal) && FMF.noNaNs())
+      Res.setNoNaNs(true);
+    return Res;
+  };
+
   // When given one NaN and one non-NaN input:
   //   - maxnum/minnum (C99 fmaxf()/fminf()) return the non-NaN input.
   //   - A simple C99 (a < b ? a : b) construction will return 'b' (as the
   //     ordered comparison fails), which could be NaN or non-NaN.
   // so here we discover exactly what NaN behavior is required/accepted.
   if (CmpInst::isFPPredicate(Pred)) {
-    bool LHSSafe = isKnownNonNaN(CmpLHS, FMF);
-    bool RHSSafe = isKnownNonNaN(CmpRHS, FMF);
+    bool LHSSafe = isKnownNonNaN(CmpLHS, NaNFMFFor(CmpLHS));
+    bool RHSSafe = isKnownNonNaN(CmpRHS, NaNFMFFor(CmpRHS));
 
     if (LHSSafe && RHSSafe) {
       // Both operands are known non-NaN.
@@ -9202,8 +9208,10 @@ SelectPatternResult llvm::matchDecomposedSelectPattern(
   CmpInst::Predicate Pred = CmpI->getPredicate();
   Value *CmpLHS = CmpI->getOperand(0);
   Value *CmpRHS = CmpI->getOperand(1);
-  if (isa<FPMathOperator>(CmpI) && CmpI->hasNoNaNs())
-    FMF.setNoNaNs();
+  FastMathFlags CmpFMF;
+  // Fast-math flags on the compare instruction.
+  if (auto *FPMO = dyn_cast<FPMathOperator>(CmpI))
+    CmpFMF = FPMO->getFastMathFlags();
 
   // Bail out early.
   if (CmpI->isEquality())
@@ -9216,7 +9224,7 @@ SelectPatternResult llvm::matchDecomposedSelectPattern(
       // -0.0 because there is no corresponding integer value.
       if (*CastOp == Instruction::FPToSI || *CastOp == Instruction::FPToUI)
         FMF.setNoSignedZeros();
-      return ::matchSelectPattern(Pred, FMF, CmpLHS, CmpRHS,
+      return ::matchSelectPattern(Pred, FMF, CmpFMF, CmpLHS, CmpRHS,
                                   cast<CastInst>(TrueVal)->getOperand(0), C,
                                   LHS, RHS, Depth);
     }
@@ -9225,13 +9233,13 @@ SelectPatternResult llvm::matchDecomposedSelectPattern(
       // -0.0 because there is no corresponding integer value.
       if (*CastOp == Instruction::FPToSI || *CastOp == Instruction::FPToUI)
         FMF.setNoSignedZeros();
-      return ::matchSelectPattern(Pred, FMF, CmpLHS, CmpRHS,
-                                  C, cast<CastInst>(FalseVal)->getOperand(0),
-                                  LHS, RHS, Depth);
+      return ::matchSelectPattern(Pred, FMF, CmpFMF, CmpLHS, CmpRHS, C,
+                                  cast<CastInst>(FalseVal)->getOperand(0), LHS,
+                                  RHS, Depth);
     }
   }
-  return ::matchSelectPattern(Pred, FMF, CmpLHS, CmpRHS, TrueVal, FalseVal,
-                              LHS, RHS, Depth);
+  return ::matchSelectPattern(Pred, FMF, CmpFMF, CmpLHS, CmpRHS, TrueVal,
+                              FalseVal, LHS, RHS, Depth);
 }
 
 CmpInst::Predicate llvm::getMinMaxPred(SelectPatternFlavor SPF, bool Ordered) {

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -595,3 +595,48 @@ define float @test_select_fcmp_uitofp_min(i8 %x) {
   %sel = select i1 %cmp, float 2.550000e+02, float %f
   ret float %sel
 }
+
+define float @test_clamp_select_nnan_ninf_fcmp_no_nnan(float %x) {
+; CHECK-LABEL: @test_clamp_select_nnan_ninf_fcmp_no_nnan(
+; CHECK-NEXT:    [[CMP2DOTINV:%.*]] = fcmp nnan ninf oge float [[X:%.*]], 2.550000e+02
+; CHECK-NEXT:    [[MIN:%.*]] = select nnan ninf i1 [[CMP2DOTINV]], float 2.550000e+02, float [[X]]
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ule float [[X]], 1.000000e+00
+; CHECK-NEXT:    [[R:%.*]] = select nnan ninf i1 [[CMP1]], float 1.000000e+00, float [[MIN]]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %cmp2 = fcmp nnan ninf ult float %x, 2.550000e+02
+  %min = select i1 %cmp2, float %x, float 2.550000e+02
+  %cmp1 = fcmp ule float %x, 1.000000e+00
+  %r = select nnan ninf i1 %cmp1, float 1.000000e+00, float %min
+  ret float %r
+}
+
+; Outer select also has nsz; outer fcmp must stay plain on %x.
+define float @test_clamp_outer_select_nnan_ninf_nsz_inner_plain(float %x) {
+; CHECK-LABEL: @test_clamp_outer_select_nnan_ninf_nsz_inner_plain(
+; CHECK-NEXT:    [[MIN:%.*]] = call nnan ninf nsz float @llvm.minnum.f32(float [[X:%.*]], float 2.550000e+02)
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ule float [[X]], 1.000000e+00
+; CHECK-NEXT:    [[R:%.*]] = select nnan ninf nsz i1 [[CMP1]], float 1.000000e+00, float [[MIN]]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %cmp2 = fcmp nnan ninf ult float %x, 2.550000e+02
+  %min = select i1 %cmp2, float %x, float 2.550000e+02
+  %cmp1 = fcmp ule float %x, 1.000000e+00
+  %r = select nnan ninf nsz i1 %cmp1, float 1.000000e+00, float %min
+  ret float %r
+}
+
+define <2 x float> @test_clamp_select_nnan_ninf_fcmp_no_nnan_vec(<2 x float> %x) {
+; CHECK-LABEL: @test_clamp_select_nnan_ninf_fcmp_no_nnan_vec(
+; CHECK-NEXT:    [[CMP2DOTINV:%.*]] = fcmp nnan ninf oge <2 x float> [[X:%.*]], splat (float 2.550000e+02)
+; CHECK-NEXT:    [[MIN:%.*]] = select nnan ninf <2 x i1> [[CMP2DOTINV]], <2 x float> splat (float 2.550000e+02), <2 x float> [[X]]
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ule <2 x float> [[X]], splat (float 1.000000e+00)
+; CHECK-NEXT:    [[R:%.*]] = select nnan ninf <2 x i1> [[CMP1]], <2 x float> splat (float 1.000000e+00), <2 x float> [[MIN]]
+; CHECK-NEXT:    ret <2 x float> [[R]]
+;
+  %cmp2 = fcmp nnan ninf ult <2 x float> %x, splat (float 2.550000e+02)
+  %min = select <2 x i1> %cmp2, <2 x float> %x, <2 x float> splat (float 2.550000e+02)
+  %cmp1 = fcmp ule <2 x float> %x, splat (float 1.000000e+00)
+  %r = select nnan ninf <2 x i1> %cmp1, <2 x float> splat (float 1.000000e+00), <2 x float> %min
+  ret <2 x float> %r
+}


### PR DESCRIPTION
matchSelectPattern incorrectly reused FMF from the select instruction for the fcmp, even when the select operands
differed from the fcmp operands.

Handle fcmp FMF independently to ensure correct NaN safety checks during pattern matching.

Fixes https://github.com/llvm/llvm-project/issues/190913 

Alive2 proof - https://alive2.llvm.org/ce/z/jgALi4