### PR TITLE
[clangd] Avoid crash on pseudo-destructor selection

### DIFF
--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -895,13 +895,19 @@ private:
     // rather than the TypeLoc nested inside it.
     // We still traverse the TypeLoc, because it may contain other targeted
     // things like the T in ~Foo<T>().
-    if (const auto *CDD = N.get<CXXDestructorDecl>())
-      return CDD->getNameInfo().getNamedTypeInfo()->getTypeLoc().getBeginLoc();
+    // FIXME: Investigate if getNamedTypeInfo() can still return null for
+    // invalid cases, and drop these checks when it never returns null.
+    if (const auto *CDD = N.get<CXXDestructorDecl>()) {
+      if (auto *TypeInfo = CDD->getNameInfo().getNamedTypeInfo())
+        return TypeInfo->getTypeLoc().getBeginLoc();
+    }
     if (const auto *ME = N.get<MemberExpr>()) {
       auto NameInfo = ME->getMemberNameInfo();
       if (NameInfo.getName().getNameKind() ==
-          DeclarationName::CXXDestructorName)
-        return NameInfo.getNamedTypeInfo()->getTypeLoc().getBeginLoc();
+          DeclarationName::CXXDestructorName) {
+        if (auto *TypeInfo = NameInfo.getNamedTypeInfo())
+          return TypeInfo->getTypeLoc().getBeginLoc();
+      }
     }
 
     return SourceRange();

--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -665,6 +665,24 @@ TEST(SelectionTest, InjectedClassName) {
   EXPECT_FALSE(D->isInjectedClassName());
 }
 
+TEST(SelectionTest, PseudoDestructorMissingTypeInfo) {
+  llvm::StringLiteral Code = R"cpp(
+    struct A { ~A(); };
+    void b(const A *y) {
+      y->~decltype(A())();
+    }
+  )cpp";
+  auto AST = TestTU::withCode(Code).build();
+  bool Seen = false;
+  // No crash.
+  SelectionTree::createEach(AST.getASTContext(), AST.getTokens(), 0,
+                            Code.size(), [&](SelectionTree) {
+                              Seen = true;
+                              return true;
+                            });
+  EXPECT_TRUE(Seen);
+}
+
 TEST(SelectionTree, Metrics) {
   const char *Code = R"cpp(
     // error-ok: testing behavior on recovery expression


### PR DESCRIPTION
clangd crashes during textDocument/codeAction on valid pseudo-destructor expressions like y->~decltype(A())(). The bug is in Selection.cpp::earlySourceRange(), which assumes destructor names always have NamedTypeInfo. The fix is adding null checks before calling getTypeLoc(). 

Fixes #195788. 