### PR TITLE
[LiveDebugValues] Avoid SmallSet for dead registers

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -986,7 +986,7 @@ private:
   /// VarLoc correspond to entries in the universal location bucket, which every
   /// VarLoc has exactly 1 entry for. Insert collected IDs into \p Collected.
   static void collectIDsForRegs(VarLocsInRange &Collected,
-                                const DefinedRegsSet &Regs,
+                                ArrayRef<Register> Regs,
                                 const VarLocSet &CollectFrom,
                                 const VarLocMap &VarLocIDs);
 
@@ -1171,9 +1171,8 @@ void VarLocBasedLDV::OpenRangesSet::erase(const VarLocsInRange &KillSet,
 void VarLocBasedLDV::OpenRangesSet::insertFromLocSet(const VarLocSet &ToLoad,
                                                      const VarLocMap &Map) {
   VarLocsInRange UniqueVarLocIDs;
-  DefinedRegsSet Regs;
-  Regs.insert(LocIndex::kUniversalLocation);
-  collectIDsForRegs(UniqueVarLocIDs, Regs, ToLoad, Map);
+  Register UniversalLoc = LocIndex::kUniversalLocation;
+  collectIDsForRegs(UniqueVarLocIDs, UniversalLoc, ToLoad, Map);
   for (uint64_t ID : UniqueVarLocIDs) {
     LocIndex Idx = LocIndex::fromRawInteger(ID);
     const VarLoc &VarL = Map[Idx];
@@ -1202,13 +1201,14 @@ VarLocBasedLDV::OpenRangesSet::getEntryValueBackup(DebugVariable Var) {
 }
 
 void VarLocBasedLDV::collectIDsForRegs(VarLocsInRange &Collected,
-                                       const DefinedRegsSet &Regs,
+                                       ArrayRef<Register> Regs,
                                        const VarLocSet &CollectFrom,
                                        const VarLocMap &VarLocIDs) {
   assert(!Regs.empty() && "Nothing to collect");
   SmallVector<Register, 32> SortedRegs;
   append_range(SortedRegs, Regs);
   llvm::sort(SortedRegs, [](Register LHS, Register RHS) { return LHS < RHS; });
+  SortedRegs.erase(llvm::unique(SortedRegs), SortedRegs.end());
   auto It = CollectFrom.find(LocIndex::rawIndexForReg(SortedRegs.front()));
   auto End = CollectFrom.end();
   for (Register Reg : SortedRegs) {
@@ -1596,7 +1596,7 @@ void VarLocBasedLDV::transferRegisterDef(MachineInstr &MI,
   Register SP = TLI->getStackPointerRegisterToSaveRestore();
 
   // Find the regs killed by MI, and find regmasks of preserved regs.
-  DefinedRegsSet DeadRegs;
+  SmallVector<Register, 32> DeadRegs;
   SmallVector<const uint32_t *, 4> RegMasks;
   for (const MachineOperand &MO : MI.operands()) {
     // Determine whether the operand is a register def.
@@ -1604,8 +1604,7 @@ void VarLocBasedLDV::transferRegisterDef(MachineInstr &MI,
         !(MI.isCall() && MO.getReg() == SP)) {
       // Remove ranges of all aliased registers.
       for (MCRegAliasIterator RAI(MO.getReg(), TRI, true); RAI.isValid(); ++RAI)
-        // FIXME: Can we break out of this loop early if no insertion occurs?
-        DeadRegs.insert((*RAI).id());
+        DeadRegs.push_back((*RAI).id());
       RegSetInstrs.erase(MO.getReg());
       RegSetInstrs.insert({MO.getReg(), &MI});
     } else if (MO.isRegMask()) {
@@ -1633,7 +1632,7 @@ void VarLocBasedLDV::transferRegisterDef(MachineInstr &MI,
             return MachineOperand::clobbersPhysReg(RegMask, Reg);
           });
       if (AnyRegMaskKillsReg)
-        DeadRegs.insert(Reg);
+        DeadRegs.push_back(Reg);
       if (AnyRegMaskKillsReg) {
         RegSetInstrs.erase(Reg);
         RegSetInstrs.insert({Reg, &MI});


### PR DESCRIPTION
transferRegisterDef builds a list of dead registers and removes open ranges for
debug locations that use those registers. This list used a SmallSet, so each
insert also does uniquing in the hot per-instruction path. This showed up under
SmallSet<Register, 32>::insertImpl on profiles of sqlite on aarch64-O0-g.

Using a SmallVector instead and uniquing in collectIDsForRegs improves
compile-time.

CTMark geomean:
- stage1-O0-g: -0.35%
- stage1-aarch64-O0-g: -0.72%
- stage2-O0-g: -0.27%

https://llvm-compile-time-tracker.com/compare.php?from=c9d713aa48a714d20b8502d06b9feb24829e6f22&to=6c0d4aafb9e325259c88577d148ac13c643ea993&stat=instructions%3Au

Assisted-by: codex