### PR TITLE
[lldb][test] Move DAP processes to own group to avoid random SIGHUPs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -434,6 +434,16 @@ class _LocalProcess(_BaseProcess):
 
         stdout = kwargs.pop("stdout", DEVNULL if not self._trace_on else None)
         stderr = kwargs.pop("stderr", None)
+        # This works around a bug in the macOS job control code where
+        # a supurious SIGHUP is sent to the the process group of our
+        # spawned subprocess when it is shutting down.
+        # While this SIGHUP doesn't cause any issues for our subprocess,
+        # it does reach the LIT process and stops the test suite run
+        # early.
+        # This parameter forces the spawned process into a new process
+        # group which prevents the supurious SIGHUP from reaching LIT.
+        # We don't
+        kwargs.setdefault("start_new_session", True)
 
         self._proc = Popen(
             [executable] + args,

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -116,6 +116,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
 
         self.setUpBaseLogging()
         self.debug_monitor_extra_args = []
+        self.start_new_session = True
 
         if self.isVerboseLoggingRequested():
             # If requested, full logs go to a log file
@@ -364,7 +365,10 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
 
         # Start the server.
         server = self.spawnSubprocess(
-            self.debug_monitor_exe, commandline_args, install_remote=False
+            self.debug_monitor_exe,
+            commandline_args,
+            install_remote=False,
+            start_new_session=self.start_new_session,
         )
         self.assertIsNotNone(server)
 

--- a/lldb/test/API/tools/lldb-server/commandline/TestStubSetSID.py
+++ b/lldb/test/API/tools/lldb-server/commandline/TestStubSetSID.py
@@ -20,10 +20,16 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         # Get the process id for the stub.
         return os.getsid(server.pid)
 
+    def prepare_test(self):
+        # Disable putting the target process into a new group/sid as we
+        # check whether the target is the same/different sid as us.
+        self.start_new_session = False
+        self.set_inferior_startup_launch()
+
     @skipIfWindows
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_same_without_setsid(self):
-        self.set_inferior_startup_launch()
+        self.prepare_test()
 
         stub_sid = self.get_stub_sid()
         self.assertEqual(stub_sid, os.getsid(0))
@@ -31,7 +37,7 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
     @skipIfWindows
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_different_with_setsid(self):
-        self.set_inferior_startup_launch()
+        self.prepare_test()
 
         stub_sid = self.get_stub_sid(["--setsid"])
         self.assertNotEqual(stub_sid, os.getsid(0))
@@ -39,7 +45,7 @@ class TestStubSetSIDTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
     @skipIfWindows
     @skipIfRemote  # --setsid not used on remote platform and currently it is also impossible to get the sid of lldb-platform running on a remote target
     def test_sid_is_different_with_S_llgs(self):
-        self.set_inferior_startup_launch()
+        self.prepare_test()
 
         stub_sid = self.get_stub_sid(["-S"])
         self.assertNotEqual(stub_sid, os.getsid(0))


### PR DESCRIPTION
On macOS, LLDB's test suite randomly receives SIGHUP signals that stop the test suite early. The source of these SIGHUP's seems to be a bug in the kernel (most likely job control).

The exact steps for reproducing this are not clear, but I have a set of three tests of which two need to run concurrently for this to trigger:

* TestDAP_runInTerminal
* TestDAP_launch_io_integratedTerminal
* TestDAP_launch_stdio_redirection_and_console

I was also running UBSan on this build which may or may not be necessary to make this random failure more persistent.

When these tests run, macOS job control will send SIGHUP to the process group of the spawned subprocesses in that test. As LIT is in the same process group, it also receives the SIGHUP and shuts down.

This patch just uses Python's API for forcing the spawned subprocess to its own process group. This won't stop the SIGHUP and only prevents it from reaching LIT.

The SIGHUP itself doesn't seem to affect the DAP test itself. My theory here is that the SIGHUP is received during test shutdown (or after it was shut down), so that's why it doesn't cause any visible failures in any of the tests.