### PR TITLE
[SCEV] Introduce PSE::getAddRecExpr, use in VPlan (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -2603,6 +2603,10 @@ public:
 
   LLVM_ABI const SCEVPredicate &getPredicate() const;
 
+  /// Forwards to ScalarEvolution::getAddRecExpr, with Loop argument.
+  LLVM_ABI const SCEV *getAddRecExpr(SCEVUse Start, SCEVUse Step,
+                                     SCEV::NoWrapFlags Flags);
+
   /// Returns the SCEV expression of V, in the context of the current SCEV
   /// predicate.  The order of transformations applied on the expression of V
   /// returned by ScalarEvolution is guaranteed to be preserved, even when

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -15468,6 +15468,12 @@ PredicatedScalarEvolution::PredicatedScalarEvolution(ScalarEvolution &SE,
   Preds = std::make_unique<SCEVUnionPredicate>(Empty, SE);
 }
 
+const SCEV *PredicatedScalarEvolution::getAddRecExpr(SCEVUse Start,
+                                                     SCEVUse Step,
+                                                     SCEV::NoWrapFlags Flags) {
+  return SE.getAddRecExpr(Start, Step, &L, Flags);
+}
+
 void ScalarEvolution::registerUser(const SCEV *User,
                                    ArrayRef<const SCEV *> Ops) {
   for (const auto *Op : Ops)

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6873,8 +6873,8 @@ void LoopVectorizationPlanner::buildVPlansWithVPRecipes(ElementCount MinVF,
       continue;
 
     // Now optimize the initial VPlan.
-    RUN_VPLAN_PASS(VPlanTransforms::hoistPredicatedLoads, *Plan, PSE, OrigLoop);
-    RUN_VPLAN_PASS(VPlanTransforms::sinkPredicatedStores, *Plan, PSE, OrigLoop);
+    RUN_VPLAN_PASS(VPlanTransforms::hoistPredicatedLoads, *Plan, PSE);
+    RUN_VPLAN_PASS(VPlanTransforms::sinkPredicatedStores, *Plan, PSE);
     RUN_VPLAN_PASS(VPlanTransforms::truncateToMinimalBitwidths, *Plan,
                    Config.getMinimalBitwidths());
     RUN_VPLAN_PASS(VPlanTransforms::optimize, *Plan);
@@ -7053,8 +7053,7 @@ LoopVectorizationPlanner::tryToBuildVPlanWithVPRecipes(VPlanPtr Plan,
   addReductionResultComputation(Plan, RecipeBuilder, Range.Start);
 
   // Optimize FindIV reductions to use sentinel-based approach when possible.
-  RUN_VPLAN_PASS(VPlanTransforms::optimizeFindIVReductions, *Plan, PSE,
-                 *OrigLoop);
+  RUN_VPLAN_PASS(VPlanTransforms::optimizeFindIVReductions, *Plan, PSE);
   RUN_VPLAN_PASS(VPlanTransforms::optimizeInductionLiveOutUsers, *Plan, PSE,
                  CM.foldTailByMasking());
 

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1182,7 +1182,7 @@ static bool areAllLoadsDereferenceable(VPBasicBlock *HeaderVPBB,
 
       // Get the pointer SCEV for dereferenceability checking.
       VPValue *Ptr = VPI->getOperand(0);
-      const SCEV *PtrSCEV = vputils::getSCEVExprForVPValue(Ptr, PSE, TheLoop);
+      const SCEV *PtrSCEV = vputils::getSCEVExprForVPValue(Ptr, PSE);
       if (isa<SCEVCouldNotCompute>(PtrSCEV)) {
         LLVM_DEBUG(dbgs() << "LV: Not vectorizing: Found non-dereferenceable "
                              "load with SCEVCouldNotCompute pointer\n");

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3319,7 +3319,7 @@ void VPReplicateRecipe::execute(VPTransformState &State) {
 static const SCEV *getAddressAccessSCEV(const VPValue *Ptr,
                                         PredicatedScalarEvolution &PSE,
                                         const Loop *L) {
-  const SCEV *Addr = vputils::getSCEVExprForVPValue(Ptr, PSE, L);
+  const SCEV *Addr = vputils::getSCEVExprForVPValue(Ptr, PSE);
   if (isa<SCEVCouldNotCompute>(Addr))
     return Addr;
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -155,7 +155,6 @@ class SinkStoreInfo {
   const SmallPtrSetImpl<VPRecipeBase *> &ExcludeRecipes;
   VPReplicateRecipe &GroupLeader;
   PredicatedScalarEvolution &PSE;
-  const Loop &L;
   VPTypeAnalysis &TypeInfo;
 
   // Return true if \p A and \p B are known to not alias for all VFs in the
@@ -166,9 +165,9 @@ class SinkStoreInfo {
       return false;
 
     VPValue *AddrA = A->getOperand(1);
-    const SCEV *SCEVA = vputils::getSCEVExprForVPValue(AddrA, PSE, &L);
+    const SCEV *SCEVA = vputils::getSCEVExprForVPValue(AddrA, PSE);
     VPValue *AddrB = B->getOperand(1);
-    const SCEV *SCEVB = vputils::getSCEVExprForVPValue(AddrB, PSE, &L);
+    const SCEV *SCEVB = vputils::getSCEVExprForVPValue(AddrB, PSE);
     if (isa<SCEVCouldNotCompute>(SCEVA) || isa<SCEVCouldNotCompute>(SCEVB))
       return false;
 
@@ -199,9 +198,9 @@ class SinkStoreInfo {
 public:
   SinkStoreInfo(const SmallPtrSetImpl<VPRecipeBase *> &ExcludeRecipes,
                 VPReplicateRecipe &GroupLeader, PredicatedScalarEvolution &PSE,
-                const Loop &L, VPTypeAnalysis &TypeInfo)
+                VPTypeAnalysis &TypeInfo)
       : ExcludeRecipes(ExcludeRecipes), GroupLeader(GroupLeader), PSE(PSE),
-        L(L), TypeInfo(TypeInfo) {}
+        TypeInfo(TypeInfo) {}
 
   /// Return true if \p R should be skipped during alias checking, either
   /// because it's in the exclude set or because no-alias can be proven via
@@ -255,7 +254,7 @@ canHoistOrSinkWithNoAliasCheck(const MemoryLocation &MemLoc,
 template <unsigned Opcode>
 static SmallVector<SmallVector<VPReplicateRecipe *, 4>>
 collectGroupedReplicateMemOps(
-    VPlan &Plan, PredicatedScalarEvolution &PSE, const Loop *L,
+    VPlan &Plan, PredicatedScalarEvolution &PSE,
     function_ref<bool(VPReplicateRecipe *)> FilterFn) {
   static_assert(Opcode == Instruction::Load || Opcode == Instruction::Store,
                 "Only Load and Store opcodes supported");
@@ -271,7 +270,7 @@ collectGroupedReplicateMemOps(
 
       // For loads, operand 0 is address; for stores, operand 1 is address.
       VPValue *Addr = RepR->getOperand(IsLoad ? 0 : 1);
-      const SCEV *AddrSCEV = vputils::getSCEVExprForVPValue(Addr, PSE, L);
+      const SCEV *AddrSCEV = vputils::getSCEVExprForVPValue(Addr, PSE);
       if (!isa<SCEVCouldNotCompute>(AddrSCEV))
         RecipesByAddress[AddrSCEV].push_back(RepR);
     }
@@ -4648,8 +4647,7 @@ static VPIRMetadata getCommonMetadata(ArrayRef<VPReplicateRecipe *> Recipes) {
 template <unsigned Opcode>
 static SmallVector<SmallVector<VPReplicateRecipe *, 4>>
 collectComplementaryPredicatedMemOps(VPlan &Plan,
-                                     PredicatedScalarEvolution &PSE,
-                                     const Loop *L) {
+                                     PredicatedScalarEvolution &PSE) {
   static_assert(Opcode == Instruction::Load || Opcode == Instruction::Store,
                 "Only Load and Store opcodes supported");
   constexpr bool IsLoad = (Opcode == Instruction::Load);
@@ -4661,8 +4659,7 @@ collectComplementaryPredicatedMemOps(VPlan &Plan,
     return TypeInfo.inferScalarType(IsLoad ? Recipe : Recipe->getOperand(0));
   };
   auto Groups = collectGroupedReplicateMemOps<Opcode>(
-      Plan, PSE, L,
-      [](VPReplicateRecipe *RepR) { return RepR->isPredicated(); });
+      Plan, PSE, [](VPReplicateRecipe *RepR) { return RepR->isPredicated(); });
   for (auto Recipes : Groups) {
     if (Recipes.size() < 2)
       continue;
@@ -4717,10 +4714,9 @@ findRecipeWithMinAlign(ArrayRef<VPReplicateRecipe *> Group) {
 }
 
 void VPlanTransforms::hoistPredicatedLoads(VPlan &Plan,
-                                           PredicatedScalarEvolution &PSE,
-                                           const Loop *L) {
+                                           PredicatedScalarEvolution &PSE) {
   auto Groups =
-      collectComplementaryPredicatedMemOps<Instruction::Load>(Plan, PSE, L);
+      collectComplementaryPredicatedMemOps<Instruction::Load>(Plan, PSE);
   if (Groups.empty())
     return;
 
@@ -4767,7 +4763,7 @@ void VPlanTransforms::hoistPredicatedLoads(VPlan &Plan,
 
 static bool
 canSinkStoreWithNoAliasCheck(ArrayRef<VPReplicateRecipe *> StoresToSink,
-                             PredicatedScalarEvolution &PSE, const Loop &L,
+                             PredicatedScalarEvolution &PSE,
                              VPTypeAnalysis &TypeInfo) {
   auto StoreLoc = vputils::getMemoryLocation(*StoresToSink.front());
   if (!StoreLoc || !StoreLoc->AATags.Scope)
@@ -4780,22 +4776,21 @@ canSinkStoreWithNoAliasCheck(ArrayRef<VPReplicateRecipe *> StoresToSink,
 
   VPBasicBlock *FirstBB = StoresToSink.front()->getParent();
   VPBasicBlock *LastBB = StoresToSink.back()->getParent();
-  SinkStoreInfo SinkInfo(StoresToSinkSet, *StoresToSink[0], PSE, L, TypeInfo);
+  SinkStoreInfo SinkInfo(StoresToSinkSet, *StoresToSink[0], PSE, TypeInfo);
   return canHoistOrSinkWithNoAliasCheck(*StoreLoc, FirstBB, LastBB, SinkInfo);
 }
 
 void VPlanTransforms::sinkPredicatedStores(VPlan &Plan,
-                                           PredicatedScalarEvolution &PSE,
-                                           const Loop *L) {
+                                           PredicatedScalarEvolution &PSE) {
   auto Groups =
-      collectComplementaryPredicatedMemOps<Instruction::Store>(Plan, PSE, L);
+      collectComplementaryPredicatedMemOps<Instruction::Store>(Plan, PSE);
   if (Groups.empty())
     return;
 
   VPTypeAnalysis TypeInfo(Plan);
 
   for (auto &Group : Groups) {
-    if (!canSinkStoreWithNoAliasCheck(Group, PSE, *L, TypeInfo))
+    if (!canSinkStoreWithNoAliasCheck(Group, PSE, TypeInfo))
       continue;
 
     // Use the last (most dominated) store's location for the unconditional
@@ -5649,8 +5644,7 @@ static VPValue *cloneBinOpForScalarIV(VPWidenRecipe *BinOp, VPValue *ScalarIV,
 }
 
 void VPlanTransforms::optimizeFindIVReductions(VPlan &Plan,
-                                               PredicatedScalarEvolution &PSE,
-                                               Loop &L) {
+                                               PredicatedScalarEvolution &PSE) {
   ScalarEvolution &SE = *PSE.getSE();
   VPRegionBlock *VectorLoopRegion = Plan.getVectorLoopRegion();
 
@@ -5709,11 +5703,10 @@ void VPlanTransforms::optimizeFindIVReductions(VPlan &Plan,
     // so, we can track the underlying IV instead and sink the expression.
     auto *IVOfExpressionToSink = getExpressionIV(FindLastExpression);
     const SCEV *IVSCEV = vputils::getSCEVExprForVPValue(
-        IVOfExpressionToSink ? IVOfExpressionToSink : FindLastExpression, PSE,
-        &L);
+        IVOfExpressionToSink ? IVOfExpressionToSink : FindLastExpression, PSE);
     const SCEV *Step;
     if (!match(IVSCEV, m_scev_AffineAddRec(m_SCEV(), m_SCEV(Step)))) {
-      assert(!match(vputils::getSCEVExprForVPValue(FindLastExpression, PSE, &L),
+      assert(!match(vputils::getSCEVExprForVPValue(FindLastExpression, PSE),
                     m_scev_AffineAddRec(m_SCEV(), m_SCEV())) &&
              "IVOfExpressionToSink not being an AddRec must imply "
              "FindLastExpression not being an AddRec.");
@@ -5737,7 +5730,7 @@ void VPlanTransforms::optimizeFindIVReductions(VPlan &Plan,
     // sinking undesirable.
     if (IVOfExpressionToSink) {
       const SCEV *FindLastExpressionSCEV =
-          vputils::getSCEVExprForVPValue(FindLastExpression, PSE, &L);
+          vputils::getSCEVExprForVPValue(FindLastExpression, PSE);
       if (match(FindLastExpressionSCEV,
                 m_scev_AffineAddRec(m_SCEV(), m_SCEV(Step)))) {
         bool NewUseMax = SE.isKnownPositive(Step);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -400,15 +400,13 @@ struct VPlanTransforms {
   /// Hoist predicated loads from the same address to the loop entry block, if
   /// they are guaranteed to execute on both paths (i.e., in replicate regions
   /// with complementary masks P and NOT P).
-  static void hoistPredicatedLoads(VPlan &Plan, PredicatedScalarEvolution &PSE,
-                                   const Loop *L);
+  static void hoistPredicatedLoads(VPlan &Plan, PredicatedScalarEvolution &PSE);
 
   /// Sink predicated stores to the same address with complementary predicates
   /// (P and NOT P) to an unconditional store with select recipes for the
   /// stored values. This eliminates branching overhead when all paths
   /// unconditionally store to the same location.
-  static void sinkPredicatedStores(VPlan &Plan, PredicatedScalarEvolution &PSE,
-                                   const Loop *L);
+  static void sinkPredicatedStores(VPlan &Plan, PredicatedScalarEvolution &PSE);
 
   // Materialize vector trip counts for constants early if it can simply be
   // computed as (Original TC / VF * UF) * VF * UF.
@@ -527,7 +525,7 @@ struct VPlanTransforms {
   /// suitable sentinel value. For expressions of IVs, the expression is sunk
   /// to the middle block.
   static void optimizeFindIVReductions(VPlan &Plan,
-                                       PredicatedScalarEvolution &PSE, Loop &L);
+                                       PredicatedScalarEvolution &PSE);
 
   /// Detect and create partial reduction recipes for scaled reductions in
   /// \p Plan. Must be called after recipe construction. If partial reductions

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -158,8 +158,7 @@ GEPNoWrapFlags vputils::getGEPFlagsForPtr(VPValue *Ptr) {
 }
 
 const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
-                                           PredicatedScalarEvolution &PSE,
-                                           const Loop *L) {
+                                           PredicatedScalarEvolution &PSE) {
   ScalarEvolution &SE = *PSE.getSE();
   if (isa<VPIRValue, VPSymbolicValue>(V)) {
     Value *LiveIn = V->getUnderlyingValue();
@@ -171,10 +170,8 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
   if (auto *RV = dyn_cast<VPRegionValue>(V)) {
     assert(RV == RV->getDefiningRegion()->getCanonicalIV() &&
            "RegionValue must be canonical IV");
-    if (!L)
-      return SE.getCouldNotCompute();
-    return SE.getAddRecExpr(SE.getZero(RV->getType()), SE.getOne(RV->getType()),
-                            L, SCEV::FlagAnyWrap);
+    return PSE.getAddRecExpr(SE.getZero(RV->getType()),
+                             SE.getOne(RV->getType()), SCEV::FlagAnyWrap);
   }
 
   // Helper to create SCEVs for binary and unary operations.
@@ -183,12 +180,12 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
       -> const SCEV * {
     SmallVector<SCEVUse, 2> SCEVOps;
     for (VPValue *Op : Ops) {
-      const SCEV *S = getSCEVExprForVPValue(Op, PSE, L);
+      const SCEV *S = getSCEVExprForVPValue(Op, PSE);
       if (isa<SCEVCouldNotCompute>(S))
         return SE.getCouldNotCompute();
       SCEVOps.push_back(S);
     }
-    return CreateFn(SCEVOps);
+    return PSE.getPredicatedSCEV(CreateFn(SCEVOps));
   };
 
   VPValue *LHSVal, *RHSVal;
@@ -210,8 +207,7 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getMulExpr(Ops[0], Ops[1], SCEV::FlagAnyWrap, 0);
     });
-  if (match(V,
-            m_Binary<Instruction::UDiv>(m_VPValue(LHSVal), m_VPValue(RHSVal))))
+  if (match(V, m_UDiv(m_VPValue(LHSVal), m_VPValue(RHSVal))))
     return CreateSCEV({LHSVal, RHSVal}, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getUDivExpr(Ops[0], Ops[1]);
     });
@@ -246,8 +242,8 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
     auto *SubR = dyn_cast<VPRecipeWithIRFlags>(LHSVal);
     if (match(LHSVal, m_Sub(m_VPValue(SubLHS), m_VPValue(SubRHS))) && SubR &&
         SubR->hasNoSignedWrap() && poisonGuaranteesUB(LHSVal)) {
-      const SCEV *V1 = getSCEVExprForVPValue(SubLHS, PSE, L);
-      const SCEV *V2 = getSCEVExprForVPValue(SubRHS, PSE, L);
+      const SCEV *V1 = getSCEVExprForVPValue(SubLHS, PSE);
+      const SCEV *V2 = getSCEVExprForVPValue(SubRHS, PSE);
       if (!isa<SCEVCouldNotCompute>(V1) && !isa<SCEVCouldNotCompute>(V2))
         return SE.getMinusSCEV(SE.getSignExtendExpr(V1, DestTy),
                                SE.getSignExtendExpr(V2, DestTy), SCEV::FlagNSW);
@@ -281,43 +277,37 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
   ArrayRef<VPValue *> Ops;
   Type *SourceElementType;
   if (match(V, m_GetElementPtr(SourceElementType, Ops))) {
-    const SCEV *GEPExpr = CreateSCEV(Ops, [&](ArrayRef<SCEVUse> Ops) {
+    return CreateSCEV(Ops, [&](ArrayRef<SCEVUse> Ops) {
       return SE.getGEPExpr(Ops.front(), Ops.drop_front(), SourceElementType);
     });
-    return PSE.getPredicatedSCEV(GEPExpr);
   }
 
-  // TODO: Support constructing SCEVs for more recipes as needed.
-  const VPRecipeBase *DefR = V->getDefiningRecipe();
-  const SCEV *Expr =
-      TypeSwitch<const VPRecipeBase *, const SCEV *>(DefR)
-          .Case([](const VPExpandSCEVRecipe *R) { return R->getSCEV(); })
-          .Case([&SE, &PSE, L](const VPWidenIntOrFpInductionRecipe *R) {
-            const SCEV *Step = getSCEVExprForVPValue(R->getStepValue(), PSE, L);
-            if (!L || isa<SCEVCouldNotCompute>(Step))
-              return SE.getCouldNotCompute();
-            const SCEV *Start =
-                getSCEVExprForVPValue(R->getStartValue(), PSE, L);
-            const SCEV *AddRec =
-                SE.getAddRecExpr(Start, Step, L, SCEV::FlagAnyWrap);
-            if (R->getTruncInst())
-              return SE.getTruncateExpr(AddRec, R->getScalarType());
-            return AddRec;
-          })
-          .Case([&SE, &PSE, L](const VPWidenPointerInductionRecipe *R) {
-            const SCEV *Start =
-                getSCEVExprForVPValue(R->getStartValue(), PSE, L);
-            if (!L || isa<SCEVCouldNotCompute>(Start))
-              return SE.getCouldNotCompute();
-            const SCEV *Step = getSCEVExprForVPValue(R->getStepValue(), PSE, L);
-            if (isa<SCEVCouldNotCompute>(Step))
-              return SE.getCouldNotCompute();
-            return SE.getAddRecExpr(Start, Step, L, SCEV::FlagAnyWrap);
-          })
-          .Case([&SE, &PSE, L](const VPDerivedIVRecipe *R) {
-            const SCEV *Start = getSCEVExprForVPValue(R->getOperand(0), PSE, L);
-            const SCEV *IV = getSCEVExprForVPValue(R->getOperand(1), PSE, L);
-            const SCEV *Scale = getSCEVExprForVPValue(R->getOperand(2), PSE, L);
+  return TypeSwitch<const VPRecipeBase *, const SCEV *>(V->getDefiningRecipe())
+      .Case([](const VPExpandSCEVRecipe *R) { return R->getSCEV(); })
+      .Case([&SE, &PSE](const VPWidenIntOrFpInductionRecipe *R) {
+        const SCEV *Step = getSCEVExprForVPValue(R->getStepValue(), PSE);
+        if (isa<SCEVCouldNotCompute>(Step))
+          return SE.getCouldNotCompute();
+        const SCEV *Start = getSCEVExprForVPValue(R->getStartValue(), PSE);
+        const SCEV *AddRec = PSE.getAddRecExpr(Start, Step, SCEV::FlagAnyWrap);
+        if (R->getTruncInst())
+          return SE.getTruncateExpr(AddRec, R->getScalarType());
+        return AddRec;
+      })
+      .Case([&SE, &PSE](const VPWidenPointerInductionRecipe *R) {
+        const SCEV *Start = getSCEVExprForVPValue(R->getStartValue(), PSE);
+        if (isa<SCEVCouldNotCompute>(Start))
+          return SE.getCouldNotCompute();
+        const SCEV *Step = getSCEVExprForVPValue(R->getStepValue(), PSE);
+        if (isa<SCEVCouldNotCompute>(Step))
+          return SE.getCouldNotCompute();
+        return PSE.getAddRecExpr(Start, Step, SCEV::FlagAnyWrap);
+      })
+      .Case(
+          [&SE, &PSE](const VPDerivedIVRecipe *R) {
+            const SCEV *Start = getSCEVExprForVPValue(R->getOperand(0), PSE);
+            const SCEV *IV = getSCEVExprForVPValue(R->getOperand(1), PSE);
+            const SCEV *Scale = getSCEVExprForVPValue(R->getOperand(2), PSE);
             if (any_of(ArrayRef({Start, IV, Scale}),
                        IsaPred<SCEVCouldNotCompute>))
               return SE.getCouldNotCompute();
@@ -327,17 +317,14 @@ const SCEV *vputils::getSCEVExprForVPValue(const VPValue *V,
                 SE.getMulExpr(
                     IV, SE.getTruncateOrSignExtend(Scale, IV->getType())));
           })
-          .Case([&SE, &PSE, L](const VPScalarIVStepsRecipe *R) {
-            const SCEV *IV = getSCEVExprForVPValue(R->getOperand(0), PSE, L);
-            const SCEV *Step = getSCEVExprForVPValue(R->getOperand(1), PSE, L);
-            if (isa<SCEVCouldNotCompute>(IV) || !isa<SCEVConstant>(Step))
-              return SE.getCouldNotCompute();
-            return SE.getTruncateOrSignExtend(IV, Step->getType());
-          })
-          .Default(
-              [&SE](const VPRecipeBase *) { return SE.getCouldNotCompute(); });
-
-  return PSE.getPredicatedSCEV(Expr);
+      .Case([&SE, &PSE](const VPScalarIVStepsRecipe *R) {
+        const SCEV *IV = getSCEVExprForVPValue(R->getOperand(0), PSE);
+        const SCEV *Step = getSCEVExprForVPValue(R->getOperand(1), PSE);
+        if (isa<SCEVCouldNotCompute>(IV) || !isa<SCEVConstant>(Step))
+          return SE.getCouldNotCompute();
+        return SE.getTruncateOrSignExtend(IV, Step->getType());
+      })
+      .Default([&SE](const VPRecipeBase *) { return SE.getCouldNotCompute(); });
 }
 
 bool vputils::isAddressSCEVForCost(const SCEV *Addr, ScalarEvolution &SE,

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -42,8 +42,7 @@ VPValue *getOrCreateVPValueForSCEVExpr(VPlan &Plan, const SCEV *Expr);
 /// Return the SCEV expression for \p V. Returns SCEVCouldNotCompute if no
 /// SCEV expression could be constructed.
 const SCEV *getSCEVExprForVPValue(const VPValue *V,
-                                  PredicatedScalarEvolution &PSE,
-                                  const Loop *L = nullptr);
+                                  PredicatedScalarEvolution &PSE);
 
 /// Returns true if \p Addr is an address SCEV that can be passed to
 /// TTI::getAddressComputationCost, i.e. the address SCEV is loop invariant, an


### PR DESCRIPTION
The PredicatedScalarEvolution is already constructed for a Loop instance: accepting a separate Loop argument in APIs is a footgun, as a different one could be passed from the one in PSE. Changes to predicate the SCEV directly in CreateSCEV of gvetSCEVExprForVPValue are non-functional.