### PR TITLE
[mlir][MemRefToLLVM] Erase conflicting func declarations before conversion

### DIFF
--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/MathExtras.h"
@@ -45,6 +46,31 @@ namespace {
 
 static bool isStaticStrideOrOffset(int64_t strideOrOffset) {
   return ShapedType::isStatic(strideOrOffset);
+}
+
+/// If a non-LLVM symbol with the given name exists and is an external function
+/// declaration with a matching signature, erase it so that lookupOrCreateFn can
+/// later create an llvm.func with the same name.  This handles Fortran
+/// `bind(c, name="free")` producing a func.func @free that conflicts with the
+/// llvm.func @free that memref lowering creates.
+static void eraseConflictingDeclaration(Operation *module, StringRef name,
+                                        ArrayRef<Type> argTypes,
+                                        unsigned numResults) {
+  Operation *existingOp = SymbolTable::lookupSymbolIn(module, name);
+  if (!existingOp)
+    return;
+  if (isa<LLVM::LLVMFuncOp>(existingOp))
+    return;
+  auto funcIface = dyn_cast<FunctionOpInterface>(existingOp);
+  if (!funcIface || !funcIface.isExternal())
+    return;
+  if (funcIface.getNumArguments() != argTypes.size() ||
+      funcIface.getNumResults() != numResults)
+    return;
+  for (unsigned i = 0; i < argTypes.size(); ++i)
+    if (funcIface.getArgumentTypes()[i] != argTypes[i])
+      return;
+  existingOp->erase();
 }
 
 static FailureOr<LLVM::LLVMFuncOp>
@@ -2127,6 +2153,15 @@ struct FinalizeMemRefToLLVMConversionPass
 
     LLVMTypeConverter typeConverter(&getContext(), options,
                                     &dataLayoutAnalysis);
+
+    // Erase non-LLVM external function declarations that would conflict with
+    // the llvm.func declarations that memref alloc/dealloc lowering creates.
+    auto ptrTy = LLVM::LLVMPointerType::get(&getContext());
+    auto indexTy = typeConverter.getIndexType();
+    eraseConflictingDeclaration(op, "free", {ptrTy}, 0);
+    eraseConflictingDeclaration(op, "malloc", {indexTy}, 1);
+    eraseConflictingDeclaration(op, "aligned_alloc", {indexTy, indexTy}, 1);
+
     RewritePatternSet patterns(&getContext());
     SymbolTableCollection symbolTables;
     populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns,

--- a/mlir/test/Conversion/FuncToLLVM/func-duplicate-symbol.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-duplicate-symbol.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -finalize-memref-to-llvm -convert-func-to-llvm -finalize-memref-to-llvm %s | FileCheck %s
+// RUN: mlir-opt -convert-func-to-llvm -finalize-memref-to-llvm %s | FileCheck %s
 
 // Verify that memref.dealloc lowering does not create a duplicate @free
 // declaration when a func.func @free already exists in the module (e.g. from

--- a/mlir/test/Conversion/MemRefToLLVM/dealloc-existing-free-decl.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/dealloc-existing-free-decl.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt -finalize-memref-to-llvm %s | FileCheck %s
+
+// Verify that memref.dealloc is lowered even when a func.func @free
+// declaration already exists in the module. The conflicting declaration
+// is erased and replaced with llvm.func @free before the conversion runs.
+
+// CHECK: llvm.func @free(!llvm.ptr)
+// CHECK-LABEL: func.func @dealloc_with_existing_free
+// CHECK:         llvm.call @free(%{{.*}}) : (!llvm.ptr) -> ()
+// CHECK:         return
+// CHECK-NOT: func.func @free
+
+func.func @dealloc_with_existing_free(%arg0: memref<?xf32>) {
+  memref.dealloc %arg0 : memref<?xf32>
+  return
+}
+
+func.func private @free(!llvm.ptr)


### PR DESCRIPTION
When MemRefToLLVM and FuncToLLVM patterns are used in the same `applyPartialConversion`, `DeallocOpLowering` may run before `func.func @free` is converted to `llvm.func`. `lookupOrCreateFn` then fails because a non-LLVM symbol with the same name already exists.

Erase non-LLVM external function declarations (e.g. `func.func @free`) as a preprocessing step in `FinalizeMemRefToLLVMConversionPass` before `applyPartialConversion` runs. Only declarations whose signature matches the expected type are erased. This avoids symbol conflicts when `DeallocOpLowering`/`AllocOpLowering` need to create `llvm.func @free`/`@malloc`/`@aligned_alloc`.