### PR TITLE
[offload] Update test after ed07c92c9629.

### DIFF
--- a/offload/test/offloading/fortran/dump_map_tables.f90
+++ b/offload/test/offloading/fortran/dump_map_tables.f90
@@ -25,7 +25,7 @@ program map_dump_example
 ! clang-format off
 ! CHECK: omptarget device 0 info: OpenMP Host-Device pointer mappings after block
 ! CHECK-NEXT: omptarget device 0 info: Host Ptr Target Ptr Size (B) DynRefCount HoldRefCount Declaration
-! CHECK-NEXT: omptarget device 0 info: {{(0x[0-9a-f]{16})}} {{(0x[0-9a-f]{16})}}  20000000 1 0 {{.*}} at a(:n):[[@LINE-8]]:11
+! CHECK-NEXT: omptarget device 0 info: {{(0x[0-9a-f]{16})}} {{(0x[0-9a-f]{16})}}  20000000 1 0 a(:n) at {{.*}}:[[@LINE-8]]:11
 ! clang-format on
 !$omp target enter data map(to:A(:N))
   call ompx_dump_mapping_tables()


### PR DESCRIPTION
We now get `a(:n) at dump_map_tables.f90:20:11` so test has been updated accordingly. This should fix the regression seen after https://github.com/llvm/llvm-project/pull/195346.