### PR TITLE
[libcxx][string] Test: fix copy&paste typo for safe_allocator

### DIFF
--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp
@@ -150,7 +150,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
   test_string<std::string>();
 #if TEST_STD_VER >= 11
   test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
-  test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
 #endif
 
 #ifndef TEST_HAS_NO_EXCEPTIONS


### PR DESCRIPTION
In test/std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp

Was missing the test for safe_allocator (test for min_allocator was called twice) safe_allocator would be consistent with the rest of that PR.