### PR TITLE
[LTO][lld] Emit textual assembly code with '--save-temps=asm'

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -620,8 +620,8 @@ static void checkZOptions(Ctx &ctx, opt::InputArgList &args) {
 }
 
 constexpr const char *saveTempsValues[] = {
-    "resolution", "preopt",     "promote", "internalize",  "import",
-    "opt",        "precodegen", "prelink", "combinedindex"};
+    "resolution", "preopt",     "promote", "internalize",   "import",
+    "opt",        "precodegen", "prelink", "combinedindex", "asm"};
 
 LinkerDriver::LinkerDriver(Ctx &ctx) : ctx(ctx) {}
 
@@ -1550,16 +1550,16 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
       !args.hasArg(OPT_relocatable) || args.hasArg(OPT_force_group_allocation);
 
   if (args.hasArg(OPT_save_temps)) {
-    // --save-temps implies saving all temps.
-    ctx.arg.saveTempsArgs.insert_range(saveTempsValues);
-  } else {
-    for (auto *arg : args.filtered(OPT_save_temps_eq)) {
-      StringRef s = arg->getValue();
-      if (llvm::is_contained(saveTempsValues, s))
-        ctx.arg.saveTempsArgs.insert(s);
-      else
-        ErrAlways(ctx) << "unknown --save-temps value: " << s;
-    }
+    // --save-temps implies saving all temps except "asm".
+    ctx.arg.saveTempsArgs.insert_range(llvm::make_filter_range(
+        saveTempsValues, [](StringRef Str) { return Str != "asm"; }));
+  }
+  for (auto *arg : args.filtered(OPT_save_temps_eq)) {
+    StringRef s = arg->getValue();
+    if (llvm::is_contained(saveTempsValues, s))
+      ctx.arg.saveTempsArgs.insert(s);
+    else
+      ErrAlways(ctx) << "unknown --save-temps value: " << s;
   }
 
   ctx.arg.searchPaths = args::getStrings(args, OPT_library_path);

--- a/lld/test/ELF/lto/save-temps-eq.ll
+++ b/lld/test/ELF/lto/save-temps-eq.ll
@@ -14,6 +14,8 @@
 ;; Create the .all dir with save-temps saving everything, this will be used to compare
 ;; with the output from individualized save-temps later
 ; RUN: ld.lld main.o thin1.o --save-temps -o %t/all/a.out
+;; --save-temps should not produce .s files.
+; RUN: not ls *.s 2>/dev/null
 ; RUN: mv a.out.lto.* *.o.*.bc %t/all
 ;; Sanity check that everything got moved
 ; RUN: ls | count 2
@@ -92,6 +94,12 @@
 ;; %t/all3 needs at least 1 copy of a.out, move it over now since its the last block
 ; RUN: mv a.out %t/all3
 ; RUN: mv *.resolution.txt %t/all3
+; RUN: ls | count 2
+
+;; Check asm.
+; RUN: ld.lld main.o thin1.o --save-temps=asm
+; RUN: cmp %t/all/a.out a.out && rm -f a.out
+; RUN: ls main.o.s thin1.o.s && rm main.o.s thin1.o.s
 ; RUN: ls | count 2
 
 ;; If no files were left out from individual stages, the .all3 dir should be identical to .all

--- a/llvm/include/llvm/LTO/Config.h
+++ b/llvm/include/llvm/LTO/Config.h
@@ -257,6 +257,11 @@ struct Config {
   /// splitting the module.
   ModuleHookFn PreCodeGenModuleHook;
 
+  /// This module hook is called before emitting textual assembly.
+  using SaveTempsAsmFn =
+      std::function<void(unsigned Task, const Module &, StringRef AsmText)>;
+  SaveTempsAsmFn SaveTempsAsmHook;
+
   /// A combined index hook is called after all per-module indexes have been
   /// combined (ThinLTO-specific). It can be used to implement -save-temps for
   /// the combined index.

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -27,6 +27,18 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/LTO/LTO.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCParser/MCAsmParser.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/ModuleSymbolTable.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -36,6 +48,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -105,36 +118,40 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
     }
   }
 
