### PR TITLE
[SSAF] Fix -Wunused-variable in b73ce3e53fcb9f72c759139e93db7e16a813c3b2

### DIFF
--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -347,7 +347,7 @@ public:
       if (!ContributorName)
         llvm::reportFatalInternalError(makeEntityNameErr(Ctx, CD));
 
-      auto [Ignored, InsertionSucceeded] = SummaryBuilder.addSummary(
+      [[maybe_unused]] auto [Ignored, InsertionSucceeded] = SummaryBuilder.addSummary(
           addEntity(*ContributorName), std::move(*EntitySummary));
 
       assert(InsertionSucceeded && "duplicated contributor extraction");


### PR DESCRIPTION
There was a variable only used in an assertion in a call to addSummary.
Mark it [[maybe_unused]] given the call has side effects.