### PR TITLE
[MLIR][NVGPU] Use NVVM enums in NVGPU dialect

### DIFF
--- a/mlir/include/mlir/Dialect/NVGPU/IR/NVGPU.td
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/NVGPU.td
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_NVGPU_IR_NVGPU_TD
 #define MLIR_DIALECT_NVGPU_IR_NVGPU_TD
 
+include "mlir/Dialect/LLVMIR/NVVMDialect.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
@@ -18,6 +19,7 @@ include "mlir/IR/EnumAttr.td"
 def NVGPU_Dialect : Dialect {
   let name = "nvgpu";
   let cppNamespace = "::mlir::nvgpu";
+  let dependentDialects = ["NVVM::NVVMDialect"];
   let description = [{
     The `NVGPU` dialect provides a bridge between higher-level target-agnostic
     dialects (GPU and Vector) and the lower-level target-specific dialect

--- a/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUDialect.h
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUDialect.h
@@ -14,6 +14,7 @@
 #define MLIR_DIALECT_NVGPU_NVGPUDIALECT_H_
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
@@ -662,8 +662,8 @@ def NVGPU_RcpOp : NVGPU_Op<"rcp", [Pure,
   }];
   let arguments = (ins VectorOfNonZeroRankOf<[F32]>:$in,
                        DefaultValuedAttr<FPRoundingModeAttr, "::mlir::NVVM::FPRoundingMode::NONE">:$rounding,
-                       UnitAttr:$approx,
-                       UnitAttr:$ftz);
+                       DefaultValuedAttr<BoolAttr, "false">:$approx,
+                       DefaultValuedAttr<BoolAttr, "false">:$ftz);
   let results = (outs VectorOfNonZeroRankOf<[F32]>:$out);
   let assemblyFormat = [{
     $in attr-dict `:` type($out)

--- a/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
@@ -20,6 +20,7 @@
 #ifndef MLIR_DIALECT_NVGPU_IR_NVGPUOPS_TD
 #define MLIR_DIALECT_NVGPU_IR_NVGPUOPS_TD
 
+include "mlir/Dialect/LLVMIR/NVVMEnums.td"
 include "mlir/Dialect/NVGPU/IR/NVGPU.td"
 include "mlir/Dialect/NVGPU/IR/NVGPUTypes.td"
 
@@ -660,12 +661,12 @@ def NVGPU_RcpOp : NVGPU_Op<"rcp", [Pure,
     The input and output must be of the same vector type and shape.
   }];
   let arguments = (ins VectorOfNonZeroRankOf<[F32]>:$in,
-                       DefaultValuedAttr<RcpRoundingModeAttr, "RcpRoundingMode::APPROX">:$rounding,
+                       DefaultValuedAttr<FPRoundingModeAttr, "::mlir::NVVM::FPRoundingMode::NONE">:$rounding,
+                       UnitAttr:$approx,
                        UnitAttr:$ftz);
   let results = (outs VectorOfNonZeroRankOf<[F32]>:$out);
   let assemblyFormat = [{
-    $in `{` `rounding` `=` $rounding (`,` `ftz` $ftz^)? `}` 
-    attr-dict `:` type($out)
+    $in attr-dict `:` type($out)
   }];
   let hasVerifier = 1;
 }

--- a/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/NVGPU/IR/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(MLIRNVGPUDialect
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect
+  MLIRNVVMDialect
   MLIRIR
   MLIRSideEffectInterfaces
   )

--- a/mlir/lib/Dialect/NVGPU/IR/NVGPUDialect.cpp
+++ b/mlir/lib/Dialect/NVGPU/IR/NVGPUDialect.cpp
@@ -684,12 +684,17 @@ LogicalResult WarpgroupMmaInitAccumulatorOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult RcpOp::verify() {
-  RcpRoundingModeAttr rounding = getRoundingAttr();
   bool ftz = getFtz();
+  bool approx = getApprox();
+  mlir::NVVM::FPRoundingModeAttr rnd = getRoundingAttr();
   // Currently, only `rcp_approx` and `ftz` is supported.
-  if (rounding.getValue() != RcpRoundingMode::APPROX || !ftz) {
-    return emitOpError() << "has a limitation. " << rounding
-                         << " or non-ftz is not supported yet.";
+  if (!approx || !ftz) {
+    return emitOpError()
+           << "has a limitation. non-approx or non-ftz is not supported yet.";
+  }
+  if (rnd.getValue() != mlir::NVVM::FPRoundingMode::NONE) {
+    return emitOpError() << "has a limitation. " << rnd
+                         << " is not supported yet.";
   }
   return success();
 }

--- a/mlir/test/Conversion/NVGPUToNVVM/nvgpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/NVGPUToNVVM/nvgpu-to-nvvm.mlir
@@ -1407,6 +1407,6 @@ func.func @rcp_approx_ftz_f32(%in: vector<32x16xf32>) {
   // CHECK: %[[ELEM_RCP0:.*]] = nvvm.rcp.approx.ftz.f %[[ELEM_0]] : f32
   // CHECK: llvm.insertelement %[[ELEM_RCP0]], %[[OUT1DVEC]][%[[IDX_0]] : i64] : vector<16xf32>
   // CHECK-COUNT-511: nvvm.rcp.approx.ftz.f
-  %out = nvgpu.rcp %in {approx, ftz} : vector<32x16xf32>
+  %out = nvgpu.rcp %in {approx = true, ftz = true} : vector<32x16xf32>
   return
 }

--- a/mlir/test/Conversion/NVGPUToNVVM/nvgpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/NVGPUToNVVM/nvgpu-to-nvvm.mlir
@@ -1407,6 +1407,6 @@ func.func @rcp_approx_ftz_f32(%in: vector<32x16xf32>) {
   // CHECK: %[[ELEM_RCP0:.*]] = nvvm.rcp.approx.ftz.f %[[ELEM_0]] : f32
   // CHECK: llvm.insertelement %[[ELEM_RCP0]], %[[OUT1DVEC]][%[[IDX_0]] : i64] : vector<16xf32>
   // CHECK-COUNT-511: nvvm.rcp.approx.ftz.f
-  %out = nvgpu.rcp %in {rounding = approx, ftz} : vector<32x16xf32>
+  %out = nvgpu.rcp %in {approx, ftz} : vector<32x16xf32>
   return
 }

--- a/mlir/test/Dialect/NVGPU/invalid.mlir
+++ b/mlir/test/Dialect/NVGPU/invalid.mlir
@@ -339,20 +339,20 @@ func.func @tma_generate_descriptor_incorrect_last_dim(%desc: !desc,  %buffer2: m
 // -----
 
 func.func @rcp_unsupported_rounding_0(%in : vector<16xf32>) {
-  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. #nvgpu<rcp_rounding_mode rn> or non-ftz is not supported yet.}}
-  %out = nvgpu.rcp %in {rounding = rn, ftz} : vector<16xf32>
+  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. #nvvm.fp_rnd_mode<rn> is not supported yet.}}
+  %out = nvgpu.rcp %in {rounding = #nvvm.fp_rnd_mode<rn>, approx, ftz} : vector<16xf32>
 }
 // -----
 
 func.func @rcp_unsupported_rounding_1(%in : vector<16xf32>) {
-  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. #nvgpu<rcp_rounding_mode rz> or non-ftz is not supported yet.}}
-  %out = nvgpu.rcp %in {rounding = rz} : vector<16xf32>
+  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. non-approx or non-ftz is not supported yet.}}
+  %out = nvgpu.rcp %in {ftz} : vector<16xf32>
 }
 // -----
 
 func.func @rcp_unsupported_ftz(%in : vector<16xf32>) {
-  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. #nvgpu<rcp_rounding_mode approx> or non-ftz is not supported yet.}}
-  %out = nvgpu.rcp %in {rounding = approx} : vector<16xf32>
+  // expected-error @+1 {{'nvgpu.rcp' op has a limitation. non-approx or non-ftz is not supported yet.}}
+  %out = nvgpu.rcp %in {approx} : vector<16xf32>
 }
 
 // -----

--- a/mlir/test/Dialect/NVGPU/invalid.mlir
+++ b/mlir/test/Dialect/NVGPU/invalid.mlir
@@ -340,19 +340,19 @@ func.func @tma_generate_descriptor_incorrect_last_dim(%desc: !desc,  %buffer2: m
 
 func.func @rcp_unsupported_rounding_0(%in : vector<16xf32>) {
   // expected-error @+1 {{'nvgpu.rcp' op has a limitation. #nvvm.fp_rnd_mode<rn> is not supported yet.}}
-  %out = nvgpu.rcp %in {rounding = #nvvm.fp_rnd_mode<rn>, approx, ftz} : vector<16xf32>
+  %out = nvgpu.rcp %in {rounding = #nvvm.fp_rnd_mode<rn>, approx = true, ftz = true} : vector<16xf32>
 }
 // -----
 
 func.func @rcp_unsupported_rounding_1(%in : vector<16xf32>) {
   // expected-error @+1 {{'nvgpu.rcp' op has a limitation. non-approx or non-ftz is not supported yet.}}
-  %out = nvgpu.rcp %in {ftz} : vector<16xf32>
+  %out = nvgpu.rcp %in {ftz = true} : vector<16xf32>
 }
 // -----
 
 func.func @rcp_unsupported_ftz(%in : vector<16xf32>) {
   // expected-error @+1 {{'nvgpu.rcp' op has a limitation. non-approx or non-ftz is not supported yet.}}
-  %out = nvgpu.rcp %in {approx} : vector<16xf32>
+  %out = nvgpu.rcp %in {approx = true} : vector<16xf32>
 }
 
 // -----


### PR DESCRIPTION
Updates the `nvgpu.rcp` Op to use the NVVM `FPRoundingModeAttr`
attribute instead of redefining the attribute in the NVGPU dialect.

Follows up https://github.com/llvm/llvm-project/pull/195811.