### PR TITLE
[lldb][windows] build lldb and lldb-dap in PR testing

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -109,7 +109,6 @@ EXCLUDE_WINDOWS = {
     "cross-project-tests",  # TODO(issues/132797): Tests are failing.
     "openmp",  # TODO(issues/132799): Does not detect perl installation.
     "libc",  # No Windows Support.
-    "lldb",  # TODO(issues/132800): Needs environment setup.
     "bolt",  # No Windows Support.
     "libcxx",
     "libcxxabi",
@@ -155,8 +154,6 @@ PROJECT_CHECK_TARGETS = {
     "flang-rt": "check-flang-rt",
     "libc": "check-libc",
     "libclc": "check-libclc",
-    "lld": "check-lld",
-    "lldb": "check-lldb",
     "mlir": "check-mlir",
     "openmp": "check-openmp",
     "polly": "check-polly",
@@ -193,6 +190,20 @@ SKIP_BUILD_PROJECTS = ["CIR", "lit"]
 
 # Projects that should not run any tests. These need to be metaprojects.
 SKIP_PROJECTS = ["docs", "gn"]
+
+# Overrides for PROJECT_CHECK_TARGETS on a per-platform basis. If a platform
+# has an entry for a given project here, its value is used as the ninja
+# target(s) instead of the default check target. This is intended for cases
+# where a project can be built but its tests are not yet stable on that
+# platform, so we still want a compile-time signal.
+PROJECT_CHECK_TARGETS_OVERRIDE = {
+    "Windows": {
+        # TODO(issues/132800): LLDB tests need environment setup on Windows.
+        # In the meantime, at least compile lldb and lldb-dap to catch
+        # breakage.
+        "lldb": "lldb lldb-dap",
+    },
+}
 
 
 def _add_dependencies(projects: Set[str], runtimes: Set[str]) -> Set[str]:
@@ -248,10 +259,15 @@ def _compute_projects_to_build(
     return _add_dependencies(projects_to_test, runtimes)
 
 
-def _compute_project_check_targets(projects_to_test: Set[str]) -> Set[str]:
+def _compute_project_check_targets(
+    projects_to_test: Set[str], platform: str
+) -> Set[str]:
     check_targets = set()
+    platform_overrides = PROJECT_CHECK_TARGETS_OVERRIDE.get(platform, {})
     for project_to_test in projects_to_test:
-        if project_to_test in PROJECT_CHECK_TARGETS:
+        if project_to_test in platform_overrides:
+            check_targets.add(platform_overrides[project_to_test])
+        elif project_to_test in PROJECT_CHECK_TARGETS:
             check_targets.add(PROJECT_CHECK_TARGETS[project_to_test])
     return check_targets
 
@@ -333,10 +349,10 @@ def get_env_variables(modified_files: list[str], platform: str) -> Set[str]:
     projects_to_build = _compute_projects_to_build(
         projects_to_test, runtimes_to_build | cross_runtimes_to_test
     )
-    projects_check_targets = _compute_project_check_targets(projects_to_test)
-    runtimes_check_targets = _compute_project_check_targets(runtimes_to_test)
+    projects_check_targets = _compute_project_check_targets(projects_to_test, platform)
+    runtimes_check_targets = _compute_project_check_targets(runtimes_to_test, platform)
     runtimes_check_targets_needs_reconfig = _compute_project_check_targets(
-        runtimes_to_test_needs_reconfig
+        runtimes_to_test_needs_reconfig, platform
     )
 
     # CIR is used as a pseudo-project in this script. It is built as part of the

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -154,6 +154,8 @@ PROJECT_CHECK_TARGETS = {
     "flang-rt": "check-flang-rt",
     "libc": "check-libc",
     "libclc": "check-libclc",
+    "lld": "check-lld",
+    "lldb": "check-lldb",
     "mlir": "check-mlir",
     "openmp": "check-openmp",
     "polly": "check-polly",

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -39,11 +39,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;llvm;mlir;polly",
+            "clang;clang-tools-extra;lld;lldb;llvm;mlir;polly",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-tools check-lld check-llvm check-mlir check-polly",
+            "check-clang check-clang-tools check-lld check-llvm check-mlir check-polly lldb lldb-dap",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(
@@ -110,10 +110,12 @@ class TestComputeProjects(unittest.TestCase):
             ["clang/CMakeLists.txt"], "Windows"
         )
         self.assertEqual(
-            env_variables["projects_to_build"], "clang;clang-tools-extra;lld;llvm"
+            env_variables["projects_to_build"],
+            "clang;clang-tools-extra;lld;lldb;llvm",
         )
         self.assertEqual(
-            env_variables["project_check_targets"], "check-clang check-clang-tools"
+            env_variables["project_check_targets"],
+            "check-clang check-clang-tools lldb lldb-dap",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "compiler-rt")
         self.assertEqual(
@@ -323,11 +325,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;llvm;mlir;polly",
+            "clang;clang-tools-extra;lld;lldb;llvm;mlir;polly",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-cir check-clang-tools check-lld check-llvm check-mlir check-polly",
+            "check-clang check-clang-cir check-clang-tools check-lld check-llvm check-mlir check-polly lldb lldb-dap",
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
@@ -460,6 +462,16 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["project_check_targets"], "check-cross-project")
         self.assertEqual(env_variables["runtimes_to_build"], "")
+        self.assertEqual(env_variables["runtimes_check_targets"], "")
+        self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+
+    def test_lldb_windows(self):
+        env_variables = compute_projects.get_env_variables(
+            ["lldb/CMakeLists.txt"], "Windows"
+        )
+        self.assertEqual(env_variables["projects_to_build"], "clang;lld;lldb;llvm")
+        self.assertEqual(env_variables["project_check_targets"], "lldb lldb-dap")
+        self.assertEqual(env_variables["runtimes_to_build"], "compiler-rt")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
 


### PR DESCRIPTION
This patch enables building `lldb` and `lldb-dap` in PR testing.

We cannot run `check-lldb` in PR testing yet because of https://github.com/llvm/llvm-project/issues/132800. We can at least test the that the projects build, which would catch build bot failures early.