### PR TITLE
clang: Avoid dummy LAST entry in OffloadArch

### DIFF
--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -120,7 +120,7 @@ enum class OffloadArch {
   GRANITERAPIDS,
   // Intel GPUs
   BMG_G21,
-  LAST,
+  LAST = BMG_G21,
 
   CudaDefault = OffloadArch::SM_52,
   HIPDefault = OffloadArch::GFX906,
@@ -140,7 +140,7 @@ static inline bool IsIntelCPUOffloadArch(OffloadArch Arch) {
 }
 
 static inline bool IsIntelGPUOffloadArch(OffloadArch Arch) {
-  return Arch >= OffloadArch::BMG_G21 && Arch < OffloadArch::LAST;
+  return Arch >= OffloadArch::BMG_G21 && Arch <= OffloadArch::LAST;
 }
 
 static inline bool IsIntelOffloadArch(OffloadArch Arch) {

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2379,8 +2379,6 @@ void CGOpenMPRuntimeGPU::processRequiresDirective(const OMPRequiresDecl *D) {
       case OffloadArch::Unused:
       case OffloadArch::Unknown:
         break;
-      case OffloadArch::LAST:
-        llvm_unreachable("Unexpected GPU arch.");
       }
     }
   }


### PR DESCRIPTION
Use this as an alias of the final entry, rather than its
own enum value. This will allow writing covered switches
that don't need to handle this case. This matches how
other places with an end enum entry handle this.