### PR TITLE
[lldb-dap] Fix crash in source request handler

### DIFF
--- a/lldb/test/API/tools/lldb-dap/source/TestDAP_source.py
+++ b/lldb/test/API/tools/lldb-dap/source/TestDAP_source.py
@@ -32,6 +32,12 @@ class TestDAP_source(lldbdap_testcase.DAPTestCaseBase):
         response = self.dap_server.request_source(sourceReference=0)
         self.assertFalse(response["success"], "verify invalid sourceReference fails")
 
+        # Check only source reference in the arguments field.
+        response = self.dap_server.request_custom("source", {"sourceReference": 0})
+        self.assertFalse(response["success"], "expected failed response")
+        error_format = self.get_dict_value(response, ["body", "error", "format"])
+        self.assertIn("unknown source reference", error_format)
+
         (stackFrames, totalFrames) = self.get_stackFrames_and_totalFramesCount()
         frameCount = len(stackFrames)
         self.assertGreaterEqual(frameCount, 3, "verify we got up to main at least")

--- a/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
@@ -31,13 +31,14 @@ llvm::Expected<protocol::SourceResponseBody>
 SourceRequestHandler::Run(const protocol::SourceArguments &args) const {
 
   uint32_t source_ref =
-      args.source->sourceReference.value_or(args.sourceReference);
+      args.source ? args.source->sourceReference.value_or(args.sourceReference)
+                  : args.sourceReference;
   const std::optional<lldb::addr_t> source_addr_opt =
       dap.GetSourceReferenceAddress(source_ref);
 
   if (!source_addr_opt)
     return llvm::make_error<DAPError>(
-        llvm::formatv("Unknown source reference {}", source_ref));
+        llvm::formatv("unknown source reference {}", source_ref));
 
   lldb::SBAddress address(*source_addr_opt, dap.target);
   if (!address.IsValid())


### PR DESCRIPTION
Check optional argument source has a value before getting the source reference.