### PR TITLE
[clang-tidy] apply fix-it for modernize-return-braced-init-list with qualifiers

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/ReturnBracedInitListCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ReturnBracedInitListCheck.cpp
@@ -81,8 +81,10 @@ void ReturnBracedInitListCheck::check(const MatchFinder::MatchResult &Result) {
        I < NumParams; ++I) {
     if (const auto *VD = dyn_cast<VarDecl>(
             MatchedConstructExpr->getConstructor()->getParamDecl(I))) {
-      if (MatchedConstructExpr->getArg(I)->getType().getCanonicalType() !=
-          VD->getType().getCanonicalType())
+      const auto ArgType = MatchedConstructExpr->getArg(I)->getType();
+      const auto ParamType = VD->getType().getNonReferenceType();
+      if (ArgType.getCanonicalType().getUnqualifiedType() !=
+          ParamType.getCanonicalType().getUnqualifiedType())
         return;
     }
   }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -420,6 +420,10 @@ Changes in existing checks
 - Improved :doc:`modernize-redundant-void-arg
   <clang-tidy/checks/modernize/redundant-void-arg>` check to work in C23.
 
+- Improved :doc:`modernize-return-braced-init-list
+  <clang-tidy/checks/modernize/return-braced-init-list>` check to apply fix-it
+  when type qualifiers and/or reference modifiers are used with parameters.
+
 - Improved :doc:`modernize-use-equals-delete
   <clang-tidy/checks/modernize/use-equals-delete>` check by only warning on
   private deleted functions, if they do not have a public overload or are a

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
@@ -241,3 +241,27 @@ Vol vn1() {
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
   // CHECK-FIXES: return {x};
 }
+
+struct Gaz {
+  Gaz(int) {}
+};
+
+Gaz hn1() {
+  return Gaz(0);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {0};
+}
+
+Gaz hn2() {
+  const int x = 1;
+  return Gaz(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}
+
+Gaz hn3() {
+  const int& x = 2;
+  return Gaz(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
@@ -176,3 +176,68 @@ Foo i7 = bazQuux.m2(b0);
 
 auto v1 = []() { return std::vector<int>({1, 2}); }();
 auto v2 = []() -> std::vector<int> { return std::vector<int>({1, 2}); }();
+
+
+struct Saz {
+  Saz(const int&) {}
+};
+
+Saz fn1() {
+  return Saz(0);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {0};
+}
+
+Saz fn2() {
+  int x = 1;
+  return Saz(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}
+
+struct Taz {
+  Taz(const int) {}
+};
+
+Taz gn1() {
+  return Taz(0);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {0};
+}
+
+Taz gn2() {
+  int x = 0;
+  return Taz(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}
+
+Taz gn3() {
+  const int& x = 0;
+  return Taz(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}
+
+struct MultiSaz {
+  MultiSaz(const int&, const double) {}
+};
+
+MultiSaz mfn1() {
+  int x = 1;
+  double y = 2.0;
+  return MultiSaz(x, y);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x, y};
+}
+
+struct Vol {
+  Vol(volatile int) {}
+};
+
+Vol vn1() {
+  int x = 1;
+  return Vol(x);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
+  // CHECK-FIXES: return {x};
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/195844

With this PR I've added robust test cases to ensure things work for many different cases.