### PR TITLE
[LoopInfo] Remove redundant LLVM_ABI from Loop member functions

### DIFF
--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -374,9 +374,8 @@ public:
   /// it to the loop metadata via makePostTransformationMetadata. Any existing
   /// attributes whose key starts with one of \p RemovePrefixes are stripped
   /// first.
-  LLVM_ABI void
-  addStringLoopAttribute(StringRef Name,
-                         ArrayRef<StringRef> RemovePrefixes = {}) const;
+  void addStringLoopAttribute(StringRef Name,
+                              ArrayRef<StringRef> RemovePrefixes = {}) const;
 
   /// Add an integer metadata attribute to this loop's loop-ID node.
   ///
@@ -384,9 +383,8 @@ public:
   /// it to the loop metadata via makePostTransformationMetadata. Any existing
   /// attributes whose key starts with one of \p RemovePrefixes are stripped
   /// first.
-  LLVM_ABI void
-  addIntLoopAttribute(StringRef Name, unsigned Value,
-                      ArrayRef<StringRef> RemovePrefixes = {}) const;
+  void addIntLoopAttribute(StringRef Name, unsigned Value,
+                           ArrayRef<StringRef> RemovePrefixes = {}) const;
 
   void dump() const;
   void dumpVerbose() const;


### PR DESCRIPTION
Remove redundant `LLVM_ABI` from `addStringLoopAttribute` and `addIntLoopAttribute`.

Addresses post-merge feedback on #194676.

This patch was generated with the help of Claude and reviewed by a human.