+  // If this is the combined module (not a ThinLTO backend compile) or the
+  // user hasn't requested using the input module's path, emit to a file
+  // named from the provided OutputFileName with the Task ID appended.
+  auto getPathPrefix = [=](const Module &M, unsigned Task) -> std::string {
+    if (M.getModuleIdentifier() == "ld-temp.o" || !UseInputModulePath) {
+      std::string Prefix = OutputFileName;
+      if (Task != (unsigned)-1)
+        Prefix += utostr(Task) + ".";
+      return Prefix;
+    }
+    return std::string(M.getModuleIdentifier()) + ".";
+  };
+
+  auto shouldSkipModule =
+      [SaveModNames = SmallVector<std::string, 1>(
+           SaveModulesList.begin(), SaveModulesList.end())](const Module &M) {
+        return !SaveModNames.empty() &&
+               !llvm::is_contained(
+                   SaveModNames,
+                   std::string(llvm::sys::path::filename(M.getName())));
+      };
+
   auto setHook = [&](std::string PathSuffix, ModuleHookFn &Hook) {
     // Keep track of the hook provided by the linker, which also needs to run.
     ModuleHookFn LinkerHook = Hook;
-    Hook = [=, SaveModNames = llvm::SmallVector<std::string, 1>(
-                   SaveModulesList.begin(), SaveModulesList.end())](
-               unsigned Task, const Module &M) {
-      // If SaveModulesList is not empty, only do save-temps if the module's
-      // filename (without path) matches a name in the list.
-      if (!SaveModNames.empty() &&
-          !llvm::is_contained(
-              SaveModNames,
-              std::string(llvm::sys::path::filename(M.getName()))))
+    Hook = [=](unsigned Task, const Module &M) {
+      if (shouldSkipModule(M))
         return false;
-
       // If the linker's hook returned false, we need to pass that result
       // through.
       if (LinkerHook && !LinkerHook(Task, M))
         return false;
 
-      std::string PathPrefix;
-      // If this is the combined module (not a ThinLTO backend compile) or the
-      // user hasn't requested using the input module's path, emit to a file
-      // named from the provided OutputFileName with the Task ID appended.
-      if (M.getModuleIdentifier() == "ld-temp.o" || !UseInputModulePath) {
-        PathPrefix = OutputFileName;
-        if (Task != (unsigned)-1)
-          PathPrefix += utostr(Task) + ".";
-      } else
-        PathPrefix = M.getModuleIdentifier() + ".";
-      std::string Path = PathPrefix + PathSuffix + ".bc";
+      std::string Path = getPathPrefix(M, Task) + PathSuffix + ".bc";
       std::error_code EC;
       raw_fd_ostream OS(Path, EC, sys::fs::OpenFlags::OF_None);
       // Because -save-temps is a debugging feature, we report the error
@@ -143,6 +160,19 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
         reportOpenError(Path, EC.message());
       WriteBitcodeToFile(M, OS, /*ShouldPreserveUseListOrder=*/false);
       return true;
+    };
+  };
+
+  auto setAsmHook = [&]() {
+    SaveTempsAsmHook = [=](unsigned Task, const Module &M, StringRef AsmText) {
+      if (shouldSkipModule(M))
+        return;
+      std::string Path = getPathPrefix(M, Task) + "s";
+      std::error_code EC;
+      raw_fd_ostream OS(Path, EC, sys::fs::OF_Text);
+      if (EC)
+        reportOpenError(Path, EC.message());
+      OS << AsmText;
     };
   };
 
@@ -189,6 +219,8 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
       setHook("5.precodegen", PreCodeGenModuleHook);
     if (SaveTempsArgs.contains("combinedindex"))
       CombinedIndexHook = SaveCombinedIndex;
+    if (SaveTempsArgs.contains("asm"))
+      setAsmHook();
   }
 
   return Error::success();
@@ -434,6 +466,44 @@ bool lto::opt(const Config &Conf, TargetMachine *TM, unsigned Task, Module &Mod,
   return !Conf.PostOptModuleHook || Conf.PostOptModuleHook(Task, Mod);
 }
 
