### PR TITLE
[lldb] Partially support ConstantPtrAuth in IRForTarget::UnfoldConstant

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -1395,6 +1395,16 @@ IRForTarget::UnfoldConstant(Constant *old_constant,
             return err;
         } break;
         }
+      } else if (ConstantPtrAuth *constant_ptr_auth =
+                     dyn_cast<ConstantPtrAuth>(constant)) {
+        // No need to handle ConstantPtrAuth users if old_constant is an address
+        // discriminator.
+        if (constant_ptr_auth->hasAddressDiscriminator() &&
+            constant_ptr_auth->getAddrDiscriminator() == old_constant)
+          continue;
+
+        return llvm::createStringErrorV("unhandled constant type \"{0}\".",
+                                        PrintValue(constant_ptr_auth));
       } else {
         return llvm::createStringErrorV("unhandled constant type \"{0}\".",
                                         PrintValue(constant));


### PR DESCRIPTION
IRForTarget aims to make generated LLVM IR relocatable. This is because LLDB JITs and executes code in an environment where the location/value of something may not be known ahead of runtime.

My motivation here is ObjC constant strings. They are generally emitted as global variables with a constant global initializer. On arm64e, these global initializers may have a ptrauth constant as the address discriminator. These can be safely skipped because address discriminators encode information about the signed value, they don't actually need to be unfolded.

In this commit I explicitly do not handle the non-address discriminator scenario. As I work through the arm64e test suite, I may come back to implement this if I find it is needed.