### PR TITLE
[lldb] Add flag to expr command to control trapping on exceptions

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -165,6 +165,18 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     break;
   }
 
+  case 'e': {
+    bool success;
+    bool tmp_value = OptionArgParser::ToBoolean(option_arg, true, &success);
+    if (success)
+      trap_on_exceptions = tmp_value;
+    else
+      error = Status::FromErrorStringWithFormat(
+          "could not convert \"%s\" to a boolean value.",
+          option_arg.str().c_str());
+    break;
+  }
+
   default:
     llvm_unreachable("Unimplemented option");
   }
@@ -195,6 +207,7 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   allow_jit = true;
   suppress_persistent_result = eLazyBoolCalculate;
   cpp_ignore_context_qualifiers = false;
+  trap_on_exceptions = true;
 }
 
 llvm::ArrayRef<OptionDefinition>
@@ -218,6 +231,7 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
       allow_jit ? EvaluateExpressionOptions::default_execution_policy
                 : lldb_private::eExecutionPolicyNever);
   options.SetCppIgnoreContextQualifiers(cpp_ignore_context_qualifiers);
+  options.SetTrapExceptions(trap_on_exceptions);
 
   bool auto_apply_fixits;
   if (this->auto_apply_fixits == eLazyBoolCalculate)

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -58,6 +58,7 @@ public:
     LazyBool auto_apply_fixits;
     LazyBool suppress_persistent_result;
     bool cpp_ignore_context_qualifiers;
+    bool trap_on_exceptions;
   };
 
   CommandObjectExpression(CommandInterpreter &interpreter);

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -718,6 +718,11 @@ let Command = "expression" in {
         Desc<
             "Should we run ${a}ll threads if the execution doesn't complete on "
             "one thread.">;
+  def expression_options_trap_exceptions
+      : Option<"trap-exceptions", "e">,
+        Groups<[1, 2]>,
+        Arg<"Boolean">,
+        Desc<"Trap on ${e}xceptions hit during expression execution">;
   def expression_options_ignore_breakpoints
       : Option<"ignore-breakpoints", "i">,
         Groups<[1, 2]>,

--- a/lldb/test/Shell/Expr/TestExprTrapExceptions.m
+++ b/lldb/test/Shell/Expr/TestExprTrapExceptions.m
@@ -1,0 +1,54 @@
+// UNSUPPORTED: system-linux, system-windows
+
+// RUN: %clang_host -g %s -o %t -framework Foundation
+// RUN: %lldb %t \
+// RUN: -o "br set -p 'I am about to throw'" \
+// RUN: -o "run" \
+// RUN: -o "expr -e false -- (int)[my_class iCatchMyself]" \
+// RUN: 2>&1 | FileCheck %s --check-prefix=NO-TRAP
+
+// NO-TRAP: (int) ${{[0-9]+}} = 57
+
+// RUN: %lldb %t \
+// RUN: -o "br set -p 'I am about to throw'" \
+// RUN: -o "run" \
+// RUN: -o "expr -e true -- (int)[my_class iCatchMyself]" \
+// RUN: 2>&1 | FileCheck %s --check-prefix=TRAP
+
+// TRAP: error: Expression execution was interrupted: internal ObjC exception breakpoint
+
+#import <Foundation/Foundation.h>
+
+@interface MyClass : NSObject {
+}
+- (int)callMeIThrow;
+- (int)iCatchMyself;
+@end
+
+@implementation MyClass
+- (int)callMeIThrow {
+  NSException *e = [NSException exceptionWithName:@"JustForTheHeckOfItException" reason:@"I felt like it" userInfo:nil];
+  @throw e;
+  return 56;
+}
+- (int)iCatchMyself {
+  int return_value = 55;
+  @try {
+    return_value = [self callMeIThrow];
+  } @catch (NSException *e) {
+    return_value = 57;
+  }
+
+  return return_value;
+}
+@end
+
+int main() {
+  int return_value;
+  MyClass *my_class = [[MyClass alloc] init];
+  NSLog(@"I am about to throw.");
+
+  return_value = [my_class iCatchMyself];
+
+  return return_value;
+}


### PR DESCRIPTION
SBExpressionOptions supports this but there's no way to control it from the expression command. I added an option (-e) to control this. It defaults to true (matching existing behavior).