### PR TITLE
[clang] Consistently store format specifiers in execution encoding

### DIFF
--- a/clang/include/clang/AST/FormatString.h
+++ b/clang/include/clang/AST/FormatString.h
@@ -396,6 +396,10 @@ public:
     return length + UsesDotPrefix;
   }
 
+  StringRef getCharacters() const {
+    return StringRef(start - UsesDotPrefix, length + UsesDotPrefix);
+  }
+
   ArgType getArgType(ASTContext &Ctx) const;
 
   void toString(raw_ostream &os) const;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -8707,16 +8707,16 @@ bool DecomposePrintfHandler::HandlePrintfSpecifier(
   const auto &FieldWidth = FS.getFieldWidth();
   if (!FieldWidth.isInvalid() && FieldWidth.hasDataArgument()) {
     FieldWidthIndex = Specs.size();
-    Specs.emplace_back(getSpecifierRange(startSpecifier, specifierLen),
-                       getLocationOfByte(FieldWidth.getStart()),
-                       analyze_format_string::LengthModifier::None, "*",
-                       FieldWidth.getArgType(S.Context),
-                       EquatableFormatArgument::FAR_FieldWidth,
-                       EquatableFormatArgument::SS_None,
-                       FieldWidth.usesPositionalArg()
-                           ? FieldWidth.getPositionalArgIndex() - 1
-                           : FieldWidthIndex,
-                       0);
+    Specs.emplace_back(
+        getSpecifierRange(startSpecifier, specifierLen),
+        getLocationOfByte(FieldWidth.getStart()),
+        analyze_format_string::LengthModifier::None, FieldWidth.getCharacters(),
+        FieldWidth.getArgType(S.Context),
+        EquatableFormatArgument::FAR_FieldWidth,
+        EquatableFormatArgument::SS_None,
+        FieldWidth.usesPositionalArg() ? FieldWidth.getPositionalArgIndex() - 1
+                                       : FieldWidthIndex,
+        0);
   }
   // precision?
   const auto &Precision = FS.getPrecision();
@@ -8725,7 +8725,7 @@ bool DecomposePrintfHandler::HandlePrintfSpecifier(
     Specs.emplace_back(
         getSpecifierRange(startSpecifier, specifierLen),
         getLocationOfByte(Precision.getStart()),
-        analyze_format_string::LengthModifier::None, ".*",
+        analyze_format_string::LengthModifier::None, Precision.getCharacters(),
         Precision.getArgType(S.Context), EquatableFormatArgument::FAR_Precision,
         EquatableFormatArgument::SS_None,
         Precision.usesPositionalArg() ? Precision.getPositionalArgIndex() - 1


### PR DESCRIPTION
`DecomposePrintfHandler::HandlePrintfSpecifier()` parses the format string and collects specifiers into `Specs`. In most cases the collected specifiers are in the execution encoding, but there were to places that used string literals in "host" encoding.

Change them to use a part of the parsed `StringLiteral` instead so that `Specs` always contain text in the execution encoding. This is achieved by adding `getCharacters()` method to `OptionalAmount` class, following `ConversionSpecifier::getCharacters()`.

This is to make #169803 smaller and is an NFC before that PR lands.