+// Converts textual assembly code into the requested object format.
+static void assemble(const Target *T, const TargetMachine *TM,
+                     StringRef AsmText, raw_pwrite_stream &OS) {
+  const llvm::Triple &TT = TM->getTargetTriple();
+  std::unique_ptr<MCRegisterInfo> MRI(T->createMCRegInfo(TT));
+  std::unique_ptr<MCAsmInfo> MAI(
+      T->createMCAsmInfo(*MRI, TT, TM->Options.MCOptions));
+  std::unique_ptr<MCSubtargetInfo> STI(T->createMCSubtargetInfo(
+      TT, TM->getTargetCPU(), TM->getTargetFeatureString()));
+  std::unique_ptr<MCInstrInfo> MCII(T->createMCInstrInfo());
+
+  MCContext Ctx(TT, *MAI, *MRI, *STI);
+  std::unique_ptr<MCObjectFileInfo> MOFI(
+      T->createMCObjectFileInfo(Ctx, /*PIC=*/false));
+  Ctx.setObjectFileInfo(MOFI.get());
+
+  std::unique_ptr<MCCodeEmitter> CE(T->createMCCodeEmitter(*MCII, Ctx));
+  std::unique_ptr<MCAsmBackend> MAB(
+      T->createMCAsmBackend(*STI, *MRI, TM->Options.MCOptions));
+  std::unique_ptr<MCObjectWriter> OW = MAB->createObjectWriter(OS);
+  std::unique_ptr<MCStreamer> Streamer(T->createMCObjectStreamer(
+      TT, Ctx, std::move(MAB), std::move(OW), std::move(CE), *STI));
+
+  auto Buf = MemoryBuffer::getMemBufferCopy(AsmText, "<save-temps-asm>");
+  SourceMgr SrcMgr;
+  SrcMgr.AddNewSourceBuffer(std::move(Buf), SMLoc());
+
+  std::unique_ptr<MCAsmParser> Parser(
+      createMCAsmParser(SrcMgr, Ctx, *Streamer, *MAI));
+  std::unique_ptr<MCTargetAsmParser> TAP(
+      T->createMCAsmParser(*STI, *Parser, *MCII));
+  if (!TAP)
+    report_fatal_error("Failed to create target asm parser");
+  Parser->setTargetParser(*TAP);
+  if (Parser->Run(false))
+    report_fatal_error("Failed to assemble save-temps assembly output");
+}
+
 static void codegen(const Config &Conf, TargetMachine *TM,
                     AddStreamFn AddStream, unsigned Task, Module &Mod,
                     const ModuleSummaryIndex &CombinedIndex) {
@@ -467,6 +537,47 @@ static void codegen(const Config &Conf, TargetMachine *TM,
     if (EC)
       report_fatal_error(Twine("Failed to open ") + DwoFile + ": " +
                          EC.message());
+  }
+
+  // Emit an intermediate assembly file phase if requested by the user.
+  if (Conf.SaveTempsAsmHook) {
+    SmallString<0> AsmBuf;
+    raw_svector_ostream AsmOS(AsmBuf);
+
+    legacy::PassManager CodeGenPasses;
+    TargetLibraryInfoImpl TLII(Mod.getTargetTriple(), TM->Options.VecLib);
+    CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
+    CodeGenPasses.add(new RuntimeLibraryInfoWrapper(
+        Mod.getTargetTriple(), TM->Options.ExceptionModel,
+        TM->Options.FloatABIType, TM->Options.EABIVersion,
+        TM->Options.MCOptions.ABIName, TM->Options.VecLib));
+    if (!isEmptyModule(Mod))
+      CodeGenPasses.add(
+          createImmutableModuleSummaryIndexWrapperPass(&CombinedIndex));
+    if (Conf.PreCodeGenPassesHook)
+      Conf.PreCodeGenPassesHook(CodeGenPasses);
+    if (TM->addPassesToEmitFile(CodeGenPasses, AsmOS, nullptr,
+                                CodeGenFileType::AssemblyFile))
+      report_fatal_error("Failed to setup codegen");
+    CodeGenPasses.run(Mod);
+
+    Conf.SaveTempsAsmHook(Task, Mod, AsmBuf.str());
+
+    Expected<std::unique_ptr<CachedFileStream>> StreamOrErr =
+        AddStream(Task, Mod.getModuleIdentifier());
+    if (Error Err = StreamOrErr.takeError())
+      report_fatal_error(std::move(Err));
+    std::unique_ptr<CachedFileStream> &Stream = *StreamOrErr;
+    TM->Options.ObjectFilenameForDebug = Stream->ObjectPathName;
+
+    assemble(&TM->getTarget(), TM, AsmBuf.str(), *Stream->OS);
+
+    if (DwoOut)
+      DwoOut->keep();
+
+    if (Error Err = Stream->commit())
+      report_fatal_error(std::move(Err));
+    return;
   }
 
   Expected<std::unique_ptr<CachedFileStream>> StreamOrErr =

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -539,12 +539,9 @@ static void codegen(const Config &Conf, TargetMachine *TM,
                          EC.message());
   }
 
