### PR TITLE
[NVPTX] Add IntrNoDuplicate to .aligned intrinsics.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -1930,8 +1930,13 @@ let TargetPrefix = "nvvm" in {
   multiclass BarrierCTAIntrinsic<list<LLVMType> ret_types = [],
                                  list<LLVMType> extra_param_types = [],
                                  bit has_all_variant = true> {
-    let IntrProperties = [IntrConvergent, IntrNoCallback] in {
-      foreach align = ["", "_aligned"] in {
+    foreach align = ["", "_aligned"] in {
+      // The .aligned variants require all threads in the warp to execute the
+      // same barrier with the same arguments, so they must not be duplicated.
+      defvar props = !if(!eq(align, "_aligned"),
+                         [IntrConvergent, IntrNoCallback, IntrNoDuplicate],
+                         [IntrConvergent, IntrNoCallback]);
+      let IntrProperties = props in {
         def align # _count :
           Intrinsic<ret_types, [llvm_i32_ty, llvm_i32_ty] # extra_param_types>;
         if has_all_variant then
@@ -1958,8 +1963,12 @@ let TargetPrefix = "nvvm" in {
     def int_nvvm_barrier_cluster_arrive : Intrinsic<[]>;
     def int_nvvm_barrier_cluster_arrive_relaxed : Intrinsic<[]>;
     def int_nvvm_barrier_cluster_wait : Intrinsic<[]>;
+  }
 
-    // 'aligned' versions of the above barrier.cluster.* intrinsics
+  // 'aligned' versions of the above barrier.cluster.* intrinsics. These require
+  // all threads in the warp to execute the same barrier and must not be
+  // duplicated.
+  let IntrProperties = [IntrConvergent, IntrNoCallback, IntrNoDuplicate] in {
     def int_nvvm_barrier_cluster_arrive_aligned : Intrinsic<[]>;
     def int_nvvm_barrier_cluster_arrive_relaxed_aligned : Intrinsic<[]>;
     def int_nvvm_barrier_cluster_wait_aligned : Intrinsic<[]>;
@@ -2597,15 +2606,19 @@ let IntrProperties = [IntrConvergent, IntrInaccessibleMemOnly, IntrNoCallback] i
 // WGMMA fence instructions
 //
 // wgmma.fence.sync.aligned;
-def int_nvvm_wgmma_fence_sync_aligned : Intrinsic<[], [], [IntrConvergent]>;
+def int_nvvm_wgmma_fence_sync_aligned
+  : Intrinsic<[], [], [IntrConvergent, IntrNoDuplicate]>;
 
 // wgmma.commit_group.sync.aligned;
 def int_nvvm_wgmma_commit_group_sync_aligned
-  : Intrinsic<[], [], [IntrConvergent], "llvm.nvvm.wgmma.commit_group.sync.aligned">;
+  : Intrinsic<[], [], [IntrConvergent, IntrNoDuplicate],
+              "llvm.nvvm.wgmma.commit_group.sync.aligned">;
 
 // wgmma.wait_group.sync.aligned N;
 def int_nvvm_wgmma_wait_group_sync_aligned
-  : Intrinsic<[], [llvm_i64_ty], [IntrConvergent, ImmArg<ArgIndex<0>>], "llvm.nvvm.wgmma.wait_group.sync.aligned">;
+  : Intrinsic<[], [llvm_i64_ty],
+              [IntrConvergent, IntrNoDuplicate, ImmArg<ArgIndex<0>>],
+              "llvm.nvvm.wgmma.wait_group.sync.aligned">;
 
 //
 // WMMA instructions
@@ -2857,7 +2870,7 @@ def int_nvvm_is_explicit_cluster
 foreach op = ["dec", "inc"] in
   def int_nvvm_setmaxnreg_ # op # _sync_aligned_u32
     : DefaultAttrsIntrinsic<[], [llvm_i32_ty],
-              [IntrConvergent, IntrNoMem, IntrHasSideEffects,
+              [IntrConvergent, IntrNoMem, IntrHasSideEffects, IntrNoDuplicate,
                ImmArg<ArgIndex<0>>, Range<ArgIndex<0>, 24, 257>]>;
 
 // Exit

--- a/llvm/test/CodeGen/NVPTX/inliner-noduplicate.ll
+++ b/llvm/test/CodeGen/NVPTX/inliner-noduplicate.ll
@@ -1,0 +1,27 @@
+; RUN: opt -mtriple=nvptx64-nvidia-cuda -mcpu=sm_100 -S --passes='cgscc(inline)' < %s | FileCheck %s
+
+; The internal callee contains a `noduplicate` intrinsic, so the inliner must
+; not inline it at the two call sites below (doing so would duplicate the
+; noduplicate call).
+
+define internal void @barrier() {
+  call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+  ret void
+}
+
+define ptx_kernel void @noinline() {
+start:
+  %tid = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  %cond = icmp slt i32 %tid, 5
+  br i1 %cond, label %bb1, label %bb2
+bb1:
+  ; CHECK: call void @barrier()
+  call void @barrier()
+  br label %exit
+bb2:
+  ; CHECK: call void @barrier()
+  call void @barrier()
+  br label %exit
+exit:
+  ret void
+}

--- a/llvm/test/Feature/intrinsic-noduplicate.ll
+++ b/llvm/test/Feature/intrinsic-noduplicate.ll
@@ -7,4 +7,4 @@
 declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32)
 
 ; CHECK: declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32) #[[ATTRNUM:[0-9]+]]
-; CHECK: attributes #[[ATTRNUM]] = { convergent nocallback nounwind }
+; CHECK: attributes #[[ATTRNUM]] = { convergent nocallback noduplicate nounwind }

--- a/llvm/test/Transforms/FunctionAttrs/convergent.ll
+++ b/llvm/test/Transforms/FunctionAttrs/convergent.ll
@@ -162,7 +162,7 @@ declare token @llvm.experimental.convergence.entry() #1
 ; CHECK: attributes #[[ATTR0]] = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
 ; CHECK: attributes #[[ATTR1]] = { convergent }
 ; CHECK: attributes #[[ATTR2]] = { norecurse }
-; CHECK: attributes #[[ATTR3:[0-9]+]] = { convergent nocallback nounwind }
+; CHECK: attributes #[[ATTR3:[0-9]+]] = { convergent nocallback noduplicate nounwind }
 ; CHECK: attributes #[[ATTR4]] = { convergent norecurse nounwind }
 ; CHECK: attributes #[[ATTR5]] = { nofree nosync nounwind memory(none) }
 ; CHECK: attributes #[[ATTR6]] = { convergent noinline optnone }

--- a/llvm/test/Transforms/OpenMP/barrier_removal.ll
+++ b/llvm/test/Transforms/OpenMP/barrier_removal.ll
@@ -1246,14 +1246,14 @@ exit:
 !16 = !{i32 7, !"openmp-device", i32 50}
 ;.
 ; MODULE: attributes #[[ATTR0:[0-9]+]] = { "llvm.assume"="ompx_aligned_barrier" }
-; MODULE: attributes #[[ATTR1:[0-9]+]] = { convergent nocallback nounwind }
+; MODULE: attributes #[[ATTR1:[0-9]+]] = { convergent nocallback noduplicate nounwind }
 ; MODULE: attributes #[[ATTR2:[0-9]+]] = { convergent nocallback nofree nounwind willreturn }
 ; MODULE: attributes #[[ATTR3:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }
 ; MODULE: attributes #[[ATTR4]] = { "kernel" }
 ; MODULE: attributes #[[ATTR5]] = { nosync memory(none) }
 ;.
 ; CGSCC: attributes #[[ATTR0]] = { "llvm.assume"="ompx_aligned_barrier" }
-; CGSCC: attributes #[[ATTR1:[0-9]+]] = { convergent nocallback nounwind }
+; CGSCC: attributes #[[ATTR1:[0-9]+]] = { convergent nocallback noduplicate nounwind }
 ; CGSCC: attributes #[[ATTR2:[0-9]+]] = { convergent nocallback nofree nounwind willreturn }
 ; CGSCC: attributes #[[ATTR3:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }
 ; CGSCC: attributes #[[ATTR4]] = { "kernel" }


### PR DESCRIPTION
Mark the corresponding NVVM intrinsics `IntrNoDuplicate` so generic optimizations preserve a single copy of each call:

  - barrier{.cta}.sync{.aligned}, barrier{.cta}.arrive{.aligned}, barrier{.cta}.red.{popc,and,or}{.aligned} (via BarrierCTAIntrinsic)
  - barrier.cluster.{arrive,arrive_relaxed,wait}.aligned
  - wgmma.{fence,commit_group,wait_group}.sync.aligned
  - setmaxnreg.{dec,inc}.sync.aligned.u32