### PR TITLE
[clang-tidy] Fix `implicit-bool-conversion` C ternary condition false positive

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -338,11 +338,15 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
   auto BitfieldConstruct = cxxConstructorDecl(hasDescendant(cxxCtorInitializer(
       withInitializer(equalsBoundNode("implicitCastFromBool")),
       forField(hasBitWidth(1)))));
+  auto BoolTernaryCondition = conditionalOperator(
+      hasCondition(equalsBoundNode("implicitCastFromBool")));
   Finder->addMatcher(
       traverse(
           TK_AsIs,
           implicitCastExpr(
-              ImplicitCastFromBool, unless(ExceptionCases),
+              ImplicitCastFromBool,
+              implicitCastExpr().bind("implicitCastFromBool"),
+              unless(ExceptionCases),
               // Exclude comparisons of bools, as they are always cast to
               // integers in such context:
               //   bool_expr_a == bool_expr_b
@@ -353,7 +357,9 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
               // Exclude logical operators in C
               unless(allOf(isC(), hasParent(binaryOperator(
                                       hasAnyOperatorName("&&", "||"))))),
-              implicitCastExpr().bind("implicitCastFromBool"),
+              // Exclude bools used as ternary operator conditions in C
+              unless(allOf(isC(), hasCastKind(CK_IntegralCast),
+                           hasParent(BoolTernaryCondition))),
               unless(hasParent(BitfieldConstruct)),
               // Check also for nested casts, for example: bool -> int -> float.
               optionally(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -563,6 +563,9 @@ Changes in existing checks
     implicit conversions of logical operator results (``&&``, ``||``, ``!``)
     to ``bool`` in C.
 
+  - Fixed a false positive where ``bool`` conditions in C conditional
+    operators were diagnosed as implicit conversions to ``int``.
+
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -123,6 +123,9 @@ Some additional accommodations are made for C:
 - ``bool`` (or ``_Bool``) operands in logical operators (``&&``, ``||``) are
   ignored.
 
+- ``bool`` (or ``_Bool``) conditions in conditional operators (``?:``) are
+  ignored.
+
 Occurrences of implicit conversions inside macros and template instantiations
 are deliberately ignored, as it is not clear how to deal with such cases.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -78,6 +78,22 @@ void implicitConversionFromBoolInComplexBoolExpressions() {
   double doubleFloating = (boolean && (anotherBoolean || boolean)) * 0.3;
 }
 
+typedef bool BoolAlias;
+
+void ignoreImplicitConversionFromBoolInConditionalOperatorCondition() {
+  bool boolean = true;
+  BoolAlias alias = false;
+  int intFromCondition = boolean ? 1 : 0;
+  int intFromParenthesizedCondition = ((boolean)) ? 1 : 0;
+  int intFromAliasCondition = alias ? 1 : 0;
+  int intFromExplicitCastCondition = (int)boolean ? 1 : 0;
+
+  bool anotherBoolean = false;
+  int intFromBranch = boolean ? anotherBoolean : 0;
+  // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: int intFromBranch = boolean ? (int)anotherBoolean : 0;
+}
+
 void implicitConversionFromBoolLiterals() {
   functionTakingInt(true);
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: implicit conversion 'bool' -> 'int'


### PR DESCRIPTION
Fixes #195604