-  // Emit an intermediate assembly file phase if requested by the user.
-  if (Conf.SaveTempsAsmHook) {
-    SmallString<0> AsmBuf;
-    raw_svector_ostream AsmOS(AsmBuf);
-
-    legacy::PassManager CodeGenPasses;
+  auto addCodeGenPasses = [&](legacy::PassManager &CodeGenPasses,
+                              raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
+                              CodeGenFileType FileType) {
     TargetLibraryInfoImpl TLII(Mod.getTargetTriple(), TM->Options.VecLib);
     CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
     CodeGenPasses.add(new RuntimeLibraryInfoWrapper(
@@ -556,9 +553,18 @@ static void codegen(const Config &Conf, TargetMachine *TM,
           createImmutableModuleSummaryIndexWrapperPass(&CombinedIndex));
     if (Conf.PreCodeGenPassesHook)
       Conf.PreCodeGenPassesHook(CodeGenPasses);
-    if (TM->addPassesToEmitFile(CodeGenPasses, AsmOS, nullptr,
-                                CodeGenFileType::AssemblyFile))
+    if (TM->addPassesToEmitFile(CodeGenPasses, Out, DwoOut, FileType))
       report_fatal_error("Failed to setup codegen");
+  };
+
+  // Emit an intermediate assembly file phase if requested by the user.
+  if (Conf.SaveTempsAsmHook) {
+    SmallString<0> AsmBuf;
+    raw_svector_ostream AsmOS(AsmBuf);
+
+    legacy::PassManager CodeGenPasses;
+    addCodeGenPasses(CodeGenPasses, AsmOS, nullptr,
+                     CodeGenFileType::AssemblyFile);
     CodeGenPasses.run(Mod);
 
     Conf.SaveTempsAsmHook(Task, Mod, AsmBuf.str());
@@ -593,27 +599,8 @@ static void codegen(const Config &Conf, TargetMachine *TM,
   // keep the pointer and may use it until their destruction. See #138194.
   {
     legacy::PassManager CodeGenPasses;
-    TargetLibraryInfoImpl TLII(Mod.getTargetTriple(), TM->Options.VecLib);
-    CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
-    CodeGenPasses.add(new RuntimeLibraryInfoWrapper(
-        Mod.getTargetTriple(), TM->Options.ExceptionModel,
-        TM->Options.FloatABIType, TM->Options.EABIVersion,
-        TM->Options.MCOptions.ABIName, TM->Options.VecLib));
-
-    // No need to make index available if the module is empty.
-    // In theory these passes should not use the index for an empty
-    // module, however, this guards against doing any unnecessary summary-based
-    // analysis in the case of a ThinLTO build where this might be an empty
-    // regular LTO combined module, with a large combined index from ThinLTO.
-    if (!isEmptyModule(Mod))
-      CodeGenPasses.add(
-          createImmutableModuleSummaryIndexWrapperPass(&CombinedIndex));
-    if (Conf.PreCodeGenPassesHook)
-      Conf.PreCodeGenPassesHook(CodeGenPasses);
-    if (TM->addPassesToEmitFile(CodeGenPasses, *Stream->OS,
-                                DwoOut ? &DwoOut->os() : nullptr,
-                                Conf.CGFileType))
-      report_fatal_error("Failed to setup codegen");
+    addCodeGenPasses(CodeGenPasses, *Stream->OS,
+                     DwoOut ? &DwoOut->os() : nullptr, Conf.CGFileType);
     CodeGenPasses.run(Mod);
 
     if (DwoOut)

--- a/llvm/test/LTO/X86/save-temps-asm.ll
+++ b/llvm/test/LTO/X86/save-temps-asm.ll
@@ -1,0 +1,14 @@
+; REQUIRES: x86-registered-target
+
+; RUN: llvm-as < %s > %t1.bc
+; RUN: llvm-lto2 run %t1.bc -r=%t1.bc,foo,plx -o %t.ref -select-save-temps=asm
+; RUN: FileCheck %s < %t.asm.0.s
+
+; CHECK: foo:
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @foo() {
+  ret void
+}

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -72,14 +72,14 @@ static cl::list<std::string> SelectSaveTemps(
     "select-save-temps",
     cl::value_desc("One, or multiple of: "
                    "resolution,preopt,promote,internalize,import,opt,precodegen"
-                   ",combinedindex"),
+                   ",combinedindex,asm"),
     cl::desc("Save selected temporary files. Cannot be specified together with "
              "-save-temps"),
     cl::CommaSeparated);
 
 constexpr const char *SaveTempsValues[] = {
-    "resolution", "preopt", "promote",    "internalize",
-    "import",     "opt",    "precodegen", "combinedindex"};
+    "resolution", "preopt",     "promote",       "internalize", "import",
+    "opt",        "precodegen", "combinedindex", "asm"};
 
 static cl::opt<bool>
     ThinLTODistributedIndexes("thinlto-distributed-indexes",


### PR DESCRIPTION
Summary:
Right now `--save-temps` does not yield `.s` files like you would
receive if run through `clang foo.bc --save-temps`. This PR adds a
simple hook that outputs a `.s` as well.

The main motivation for this is for the AMD GPU target and offloading
where `--lto-emit-asm` does not work because the linker step occurs in
the middle of the compilation. This means the lack of output causes the
rest of the compilation to fail.

The approach outputs textual assembly and then creates a machine
compiler instance to convert that to the original object code. This
is how clang does it and ensures the assembly is 1-to-1 with the
created executable.