### PR TITLE
fix libMLIRCAPIInterfaces after #195505

### DIFF
--- a/mlir/lib/CAPI/Interfaces/CMakeLists.txt
+++ b/mlir/lib/CAPI/Interfaces/CMakeLists.txt
@@ -2,4 +2,5 @@ add_mlir_upstream_c_api_library(MLIRCAPIInterfaces
   Interfaces.cpp
 
   LINK_LIBS PUBLIC
-  MLIRInferTypeOpInterface)
+  MLIRInferTypeOpInterface
+  MLIRSideEffectInterfaces)


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/195505 missed `MLIRSideEffectInterfaces` in the CMakeLists.txt.