### PR TITLE
[mlir][Linalg] Preserve init in tiled in-place update patterns

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
@@ -92,6 +92,22 @@ struct MoveInitOperandsToInput : public OpRewritePattern<GenericOp> {
     for (OpOperand &op : outputOperands) {
       if (genericOp.getMatchingBlockArgument(&op).use_empty())
         continue;
+      // When DropUnitDims folds a unit reduction dim, the generic becomes
+      // all-parallel but the former accumulator remains in outs. Moving it
+      // to ins is correct in general, but NOT when the init participates in
+      // an extract_slice -> generic -> insert_slice chain which is the
+      // canonical in-place update pattern that one-shot bufferize relies on.
+      // Replacing outs with tensor.empty() would force bufferize to allocate
+      // a new buffer and copy.
+      Value initVal = op.get();
+      unsigned resultIdx = op.getOperandNumber() -
+                           genericOp.getDpsInits().getBeginOperandIndex();
+      Value result = genericOp.getResult(resultIdx);
+      if (initVal.getDefiningOp<tensor::ExtractSliceOp>() &&
+          llvm::any_of(result.getUsers(), [](Operation *user) {
+            return isa<tensor::InsertSliceOp>(user);
+          }))
+        continue;
       candidates.insert(&op);
     }
 

--- a/mlir/test/Dialect/Linalg/drop-unit-dims-split-reduction.mlir
+++ b/mlir/test/Dialect/Linalg/drop-unit-dims-split-reduction.mlir
@@ -1,0 +1,57 @@
+// RUN: mlir-opt %s -linalg-fold-unit-extent-dims -split-input-file | FileCheck %s
+
+// Test that the init operand is preserved in outs() when it
+// participates in an extract_slice -> generic -> insert_slice
+// chain. Moving it to ins() would prevent bufferization from
+// emitting an in-place update of the enclosing tensor.
+
+// CHECK-LABEL: func @test1
+// CHECK:         %[[IN:.*]] = tensor.extract_slice %{{.*}}[%{{.*}}, 0]
+// CHECK:         %[[OUT:.*]] = tensor.extract_slice %{{.*}}[0]
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins(%[[IN]] : tensor<64xf16>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<64xf16>)
+// CHECK:         tensor.insert_slice
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+
+func.func @test1(%input: tensor<4x128xf16>, %acc: tensor<128xf16>, %iv: index) -> tensor<128xf16> {
+  %in_slice = tensor.extract_slice %input[%iv, 0] [1, 64] [1, 1] : tensor<4x128xf16> to tensor<1x64xf16>
+  %out_slice = tensor.extract_slice %acc[0] [64] [1] : tensor<128xf16> to tensor<64xf16>
+  %generic = linalg.generic {
+      indexing_maps = [#map, #map1], iterator_types = ["reduction", "parallel"]}
+      ins(%in_slice : tensor<1x64xf16>) outs(%out_slice : tensor<64xf16>) {
+    ^bb0(%in: f16, %out: f16):
+      %max = arith.maxnumf %in, %out : f16
+      linalg.yield %max : f16
+  } -> tensor<64xf16>
+  %result = tensor.insert_slice %generic into %acc[0] [64] [1] : tensor<64xf16> into tensor<128xf16>
+  return %result : tensor<128xf16>
+}
+
+// -----
+
+// Test that the unit-dim fold still moves the init operand to ins()
+// and replaces outs() with tensor.empty() when there is no surrounding
+// extract_slice -> insert_slice chain.
+
+// CHECK-LABEL: func @test2
+// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<64xf16>
+// CHECK:         linalg.generic
+// CHECK-SAME:      outs(%[[EMPTY]] : tensor<64xf16>)
+
+#map2 = affine_map<(d0) -> (d0)>
+
+func.func @test2(%arg0: tensor<64xf16>, %arg1: tensor<64xf16>) -> tensor<64xf16> {
+  %cst = arith.constant 0xFC00 : f16
+  %init = linalg.fill ins(%cst : f16) outs(%arg1 : tensor<64xf16>) -> tensor<64xf16>
+  %result = linalg.generic {
+      indexing_maps = [#map2, #map2], iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<64xf16>) outs(%init : tensor<64xf16>) {
+    ^bb0(%in: f16, %out: f16):
+      %add = arith.addf %in, %out : f16
+      linalg.yield %add : f16
+  } -> tensor<64xf16>
+  return %result : tensor<64xf16>
+}


### PR DESCRIPTION
When dropping unit extent dimensions from a linalg.generic whose output block argument is used in the body as init/accumulator, the existing rewrite moves the outs() operand to ins() and replaces the outs with tensor.empty(). This breaks the canonical extract_slice -> outs -> insert_slice chain so the bufferization can no longer recognizes it as an in-place update and emits a fresh allocation plus copy.

This patch skips the rewrite when the init is defined by a tensor.ExtractSliceOp and the corresponding result has a tensor.InsertSliceOp user.

Assisted-by: Claude Opus 4.7