### PR TITLE
clang: Print effective triple in -ccc-print-bindings

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6306,8 +6306,8 @@ InputInfoList Driver::BuildJobsForActionNoCache(
   }
 
   if (CCCPrintBindings && !CCGenDiagnostics) {
-    llvm::errs() << "# \"" << T->getToolChain().getTripleString() << '"'
-                 << " - \"" << T->getName() << "\", inputs: [";
+    llvm::errs() << "# \"" << T->getToolChain().getEffectiveTriple().str()
+                 << '"' << " - \"" << T->getName() << "\", inputs: [";
     for (unsigned i = 0, e = InputInfos.size(); i != e; ++i) {
       llvm::errs() << InputInfos[i].getAsString();
       if (i + 1 != e)

--- a/clang/test/Driver/bindings.c
+++ b/clang/test/Driver/bindings.c
@@ -30,4 +30,4 @@
 
 // Darwin StaticLibTool binding
 // RUN: %clang -target i386-apple-darwin11 -ccc-print-bindings --emit-static-lib %s 2>&1 | FileCheck %s --check-prefix=CHECK16
-// CHECK16: "i386-apple-darwin11" - "darwin::StaticLibTool", inputs: ["{{.*}}.o"], output: "a.out"
+// CHECK16: "i386-apple-macosx10.7.0" - "darwin::StaticLibTool", inputs: ["{{.*}}.o"], output: "a.out"

--- a/clang/test/Driver/darwin-dsymutil.c
+++ b/clang/test/Driver/darwin-dsymutil.c
@@ -19,8 +19,8 @@
 // RUN:   -arch i386 -arch x86_64 %s -g 2> %t
 // RUN: FileCheck -check-prefix=CHECK-MULTIARCH-BINDINGS < %t %s
 //
-// CHECK-MULTIARCH-BINDINGS: "x86_64-apple-darwin11" - "darwin::Lipo", inputs: [{{.*}}, {{.*}}], output: "a.out"
-// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-darwin11" - "darwin::Dsymutil", inputs: ["a.out"], output: "a.out.dSYM"
+// CHECK-MULTIARCH-BINDINGS: "x86_64-apple-macosx10.7.0" - "darwin::Lipo", inputs: [{{.*}}, {{.*}}], output: "a.out"
+// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-macosx10.7.0" - "darwin::Dsymutil", inputs: ["a.out"], output: "a.out.dSYM"
 
 // Check output name derivation.
 //
@@ -39,8 +39,8 @@
 // RUN: FileCheck -Doutfile=bar/foo -Ddsymfile=external/foo.dSYM \
 // RUN:           -check-prefix=CHECK-OUTPUT-NAME < %t %s
 //
-// CHECK-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::Linker", inputs: [{{.*}}], output: "[[outfile]]"
-// CHECK-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::Dsymutil", inputs: ["[[outfile]]"], output: "[[dsymfile]]"
+// CHECK-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::Linker", inputs: [{{.*}}], output: "[[outfile]]"
+// CHECK-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::Dsymutil", inputs: ["[[outfile]]"], output: "[[dsymfile]]"
 
 // Check output name derivation for multiple -arch options.
 //
@@ -48,17 +48,17 @@
 // RUN:   -arch x86_64 -arch arm64 -ccc-print-bindings %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-MULTIARCH-OUTPUT-NAME < %t %s
 //
-// CHECK-MULTIARCH-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::Linker", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out"
-// CHECK-MULTIARCH-OUTPUT-NAME: "arm64-apple-darwin11" - "darwin::Linker", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-arm64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"
-// CHECK-MULTIARCH-OUTPUT-NAME: "arm64-apple-darwin11" - "darwin::Lipo", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out", "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"], output: "a.out"
+// CHECK-MULTIARCH-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::Linker", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out"
+// CHECK-MULTIARCH-OUTPUT-NAME: "arm64-apple-macosx10.7.0" - "darwin::Linker", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-arm64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"
+// CHECK-MULTIARCH-OUTPUT-NAME: "arm64-apple-macosx10.7.0" - "darwin::Lipo", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out", "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"], output: "a.out"
 //
 // RUN: %clang -target x86_64-apple-darwin11 \
 // RUN:   -Wl,-foo -arch x86_64 -arch arm64 -ccc-print-bindings %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG < %t %s
 //
-// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "x86_64-apple-darwin11" - "darwin::Linker", inputs: [(input arg), "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out"
-// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "arm64-apple-darwin11" - "darwin::Linker", inputs: [(input arg), "{{.*}}{{/|\\}}darwin-dsymutil-arm64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"
-// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "arm64-apple-darwin11" - "darwin::Lipo", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out", "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"], output: "a.out"
+// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "x86_64-apple-macosx10.7.0" - "darwin::Linker", inputs: [(input arg), "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out"
+// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "arm64-apple-macosx10.7.0" - "darwin::Linker", inputs: [(input arg), "{{.*}}{{/|\\}}darwin-dsymutil-arm64.o"], output: "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"
+// CHECK-MULTIARCH-OUTPUT-NAME-WITH-ARG: "arm64-apple-macosx10.7.0" - "darwin::Lipo", inputs: ["{{.*}}{{/|\\}}darwin-dsymutil-x86_64.out", "{{.*}}{{/|\\}}darwin-dsymutil-arm64.out"], output: "a.out"
 
 // Check that we only use dsymutil when needed.
 //

--- a/clang/test/Driver/darwin-verify-debug.c
+++ b/clang/test/Driver/darwin-verify-debug.c
@@ -12,8 +12,8 @@
 // RUN:   --verify-debug-info -arch i386 -arch x86_64 %s -g 2> %t
 // RUN: FileCheck -check-prefix=CHECK-MULTIARCH-BINDINGS < %t %s
 //
-// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-darwin11" - "darwin::Dsymutil", inputs: ["a.out"], output: "a.out.dSYM"
-// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-darwin11" - "darwin::VerifyDebug", inputs: ["a.out.dSYM"], output: (nothing)
+// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-macosx10.7.0" - "darwin::Dsymutil", inputs: ["a.out"], output: "a.out.dSYM"
+// CHECK-MULTIARCH-BINDINGS: # "x86_64-apple-macosx10.7.0" - "darwin::VerifyDebug", inputs: ["a.out.dSYM"], output: (nothing)
 
 // Check output name derivation.
 //
@@ -21,9 +21,9 @@
 // RUN:   --verify-debug-info -o foo %s -g 2> %t
 // RUN: FileCheck -check-prefix=CHECK-OUTPUT-NAME < %t %s
 //
-// CHECK-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::Linker", inputs: [{{.*}}], output: "foo"
-// CHECK-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::Dsymutil", inputs: ["foo"], output: "foo.dSYM"
-// CHECK-OUTPUT-NAME: "x86_64-apple-darwin11" - "darwin::VerifyDebug", inputs: ["foo.dSYM"], output: (nothing)
+// CHECK-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::Linker", inputs: [{{.*}}], output: "foo"
+// CHECK-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::Dsymutil", inputs: ["foo"], output: "foo.dSYM"
+// CHECK-OUTPUT-NAME: "x86_64-apple-macosx10.7.0" - "darwin::VerifyDebug", inputs: ["foo.dSYM"], output: (nothing)
 
 // Check that we only verify when needed.
 //


### PR DESCRIPTION
Previously this would print the original triple, rather
than the adjusted triple for the tool invocation which I found
confusing.