### PR TITLE
[libcxx][string] Test: default constructed allocators can be unequal

### DIFF
--- a/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
@@ -28,7 +28,6 @@
 template <class S, class SV>
 TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
   typedef typename S::size_type Size;
   if (pos <= sv.size()) {
     S s2(sv, static_cast<Size>(pos), static_cast<Size>(n));
@@ -37,7 +36,7 @@ TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n) {
     std::size_t rlen = std::min(sv.size() - pos, n);
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), sv.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }

--- a/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
@@ -28,7 +28,6 @@
 template <class S, class SV>
 TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
   typedef typename S::size_type Size;
   if (pos <= sv.size()) {
     S s2(sv, static_cast<Size>(pos), static_cast<Size>(n));
@@ -37,7 +36,6 @@ TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n) {
     std::size_t rlen = std::min(sv.size() - pos, n);
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), sv.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -150,11 +148,41 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class SV>
+void test_default_alloc_arg(SV sv, std::size_t pos, std::size_t n) {
+  using A = ControlledDefaultConstructorAllocator<char>;
+  using S = std::basic_string<char, std::char_traits<char>, A>;
+
+  typedef typename S::size_type Size;
+  if (pos <= sv.size()) {
+    A::reset_to_base();
+    S s2(sv, static_cast<Size>(pos), static_cast<Size>(n));
+    assert(s2.get_allocator().is_base());
+  }
+}
+
+void test_default_alloc_arg() {
+  using SV = std::basic_string_view<char, std::char_traits<char> >;
+
+  test_default_alloc_arg(SV(), 0, 0);
+  test_default_alloc_arg(SV(), 0, 1);
+  test_default_alloc_arg(SV(), 1, 0);
+  test_default_alloc_arg(SV(), 1, 1);
+  test_default_alloc_arg(SV(), 1, 2);
+  test_default_alloc_arg(SV("1"), 0, 0);
+  test_default_alloc_arg(SV("1"), 0, 1);
+  test_default_alloc_arg(SV("1234567890123456789012345678901234567890123456789012345678901234567890"), 50, 0);
+  test_default_alloc_arg(SV("1234567890123456789012345678901234567890123456789012345678901234567890"), 50, 1);
+  test_default_alloc_arg(SV("1234567890123456789012345678901234567890123456789012345678901234567890"), 50, 10);
+  test_default_alloc_arg(SV("1234567890123456789012345678901234567890123456789012345678901234567890"), 50, 100);
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/alloc.pass.cpp
@@ -67,7 +67,10 @@ TEST_CONSTEXPR_CXX20 void test2() {
     assert(s.data());
     assert(s.size() == 0);
     assert(s.capacity() >= s.size());
-    assert(s.get_allocator() == typename S::allocator_type());
+#  if TEST_STD_VER >= 11
+    static_assert(std::is_same<decltype(s.get_allocator()), typename S::allocator_type>::value, "");
+#  endif
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s);
     LIBCPP_ASSERT(is_string_asan_correct(s));
   }
   {
@@ -78,12 +81,13 @@ TEST_CONSTEXPR_CXX20 void test2() {
                    std::is_nothrow_copy_constructible<typename S::allocator_type>::value),
                   "");
 #  endif
-    S s(typename S::allocator_type{});
+    typename S::allocator_type a{};
+    S s(a);
     LIBCPP_ASSERT(s.__invariants());
     assert(s.data());
     assert(s.size() == 0);
     assert(s.capacity() >= s.size());
