### PR TITLE
[fir] Lower to llvm int constants with appropriately typed int attrs

### DIFF
--- a/flang/lib/Optimizer/Support/Utils.cpp
+++ b/flang/lib/Optimizer/Support/Utils.cpp
@@ -65,7 +65,7 @@ mlir::LLVM::ConstantOp
 fir::genConstantIndex(mlir::Location loc, mlir::Type ity,
                       mlir::ConversionPatternRewriter &rewriter,
                       std::int64_t offset) {
-  auto cattr = rewriter.getI64IntegerAttr(offset);
+  auto cattr = rewriter.getIntegerAttr(ity, offset);
   return mlir::LLVM::ConstantOp::create(rewriter, loc, ity, cattr);
 }
 

--- a/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
+++ b/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
@@ -696,13 +696,13 @@ func.func @_QPsb() {
 
 // CHECK:  omp.declare_reduction @[[EQV_REDUCTION:.*]] : i32 init {
 // CHECK:  ^bb0(%{{.*}}: i32):
-// CHECK:    %[[TRUE:.*]] = llvm.mlir.constant(1 : i64) : i32
+// CHECK:    %[[TRUE:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:    omp.yield(%[[TRUE]] : i32)
 // CHECK:  } combiner {
 // CHECK:  ^bb0(%[[ARG_1:.*]]: i32, %[[ARG_2:.*]]: i32):
-// CHECK:    %[[ZERO_1:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:    %[[ZERO_1:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:    %[[ARGVAL_1:.*]] = llvm.icmp "ne" %[[ARG_1]], %[[ZERO_1]] : i32
-// CHECK:    %[[ZERO_2:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:    %[[ZERO_2:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:    %[[ARGVAL_2:.*]] = llvm.icmp "ne" %[[ARG_2]], %[[ZERO_2]] : i32
 // CHECK:    %[[RES:.*]] = llvm.icmp "eq" %[[ARGVAL_1]], %[[ARGVAL_2]] : i1
 // CHECK:    %[[RES_EXT:.*]] = llvm.zext %[[RES]] : i1 to i32
@@ -718,9 +718,9 @@ func.func @_QPsb() {
 // CHECK:          %[[ARRAY_ELEM_REF:.*]] = llvm.getelementptr %[[ARRAY_REF]][0, %{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr
 // CHECK:          %[[ARRAY_ELEM:.*]] = llvm.load %[[ARRAY_ELEM_REF]] : !llvm.ptr -> i32
 // CHECK:          %[[LPRV:.+]] = llvm.load %[[PRV]] : !llvm.ptr -> i32
-// CHECK:          %[[ZERO_1:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:          %[[ZERO_1:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:          %[[ARGVAL_1:.*]] = llvm.icmp "ne" %[[LPRV]], %[[ZERO_1]] : i32
-// CHECK:          %[[ZERO_2:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:          %[[ZERO_2:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:          %[[ARGVAL_2:.*]] = llvm.icmp "ne" %[[ARRAY_ELEM]], %[[ZERO_2]] : i32
 // CHECK:          %[[RES:.*]] = llvm.icmp "eq" %[[ARGVAL_2]], %[[ARGVAL_1]] : i1
 // CHECK:          %[[RES_EXT:.*]] = llvm.zext %[[RES]] : i1 to i32

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -1104,7 +1104,7 @@ func.func @box_isarray(%arg0: !fir.box<!fir.array<*:f64>>) -> i1 {
 // CHECK-SAME:                         %[[ARG0:.*]]: !llvm.ptr) -> i1
 // CHECK:         %[[GEP:.*]] = llvm.getelementptr %[[ARG0]][0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}}, i{{.*}})>
 // CHECK:         %[[RANK:.*]] = llvm.load %[[GEP]] : !llvm.ptr -> i8
-// CHECK:         %[[C0_ISARRAY:.*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK:         %[[C0_ISARRAY:.*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK:         %[[IS_ARRAY:.*]] = llvm.icmp "ne" %[[RANK]], %[[C0_ISARRAY]] : i8
 // CHECK:         llvm.return %[[IS_ARRAY]] : i1
 
@@ -1482,7 +1482,7 @@ func.func @select_case_logical(%arg0: !fir.ref<!fir.logical<4>>) {
 // CHECK-LABEL: llvm.func @select_case_logical(
 // CHECK-SAME:                                 %[[ARG0:.*]]: !llvm.ptr
 // CHECK:         %[[LOAD_ARG0:.*]] = llvm.load %[[ARG0]] : !llvm.ptr -> i32
-// CHECK:         %[[CST_ZERO:.*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK:         %[[CST_ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:         %[[SELECT_VALUE:.*]] = llvm.icmp "ne" %[[LOAD_ARG0]], %[[CST_ZERO]] : i32
 // CHECK:         %[[CST_FALSE:.*]] = llvm.mlir.constant(false) : i1
 // CHECK:         %[[CST_TRUE:.*]] = llvm.mlir.constant(true) : i1

--- a/flang/test/Fir/global-initialization.fir
+++ b/flang/test/Fir/global-initialization.fir
@@ -40,7 +40,7 @@ fir.global internal @_QEmasklogical : !fir.array<32768x!fir.logical<4>> {
 // CHECK: llvm.mlir.global internal @_QEmasklogical() {addr_space = 0 : i32} : !llvm.array<32768 x i32> {
 // CHECK:   [[VAL0:%.*]] = llvm.mlir.constant(true) : i1
 // CHECK:   [[VAL1:%.*]] = llvm.mlir.undef : !llvm.array<32768 x i32>
-// CHECK:   [[VAL2:%.*]] = llvm.mlir.constant(1 : i64) : i32
+// CHECK:   [[VAL2:%.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:   [[VAL3:%.*]] = llvm.mlir.constant(dense<true> : vector<32768xi1>) : !llvm.array<32768 x i32>
 // CHECK:   llvm.return [[VAL3]] : !llvm.array<32768 x i32>
 // CHECK: }

--- a/flang/test/Fir/logical-convert.fir
+++ b/flang/test/Fir/logical-convert.fir
@@ -5,7 +5,7 @@
 
 // -----
 // CHECK-LABEL: @test_l1_i1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: llvm.return [[t1]] : i1
 func.func @test_l1_i1(%arg0: !fir.logical<1>) -> i1 {
@@ -14,7 +14,7 @@ func.func @test_l1_i1(%arg0: !fir.logical<1>) -> i1 {
 }
 // -----
 // CHECK-LABEL: @test_l1_i8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -24,7 +24,7 @@ func.func @test_l1_i8(%arg0: !fir.logical<1>) -> i8 {
 }
 // -----
 // CHECK-LABEL: @test_l1_i16
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -34,7 +34,7 @@ func.func @test_l1_i16(%arg0: !fir.logical<1>) -> i16 {
 }
 // -----
 // CHECK-LABEL: @test_l1_i32
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -44,7 +44,7 @@ func.func @test_l1_i32(%arg0: !fir.logical<1>) -> i32 {
 }
 // -----
 // CHECK-LABEL: @test_l1_i64
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -54,7 +54,7 @@ func.func @test_l1_i64(%arg0: !fir.logical<1>) -> i64 {
 }
 // -----
 // CHECK-LABEL: @test_l2_i1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: llvm.return [[t1]] : i1
 func.func @test_l2_i1(%arg0: !fir.logical<2>) -> i1 {
@@ -63,7 +63,7 @@ func.func @test_l2_i1(%arg0: !fir.logical<2>) -> i1 {
 }
 // -----
 // CHECK-LABEL: @test_l2_i8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -73,7 +73,7 @@ func.func @test_l2_i8(%arg0: !fir.logical<2>) -> i8 {
 }
 // -----
 // CHECK-LABEL: @test_l2_i16
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -83,7 +83,7 @@ func.func @test_l2_i16(%arg0: !fir.logical<2>) -> i16 {
 }
 // -----
 // CHECK-LABEL: @test_l2_i32
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -93,7 +93,7 @@ func.func @test_l2_i32(%arg0: !fir.logical<2>) -> i32 {
 }
 // -----
 // CHECK-LABEL: @test_l2_i64
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -103,7 +103,7 @@ func.func @test_l2_i64(%arg0: !fir.logical<2>) -> i64 {
 }
 // -----
 // CHECK-LABEL: @test_l4_i1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: llvm.return [[t1]] : i1
 func.func @test_l4_i1(%arg0: !fir.logical<4>) -> i1 {
@@ -112,7 +112,7 @@ func.func @test_l4_i1(%arg0: !fir.logical<4>) -> i1 {
 }
 // -----
 // CHECK-LABEL: @test_l4_i8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -122,7 +122,7 @@ func.func @test_l4_i8(%arg0: !fir.logical<4>) -> i8 {
 }
 // -----
 // CHECK-LABEL: @test_l4_i16
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -132,7 +132,7 @@ func.func @test_l4_i16(%arg0: !fir.logical<4>) -> i16 {
 }
 // -----
 // CHECK-LABEL: @test_l4_i32
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -142,7 +142,7 @@ func.func @test_l4_i32(%arg0: !fir.logical<4>) -> i32 {
 }
 // -----
 // CHECK-LABEL: @test_l4_i64
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -233,7 +233,7 @@ func.func @test_i1_l8(%arg0: i1) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_i8_l1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -243,7 +243,7 @@ func.func @test_i8_l1(%arg0: i8) -> !fir.logical<1> {
 }
 // -----
 // CHECK-LABEL: @test_i8_l2
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -253,7 +253,7 @@ func.func @test_i8_l2(%arg0: i8) -> !fir.logical<2> {
 }
 // -----
 // CHECK-LABEL: @test_i8_l4
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -263,7 +263,7 @@ func.func @test_i8_l4(%arg0: i8) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_i8_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -273,7 +273,7 @@ func.func @test_i8_l8(%arg0: i8) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_i16_l1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -283,7 +283,7 @@ func.func @test_i16_l1(%arg0: i16) -> !fir.logical<1> {
 }
 // -----
 // CHECK-LABEL: @test_i16_l2
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -293,7 +293,7 @@ func.func @test_i16_l2(%arg0: i16) -> !fir.logical<2> {
 }
 // -----
 // CHECK-LABEL: @test_i16_l4
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -303,7 +303,7 @@ func.func @test_i16_l4(%arg0: i16) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_i16_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -313,7 +313,7 @@ func.func @test_i16_l8(%arg0: i16) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_i32_l1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -323,7 +323,7 @@ func.func @test_i32_l1(%arg0: i32) -> !fir.logical<1> {
 }
 // -----
 // CHECK-LABEL: @test_i32_l2
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -333,7 +333,7 @@ func.func @test_i32_l2(%arg0: i32) -> !fir.logical<2> {
 }
 // -----
 // CHECK-LABEL: @test_i32_l4
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -343,7 +343,7 @@ func.func @test_i32_l4(%arg0: i32) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_i32_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -393,7 +393,7 @@ func.func @test_i64_l8(%arg0: i64) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_l1_l2
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -403,7 +403,7 @@ func.func @test_l1_l2(%arg0: !fir.logical<1>) -> !fir.logical<2> {
 }
 // -----
 // CHECK-LABEL: @test_l1_l4
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -413,7 +413,7 @@ func.func @test_l1_l4(%arg0: !fir.logical<1>) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_l1_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i8
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -423,7 +423,7 @@ func.func @test_l1_l8(%arg0: !fir.logical<1>) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_l2_l1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -433,7 +433,7 @@ func.func @test_l2_l1(%arg0: !fir.logical<2>) -> !fir.logical<1> {
 }
 // -----
 // CHECK-LABEL: @test_l2_l4
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i32
 // CHECK: llvm.return [[t2]] : i32
@@ -443,7 +443,7 @@ func.func @test_l2_l4(%arg0: !fir.logical<2>) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_l2_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i16
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i16) : i16
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i16
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -453,7 +453,7 @@ func.func @test_l2_l8(%arg0: !fir.logical<2>) -> !fir.logical<8> {
 }
 // -----
 // CHECK-LABEL: @test_l4_l1
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i8
 // CHECK: llvm.return [[t2]] : i8
@@ -463,7 +463,7 @@ func.func @test_l4_l1(%arg0: !fir.logical<4>) -> !fir.logical<1> {
 }
 // -----
 // CHECK-LABEL: @test_l4_l2
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i16
 // CHECK: llvm.return [[t2]] : i16
@@ -473,7 +473,7 @@ func.func @test_l4_l2(%arg0: !fir.logical<4>) -> !fir.logical<2> {
 }
 // -----
 // CHECK-LABEL: @test_l4_l8
-// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[t0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[t1:%[0-9]*]] = llvm.icmp "ne" %arg0, [[t0]] : i32
 // CHECK: [[t2:%[0-9]*]] = llvm.zext [[t1]] : i1 to i64
 // CHECK: llvm.return [[t2]] : i64
@@ -513,9 +513,9 @@ func.func @test_l8_l4(%arg0: !fir.logical<8>) -> !fir.logical<4> {
 }
 // -----
 // CHECK-LABEL: @test_logical_and_l4
-// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[A:%[0-9]*]] = llvm.icmp "ne" %arg0, [[ZERO0]] : i32
-// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[B:%[0-9]*]] = llvm.icmp "ne" %arg1, [[ZERO1]] : i32
 // CHECK: [[RES:%[0-9]*]] = llvm.and [[A]], [[B]] : i1
 // CHECK: [[EXT:%[0-9]*]] = llvm.zext [[RES]] : i1 to i32
@@ -526,9 +526,9 @@ func.func @test_logical_and_l4(%arg0: !fir.logical<4>, %arg1: !fir.logical<4>) -
 }
 // -----
 // CHECK-LABEL: @test_logical_or_l4
-// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[A:%[0-9]*]] = llvm.icmp "ne" %arg0, [[ZERO0]] : i32
-// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[B:%[0-9]*]] = llvm.icmp "ne" %arg1, [[ZERO1]] : i32
 // CHECK: [[RES:%[0-9]*]] = llvm.or [[A]], [[B]] : i1
 // CHECK: [[EXT:%[0-9]*]] = llvm.zext [[RES]] : i1 to i32
@@ -539,9 +539,9 @@ func.func @test_logical_or_l4(%arg0: !fir.logical<4>, %arg1: !fir.logical<4>) ->
 }
 // -----
 // CHECK-LABEL: @test_eqv_l4
-// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[A:%[0-9]*]] = llvm.icmp "ne" %arg0, [[ZERO0]] : i32
-// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[B:%[0-9]*]] = llvm.icmp "ne" %arg1, [[ZERO1]] : i32
 // CHECK: [[RES:%[0-9]*]] = llvm.icmp "eq" [[A]], [[B]] : i1
 // CHECK: [[EXT:%[0-9]*]] = llvm.zext [[RES]] : i1 to i32
@@ -552,9 +552,9 @@ func.func @test_eqv_l4(%arg0: !fir.logical<4>, %arg1: !fir.logical<4>) -> !fir.l
 }
 // -----
 // CHECK-LABEL: @test_neqv_l4
-// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[A:%[0-9]*]] = llvm.icmp "ne" %arg0, [[ZERO0]] : i32
-// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[B:%[0-9]*]] = llvm.icmp "ne" %arg1, [[ZERO1]] : i32
 // CHECK: [[RES:%[0-9]*]] = llvm.icmp "ne" [[A]], [[B]] : i1
 // CHECK: [[EXT:%[0-9]*]] = llvm.zext [[RES]] : i1 to i32
@@ -575,9 +575,9 @@ func.func @test_logical_and_i1(%arg0: i1, %arg1: i1) -> i1 {
 // -----
 // Test on i32 type
 // CHECK-LABEL: @test_logical_and_i32
-// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO0:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[A:%[0-9]*]] = llvm.icmp "ne" %arg0, [[ZERO0]] : i32
-// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i64) : i32
+// CHECK: [[ZERO1:%[0-9]*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK: [[B:%[0-9]*]] = llvm.icmp "ne" %arg1, [[ZERO1]] : i32
 // CHECK: [[RES:%[0-9]*]] = llvm.and [[A]], [[B]] : i1
 // CHECK: [[EXT:%[0-9]*]] = llvm.zext [[RES]] : i1 to i32

--- a/flang/test/Fir/tbaa.fir
+++ b/flang/test/Fir/tbaa.fir
@@ -271,7 +271,7 @@ func.func @tbaa(%arg0: !fir.box<!fir.array<*:f64>>) -> i1 {
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> i1 {
 // CHECK:           %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8, array<15 x array<3 x i64>>)>
 // CHECK:           %[[VAL_2:.*]] = llvm.load %[[VAL_1]] {tbaa = [#[[$BOXT]]]} : !llvm.ptr -> i8
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i8
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK:           %[[VAL_4:.*]] = llvm.icmp "ne" %[[VAL_2]], %[[VAL_3]] : i8
 // CHECK:           llvm.return %[[VAL_4]] : i1
 // CHECK:         }


### PR DESCRIPTION
When we lower fir operations to llvm int constants, we used to always generate `llvm.mlir.constant`s with a i64 integer attribute regardless of the width of the constant type. This made some llvm dialect level folding hit assertions in some cases.

Fix this by generating the appropriately typed integer attributes matching the constant type.