### PR TITLE
[lldb] Fix invalid-enum-load errors for ValueType

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -330,7 +330,7 @@ enum ErrorType {
   eErrorTypeWin32       ///< Standard Win32 error codes.
 };
 
-enum ValueType {
+enum ValueType : uint8_t {
   eValueTypeInvalid = 0,
   eValueTypeVariableGlobal = 1,   ///< globals variable
   eValueTypeVariableStatic = 2,   ///< static variable


### PR DESCRIPTION
`TestScriptedFrameProvider.py` currently fails with the following UBSan error:

```
runtime error: load of value 39, which is not a valid value for type 'lldb::ValueType'
```

The reason for this is that we don't specify an underlying type, so the compiler infers the range based on the bits needed to represent all enumerators.
But when we OR in ValueTypeSyntheticMask, the resulting value is larger than the inferred bit-range from the enumerators.

This patch just assigns an underlying type that is large enough to store all enum values + the ValueTypeSyntheticMask bit.