### PR TITLE
[llvm-cas][test] Use portable truncate size spelling

### DIFF
--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -42,5 +42,5 @@ RUN: llvm-cas --cas %t/ac --validate
 
 # Note: records are 40 bytes (32 hash bytes + 8 byte value), so trim the last
 # allocated record, leaving it invalid.
-RUN: truncate -s -40 %t/ac/v1.1/actions.v1
+RUN: truncate -s-40 %t/ac/v1.1/actions.v1
 RUN: not llvm-cas --cas %t/ac --validate


### PR DESCRIPTION
Use `truncate -s-40` instead of `truncate -s -40` in the CAS validation test.

Some truncate implementations, such as uutils coreutils(Ubuntu 25.10), parse the split negative size argument as an option and reject it. Attaching the argument to `-s` keeps the behavior the same while avoiding that parsing issue.

This fixes the test on systems where `truncate -s -40` fails.

Example error message:
```
truncate -s -40 /collabora/LLVM/llvm-project/build/test/tools/llvm-cas/Output/validation.test.tmp/ac/v1.1/actions.v1
# executed command: truncate -s -40 /collabora/LLVM/llvm-project/build/test/tools/llvm-cas/Output/validation.test.tmp/ac/v1.1/actions.v1
# .---command stderr------------
# | error: unexpected argument '-4' found
# | 
# |   tip: to pass '-4' as a value, use '-- -4'
# | 
# | Usage: truncate [OPTION]... [FILE]...
# | 
# | For more information, try '--help'.
# `-----------------------------
# error: command failed with exit status: 1
```