### PR TITLE
[LLDB][PosixELF] Move m_mem_region_cache to generic ELF layer

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.h
@@ -101,7 +101,6 @@ private:
   ArchSpec m_arch;
   MainLoop &m_main_loop;
   LazyBool m_supports_mem_region = eLazyBoolCalculate;
-  std::vector<std::pair<MemoryRegionInfo, FileSpec>> m_mem_region_cache;
 
   // Private Instance Methods
   NativeProcessFreeBSD(::pid_t pid, int terminal_fd, NativeDelegate &delegate,

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1313,14 +1313,6 @@ Status NativeProcessLinux::PopulateMemoryRegionCache() {
   return Status();
 }
 
-void NativeProcessLinux::DoStopIDBumped(uint32_t newBumpId) {
-  Log *log = GetLog(POSIXLog::Process);
-  LLDB_LOG(log, "newBumpId={0}", newBumpId);
-  LLDB_LOG(log, "clearing {0} entries from memory region cache",
-           m_mem_region_cache.size());
-  m_mem_region_cache.clear();
-}
-
 llvm::Expected<uint64_t>
 NativeProcessLinux::Syscall(llvm::ArrayRef<uint64_t> args) {
   PopulateMemoryRegionCache();

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.h
@@ -122,8 +122,6 @@ public:
 
   Status RemoveBreakpoint(lldb::addr_t addr, bool hardware = false) override;
 
-  void DoStopIDBumped(uint32_t newBumpId) override;
-
   Status GetLoadedModuleFileSpec(const char *module_path,
                                  FileSpec &file_spec) override;
 
@@ -177,7 +175,6 @@ private:
   ArchSpec m_arch;
 
   LazyBool m_supports_mem_region = eLazyBoolCalculate;
-  std::vector<std::pair<MemoryRegionInfo, FileSpec>> m_mem_region_cache;
 
   lldb::tid_t m_pending_notification_tid = LLDB_INVALID_THREAD_ID;
 

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.h
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.h
@@ -97,7 +97,6 @@ private:
   ArchSpec m_arch;
   MainLoop& m_main_loop;
   LazyBool m_supports_mem_region = eLazyBoolCalculate;
-  std::vector<std::pair<MemoryRegionInfo, FileSpec>> m_mem_region_cache;
 
   // Private Instance Methods
   NativeProcessNetBSD(::pid_t pid, int terminal_fd, NativeDelegate &delegate,

--- a/lldb/source/Plugins/Process/POSIX/NativeProcessELF.cpp
+++ b/lldb/source/Plugins/Process/POSIX/NativeProcessELF.cpp
@@ -186,4 +186,12 @@ void NativeProcessELF::NotifyDidExec() {
   m_shared_library_info_addr.reset();
 }
 
+void NativeProcessELF::DoStopIDBumped(uint32_t newBumpId) {
+  Log *log = GetLog(POSIXLog::Process);
+  LLDB_LOG(log, "newBumpId={0}", newBumpId);
+  LLDB_LOG(log, "clearing {0} entries from memory region cache",
+           m_mem_region_cache.size());
+  m_mem_region_cache.clear();
+}
+
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/POSIX/NativeProcessELF.h
+++ b/lldb/source/Plugins/Process/POSIX/NativeProcessELF.h
@@ -9,8 +9,10 @@
 #ifndef liblldb_NativeProcessELF_H_
 #define liblldb_NativeProcessELF_H_
 
+#include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #include "Plugins/Process/Utility/AuxVector.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
+#include "lldb/Target/MemoryRegionInfo.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include <optional>
 
@@ -24,6 +26,7 @@ class NativeProcessELF : public NativeProcessProtocol {
 
 public:
   std::optional<uint64_t> GetAuxValue(enum AuxVector::EntryType type);
+  void DoStopIDBumped(uint32_t newBumpId) override;
 
 protected:
   template <typename T> struct ELFLinkMap {
@@ -50,6 +53,7 @@ protected:
 
   std::unique_ptr<AuxVector> m_aux_vector;
   std::optional<lldb::addr_t> m_shared_library_info_addr;
+  std::vector<std::pair<MemoryRegionInfo, FileSpec>> m_mem_region_cache;
 };
 
 // Explicitly declare the two 32/64 bit templates that NativeProcessELF.cpp will

--- a/lldb/test/Shell/Breakpoint/Inputs/break_stepout.c
+++ b/lldb/test/Shell/Breakpoint/Inputs/break_stepout.c
@@ -1,0 +1,2 @@
+#include <stdio.h>
+int main() { printf("Hello World\n"); }

--- a/lldb/test/Shell/Breakpoint/step-out.test
+++ b/lldb/test/Shell/Breakpoint/step-out.test
@@ -1,0 +1,13 @@
+# REQUIRES: system-freebsd
+
+# RUN: cp %p/Inputs/break_stepout.c %t.c
+# RUN: %clang_host -O0 -g -o %t %t.c
+# RUN: rm %t.c
+# RUN: %lldb -b -o "br set -n vfprintf" -o run -o "thread step-out" -o "thread step-out" %t 2>&1 | FileCheck %s
+
+## Check if we step-out twice sucessfully
+
+CHECK: stop reason = step out
+CHECK-NEXT: printf
+CHECK: stop reason = step out
+CHECK-NEXT: main


### PR DESCRIPTION
All native ELF process implementations (Linux, FreeBSD, NetBSD) use m_mem_region_cache to cache mmap regions. Move this cache object into the generic ELF layer to eliminate duplication.
    
Also, implement DoStopIDBumped in the generic ELF layer, since all implementations require flushing the cache on stop.