-    assert(s.get_allocator() == typename S::allocator_type());
+    assert(s.get_allocator() == a);
     LIBCPP_ASSERT(is_string_asan_correct(s));
   }
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/alloc.pass.cpp
@@ -59,7 +59,7 @@ TEST_CONSTEXPR_CXX20 void test2() {
   {
 #  if TEST_STD_VER > 14
     static_assert((noexcept(S{})), "");
-#  elif TEST_STD_VER >= 11
+#  else
     static_assert((noexcept(S()) == noexcept(typename S::allocator_type())), "");
 #  endif
     S s;
@@ -67,23 +67,23 @@ TEST_CONSTEXPR_CXX20 void test2() {
     assert(s.data());
     assert(s.size() == 0);
     assert(s.capacity() >= s.size());
-    assert(s.get_allocator() == typename S::allocator_type());
     LIBCPP_ASSERT(is_string_asan_correct(s));
   }
   {
 #  if TEST_STD_VER > 14
     static_assert((noexcept(S{typename S::allocator_type{}})), "");
-#  elif TEST_STD_VER >= 11
+#  else
     static_assert((noexcept(S(typename S::allocator_type())) ==
                    std::is_nothrow_copy_constructible<typename S::allocator_type>::value),
                   "");
 #  endif
-    S s(typename S::allocator_type{});
+    typename S::allocator_type a{};
+    S s(a);
     LIBCPP_ASSERT(s.__invariants());
     assert(s.data());
     assert(s.size() == 0);
     assert(s.capacity() >= s.size());
-    assert(s.get_allocator() == typename S::allocator_type());
+    assert(s.get_allocator() == a);
     LIBCPP_ASSERT(is_string_asan_correct(s));
   }
 }
@@ -101,11 +101,21 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+void test_default_alloc_arg() {
+  using A = ControlledDefaultConstructorAllocator<char>;
+  using S = std::basic_string<char, std::char_traits<char>, A>;
+
+  A::reset_to_base();
+  S s;
+  assert(s.get_allocator().is_base());
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/iter_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/iter_alloc.pass.cpp
@@ -36,7 +36,7 @@ TEST_CONSTEXPR_CXX20 void test(It first, It last) {
     ++it;
     ++i;
   }
-  assert(s2.get_allocator() == Alloc());
+  ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/iter_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/iter_alloc.pass.cpp
@@ -36,7 +36,6 @@ TEST_CONSTEXPR_CXX20 void test(It first, It last) {
     ++it;
     ++i;
   }
-  assert(s2.get_allocator() == Alloc());
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }
@@ -102,11 +101,36 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class It>
+void test_default_alloc_arg(It first, It last) {
+  typedef typename std::iterator_traits<It>::value_type charT;
+  using A = ControlledDefaultConstructorAllocator<charT>;
+  using S = std::basic_string<charT, std::char_traits<charT>, A>;
+
+  A::reset_to_base();
+  S s2(first, last);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  const char* s = "12345678901234567890123456789012345678901234567890";
+
+  test_default_alloc_arg(s, s);
+  test_default_alloc_arg(s, s + 1);
+  test_default_alloc_arg(s, s + 10);
+  test_default_alloc_arg(s, s + 50);
+  test_default_alloc_arg(cpp17_input_iterator<const char*>(s), cpp17_input_iterator<const char*>(s));
+  test_default_alloc_arg(cpp17_input_iterator<const char*>(s), cpp17_input_iterator<const char*>(s + 1));
+  test_default_alloc_arg(cpp17_input_iterator<const char*>(s), cpp17_input_iterator<const char*>(s + 10));
+  test_default_alloc_arg(cpp17_input_iterator<const char*>(s), cpp17_input_iterator<const char*>(s + 50));
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/pointer_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/pointer_alloc.pass.cpp
@@ -30,7 +30,7 @@ TEST_CONSTEXPR_CXX20 void test(const charT* s) {
   LIBCPP_ASSERT(s2.__invariants());
   assert(s2.size() == n);
   assert(T::compare(s2.data(), s, n) == 0);
-  assert(s2.get_allocator() == Alloc());
+  ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/pointer_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/pointer_alloc.pass.cpp
@@ -30,7 +30,6 @@ TEST_CONSTEXPR_CXX20 void test(const charT* s) {
   LIBCPP_ASSERT(s2.__invariants());
   assert(s2.size() == n);
   assert(T::compare(s2.data(), s, n) == 0);
-  assert(s2.get_allocator() == Alloc());
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }
@@ -76,11 +75,29 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class CharT>
+void test_default_alloc_arg(const CharT* s) {
+  using A = ControlledDefaultConstructorAllocator<CharT>;
+  using S = std::basic_string<CharT, std::char_traits<CharT>, A>;
+
+  A::reset_to_base();
+  S s2(s);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  test_default_alloc_arg("");
+  test_default_alloc_arg("1");
+  test_default_alloc_arg("1234567980");
+  test_default_alloc_arg("123456798012345679801234567980123456798012345679801234567980");
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/pointer_size_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/pointer_size_alloc.pass.cpp
@@ -28,7 +28,7 @@ TEST_CONSTEXPR_CXX20 void test(const CharT* s, unsigned n) {
   LIBCPP_ASSERT(s2.__invariants());
   assert(s2.size() == n);
   assert(T::compare(s2.data(), s, n) == 0);
-  assert(s2.get_allocator() == Alloc());
+  ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/pointer_size_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/pointer_size_alloc.pass.cpp
@@ -28,7 +28,6 @@ TEST_CONSTEXPR_CXX20 void test(const CharT* s, unsigned n) {
   LIBCPP_ASSERT(s2.__invariants());
   assert(s2.size() == n);
   assert(T::compare(s2.data(), s, n) == 0);
-  assert(s2.get_allocator() == Alloc());
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }
@@ -81,11 +80,29 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class CharT>
+void test_default_alloc_arg(const CharT* s, unsigned n) {
+  using A = ControlledDefaultConstructorAllocator<CharT>;
+  using S = std::basic_string<CharT, std::char_traits<CharT>, A>;
+
+  A::reset_to_base();
+  S s2(s, n);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  test_default_alloc_arg("", 0);
+  test_default_alloc_arg("1", 1);
+  test_default_alloc_arg("1234567980", 10);
+  test_default_alloc_arg("123456798012345679801234567980123456798012345679801234567980", 60);
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/size_char_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/size_char_alloc.pass.cpp
@@ -29,7 +29,7 @@ TEST_CONSTEXPR_CXX20 void test(unsigned n, charT c) {
   assert(s2.size() == n);
   for (unsigned i = 0; i < n; ++i)
     assert(s2[i] == c);
-  assert(s2.get_allocator() == Alloc());
+  ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }
@@ -56,7 +56,7 @@ TEST_CONSTEXPR_CXX20 void test(Tp n, Tp c) {
   assert(s2.size() == static_cast<std::size_t>(n));
   for (int i = 0; i < n; ++i)
     assert(s2[i] == c);
-  assert(s2.get_allocator() == Alloc());
+  ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
   assert(s2.capacity() >= s2.size());
 }
 

--- a/libcxx/test/std/strings/basic.string/string.cons/size_char_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/size_char_alloc.pass.cpp
@@ -29,7 +29,6 @@ TEST_CONSTEXPR_CXX20 void test(unsigned n, charT c) {
   assert(s2.size() == n);
   for (unsigned i = 0; i < n; ++i)
     assert(s2[i] == c);
-  assert(s2.get_allocator() == Alloc());
   assert(s2.capacity() >= s2.size());
   LIBCPP_ASSERT(is_string_asan_correct(s2));
 }
@@ -56,7 +55,6 @@ TEST_CONSTEXPR_CXX20 void test(Tp n, Tp c) {
   assert(s2.size() == static_cast<std::size_t>(n));
   for (int i = 0; i < n; ++i)
     assert(s2[i] == c);
-  assert(s2.get_allocator() == Alloc());
   assert(s2.capacity() >= s2.size());
 }
 
@@ -103,11 +101,30 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class Tp, class CharT>
+void test_default_alloc_arg(Tp n, CharT c) {
+  using A = ControlledDefaultConstructorAllocator<CharT>;
+  using S = std::basic_string<CharT, std::char_traits<CharT>, A>;
+
+  A::reset_to_base();
+  S s2(n, c);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  test_default_alloc_arg(0, 'a');
+  test_default_alloc_arg(1, 'a');
+  test_default_alloc_arg(10, 'a');
+  test_default_alloc_arg(100, 'a');
+  test_default_alloc_arg(static_cast<char>(100), static_cast<char>(65));
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/string_view.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/string_view.pass.cpp
@@ -34,7 +34,7 @@ TEST_CONSTEXPR_CXX20 void test(std::basic_string_view<CharT> sv) {
     LIBCPP_ASSERT(s2.__invariants());
     assert(s2.size() == sv.size());
     assert(T::compare(s2.data(), sv.data(), sv.size()) == 0);
-    assert(s2.get_allocator() == Alloc());
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -44,7 +44,7 @@ TEST_CONSTEXPR_CXX20 void test(std::basic_string_view<CharT> sv) {
     LIBCPP_ASSERT(s2.__invariants());
     assert(s2.size() == sv.size());
     assert(T::compare(s2.data(), sv.data(), sv.size()) == 0);
-    assert(s2.get_allocator() == Alloc());
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }

--- a/libcxx/test/std/strings/basic.string/string.cons/string_view.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/string_view.pass.cpp
@@ -34,7 +34,6 @@ TEST_CONSTEXPR_CXX20 void test(std::basic_string_view<CharT> sv) {
     LIBCPP_ASSERT(s2.__invariants());
     assert(s2.size() == sv.size());
     assert(T::compare(s2.data(), sv.data(), sv.size()) == 0);
-    assert(s2.get_allocator() == Alloc());
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -44,8 +43,6 @@ TEST_CONSTEXPR_CXX20 void test(std::basic_string_view<CharT> sv) {
     LIBCPP_ASSERT(s2.__invariants());
     assert(s2.size() == sv.size());
     assert(T::compare(s2.data(), sv.data(), sv.size()) == 0);
-    assert(s2.get_allocator() == Alloc());
-    assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
 }
@@ -104,11 +101,36 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class CharT>
+void test_default_alloc_arg(std::basic_string_view<CharT> sv) {
+  using A = ControlledDefaultConstructorAllocator<CharT>;
+  using S = std::basic_string<CharT, std::char_traits<CharT>, A>;
+
+  A::reset_to_base();
+  S s;
+  s = sv;
+  assert(s.get_allocator().is_base());
+
+  A::reset_to_base();
+  S s2(sv);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  typedef std::basic_string_view<char, std::char_traits<char> > SV;
+
+  test_default_alloc_arg(SV(""));
+  test_default_alloc_arg(SV("1"));
+  test_default_alloc_arg(SV("1234567980"));
+  test_default_alloc_arg(SV("123456798012345679801234567980123456798012345679801234567980"));
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
@@ -31,7 +31,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
 
   if (pos <= str.size()) {
     S s2(str, pos);
@@ -39,7 +38,7 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
     typename S::size_type rlen = str.size() - pos;
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), str.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -58,14 +57,13 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos, unsigned n) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
   if (pos <= str.size()) {
     S s2(str, pos, n);
     LIBCPP_ASSERT(s2.__invariants());
     typename S::size_type rlen = std::min<typename S::size_type>(str.size() - pos, n);
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), str.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
+    ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(S, s2);
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }

--- a/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
@@ -31,7 +31,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
 
   if (pos <= str.size()) {
     S s2(str, pos);
@@ -39,7 +38,6 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
     typename S::size_type rlen = str.size() - pos;
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), str.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -58,14 +56,12 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos, unsigned n) {
   typedef typename S::traits_type T;
-  typedef typename S::allocator_type A;
   if (pos <= str.size()) {
     S s2(str, pos, n);
     LIBCPP_ASSERT(s2.__invariants());
     typename S::size_type rlen = std::min<typename S::size_type>(str.size() - pos, n);
     assert(s2.size() == rlen);
     assert(T::compare(s2.data(), str.data() + pos, rlen) == 0);
-    assert(s2.get_allocator() == A());
     assert(s2.capacity() >= s2.size());
     LIBCPP_ASSERT(is_string_asan_correct(s2));
   }
@@ -174,12 +170,56 @@ TEST_CONSTEXPR_CXX20 bool test() {
   return true;
 }
 
+template <class S>
+void test_default_alloc_arg(S str, unsigned pos) {
+  using A = typename S::allocator_type;
+  A::reset_to_base();
+  S s2(str, pos);
+  assert(s2.get_allocator().is_base());
+}
+
+template <class S>
+void test_default_alloc_arg(S str, unsigned pos, unsigned n) {
+  using A = typename S::allocator_type;
+  A::reset_to_base();
+  S s2(str, pos, n);
+  assert(s2.get_allocator().is_base());
+}
+
+void test_default_alloc_arg() {
+  using Alloc = ControlledDefaultConstructorAllocator<char>;
+  using S     = std::basic_string<char, std::char_traits<char>, Alloc>;
+  Alloc a1;
+  test(S(Alloc(a1)), 0);
+  test(S(Alloc(a1)), 1);
+  test(S("1", Alloc(a1)), 0);
+  test(S("1", Alloc(a1)), 1);
+  test(S("1", Alloc(a1)), 2);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 0);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 5);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 50);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 500);
+
+  test(S(Alloc(a1)), 0, 0);
+  test(S(Alloc(a1)), 0, 1);
+  test(S(Alloc(a1)), 1, 0);
+  test(S(Alloc(a1)), 1, 1);
+  test(S(Alloc(a1)), 1, 2);
+  test(S("1", Alloc(a1)), 0, 0);
+  test(S("1", Alloc(a1)), 0, 1);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 50, 0);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 50, 1);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 50, 10);
+  test(S("1234567890123456789012345678901234567890123456789012345678901234567890", Alloc(a1)), 50, 100);
+}
+
 int main(int, char**) {
   test();
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif
   test_lwg2583();
+  test_default_alloc_arg();
 
   return 0;
 }

--- a/libcxx/test/std/strings/basic.string/string.cons/substr_rvalue.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/substr_rvalue.pass.cpp
@@ -33,12 +33,14 @@ constexpr struct should_throw_exception_t {
 
 template <class S>
 constexpr void test_string_pos(S orig, typename S::size_type pos, S expected) {
+  const bool expect_no_allocation = orig.get_allocator() == typename S::allocator_type();
 #ifdef _LIBCPP_VERSION
-  ConstexprDisableAllocationGuard g;
+  ConstexprDisableAllocationGuard g(expect_no_allocation);
 #endif
   S substr(std::move(orig), pos);
   LIBCPP_ASSERT(orig.__invariants());
-  LIBCPP_ASSERT(orig.empty());
+  if (expect_no_allocation)
+    LIBCPP_ASSERT(orig.empty());
   LIBCPP_ASSERT(substr.__invariants());
   assert(substr == expected);
   LIBCPP_ASSERT(is_string_asan_correct(orig));
@@ -93,12 +95,14 @@ constexpr void test_string_pos_alloc(
 
 template <class S>
 constexpr void test_string_pos_n(S orig, typename S::size_type pos, typename S::size_type n, S expected) {
+  const bool expect_no_allocation = orig.get_allocator() == typename S::allocator_type();
 #ifdef _LIBCPP_VERSION
-  ConstexprDisableAllocationGuard g;
+  ConstexprDisableAllocationGuard g(expect_no_allocation);
 #endif
   S substr(std::move(orig), pos, n);
   LIBCPP_ASSERT(orig.__invariants());
-  LIBCPP_ASSERT(orig.empty());
+  if (expect_no_allocation)
+    LIBCPP_ASSERT(orig.empty());
   LIBCPP_ASSERT(substr.__invariants());
   assert(substr == expected);
   LIBCPP_ASSERT(is_string_asan_correct(orig));

--- a/libcxx/test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
@@ -25,7 +25,9 @@ TEST_CONSTEXPR_CXX20 void test(const S& s, const typename S::allocator_type& a) 
 template <class Alloc>
 TEST_CONSTEXPR_CXX20 void test_string(const Alloc& a) {
   using S = std::basic_string<char, std::char_traits<char>, Alloc>;
-  test(S(""), Alloc());
+  if (are_default_allocators_always_equal<Alloc>::value)
+    test(S(""), Alloc());
+  test(S("", Alloc(a)), Alloc(a));
   test(S("abcde", Alloc(a)), Alloc(a));
   test(S("abcdefghij", Alloc(a)), Alloc(a));
   test(S("abcdefghijklmnopqrst", Alloc(a)), Alloc(a));

--- a/libcxx/test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.ops/string.accessors/get_allocator.pass.cpp
@@ -19,13 +19,14 @@
 
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(const S& s, const typename S::allocator_type& a) {
+  static_assert(std::is_same<decltype(s.get_allocator()), typename S::allocator_type>::value, "");
   assert(s.get_allocator() == a);
 }
 
 template <class Alloc>
 TEST_CONSTEXPR_CXX20 void test_string(const Alloc& a) {
   using S = std::basic_string<char, std::char_traits<char>, Alloc>;
-  test(S(""), Alloc());
+  test(S("", Alloc(a)), Alloc(a));
   test(S("abcde", Alloc(a)), Alloc(a));
   test(S("abcdefghij", Alloc(a)), Alloc(a));
   test(S("abcdefghijklmnopqrst", Alloc(a)), Alloc(a));

--- a/libcxx/test/support/test_allocator.h
+++ b/libcxx/test/support/test_allocator.h
@@ -20,6 +20,18 @@
 
 #include "test_macros.h"
 
+// unless explicitly specified as false
+template <class T>
+struct are_default_allocators_always_equal {
+  enum { value = 1 };
+};
+
+#define ASSERT_CONTAINER_ALLOCATOR_EQUALS_DEFAULT(C, c)                                                                \
+  do {                                                                                                                 \
+    if (are_default_allocators_always_equal<typename C::allocator_type>::value)                                        \
+      assert(c.get_allocator() == typename C::allocator_type());                                                       \
+  } while (0)
+
 template <class Alloc>
 TEST_CONSTEXPR_CXX20 inline typename std::allocator_traits<Alloc>::size_type alloc_max_size(Alloc const& a) {
   typedef std::allocator_traits<Alloc> AT;

--- a/libcxx/test/support/test_allocator.h
+++ b/libcxx/test/support/test_allocator.h
@@ -515,4 +515,40 @@ struct SocccAllocator {
   using propagate_on_container_swap            = std::false_type;
 };
 
+// Track how many times the allocator was default-constructed
+//
+
+template <class T>
+class ControlledDefaultConstructorAllocator : public std::allocator<T> {
+public:
+  template <class U>
+  struct rebind {
+    typedef ControlledDefaultConstructorAllocator<U> other;
+  };
+
+  ControlledDefaultConstructorAllocator() TEST_NOEXCEPT { default_constructed_tag_ = next_default_constructed_tag_++; }
+  bool is_base() const TEST_NOEXCEPT { return default_constructed_tag_ == base_default_constructed_tag_; }
+
+  static void reset_to_base() { next_default_constructed_tag_ = base_default_constructed_tag_; }
+
+  friend bool operator==(ControlledDefaultConstructorAllocator x, ControlledDefaultConstructorAllocator y) {
+    return x.default_constructed_tag_ == y.default_constructed_tag_;
+  }
+  friend bool operator!=(ControlledDefaultConstructorAllocator x, ControlledDefaultConstructorAllocator y) {
+    return !(x == y);
+  }
+
+  const static int base_default_constructed_tag_;
+  static int next_default_constructed_tag_;
+
+  int default_constructed_tag_;
+};
+
+template <class T>
+const int ControlledDefaultConstructorAllocator<T>::base_default_constructed_tag_ = 42;
+
+template <class T>
+int ControlledDefaultConstructorAllocator<T>::next_default_constructed_tag_ =
+    ControlledDefaultConstructorAllocator<T>::base_default_constructed_tag_;
+
 #endif // TEST_ALLOCATOR_H


### PR DESCRIPTION
In the original code base, multiple basic_string constructor tests for the
constructors with default allocator arguments were checking that the resulting
allocator is equal to default-constructed allocator. This check is neither
sufficient nor valid.

In particular, in yet to be merged fancy_pointer_allocator multiple default
constructed instances of the allocator may have unrelated internal states,
so this test will unnecessarily fail.

In this PR, these basic_string constructor tests were changed to rely on a
helper ControlledDefaultConstructorAllocator class, which allows us to check
directly whether the alloctor instance for the default argument was constructed.

In addition, one missing test path where substring move will cause allocation
due to incompatible allocators (as already implemented in basic_string) was found
and addressed.
