### PR TITLE
Introduce tensorEncodingToMemref

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
@@ -269,6 +269,14 @@ struct BufferizationOptions {
   /// Parameters: tensor type, memory space, bufferization options
   using UnknownTypeConverterFn = std::function<BaseMemRefType(
       TensorType, Attribute memorySpace, const BufferizationOptions &)>;
+  /// Build a MemRefLayoutAttrInterface from the encoding of `tensorType`.
+  /// Called whenever bufferization materializes a memref for a tensor value
+  /// (function arguments, `bufferization.alloc_tensor`, generic tensor-like
+  /// conversion fallback). Returning `nullptr` keeps the default layout
+  /// (identity or fully-dynamic, depending on the call site). The hook must
+  /// not change rank / shape / element type of the result.
+  using TensorEncodingToMemRefLayoutFn =
+      std::function<MemRefLayoutAttrInterface(TensorType)>;
   // Produce a MemorySpace attribute from a tensor type
   using DefaultMemorySpaceFn =
       std::function<std::optional<Attribute>(TensorType t)>;
@@ -363,6 +371,14 @@ struct BufferizationOptions {
   // failure to determine memory space for a tensor type).
   DefaultMemorySpaceFn defaultMemorySpaceFn =
       [](TensorType t) -> std::optional<Attribute> { return Attribute(); };
+
+  /// Hook to derive a MemRef layout from a tensor encoding.
+  /// The default implementation returns the tensor encoding itself when it
+  /// already implements `MemRefLayoutAttrInterface`, and `{}` otherwise; this
+  /// makes `tensor<..., #layout>` naturally map to `memref<..., #layout>`.
+  /// Downstream callers can override the hook to provide custom mapping for
+  /// dialect-specific encodings.
+  TensorEncodingToMemRefLayoutFn tensorEncodingToMemRefLayoutFn = nullptr;
 
   /// If set to `true`, the analysis is skipped. A buffer is copied before every
   /// write. This flag cannot be used together with `testAnalysisOnly = true`.

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -370,12 +370,24 @@ defaultUnknownTypeConverter(TensorType tensorType, Attribute memorySpace,
   return getMemRefTypeWithFullyDynamicLayout(tensorType, memorySpace);
 }
 
+/// Default tensor-encoding to memref-layout hook: if the tensor is a
+/// `RankedTensorType` whose encoding already implements
+/// `MemRefLayoutAttrInterface`, use it directly. Downstream callers can
+/// override the hook on `BufferizationOptions` to customize this mapping.
+MemRefLayoutAttrInterface defaultTensorEncodingToMemRefLayout(TensorType t) {
+  auto rtt = dyn_cast<RankedTensorType>(t);
+  if (!rtt)
+    return {};
+  return dyn_cast_or_null<MemRefLayoutAttrInterface>(rtt.getEncoding());
+}
+
 } // namespace
 
 // Default constructor for BufferizationOptions.
 BufferizationOptions::BufferizationOptions()
     : functionArgTypeConverterFn(defaultFunctionArgTypeConverter),
-      unknownTypeConverterFn(defaultUnknownTypeConverter) {}
+      unknownTypeConverterFn(defaultUnknownTypeConverter),
+      tensorEncodingToMemRefLayoutFn(defaultTensorEncodingToMemRefLayout) {}
 
 bool BufferizationOptions::isOpAllowed(Operation *op) const {
   // Special case: If function boundary bufferization is deactivated, do not

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -346,12 +346,19 @@ bool OpFilter::isOpAllowed(Operation *op) const {
 
 namespace {
 
-/// Default function arg type converter: Use a fully dynamic layout map.
+/// Default function arg type converter: Use a fully dynamic layout map, or
+/// the layout produced by `tensorEncodingToMemRefLayoutFn` when the hook is
+/// set and returns a non-null layout.
 BufferLikeType
 defaultFunctionArgTypeConverter(TensorLikeType type, Attribute memorySpace,
                                 func::FuncOp funcOp,
                                 const BufferizationOptions &options) {
   if (auto tensorType = mlir::dyn_cast<TensorType>(type)) {
+    if (options.tensorEncodingToMemRefLayoutFn) {
+      if (auto layout = options.tensorEncodingToMemRefLayoutFn(tensorType))
+        return cast<BufferLikeType>(
+            getMemRefType(tensorType, options, layout, memorySpace));
+    }
     return cast<BufferLikeType>(
         getMemRefTypeWithFullyDynamicLayout(tensorType, memorySpace));
   }
@@ -363,10 +370,17 @@ defaultFunctionArgTypeConverter(TensorLikeType type, Attribute memorySpace,
          "a valid buffer is always expected at function boundary");
   return *bufferType;
 }
-/// Default unknown type converter: Use a fully dynamic layout map.
+/// Default unknown type converter: Use a fully dynamic layout map, or the
+/// layout produced by `tensorEncodingToMemRefLayoutFn` when the hook is set
+/// and returns a non-null layout.
 BaseMemRefType
 defaultUnknownTypeConverter(TensorType tensorType, Attribute memorySpace,
                             const BufferizationOptions &options) {
+  if (options.tensorEncodingToMemRefLayoutFn) {
+    if (auto layout = options.tensorEncodingToMemRefLayoutFn(tensorType))
+      return cast<BaseMemRefType>(
+          getMemRefType(tensorType, options, layout, memorySpace));
+  }
   return getMemRefTypeWithFullyDynamicLayout(tensorType, memorySpace);
 }
 
@@ -420,6 +434,12 @@ void BufferizationOptions::setFunctionBoundaryTypeConversion(
                                    func::FuncOp funcOp,
                                    const BufferizationOptions &options) {
     if (auto tensorType = mlir::dyn_cast<TensorType>(type)) {
+      if (options.tensorEncodingToMemRefLayoutFn) {
+        if (auto layout = options.tensorEncodingToMemRefLayoutFn(tensorType))
+          return cast<BufferLikeType>(
+              bufferization::getMemRefType(tensorType, options, layout,
+                                           memorySpace));
+      }
       if (layoutMapOption == LayoutMapOption::IdentityLayoutMap)
         return cast<BufferLikeType>(
             bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationDialect.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationDialect.cpp
@@ -47,8 +47,11 @@ struct BuiltinTensorExternalModel
     if (!memSpace.has_value())
       return emitError() << "could not infer memory space";
 
+    MemRefLayoutAttrInterface layout = {};
+    if (options.tensorEncodingToMemRefLayoutFn)
+      layout = options.tensorEncodingToMemRefLayoutFn(tensorType);
     return cast<BufferLikeType>(
-        getMemRefType(tensorType, options, /*layout=*/{}, *memSpace));
+        getMemRefType(tensorType, options, layout, *memSpace));
   }
 
   mlir::LogicalResult verifyCompatibleBufferType(

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
@@ -246,6 +246,13 @@ AllocTensorOp::getBufferType(Value value, const BufferizationOptions &options,
     return getOperation()->emitError("could not infer memory space");
   }
 
+  if (options.tensorEncodingToMemRefLayoutFn) {
+    if (auto layout = options.tensorEncodingToMemRefLayoutFn(getType())) {
+      return cast<BufferLikeType>(
+          getMemRefType(getType(), options, layout, memorySpace));
+    }
+  }
+
   return cast<BufferLikeType>(
       getMemRefTypeWithStaticIdentityLayout(getType(), memorySpace));
 }

--- a/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
@@ -111,6 +111,13 @@ struct OneShotBufferizePass
       opt.unknownTypeConverterFn = [=](TensorType tensorType,
                                        Attribute memorySpace,
                                        const BufferizationOptions &options) {
+        if (options.tensorEncodingToMemRefLayoutFn) {
+          if (auto layout =
+                  options.tensorEncodingToMemRefLayoutFn(tensorType)) {
+            return cast<BaseMemRefType>(bufferization::getMemRefType(
+                tensorType, options, layout, memorySpace));
+          }
+        }
         if (unknownTypeConversionOption == LayoutMapOption::IdentityLayoutMap)
           return bufferization::getMemRefTypeWithStaticIdentityLayout(
               tensorType, memorySpace);

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encoding-layout.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-bufferize-encoding-layout.mlir
@@ -1,0 +1,71 @@
+// Default: function-boundary-type-conversion=infer-layout-map.
+// RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries=1 allow-unknown-ops" -split-input-file | FileCheck %s
+
+// The tensor encoding implements `MemRefLayoutAttrInterface`, so it wins over
+// the requested layout option and the resulting memref uses the encoding.
+// RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries=1 allow-unknown-ops function-boundary-type-conversion=identity-layout-map unknown-type-conversion=identity-layout-map" -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries=1 allow-unknown-ops function-boundary-type-conversion=fully-dynamic-layout-map unknown-type-conversion=fully-dynamic-layout-map" -split-input-file | FileCheck %s
+
+// Exercises the `tensorEncodingToMemRefLayoutFn` hook on the three
+// tensor-to-memref paths that do not delegate to an op-specific
+// `BufferizableOpInterface::getBufferType`:
+//   * function-boundary conversion (arg + result),
+//   * `bufferization.alloc_tensor`,
+//   * unknown-type fallback (unknown op result).
+
+#transpose = affine_map<(d0, d1) -> (d1, d0)>
+
+// CHECK-LABEL: func @encoding_layout_function_boundary(
+//  CHECK-SAME:     %[[A:.*]]: memref<4x4xf32, #[[$MAP:[^>]+]]>) -> memref<4x4xf32, #[[$MAP]]> {
+//       CHECK:   return %[[A]] : memref<4x4xf32, #[[$MAP]]>
+func.func @encoding_layout_function_boundary(
+    %arg0: tensor<4x4xf32, #transpose>) -> tensor<4x4xf32, #transpose> {
+  return %arg0 : tensor<4x4xf32, #transpose>
+}
+
+// -----
+
+#transpose = affine_map<(d0, d1) -> (d1, d0)>
+
+// The alloc layout must come from the encoding, not from the default static
+// identity layout used by `alloc_tensor` otherwise.
+// CHECK-LABEL: func @encoding_layout_alloc_tensor(
+//       CHECK:   %[[ALLOC:.*]] = memref.alloc() {{.*}} : memref<4x4xf32, #{{.*}}>
+//       CHECK:   return %[[ALLOC]] : memref<4x4xf32, #{{.*}}>
+func.func @encoding_layout_alloc_tensor() -> tensor<4x4xf32, #transpose> {
+  %0 = bufferization.alloc_tensor() : tensor<4x4xf32, #transpose>
+  return %0 : tensor<4x4xf32, #transpose>
+}
+
+// -----
+
+#transpose = affine_map<(d0, d1) -> (d1, d0)>
+
+// The unknown op stays on tensors but is bracketed by to_tensor/to_buffer
+// conversions whose memref types must use the encoding layout.
+// CHECK-LABEL: func @encoding_layout_unknown_op(
+//  CHECK-SAME:     %[[A:.*]]: memref<4x4xf32, #[[$MAP:[^>]+]]>
+//       CHECK:   %[[T:.*]] = bufferization.to_tensor %[[A]] : memref<4x4xf32, #[[$MAP]]>
+//       CHECK:   %[[R:.*]] = "test.dummy_op"(%[[T]])
+//       CHECK:   %[[B:.*]] = bufferization.to_buffer %[[R]] {{.*}} to memref<4x4xf32, #[[$MAP]]>
+//       CHECK:   return %[[B]] : memref<4x4xf32, #[[$MAP]]>
+func.func @encoding_layout_unknown_op(
+    %arg0: tensor<4x4xf32, #transpose>) -> tensor<4x4xf32, #transpose> {
+  %0 = "test.dummy_op"(%arg0)
+      : (tensor<4x4xf32, #transpose>) -> tensor<4x4xf32, #transpose>
+  return %0 : tensor<4x4xf32, #transpose>
+}
+
+// -----
+
+// Control case: without an encoding that implements `MemRefLayoutAttrInterface`
+// the default path is taken. The function boundary infers the layout (identity
+// for an equivalent return), matching the behavior of other bufferization
+// tests.
+// CHECK-LABEL: func @no_encoding_function_boundary(
+//  CHECK-SAME:     %[[A:.*]]: memref<4x4xf32{{.*}}>) -> memref<4x4xf32{{.*}}> {
+//       CHECK:   return %[[A]]
+func.func @no_encoding_function_boundary(
+    %arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  return %arg0 : tensor<4x4xf32>
+}


### PR DESCRIPTION
Implement TensorEncodingToMemref (previously called as "ConstructMemRefLayoutFn") 

Missing some better lit tests - (partially introduced at https://github.com/Devjiu/llvm-project/pull/2/changes) 

Should be easy to merge as no breaking changes were introduced