### PR TITLE
[analyzer][NFC] Rename class `StackFrameContext` to `StackFrame`

### DIFF
--- a/clang/docs/analyzer/developer-docs/IPA.rst
+++ b/clang/docs/analyzer/developer-docs/IPA.rst
@@ -393,4 +393,4 @@ __attribute__((nonnull))), and attempting to inline a call.
 CallEvents are reference-counted objects managed by a CallEventManager. While
 there is no inherent issue with persisting them (say, in a ProgramState's GDM),
 they are intended for short-lived use, and can be recreated from CFGElements or
-non-top-level StackFrameContexts fairly easily.
+non-top-level StackFrames fairly easily.

--- a/clang/include/clang/Analysis/AnalysisDeclContext.h
+++ b/clang/include/clang/Analysis/AnalysisDeclContext.h
@@ -41,7 +41,7 @@ class ImplicitParamDecl;
 class LocationContext;
 class LocationContextManager;
 class ParentMap;
-class StackFrameContext;
+class StackFrame;
 class Stmt;
 class VarDecl;
 
@@ -177,10 +177,10 @@ public:
   const ImplicitParamDecl *getSelfDecl() const;
 
   /// \copydoc LocationContextManager::getStackFrame()
-  const StackFrameContext *getStackFrame(LocationContext const *ParentLC,
-                                         const void *Data, const Expr *E,
-                                         const CFGBlock *Blk,
-                                         unsigned BlockCount, unsigned Index);
+  const StackFrame *getStackFrame(LocationContext const *ParentLC,
+                                  const void *Data, const Expr *E,
+                                  const CFGBlock *Blk, unsigned BlockCount,
+                                  unsigned Index);
 
   /// \returns The specified analysis object, lazily running the analysis if
   /// necessary or nullptr if the analysis could not run.
@@ -205,7 +205,7 @@ private:
 
 class LocationContext : public llvm::FoldingSetNode {
 public:
-  enum ContextKind { StackFrame };
+  enum ContextKind { StackFrameKind };
 
 private:
   ContextKind Kind;
@@ -250,7 +250,7 @@ public:
   /// \copydoc AnalysisDeclContext::getSelfDecl()
   const ImplicitParamDecl *getSelfDecl() const { return Ctx->getSelfDecl(); }
 
-  const StackFrameContext *getStackFrame() const;
+  const StackFrame *getStackFrame() const;
 
   /// \returns Whether the current LocationContext has no caller context.
   virtual bool inTopFrame() const;
@@ -287,7 +287,7 @@ public:
 };
 
 /// It represents a stack frame of the call stack (based on CallEvent).
-class StackFrameContext : public LocationContext {
+class StackFrame : public LocationContext {
   friend class LocationContextManager;
 
   // Extra data for BlockInvocations
@@ -307,14 +307,14 @@ class StackFrameContext : public LocationContext {
   // The index of the call site in the CFGBlock.
   const unsigned Index;
 
-  StackFrameContext(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
-                    const void *Data, const Expr *E, const CFGBlock *Block,
-                    unsigned BlockCount, unsigned Index, int64_t ID)
-      : LocationContext(StackFrame, ADC, ParentLC, ID), Data(Data), CallSite(E),
-        Block(Block), BlockCount(BlockCount), Index(Index) {}
+  StackFrame(AnalysisDeclContext *ADC, const LocationContext *ParentLC,
+             const void *Data, const Expr *E, const CFGBlock *Block,
+             unsigned BlockCount, unsigned Index, int64_t ID)
+      : LocationContext(StackFrameKind, ADC, ParentLC, ID), Data(Data),
+        CallSite(E), Block(Block), BlockCount(BlockCount), Index(Index) {}
 
 public:
-  ~StackFrameContext() override = default;
+  ~StackFrame() override = default;
 
   const void *getData() const { return Data; }
 
@@ -334,7 +334,7 @@ public:
                       const LocationContext *ParentLC, const void *Data,
                       const Expr *E, const CFGBlock *Block, unsigned BlockCount,
                       unsigned Index) {
-    ProfileCommon(ID, StackFrame, ADC, ParentLC, E);
+    ProfileCommon(ID, StackFrameKind, ADC, ParentLC, E);
     ID.AddPointer(Data);
     ID.AddPointer(Block);
     ID.AddInteger(BlockCount);
@@ -342,7 +342,7 @@ public:
   }
 
   static bool classof(const LocationContext *LC) {
-    return LC->getKind() == StackFrame;
+    return LC->getKind() == StackFrameKind;
   }
 };
 
@@ -360,7 +360,7 @@ public:
   /// \param ADC        The AnalysisDeclContext.
   /// \param ParentLC   The parent context of this newly created
   ///                   context.
-  /// \param Data       Extra data in case this StackFrameContext is
+  /// \param Data       Extra data in case this StackFrame is
   ///                   created for a BlockInvocation.
   /// \param E          The call expression.
   /// \param Block      The basic block.
@@ -368,11 +368,11 @@ public:
   /// \param StmtIdx    The index of the call expression \p E among the
   ///                   statements of the CFGBlock \p Block.
   /// \returns The stack frame context corresponding to the call.
-  const StackFrameContext *getStackFrame(AnalysisDeclContext *ADC,
-                                         const LocationContext *ParentLC,
-                                         const void *Data, const Expr *E,
-                                         const CFGBlock *Block,
-                                         unsigned BlockCount, unsigned StmtIdx);
+  const StackFrame *getStackFrame(AnalysisDeclContext *ADC,
+                                  const LocationContext *ParentLC,
+                                  const void *Data, const Expr *E,
+                                  const CFGBlock *Block, unsigned BlockCount,
+                                  unsigned StmtIdx);
 
   /// Discard all previously created LocationContext objects.
   void clear();
@@ -423,7 +423,7 @@ public:
   /// Obtain the beginning context of the analysis.
   ///
   /// \returns The top level stack frame for \p D.
-  const StackFrameContext *getStackFrame(const Decl *D) {
+  const StackFrame *getStackFrame(const Decl *D) {
     return LocCtxMgr.getStackFrame(getContext(D), nullptr, nullptr, nullptr,
                                    nullptr, 0, 0);
   }

--- a/clang/include/clang/Analysis/ProgramPoint.h
+++ b/clang/include/clang/Analysis/ProgramPoint.h
@@ -182,7 +182,7 @@ public:
     return L.getPointer();
   }
 
-  const StackFrameContext *getStackFrame() const {
+  const StackFrame *getStackFrame() const {
     return getLocationContext()->getStackFrame();
   }
 
@@ -637,21 +637,21 @@ private:
 /// CallEnter uses the caller's location context.
 class CallEnter : public ProgramPoint {
 public:
-  CallEnter(const Stmt *stmt, const StackFrameContext *calleeCtx,
+  CallEnter(const Stmt *stmt, const StackFrame *calleeCtx,
             const LocationContext *callerCtx)
-    : ProgramPoint(stmt, calleeCtx, CallEnterKind, callerCtx, nullptr) {}
+      : ProgramPoint(stmt, calleeCtx, CallEnterKind, callerCtx, nullptr) {}
 
   const Stmt *getCallExpr() const {
     return static_cast<const Stmt *>(getData1());
   }
 
-  const StackFrameContext *getCalleeContext() const {
-    return static_cast<const StackFrameContext *>(getData2());
+  const StackFrame *getCalleeContext() const {
+    return static_cast<const StackFrame *>(getData2());
   }
 
   /// Returns the entry block in the CFG for the entered function.
   const CFGBlock *getEntry() const {
-    const StackFrameContext *CalleeCtx = getCalleeContext();
+    const StackFrame *CalleeCtx = getCalleeContext();
     const CFG *CalleeCFG = CalleeCtx->getCFG();
     return &(CalleeCFG->getEntry());
   }
@@ -676,8 +676,8 @@ private:
 class CallExitBegin : public ProgramPoint {
 public:
   // CallExitBegin uses the callee's location context.
-  CallExitBegin(const StackFrameContext *L, const ReturnStmt *RS)
-    : ProgramPoint(RS, CallExitBeginKind, L, nullptr) { }
+  CallExitBegin(const StackFrame *L, const ReturnStmt *RS)
+      : ProgramPoint(RS, CallExitBeginKind, L, nullptr) {}
 
   const ReturnStmt *getReturnStmt() const {
     return static_cast<const ReturnStmt *>(getData1());
@@ -696,12 +696,11 @@ private:
 class CallExitEnd : public ProgramPoint {
 public:
   // CallExitEnd uses the caller's location context.
-  CallExitEnd(const StackFrameContext *CalleeCtx,
-              const LocationContext *CallerCtx)
-    : ProgramPoint(CalleeCtx, CallExitEndKind, CallerCtx, nullptr) {}
+  CallExitEnd(const StackFrame *CalleeCtx, const LocationContext *CallerCtx)
+      : ProgramPoint(CalleeCtx, CallExitEndKind, CallerCtx, nullptr) {}
 
-  const StackFrameContext *getCalleeContext() const {
-    return static_cast<const StackFrameContext *>(getData1());
+  const StackFrame *getCalleeContext() const {
+    return static_cast<const StackFrame *>(getData1());
   }
 
 private:

--- a/clang/include/clang/Analysis/ProgramPoint.h
+++ b/clang/include/clang/Analysis/ProgramPoint.h
@@ -637,9 +637,9 @@ private:
 /// CallEnter uses the caller's location context.
 class CallEnter : public ProgramPoint {
 public:
-  CallEnter(const Stmt *stmt, const StackFrame *calleeCtx,
+  CallEnter(const Stmt *stmt, const StackFrame *CalleeSF,
             const LocationContext *callerCtx)
-      : ProgramPoint(stmt, calleeCtx, CallEnterKind, callerCtx, nullptr) {}
+      : ProgramPoint(stmt, CalleeSF, CallEnterKind, callerCtx, nullptr) {}
 
   const Stmt *getCallExpr() const {
     return static_cast<const Stmt *>(getData1());
@@ -651,8 +651,8 @@ public:
 
   /// Returns the entry block in the CFG for the entered function.
   const CFGBlock *getEntry() const {
-    const StackFrame *CalleeCtx = getCalleeContext();
-    const CFG *CalleeCFG = CalleeCtx->getCFG();
+    const StackFrame *CalleeSF = getCalleeContext();
+    const CFG *CalleeCFG = CalleeSF->getCFG();
     return &(CalleeCFG->getEntry());
   }
 
@@ -676,8 +676,8 @@ private:
 class CallExitBegin : public ProgramPoint {
 public:
   // CallExitBegin uses the callee's location context.
-  CallExitBegin(const StackFrame *L, const ReturnStmt *RS)
-      : ProgramPoint(RS, CallExitBeginKind, L, nullptr) {}
+  CallExitBegin(const StackFrame *SF, const ReturnStmt *RS)
+      : ProgramPoint(RS, CallExitBeginKind, SF, nullptr) {}
 
   const ReturnStmt *getReturnStmt() const {
     return static_cast<const ReturnStmt *>(getData1());
@@ -696,8 +696,8 @@ private:
 class CallExitEnd : public ProgramPoint {
 public:
   // CallExitEnd uses the caller's location context.
-  CallExitEnd(const StackFrame *CalleeCtx, const LocationContext *CallerCtx)
-      : ProgramPoint(CalleeCtx, CallExitEndKind, CallerCtx, nullptr) {}
+  CallExitEnd(const StackFrame *CalleeSF, const LocationContext *CallerCtx)
+      : ProgramPoint(CalleeSF, CallExitEndKind, CallerCtx, nullptr) {}
 
   const StackFrame *getCalleeContext() const {
     return static_cast<const StackFrame *>(getData1());

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
@@ -640,7 +640,7 @@ private:
   /// The calculation is cached in FramesModifying.
   bool isModifiedInFrame(const ExplodedNode *CallExitBeginN);
 
-  void markFrameAsModifying(const StackFrame *SCtx);
+  void markFrameAsModifying(const StackFrame *SF);
 
   /// Write to \c FramesModifying all stack frames along the path in the current
   /// stack frame which modifies the state.

--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporterVisitors.h
@@ -233,7 +233,7 @@ public:
   ///        this visitor can prevent that without polluting the bugpath too
   ///        much.
   virtual Result track(SVal V, const MemRegion *R, TrackingOptions Opts = {},
-                       const StackFrameContext *Origin = nullptr);
+                       const StackFrame *Origin = nullptr);
 
   /// Handle the store operation and produce the note.
   ///
@@ -386,7 +386,7 @@ bool trackExpressionValue(const ExplodedNode *N, const Expr *E,
 ///        much.
 void trackStoredValue(SVal V, const MemRegion *R,
                       PathSensitiveBugReport &Report, TrackingOptions Opts = {},
-                      const StackFrameContext *Origin = nullptr);
+                      const StackFrame *Origin = nullptr);
 
 const Expr *getDerefExpr(const Stmt *S);
 
@@ -632,15 +632,15 @@ private:
   /// along the path.
   // TODO: Can't we just use a map instead? This is likely not as cheap as it
   // makes the code difficult to read.
-  llvm::SmallPtrSet<const StackFrameContext *, 32> FramesModifying;
-  llvm::SmallPtrSet<const StackFrameContext *, 32> FramesModifyingCalculated;
+  llvm::SmallPtrSet<const StackFrame *, 32> FramesModifying;
+  llvm::SmallPtrSet<const StackFrame *, 32> FramesModifyingCalculated;
 
   /// Check and lazily calculate whether the state is modified in the stack
   /// frame to which \p CallExitBeginN belongs.
   /// The calculation is cached in FramesModifying.
   bool isModifiedInFrame(const ExplodedNode *CallExitBeginN);
 
-  void markFrameAsModifying(const StackFrameContext *SCtx);
+  void markFrameAsModifying(const StackFrame *SCtx);
 
   /// Write to \c FramesModifying all stack frames along the path in the current
   /// stack frame which modifies the state.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/BlockCounter.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/BlockCounter.h
@@ -19,7 +19,7 @@
 
 namespace clang {
 
-class StackFrameContext;
+class StackFrame;
 
 namespace ento {
 
@@ -34,8 +34,7 @@ class BlockCounter {
 public:
   BlockCounter() : Data(nullptr) {}
 
-  unsigned getNumVisited(const StackFrameContext *CallSite,
-                         unsigned BlockID) const;
+  unsigned getNumVisited(const StackFrame *CallSite, unsigned BlockID) const;
 
   class Factory {
     void *F;
@@ -44,9 +43,8 @@ public:
     ~Factory();
 
     BlockCounter GetEmptyCounter();
-    BlockCounter IncrementCount(BlockCounter BC,
-                                  const StackFrameContext *CallSite,
-                                  unsigned BlockID);
+    BlockCounter IncrementCount(BlockCounter BC, const StackFrame *CallSite,
+                                unsigned BlockID);
   };
 
   friend class Factory;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -53,7 +53,7 @@ namespace clang {
 class LocationContext;
 class ProgramPoint;
 class ProgramPointTag;
-class StackFrameContext;
+class StackFrame;
 
 namespace ento {
 
@@ -382,7 +382,7 @@ public:
 
   /// Populates the given SmallVector with the bindings in the callee's stack
   /// frame at the start of this call.
-  virtual void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  virtual void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                             BindingsTy &Bindings) const = 0;
 
   /// Returns a copy of this CallEvent, but using the given state.
@@ -416,7 +416,7 @@ public:
   /// during analysis if the call is inlined, but it may still be useful
   /// in intermediate calculations even if the call isn't inlined.
   /// May fail; returns null on failure.
-  const StackFrameContext *getCalleeStackFrame(unsigned BlockCount) const;
+  const StackFrame *getCalleeStackFrame(unsigned BlockCount) const;
 
   /// Returns memory location for a parameter variable within the callee stack
   /// frame. The behavior is undefined if the block count is different from the
@@ -530,7 +530,7 @@ public:
 
   bool argumentsMayEscape() const override;
 
-  void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -674,7 +674,7 @@ public:
 
   bool argumentsMayEscape() const override { return true; }
 
-  void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -719,7 +719,7 @@ public:
 
   RuntimeDefinition getRuntimeDefinition() const override;
 
-  void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                     BindingsTy &Bindings) const override;
 
   static bool classof(const CallEvent *CA) {
@@ -978,7 +978,7 @@ protected:
       ValueList &Values,
       RegionAndSymbolInvalidationTraits *ETraits) const override;
 
-  void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                     BindingsTy &Bindings) const override;
 
 public:
@@ -1091,7 +1091,7 @@ public:
 
   /// Obtain the stack frame of the inheriting constructor. Argument expressions
   /// can be found on the call site of that stack frame.
-  const StackFrameContext *getInheritingStackFrame() const;
+  const StackFrame *getInheritingStackFrame() const;
 
   /// Obtain the CXXConstructExpr for the sub-class that inherited the current
   /// constructor (possibly indirectly). It's the statement that contains
@@ -1351,7 +1351,7 @@ public:
 
   bool argumentsMayEscape() const override;
 
-  void getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -1428,8 +1428,7 @@ public:
   CallEventManager(llvm::BumpPtrAllocator &alloc);
 
   /// Gets an outside caller given a callee context.
-  CallEventRef<> getCaller(const StackFrameContext *CalleeCtx,
-                           ProgramStateRef State);
+  CallEventRef<> getCaller(const StackFrame *CalleeCtx, ProgramStateRef State);
 
   /// Gets a call event for a function call, Objective-C method call,
   /// a 'new', or a 'delete' call.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -382,7 +382,7 @@ public:
 
   /// Populates the given SmallVector with the bindings in the callee's stack
   /// frame at the start of this call.
-  virtual void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  virtual void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                             BindingsTy &Bindings) const = 0;
 
   /// Returns a copy of this CallEvent, but using the given state.
@@ -530,7 +530,7 @@ public:
 
   bool argumentsMayEscape() const override;
 
-  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -674,7 +674,7 @@ public:
 
   bool argumentsMayEscape() const override { return true; }
 
-  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -719,7 +719,7 @@ public:
 
   RuntimeDefinition getRuntimeDefinition() const override;
 
-  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                     BindingsTy &Bindings) const override;
 
   static bool classof(const CallEvent *CA) {
@@ -978,7 +978,7 @@ protected:
       ValueList &Values,
       RegionAndSymbolInvalidationTraits *ETraits) const override;
 
-  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                     BindingsTy &Bindings) const override;
 
 public:
@@ -1351,7 +1351,7 @@ public:
 
   bool argumentsMayEscape() const override;
 
-  void getInitialStackFrameContents(const StackFrame *CalleeCtx,
+  void getInitialStackFrameContents(const StackFrame *CalleeSF,
                                     BindingsTy &Bindings) const override;
 
   ArrayRef<ParmVarDecl *> parameters() const override;
@@ -1428,7 +1428,7 @@ public:
   CallEventManager(llvm::BumpPtrAllocator &alloc);
 
   /// Gets an outside caller given a callee context.
-  CallEventRef<> getCaller(const StackFrame *CalleeCtx, ProgramStateRef State);
+  CallEventRef<> getCaller(const StackFrame *CalleeSF, ProgramStateRef State);
 
   /// Gets a call event for a function call, Objective-C method call,
   /// a 'new', or a 'delete' call.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -105,9 +105,7 @@ public:
     return Pred->getLocationContext();
   }
 
-  const StackFrameContext *getStackFrame() const {
-    return Pred->getStackFrame();
-  }
+  const StackFrame *getStackFrame() const { return Pred->getStackFrame(); }
 
   /// Return true if the current LocationContext has no caller context.
   bool inTopFrame() const { return getLocationContext()->inTopFrame();  }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Environment.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Environment.h
@@ -32,8 +32,7 @@ class SymbolReaper;
 /// This allows the environment to manage context-sensitive bindings,
 /// which is essentially for modeling recursive function analysis, among
 /// other things.
-class EnvironmentEntry
-    : public std::pair<const Expr *, const StackFrameContext *> {
+class EnvironmentEntry : public std::pair<const Expr *, const StackFrame *> {
 public:
   EnvironmentEntry(const Expr *E, const LocationContext *L);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -144,7 +144,7 @@ public:
     return getLocation().getLocationContext();
   }
 
-  const StackFrameContext *getStackFrame() const {
+  const StackFrame *getStackFrame() const {
     return getLocation().getStackFrame();
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -419,18 +419,18 @@ public:
 class StackSpaceRegion : public MemSpaceRegion {
   virtual void anchor();
 
-  const StackFrame *SFC;
+  const StackFrame *SF;
 
 protected:
-  StackSpaceRegion(MemRegionManager &mgr, Kind k, const StackFrame *sfc)
-      : MemSpaceRegion(mgr, k), SFC(sfc) {
+  StackSpaceRegion(MemRegionManager &mgr, Kind k, const StackFrame *SF)
+      : MemSpaceRegion(mgr, k), SF(SF) {
     assert(classof(this));
-    assert(sfc);
+    assert(SF);
   }
 
 public:
   LLVM_ATTRIBUTE_RETURNS_NONNULL
-  const StackFrame *getStackFrame() const { return SFC; }
+  const StackFrame *getStackFrame() const { return SF; }
 
   void Profile(llvm::FoldingSetNodeID &ID) const override;
 
@@ -443,8 +443,8 @@ public:
 class StackLocalsSpaceRegion : public StackSpaceRegion {
   friend class MemRegionManager;
 
-  StackLocalsSpaceRegion(MemRegionManager &mgr, const StackFrame *sfc)
-      : StackSpaceRegion(mgr, StackLocalsSpaceRegionKind, sfc) {}
+  StackLocalsSpaceRegion(MemRegionManager &mgr, const StackFrame *SF)
+      : StackSpaceRegion(mgr, StackLocalsSpaceRegionKind, SF) {}
 
 public:
   void dumpToStream(raw_ostream &os) const override;
@@ -458,8 +458,8 @@ class StackArgumentsSpaceRegion : public StackSpaceRegion {
 private:
   friend class MemRegionManager;
 
-  StackArgumentsSpaceRegion(MemRegionManager &mgr, const StackFrame *sfc)
-      : StackSpaceRegion(mgr, StackArgumentsSpaceRegionKind, sfc) {}
+  StackArgumentsSpaceRegion(MemRegionManager &mgr, const StackFrame *SF)
+      : StackSpaceRegion(mgr, StackArgumentsSpaceRegionKind, SF) {}
 
 public:
   void dumpToStream(raw_ostream &os) const override;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1471,12 +1471,12 @@ public:
 
   /// getStackLocalsRegion - Retrieve the memory region associated with the
   ///  specified stack frame.
-  const StackLocalsSpaceRegion *getStackLocalsRegion(const StackFrame *STC);
+  const StackLocalsSpaceRegion *getStackLocalsRegion(const StackFrame *SF);
 
   /// getStackArgumentsRegion - Retrieve the memory region associated with
   ///  function/method arguments of the specified stack frame.
   const StackArgumentsSpaceRegion *
-  getStackArgumentsRegion(const StackFrame *STC);
+  getStackArgumentsRegion(const StackFrame *SF);
 
   /// getGlobalsRegion - Retrieve the memory region associated with
   ///  global variables.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -49,7 +49,7 @@ class AnalysisDeclContext;
 class CXXRecordDecl;
 class Decl;
 class LocationContext;
-class StackFrameContext;
+class StackFrame;
 
 namespace ento {
 
@@ -419,10 +419,10 @@ public:
 class StackSpaceRegion : public MemSpaceRegion {
   virtual void anchor();
 
-  const StackFrameContext *SFC;
+  const StackFrame *SFC;
 
 protected:
-  StackSpaceRegion(MemRegionManager &mgr, Kind k, const StackFrameContext *sfc)
+  StackSpaceRegion(MemRegionManager &mgr, Kind k, const StackFrame *sfc)
       : MemSpaceRegion(mgr, k), SFC(sfc) {
     assert(classof(this));
     assert(sfc);
@@ -430,7 +430,7 @@ protected:
 
 public:
   LLVM_ATTRIBUTE_RETURNS_NONNULL
-  const StackFrameContext *getStackFrame() const { return SFC; }
+  const StackFrame *getStackFrame() const { return SFC; }
 
   void Profile(llvm::FoldingSetNodeID &ID) const override;
 
@@ -443,7 +443,7 @@ public:
 class StackLocalsSpaceRegion : public StackSpaceRegion {
   friend class MemRegionManager;
 
-  StackLocalsSpaceRegion(MemRegionManager &mgr, const StackFrameContext *sfc)
+  StackLocalsSpaceRegion(MemRegionManager &mgr, const StackFrame *sfc)
       : StackSpaceRegion(mgr, StackLocalsSpaceRegionKind, sfc) {}
 
 public:
@@ -458,7 +458,7 @@ class StackArgumentsSpaceRegion : public StackSpaceRegion {
 private:
   friend class MemRegionManager;
 
-  StackArgumentsSpaceRegion(MemRegionManager &mgr, const StackFrameContext *sfc)
+  StackArgumentsSpaceRegion(MemRegionManager &mgr, const StackFrame *sfc)
       : StackSpaceRegion(mgr, StackArgumentsSpaceRegionKind, sfc) {}
 
 public:
@@ -994,7 +994,7 @@ public:
   const VarDecl *getDecl() const override = 0;
 
   /// It might return null.
-  const StackFrameContext *getStackFrame() const;
+  const StackFrame *getStackFrame() const;
 
   QualType getValueType() const override {
     // FIXME: We can cache this if needed.
@@ -1287,7 +1287,7 @@ public:
   const Expr *getExpr() const { return Ex; }
 
   LLVM_ATTRIBUTE_RETURNS_NONNULL
-  const StackFrameContext *getStackFrame() const;
+  const StackFrame *getStackFrame() const;
 
   QualType getValueType() const override { return Ex->getType(); }
 
@@ -1326,7 +1326,7 @@ public:
   LLVM_ATTRIBUTE_RETURNS_NONNULL
   const ValueDecl *getExtendingDecl() const { return ExD; }
   /// It might return null.
-  const StackFrameContext *getStackFrame() const;
+  const StackFrame *getStackFrame() const;
 
   QualType getValueType() const override { return Ex->getType(); }
 
@@ -1444,10 +1444,10 @@ class MemRegionManager {
   GlobalSystemSpaceRegion *SystemGlobals = nullptr;
   GlobalImmutableSpaceRegion *ImmutableGlobals = nullptr;
 
-  llvm::DenseMap<const StackFrameContext *, StackLocalsSpaceRegion *>
-    StackLocalsSpaceRegions;
-  llvm::DenseMap<const StackFrameContext *, StackArgumentsSpaceRegion *>
-    StackArgumentsSpaceRegions;
+  llvm::DenseMap<const StackFrame *, StackLocalsSpaceRegion *>
+      StackLocalsSpaceRegions;
+  llvm::DenseMap<const StackFrame *, StackArgumentsSpaceRegion *>
+      StackArgumentsSpaceRegions;
   llvm::DenseMap<const CodeTextRegion *, StaticGlobalSpaceRegion *>
     StaticsGlobalSpaceRegions;
 
@@ -1471,13 +1471,12 @@ public:
 
   /// getStackLocalsRegion - Retrieve the memory region associated with the
   ///  specified stack frame.
-  const StackLocalsSpaceRegion *
-  getStackLocalsRegion(const StackFrameContext *STC);
+  const StackLocalsSpaceRegion *getStackLocalsRegion(const StackFrame *STC);
 
   /// getStackArgumentsRegion - Retrieve the memory region associated with
   ///  function/method arguments of the specified stack frame.
   const StackArgumentsSpaceRegion *
-  getStackArgumentsRegion(const StackFrameContext *STC);
+  getStackArgumentsRegion(const StackFrame *STC);
 
   /// getGlobalsRegion - Retrieve the memory region associated with
   ///  global variables.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -346,7 +346,7 @@ public:
   /// enterStackFrame - Returns the state for entry to the given stack frame,
   ///  preserving the current state.
   [[nodiscard]] ProgramStateRef
-  enterStackFrame(const CallEvent &Call, const StackFrame *CalleeCtx) const;
+  enterStackFrame(const CallEvent &Call, const StackFrame *CalleeSF) const;
 
   /// Return the value of 'self' if available in the given context.
   SVal getSelfSVal(const LocationContext *LC) const;
@@ -584,7 +584,7 @@ public:
   ExprEngine &getOwningEngine() { return *Eng; }
 
   ProgramStateRef removeDeadBindingsFromEnvironmentAndStore(
-      ProgramStateRef St, const StackFrame *LCtx, SymbolReaper &SymReaper);
+      ProgramStateRef St, const StackFrame *SF, SymbolReaper &SymReaper);
 
 public:
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -346,8 +346,7 @@ public:
   /// enterStackFrame - Returns the state for entry to the given stack frame,
   ///  preserving the current state.
   [[nodiscard]] ProgramStateRef
-  enterStackFrame(const CallEvent &Call,
-                  const StackFrameContext *CalleeCtx) const;
+  enterStackFrame(const CallEvent &Call, const StackFrame *CalleeCtx) const;
 
   /// Return the value of 'self' if available in the given context.
   SVal getSelfSVal(const LocationContext *LC) const;
@@ -584,10 +583,8 @@ public:
   }
   ExprEngine &getOwningEngine() { return *Eng; }
 
-  ProgramStateRef
-  removeDeadBindingsFromEnvironmentAndStore(ProgramStateRef St,
-                                            const StackFrameContext *LCtx,
-                                            SymbolReaper &SymReaper);
+  ProgramStateRef removeDeadBindingsFromEnvironmentAndStore(
+      ProgramStateRef St, const StackFrame *LCtx, SymbolReaper &SymReaper);
 
 public:
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -391,10 +391,10 @@ public:
   }
 
   /// Return a memory region for the 'this' object reference.
-  loc::MemRegionVal getCXXThis(const CXXMethodDecl *D, const StackFrame *SFC);
+  loc::MemRegionVal getCXXThis(const CXXMethodDecl *D, const StackFrame *SF);
 
   /// Return a memory region for the 'this' object reference.
-  loc::MemRegionVal getCXXThis(const CXXRecordDecl *D, const StackFrame *SFC);
+  loc::MemRegionVal getCXXThis(const CXXRecordDecl *D, const StackFrame *SF);
 };
 
 SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &alloc,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -42,7 +42,7 @@ class CXXRecordDecl;
 class DeclaratorDecl;
 class FunctionDecl;
 class LocationContext;
-class StackFrameContext;
+class StackFrame;
 class Stmt;
 
 namespace ento {
@@ -391,12 +391,10 @@ public:
   }
 
   /// Return a memory region for the 'this' object reference.
-  loc::MemRegionVal getCXXThis(const CXXMethodDecl *D,
-                               const StackFrameContext *SFC);
+  loc::MemRegionVal getCXXThis(const CXXMethodDecl *D, const StackFrame *SFC);
 
   /// Return a memory region for the 'this' object reference.
-  loc::MemRegionVal getCXXThis(const CXXRecordDecl *D,
-                               const StackFrameContext *SFC);
+  loc::MemRegionVal getCXXThis(const CXXRecordDecl *D, const StackFrame *SFC);
 };
 
 SValBuilder* createSimpleSValBuilder(llvm::BumpPtrAllocator &alloc,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -39,7 +39,7 @@ class Decl;
 class Expr;
 class LocationContext;
 class ObjCIvarDecl;
-class StackFrameContext;
+class StackFrame;
 
 namespace ento {
 
@@ -193,7 +193,7 @@ public:
   std::optional<const MemRegion *> castRegion(const MemRegion *region,
                                               QualType CastToTy);
 
-  virtual StoreRef removeDeadBindings(Store store, const StackFrameContext *LCtx,
+  virtual StoreRef removeDeadBindings(Store store, const StackFrame *LCtx,
                                       SymbolReaper &SymReaper) = 0;
 
   virtual bool includedInBindings(Store store,
@@ -249,7 +249,7 @@ public:
   /// enterStackFrame - Let the StoreManager to do something when execution
   /// engine is about to execute into a callee.
   BindResult enterStackFrame(Store store, const CallEvent &Call,
-                             const StackFrameContext *CalleeCtx);
+                             const StackFrame *CalleeCtx);
 
   /// Finds the transitive closure of symbols within the given region.
   ///

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -193,7 +193,7 @@ public:
   std::optional<const MemRegion *> castRegion(const MemRegion *region,
                                               QualType CastToTy);
 
-  virtual StoreRef removeDeadBindings(Store store, const StackFrame *LCtx,
+  virtual StoreRef removeDeadBindings(Store store, const StackFrame *SF,
                                       SymbolReaper &SymReaper) = 0;
 
   virtual bool includedInBindings(Store store,
@@ -249,7 +249,7 @@ public:
   /// enterStackFrame - Let the StoreManager to do something when execution
   /// engine is about to execute into a callee.
   BindResult enterStackFrame(Store store, const CallEvent &Call,
-                             const StackFrame *CalleeCtx);
+                             const StackFrame *CalleeSF);
 
   /// Finds the transitive closure of symbols within the given region.
   ///

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -578,7 +578,7 @@ class SymbolReaper {
   // lazyCompoundVal.
   RegionSetTy LazilyCopiedRegionRoots;
 
-  const StackFrameContext *LCtx;
+  const StackFrame *LCtx;
   const Stmt *Loc;
   SymbolManager& SymMgr;
   StoreRef reapedStore;
@@ -592,8 +592,8 @@ public:
   /// considered live.
   /// If the stack frame context is NULL, everything on stack is considered
   /// dead.
-  SymbolReaper(const StackFrameContext *Ctx, const Stmt *s,
-               SymbolManager &symmgr, StoreManager &storeMgr)
+  SymbolReaper(const StackFrame *Ctx, const Stmt *s, SymbolManager &symmgr,
+               StoreManager &storeMgr)
       : LCtx(Ctx), Loc(s), SymMgr(symmgr), reapedStore(nullptr, storeMgr) {}
 
   /// It might return null.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h
@@ -578,7 +578,7 @@ class SymbolReaper {
   // lazyCompoundVal.
   RegionSetTy LazilyCopiedRegionRoots;
 
-  const StackFrame *LCtx;
+  const StackFrame *SF;
   const Stmt *Loc;
   SymbolManager& SymMgr;
   StoreRef reapedStore;
@@ -592,12 +592,12 @@ public:
   /// considered live.
   /// If the stack frame context is NULL, everything on stack is considered
   /// dead.
-  SymbolReaper(const StackFrame *Ctx, const Stmt *s, SymbolManager &symmgr,
+  SymbolReaper(const StackFrame *SF, const Stmt *s, SymbolManager &symmgr,
                StoreManager &storeMgr)
-      : LCtx(Ctx), Loc(s), SymMgr(symmgr), reapedStore(nullptr, storeMgr) {}
+      : SF(SF), Loc(s), SymMgr(symmgr), reapedStore(nullptr, storeMgr) {}
 
   /// It might return null.
-  const LocationContext *getLocationContext() const { return LCtx; }
+  const LocationContext *getLocationContext() const { return SF; }
 
   bool isLive(SymbolRef sym);
   bool isLiveRegion(const MemRegion *region);

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -310,7 +310,7 @@ AnalysisDeclContext *AnalysisDeclContextManager::getContext(const Decl *D) {
 
 BodyFarm &AnalysisDeclContextManager::getBodyFarm() { return FunctionBodyFarm; }
 
-const StackFrameContext *AnalysisDeclContext::getStackFrame(
+const StackFrame *AnalysisDeclContext::getStackFrame(
     const LocationContext *ParentLC, const void *Data, const Expr *E,
     const CFGBlock *Blk, unsigned BlockCount, unsigned Index) {
   return getLocationContextManager().getStackFrame(this, ParentLC, Data, E, Blk,
@@ -407,7 +407,7 @@ void LocationContext::ProfileCommon(llvm::FoldingSetNodeID &ID,
   ID.AddPointer(data);
 }
 
-void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
+void StackFrame::Profile(llvm::FoldingSetNodeID &ID) {
   Profile(ID, getAnalysisDeclContext(), getParent(), Data, CallSite, Block,
           BlockCount, Index);
 }
@@ -416,18 +416,16 @@ void StackFrameContext::Profile(llvm::FoldingSetNodeID &ID) {
 // LocationContext creation.
 //===----------------------------------------------------------------------===//
 
-const StackFrameContext *LocationContextManager::getStackFrame(
+const StackFrame *LocationContextManager::getStackFrame(
     AnalysisDeclContext *Ctx, const LocationContext *Parent, const void *Data,
     const Expr *E, const CFGBlock *Blk, unsigned BlockCount, unsigned StmtIdx) {
   llvm::FoldingSetNodeID ID;
-  StackFrameContext::Profile(ID, Ctx, Parent, Data, E, Blk, BlockCount,
-                             StmtIdx);
+  StackFrame::Profile(ID, Ctx, Parent, Data, E, Blk, BlockCount, StmtIdx);
   void *InsertPos;
   auto *L =
-   cast_or_null<StackFrameContext>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
+      cast_or_null<StackFrame>(Contexts.FindNodeOrInsertPos(ID, InsertPos));
   if (!L) {
-    L = new StackFrameContext(Ctx, Parent, Data, E, Blk, BlockCount, StmtIdx,
-                              ++NewID);
+    L = new StackFrame(Ctx, Parent, Data, E, Blk, BlockCount, StmtIdx, ++NewID);
     Contexts.InsertNode(L, InsertPos);
   }
   return L;
@@ -437,10 +435,10 @@ const StackFrameContext *LocationContextManager::getStackFrame(
 // LocationContext methods.
 //===----------------------------------------------------------------------===//
 
-const StackFrameContext *LocationContext::getStackFrame() const {
+const StackFrame *LocationContext::getStackFrame() const {
   const LocationContext *LC = this;
   while (LC) {
-    if (const auto *SFC = dyn_cast<StackFrameContext>(LC))
+    if (const auto *SFC = dyn_cast<StackFrame>(LC))
       return SFC;
     LC = LC->getParent();
   }
@@ -482,14 +480,14 @@ void LocationContext::dumpStack(raw_ostream &Out) const {
   unsigned Frame = 0;
   for (const LocationContext *LCtx = this; LCtx; LCtx = LCtx->getParent()) {
     switch (LCtx->getKind()) {
-    case StackFrame:
+    case StackFrameKind:
       Out << "\t#" << Frame << ' ';
       ++Frame;
       if (const auto *D = dyn_cast<NamedDecl>(LCtx->getDecl()))
         Out << "Calling " << AnalysisDeclContext::getFunctionName(D);
       else
         Out << "Calling anonymous code";
-      if (const Expr *E = cast<StackFrameContext>(LCtx)->getCallSite()) {
+      if (const Expr *E = cast<StackFrame>(LCtx)->getCallSite()) {
         Out << " at line ";
         printLocation(Out, SM, E->getBeginLoc());
       }
@@ -515,7 +513,7 @@ void LocationContext::printJson(raw_ostream &Out, const char *NL,
     Indent(Out, Space, IsDot)
         << "{ \"lctx_id\": " << LCtx->getID() << ", \"location_context\": \"";
     switch (LCtx->getKind()) {
-    case StackFrame:
+    case StackFrameKind:
       Out << '#' << Frame << " Call\", \"calling\": \"";
       ++Frame;
       if (const auto *D = dyn_cast<NamedDecl>(LCtx->getDecl()))
@@ -524,7 +522,7 @@ void LocationContext::printJson(raw_ostream &Out, const char *NL,
         Out << "anonymous code";
 
       Out << "\", \"location\": ";
-      if (const Expr *E = cast<StackFrameContext>(LCtx)->getCallSite()) {
+      if (const Expr *E = cast<StackFrame>(LCtx)->getCallSite()) {
         printSourceLocationAsJson(Out, E->getBeginLoc(), SM);
       } else {
         Out << "null";

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -438,8 +438,8 @@ const StackFrame *LocationContextManager::getStackFrame(
 const StackFrame *LocationContext::getStackFrame() const {
   const LocationContext *LC = this;
   while (LC) {
-    if (const auto *SFC = dyn_cast<StackFrame>(LC))
-      return SFC;
+    if (const auto *SF = dyn_cast<StackFrame>(LC))
+      return SF;
     LC = LC->getParent();
   }
   return nullptr;

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -6465,7 +6465,7 @@ bool CFGBlock::isInevitablySinking() const {
     // If at least one path reaches the CFG exit, it means that control is
     // returned to the caller. For now, say that we are not sure what
     // happens next. If necessary, this can be improved to analyze
-    // the parent StackFrameContext's call site in a similar manner.
+    // the parent StackFrame's call site in a similar manner.
     if (Blk == &Cfg.getExit())
       return false;
 

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -514,8 +514,7 @@ SourceLocation PathDiagnosticLocation::getValidSourceLocation(
 }
 
 static PathDiagnosticLocation
-getLocationForCaller(const StackFrameContext *SFC,
-                     const LocationContext *CallerCtx,
+getLocationForCaller(const StackFrame *SFC, const LocationContext *CallerCtx,
                      const SourceManager &SM) {
   const CFGBlock &Block = *SFC->getCallSiteBlock();
   CFGElement Source = Block[SFC->getIndex()];
@@ -866,7 +865,7 @@ PathDiagnosticCallPiece::construct(PathPieces &path,
 
 void PathDiagnosticCallPiece::setCallee(const CallEnter &CE,
                                         const SourceManager &SM) {
-  const StackFrameContext *CalleeCtx = CE.getCalleeContext();
+  const StackFrame *CalleeCtx = CE.getCalleeContext();
   Callee = CalleeCtx->getDecl();
 
   callEnterWithin = PathDiagnosticLocation::createBegin(Callee, SM);

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -514,10 +514,10 @@ SourceLocation PathDiagnosticLocation::getValidSourceLocation(
 }
 
 static PathDiagnosticLocation
-getLocationForCaller(const StackFrame *SFC, const LocationContext *CallerCtx,
+getLocationForCaller(const StackFrame *SF, const LocationContext *CallerCtx,
                      const SourceManager &SM) {
-  const CFGBlock &Block = *SFC->getCallSiteBlock();
-  CFGElement Source = Block[SFC->getIndex()];
+  const CFGBlock &Block = *SF->getCallSiteBlock();
+  CFGElement Source = Block[SF->getIndex()];
 
   switch (Source.getKind()) {
   case CFGElement::Statement:

--- a/clang/lib/Analysis/PathDiagnostic.cpp
+++ b/clang/lib/Analysis/PathDiagnostic.cpp
@@ -865,11 +865,11 @@ PathDiagnosticCallPiece::construct(PathPieces &path,
 
 void PathDiagnosticCallPiece::setCallee(const CallEnter &CE,
                                         const SourceManager &SM) {
-  const StackFrame *CalleeCtx = CE.getCalleeContext();
-  Callee = CalleeCtx->getDecl();
+  const StackFrame *CalleeSF = CE.getCalleeContext();
+  Callee = CalleeSF->getDecl();
 
   callEnterWithin = PathDiagnosticLocation::createBegin(Callee, SM);
-  callEnter = getLocationForCaller(CalleeCtx, CE.getLocationContext(), SM);
+  callEnter = getLocationForCaller(CalleeSF, CE.getLocationContext(), SM);
 
   // Autosynthesized property accessors are special because we'd never
   // pop back up to non-autosynthesized code until we leave them.
@@ -878,9 +878,9 @@ void PathDiagnosticCallPiece::setCallee(const CallEnter &CE,
   // Unless set here, the IsCalleeAnAutosynthesizedPropertyAccessor flag
   // defaults to false.
   if (const auto *MD = dyn_cast<ObjCMethodDecl>(Callee))
-    IsCalleeAnAutosynthesizedPropertyAccessor = (
-        MD->isPropertyAccessor() &&
-        CalleeCtx->getAnalysisDeclContext()->isBodyAutosynthesized());
+    IsCalleeAnAutosynthesizedPropertyAccessor =
+        (MD->isPropertyAccessor() &&
+         CalleeSF->getAnalysisDeclContext()->isBodyAutosynthesized());
 }
 
 static void describeTemplateParameters(raw_ostream &Out,

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -945,7 +945,7 @@ void GenericTaintChecker::checkPostCall(const CallEvent &Call,
   // Set the marked values as tainted. The return value only accessible from
   // checkPostStmt.
   ProgramStateRef State = C.getState();
-  const StackFrameContext *CurrentFrame = C.getStackFrame();
+  const StackFrame *CurrentFrame = C.getStackFrame();
 
   // Depending on what was tainted at pre-visit, we determined a set of
   // arguments which should be tainted after the function returns. These are

--- a/clang/lib/StaticAnalyzer/Checkers/MIGChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MIGChecker.cpp
@@ -152,7 +152,7 @@ static bool isInMIGCall(CheckerContext &C) {
   const LocationContext *LC = C.getLocationContext();
   assert(LC && "Unknown location context");
 
-  const StackFrameContext *SFC;
+  const StackFrame *SFC;
   // Find the top frame.
   while (LC) {
     SFC = LC->getStackFrame();

--- a/clang/lib/StaticAnalyzer/Checkers/MIGChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MIGChecker.cpp
@@ -152,14 +152,14 @@ static bool isInMIGCall(CheckerContext &C) {
   const LocationContext *LC = C.getLocationContext();
   assert(LC && "Unknown location context");
 
-  const StackFrame *SFC;
+  const StackFrame *SF;
   // Find the top frame.
   while (LC) {
-    SFC = LC->getStackFrame();
-    LC = SFC->getParent();
+    SF = LC->getStackFrame();
+    LC = SF->getParent();
   }
 
-  const Decl *D = SFC->getDecl();
+  const Decl *D = SF->getDecl();
 
   if (std::optional<AnyCall> AC = AnyCall::forDecl(D)) {
     // Even though there's a Sema warning when the return type of an annotated

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -985,7 +985,7 @@ protected:
 
   // A release function stack frame in which memory was released. Used for
   // miscellaneous false positive suppression.
-  const StackFrameContext *ReleaseFunctionLC;
+  const StackFrame *ReleaseFunctionLC;
 
   bool IsLeak;
 

--- a/clang/lib/StaticAnalyzer/Checkers/NSErrorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NSErrorChecker.cpp
@@ -182,7 +182,7 @@ static void setFlag(ProgramStateRef state, SVal val, CheckerContext &C) {
 }
 
 static QualType parameterTypeFromSVal(SVal val, CheckerContext &C) {
-  const StackFrameContext * SFC = C.getStackFrame();
+  const StackFrame *SFC = C.getStackFrame();
   if (std::optional<loc::MemRegionVal> X = val.getAs<loc::MemRegionVal>()) {
     const MemRegion* R = X->getRegion();
     if (const VarRegion *VR = R->getAs<VarRegion>())

--- a/clang/lib/StaticAnalyzer/Checkers/NSErrorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NSErrorChecker.cpp
@@ -182,13 +182,13 @@ static void setFlag(ProgramStateRef state, SVal val, CheckerContext &C) {
 }
 
 static QualType parameterTypeFromSVal(SVal val, CheckerContext &C) {
-  const StackFrame *SFC = C.getStackFrame();
+  const StackFrame *SF = C.getStackFrame();
   if (std::optional<loc::MemRegionVal> X = val.getAs<loc::MemRegionVal>()) {
     const MemRegion* R = X->getRegion();
     if (const VarRegion *VR = R->getAs<VarRegion>())
       if (const auto *StackSpace =
               VR->getMemorySpaceAs<StackArgumentsSpaceRegion>(C.getState()))
-        if (StackSpace->getStackFrame() == SFC)
+        if (StackSpace->getStackFrame() == SF)
           return VR->getValueType();
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountChecker.h
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountChecker.h
@@ -372,7 +372,7 @@ const RefVal *getRefBinding(ProgramStateRef State, SymbolRef Sym);
 
 /// Returns true if this stack frame is for an Objective-C method that is a
 /// property getter or setter whose body has been synthesized by the analyzer.
-inline bool isSynthesizedAccessor(const StackFrameContext *SFC) {
+inline bool isSynthesizedAccessor(const StackFrame *SFC) {
   auto Method = dyn_cast_or_null<ObjCMethodDecl>(SFC->getDecl());
   if (!Method || !Method->isPropertyAccessor())
     return false;

--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountChecker.h
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountChecker.h
@@ -372,12 +372,12 @@ const RefVal *getRefBinding(ProgramStateRef State, SymbolRef Sym);
 
 /// Returns true if this stack frame is for an Objective-C method that is a
 /// property getter or setter whose body has been synthesized by the analyzer.
-inline bool isSynthesizedAccessor(const StackFrame *SFC) {
-  auto Method = dyn_cast_or_null<ObjCMethodDecl>(SFC->getDecl());
+inline bool isSynthesizedAccessor(const StackFrame *SF) {
+  auto Method = dyn_cast_or_null<ObjCMethodDecl>(SF->getDecl());
   if (!Method || !Method->isPropertyAccessor())
     return false;
 
-  return SFC->getAnalysisDeclContext()->isBodyAutosynthesized();
+  return SF->getAnalysisDeclContext()->isBodyAutosynthesized();
 }
 
 } // end namespace retaincountchecker

--- a/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/RetainCountChecker/RetainCountDiagnostics.cpp
@@ -303,10 +303,10 @@ private:
 
 /// Find the first node with the parent stack frame.
 static const ExplodedNode *getCalleeNode(const ExplodedNode *Pred) {
-  const StackFrameContext *SC = Pred->getStackFrame();
+  const StackFrame *SC = Pred->getStackFrame();
   if (SC->inTopFrame())
     return nullptr;
-  const StackFrameContext *PC = SC->getParent()->getStackFrame();
+  const StackFrame *PC = SC->getParent()->getStackFrame();
   if (!PC)
     return nullptr;
 

--- a/clang/lib/StaticAnalyzer/Checkers/ReturnUndefChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ReturnUndefChecker.cpp
@@ -42,7 +42,7 @@ void ReturnUndefChecker::checkPreStmt(const ReturnStmt *RS,
     return;
   SVal RetVal = C.getSVal(RetE);
 
-  const StackFrameContext *SFC = C.getStackFrame();
+  const StackFrame *SFC = C.getStackFrame();
   QualType RT = CallEvent::getDeclaredResultType(SFC->getDecl());
 
   if (RetVal.isUndef()) {

--- a/clang/lib/StaticAnalyzer/Checkers/ReturnUndefChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ReturnUndefChecker.cpp
@@ -42,8 +42,8 @@ void ReturnUndefChecker::checkPreStmt(const ReturnStmt *RS,
     return;
   SVal RetVal = C.getSVal(RetE);
 
-  const StackFrame *SFC = C.getStackFrame();
-  QualType RT = CallEvent::getDeclaredResultType(SFC->getDecl());
+  const StackFrame *SF = C.getStackFrame();
+  QualType RT = CallEvent::getDeclaredResultType(SF->getDecl());
 
   if (RetVal.isUndef()) {
     // "return;" is modeled to evaluate to an UndefinedVal. Allow UndefinedVal
@@ -60,7 +60,7 @@ void ReturnUndefChecker::checkPreStmt(const ReturnStmt *RS,
     // Not all blocks have explicitly-specified return types; if the return type
     // is not available, but the return value expression has 'void' type, assume
     // Sema already checked it.
-    if (RT.isNull() && isa<BlockDecl>(SFC->getDecl()) &&
+    if (RT.isNull() && isa<BlockDecl>(SF->getDecl()) &&
         RetE->getType()->isVoidType())
       return;
 

--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -278,9 +278,9 @@ private:
     if (!SSR)
       return;
 
-    const StackFrame *CapturedSFC = SSR->getStackFrame();
-    if (CapturedSFC == PoppedStackFrame ||
-        PoppedStackFrame->isParentOf(CapturedSFC))
+    const StackFrame *CapturedSF = SSR->getStackFrame();
+    if (CapturedSF == PoppedStackFrame ||
+        PoppedStackFrame->isParentOf(CapturedSF))
       EscapingStackRegions.push_back(MR);
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -246,7 +246,7 @@ void StackAddrEscapeChecker::checkPreCall(const CallEvent &Call,
 /// that would leak.
 class FindStackRegionsSymbolVisitor final : public SymbolVisitor {
   CheckerContext &Ctxt;
-  const StackFrameContext *PoppedStackFrame;
+  const StackFrame *PoppedStackFrame;
   SmallVectorImpl<const MemRegion *> &EscapingStackRegions;
   llvm::SmallPtrSet<const MemRegion *, 16> VisitedRegions;
 
@@ -278,7 +278,7 @@ private:
     if (!SSR)
       return;
 
-    const StackFrameContext *CapturedSFC = SSR->getStackFrame();
+    const StackFrame *CapturedSFC = SSR->getStackFrame();
     if (CapturedSFC == PoppedStackFrame ||
         PoppedStackFrame->isParentOf(CapturedSFC))
       EscapingStackRegions.push_back(MR);
@@ -476,7 +476,7 @@ void StackAddrEscapeChecker::checkEndFunction(const ReturnStmt *RS,
   private:
     CheckerContext &Ctx;
     ProgramStateRef State;
-    const StackFrameContext *PoppedFrame;
+    const StackFrame *PoppedFrame;
     const bool TopFrame;
 
     /// Look for stack variables referring to popped stack variables.

--- a/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
@@ -34,7 +34,7 @@ public:
   ZeroState(SymbolRef S, unsigned B, const StackFrame *SF)
       : ZeroSymbol(S), BlockID(B), SF(SF) {}
 
-  const StackFrame *getStackFrameContext() const { return SF; }
+  const StackFrame *getStackFrame() const { return SF; }
 
   bool operator==(const ZeroState &X) const {
     return BlockID == X.BlockID && SF == X.SF && ZeroSymbol == X.ZeroSymbol;
@@ -184,7 +184,7 @@ void TestAfterDivZeroChecker::checkEndFunction(const ReturnStmt *,
 
   DivZeroMapTy::Factory &F = State->get_context<DivZeroMap>();
   for (const ZeroState &ZS : DivZeroes) {
-    if (ZS.getStackFrameContext() == C.getStackFrame())
+    if (ZS.getStackFrame() == C.getStackFrame())
       DivZeroes = F.remove(DivZeroes, ZS);
   }
   C.addTransition(State->set<DivZeroMap>(DivZeroes));

--- a/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
@@ -28,13 +28,13 @@ class ZeroState {
 private:
   SymbolRef ZeroSymbol;
   unsigned BlockID;
-  const StackFrameContext *SFC;
+  const StackFrame *SFC;
 
 public:
-  ZeroState(SymbolRef S, unsigned B, const StackFrameContext *SFC)
+  ZeroState(SymbolRef S, unsigned B, const StackFrame *SFC)
       : ZeroSymbol(S), BlockID(B), SFC(SFC) {}
 
-  const StackFrameContext *getStackFrameContext() const { return SFC; }
+  const StackFrame *getStackFrameContext() const { return SFC; }
 
   bool operator==(const ZeroState &X) const {
     return BlockID == X.BlockID && SFC == X.SFC && ZeroSymbol == X.ZeroSymbol;
@@ -55,11 +55,11 @@ public:
 class DivisionBRVisitor : public BugReporterVisitor {
 private:
   SymbolRef ZeroSymbol;
-  const StackFrameContext *SFC;
+  const StackFrame *SFC;
   bool Satisfied;
 
 public:
-  DivisionBRVisitor(SymbolRef ZeroSymbol, const StackFrameContext *SFC)
+  DivisionBRVisitor(SymbolRef ZeroSymbol, const StackFrame *SFC)
       : ZeroSymbol(ZeroSymbol), SFC(SFC), Satisfied(false) {}
 
   void Profile(llvm::FoldingSetNodeID &ID) const override {

--- a/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/TestAfterDivZeroChecker.cpp
@@ -28,26 +28,26 @@ class ZeroState {
 private:
   SymbolRef ZeroSymbol;
   unsigned BlockID;
-  const StackFrame *SFC;
+  const StackFrame *SF;
 
 public:
-  ZeroState(SymbolRef S, unsigned B, const StackFrame *SFC)
-      : ZeroSymbol(S), BlockID(B), SFC(SFC) {}
+  ZeroState(SymbolRef S, unsigned B, const StackFrame *SF)
+      : ZeroSymbol(S), BlockID(B), SF(SF) {}
 
-  const StackFrame *getStackFrameContext() const { return SFC; }
+  const StackFrame *getStackFrameContext() const { return SF; }
 
   bool operator==(const ZeroState &X) const {
-    return BlockID == X.BlockID && SFC == X.SFC && ZeroSymbol == X.ZeroSymbol;
+    return BlockID == X.BlockID && SF == X.SF && ZeroSymbol == X.ZeroSymbol;
   }
 
   bool operator<(const ZeroState &X) const {
-    return std::tie(BlockID, SFC, ZeroSymbol) <
-           std::tie(X.BlockID, X.SFC, X.ZeroSymbol);
+    return std::tie(BlockID, SF, ZeroSymbol) <
+           std::tie(X.BlockID, X.SF, X.ZeroSymbol);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddInteger(BlockID);
-    ID.AddPointer(SFC);
+    ID.AddPointer(SF);
     ID.AddPointer(ZeroSymbol);
   }
 };
@@ -55,16 +55,16 @@ public:
 class DivisionBRVisitor : public BugReporterVisitor {
 private:
   SymbolRef ZeroSymbol;
-  const StackFrame *SFC;
+  const StackFrame *SF;
   bool Satisfied;
 
 public:
-  DivisionBRVisitor(SymbolRef ZeroSymbol, const StackFrame *SFC)
-      : ZeroSymbol(ZeroSymbol), SFC(SFC), Satisfied(false) {}
+  DivisionBRVisitor(SymbolRef ZeroSymbol, const StackFrame *SF)
+      : ZeroSymbol(ZeroSymbol), SF(SF), Satisfied(false) {}
 
   void Profile(llvm::FoldingSetNodeID &ID) const override {
     ID.Add(ZeroSymbol);
-    ID.Add(SFC);
+    ID.Add(SF);
   }
 
   PathDiagnosticPieceRef VisitNode(const ExplodedNode *Succ,
@@ -111,7 +111,7 @@ DivisionBRVisitor::VisitNode(const ExplodedNode *Succ, BugReporterContext &BRC,
     return nullptr;
 
   SVal S = Succ->getSVal(E);
-  if (ZeroSymbol == S.getAsSymbol() && SFC == Succ->getStackFrame()) {
+  if (ZeroSymbol == S.getAsSymbol() && SF == Succ->getStackFrame()) {
     Satisfied = true;
 
     // Construct a new PathDiagnosticPiece.

--- a/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
@@ -28,7 +28,7 @@ using namespace ento;
 namespace {
 enum class ObjectState : bool { CtorCalled, DtorCalled };
 } // end namespace
-  // FIXME: Ascending over StackFrameContext maybe another method.
+  // FIXME: Ascending over StackFrame maybe another method.
 
 namespace llvm {
 template <> struct FoldingSetTrait<ObjectState> {

--- a/clang/lib/StaticAnalyzer/Core/BlockCounter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BlockCounter.cpp
@@ -21,12 +21,11 @@ using namespace ento;
 namespace {
 
 class CountKey {
-  const StackFrameContext *CallSite;
+  const StackFrame *CallSite;
   unsigned BlockID;
 
 public:
-  CountKey(const StackFrameContext *CS, unsigned ID)
-    : CallSite(CS), BlockID(ID) {}
+  CountKey(const StackFrame *CS, unsigned ID) : CallSite(CS), BlockID(ID) {}
 
   bool operator==(const CountKey &RHS) const {
     return (CallSite == RHS.CallSite) && (BlockID == RHS.BlockID);
@@ -54,8 +53,8 @@ static inline CountMap::Factory& GetFactory(void *F) {
   return *static_cast<CountMap::Factory*>(F);
 }
 
-unsigned BlockCounter::getNumVisited(const StackFrameContext *CallSite,
-                                       unsigned BlockID) const {
+unsigned BlockCounter::getNumVisited(const StackFrame *CallSite,
+                                     unsigned BlockID) const {
   CountMap M = GetMap(Data);
   CountMap::data_type* T = M.lookup(CountKey(CallSite, BlockID));
   return T ? *T : 0;
@@ -69,10 +68,9 @@ BlockCounter::Factory::~Factory() {
   delete static_cast<CountMap::Factory*>(F);
 }
 
-BlockCounter
-BlockCounter::Factory::IncrementCount(BlockCounter BC,
-                                        const StackFrameContext *CallSite,
-                                        unsigned BlockID) {
+BlockCounter BlockCounter::Factory::IncrementCount(BlockCounter BC,
+                                                   const StackFrame *CallSite,
+                                                   unsigned BlockID) {
   return BlockCounter(GetFactory(F).add(GetMap(BC.Data),
                                           CountKey(CallSite, BlockID),
                              BC.getNumVisited(CallSite, BlockID)+1).getRoot());

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -1161,7 +1161,7 @@ void PathDiagnosticBuilder::generatePathDiagnosticsForNode(
 
     if (C.shouldAddPathEdges()) {
       // Add an edge to the start of the function.
-      const StackFrameContext *CalleeLC = CE->getCalleeContext();
+      const StackFrame *CalleeLC = CE->getCalleeContext();
       const Decl *D = CalleeLC->getDecl();
       // Add the edge only when the callee has body. We jump to the beginning
       // of the *declaration*, however we expect it to be followed by the
@@ -2074,7 +2074,7 @@ PathDiagnosticBuilder::generate(const PathDiagnosticConsumer *PDC) const {
   if (PDC->shouldAddPathEdges()) {
     // Add an edge to the start of the function.
     // We'll prune it out later, but it helps make diagnostics more uniform.
-    const StackFrameContext *CalleeLC =
+    const StackFrame *CalleeLC =
         Construct.getLocationContextForActivePath()->getStackFrame();
     const Decl *D = CalleeLC->getDecl();
     addEdgeToPath(Construct.getActivePath(), PrevLoc,

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -379,14 +379,13 @@ BugReporterVisitor::getDefaultEndPath(const BugReporterContext &BRC,
 
 bool NoStateChangeFuncVisitor::isModifiedInFrame(const ExplodedNode *N) {
   const LocationContext *Ctx = N->getLocationContext();
-  const StackFrameContext *SCtx = Ctx->getStackFrame();
+  const StackFrame *SCtx = Ctx->getStackFrame();
   if (!FramesModifyingCalculated.count(SCtx))
     findModifyingFrames(N);
   return FramesModifying.count(SCtx);
 }
 
-void NoStateChangeFuncVisitor::markFrameAsModifying(
-    const StackFrameContext *SCtx) {
+void NoStateChangeFuncVisitor::markFrameAsModifying(const StackFrame *SCtx) {
   while (!SCtx->inTopFrame()) {
     auto p = FramesModifying.insert(SCtx);
     if (!p.second)
@@ -400,7 +399,7 @@ static const ExplodedNode *getMatchingCallExitEnd(const ExplodedNode *N) {
   assert(N->getLocationAs<CallEnter>());
   // The stackframe of the callee is only found in the nodes succeeding
   // the CallEnter node. CallEnter's stack frame refers to the caller.
-  const StackFrameContext *OrigSCtx = N->getFirstSucc()->getStackFrame();
+  const StackFrame *OrigSCtx = N->getFirstSucc()->getStackFrame();
 
   // Similarly, the nodes preceding CallExitEnd refer to the callee's stack
   // frame.
@@ -421,11 +420,11 @@ void NoStateChangeFuncVisitor::findModifyingFrames(
 
   assert(CallExitBeginN->getLocationAs<CallExitBegin>());
 
-  const StackFrameContext *const OriginalSCtx =
+  const StackFrame *const OriginalSCtx =
       CallExitBeginN->getLocationContext()->getStackFrame();
 
   const ExplodedNode *CurrCallExitBeginN = CallExitBeginN;
-  const StackFrameContext *CurrentSCtx = OriginalSCtx;
+  const StackFrame *CurrentSCtx = OriginalSCtx;
 
   for (const ExplodedNode *CurrN = CallExitBeginN; CurrN;
        CurrN = CurrN->getFirstPred()) {
@@ -467,7 +466,7 @@ PathDiagnosticPieceRef NoStateChangeFuncVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BR, PathSensitiveBugReport &R) {
 
   const LocationContext *Ctx = N->getLocationContext();
-  const StackFrameContext *SCtx = Ctx->getStackFrame();
+  const StackFrame *SCtx = Ctx->getStackFrame();
   ProgramStateRef State = N->getState();
   auto CallExitLoc = N->getLocationAs<CallExitBegin>();
 
@@ -901,7 +900,7 @@ namespace {
 /// This visitor is intended to be used when another visitor discovers that an
 /// interesting value comes from an inlined function call.
 class ReturnVisitor : public TrackingBugReporterVisitor {
-  const StackFrameContext *CalleeSFC;
+  const StackFrame *CalleeSFC;
   enum {
     Initial,
     MaybeUnsuppress,
@@ -914,7 +913,7 @@ class ReturnVisitor : public TrackingBugReporterVisitor {
   bugreporter::TrackingKind TKind;
 
 public:
-  ReturnVisitor(TrackerRef ParentTracker, const StackFrameContext *Frame,
+  ReturnVisitor(TrackerRef ParentTracker, const StackFrame *Frame,
                 bool Suppressed, AnalyzerOptions &Options,
                 bugreporter::TrackingKind TKind)
       : TrackingBugReporterVisitor(ParentTracker), CalleeSFC(Frame),
@@ -1139,7 +1138,7 @@ class StoreSiteFinder final : public TrackingBugReporterVisitor {
   bool Satisfied = false;
 
   TrackingOptions Options;
-  const StackFrameContext *OriginSFC;
+  const StackFrame *OriginSFC;
 
 public:
   /// \param V We're searching for the store where \c R received this value.
@@ -1154,7 +1153,7 @@ public:
   ///        much.
   StoreSiteFinder(bugreporter::TrackerRef ParentTracker, SVal V,
                   const MemRegion *R, TrackingOptions Options,
-                  const StackFrameContext *OriginSFC = nullptr)
+                  const StackFrame *OriginSFC = nullptr)
       : TrackingBugReporterVisitor(ParentTracker), R(R), V(V), Options(Options),
         OriginSFC(OriginSFC) {
     assert(R);
@@ -2296,7 +2295,7 @@ public:
                          const ExplodedNode *LVNode,
                          TrackingOptions Opts) override {
     ProgramStateRef LVState = LVNode->getState();
-    const StackFrameContext *SFC = LVNode->getStackFrame();
+    const StackFrame *SFC = LVNode->getStackFrame();
     PathSensitiveBugReport &Report = getParentTracker().getReport();
     Tracker::Result Result;
 
@@ -2388,7 +2387,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
     const bool BypassCXXNewExprEval = isa<CXXNewExpr>(E);
 
     // This is moving forward when we enter into another context.
-    const StackFrameContext *CurrentSFC = ExprNode->getStackFrame();
+    const StackFrame *CurrentSFC = ExprNode->getStackFrame();
 
     do {
       // If that is satisfied we found our statement as an inlined call.
@@ -2402,7 +2401,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
       if (!ExprNode)
         break;
 
-      const StackFrameContext *PredSFC = ExprNode->getStackFrame();
+      const StackFrame *PredSFC = ExprNode->getStackFrame();
 
       // If that is satisfied we found our statement.
       // FIXME: This code currently bypasses the call site for the
@@ -2427,7 +2426,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
     if (!CEE)
       return {};
 
-    const StackFrameContext *CalleeContext = CEE->getCalleeContext();
+    const StackFrame *CalleeContext = CEE->getCalleeContext();
     if (CalleeContext->getCallSite() != E)
       return {};
 
@@ -2464,7 +2463,7 @@ public:
                          const ExplodedNode *LVNode,
                          TrackingOptions Opts) override {
     ProgramStateRef LVState = LVNode->getState();
-    const StackFrameContext *SFC = LVNode->getStackFrame();
+    const StackFrame *SFC = LVNode->getStackFrame();
     PathSensitiveBugReport &Report = getParentTracker().getReport();
     Tracker::Result Result;
 
@@ -2621,7 +2620,7 @@ Tracker::Result Tracker::track(const Expr *E, const ExplodedNode *N,
 }
 
 Tracker::Result Tracker::track(SVal V, const MemRegion *R, TrackingOptions Opts,
-                               const StackFrameContext *Origin) {
+                               const StackFrame *Origin) {
   if (!V.isUnknown()) {
     Report.addVisitor<StoreSiteFinder>(this, V, R, Opts, Origin);
     return {true};
@@ -2654,7 +2653,7 @@ bool bugreporter::trackExpressionValue(const ExplodedNode *InputNode,
 void bugreporter::trackStoredValue(SVal V, const MemRegion *R,
                                    PathSensitiveBugReport &Report,
                                    TrackingOptions Opts,
-                                   const StackFrameContext *Origin) {
+                                   const StackFrame *Origin) {
   Tracker::create(Report)->track(V, R, Opts, Origin);
 }
 

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -2295,7 +2295,7 @@ public:
                          const ExplodedNode *LVNode,
                          TrackingOptions Opts) override {
     ProgramStateRef LVState = LVNode->getState();
-    const StackFrame *SFC = LVNode->getStackFrame();
+    const StackFrame *SF = LVNode->getStackFrame();
     PathSensitiveBugReport &Report = getParentTracker().getReport();
     Tracker::Result Result;
 
@@ -2311,7 +2311,7 @@ public:
       // pointer. In addition, we should find the store at which the reference
       // got initialized.
       if (RR && !LVIsNull)
-        Result.combineWith(getParentTracker().track(LVal, RR, Opts, SFC));
+        Result.combineWith(getParentTracker().track(LVal, RR, Opts, SF));
 
       // In case of C++ references, we want to differentiate between a null
       // reference and reference to null pointer.
@@ -2356,7 +2356,7 @@ public:
             // previously.
             Report.addVisitor<SuppressInlineDefensiveChecksVisitor>(*DV,
                                                                     InputNode);
-        getParentTracker().track(V, R, Opts, SFC);
+        getParentTracker().track(V, R, Opts, SF);
       }
     }
 
@@ -2463,7 +2463,7 @@ public:
                          const ExplodedNode *LVNode,
                          TrackingOptions Opts) override {
     ProgramStateRef LVState = LVNode->getState();
-    const StackFrame *SFC = LVNode->getStackFrame();
+    const StackFrame *SF = LVNode->getStackFrame();
     PathSensitiveBugReport &Report = getParentTracker().getReport();
     Tracker::Result Result;
 
@@ -2499,7 +2499,7 @@ public:
 
         if (!RVal.isUnknown())
           Result.combineWith(
-              getParentTracker().track(RVal, L->getRegion(), Opts, SFC));
+              getParentTracker().track(RVal, L->getRegion(), Opts, SF));
       }
 
       const MemRegion *RegionRVal = RVal.getAsRegion();

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -379,19 +379,19 @@ BugReporterVisitor::getDefaultEndPath(const BugReporterContext &BRC,
 
 bool NoStateChangeFuncVisitor::isModifiedInFrame(const ExplodedNode *N) {
   const LocationContext *Ctx = N->getLocationContext();
-  const StackFrame *SCtx = Ctx->getStackFrame();
-  if (!FramesModifyingCalculated.count(SCtx))
+  const StackFrame *SF = Ctx->getStackFrame();
+  if (!FramesModifyingCalculated.count(SF))
     findModifyingFrames(N);
-  return FramesModifying.count(SCtx);
+  return FramesModifying.count(SF);
 }
 
-void NoStateChangeFuncVisitor::markFrameAsModifying(const StackFrame *SCtx) {
-  while (!SCtx->inTopFrame()) {
-    auto p = FramesModifying.insert(SCtx);
+void NoStateChangeFuncVisitor::markFrameAsModifying(const StackFrame *SF) {
+  while (!SF->inTopFrame()) {
+    auto p = FramesModifying.insert(SF);
     if (!p.second)
       break; // Frame and all its parents already inserted.
 
-    SCtx = SCtx->getParent()->getStackFrame();
+    SF = SF->getParent()->getStackFrame();
   }
 }
 
@@ -399,13 +399,13 @@ static const ExplodedNode *getMatchingCallExitEnd(const ExplodedNode *N) {
   assert(N->getLocationAs<CallEnter>());
   // The stackframe of the callee is only found in the nodes succeeding
   // the CallEnter node. CallEnter's stack frame refers to the caller.
-  const StackFrame *OrigSCtx = N->getFirstSucc()->getStackFrame();
+  const StackFrame *OrigSF = N->getFirstSucc()->getStackFrame();
 
   // Similarly, the nodes preceding CallExitEnd refer to the callee's stack
   // frame.
-  auto IsMatchingCallExitEnd = [OrigSCtx](const ExplodedNode *N) {
+  auto IsMatchingCallExitEnd = [OrigSF](const ExplodedNode *N) {
     return N->getLocationAs<CallExitEnd>() &&
-           OrigSCtx == N->getFirstPred()->getStackFrame();
+           OrigSF == N->getFirstPred()->getStackFrame();
   };
   while (N && !IsMatchingCallExitEnd(N)) {
     assert(N->succ_size() <= 1 &&
@@ -420,19 +420,19 @@ void NoStateChangeFuncVisitor::findModifyingFrames(
 
   assert(CallExitBeginN->getLocationAs<CallExitBegin>());
 
-  const StackFrame *const OriginalSCtx =
+  const StackFrame *const OriginalSF =
       CallExitBeginN->getLocationContext()->getStackFrame();
 
   const ExplodedNode *CurrCallExitBeginN = CallExitBeginN;
-  const StackFrame *CurrentSCtx = OriginalSCtx;
+  const StackFrame *CurrentSF = OriginalSF;
 
   for (const ExplodedNode *CurrN = CallExitBeginN; CurrN;
        CurrN = CurrN->getFirstPred()) {
     // Found a new inlined call.
     if (CurrN->getLocationAs<CallExitBegin>()) {
       CurrCallExitBeginN = CurrN;
-      CurrentSCtx = CurrN->getStackFrame();
-      FramesModifyingCalculated.insert(CurrentSCtx);
+      CurrentSF = CurrN->getStackFrame();
+      FramesModifyingCalculated.insert(CurrentSF);
       // We won't see a change in between two identical exploded nodes: skip.
       continue;
     }
@@ -440,10 +440,10 @@ void NoStateChangeFuncVisitor::findModifyingFrames(
     if (auto CE = CurrN->getLocationAs<CallEnter>()) {
       if (const ExplodedNode *CallExitEndN = getMatchingCallExitEnd(CurrN))
         if (wasModifiedInFunction(CurrN, CallExitEndN))
-          markFrameAsModifying(CurrentSCtx);
+          markFrameAsModifying(CurrentSF);
 
       // We exited this inlined call, lets actualize the stack frame.
-      CurrentSCtx = CurrN->getStackFrame();
+      CurrentSF = CurrN->getStackFrame();
 
       // Stop calculating at the current function, but always regard it as
       // modifying, so we can avoid notes like this:
@@ -451,14 +451,14 @@ void NoStateChangeFuncVisitor::findModifyingFrames(
       //     F.field = 0; // note: 0 assigned to 'F.field'
       //                  // note: returning without writing to 'F.field'
       //   }
-      if (CE->getCalleeContext() == OriginalSCtx) {
-        markFrameAsModifying(CurrentSCtx);
+      if (CE->getCalleeContext() == OriginalSF) {
+        markFrameAsModifying(CurrentSF);
         break;
       }
     }
 
     if (wasModifiedBeforeCallExit(CurrN, CurrCallExitBeginN))
-      markFrameAsModifying(CurrentSCtx);
+      markFrameAsModifying(CurrentSF);
   }
 }
 
@@ -466,7 +466,7 @@ PathDiagnosticPieceRef NoStateChangeFuncVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BR, PathSensitiveBugReport &R) {
 
   const LocationContext *Ctx = N->getLocationContext();
-  const StackFrame *SCtx = Ctx->getStackFrame();
+  const StackFrame *SF = Ctx->getStackFrame();
   ProgramStateRef State = N->getState();
   auto CallExitLoc = N->getLocationAs<CallExitBegin>();
 
@@ -475,7 +475,7 @@ PathDiagnosticPieceRef NoStateChangeFuncVisitor::VisitNode(
     return nullptr;
 
   CallEventRef<> Call =
-      BR.getStateManager().getCallEventManager().getCaller(SCtx, State);
+      BR.getStateManager().getCallEventManager().getCaller(SF, State);
 
   // Optimistically suppress uninitialized value bugs that result
   // from system headers having a chance to initialize the value
@@ -900,7 +900,7 @@ namespace {
 /// This visitor is intended to be used when another visitor discovers that an
 /// interesting value comes from an inlined function call.
 class ReturnVisitor : public TrackingBugReporterVisitor {
-  const StackFrame *CalleeSFC;
+  const StackFrame *CalleeSF;
   enum {
     Initial,
     MaybeUnsuppress,
@@ -916,7 +916,7 @@ public:
   ReturnVisitor(TrackerRef ParentTracker, const StackFrame *Frame,
                 bool Suppressed, AnalyzerOptions &Options,
                 bugreporter::TrackingKind TKind)
-      : TrackingBugReporterVisitor(ParentTracker), CalleeSFC(Frame),
+      : TrackingBugReporterVisitor(ParentTracker), CalleeSF(Frame),
         EnableNullFPSuppression(Suppressed), Options(Options), TKind(TKind) {}
 
   static void *getTag() {
@@ -926,7 +926,7 @@ public:
 
   void Profile(llvm::FoldingSetNodeID &ID) const override {
     ID.AddPointer(ReturnVisitor::getTag());
-    ID.AddPointer(CalleeSFC);
+    ID.AddPointer(CalleeSF);
     ID.AddBoolean(EnableNullFPSuppression);
   }
 
@@ -934,7 +934,7 @@ public:
                                           BugReporterContext &BRC,
                                           PathSensitiveBugReport &BR) {
     // Only print a message at the interesting return statement.
-    if (N->getLocationContext() != CalleeSFC)
+    if (N->getLocationContext() != CalleeSF)
       return nullptr;
 
     std::optional<StmtPoint> SP = N->getLocationAs<StmtPoint>();
@@ -951,7 +951,7 @@ public:
     const Expr *RV = Ret->getRetValue();
     if (!RV)
       return nullptr;
-    SVal V = State->getSVal(RV, CalleeSFC);
+    SVal V = State->getSVal(RV, CalleeSF);
     if (V.isUnknownOrUndef())
       return nullptr;
 
@@ -1036,7 +1036,7 @@ public:
           Out << " (loaded from '" << *DD << "')";
     }
 
-    PathDiagnosticLocation L(Ret, BRC.getSourceManager(), CalleeSFC);
+    PathDiagnosticLocation L(Ret, BRC.getSourceManager(), CalleeSF);
     if (!L.isValid() || !L.asLocation().isValid())
       return nullptr;
 
@@ -1050,7 +1050,7 @@ public:
     if (WouldEventBeMeaningless)
       EventPiece->setPrunable(true);
     else
-      BR.markInteresting(CalleeSFC);
+      BR.markInteresting(CalleeSF);
 
     return EventPiece;
   }
@@ -1065,7 +1065,7 @@ public:
     if (!CE)
       return nullptr;
 
-    if (CE->getCalleeContext() != CalleeSFC)
+    if (CE->getCalleeContext() != CalleeSF)
       return nullptr;
 
     Mode = Satisfied;
@@ -1077,7 +1077,7 @@ public:
     CallEventManager &CallMgr = StateMgr.getCallEventManager();
 
     ProgramStateRef State = N->getState();
-    CallEventRef<> Call = CallMgr.getCaller(CalleeSFC, State);
+    CallEventRef<> Call = CallMgr.getCaller(CalleeSF, State);
     for (unsigned I = 0, E = Call->getNumArgs(); I != E; ++I) {
       std::optional<Loc> ArgV = Call->getArgSVal(I).getAs<Loc>();
       if (!ArgV)
@@ -1122,7 +1122,7 @@ public:
   void finalizeVisitor(BugReporterContext &, const ExplodedNode *,
                        PathSensitiveBugReport &BR) override {
     if (EnableNullFPSuppression && ShouldInvalidate)
-      BR.markInvalid(ReturnVisitor::getTag(), CalleeSFC);
+      BR.markInvalid(ReturnVisitor::getTag(), CalleeSF);
   }
 };
 
@@ -1138,13 +1138,13 @@ class StoreSiteFinder final : public TrackingBugReporterVisitor {
   bool Satisfied = false;
 
   TrackingOptions Options;
-  const StackFrame *OriginSFC;
+  const StackFrame *OriginSF;
 
 public:
   /// \param V We're searching for the store where \c R received this value.
   /// \param R The region we're tracking.
   /// \param Options Tracking behavior options.
-  /// \param OriginSFC Only adds notes when the last store happened in a
+  /// \param OriginSF Only adds notes when the last store happened in a
   ///        different stackframe to this one. Disregarded if the tracking kind
   ///        is thorough.
   ///        This is useful, because for non-tracked regions, notes about
@@ -1153,9 +1153,9 @@ public:
   ///        much.
   StoreSiteFinder(bugreporter::TrackerRef ParentTracker, SVal V,
                   const MemRegion *R, TrackingOptions Options,
-                  const StackFrame *OriginSFC = nullptr)
+                  const StackFrame *OriginSF = nullptr)
       : TrackingBugReporterVisitor(ParentTracker), R(R), V(V), Options(Options),
-        OriginSFC(OriginSFC) {
+        OriginSF(OriginSF) {
     assert(R);
   }
 
@@ -1717,8 +1717,8 @@ PathDiagnosticPieceRef StoreSiteFinder::VisitNode(const ExplodedNode *Succ,
     }
   }
 
-  if (Options.Kind == TrackingKind::Condition && OriginSFC &&
-      !OriginSFC->isParentOf(StoreSite->getStackFrame()))
+  if (Options.Kind == TrackingKind::Condition && OriginSF &&
+      !OriginSF->isParentOf(StoreSite->getStackFrame()))
     return nullptr;
 
   // Okay, we've found the binding. Emit an appropriate message.
@@ -1749,7 +1749,7 @@ PathDiagnosticPieceRef StoreSiteFinder::VisitNode(const ExplodedNode *Succ,
                 dyn_cast_or_null<BlockDataRegion>(V.getAsRegion())) {
           if (const VarRegion *OriginalR = BDR->getOriginalRegion(VR)) {
             getParentTracker().track(State->getSVal(OriginalR), OriginalR,
-                                     Options, OriginSFC);
+                                     Options, OriginSF);
           }
         }
       }
@@ -2387,7 +2387,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
     const bool BypassCXXNewExprEval = isa<CXXNewExpr>(E);
 
     // This is moving forward when we enter into another context.
-    const StackFrame *CurrentSFC = ExprNode->getStackFrame();
+    const StackFrame *CurrentSF = ExprNode->getStackFrame();
 
     do {
       // If that is satisfied we found our statement as an inlined call.
@@ -2401,7 +2401,7 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
       if (!ExprNode)
         break;
 
-      const StackFrame *PredSFC = ExprNode->getStackFrame();
+      const StackFrame *PredSF = ExprNode->getStackFrame();
 
       // If that is satisfied we found our statement.
       // FIXME: This code currently bypasses the call site for the
@@ -2409,11 +2409,11 @@ class InlinedFunctionCallHandler final : public ExpressionHandler {
       if (!BypassCXXNewExprEval)
         if (std::optional<StmtPoint> SP = ExprNode->getLocationAs<StmtPoint>())
           // See if we do not enter into another context.
-          if (SP->getStmt() == E && CurrentSFC == PredSFC)
+          if (SP->getStmt() == E && CurrentSF == PredSF)
             break;
 
-      CurrentSFC = PredSFC;
-    } while (ExprNode->getStackFrame() == CurrentSFC);
+      CurrentSF = PredSF;
+    } while (ExprNode->getStackFrame() == CurrentSF);
 
     // Next, step over any post-statement checks.
     while (ExprNode && ExprNode->getLocation().getAs<PostStmt>())

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -475,7 +475,7 @@ static SVal castArgToParamTypeIfNeeded(const CallEvent &Call, unsigned ArgIdx,
   return SVB.evalCast(ArgVal, Param->getType(), ArgExpr->getType());
 }
 
-static void addParameterValuesToBindings(const StackFrame *CalleeCtx,
+static void addParameterValuesToBindings(const StackFrame *CalleeSF,
                                          CallEvent::BindingsTy &Bindings,
                                          SValBuilder &SVB,
                                          const CallEvent &Call,
@@ -509,7 +509,7 @@ static void addParameterValuesToBindings(const StackFrame *CalleeCtx,
     ArgVal = castArgToParamTypeIfNeeded(Call, Idx, ArgVal, SVB);
 
     Loc ParamLoc = SVB.makeLoc(
-        MRMgr.getParamVarRegion(Call.getOriginExpr(), Idx, CalleeCtx));
+        MRMgr.getParamVarRegion(Call.getOriginExpr(), Idx, CalleeSF));
     Bindings.push_back(
         std::make_pair(ParamLoc, processArgument(ArgVal, ArgExpr, *I, SVB)));
   }
@@ -539,12 +539,12 @@ const CallEventRef<> CallEvent::getCaller() const {
   if (!CallLocationContext || CallLocationContext->inTopFrame())
     return nullptr;
 
-  const auto *CallStackFrameContext = CallLocationContext->getStackFrame();
-  if (!CallStackFrameContext)
+  const auto *CallSF = CallLocationContext->getStackFrame();
+  if (!CallSF)
     return nullptr;
 
   CallEventManager &CEMgr = State->getStateManager().getCallEventManager();
-  return CEMgr.getCaller(CallStackFrameContext, State);
+  return CEMgr.getCaller(CallSF, State);
 }
 
 bool CallEvent::isCalledFromSystemHeader() const {
@@ -632,12 +632,11 @@ RuntimeDefinition AnyFunctionCall::getRuntimeDefinition() const {
   return RuntimeDefinition(*CTUDeclOrError, /*Foreign=*/true);
 }
 
-void AnyFunctionCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+void AnyFunctionCall::getInitialStackFrameContents(const StackFrame *CalleeSF,
                                                    BindingsTy &Bindings) const {
-  const auto *D = cast<FunctionDecl>(CalleeCtx->getDecl());
+  const auto *D = cast<FunctionDecl>(CalleeSF->getDecl());
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
-  addParameterValuesToBindings(CalleeCtx, Bindings, SVB, *this,
-                               D->parameters());
+  addParameterValuesToBindings(CalleeSF, Bindings, SVB, *this, D->parameters());
 }
 
 bool AnyFunctionCall::argumentsMayEscape() const {
@@ -845,9 +844,9 @@ RuntimeDefinition CXXInstanceCall::getRuntimeDefinition() const {
   return RuntimeDefinition(Definition, /*DispatchRegion=*/nullptr);
 }
 
-void CXXInstanceCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+void CXXInstanceCall::getInitialStackFrameContents(const StackFrame *CalleeSF,
                                                    BindingsTy &Bindings) const {
-  AnyFunctionCall::getInitialStackFrameContents(CalleeCtx, Bindings);
+  AnyFunctionCall::getInitialStackFrameContents(CalleeSF, Bindings);
 
   // Handle the binding of 'this' in the new stack frame.
   SVal ThisVal = getCXXThisVal();
@@ -855,8 +854,8 @@ void CXXInstanceCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
     ProgramStateManager &StateMgr = getState()->getStateManager();
     SValBuilder &SVB = StateMgr.getSValBuilder();
 
-    const auto *MD = cast<CXXMethodDecl>(CalleeCtx->getDecl());
-    Loc ThisLoc = SVB.getCXXThis(MD, CalleeCtx);
+    const auto *MD = cast<CXXMethodDecl>(CalleeSF->getDecl());
+    Loc ThisLoc = SVB.getCXXThis(MD, CalleeSF);
 
     // If we devirtualized to a different member function, we need to make sure
     // we have the proper layering of CXXBaseObjectRegions.
@@ -927,12 +926,12 @@ void BlockCall::getExtraInvalidatedValues(ValueList &Values,
     Values.push_back(loc::MemRegionVal(R));
 }
 
-void BlockCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+void BlockCall::getInitialStackFrameContents(const StackFrame *CalleeSF,
                                              BindingsTy &Bindings) const {
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
   ArrayRef<ParmVarDecl*> Params;
   if (isConversionFromLambda()) {
-    auto *LambdaOperatorDecl = cast<CXXMethodDecl>(CalleeCtx->getDecl());
+    auto *LambdaOperatorDecl = cast<CXXMethodDecl>(CalleeSF->getDecl());
     Params = LambdaOperatorDecl->parameters();
 
     // For blocks converted from a C++ lambda, the callee declaration is the
@@ -940,14 +939,13 @@ void BlockCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
     // the lambda captured by the block.
     const VarRegion *CapturedLambdaRegion = getRegionStoringCapturedLambda();
     SVal ThisVal = loc::MemRegionVal(CapturedLambdaRegion);
-    Loc ThisLoc = SVB.getCXXThis(LambdaOperatorDecl, CalleeCtx);
+    Loc ThisLoc = SVB.getCXXThis(LambdaOperatorDecl, CalleeSF);
     Bindings.push_back(std::make_pair(ThisLoc, ThisVal));
   } else {
-    Params = cast<BlockDecl>(CalleeCtx->getDecl())->parameters();
+    Params = cast<BlockDecl>(CalleeSF->getDecl())->parameters();
   }
 
-  addParameterValuesToBindings(CalleeCtx, Bindings, SVB, *this,
-                               Params);
+  addParameterValuesToBindings(CalleeSF, Bindings, SVB, *this, Params);
 }
 
 SVal AnyCXXConstructorCall::getCXXThisVal() const {
@@ -974,14 +972,14 @@ void AnyCXXConstructorCall::getExtraInvalidatedValues(ValueList &Values,
 }
 
 void AnyCXXConstructorCall::getInitialStackFrameContents(
-    const StackFrame *CalleeCtx, BindingsTy &Bindings) const {
-  AnyFunctionCall::getInitialStackFrameContents(CalleeCtx, Bindings);
+    const StackFrame *CalleeSF, BindingsTy &Bindings) const {
+  AnyFunctionCall::getInitialStackFrameContents(CalleeSF, Bindings);
 
   SVal ThisVal = getCXXThisVal();
   if (!ThisVal.isUnknown()) {
     SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
-    const auto *MD = cast<CXXMethodDecl>(CalleeCtx->getDecl());
-    Loc ThisLoc = SVB.getCXXThis(MD, CalleeCtx);
+    const auto *MD = cast<CXXMethodDecl>(CalleeSF->getDecl());
+    Loc ThisLoc = SVB.getCXXThis(MD, CalleeSF);
     Bindings.push_back(std::make_pair(ThisLoc, ThisVal));
   }
 }
@@ -1417,18 +1415,17 @@ bool ObjCMethodCall::argumentsMayEscape() const {
   return CallEvent::argumentsMayEscape();
 }
 
-void ObjCMethodCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+void ObjCMethodCall::getInitialStackFrameContents(const StackFrame *CalleeSF,
                                                   BindingsTy &Bindings) const {
-  const auto *D = cast<ObjCMethodDecl>(CalleeCtx->getDecl());
+  const auto *D = cast<ObjCMethodDecl>(CalleeSF->getDecl());
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
-  addParameterValuesToBindings(CalleeCtx, Bindings, SVB, *this,
-                               D->parameters());
+  addParameterValuesToBindings(CalleeSF, Bindings, SVB, *this, D->parameters());
 
   SVal SelfVal = getReceiverSVal();
   if (!SelfVal.isUnknown()) {
-    const VarDecl *SelfD = CalleeCtx->getAnalysisDeclContext()->getSelfDecl();
+    const VarDecl *SelfD = CalleeSF->getAnalysisDeclContext()->getSelfDecl();
     MemRegionManager &MRMgr = SVB.getRegionManager();
-    Loc SelfLoc = SVB.makeLoc(MRMgr.getVarRegion(SelfD, CalleeCtx));
+    Loc SelfLoc = SVB.makeLoc(MRMgr.getVarRegion(SelfD, CalleeSF));
     Bindings.push_back(std::make_pair(SelfLoc, SelfVal));
   }
 }
@@ -1465,23 +1462,23 @@ CallEventManager::getSimpleCall(const CallExpr *CE, ProgramStateRef State,
   return create<SimpleFunctionCall>(CE, State, LCtx, ElemRef);
 }
 
-CallEventRef<> CallEventManager::getCaller(const StackFrame *CalleeCtx,
+CallEventRef<> CallEventManager::getCaller(const StackFrame *CalleeSF,
                                            ProgramStateRef State) {
-  const LocationContext *ParentCtx = CalleeCtx->getParent();
+  const LocationContext *ParentCtx = CalleeSF->getParent();
   const LocationContext *CallerCtx = ParentCtx->getStackFrame();
-  CFGBlock::ConstCFGElementRef ElemRef = {CalleeCtx->getCallSiteBlock(),
-                                          CalleeCtx->getIndex()};
+  CFGBlock::ConstCFGElementRef ElemRef = {CalleeSF->getCallSiteBlock(),
+                                          CalleeSF->getIndex()};
   assert(CallerCtx && "This should not be used for top-level stack frames");
 
-  const Expr *CallSite = CalleeCtx->getCallSite();
+  const Expr *CallSite = CalleeSF->getCallSite();
 
   if (CallSite) {
     if (CallEventRef<> Out = getCall(CallSite, State, CallerCtx, ElemRef))
       return Out;
 
     SValBuilder &SVB = State->getStateManager().getSValBuilder();
-    const auto *Ctor = cast<CXXMethodDecl>(CalleeCtx->getDecl());
-    Loc ThisPtr = SVB.getCXXThis(Ctor, CalleeCtx);
+    const auto *Ctor = cast<CXXMethodDecl>(CalleeSF->getDecl());
+    Loc ThisPtr = SVB.getCXXThis(Ctor, CalleeSF);
     SVal ThisVal = State->getSVal(ThisPtr);
 
     if (const auto *CE = dyn_cast<CXXConstructExpr>(CallSite))
@@ -1496,14 +1493,14 @@ CallEventRef<> CallEventManager::getCaller(const StackFrame *CalleeCtx,
 
   // Fall back to the CFG. The only thing we haven't handled yet is
   // destructors, though this could change in the future.
-  const CFGBlock *B = CalleeCtx->getCallSiteBlock();
-  CFGElement E = (*B)[CalleeCtx->getIndex()];
+  const CFGBlock *B = CalleeSF->getCallSiteBlock();
+  CFGElement E = (*B)[CalleeSF->getIndex()];
   assert((E.getAs<CFGImplicitDtor>() || E.getAs<CFGTemporaryDtor>()) &&
          "All other CFG elements should have exprs");
 
   SValBuilder &SVB = State->getStateManager().getSValBuilder();
-  const auto *Dtor = cast<CXXDestructorDecl>(CalleeCtx->getDecl());
-  Loc ThisPtr = SVB.getCXXThis(Dtor, CalleeCtx);
+  const auto *Dtor = cast<CXXDestructorDecl>(CalleeSF->getDecl());
+  Loc ThisPtr = SVB.getCXXThis(Dtor, CalleeSF);
   SVal ThisVal = State->getSVal(ThisPtr);
 
   const Stmt *Trigger;

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -190,14 +190,14 @@ const StackFrame *CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
 
 const ParamVarRegion
 *CallEvent::getParameterLocation(unsigned Index, unsigned BlockCount) const {
-  const StackFrame *SFC = getCalleeStackFrame(BlockCount);
+  const StackFrame *SF = getCalleeStackFrame(BlockCount);
   // We cannot construct a VarRegion without a stack frame.
-  if (!SFC)
+  if (!SF)
     return nullptr;
 
   const ParamVarRegion *PVR =
-    State->getStateManager().getRegionManager().getParamVarRegion(
-        getOriginExpr(), Index, SFC);
+      State->getStateManager().getRegionManager().getParamVarRegion(
+          getOriginExpr(), Index, SF);
   return PVR;
 }
 
@@ -987,10 +987,10 @@ void AnyCXXConstructorCall::getInitialStackFrameContents(
 }
 
 const StackFrame *CXXInheritedConstructorCall::getInheritingStackFrame() const {
-  const StackFrame *SFC = getLocationContext()->getStackFrame();
-  while (isa<CXXInheritedCtorInitExpr>(SFC->getCallSite()))
-    SFC = SFC->getParent()->getStackFrame();
-  return SFC;
+  const StackFrame *SF = getLocationContext()->getStackFrame();
+  while (isa<CXXInheritedCtorInitExpr>(SF->getCallSite()))
+    SF = SF->getParent()->getStackFrame();
+  return SF;
 }
 
 SVal CXXDestructorCall::getCXXThisVal() const {

--- a/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CallEvent.cpp
@@ -159,8 +159,7 @@ AnalysisDeclContext *CallEvent::getCalleeAnalysisDeclContext() const {
   return ADC;
 }
 
-const StackFrameContext *
-CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
+const StackFrame *CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
   AnalysisDeclContext *ADC = getCalleeAnalysisDeclContext();
   if (!ADC)
     return nullptr;
@@ -191,7 +190,7 @@ CallEvent::getCalleeStackFrame(unsigned BlockCount) const {
 
 const ParamVarRegion
 *CallEvent::getParameterLocation(unsigned Index, unsigned BlockCount) const {
-  const StackFrameContext *SFC = getCalleeStackFrame(BlockCount);
+  const StackFrame *SFC = getCalleeStackFrame(BlockCount);
   // We cannot construct a VarRegion without a stack frame.
   if (!SFC)
     return nullptr;
@@ -476,11 +475,11 @@ static SVal castArgToParamTypeIfNeeded(const CallEvent &Call, unsigned ArgIdx,
   return SVB.evalCast(ArgVal, Param->getType(), ArgExpr->getType());
 }
 
-static void addParameterValuesToBindings(const StackFrameContext *CalleeCtx,
+static void addParameterValuesToBindings(const StackFrame *CalleeCtx,
                                          CallEvent::BindingsTy &Bindings,
                                          SValBuilder &SVB,
                                          const CallEvent &Call,
-                                         ArrayRef<ParmVarDecl*> parameters) {
+                                         ArrayRef<ParmVarDecl *> parameters) {
   MemRegionManager &MRMgr = SVB.getRegionManager();
 
   // If the function has fewer parameters than the call has arguments, we simply
@@ -519,7 +518,7 @@ static void addParameterValuesToBindings(const StackFrameContext *CalleeCtx,
 }
 
 const ConstructionContext *CallEvent::getConstructionContext() const {
-  const StackFrameContext *StackFrame = getCalleeStackFrame(0);
+  const StackFrame *StackFrame = getCalleeStackFrame(0);
   if (!StackFrame)
     return nullptr;
 
@@ -633,9 +632,8 @@ RuntimeDefinition AnyFunctionCall::getRuntimeDefinition() const {
   return RuntimeDefinition(*CTUDeclOrError, /*Foreign=*/true);
 }
 
-void AnyFunctionCall::getInitialStackFrameContents(
-                                        const StackFrameContext *CalleeCtx,
-                                        BindingsTy &Bindings) const {
+void AnyFunctionCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+                                                   BindingsTy &Bindings) const {
   const auto *D = cast<FunctionDecl>(CalleeCtx->getDecl());
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
   addParameterValuesToBindings(CalleeCtx, Bindings, SVB, *this,
@@ -847,9 +845,8 @@ RuntimeDefinition CXXInstanceCall::getRuntimeDefinition() const {
   return RuntimeDefinition(Definition, /*DispatchRegion=*/nullptr);
 }
 
-void CXXInstanceCall::getInitialStackFrameContents(
-                                            const StackFrameContext *CalleeCtx,
-                                            BindingsTy &Bindings) const {
+void CXXInstanceCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+                                                   BindingsTy &Bindings) const {
   AnyFunctionCall::getInitialStackFrameContents(CalleeCtx, Bindings);
 
   // Handle the binding of 'this' in the new stack frame.
@@ -930,7 +927,7 @@ void BlockCall::getExtraInvalidatedValues(ValueList &Values,
     Values.push_back(loc::MemRegionVal(R));
 }
 
-void BlockCall::getInitialStackFrameContents(const StackFrameContext *CalleeCtx,
+void BlockCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
                                              BindingsTy &Bindings) const {
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
   ArrayRef<ParmVarDecl*> Params;
@@ -977,8 +974,7 @@ void AnyCXXConstructorCall::getExtraInvalidatedValues(ValueList &Values,
 }
 
 void AnyCXXConstructorCall::getInitialStackFrameContents(
-                                             const StackFrameContext *CalleeCtx,
-                                             BindingsTy &Bindings) const {
+    const StackFrame *CalleeCtx, BindingsTy &Bindings) const {
   AnyFunctionCall::getInitialStackFrameContents(CalleeCtx, Bindings);
 
   SVal ThisVal = getCXXThisVal();
@@ -990,9 +986,8 @@ void AnyCXXConstructorCall::getInitialStackFrameContents(
   }
 }
 
-const StackFrameContext *
-CXXInheritedConstructorCall::getInheritingStackFrame() const {
-  const StackFrameContext *SFC = getLocationContext()->getStackFrame();
+const StackFrame *CXXInheritedConstructorCall::getInheritingStackFrame() const {
+  const StackFrame *SFC = getLocationContext()->getStackFrame();
   while (isa<CXXInheritedCtorInitExpr>(SFC->getCallSite()))
     SFC = SFC->getParent()->getStackFrame();
   return SFC;
@@ -1422,9 +1417,8 @@ bool ObjCMethodCall::argumentsMayEscape() const {
   return CallEvent::argumentsMayEscape();
 }
 
-void ObjCMethodCall::getInitialStackFrameContents(
-                                             const StackFrameContext *CalleeCtx,
-                                             BindingsTy &Bindings) const {
+void ObjCMethodCall::getInitialStackFrameContents(const StackFrame *CalleeCtx,
+                                                  BindingsTy &Bindings) const {
   const auto *D = cast<ObjCMethodDecl>(CalleeCtx->getDecl());
   SValBuilder &SVB = getState()->getStateManager().getSValBuilder();
   addParameterValuesToBindings(CalleeCtx, Bindings, SVB, *this,
@@ -1471,9 +1465,8 @@ CallEventManager::getSimpleCall(const CallExpr *CE, ProgramStateRef State,
   return create<SimpleFunctionCall>(CE, State, LCtx, ElemRef);
 }
 
-CallEventRef<>
-CallEventManager::getCaller(const StackFrameContext *CalleeCtx,
-                            ProgramStateRef State) {
+CallEventRef<> CallEventManager::getCaller(const StackFrame *CalleeCtx,
+                                           ProgramStateRef State) {
   const LocationContext *ParentCtx = CalleeCtx->getParent();
   const LocationContext *CallerCtx = ParentCtx->getStackFrame();
   CFGBlock::ConstCFGElementRef ElemRef = {CalleeCtx->getCallSiteBlock(),

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -589,7 +589,7 @@ void CoreEngine::enqueueStmtNode(ExplodedNode *N,
   // Check if this node entered a callee.
   if (N->getLocation().getAs<CallEnter>()) {
     // Still use the index of the CallExpr. It's needed to create the callee
-    // StackFrameContext.
+    // StackFrame.
     WList->enqueue(N, Block, Idx);
     return;
   }
@@ -671,7 +671,7 @@ void CoreEngine::enqueueEndOfFunction(ExplodedNodeSet &Set, const ReturnStmt *RS
     // If we are in an inlined call, generate CallExitBegin node.
     if (LocCtx->getParent()) {
       // Use the callee location context.
-      CallExitBegin Loc(cast<StackFrameContext>(LocCtx), RS);
+      CallExitBegin Loc(cast<StackFrame>(LocCtx), RS);
       if (ExplodedNode *Succ = makeNode(Loc, Node->getState(), Node))
         WList->enqueue(Succ);
     } else {

--- a/clang/lib/StaticAnalyzer/Core/Environment.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Environment.cpp
@@ -64,7 +64,7 @@ static const Expr *ignoreTransparentExprs(const Expr *E) {
 }
 
 EnvironmentEntry::EnvironmentEntry(const Expr *E, const LocationContext *L)
-    : std::pair<const Expr *, const StackFrameContext *>(
+    : std::pair<const Expr *, const StackFrame *>(
           ignoreTransparentExprs(E), L ? L->getStackFrame() : nullptr) {}
 
 SVal Environment::lookupExpr(const EnvironmentEntry &E) const {

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -320,7 +320,7 @@ const Stmt *ExplodedNode::getStmtForDiagnostics() const {
   const LocationContext *LC = getLocationContext();
   if (LC->getAnalysisDeclContext()->isBodyAutosynthesized()) {
     // It must be a stack frame because we only autosynthesize functions.
-    return cast<StackFrameContext>(findTopAutosynthesizedParentContext(LC))
+    return cast<StackFrame>(findTopAutosynthesizedParentContext(LC))
         ->getCallSite();
   }
   // Otherwise, see if the node's program point directly points to a statement.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -305,7 +305,7 @@ ProgramStateRef ExprEngine::getInitialState(const LocationContext *InitLoc) {
       // Precondition: 'this' is always non-null upon entry to the
       // top-level function.  This is our starting assumption for
       // analyzing an "open" program.
-      const StackFrameContext *SFC = InitLoc->getStackFrame();
+      const StackFrame *SFC = InitLoc->getStackFrame();
       if (SFC->getParent() == nullptr) {
         loc::MemRegionVal L = svalBuilder.getCXXThis(MD, SFC);
         SVal V = state->getSVal(L);
@@ -1055,7 +1055,7 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
     LC = LC->getParent();
   }
 
-  const StackFrameContext *SFC = LC ? LC->getStackFrame() : nullptr;
+  const StackFrame *SFC = LC ? LC->getStackFrame() : nullptr;
   SymbolReaper SymReaper(SFC, ReferenceStmt, SymMgr, getStoreManager());
 
   for (auto I : CleanedState->get<ObjectsUnderConstruction>()) {
@@ -1173,7 +1173,7 @@ void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
                                 "Error evaluating initializer");
 
   // We don't clean up dead bindings here.
-  const auto *stackFrame = cast<StackFrameContext>(Pred->getLocationContext());
+  const auto *stackFrame = cast<StackFrame>(Pred->getLocationContext());
   const auto *decl = cast<CXXConstructorDecl>(stackFrame->getDecl());
 
   ProgramStateRef State = Pred->getState();
@@ -2469,8 +2469,8 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
 
 bool ExprEngine::replayWithoutInlining(ExplodedNode *N,
                                        const LocationContext *CalleeLC) {
-  const StackFrameContext *CalleeSF = CalleeLC->getStackFrame();
-  const StackFrameContext *CallerSF = CalleeSF->getParent()->getStackFrame();
+  const StackFrame *CalleeSF = CalleeLC->getStackFrame();
+  const StackFrame *CallerSF = CalleeSF->getParent()->getStackFrame();
   assert(CalleeSF && CallerSF);
   ExplodedNode *BeforeProcessingCall = nullptr;
   const Expr *CE = CalleeSF->getCallSite();

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -305,9 +305,9 @@ ProgramStateRef ExprEngine::getInitialState(const LocationContext *InitLoc) {
       // Precondition: 'this' is always non-null upon entry to the
       // top-level function.  This is our starting assumption for
       // analyzing an "open" program.
-      const StackFrame *SFC = InitLoc->getStackFrame();
-      if (SFC->getParent() == nullptr) {
-        loc::MemRegionVal L = svalBuilder.getCXXThis(MD, SFC);
+      const StackFrame *SF = InitLoc->getStackFrame();
+      if (SF->getParent() == nullptr) {
+        loc::MemRegionVal L = svalBuilder.getCXXThis(MD, SF);
         SVal V = state->getSVal(L);
         if (std::optional<Loc> LV = V.getAs<Loc>()) {
           state = state->assume(*LV, true);
@@ -1055,8 +1055,8 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
     LC = LC->getParent();
   }
 
-  const StackFrame *SFC = LC ? LC->getStackFrame() : nullptr;
-  SymbolReaper SymReaper(SFC, ReferenceStmt, SymMgr, getStoreManager());
+  const StackFrame *SF = LC ? LC->getStackFrame() : nullptr;
+  SymbolReaper SymReaper(SF, ReferenceStmt, SymMgr, getStoreManager());
 
   for (auto I : CleanedState->get<ObjectsUnderConstruction>()) {
     if (SymbolRef Sym = I.second.getAsSymbol())
@@ -1071,7 +1071,7 @@ void ExprEngine::removeDead(ExplodedNode *Pred, ExplodedNodeSet &Out,
   // and the store. TODO: The function should just return new env and store,
   // not a new state.
   CleanedState = StateMgr.removeDeadBindingsFromEnvironmentAndStore(
-      CleanedState, SFC, SymReaper);
+      CleanedState, SF, SymReaper);
 
   // Process any special transfer function for dead symbols.
   // Call checkers with the non-cleaned state so that they could query the

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -212,7 +212,7 @@ SVal ExprEngine::computeObjectUnderConstruction(
       // The temporary is to be managed by the parent stack frame.
       // So build it in the parent stack frame if we're not in the
       // top frame of the analysis.
-      const StackFrameContext *SFC = LCtx->getStackFrame();
+      const StackFrame *SFC = LCtx->getStackFrame();
       if (const LocationContext *CallerLCtx = SFC->getParent()) {
         auto RTC = (*SFC->getCallSiteBlock())[SFC->getIndex()]
                        .getAs<CFGCXXRecordTypedCall>();
@@ -431,7 +431,7 @@ ProgramStateRef ExprEngine::updateObjectsUnderConstruction(
     }
     case ConstructionContext::SimpleReturnedValueKind:
     case ConstructionContext::CXX17ElidedCopyReturnedValueKind: {
-      const StackFrameContext *SFC = LCtx->getStackFrame();
+      const StackFrame *SFC = LCtx->getStackFrame();
       const LocationContext *CallerLCtx = SFC->getParent();
       if (!CallerLCtx) {
         // No extra work is necessary in top frame.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -212,9 +212,9 @@ SVal ExprEngine::computeObjectUnderConstruction(
       // The temporary is to be managed by the parent stack frame.
       // So build it in the parent stack frame if we're not in the
       // top frame of the analysis.
-      const StackFrame *SFC = LCtx->getStackFrame();
-      if (const LocationContext *CallerLCtx = SFC->getParent()) {
-        auto RTC = (*SFC->getCallSiteBlock())[SFC->getIndex()]
+      const StackFrame *SF = LCtx->getStackFrame();
+      if (const LocationContext *CallerLCtx = SF->getParent()) {
+        auto RTC = (*SF->getCallSiteBlock())[SF->getIndex()]
                        .getAs<CFGCXXRecordTypedCall>();
         if (!RTC) {
           // We were unable to find the correct construction context for the
@@ -223,9 +223,9 @@ SVal ExprEngine::computeObjectUnderConstruction(
           break;
         }
 
-        unsigned NVCaller = getNumVisited(CallerLCtx, SFC->getCallSiteBlock());
+        unsigned NVCaller = getNumVisited(CallerLCtx, SF->getCallSiteBlock());
         return computeObjectUnderConstruction(
-            SFC->getCallSite(), State, NVCaller, CallerLCtx,
+            SF->getCallSite(), State, NVCaller, CallerLCtx,
             RTC->getConstructionContext(), CallOpts);
       } else {
         // We are on the top frame of the analysis. We do not know where is the
@@ -246,7 +246,7 @@ SVal ExprEngine::computeObjectUnderConstruction(
         QualType ReturnTy = RetE->getType();
         QualType RegionTy = ACtx.getPointerType(ReturnTy);
         return SVB.conjureSymbolVal(&TopLevelSymRegionTag, getCFGElementRef(),
-                                    SFC, RegionTy, getNumVisitedCurrent());
+                                    SF, RegionTy, getNumVisitedCurrent());
       }
       llvm_unreachable("Unhandled return value construction context!");
     }
@@ -431,19 +431,19 @@ ProgramStateRef ExprEngine::updateObjectsUnderConstruction(
     }
     case ConstructionContext::SimpleReturnedValueKind:
     case ConstructionContext::CXX17ElidedCopyReturnedValueKind: {
-      const StackFrame *SFC = LCtx->getStackFrame();
-      const LocationContext *CallerLCtx = SFC->getParent();
+      const StackFrame *SF = LCtx->getStackFrame();
+      const LocationContext *CallerLCtx = SF->getParent();
       if (!CallerLCtx) {
         // No extra work is necessary in top frame.
         return State;
       }
 
-      auto RTC = (*SFC->getCallSiteBlock())[SFC->getIndex()]
+      auto RTC = (*SF->getCallSiteBlock())[SF->getIndex()]
                      .getAs<CFGCXXRecordTypedCall>();
       assert(RTC && "Could not have had a target region without it");
 
       return updateObjectsUnderConstruction(
-          V, SFC->getCallSite(), State, CallerLCtx,
+          V, SF->getCallSite(), State, CallerLCtx,
           RTC->getConstructionContext(), CallOpts);
     }
     case ConstructionContext::ElidedTemporaryObjectKind: {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -461,8 +461,8 @@ void ExprEngine::examineStackFrames(const Decl *D, const LocationContext *LCtx,
   StackDepth = 0;
 
   while (LCtx) {
-    if (const StackFrame *SFC = dyn_cast<StackFrame>(LCtx)) {
-      const Decl *DI = SFC->getDecl();
+    if (const StackFrame *SF = dyn_cast<StackFrame>(LCtx)) {
+      const Decl *DI = SF->getDecl();
 
       // Mark recursive (and mutually recursive) functions and always count
       // them when measuring the stack depth.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -253,13 +253,13 @@ ProgramStateRef ExprEngine::removeStateTraitsUsedForArrayEvaluation(
 /// steps 4-5. happen in the caller context.
 void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
   // Step 1 CEBNode was generated before the call.
-  const StackFrame *CalleeCtx = CEBNode->getStackFrame();
+  const StackFrame *CalleeSF = CEBNode->getStackFrame();
 
   // The parent context might not be a stack frame, so make sure we
   // look up the first enclosing stack frame.
-  const StackFrame *CallerCtx = CalleeCtx->getParent()->getStackFrame();
+  const StackFrame *CallerSF = CalleeSF->getParent()->getStackFrame();
 
-  const Expr *CE = CalleeCtx->getCallSite();
+  const Expr *CE = CalleeSF->getCallSite();
   ProgramStateRef State = CEBNode->getState();
   // Find the last statement in the function and the corresponding basic block.
   auto [LastSt, Blk] = getLastStmt(CEBNode);
@@ -267,12 +267,12 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
   const CFGBlock *PrePurgeBlock =
       isa_and_nonnull<ReturnStmt>(LastSt) ? Blk : &CEBNode->getCFG().getExit();
   // The first half of this process happens in the callee context:
-  setCurrLocationContextAndBlock(CalleeCtx, PrePurgeBlock);
+  setCurrLocationContextAndBlock(CalleeSF, PrePurgeBlock);
 
   // Generate a CallEvent /before/ cleaning the State, so that we can get the
   // correct value for 'this' (if necessary).
   CallEventManager &CEMgr = getStateManager().getCallEventManager();
-  CallEventRef<> Call = CEMgr.getCaller(CalleeCtx, State);
+  CallEventRef<> Call = CEMgr.getCaller(CalleeSF, State);
 
   // Step 2: generate node with bound return value: CEBNode -> BoundRetNode.
 
@@ -285,10 +285,10 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
 
   if (const auto *DtorDecl =
           dyn_cast_or_null<CXXDestructorDecl>(Call->getDecl())) {
-    if (auto Idx = getPendingArrayDestruction(State, CallerCtx)) {
+    if (auto Idx = getPendingArrayDestruction(State, CallerSF)) {
       ShouldRepeatCall = *Idx > 0;
 
-      auto ThisVal = svalBuilder.getCXXThis(DtorDecl->getParent(), CalleeCtx);
+      auto ThisVal = svalBuilder.getCXXThis(DtorDecl->getParent(), CalleeSF);
       State = State->killBinding(ThisVal);
     }
   }
@@ -303,27 +303,27 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
         V = State->getSVal(RS->getRetValue(), LCtx);
 
       // Ensure that the return type matches the type of the returned Expr.
-      if (wasDifferentDeclUsedForInlining(Call, CalleeCtx)) {
+      if (wasDifferentDeclUsedForInlining(Call, CalleeSF)) {
         QualType ReturnedTy =
-            CallEvent::getDeclaredResultType(CalleeCtx->getDecl());
+            CallEvent::getDeclaredResultType(CalleeSF->getDecl());
         if (!ReturnedTy.isNull()) {
           V = adjustReturnValue(V, CE->getType(), ReturnedTy,
                                 getStoreManager());
         }
       }
 
-      State = State->BindExpr(CE, CallerCtx, V);
+      State = State->BindExpr(CE, CallerSF, V);
     }
 
     // Bind the constructed object value to CXXConstructExpr.
     if (const CXXConstructExpr *CCE = dyn_cast<CXXConstructExpr>(CE)) {
       loc::MemRegionVal This =
-          svalBuilder.getCXXThis(CCE->getConstructor()->getParent(), CalleeCtx);
+          svalBuilder.getCXXThis(CCE->getConstructor()->getParent(), CalleeSF);
       SVal ThisV = State->getSVal(This);
       ThisV = State->getSVal(ThisV.castAs<Loc>());
-      State = State->BindExpr(CCE, CallerCtx, ThisV);
+      State = State->BindExpr(CCE, CallerSF, ThisV);
 
-      ShouldRepeatCall = shouldRepeatCtorCall(State, CCE, CallerCtx);
+      ShouldRepeatCall = shouldRepeatCtorCall(State, CCE, CallerSF);
     }
 
     if (const auto *CNE = dyn_cast<CXXNewExpr>(CE)) {
@@ -332,19 +332,19 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
       // region for later use.
       // Additionally cast the return value of the inlined operator new
       // (which is of type 'void *') to the correct object type.
-      SVal AllocV = State->getSVal(CNE, CallerCtx);
+      SVal AllocV = State->getSVal(CNE, CallerSF);
       AllocV = svalBuilder.evalCast(
           AllocV, CNE->getType(),
           getContext().getPointerType(getContext().VoidTy));
 
-      State = addObjectUnderConstruction(State, CNE, CalleeCtx->getParent(),
-                                         AllocV);
+      State =
+          addObjectUnderConstruction(State, CNE, CalleeSF->getParent(), AllocV);
     }
   }
 
   if (!ShouldRepeatCall) {
     State = removeStateTraitsUsedForArrayEvaluation(
-        State, dyn_cast_or_null<CXXConstructExpr>(CE), CallerCtx);
+        State, dyn_cast_or_null<CXXConstructExpr>(CE), CallerSF);
   }
 
   // Step 3: BoundRetNode -> CleanedNodes
@@ -356,8 +356,8 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
   if (LastSt && Blk && AMgr.options.AnalysisPurgeOpt != PurgeNone) {
     static SimpleProgramPointTag RetValBind("ExprEngine", "Bind Return Value");
     auto Loc = isa<ReturnStmt>(LastSt)
-                   ? ProgramPoint{PostStmt(LastSt, CalleeCtx, &RetValBind)}
-                   : ProgramPoint{EpsilonPoint(CalleeCtx, /*Data1=*/nullptr,
+                   ? ProgramPoint{PostStmt(LastSt, CalleeSF, &RetValBind)}
+                   : ProgramPoint{EpsilonPoint(CalleeSF, /*Data1=*/nullptr,
                                                /*Data2=*/nullptr, &RetValBind)};
 
     ExplodedNode *BoundRetNode = Engine.makeNode(Loc, State, CEBNode);
@@ -365,10 +365,9 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
       return;
 
     // We call removeDead in the context of the callee.
-    removeDead(
-        BoundRetNode, CleanedNodes, /*ReferenceStmt=*/nullptr, CalleeCtx,
-        /*DiagnosticStmt=*/CalleeCtx->getAnalysisDeclContext()->getBody(),
-        ProgramPoint::PostStmtPurgeDeadSymbolsKind);
+    removeDead(BoundRetNode, CleanedNodes, /*ReferenceStmt=*/nullptr, CalleeSF,
+               /*DiagnosticStmt=*/CalleeSF->getAnalysisDeclContext()->getBody(),
+               ProgramPoint::PostStmtPurgeDeadSymbolsKind);
   } else {
     CleanedNodes.insert(CEBNode);
   }
@@ -377,13 +376,13 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
   // exception to the general rule that the current LocationContext and Block
   // stay the same within a single call to dispatchWorkItem.
   resetCurrLocationContextAndBlock();
-  setCurrLocationContextAndBlock(CallerCtx, CalleeCtx->getCallSiteBlock());
-  SaveAndRestore CBISave(currStmtIdx, CalleeCtx->getIndex());
+  setCurrLocationContextAndBlock(CallerSF, CalleeSF->getCallSiteBlock());
+  SaveAndRestore CBISave(currStmtIdx, CalleeSF->getIndex());
 
   for (ExplodedNode *N : CleanedNodes) {
     // Step 4: Generate the CallExitEnd node.
     // CleanedNodes -> CEENode
-    CallExitEnd Loc(CalleeCtx, CallerCtx);
+    CallExitEnd Loc(CalleeSF, CallerSF);
     ProgramStateRef CEEState = (N == CEBNode) ? State : N->getState();
 
     ExplodedNode *CEENode = Engine.makeNode(Loc, CEEState, N);
@@ -427,10 +426,9 @@ void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
 
     // Enqueue the next element in the block.
     for (ExplodedNode *DstNode : Dst) {
-      unsigned Idx = CalleeCtx->getIndex() + (ShouldRepeatCall ? 0 : 1);
+      unsigned Idx = CalleeSF->getIndex() + (ShouldRepeatCall ? 0 : 1);
 
-      Engine.getWorkList()->enqueue(DstNode, CalleeCtx->getCallSiteBlock(),
-                                    Idx);
+      Engine.getWorkList()->enqueue(DstNode, CalleeSF->getCallSiteBlock(), Idx);
     }
   }
 }
@@ -533,7 +531,7 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   assert(D);
 
   const LocationContext *CurLC = Pred->getLocationContext();
-  const StackFrame *CallerSFC = CurLC->getStackFrame();
+  const StackFrame *CallerSF = CurLC->getStackFrame();
   const BlockDataRegion *BlockInvocationData = nullptr;
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
@@ -547,15 +545,15 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
 
   // Construct a new stack frame for the callee.
   AnalysisDeclContext *CalleeADC = AMgr.getAnalysisDeclContext(D);
-  const StackFrame *CalleeSFC = CalleeADC->getStackFrame(
-      CallerSFC, BlockInvocationData, CallE, getCurrBlock(),
+  const StackFrame *CalleeSF = CalleeADC->getStackFrame(
+      CallerSF, BlockInvocationData, CallE, getCurrBlock(),
       getNumVisitedCurrent(), currStmtIdx);
 
-  CallEnter Loc(CallE, CalleeSFC, CurLC);
+  CallEnter Loc(CallE, CalleeSF, CurLC);
 
   // Construct a new state which contains the mapping from actual to
   // formal arguments.
-  State = State->enterStackFrame(Call, CalleeSFC);
+  State = State->enterStackFrame(Call, CalleeSF);
 
   bool isNew;
   if (ExplodedNode *N = G.getNode(Loc, State, false, &isNew)) {
@@ -840,7 +838,7 @@ ExprEngine::mayInlineCallKind(const CallEvent &Call, const ExplodedNode *Pred,
                               AnalyzerOptions &Opts,
                               const EvalCallOptions &CallOpts) {
   const LocationContext *CurLC = Pred->getLocationContext();
-  const StackFrame *CallerSFC = CurLC->getStackFrame();
+  const StackFrame *CallerSF = CurLC->getStackFrame();
   switch (Call.getKind()) {
   case CE_Function:
   case CE_CXXStaticOperator:
@@ -873,7 +871,7 @@ ExprEngine::mayInlineCallKind(const CallEvent &Call, const ExplodedNode *Pred,
     }
 
     // Inlining constructors requires including initializers in the CFG.
-    const AnalysisDeclContext *ADC = CallerSFC->getAnalysisDeclContext();
+    const AnalysisDeclContext *ADC = CallerSF->getAnalysisDeclContext();
     assert(ADC->getCFGBuildOptions().AddInitializers && "No CFG initializers");
     (void)ADC;
 
@@ -917,7 +915,7 @@ ExprEngine::mayInlineCallKind(const CallEvent &Call, const ExplodedNode *Pred,
       return CIP_DisallowedAlways;
 
     // Inlining destructors requires building the CFG correctly.
-    const AnalysisDeclContext *ADC = CallerSFC->getAnalysisDeclContext();
+    const AnalysisDeclContext *ADC = CallerSF->getAnalysisDeclContext();
     assert(ADC->getCFGBuildOptions().AddImplicitDtors && "No CFG destructors");
     (void)ADC;
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -78,7 +78,7 @@ static std::pair<const Stmt*,
                  const CFGBlock*> getLastStmt(const ExplodedNode *Node) {
   const Stmt *S = nullptr;
   const CFGBlock *Blk = nullptr;
-  const StackFrameContext *SF = Node->getStackFrame();
+  const StackFrame *SF = Node->getStackFrame();
 
   // Back up through the ExplodedGraph until we reach a statement node in this
   // stack frame.
@@ -185,7 +185,7 @@ void ExprEngine::removeDeadOnEndOfFunction(ExplodedNode *Pred,
 }
 
 static bool wasDifferentDeclUsedForInlining(CallEventRef<> Call,
-    const StackFrameContext *calleeCtx) {
+                                            const StackFrame *calleeCtx) {
   const Decl *RuntimeCallee = calleeCtx->getDecl();
   const Decl *StaticDecl = Call->getDecl();
   assert(RuntimeCallee);
@@ -253,11 +253,11 @@ ProgramStateRef ExprEngine::removeStateTraitsUsedForArrayEvaluation(
 /// steps 4-5. happen in the caller context.
 void ExprEngine::processCallExit(ExplodedNode *CEBNode) {
   // Step 1 CEBNode was generated before the call.
-  const StackFrameContext *CalleeCtx = CEBNode->getStackFrame();
+  const StackFrame *CalleeCtx = CEBNode->getStackFrame();
 
   // The parent context might not be a stack frame, so make sure we
   // look up the first enclosing stack frame.
-  const StackFrameContext *CallerCtx = CalleeCtx->getParent()->getStackFrame();
+  const StackFrame *CallerCtx = CalleeCtx->getParent()->getStackFrame();
 
   const Expr *CE = CalleeCtx->getCallSite();
   ProgramStateRef State = CEBNode->getState();
@@ -461,7 +461,7 @@ void ExprEngine::examineStackFrames(const Decl *D, const LocationContext *LCtx,
   StackDepth = 0;
 
   while (LCtx) {
-    if (const StackFrameContext *SFC = dyn_cast<StackFrameContext>(LCtx)) {
+    if (const StackFrame *SFC = dyn_cast<StackFrame>(LCtx)) {
       const Decl *DI = SFC->getDecl();
 
       // Mark recursive (and mutually recursive) functions and always count
@@ -533,7 +533,7 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
   assert(D);
 
   const LocationContext *CurLC = Pred->getLocationContext();
-  const StackFrameContext *CallerSFC = CurLC->getStackFrame();
+  const StackFrame *CallerSFC = CurLC->getStackFrame();
   const BlockDataRegion *BlockInvocationData = nullptr;
   if (Call.getKind() == CE_Block &&
       !cast<BlockCall>(Call).isConversionFromLambda()) {
@@ -547,7 +547,7 @@ void ExprEngine::inlineCall(WorkList *WList, const CallEvent &Call,
 
   // Construct a new stack frame for the callee.
   AnalysisDeclContext *CalleeADC = AMgr.getAnalysisDeclContext(D);
-  const StackFrameContext *CalleeSFC = CalleeADC->getStackFrame(
+  const StackFrame *CalleeSFC = CalleeADC->getStackFrame(
       CallerSFC, BlockInvocationData, CallE, getCurrBlock(),
       getNumVisitedCurrent(), currStmtIdx);
 
@@ -840,7 +840,7 @@ ExprEngine::mayInlineCallKind(const CallEvent &Call, const ExplodedNode *Pred,
                               AnalyzerOptions &Opts,
                               const EvalCallOptions &CallOpts) {
   const LocationContext *CurLC = Pred->getLocationContext();
-  const StackFrameContext *CallerSFC = CurLC->getStackFrame();
+  const StackFrame *CallerSFC = CurLC->getStackFrame();
   switch (Call.getKind()) {
   case CE_Function:
   case CE_CXXStaticOperator:

--- a/clang/lib/StaticAnalyzer/Core/LoopWidening.cpp
+++ b/clang/lib/StaticAnalyzer/Core/LoopWidening.cpp
@@ -37,10 +37,10 @@ ProgramStateRef getWidenedLoopState(ProgramStateRef PrevState,
   //      being so inprecise. When the invalidation is improved, the handling
   //      of nested loops will also need to be improved.
   ASTContext &ASTCtx = LCtx->getAnalysisDeclContext()->getASTContext();
-  const StackFrame *STC = LCtx->getStackFrame();
+  const StackFrame *SF = LCtx->getStackFrame();
   MemRegionManager &MRMgr = PrevState->getStateManager().getRegionManager();
-  const MemRegion *Regions[] = {MRMgr.getStackLocalsRegion(STC),
-                                MRMgr.getStackArgumentsRegion(STC),
+  const MemRegion *Regions[] = {MRMgr.getStackLocalsRegion(SF),
+                                MRMgr.getStackArgumentsRegion(SF),
                                 MRMgr.getGlobalsRegion()};
   RegionAndSymbolInvalidationTraits ITraits;
   for (auto *Region : Regions) {
@@ -66,10 +66,10 @@ ProgramStateRef getWidenedLoopState(ProgramStateRef PrevState,
   // is located in a method, constructor or destructor, the value of 'this'
   // pointer should remain unchanged.  Ignore static methods, since they do not
   // have 'this' pointers.
-  const CXXMethodDecl *CXXMD = dyn_cast<CXXMethodDecl>(STC->getDecl());
+  const CXXMethodDecl *CXXMD = dyn_cast<CXXMethodDecl>(SF->getDecl());
   if (CXXMD && CXXMD->isImplicitObjectMemberFunction()) {
     const CXXThisRegion *ThisR =
-        MRMgr.getCXXThisRegion(CXXMD->getThisType(), STC);
+        MRMgr.getCXXThisRegion(CXXMD->getThisType(), SF);
     ITraits.setTrait(ThisR,
                      RegionAndSymbolInvalidationTraits::TK_PreserveContents);
   }

--- a/clang/lib/StaticAnalyzer/Core/LoopWidening.cpp
+++ b/clang/lib/StaticAnalyzer/Core/LoopWidening.cpp
@@ -37,7 +37,7 @@ ProgramStateRef getWidenedLoopState(ProgramStateRef PrevState,
   //      being so inprecise. When the invalidation is improved, the handling
   //      of nested loops will also need to be improved.
   ASTContext &ASTCtx = LCtx->getAnalysisDeclContext()->getASTContext();
-  const StackFrameContext *STC = LCtx->getStackFrame();
+  const StackFrame *STC = LCtx->getStackFrame();
   MemRegionManager &MRMgr = PrevState->getStateManager().getRegionManager();
   const MemRegion *Regions[] = {MRMgr.getStackLocalsRegion(STC),
                                 MRMgr.getStackArgumentsRegion(STC),

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1000,12 +1000,12 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
                                       const DeclContext *DC,
                                       const VarDecl *VD) {
   while (LC) {
-    if (const auto *SFC = dyn_cast<StackFrame>(LC)) {
-      if (cast<DeclContext>(SFC->getDecl()) == DC)
-        return SFC;
-      if (SFC->getData()) {
+    if (const auto *SF = dyn_cast<StackFrame>(LC)) {
+      if (cast<DeclContext>(SF->getDecl()) == DC)
+        return SF;
+      if (SF->getData()) {
         // FIXME: This can be made more efficient.
-        for (auto Var : static_cast<const BlockDataRegion *>(SFC->getData())
+        for (auto Var : static_cast<const BlockDataRegion *>(SF->getData())
                             ->referenced_vars()) {
           const TypedValueRegion *OrigR = Var.getOriginalRegion();
           if (const auto *VR = dyn_cast<VarRegion>(OrigR)) {
@@ -1042,10 +1042,10 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
   const auto *PVD = dyn_cast<ParmVarDecl>(D);
   if (PVD) {
     unsigned Index = PVD->getFunctionScopeIndex();
-    const StackFrame *SFC = LC->getStackFrame();
-    const Expr *CallSite = SFC->getCallSite();
+    const StackFrame *SF = LC->getStackFrame();
+    const Expr *CallSite = SF->getCallSite();
     if (CallSite) {
-      const Decl *CalleeDecl = SFC->getDecl();
+      const Decl *CalleeDecl = SF->getDecl();
       bool CurrentParam = true;
       if (const auto *FD = dyn_cast<FunctionDecl>(CalleeDecl)) {
         CurrentParam =
@@ -1059,7 +1059,7 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
         // If this is a parameter of the *current* stack frame, we can
         // represent it with a `ParamVarRegion`.
         return getSubRegion<ParamVarRegion>(CallSite, Index,
-                                            getStackArgumentsRegion(SFC));
+                                            getStackArgumentsRegion(SF));
       } else {
         // TODO: Parameters of other stack frames (which may have been be
         // captured by a lambda or a block) are currently represented by
@@ -1175,10 +1175,10 @@ MemRegionManager::getNonParamVarRegion(const VarDecl *D,
 const ParamVarRegion *
 MemRegionManager::getParamVarRegion(const Expr *OriginExpr, unsigned Index,
                                     const LocationContext *LC) {
-  const StackFrame *SFC = LC->getStackFrame();
-  assert(SFC);
+  const StackFrame *SF = LC->getStackFrame();
+  assert(SF);
   return getSubRegion<ParamVarRegion>(OriginExpr, Index,
-                                      getStackArgumentsRegion(SFC));
+                                      getStackArgumentsRegion(SF));
 }
 
 const BlockDataRegion *
@@ -1299,18 +1299,18 @@ MemRegionManager::getObjCIvarRegion(const ObjCIvarDecl *d,
 const CXXTempObjectRegion*
 MemRegionManager::getCXXTempObjectRegion(Expr const *E,
                                          LocationContext const *LC) {
-  const StackFrame *SFC = LC->getStackFrame();
-  assert(SFC);
-  return getSubRegion<CXXTempObjectRegion>(E, getStackLocalsRegion(SFC));
+  const StackFrame *SF = LC->getStackFrame();
+  assert(SF);
+  return getSubRegion<CXXTempObjectRegion>(E, getStackLocalsRegion(SF));
 }
 
 const CXXLifetimeExtendedObjectRegion *
 MemRegionManager::getCXXLifetimeExtendedObjectRegion(
     const Expr *Ex, const ValueDecl *VD, const LocationContext *LC) {
-  const StackFrame *SFC = LC->getStackFrame();
-  assert(SFC);
+  const StackFrame *SF = LC->getStackFrame();
+  assert(SF);
   return getSubRegion<CXXLifetimeExtendedObjectRegion>(
-      Ex, VD, getStackLocalsRegion(SFC));
+      Ex, VD, getStackLocalsRegion(SF));
 }
 
 const CXXLifetimeExtendedObjectRegion *

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -163,18 +163,17 @@ MemRegionManager &SubRegion::getMemRegionManager() const {
   } while (true);
 }
 
-const StackFrameContext *VarRegion::getStackFrame() const {
+const StackFrame *VarRegion::getStackFrame() const {
   const auto *SSR = dyn_cast<StackSpaceRegion>(getRawMemorySpace());
   return SSR ? SSR->getStackFrame() : nullptr;
 }
 
-const StackFrameContext *
-CXXLifetimeExtendedObjectRegion::getStackFrame() const {
+const StackFrame *CXXLifetimeExtendedObjectRegion::getStackFrame() const {
   const auto *SSR = dyn_cast<StackSpaceRegion>(getRawMemorySpace());
   return SSR ? SSR->getStackFrame() : nullptr;
 }
 
-const StackFrameContext *CXXTempObjectRegion::getStackFrame() const {
+const StackFrame *CXXTempObjectRegion::getStackFrame() const {
   assert(isa<StackSpaceRegion>(getRawMemorySpace()) &&
          "A temporary object can only be allocated on the stack");
   return cast<StackSpaceRegion>(getRawMemorySpace())->getStackFrame();
@@ -921,8 +920,8 @@ const REG *MemRegionManager::LazyAllocate(REG*& region, ARG a) {
   return region;
 }
 
-const StackLocalsSpaceRegion*
-MemRegionManager::getStackLocalsRegion(const StackFrameContext *STC) {
+const StackLocalsSpaceRegion *
+MemRegionManager::getStackLocalsRegion(const StackFrame *STC) {
   assert(STC);
   StackLocalsSpaceRegion *&R = StackLocalsSpaceRegions[STC];
 
@@ -934,7 +933,7 @@ MemRegionManager::getStackLocalsRegion(const StackFrameContext *STC) {
 }
 
 const StackArgumentsSpaceRegion *
-MemRegionManager::getStackArgumentsRegion(const StackFrameContext *STC) {
+MemRegionManager::getStackArgumentsRegion(const StackFrame *STC) {
   assert(STC);
   StackArgumentsSpaceRegion *&R = StackArgumentsSpaceRegions[STC];
 
@@ -994,14 +993,14 @@ MemRegionManager::getObjCStringRegion(const ObjCStringLiteral *Str){
 }
 
 /// Look through a chain of LocationContexts to either find the
-/// StackFrameContext that matches a DeclContext, or find a VarRegion
+/// StackFrame that matches a DeclContext, or find a VarRegion
 /// for a variable captured by a block.
-static llvm::PointerUnion<const StackFrameContext *, const VarRegion *>
+static llvm::PointerUnion<const StackFrame *, const VarRegion *>
 getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
                                       const DeclContext *DC,
                                       const VarDecl *VD) {
   while (LC) {
-    if (const auto *SFC = dyn_cast<StackFrameContext>(LC)) {
+    if (const auto *SFC = dyn_cast<StackFrame>(LC)) {
       if (cast<DeclContext>(SFC->getDecl()) == DC)
         return SFC;
       if (SFC->getData()) {
@@ -1019,7 +1018,7 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
 
     LC = LC->getParent();
   }
-  return (const StackFrameContext *)nullptr;
+  return (const StackFrame *)nullptr;
 }
 
 static bool isStdStreamVar(const VarDecl *D) {
@@ -1043,7 +1042,7 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
   const auto *PVD = dyn_cast<ParmVarDecl>(D);
   if (PVD) {
     unsigned Index = PVD->getFunctionScopeIndex();
-    const StackFrameContext *SFC = LC->getStackFrame();
+    const StackFrame *SFC = LC->getStackFrame();
     const Expr *CallSite = SFC->getCallSite();
     if (CallSite) {
       const Decl *CalleeDecl = SFC->getDecl();
@@ -1106,13 +1105,13 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
     // FIXME: Once we implement scope handling, we will need to properly lookup
     // 'D' to the proper LocationContext.
     const DeclContext *DC = D->getDeclContext();
-    llvm::PointerUnion<const StackFrameContext *, const VarRegion *> V =
-      getStackOrCaptureRegionForDeclContext(LC, DC, D);
+    llvm::PointerUnion<const StackFrame *, const VarRegion *> V =
+        getStackOrCaptureRegionForDeclContext(LC, DC, D);
 
     if (const auto *VR = dyn_cast_if_present<const VarRegion *>(V))
       return VR;
 
-    const auto *STC = cast<const StackFrameContext *>(V);
+    const auto *STC = cast<const StackFrame *>(V);
 
     if (!STC) {
       // FIXME: Assign a more sensible memory space to static locals
@@ -1176,7 +1175,7 @@ MemRegionManager::getNonParamVarRegion(const VarDecl *D,
 const ParamVarRegion *
 MemRegionManager::getParamVarRegion(const Expr *OriginExpr, unsigned Index,
                                     const LocationContext *LC) {
-  const StackFrameContext *SFC = LC->getStackFrame();
+  const StackFrame *SFC = LC->getStackFrame();
   assert(SFC);
   return getSubRegion<ParamVarRegion>(OriginExpr, Index,
                                       getStackArgumentsRegion(SFC));
@@ -1201,7 +1200,7 @@ MemRegionManager::getBlockDataRegion(const BlockCodeRegion *BC,
     if (!IsArcManagedBlock && LC) {
       // FIXME: Once we implement scope handling, we want the parent region
       // to be the scope.
-      const StackFrameContext *STC = LC->getStackFrame();
+      const StackFrame *STC = LC->getStackFrame();
       assert(STC);
       sReg = getStackLocalsRegion(STC);
     } else {
@@ -1222,7 +1221,7 @@ MemRegionManager::getCompoundLiteralRegion(const CompoundLiteralExpr *CL,
   if (CL->isFileScope())
     sReg = getGlobalsRegion();
   else {
-    const StackFrameContext *STC = LC->getStackFrame();
+    const StackFrame *STC = LC->getStackFrame();
     assert(STC);
     sReg = getStackLocalsRegion(STC);
   }
@@ -1300,7 +1299,7 @@ MemRegionManager::getObjCIvarRegion(const ObjCIvarDecl *d,
 const CXXTempObjectRegion*
 MemRegionManager::getCXXTempObjectRegion(Expr const *E,
                                          LocationContext const *LC) {
-  const StackFrameContext *SFC = LC->getStackFrame();
+  const StackFrame *SFC = LC->getStackFrame();
   assert(SFC);
   return getSubRegion<CXXTempObjectRegion>(E, getStackLocalsRegion(SFC));
 }
@@ -1308,7 +1307,7 @@ MemRegionManager::getCXXTempObjectRegion(Expr const *E,
 const CXXLifetimeExtendedObjectRegion *
 MemRegionManager::getCXXLifetimeExtendedObjectRegion(
     const Expr *Ex, const ValueDecl *VD, const LocationContext *LC) {
-  const StackFrameContext *SFC = LC->getStackFrame();
+  const StackFrame *SFC = LC->getStackFrame();
   assert(SFC);
   return getSubRegion<CXXLifetimeExtendedObjectRegion>(
       Ex, VD, getStackLocalsRegion(SFC));
@@ -1386,7 +1385,7 @@ MemRegionManager::getCXXThisRegion(QualType thisPointerTy,
     LC = LC->getParent();
     D = dyn_cast<CXXMethodDecl>(LC->getDecl());
   }
-  const StackFrameContext *STC = LC->getStackFrame();
+  const StackFrame *STC = LC->getStackFrame();
   assert(STC);
   return getSubRegion<CXXThisRegion>(PT, getStackArgumentsRegion(STC));
 }
@@ -1394,7 +1393,7 @@ MemRegionManager::getCXXThisRegion(QualType thisPointerTy,
 const AllocaRegion*
 MemRegionManager::getAllocaRegion(const Expr *E, unsigned cnt,
                                   const LocationContext *LC) {
-  const StackFrameContext *STC = LC->getStackFrame();
+  const StackFrame *STC = LC->getStackFrame();
   assert(STC);
   return getSubRegion<AllocaRegion>(E, cnt, getStackLocalsRegion(STC));
 }

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -921,26 +921,26 @@ const REG *MemRegionManager::LazyAllocate(REG*& region, ARG a) {
 }
 
 const StackLocalsSpaceRegion *
-MemRegionManager::getStackLocalsRegion(const StackFrame *STC) {
-  assert(STC);
-  StackLocalsSpaceRegion *&R = StackLocalsSpaceRegions[STC];
+MemRegionManager::getStackLocalsRegion(const StackFrame *SF) {
+  assert(SF);
+  StackLocalsSpaceRegion *&R = StackLocalsSpaceRegions[SF];
 
   if (R)
     return R;
 
-  R = new (A) StackLocalsSpaceRegion(*this, STC);
+  R = new (A) StackLocalsSpaceRegion(*this, SF);
   return R;
 }
 
 const StackArgumentsSpaceRegion *
-MemRegionManager::getStackArgumentsRegion(const StackFrame *STC) {
-  assert(STC);
-  StackArgumentsSpaceRegion *&R = StackArgumentsSpaceRegions[STC];
+MemRegionManager::getStackArgumentsRegion(const StackFrame *SF) {
+  assert(SF);
+  StackArgumentsSpaceRegion *&R = StackArgumentsSpaceRegions[SF];
 
   if (R)
     return R;
 
-  R = new (A) StackArgumentsSpaceRegion(*this, STC);
+  R = new (A) StackArgumentsSpaceRegion(*this, SF);
   return R;
 }
 
@@ -1111,22 +1111,21 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
     if (const auto *VR = dyn_cast_if_present<const VarRegion *>(V))
       return VR;
 
-    const auto *STC = cast<const StackFrame *>(V);
+    const auto *SF = cast<const StackFrame *>(V);
 
-    if (!STC) {
+    if (!SF) {
       // FIXME: Assign a more sensible memory space to static locals
       // we see from within blocks that we analyze as top-level declarations.
       sReg = getUnknownRegion();
     } else {
       if (D->hasLocalStorage()) {
-        sReg =
-            isa<ParmVarDecl, ImplicitParamDecl>(D)
-                ? static_cast<const MemRegion *>(getStackArgumentsRegion(STC))
-                : static_cast<const MemRegion *>(getStackLocalsRegion(STC));
+        sReg = isa<ParmVarDecl, ImplicitParamDecl>(D)
+                   ? static_cast<const MemRegion *>(getStackArgumentsRegion(SF))
+                   : static_cast<const MemRegion *>(getStackLocalsRegion(SF));
       }
       else {
         assert(D->isStaticLocal());
-        const Decl *STCD = STC->getDecl();
+        const Decl *STCD = SF->getDecl();
         if (isa<FunctionDecl, ObjCMethodDecl>(STCD))
           sReg = getGlobalsRegion(MemRegion::StaticGlobalSpaceRegionKind,
                                   getFunctionCodeRegion(cast<NamedDecl>(STCD)));
@@ -1146,9 +1145,8 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
           }
           T = getContext().getBlockPointerType(T);
 
-          const BlockCodeRegion *BTR =
-            getBlockCodeRegion(BD, Ctx.getCanonicalType(T),
-                               STC->getAnalysisDeclContext());
+          const BlockCodeRegion *BTR = getBlockCodeRegion(
+              BD, Ctx.getCanonicalType(T), SF->getAnalysisDeclContext());
           sReg = getGlobalsRegion(MemRegion::StaticGlobalSpaceRegionKind,
                                   BTR);
         }
@@ -1200,9 +1198,9 @@ MemRegionManager::getBlockDataRegion(const BlockCodeRegion *BC,
     if (!IsArcManagedBlock && LC) {
       // FIXME: Once we implement scope handling, we want the parent region
       // to be the scope.
-      const StackFrame *STC = LC->getStackFrame();
-      assert(STC);
-      sReg = getStackLocalsRegion(STC);
+      const StackFrame *SF = LC->getStackFrame();
+      assert(SF);
+      sReg = getStackLocalsRegion(SF);
     } else {
       // We allow 'LC' to be NULL for cases where want BlockDataRegions
       // without context-sensitivity.
@@ -1221,9 +1219,9 @@ MemRegionManager::getCompoundLiteralRegion(const CompoundLiteralExpr *CL,
   if (CL->isFileScope())
     sReg = getGlobalsRegion();
   else {
-    const StackFrame *STC = LC->getStackFrame();
-    assert(STC);
-    sReg = getStackLocalsRegion(STC);
+    const StackFrame *SF = LC->getStackFrame();
+    assert(SF);
+    sReg = getStackLocalsRegion(SF);
   }
 
   return getSubRegion<CompoundLiteralRegion>(CL, sReg);
@@ -1385,17 +1383,17 @@ MemRegionManager::getCXXThisRegion(QualType thisPointerTy,
     LC = LC->getParent();
     D = dyn_cast<CXXMethodDecl>(LC->getDecl());
   }
-  const StackFrame *STC = LC->getStackFrame();
-  assert(STC);
-  return getSubRegion<CXXThisRegion>(PT, getStackArgumentsRegion(STC));
+  const StackFrame *SF = LC->getStackFrame();
+  assert(SF);
+  return getSubRegion<CXXThisRegion>(PT, getStackArgumentsRegion(SF));
 }
 
 const AllocaRegion*
 MemRegionManager::getAllocaRegion(const Expr *E, unsigned cnt,
                                   const LocationContext *LC) {
-  const StackFrame *STC = LC->getStackFrame();
-  assert(STC);
-  return getSubRegion<AllocaRegion>(E, cnt, getStackLocalsRegion(STC));
+  const StackFrame *SF = LC->getStackFrame();
+  assert(SF);
+  return getSubRegion<AllocaRegion>(E, cnt, getStackLocalsRegion(SF));
 }
 
 const MemSpaceRegion *MemRegion::getRawMemorySpace() const {

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -88,7 +88,7 @@ ProgramStateManager::~ProgramStateManager() {
 }
 
 ProgramStateRef ProgramStateManager::removeDeadBindingsFromEnvironmentAndStore(
-    ProgramStateRef state, const StackFrame *LCtx, SymbolReaper &SymReaper) {
+    ProgramStateRef state, const StackFrame *SF, SymbolReaper &SymReaper) {
 
   // This code essentially performs a "mark-and-sweep" of the VariableBindings.
   // The roots are any Block-level exprs and Decls that our liveness algorithm
@@ -101,8 +101,8 @@ ProgramStateRef ProgramStateManager::removeDeadBindingsFromEnvironmentAndStore(
   NewState.Env = EnvMgr.removeDeadBindings(NewState.Env, SymReaper, state);
 
   // Clean up the store.
-  StoreRef newStore = StoreMgr->removeDeadBindings(NewState.getStore(), LCtx,
-                                                   SymReaper);
+  StoreRef newStore =
+      StoreMgr->removeDeadBindings(NewState.getStore(), SF, SymReaper);
   NewState.setStore(newStore);
   SymReaper.setReapedStore(newStore);
 

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -88,8 +88,7 @@ ProgramStateManager::~ProgramStateManager() {
 }
 
 ProgramStateRef ProgramStateManager::removeDeadBindingsFromEnvironmentAndStore(
-    ProgramStateRef state, const StackFrameContext *LCtx,
-    SymbolReaper &SymReaper) {
+    ProgramStateRef state, const StackFrame *LCtx, SymbolReaper &SymReaper) {
 
   // This code essentially performs a "mark-and-sweep" of the VariableBindings.
   // The roots are any Block-level exprs and Decls that our liveness algorithm
@@ -231,7 +230,7 @@ SVal ProgramState::wrapSymbolicRegion(SVal Val) const {
 
 ProgramStateRef
 ProgramState::enterStackFrame(const CallEvent &Call,
-                              const StackFrameContext *CalleeCtx) const {
+                              const StackFrame *CalleeCtx) const {
   return makeWithStore(
       getStateManager().StoreMgr->enterStackFrame(getStore(), Call, CalleeCtx));
 }

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -786,7 +786,7 @@ public: // Part of public interface to class.
 
   /// removeDeadBindings - Scans the RegionStore of 'state' for dead values.
   ///  It returns a new Store with these values removed.
-  StoreRef removeDeadBindings(Store store, const StackFrame *LCtx,
+  StoreRef removeDeadBindings(Store store, const StackFrame *SF,
                               SymbolReaper &SymReaper) override;
 
   //===------------------------------------------------------------------===//
@@ -2949,14 +2949,14 @@ class RemoveDeadBindingsWorker
     : public ClusterAnalysis<RemoveDeadBindingsWorker> {
   SmallVector<const SymbolicRegion *, 12> Postponed;
   SymbolReaper &SymReaper;
-  const StackFrame *CurrentLCtx;
+  const StackFrame *CurrentSF;
 
 public:
   RemoveDeadBindingsWorker(RegionStoreManager &rm,
                            ProgramStateManager &stateMgr, RegionBindingsRef b,
-                           SymbolReaper &symReaper, const StackFrame *LCtx)
+                           SymbolReaper &symReaper, const StackFrame *SF)
       : ClusterAnalysis<RemoveDeadBindingsWorker>(rm, stateMgr, b),
-        SymReaper(symReaper), CurrentLCtx(LCtx) {}
+        SymReaper(symReaper), CurrentSF(SF) {}
 
   // Called by ClusterAnalysis.
   void VisitAddedToCluster(const MemRegion *baseR, const ClusterBindings &C);
@@ -3005,9 +3005,8 @@ void RemoveDeadBindingsWorker::VisitAddedToCluster(const MemRegion *baseR,
   if (const CXXThisRegion *TR = dyn_cast<CXXThisRegion>(baseR)) {
     const auto *StackReg =
         cast<StackArgumentsSpaceRegion>(TR->getSuperRegion());
-    const StackFrame *RegCtx = StackReg->getStackFrame();
-    if (CurrentLCtx &&
-        (RegCtx == CurrentLCtx || RegCtx->isParentOf(CurrentLCtx)))
+    const StackFrame *RegSF = StackReg->getStackFrame();
+    if (CurrentSF && (RegSF == CurrentSF || RegSF->isParentOf(CurrentSF)))
       AddToWorkList(TR, &C);
   }
 }
@@ -3080,10 +3079,10 @@ bool RemoveDeadBindingsWorker::UpdatePostponed() {
 }
 
 StoreRef RegionStoreManager::removeDeadBindings(Store store,
-                                                const StackFrame *LCtx,
+                                                const StackFrame *SF,
                                                 SymbolReaper &SymReaper) {
   RegionBindingsRef B = getRegionBindings(store);
-  RemoveDeadBindingsWorker W(*this, StateMgr, B, SymReaper, LCtx);
+  RemoveDeadBindingsWorker W(*this, StateMgr, B, SymReaper, SF);
   W.GenerateClusters();
 
   // Enqueue the region roots onto the worklist.

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -786,8 +786,8 @@ public: // Part of public interface to class.
 
   /// removeDeadBindings - Scans the RegionStore of 'state' for dead values.
   ///  It returns a new Store with these values removed.
-  StoreRef removeDeadBindings(Store store, const StackFrameContext *LCtx,
-                              SymbolReaper& SymReaper) override;
+  StoreRef removeDeadBindings(Store store, const StackFrame *LCtx,
+                              SymbolReaper &SymReaper) override;
 
   //===------------------------------------------------------------------===//
   // Utility methods.
@@ -2949,15 +2949,14 @@ class RemoveDeadBindingsWorker
     : public ClusterAnalysis<RemoveDeadBindingsWorker> {
   SmallVector<const SymbolicRegion *, 12> Postponed;
   SymbolReaper &SymReaper;
-  const StackFrameContext *CurrentLCtx;
+  const StackFrame *CurrentLCtx;
 
 public:
   RemoveDeadBindingsWorker(RegionStoreManager &rm,
-                           ProgramStateManager &stateMgr,
-                           RegionBindingsRef b, SymbolReaper &symReaper,
-                           const StackFrameContext *LCtx)
-    : ClusterAnalysis<RemoveDeadBindingsWorker>(rm, stateMgr, b),
-      SymReaper(symReaper), CurrentLCtx(LCtx) {}
+                           ProgramStateManager &stateMgr, RegionBindingsRef b,
+                           SymbolReaper &symReaper, const StackFrame *LCtx)
+      : ClusterAnalysis<RemoveDeadBindingsWorker>(rm, stateMgr, b),
+        SymReaper(symReaper), CurrentLCtx(LCtx) {}
 
   // Called by ClusterAnalysis.
   void VisitAddedToCluster(const MemRegion *baseR, const ClusterBindings &C);
@@ -3006,7 +3005,7 @@ void RemoveDeadBindingsWorker::VisitAddedToCluster(const MemRegion *baseR,
   if (const CXXThisRegion *TR = dyn_cast<CXXThisRegion>(baseR)) {
     const auto *StackReg =
         cast<StackArgumentsSpaceRegion>(TR->getSuperRegion());
-    const StackFrameContext *RegCtx = StackReg->getStackFrame();
+    const StackFrame *RegCtx = StackReg->getStackFrame();
     if (CurrentLCtx &&
         (RegCtx == CurrentLCtx || RegCtx->isParentOf(CurrentLCtx)))
       AddToWorkList(TR, &C);
@@ -3081,8 +3080,8 @@ bool RemoveDeadBindingsWorker::UpdatePostponed() {
 }
 
 StoreRef RegionStoreManager::removeDeadBindings(Store store,
-                                                const StackFrameContext *LCtx,
-                                                SymbolReaper& SymReaper) {
+                                                const StackFrame *LCtx,
+                                                SymbolReaper &SymReaper) {
   RegionBindingsRef B = getRegionBindings(store);
   RemoveDeadBindingsWorker W(*this, StateMgr, B, SymReaper, LCtx);
   W.GenerateClusters();

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -312,14 +312,14 @@ SValBuilder::getCastedMemRegionVal(const MemRegion *R, QualType Ty) {
 
 /// Return a memory region for the 'this' object reference.
 loc::MemRegionVal SValBuilder::getCXXThis(const CXXMethodDecl *D,
-                                          const StackFrameContext *SFC) {
+                                          const StackFrame *SFC) {
   return loc::MemRegionVal(
       getRegionManager().getCXXThisRegion(D->getThisType(), SFC));
 }
 
 /// Return a memory region for the 'this' object reference.
 loc::MemRegionVal SValBuilder::getCXXThis(const CXXRecordDecl *D,
-                                          const StackFrameContext *SFC) {
+                                          const StackFrame *SFC) {
   CanQualType PT =
       getContext().getPointerType(getContext().getCanonicalTagType(D));
   return loc::MemRegionVal(getRegionManager().getCXXThisRegion(PT, SFC));

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -312,17 +312,17 @@ SValBuilder::getCastedMemRegionVal(const MemRegion *R, QualType Ty) {
 
 /// Return a memory region for the 'this' object reference.
 loc::MemRegionVal SValBuilder::getCXXThis(const CXXMethodDecl *D,
-                                          const StackFrame *SFC) {
+                                          const StackFrame *SF) {
   return loc::MemRegionVal(
-      getRegionManager().getCXXThisRegion(D->getThisType(), SFC));
+      getRegionManager().getCXXThisRegion(D->getThisType(), SF));
 }
 
 /// Return a memory region for the 'this' object reference.
 loc::MemRegionVal SValBuilder::getCXXThis(const CXXRecordDecl *D,
-                                          const StackFrame *SFC) {
+                                          const StackFrame *SF) {
   CanQualType PT =
       getContext().getPointerType(getContext().getCanonicalTagType(D));
-  return loc::MemRegionVal(getRegionManager().getCXXThisRegion(PT, SFC));
+  return loc::MemRegionVal(getRegionManager().getCXXThisRegion(PT, SF));
 }
 
 std::optional<SVal> SValBuilder::getConstantVal(const Expr *E) {

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -43,11 +43,11 @@ StoreManager::StoreManager(ProgramStateManager &stateMgr)
       MRMgr(svalBuilder.getRegionManager()), Ctx(stateMgr.getContext()) {}
 
 BindResult StoreManager::enterStackFrame(Store OldStore, const CallEvent &Call,
-                                         const StackFrame *LCtx) {
+                                         const StackFrame *SF) {
   BindResult Result{StoreRef(OldStore, *this), {}};
 
   SmallVector<CallEvent::FrameBindingTy, 16> InitialBindings;
-  Call.getInitialStackFrameContents(LCtx, InitialBindings);
+  Call.getInitialStackFrameContents(SF, InitialBindings);
 
   for (const auto &[Location, Val] : InitialBindings) {
     Store S = Result.ResultingStore.getStore();

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -43,7 +43,7 @@ StoreManager::StoreManager(ProgramStateManager &stateMgr)
       MRMgr(svalBuilder.getRegionManager()), Ctx(stateMgr.getContext()) {}
 
 BindResult StoreManager::enterStackFrame(Store OldStore, const CallEvent &Call,
-                                         const StackFrameContext *LCtx) {
+                                         const StackFrame *LCtx) {
   BindResult Result{StoreRef(OldStore, *this), {}};
 
   SmallVector<CallEvent::FrameBindingTy, 16> InitialBindings;

--- a/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
@@ -388,13 +388,13 @@ bool SymbolReaper::isLive(SymbolRef sym) {
 
 bool
 SymbolReaper::isLive(const Expr *ExprVal, const LocationContext *ELCtx) const {
-  if (LCtx == nullptr)
+  if (SF == nullptr)
     return false;
 
-  if (LCtx != ELCtx) {
+  if (SF != ELCtx) {
     // If the reaper's location context is a parent of the expression's
     // location context, then the expression value is now "out of scope".
-    if (LCtx->isParentOf(ELCtx))
+    if (SF->isParentOf(ELCtx))
       return false;
     return true;
   }
@@ -404,20 +404,20 @@ SymbolReaper::isLive(const Expr *ExprVal, const LocationContext *ELCtx) const {
   if (!Loc)
     return true;
 
-  return LCtx->getAnalysis<RelaxedLiveVariables>()->isLive(Loc, ExprVal);
+  return SF->getAnalysis<RelaxedLiveVariables>()->isLive(Loc, ExprVal);
 }
 
 bool SymbolReaper::isLive(const VarRegion *VR, bool includeStoreBindings) const{
-  const StackFrame *VarContext = VR->getStackFrame();
+  const StackFrame *VarSF = VR->getStackFrame();
 
-  if (!VarContext)
+  if (!VarSF)
     return true;
 
-  if (!LCtx)
+  if (!SF)
     return false;
-  const StackFrame *CurrentContext = LCtx->getStackFrame();
+  const StackFrame *CurrentSF = SF->getStackFrame();
 
-  if (VarContext == CurrentContext) {
+  if (VarSF == CurrentSF) {
     // If no statement is provided, everything is live.
     if (!Loc)
       return true;
@@ -427,7 +427,7 @@ bool SymbolReaper::isLive(const VarRegion *VR, bool includeStoreBindings) const{
     if (isa<CXXInheritedCtorInitExpr>(Loc))
       return true;
 
-    if (LCtx->getAnalysis<RelaxedLiveVariables>()->isLive(Loc, VR->getDecl()))
+    if (SF->getAnalysis<RelaxedLiveVariables>()->isLive(Loc, VR->getDecl()))
       return true;
 
     if (!includeStoreBindings)
@@ -451,5 +451,5 @@ bool SymbolReaper::isLive(const VarRegion *VR, bool includeStoreBindings) const{
     return false;
   }
 
-  return VarContext->isParentOf(CurrentContext);
+  return VarSF->isParentOf(CurrentSF);
 }

--- a/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SymbolManager.cpp
@@ -408,14 +408,14 @@ SymbolReaper::isLive(const Expr *ExprVal, const LocationContext *ELCtx) const {
 }
 
 bool SymbolReaper::isLive(const VarRegion *VR, bool includeStoreBindings) const{
-  const StackFrameContext *VarContext = VR->getStackFrame();
+  const StackFrame *VarContext = VR->getStackFrame();
 
   if (!VarContext)
     return true;
 
   if (!LCtx)
     return false;
-  const StackFrameContext *CurrentContext = LCtx->getStackFrame();
+  const StackFrame *CurrentContext = LCtx->getStackFrame();
 
   if (VarContext == CurrentContext) {
     // If no statement is provided, everything is live.

--- a/clang/lib/StaticAnalyzer/Core/WorkList.cpp
+++ b/clang/lib/StaticAnalyzer/Core/WorkList.cpp
@@ -137,7 +137,7 @@ class UnexploredFirstStack : public WorkList {
   SmallVector<WorkListUnit, 20> StackOthers;
 
   using BlockID = unsigned;
-  using LocIdentifier = std::pair<BlockID, const StackFrameContext *>;
+  using LocIdentifier = std::pair<BlockID, const StackFrame *>;
 
   llvm::DenseSet<LocIdentifier> Reachable;
 
@@ -192,7 +192,7 @@ std::unique_ptr<WorkList> WorkList::makeUnexploredFirst() {
 namespace {
 class UnexploredFirstPriorityQueue : public WorkList {
   using BlockID = unsigned;
-  using LocIdentifier = std::pair<BlockID, const StackFrameContext *>;
+  using LocIdentifier = std::pair<BlockID, const StackFrame *>;
 
   // How many times each location was visited.
   // Is signed because we negate it later in order to have a reversed

--- a/clang/test/Analysis/stack-frame-context-revision.cpp
+++ b/clang/test/Analysis/stack-frame-context-revision.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_analyze_cc1 -std=c++14 -analyzer-checker=core,cplusplus.NewDelete -verify %s
 
 // expected-no-diagnostics:
-// From now the profile of the 'StackFrameContext' also contains the
+// From now the profile of the 'StackFrame' also contains the
 // 'NodeBuilderContext::blockCount()'. With this addition we can distinguish
 // between the 'StackArgumentsSpaceRegion' of the 'P' arguments being different
 // on every iteration.

--- a/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
@@ -64,9 +64,8 @@ class CallDescriptionConsumer : public ExprEngineConsumer {
     if (!D->hasBody())
       return;
 
-    const StackFrame *SFC =
-        Eng.getAnalysisDeclContextManager().getStackFrame(D);
-    const ProgramStateRef State = Eng.getInitialState(SFC);
+    const StackFrame *SF = Eng.getAnalysisDeclContextManager().getStackFrame(D);
+    const ProgramStateRef State = Eng.getInitialState(SF);
 
     // FIXME: Maybe use std::variant and std::visit for these.
     const auto MatcherCreator = []() {
@@ -85,13 +84,13 @@ class CallDescriptionConsumer : public ExprEngineConsumer {
 
     CallEventManager &CEMgr = Eng.getStateManager().getCallEventManager();
     CallEventRef<> Call = [=, &CEMgr]() -> CallEventRef<CallEvent> {
-      CFGBlock::ConstCFGElementRef ElemRef = {SFC->getCallSiteBlock(),
-                                              SFC->getIndex()};
+      CFGBlock::ConstCFGElementRef ElemRef = {SF->getCallSiteBlock(),
+                                              SF->getIndex()};
       if (std::is_base_of<CallExpr, T>::value)
-        return CEMgr.getCall(E, State, SFC, ElemRef);
+        return CEMgr.getCall(E, State, SF, ElemRef);
       if (std::is_same<T, CXXConstructExpr>::value)
         return CEMgr.getCXXConstructorCall(cast<CXXConstructExpr>(E),
-                                           /*Target=*/nullptr, State, SFC,
+                                           /*Target=*/nullptr, State, SF,
                                            ElemRef);
       llvm_unreachable("Only these expressions are supported for now.");
     }();

--- a/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallDescriptionTest.cpp
@@ -64,7 +64,7 @@ class CallDescriptionConsumer : public ExprEngineConsumer {
     if (!D->hasBody())
       return;
 
-    const StackFrameContext *SFC =
+    const StackFrame *SFC =
         Eng.getAnalysisDeclContextManager().getStackFrame(D);
     const ProgramStateRef State = Eng.getInitialState(SFC);
 

--- a/clang/unittests/StaticAnalyzer/ParamRegionTest.cpp
+++ b/clang/unittests/StaticAnalyzer/ParamRegionTest.cpp
@@ -16,8 +16,7 @@ namespace ento {
 namespace {
 
 class ParamRegionTestConsumer : public ExprEngineConsumer {
-  void checkForSameParamRegions(MemRegionManager &MRMgr,
-                                const StackFrameContext *SFC,
+  void checkForSameParamRegions(MemRegionManager &MRMgr, const StackFrame *SFC,
                                 const ParmVarDecl *PVD) {
     ASSERT_TRUE(llvm::all_of(PVD->redecls(), [&](const clang::VarDecl *D2) {
       return MRMgr.getVarRegion(PVD, SFC) ==
@@ -28,7 +27,7 @@ class ParamRegionTestConsumer : public ExprEngineConsumer {
   void performTest(const Decl *D) {
     StoreManager &StMgr = Eng.getStoreManager();
     MemRegionManager &MRMgr = StMgr.getRegionManager();
-    const StackFrameContext *SFC =
+    const StackFrame *SFC =
         Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     if (const auto *FD = dyn_cast<FunctionDecl>(D)) {

--- a/clang/unittests/StaticAnalyzer/ParamRegionTest.cpp
+++ b/clang/unittests/StaticAnalyzer/ParamRegionTest.cpp
@@ -16,43 +16,42 @@ namespace ento {
 namespace {
 
 class ParamRegionTestConsumer : public ExprEngineConsumer {
-  void checkForSameParamRegions(MemRegionManager &MRMgr, const StackFrame *SFC,
+  void checkForSameParamRegions(MemRegionManager &MRMgr, const StackFrame *SF,
                                 const ParmVarDecl *PVD) {
     ASSERT_TRUE(llvm::all_of(PVD->redecls(), [&](const clang::VarDecl *D2) {
-      return MRMgr.getVarRegion(PVD, SFC) ==
-             MRMgr.getVarRegion(cast<ParmVarDecl>(D2), SFC);
+      return MRMgr.getVarRegion(PVD, SF) ==
+             MRMgr.getVarRegion(cast<ParmVarDecl>(D2), SF);
     }));
   }
 
   void performTest(const Decl *D) {
     StoreManager &StMgr = Eng.getStoreManager();
     MemRegionManager &MRMgr = StMgr.getRegionManager();
-    const StackFrame *SFC =
-        Eng.getAnalysisDeclContextManager().getStackFrame(D);
+    const StackFrame *SF = Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
       for (const auto *P : FD->parameters()) {
-        if (SFC->inTopFrame())
-          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
+        if (SF->inTopFrame())
+          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SF)));
         else
-          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
-        checkForSameParamRegions(MRMgr, SFC, P);
+          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SF)));
+        checkForSameParamRegions(MRMgr, SF, P);
       }
     } else if (const auto *CD = dyn_cast<CXXConstructorDecl>(D)) {
       for (const auto *P : CD->parameters()) {
-        if (SFC->inTopFrame())
-          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
+        if (SF->inTopFrame())
+          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SF)));
         else
-          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
-        checkForSameParamRegions(MRMgr, SFC, P);
+          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SF)));
+        checkForSameParamRegions(MRMgr, SF, P);
       }
     } else if (const auto *MD = dyn_cast<ObjCMethodDecl>(D)) {
       for (const auto *P : MD->parameters()) {
-        if (SFC->inTopFrame())
-          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
+        if (SF->inTopFrame())
+          assert(isa<NonParamVarRegion>(MRMgr.getVarRegion(P, SF)));
         else
-          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SFC)));
-        checkForSameParamRegions(MRMgr, SFC, P);
+          assert(isa<ParamVarRegion>(MRMgr.getVarRegion(P, SF)));
+        checkForSameParamRegions(MRMgr, SF, P);
       }
     }
   }

--- a/clang/unittests/StaticAnalyzer/StoreTest.cpp
+++ b/clang/unittests/StaticAnalyzer/StoreTest.cpp
@@ -54,7 +54,7 @@ class VariableBindConsumer : public StoreTestConsumer {
 
     ASSERT_TRUE(VDX0 && VDY0 && VDZ0 && VDX1 && VDY1);
 
-    const StackFrameContext *SFC =
+    const StackFrame *SFC =
         Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     Loc LX0 = loc::MemRegionVal(MRManager.getVarRegion(VDX0, SFC));
@@ -119,7 +119,7 @@ class LiteralCompoundConsumer : public StoreTestConsumer {
 
     const auto *CL = findNode<CompoundLiteralExpr>(D, compoundLiteralExpr());
 
-    const StackFrameContext *SFC =
+    const StackFrame *SFC =
         Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     QualType Int = ASTCtxt.IntTy;

--- a/clang/unittests/StaticAnalyzer/StoreTest.cpp
+++ b/clang/unittests/StaticAnalyzer/StoreTest.cpp
@@ -54,16 +54,15 @@ class VariableBindConsumer : public StoreTestConsumer {
 
     ASSERT_TRUE(VDX0 && VDY0 && VDZ0 && VDX1 && VDY1);
 
-    const StackFrame *SFC =
-        Eng.getAnalysisDeclContextManager().getStackFrame(D);
+    const StackFrame *SF = Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
-    Loc LX0 = loc::MemRegionVal(MRManager.getVarRegion(VDX0, SFC));
-    Loc LY0 = loc::MemRegionVal(MRManager.getVarRegion(VDY0, SFC));
-    Loc LZ0 = loc::MemRegionVal(MRManager.getVarRegion(VDZ0, SFC));
-    Loc LX1 = loc::MemRegionVal(MRManager.getVarRegion(VDX1, SFC));
-    Loc LY1 = loc::MemRegionVal(MRManager.getVarRegion(VDY1, SFC));
+    Loc LX0 = loc::MemRegionVal(MRManager.getVarRegion(VDX0, SF));
+    Loc LY0 = loc::MemRegionVal(MRManager.getVarRegion(VDY0, SF));
+    Loc LZ0 = loc::MemRegionVal(MRManager.getVarRegion(VDZ0, SF));
+    Loc LX1 = loc::MemRegionVal(MRManager.getVarRegion(VDX1, SF));
+    Loc LY1 = loc::MemRegionVal(MRManager.getVarRegion(VDY1, SF));
 
-    Store StInit = SManager.getInitialStore(SFC).getStore();
+    Store StInit = SManager.getInitialStore(SF).getStore();
     SVal Zero = Builder.makeZeroVal(ASTCtxt.IntTy);
     SVal One = Builder.makeIntVal(1, ASTCtxt.IntTy);
     SVal NarrowZero = Builder.makeZeroVal(ASTCtxt.CharTy);
@@ -119,20 +118,19 @@ class LiteralCompoundConsumer : public StoreTestConsumer {
 
     const auto *CL = findNode<CompoundLiteralExpr>(D, compoundLiteralExpr());
 
-    const StackFrame *SFC =
-        Eng.getAnalysisDeclContextManager().getStackFrame(D);
+    const StackFrame *SF = Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     QualType Int = ASTCtxt.IntTy;
 
     // Get region for 'test'
-    const SubRegion *CLRegion = MRManager.getCompoundLiteralRegion(CL, SFC);
+    const SubRegion *CLRegion = MRManager.getCompoundLiteralRegion(CL, SF);
 
     // Get value for 'test[0]'
     NonLoc Zero = Builder.makeIntVal(0, false);
     loc::MemRegionVal ZeroElement(
         MRManager.getElementRegion(ASTCtxt.IntTy, Zero, CLRegion, ASTCtxt));
 
-    Store StInit = SManager.getInitialStore(SFC).getStore();
+    Store StInit = SManager.getInitialStore(SF).getStore();
     // Let's bind constant 1 to 'test[0]'
     SVal One = Builder.makeIntVal(1, Int);
     Store StX =

--- a/clang/unittests/StaticAnalyzer/SymbolReaperTest.cpp
+++ b/clang/unittests/StaticAnalyzer/SymbolReaperTest.cpp
@@ -23,11 +23,10 @@ class SuperRegionLivenessConsumer : public ExprEngineConsumer {
 
     // The variable must belong to a stack frame,
     // otherwise SymbolReaper would think it's a global.
-    const StackFrame *SFC =
-        Eng.getAnalysisDeclContextManager().getStackFrame(D);
+    const StackFrame *SF = Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     // Create regions for 's' and 's.x'.
-    const VarRegion *VR = Eng.getRegionManager().getVarRegion(VD, SFC);
+    const VarRegion *VR = Eng.getRegionManager().getVarRegion(VD, SF);
     const FieldRegion *FR = Eng.getRegionManager().getFieldRegion(FD, VR);
 
     // Pass a null location context to the SymbolReaper so that

--- a/clang/unittests/StaticAnalyzer/SymbolReaperTest.cpp
+++ b/clang/unittests/StaticAnalyzer/SymbolReaperTest.cpp
@@ -23,7 +23,7 @@ class SuperRegionLivenessConsumer : public ExprEngineConsumer {
 
     // The variable must belong to a stack frame,
     // otherwise SymbolReaper would think it's a global.
-    const StackFrameContext *SFC =
+    const StackFrame *SFC =
         Eng.getAnalysisDeclContextManager().getStackFrame(D);
 
     // Create regions for 's' and 's.x'.
@@ -32,7 +32,7 @@ class SuperRegionLivenessConsumer : public ExprEngineConsumer {
 
     // Pass a null location context to the SymbolReaper so that
     // it was thinking that the variable is dead.
-    SymbolReaper SymReaper((StackFrameContext *)nullptr, (Stmt *)nullptr,
+    SymbolReaper SymReaper((StackFrame *)nullptr, (Stmt *)nullptr,
                            Eng.getSymbolManager(), Eng.getStoreManager());
 
     SymReaper.markLive(FR);


### PR DESCRIPTION
This patch continues the refactoring roadmap described in issue #190973 by renaming the `StackFrameContext` class to just `StackFrame`. Many variables of type `const StackFrame *` also had their names updated to reflect the new class name `StackFrame`.