### PR TITLE
[BOLT][AArch64] Refuse to run Stoke analysis on AArch64

### DIFF
--- a/bolt/lib/Passes/StokeInfo.cpp
+++ b/bolt/lib/Passes/StokeInfo.cpp
@@ -146,6 +146,11 @@ bool StokeInfo::checkFunction(BinaryFunction &BF, DataflowInfoManager &DInfo,
 }
 
 Error StokeInfo::runOnFunctions(BinaryContext &BC) {
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is supported only on X86\n";
+    exit(1);
+  }
+
   BC.outs() << "STOKE-INFO: begin of stoke pass\n";
 
   std::ofstream Outfile;

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -16,8 +16,10 @@ CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported 
 // Passes specific to X86 arch
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV
 RUN: not llvm-bolt %t -o %t.bolt --reg-reassign 2>&1 | FileCheck %s --check-prefix=CHECK-REG-REASSIGN
+RUN: not llvm-bolt %t -o %t.bolt --stoke --stoke-out=%t.stoke.csv 2>&1 | FileCheck %s --check-prefix=CHECK-STOKE
 CHECK-CMOV-CONV: BOLT-ERROR: CMOV conversion is supported only on X86
 CHECK-REG-REASSIGN: BOLT-ERROR: reg-reassign is supported only on X86
+CHECK-STOKE: BOLT-ERROR: stoke-get-stat is supported only on X86
 
 RUN: not llvm-bolt %t -o %t.bolt split-functions --split-strategy=cdsplit 2>&1 | FileCheck %s --check-prefix=CHECK-CDSPLIT
 CHECK-CDSPLIT: BOLT-ERROR: CDSplit is not supported with LongJmp. Try with '--compact-code-model'


### PR DESCRIPTION
`--stoke` and `--stoke-out` yields an UNIMPLEMENTED crash on AArch64. It is a fundamentally X86 pass.

- Add a non-X86 guard
- Add the error message to unsupported-passes.test.