### PR TITLE
[libc] prefer *at syscalls in sys/stat wrappers

### DIFF
--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/chmod.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/chmod.h
@@ -26,13 +26,13 @@ namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
 
 LIBC_INLINE ErrorOr<int> chmod(const char *path, mode_t mode) {
-#ifdef SYS_chmod
-  int ret = syscall_impl<int>(SYS_chmod, path, mode);
-#elif defined(SYS_fchmodat)
+#ifdef SYS_fchmodat
   int ret = syscall_impl<int>(SYS_fchmodat, AT_FDCWD, path, mode, 0);
 #elif defined(SYS_fchmodat2)
   int ret = syscall_impl<int>(SYS_fchmodat2, AT_FDCWD, path, mode, 0,
                               AT_SYMLINK_NOFOLLOW);
+#elif defined(SYS_chmod)
+  int ret = syscall_impl<int>(SYS_chmod, path, mode);
 #else
 #error "chmod, fchmodat and fchmodat2 syscalls not available."
 #endif

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdir.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/mkdir.h
@@ -26,10 +26,10 @@ namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
 
 LIBC_INLINE ErrorOr<int> mkdir(const char *path, mode_t mode) {
-#ifdef SYS_mkdir
-  int ret = syscall_impl<int>(SYS_mkdir, path, mode);
-#else
+#ifdef SYS_mkdirat
   int ret = syscall_impl<int>(SYS_mkdirat, AT_FDCWD, path, mode);
+#else
+  int ret = syscall_impl<int>(SYS_mkdir, path, mode);
 #endif
   if (ret < 0)
     return Error(-ret);


### PR DESCRIPTION
  - Flips the #ifdef order to prefer the *at syscalls over normal ones.
  - from #195620 