### PR TITLE
[lldb] Handle SIGINT via the MainLoop signal thread (on POSIX)

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -651,11 +651,10 @@ void Driver::UpdateWindowSize() {
   }
 }
 
-void sigint_handler(int signo) {
 #ifdef _WIN32
+void sigint_handler(int signo) {
   // Restore handler as it is not persistent on Windows.
   signal(SIGINT, sigint_handler);
-#endif
 
   static std::atomic_flag g_interrupt_sent = ATOMIC_FLAG_INIT;
   if (g_driver != nullptr) {
@@ -668,6 +667,7 @@ void sigint_handler(int signo) {
 
   _exit(signo);
 }
+#endif
 
 static void printHelp(LLDBOptTable &table, llvm::StringRef tool_name) {
   std::string usage_str = tool_name.str() + " [options]";
@@ -781,14 +781,40 @@ int main(int argc, char const *argv[]) {
   // Setup LLDB signal handlers once the debugger has been initialized.
   SBDebugger::PrintDiagnosticsOnError();
 
-  //  FIXME: Migrate the SIGINT handler to be handled by the signal loop below.
+#ifdef _WIN32
   signal(SIGINT, sigint_handler);
-#if !defined(_WIN32)
+#else
   signal(SIGPIPE, SIG_IGN);
 
   // Handle signals in a MainLoop running on a separate thread.
   MainLoop signal_loop;
   Status signal_status;
+
+  auto sigint_handler = signal_loop.RegisterSignal(
+      SIGINT,
+      [&](MainLoopBase &) {
+        // Temporarily restore the default disposition so that a second SIGINT
+        // delivered while DispatchInputInterrupt is running hard-terminates
+        // the process. This preserves the "double Ctrl-C to force exit"
+        // escape hatch users rely on when the debugger is unresponsive.
+        struct sigaction old_action;
+        struct sigaction new_action = {};
+        new_action.sa_handler = SIG_DFL;
+        sigemptyset(&new_action.sa_mask);
+
+        int ret = sigaction(SIGINT, &new_action, &old_action);
+        UNUSED_IF_ASSERT_DISABLED(ret);
+        assert(ret == 0 && "sigaction failed");
+
+        if (g_driver)
+          g_driver->GetDebugger().DispatchInputInterrupt();
+
+        ret = sigaction(SIGINT, &old_action, nullptr);
+        UNUSED_IF_ASSERT_DISABLED(ret);
+        assert(ret == 0 && "sigaction failed");
+      },
+      signal_status);
+  assert(sigint_handler && signal_status.Success());
 
   auto sigwinch_handler = signal_loop.RegisterSignal(
       SIGWINCH,

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -789,17 +789,12 @@ int main(int argc, char const *argv[]) {
 #else
   signal(SIGPIPE, SIG_IGN);
 
-  // Install a no-op handler for SIGURG so the signal thread can use
-  // pthread_kill(main_tid, SIGURG) to interrupt blocking syscalls (e.g.
-  // Python's time.sleep or input()) on the main thread without causing the
-  // process to terminate or re-entering the SIGINT callback.
-  struct sigaction wakeup_action = {};
-  wakeup_action.sa_handler = [](int) {};
-  sigemptyset(&wakeup_action.sa_mask);
-  sigaction(SIGURG, &wakeup_action, nullptr);
-
   // Capture the main thread's id so the signal thread can target it.
   pthread_t main_thread = pthread_self();
+
+  // Set when the signal thread sends itself a SIGINT to wake the main thread.
+  // The next SIGINT callback invocation observes this flag and skips the work.
+  std::atomic<bool> skip_next_sigint{false};
 
   // Handle signals in a MainLoop running on a separate thread.
   MainLoop signal_loop;
@@ -808,6 +803,11 @@ int main(int argc, char const *argv[]) {
   auto sigint_handler = signal_loop.RegisterSignal(
       SIGINT,
       [&, main_thread](MainLoopBase &) {
+        // Skip the self-sent wakeup SIGINT queued at the end of the previous
+        // invocation.
+        if (skip_next_sigint.exchange(false))
+          return;
+
         // Temporarily restore the default disposition so that a second SIGINT
         // delivered while DispatchInputInterrupt is running hard-terminates
         // the process. This preserves the "double Ctrl-C to force exit"
@@ -831,8 +831,10 @@ int main(int argc, char const *argv[]) {
         // Wake the main thread so any blocking syscall (e.g. the Python REPL
         // waiting on input or sleeping) returns with EINTR. This lets Python
         // observe the pending interrupt queued by DispatchInputInterrupt and
-        // raise KeyboardInterrupt.
-        pthread_kill(main_thread, SIGURG);
+        // raise KeyboardInterrupt. Flag the resulting callback invocation so
+        // it's skipped rather than re-running DispatchInputInterrupt.
+        skip_next_sigint.store(true);
+        pthread_kill(main_thread, SIGINT);
       },
       signal_status);
   assert(sigint_handler && signal_status.Success());

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -43,6 +43,9 @@
 #include <clocale>
 #include <csignal>
 #include <future>
+#ifndef _WIN32
+#include <pthread.h>
+#endif
 #include <string>
 #include <thread>
 #include <utility>
@@ -786,13 +789,25 @@ int main(int argc, char const *argv[]) {
 #else
   signal(SIGPIPE, SIG_IGN);
 
+  // Install a no-op handler for SIGURG so the signal thread can use
+  // pthread_kill(main_tid, SIGURG) to interrupt blocking syscalls (e.g.
+  // Python's time.sleep or input()) on the main thread without causing the
+  // process to terminate or re-entering the SIGINT callback.
+  struct sigaction wakeup_action = {};
+  wakeup_action.sa_handler = [](int) {};
+  sigemptyset(&wakeup_action.sa_mask);
+  sigaction(SIGURG, &wakeup_action, nullptr);
+
+  // Capture the main thread's id so the signal thread can target it.
+  pthread_t main_thread = pthread_self();
+
   // Handle signals in a MainLoop running on a separate thread.
   MainLoop signal_loop;
   Status signal_status;
 
   auto sigint_handler = signal_loop.RegisterSignal(
       SIGINT,
-      [&](MainLoopBase &) {
+      [&, main_thread](MainLoopBase &) {
         // Temporarily restore the default disposition so that a second SIGINT
         // delivered while DispatchInputInterrupt is running hard-terminates
         // the process. This preserves the "double Ctrl-C to force exit"
@@ -812,6 +827,12 @@ int main(int argc, char const *argv[]) {
         ret = sigaction(SIGINT, &old_action, nullptr);
         UNUSED_IF_ASSERT_DISABLED(ret);
         assert(ret == 0 && "sigaction failed");
+
+        // Wake the main thread so any blocking syscall (e.g. the Python REPL
+        // waiting on input or sleeping) returns with EINTR. This lets Python
+        // observe the pending interrupt queued by DispatchInputInterrupt and
+        // raise KeyboardInterrupt.
+        pthread_kill(main_thread, SIGURG);
       },
       signal_status);
   assert(sigint_handler && signal_status.Success());

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -793,8 +793,11 @@ int main(int argc, char const *argv[]) {
   pthread_t main_thread = pthread_self();
 
   // Set when the signal thread sends itself a SIGINT to wake the main thread.
-  // The next SIGINT callback invocation observes this flag and skips the work.
-  std::atomic<bool> skip_next_sigint{false};
+  // The next callback invocation observes this flag and skips the work. A
+  // plain bool is sufficient because the callback only ever runs on the
+  // signal thread; it lives outside the lambda because MainLoopPosix copies
+  // the callback on every dispatch, which would discard in-lambda state.
+  bool skip_next_sigint = false;
 
   // Handle signals in a MainLoop running on a separate thread.
   MainLoop signal_loop;
@@ -805,7 +808,7 @@ int main(int argc, char const *argv[]) {
       [&, main_thread](MainLoopBase &) {
         // Skip the self-sent wakeup SIGINT queued at the end of the previous
         // invocation.
-        if (skip_next_sigint.exchange(false))
+        if (std::exchange(skip_next_sigint, false))
           return;
 
         // Temporarily restore the default disposition so that a second SIGINT
@@ -833,7 +836,7 @@ int main(int argc, char const *argv[]) {
         // observe the pending interrupt queued by DispatchInputInterrupt and
         // raise KeyboardInterrupt. Flag the resulting callback invocation so
         // it's skipped rather than re-running DispatchInputInterrupt.
-        skip_next_sigint.store(true);
+        skip_next_sigint = true;
         pthread_kill(main_thread, SIGINT);
       },
       signal_status);


### PR DESCRIPTION
The driver's async SIGINT handler called SBDebugger::DispatchInputInterrupt directly. That is not async-signal-safe and can lead to a crash.

Register SIGINT with the existing signal-thread MainLoop instead so DispatchInputInterrupt runs in normal thread context. The Windows path is unchanged and keeps the legacy async handler.

While DispatchInputInterrupt runs, the callback temporarily installs SIG_DFL so a second Ctrl-C still hard-terminates the process, preserving the escape hatch users rely on when the debugger is unresponsive.

Moving SIGINT off the main thread means a Ctrl-C no longer interrupts blocking syscalls there (e.g. a Python REPL waiting on input or sleeping), so Python never observes the queued interrupt and KeyboardInterrupt is not raised. To restore that behavior, after dispatching the interrupt the callback re-raises SIGINT on the main thread via pthread_kill; the resulting EINTR lets Python pick up the pending interrupt. A skip flag suppresses the re-entry that this self-send produces. Because the callback only ever runs on the signal thread, the flag and the captured main-thread id live in the lambda's captures and need no synchronization.

rdar://158218595