### PR TITLE
[libc++][mdspan] LWG3974: `mdspan::operator[]` should not copy `OtherIndexTypes`

### DIFF
--- a/libcxx/docs/Status/Cxx2cIssues.csv
+++ b/libcxx/docs/Status/Cxx2cIssues.csv
@@ -35,7 +35,7 @@
 "`LWG3965 <https://wg21.link/LWG3965>`__","Incorrect example in [format.string.escaped] p3 for formatting of combining characters","2023-11 (Kona)","|Complete|","19","`#105305 <https://github.com/llvm/llvm-project/issues/105305>`__",""
 "`LWG3970 <https://wg21.link/LWG3970>`__","[mdspan.syn] Missing definition of ``full_extent_t`` and ``full_extent``","2023-11 (Kona)","","","`#105306 <https://github.com/llvm/llvm-project/issues/105306>`__",""
 "`LWG3973 <https://wg21.link/LWG3973>`__","Monadic operations should be ADL-proof","2023-11 (Kona)","","","`#105307 <https://github.com/llvm/llvm-project/issues/105307>`__",""
-"`LWG3974 <https://wg21.link/LWG3974>`__","``mdspan::operator[]`` should not copy ``OtherIndexTypes``","2023-11 (Kona)","","","`#105308 <https://github.com/llvm/llvm-project/issues/105308>`__",""
+"`LWG3974 <https://wg21.link/LWG3974>`__","``mdspan::operator[]`` should not copy ``OtherIndexTypes``","2023-11 (Kona)","|Complete|","23","`#105308 <https://github.com/llvm/llvm-project/issues/105308>`__",""
 "`LWG3987 <https://wg21.link/LWG3987>`__","Including ``<flat_foo>`` doesn't provide ``std::begin``/``end``","2023-11 (Kona)","|Complete|","","`#105309 <https://github.com/llvm/llvm-project/issues/105309>`__",""
 "`LWG3990 <https://wg21.link/LWG3990>`__","Program-defined specializations of ``std::tuple`` and ``std::variant`` can't be properly supported","2023-11 (Kona)","|Complete|","21","`#105310 <https://github.com/llvm/llvm-project/issues/105310>`__",""
 "`LWG4001 <https://wg21.link/LWG4001>`__","``iota_view`` should provide ``empty``","2023-11 (Kona)","|Complete|","19","`#105311 <https://github.com/llvm/llvm-project/issues/105311>`__",""

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -204,7 +204,7 @@ public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr reference
   operator[](const array< _OtherIndexType, rank()>& __indices) const {
     return __acc_.access(__ptr_, [&]<size_t... _Idxs>(index_sequence<_Idxs...>) {
-      return __map_(__indices[_Idxs]...);
+      return __map_(extents_type::__index_cast(__indices[_Idxs])...);
     }(make_index_sequence<rank()>()));
   }
 
@@ -213,7 +213,7 @@ public:
              is_nothrow_constructible_v<index_type, const _OtherIndexType&>)
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr reference operator[](span<_OtherIndexType, rank()> __indices) const {
     return __acc_.access(__ptr_, [&]<size_t... _Idxs>(index_sequence<_Idxs...>) {
-      return __map_(__indices[_Idxs]...);
+      return __map_(extents_type::__index_cast(__indices[_Idxs])...);
     }(make_index_sequence<rank()>()));
   }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -196,9 +196,27 @@ constexpr void test_layout_large() {
   test_iteration(construct_mapping(Layout(), std::extents<int64_t, D, 4, 1, D>(3, 6)));
 }
 
+struct Index {
+  Index()             = default;
+  Index(const Index&) = delete;
+  constexpr operator int() const noexcept { return 0; }
+};
+
 // mdspan::operator[] casts to index_type before calling mapping
 // mapping requirements only require the index operator to mixed integer types not anything convertible to index_type
-constexpr void test_index_cast_happens() {}
+constexpr void test_index_cast_happens() {
+  int data[1]{};
+  std::mdspan m(data, std::extents<int, 1>{1});
+
+  // Index i;
+  std::array<Index, 1> a{};
+  std::span s(a);
+
+  // LWG3995: Issue with custom index conversion in <mdspan>
+  // TEST_IGNORE_NODISCARD m[i];
+  TEST_IGNORE_NODISCARD m[a];
+  TEST_IGNORE_NODISCARD m[s];
+}
 
 struct RValueInt {
   constexpr operator int() && noexcept { return 0; }
@@ -213,6 +231,7 @@ constexpr bool test() {
   std::mdspan m(data, std::extents<int, 1>{1});
   TEST_IGNORE_NODISCARD m[RValueInt{}];
 
+  test_index_cast_happens();
   return true;
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -196,26 +196,28 @@ constexpr void test_layout_large() {
   test_iteration(construct_mapping(Layout(), std::extents<int64_t, D, 4, 1, D>(3, 6)));
 }
 
-struct Index {
-  Index()             = default;
-  Index(const Index&) = delete;
-  constexpr operator int() const noexcept { return 0; }
+struct NoCopyIndex {
+  int val = 0;
+  constexpr NoCopyIndex(int v) : val(v) {}
+  constexpr NoCopyIndex(const NoCopyIndex&) = delete;
+  constexpr operator int() const noexcept { return val; }
 };
 
 // mdspan::operator[] casts to index_type before calling mapping
 // mapping requirements only require the index operator to mixed integer types not anything convertible to index_type
-constexpr void test_index_cast_happens() {
-  int data[1]{};
-  std::mdspan m(data, std::extents<int, 1>{1});
+constexpr void test_index_cast() {
+  std::array data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  const std::mdspan m{data.data(), std::dextents<int, 1>{10}};
 
-  // Index i;
-  std::array<Index, 1> a{};
-  std::span s(a);
+  std::array indices{NoCopyIndex{3}};
+
+  assert(&m[NoCopyIndex{3}] == &data[3]);
+  assert(&m[indices] == &data[3]);
+  assert(&m[std::span{indices}] == &data[3]);
 
   // LWG3995: Issue with custom index conversion in <mdspan>
-  // TEST_IGNORE_NODISCARD m[i];
-  TEST_IGNORE_NODISCARD m[a];
-  TEST_IGNORE_NODISCARD m[s];
+  // NoCopyIndex index(3);
+  // assert(&m[index] == &data[3]);
 }
 
 struct RValueInt {
@@ -231,7 +233,7 @@ constexpr bool test() {
   std::mdspan m(data, std::extents<int, 1>{1});
   TEST_IGNORE_NODISCARD m[RValueInt{}];
 
-  test_index_cast_happens();
+  test_index_cast();
   return true;
 }
 


### PR DESCRIPTION
Fixes: #105308
