### PR TITLE
[clang-tidy] Add `llvm-formatv-string`

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangTidyLLVMModule STATIC
+  FormatvStringCheck.cpp
   HeaderGuardCheck.cpp
   IncludeOrderCheck.cpp
   LLVMTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -104,7 +104,7 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
     Input = Rest;
     if (Entry.empty())
       continue;
-    auto [Name, IdxStr] = Entry.rsplit(':');
+    const auto [Name, IdxStr] = Entry.rsplit(':');
     unsigned Idx = 0;
     if (Name.empty() || IdxStr.empty() || IdxStr.getAsInteger(10, Idx)) {
       configurationDiag("invalid entry '%0' in option AdditionalFunctions, "

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -53,7 +53,7 @@ static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
       return llvm::createStringError("unterminated brace in format string");
 
     // Extract the content between braces.
-    llvm::StringRef Content = Fmt.substr(1, CloseBrace - 1);
+    const llvm::StringRef Content = Fmt.substr(1, CloseBrace - 1);
     Fmt = Fmt.drop_front(CloseBrace + 1);
 
     // Parse the replacement field: [index] ["," layout] [":" format]
@@ -159,7 +159,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   if (!FmtLiteral)
     return;
 
-  llvm::StringRef FmtStr = FmtLiteral->getString();
+  const llvm::StringRef FmtStr = FmtLiteral->getString();
   const unsigned FirstArgIdx = FmtArgIdx + 1;
   const int NumArgs = Call->getNumArgs() - FirstArgIdx;
 
@@ -184,7 +184,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   // Check for holes in indices.
   if (!Parsed.Indices.empty()) {
     llvm::SmallBitVector UsedIndices(NumRequiredArgs);
-    for (unsigned Index : Parsed.Indices)
+    for (const unsigned Index : Parsed.Indices)
       UsedIndices.set(Index);
 
     const int UnusedIndex = UsedIndices.find_first_unset();

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -100,7 +100,7 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
   // Parse "name1:idx1;name2:idx2;..." from AdditionalFunctions.
   llvm::StringRef Input(AdditionalFunctions);
   while (!Input.empty()) {
-    auto [Entry, Rest] = Input.split(';');
+    const auto [Entry, Rest] = Input.split(';');
     Input = Rest;
     if (Entry.empty())
       continue;

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -12,7 +12,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
 using namespace clang::ast_matchers;
@@ -104,15 +103,15 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
     Input = Rest;
     if (Entry.empty())
       continue;
-    const auto [Name, IdxStr] = Entry.rsplit(':');
-    unsigned Idx = 0;
-    if (Name.empty() || IdxStr.empty() || IdxStr.getAsInteger(10, Idx)) {
+    const auto [Name, IndexStr] = Entry.rsplit(':');
+    unsigned Index = 0;
+    if (Name.empty() || IndexStr.empty() || IndexStr.getAsInteger(10, Index)) {
       configurationDiag("invalid entry '%0' in option AdditionalFunctions, "
                         "expected 'fully::qualified::name:fmt_arg_index'")
           << Entry;
       continue;
     }
-    Functions[Name] = Idx;
+    Functions[Name] = Index;
   }
 }
 
@@ -127,43 +126,43 @@ void FormatvStringCheck::registerMatchers(MatchFinder *Finder) {
   llvm::copy(Functions.keys(), std::back_inserter(Names));
 
   Finder->addMatcher(
-      callExpr(callee(functionDecl(hasAnyName(Names)))).bind("call"), this);
+      callExpr(callee(functionDecl(hasAnyName(Names))), argumentCountAtLeast(1))
+          .bind("call"),
+      this);
 }
 
 void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *Call = Result.Nodes.getNodeAs<CallExpr>("call");
-  if (!Call || Call->getNumArgs() == 0)
-    return;
+  assert(Call && Call->getNumArgs() > 0);
 
   const auto *FD = Call->getDirectCallee();
-  if (!FD)
-    return;
+  assert(FD);
 
-  // Look up the format string parameter index for this function.
+  // Look up the index of the format string parameter for this function.
   const std::string QualName = FD->getQualifiedNameAsString();
   assert(Functions.contains(QualName) &&
          "matched function not in Functions map");
-  unsigned FmtArgIdx = Functions.lookup(QualName);
+  unsigned FmtStringIndex = Functions.lookup(QualName);
 
   // For llvm::formatv, also handle the (bool, const char*, ...) overload.
   if (QualName == "llvm::formatv" && FD->getNumParams() > 0 &&
       FD->getParamDecl(0)->getType()->isBooleanType())
-    FmtArgIdx = 1;
+    FmtStringIndex = 1;
 
-  if (Call->getNumArgs() <= FmtArgIdx)
+  if (Call->getNumArgs() <= FmtStringIndex)
     return;
 
   // Extract the format string literal.
-  const Expr *FmtArg = Call->getArg(FmtArgIdx)->IgnoreParenImpCasts();
+  const Expr *FmtArg = Call->getArg(FmtStringIndex)->IgnoreParenImpCasts();
   const auto *FmtLiteral = dyn_cast<StringLiteral>(FmtArg);
   if (!FmtLiteral)
     return;
 
-  const llvm::StringRef FmtStr = FmtLiteral->getString();
-  const unsigned FirstArgIdx = FmtArgIdx + 1;
-  const int NumArgs = Call->getNumArgs() - FirstArgIdx;
+  const llvm::StringRef FmtString = FmtLiteral->getString();
+  const unsigned FirstFmtArgIndex = FmtStringIndex + 1;
+  const int NumFmtArgs = Call->getNumArgs() - FirstFmtArgIndex;
 
-  auto ParsedOrErr = parseFormatvString(FmtStr);
+  auto ParsedOrErr = parseFormatvString(FmtString);
   if (!ParsedOrErr) {
     diag(FmtLiteral->getBeginLoc(), "formatv() %0")
         << llvm::toString(ParsedOrErr.takeError());
@@ -173,15 +172,15 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   const ParseResult &Parsed = *ParsedOrErr;
   const int NumRequiredArgs = Parsed.Indices.empty() ? 0 : Parsed.MaxIndex + 1;
 
-  if (NumRequiredArgs != NumArgs) {
+  if (NumRequiredArgs != NumFmtArgs) {
     diag(FmtLiteral->getBeginLoc(),
-         "formatv() format string requires %0 argument(s), but %1 "
-         "argument(s) were provided")
-        << NumRequiredArgs << NumArgs;
+         "formatv() format string requires %0 argument%s0, but %1 argument%s1 "
+         "%plural{1:was|:were}1 provided")
+        << NumRequiredArgs << NumFmtArgs;
     return;
   }
 
-  // Check for holes in indices.
+  // Check for unused arguments.
   if (!Parsed.Indices.empty()) {
     llvm::SmallBitVector UsedIndices(NumRequiredArgs);
     for (const unsigned Index : Parsed.Indices)
@@ -190,10 +189,9 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     const int UnusedIndex = UsedIndices.find_first_unset();
     if (0 <= UnusedIndex && UnusedIndex < NumRequiredArgs) {
       // Point to the unused argument.
-      const Expr *UnusedArg = Call->getArg(FirstArgIdx + UnusedIndex);
+      const Expr *UnusedArg = Call->getArg(FirstFmtArgIndex + UnusedIndex);
       diag(UnusedArg->getBeginLoc(),
-           "formatv() format string does not use argument at index %0")
-          << UnusedIndex;
+           "formatv() argument unused in format string");
       return;
     }
   }

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "FormatvStringCheck.h"
+#include "clang/AST/Expr.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::llvm_check {
+
+namespace {
+
+struct ParseResult {
+  llvm::SmallVector<unsigned, 4> Indices;
+  unsigned MaxIndex = 0;
+};
+
+} // namespace
+
+static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
+  ParseResult Result;
+  unsigned NextAutoIndex = 0;
+  bool HasAutomatic = false;
+  bool HasExplicit = false;
+
+  while (!Fmt.empty()) {
+    const size_t OpenBrace = Fmt.find('{');
+    if (OpenBrace == llvm::StringRef::npos)
+      break;
+
+    Fmt = Fmt.drop_front(OpenBrace);
+
+    // Handle escaped braces '{{'.
+    if (Fmt.size() > 1 && Fmt[1] == '{') {
+      Fmt = Fmt.drop_front(2);
+      continue;
+    }
+
+    // Find the closing '}'.
+    const size_t CloseBrace = Fmt.find('}');
+    if (CloseBrace == llvm::StringRef::npos)
+      return llvm::createStringError("unterminated brace in format string");
+
+    // Extract the content between braces.
+    llvm::StringRef Content = Fmt.substr(1, CloseBrace - 1);
+    Fmt = Fmt.drop_front(CloseBrace + 1);
+
+    // Parse the replacement field: [index] ["," layout] [":" format]
+    llvm::StringRef IndexStr = Content;
+
+    // Strip layout and format parts for index parsing.
+    const size_t CommaPos = Content.find(',');
+    const size_t ColonPos = Content.find(':');
+    if (CommaPos != llvm::StringRef::npos)
+      IndexStr = Content.substr(0, CommaPos);
+    else if (ColonPos != llvm::StringRef::npos)
+      IndexStr = Content.substr(0, ColonPos);
+
+    IndexStr = IndexStr.trim();
+
+    unsigned Index = 0;
+    if (IndexStr.empty()) {
+      Index = NextAutoIndex++;
+      HasAutomatic = true;
+    } else {
+      if (IndexStr.getAsInteger(10, Index))
+        return llvm::createStringError("invalid replacement index");
+      HasExplicit = true;
+    }
+
+    Result.Indices.push_back(Index);
+    Result.MaxIndex = std::max(Result.MaxIndex, Index);
+  }
+
+  if (HasAutomatic && HasExplicit)
+    return llvm::createStringError(
+        "format string mixes automatic and explicit indices");
+
+  return Result;
+}
+
+FormatvStringCheck::FormatvStringCheck(StringRef Name,
+                                       ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      AdditionalFunctions(Options.get("AdditionalFunctions", "")) {
+  // Always check llvm::formatv (both overloads).
+  Functions["llvm::formatv"] = 0;
+
+  // Parse "name1:idx1;name2:idx2;..." from AdditionalFunctions.
+  llvm::StringRef Input(AdditionalFunctions);
+  while (!Input.empty()) {
+    auto [Entry, Rest] = Input.split(';');
+    Input = Rest;
+    if (Entry.empty())
+      continue;
+    auto [Name, IdxStr] = Entry.rsplit(':');
+    unsigned Idx = 0;
+    if (Name.empty() || IdxStr.empty() || IdxStr.getAsInteger(10, Idx)) {
+      configurationDiag("invalid entry '%0' in option AdditionalFunctions, "
+                        "expected 'fully::qualified::name:fmt_arg_index'")
+          << Entry;
+      continue;
+    }
+    Functions[Name] = Idx;
+  }
+}
+
+void FormatvStringCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "AdditionalFunctions", AdditionalFunctions);
+}
+
+void FormatvStringCheck::registerMatchers(MatchFinder *Finder) {
+  // Build a matcher for all configured function names.
+  std::vector<llvm::StringRef> Names;
+  Names.reserve(Functions.size());
+  llvm::copy(Functions.keys(), std::back_inserter(Names));
+
+  Finder->addMatcher(
+      callExpr(callee(functionDecl(hasAnyName(Names)))).bind("call"), this);
+}
+
+void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Call = Result.Nodes.getNodeAs<CallExpr>("call");
+  if (!Call || Call->getNumArgs() == 0)
+    return;
+
+  const auto *FD = Call->getDirectCallee();
+  if (!FD)
+    return;
+
+  // Look up the format string parameter index for this function.
+  const std::string QualName = FD->getQualifiedNameAsString();
+  assert(Functions.contains(QualName) &&
+         "matched function not in Functions map");
+  unsigned FmtArgIdx = Functions.lookup(QualName);
+
+  // For llvm::formatv, also handle the (bool, const char*, ...) overload.
+  if (QualName == "llvm::formatv" && FD->getNumParams() > 0 &&
+      FD->getParamDecl(0)->getType()->isBooleanType())
+    FmtArgIdx = 1;
+
+  if (Call->getNumArgs() <= FmtArgIdx)
+    return;
+
+  // Extract the format string literal.
+  const Expr *FmtArg = Call->getArg(FmtArgIdx)->IgnoreParenImpCasts();
+  const auto *FmtLiteral = dyn_cast<StringLiteral>(FmtArg);
+  if (!FmtLiteral)
+    return;
+
+  llvm::StringRef FmtStr = FmtLiteral->getString();
+  const unsigned FirstArgIdx = FmtArgIdx + 1;
+  const int NumArgs = Call->getNumArgs() - FirstArgIdx;
+
+  auto ParsedOrErr = parseFormatvString(FmtStr);
+  if (!ParsedOrErr) {
+    diag(FmtLiteral->getBeginLoc(), "formatv() %0")
+        << llvm::toString(ParsedOrErr.takeError());
+    return;
+  }
+
+  const ParseResult &Parsed = *ParsedOrErr;
+  const int NumRequiredArgs = Parsed.Indices.empty() ? 0 : Parsed.MaxIndex + 1;
+
+  if (NumRequiredArgs != NumArgs) {
+    diag(FmtLiteral->getBeginLoc(),
+         "formatv() format string requires %0 argument(s), but %1 "
+         "argument(s) were provided")
+        << NumRequiredArgs << NumArgs;
+    return;
+  }
+
+  // Check for holes in indices.
+  if (!Parsed.Indices.empty()) {
+    llvm::SmallBitVector UsedIndices(NumRequiredArgs);
+    for (unsigned Index : Parsed.Indices)
+      UsedIndices.set(Index);
+
+    const int UnusedIndex = UsedIndices.find_first_unset();
+    if (0 <= UnusedIndex && UnusedIndex < NumRequiredArgs) {
+      // Point to the unused argument.
+      const Expr *UnusedArg = Call->getArg(FirstArgIdx + UnusedIndex);
+      diag(UnusedArg->getBeginLoc(),
+           "formatv() format string does not use argument at index %0")
+          << UnusedIndex;
+      return;
+    }
+  }
+}
+
+} // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FormatvStringCheck.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "llvm/ADT/STLExtras.h"
@@ -93,25 +94,17 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
                                        ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       AdditionalFunctions(Options.get("AdditionalFunctions", "")) {
-  // Always check llvm::formatv (both overloads).
-  Functions["llvm::formatv"] = 0;
+  Functions.insert("llvm::formatv");
+  Functions.insert("llvm::createStringErrorV");
 
-  // Parse "name1:idx1;name2:idx2;..." from AdditionalFunctions.
-  llvm::StringRef Input(AdditionalFunctions);
-  while (!Input.empty()) {
-    const auto [Entry, Rest] = Input.split(';');
-    Input = Rest;
-    if (Entry.empty())
-      continue;
-    const auto [Name, IndexStr] = Entry.rsplit(':');
-    unsigned Index = 0;
-    if (Name.empty() || IndexStr.empty() || IndexStr.getAsInteger(10, Index)) {
-      configurationDiag("invalid entry '%0' in option AdditionalFunctions, "
-                        "expected 'fully::qualified::name:fmt_arg_index'")
-          << Entry;
-      continue;
-    }
-    Functions[Name] = Index;
+  // Parse semicolon-separated function names from AdditionalFunctions.
+  const llvm::StringRef Input(AdditionalFunctions);
+  llvm::SmallVector<llvm::StringRef, 8> Entries;
+  Input.split(Entries, ';', -1, false);
+  for (llvm::StringRef Entry : Entries) {
+    Entry = Entry.trim();
+    if (!Entry.empty())
+      Functions.insert(Entry);
   }
 }
 
@@ -126,7 +119,9 @@ void FormatvStringCheck::registerMatchers(MatchFinder *Finder) {
   llvm::copy(Functions.keys(), std::back_inserter(Names));
 
   Finder->addMatcher(
-      callExpr(callee(functionDecl(hasAnyName(Names))), argumentCountAtLeast(1))
+      callExpr(callee(functionDecl(hasAnyName(Names),
+                                   ast_matchers::isTemplateInstantiation())),
+               argumentCountAtLeast(1))
           .bind("call"),
       this);
 }
@@ -138,16 +133,21 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *FD = Call->getDirectCallee();
   assert(FD);
 
-  // Look up the index of the format string parameter for this function.
-  const std::string QualName = FD->getQualifiedNameAsString();
-  assert(Functions.contains(QualName) &&
-         "matched function not in Functions map");
-  unsigned FmtStringIndex = Functions.lookup(QualName);
+  // Find the format string index from the template signature: it's the
+  // parameter immediately before the trailing parameter pack.
+  const FunctionDecl *TemplateDecl = FD;
+  if (const FunctionTemplateDecl *Primary = FD->getPrimaryTemplate())
+    TemplateDecl = Primary->getTemplatedDecl();
 
-  // For llvm::formatv, also handle the (bool, const char*, ...) overload.
-  if (QualName == "llvm::formatv" && FD->getNumParams() > 0 &&
-      FD->getParamDecl(0)->getType()->isBooleanType())
-    FmtStringIndex = 1;
+  const unsigned NumDeclParams = TemplateDecl->getNumParams();
+  if (NumDeclParams < 2)
+    return;
+
+  const unsigned PackParamIndex = NumDeclParams - 1;
+  if (!TemplateDecl->getParamDecl(PackParamIndex)->isParameterPack())
+    return;
+
+  const unsigned FmtStringIndex = PackParamIndex - 1;
 
   if (Call->getNumArgs() <= FmtStringIndex)
     return;
@@ -159,8 +159,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     return;
 
   const llvm::StringRef FmtString = FmtLiteral->getString();
-  const unsigned FirstFmtArgIndex = FmtStringIndex + 1;
-  const int NumFmtArgs = Call->getNumArgs() - FirstFmtArgIndex;
+  const int NumFmtArgs = Call->getNumArgs() - PackParamIndex;
 
   auto ParsedOrErr = parseFormatvString(FmtString);
   if (!ParsedOrErr) {
@@ -189,7 +188,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     const int UnusedIndex = UsedIndices.find_first_unset();
     if (0 <= UnusedIndex && UnusedIndex < NumRequiredArgs) {
       // Point to the unused argument.
-      const Expr *UnusedArg = Call->getArg(FirstFmtArgIndex + UnusedIndex);
+      const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
       diag(UnusedArg->getBeginLoc(),
            "formatv() argument unused in format string");
       return;

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -98,11 +98,9 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
                                        ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       AdditionalFunctions(Options.get("AdditionalFunctions", "")) {
-  Functions = {"llvm::formatv", "llvm::createStringErrorV"};
-
-  std::vector<StringRef> CustomFunctions =
-      utils::options::parseStringList(AdditionalFunctions);
-  copy(CustomFunctions, std::back_inserter(Functions));
+  Functions = utils::options::parseStringList(AdditionalFunctions);
+  Functions.emplace_back("::llvm::formatv");
+  Functions.emplace_back("::llvm::createStringErrorV");
 }
 
 void FormatvStringCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -11,11 +11,9 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
-#include <iterator>
 #include <vector>
 
 using namespace clang::ast_matchers;

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -59,15 +59,7 @@ static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
 
     // Parse the replacement field: [index] ["," layout] [":" format]
     // Strip the format part first, since it may contain commas (e.g. {0:$[,]}).
-    StringRef IndexStr = Content;
-
-    const size_t ColonPos = Content.find(':');
-    if (ColonPos != StringRef::npos)
-      IndexStr = Content.substr(0, ColonPos);
-
-    const size_t CommaPos = IndexStr.find(',');
-    if (CommaPos != StringRef::npos)
-      IndexStr = IndexStr.substr(0, CommaPos);
+    const StringRef IndexStr = Content.substr(0, Content.find_first_of(",:");
 
     IndexStr = IndexStr.trim();
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -171,12 +171,11 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
 
   // Check for unused arguments.
   if (!Parsed.Indices.empty()) {
-    llvm::SmallBitVector UsedIndices(NumRequiredArgs);
+    llvm::SmallBitVector UnusedIndices(NumRequiredArgs, true);
     for (const unsigned Index : Parsed.Indices)
-      UsedIndices.set(Index);
+      UsedIndices.reset(Index);
 
-    auto UnusedIndices = UsedIndices.flip();
-    for (auto UnusedIndex : UnusedIndices.set_bits()) {
+    for (const auto UnusedIndex : UnusedIndices.set_bits()) {
       // Point to unused arguments.
       const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
       diag(UnusedArg->getBeginLoc(), "argument unused in format string");

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FormatvStringCheck.h"
+#include "../utils/OptionsUtils.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
@@ -14,6 +15,8 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
+#include <iterator>
+#include <vector>
 
 using namespace clang::ast_matchers;
 
@@ -95,18 +98,11 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
                                        ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       AdditionalFunctions(Options.get("AdditionalFunctions", "")) {
-  Functions.insert("llvm::formatv");
-  Functions.insert("llvm::createStringErrorV");
+  Functions = {"llvm::formatv", "llvm::createStringErrorV"};
 
-  // Parse semicolon-separated function names from AdditionalFunctions.
-  const StringRef Input(AdditionalFunctions);
-  SmallVector<StringRef, 8> Entries;
-  Input.split(Entries, ';', -1, false);
-  for (StringRef Entry : Entries) {
-    Entry = Entry.trim();
-    if (!Entry.empty())
-      Functions.insert(Entry);
-  }
+  std::vector<StringRef> CustomFunctions =
+      utils::options::parseStringList(AdditionalFunctions);
+  copy(CustomFunctions, std::back_inserter(Functions));
 }
 
 void FormatvStringCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
@@ -115,12 +111,8 @@ void FormatvStringCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void FormatvStringCheck::registerMatchers(MatchFinder *Finder) {
   // Build a matcher for all configured function names.
-  std::vector<StringRef> Names;
-  Names.reserve(Functions.size());
-  copy(Functions.keys(), std::back_inserter(Names));
-
   Finder->addMatcher(
-      callExpr(callee(functionDecl(hasAnyName(Names),
+      callExpr(callee(functionDecl(hasAnyName(Functions),
                                    ast_matchers::isTemplateInstantiation())),
                argumentCountAtLeast(1))
           .bind("call"),

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -75,7 +75,8 @@ static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
       HasAutomatic = true;
     } else {
       if (IndexStr.getAsInteger(10, Index))
-        return llvm::createStringError("invalid replacement index");
+        return llvm::createStringError(
+            "invalid replacement index in format string");
       HasExplicit = true;
     }
 
@@ -163,8 +164,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
 
   auto ParsedOrErr = parseFormatvString(FmtString);
   if (!ParsedOrErr) {
-    diag(FmtLiteral->getBeginLoc(), "formatv() %0")
-        << llvm::toString(ParsedOrErr.takeError());
+    diag(FmtLiteral->getBeginLoc(), llvm::toString(ParsedOrErr.takeError()));
     return;
   }
 
@@ -173,7 +173,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (NumRequiredArgs != NumFmtArgs) {
     diag(FmtLiteral->getBeginLoc(),
-         "formatv() format string requires %0 argument%s0, but %1 argument%s1 "
+         "format string requires %0 argument%s0, but %1 argument%s1 "
          "%plural{1:was|:were}1 provided")
         << NumRequiredArgs << NumFmtArgs;
     return;
@@ -189,8 +189,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     if (0 <= UnusedIndex && UnusedIndex < NumRequiredArgs) {
       // Point to the unused argument.
       const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
-      diag(UnusedArg->getBeginLoc(),
-           "formatv() argument unused in format string");
+      diag(UnusedArg->getBeginLoc(), "argument unused in format string");
       return;
     }
   }

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -58,15 +58,16 @@ static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
     Fmt = Fmt.drop_front(CloseBrace + 1);
 
     // Parse the replacement field: [index] ["," layout] [":" format]
+    // Strip the format part first, since it may contain commas (e.g. {0:$[,]}).
     StringRef IndexStr = Content;
 
-    // Strip layout and format parts for index parsing.
-    const size_t CommaPos = Content.find(',');
     const size_t ColonPos = Content.find(':');
-    if (CommaPos != StringRef::npos)
-      IndexStr = Content.substr(0, CommaPos);
-    else if (ColonPos != StringRef::npos)
+    if (ColonPos != StringRef::npos)
       IndexStr = Content.substr(0, ColonPos);
+
+    const size_t CommaPos = IndexStr.find(',');
+    if (CommaPos != StringRef::npos)
+      IndexStr = IndexStr.substr(0, CommaPos);
 
     IndexStr = IndexStr.trim();
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -22,13 +22,13 @@ namespace clang::tidy::llvm_check {
 namespace {
 
 struct ParseResult {
-  llvm::SmallVector<unsigned, 4> Indices;
+  SmallVector<unsigned, 4> Indices;
   unsigned MaxIndex = 0;
 };
 
 } // namespace
 
-static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
+static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
   ParseResult Result;
   unsigned NextAutoIndex = 0;
   bool HasAutomatic = false;
@@ -36,7 +36,7 @@ static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
 
   while (!Fmt.empty()) {
     const size_t OpenBrace = Fmt.find('{');
-    if (OpenBrace == llvm::StringRef::npos)
+    if (OpenBrace == StringRef::npos)
       break;
 
     Fmt = Fmt.drop_front(OpenBrace);
@@ -49,22 +49,22 @@ static llvm::Expected<ParseResult> parseFormatvString(llvm::StringRef Fmt) {
 
     // Find the closing '}'.
     const size_t CloseBrace = Fmt.find('}');
-    if (CloseBrace == llvm::StringRef::npos)
+    if (CloseBrace == StringRef::npos)
       return llvm::createStringError("unterminated brace in format string");
 
     // Extract the content between braces.
-    const llvm::StringRef Content = Fmt.substr(1, CloseBrace - 1);
+    const StringRef Content = Fmt.substr(1, CloseBrace - 1);
     Fmt = Fmt.drop_front(CloseBrace + 1);
 
     // Parse the replacement field: [index] ["," layout] [":" format]
-    llvm::StringRef IndexStr = Content;
+    StringRef IndexStr = Content;
 
     // Strip layout and format parts for index parsing.
     const size_t CommaPos = Content.find(',');
     const size_t ColonPos = Content.find(':');
-    if (CommaPos != llvm::StringRef::npos)
+    if (CommaPos != StringRef::npos)
       IndexStr = Content.substr(0, CommaPos);
-    else if (ColonPos != llvm::StringRef::npos)
+    else if (ColonPos != StringRef::npos)
       IndexStr = Content.substr(0, ColonPos);
 
     IndexStr = IndexStr.trim();
@@ -100,9 +100,9 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
 
   // Parse semicolon-separated function names from AdditionalFunctions.
   const StringRef Input(AdditionalFunctions);
-  llvm::SmallVector<llvm::StringRef, 8> Entries;
+  SmallVector<StringRef, 8> Entries;
   Input.split(Entries, ';', -1, false);
-  for (llvm::StringRef Entry : Entries) {
+  for (StringRef Entry : Entries) {
     Entry = Entry.trim();
     if (!Entry.empty())
       Functions.insert(Entry);
@@ -115,9 +115,9 @@ void FormatvStringCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void FormatvStringCheck::registerMatchers(MatchFinder *Finder) {
   // Build a matcher for all configured function names.
-  std::vector<llvm::StringRef> Names;
+  std::vector<StringRef> Names;
   Names.reserve(Functions.size());
-  llvm::copy(Functions.keys(), std::back_inserter(Names));
+  copy(Functions.keys(), std::back_inserter(Names));
 
   Finder->addMatcher(
       callExpr(callee(functionDecl(hasAnyName(Names),
@@ -159,12 +159,12 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   if (!FmtLiteral)
     return;
 
-  const llvm::StringRef FmtString = FmtLiteral->getString();
+  const StringRef FmtString = FmtLiteral->getString();
   const int NumFmtArgs = Call->getNumArgs() - PackParamIndex;
 
   auto ParsedOrErr = parseFormatvString(FmtString);
   if (!ParsedOrErr) {
-    diag(FmtLiteral->getBeginLoc(), llvm::toString(ParsedOrErr.takeError()));
+    diag(FmtLiteral->getBeginLoc(), toString(ParsedOrErr.takeError()));
     return;
   }
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -170,16 +170,14 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   // Check for unused arguments.
-  if (!Parsed.Indices.empty()) {
-    llvm::SmallBitVector UnusedIndices(NumRequiredArgs, true);
-    for (const unsigned Index : Parsed.Indices)
-      UsedIndices.reset(Index);
+  llvm::SmallBitVector UnusedIndices(NumRequiredArgs, true);
+  for (const unsigned Index : Parsed.Indices)
+    UnusedIndices.reset(Index);
 
-    for (const auto UnusedIndex : UnusedIndices.set_bits()) {
-      // Point to unused arguments.
-      const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
-      diag(UnusedArg->getBeginLoc(), "argument unused in format string");
-    }
+  for (const auto UnusedIndex : UnusedIndices.set_bits()) {
+    // Point to unused arguments.
+    const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
+    diag(UnusedArg->getBeginLoc(), "argument unused in format string");
   }
 }
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -152,7 +152,7 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
   const ParseResult &Parsed = *ParsedOrErr;
   const int NumRequiredArgs = Parsed.Indices.empty() ? 0 : Parsed.MaxIndex + 1;
 
-  if (NumRequiredArgs != NumFmtArgs) {
+  if (NumRequiredArgs > NumFmtArgs) {
     diag(FmtLiteral->getBeginLoc(),
          "format string requires %0 argument%s0, but %1 argument%s1 "
          "%plural{1:was|:were}1 provided")
@@ -160,13 +160,13 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     return;
   }
 
-  // Check for unused arguments.
-  llvm::SmallBitVector UnusedIndices(NumRequiredArgs, true);
+  // Check for unused arguments: both indices not referenced by the format
+  // string, and trailing arguments beyond what the format string requires.
+  llvm::SmallBitVector UnusedIndices(NumFmtArgs, true);
   for (const unsigned Index : Parsed.Indices)
     UnusedIndices.reset(Index);
 
   for (const auto UnusedIndex : UnusedIndices.set_bits()) {
-    // Point to unused arguments.
     const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
     diag(UnusedArg->getBeginLoc(), "argument unused in format string");
   }

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -14,7 +14,6 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
-#include <vector>
 
 using namespace clang::ast_matchers;
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -177,12 +177,11 @@ void FormatvStringCheck::check(const MatchFinder::MatchResult &Result) {
     for (const unsigned Index : Parsed.Indices)
       UsedIndices.set(Index);
 
-    const int UnusedIndex = UsedIndices.find_first_unset();
-    if (0 <= UnusedIndex && UnusedIndex < NumRequiredArgs) {
-      // Point to the unused argument.
+    auto UnusedIndices = UsedIndices.flip();
+    for (auto UnusedIndex : UnusedIndices.set_bits()) {
+      // Point to unused arguments.
       const Expr *UnusedArg = Call->getArg(PackParamIndex + UnusedIndex);
       diag(UnusedArg->getBeginLoc(), "argument unused in format string");
-      return;
     }
   }
 }

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -42,10 +42,8 @@ static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
     Fmt = Fmt.drop_front(OpenBrace);
 
     // Handle escaped braces '{{'.
-    if (Fmt.size() > 1 && Fmt[1] == '{') {
-      Fmt = Fmt.drop_front(2);
+    if (Fmt.consume_front("{{"))
       continue;
-    }
 
     // Find the closing '}'.
     const size_t CloseBrace = Fmt.find('}');

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -99,7 +99,7 @@ FormatvStringCheck::FormatvStringCheck(StringRef Name,
   Functions.insert("llvm::createStringErrorV");
 
   // Parse semicolon-separated function names from AdditionalFunctions.
-  const llvm::StringRef Input(AdditionalFunctions);
+  const StringRef Input(AdditionalFunctions);
   llvm::SmallVector<llvm::StringRef, 8> Entries;
   Input.split(Entries, ';', -1, false);
   for (llvm::StringRef Entry : Entries) {

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -59,7 +59,7 @@ static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
 
     // Parse the replacement field: [index] ["," layout] [":" format]
     // Strip the format part first, since it may contain commas (e.g. {0:$[,]}).
-    const StringRef IndexStr = Content.substr(0, Content.find_first_of(",:");
+    StringRef IndexStr = Content.substr(0, Content.find_first_of(",:"));
 
     IndexStr = IndexStr.trim();
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.cpp
@@ -57,7 +57,6 @@ static Expected<ParseResult> parseFormatvString(StringRef Fmt) {
     Fmt = Fmt.drop_front(CloseBrace + 1);
 
     // Parse the replacement field: [index] ["," layout] [":" format]
-    // Strip the format part first, since it may contain commas (e.g. {0:$[,]}).
     StringRef IndexStr = Content.substr(0, Content.find_first_of(",:"));
 
     IndexStr = IndexStr.trim();

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_FORMATVSTRINGCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_FORMATVSTRINGCHECK_H
+
+#include "../ClangTidyCheck.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace clang::tidy::llvm_check {
+
+/// Validates llvm::formatv format strings against the provided arguments.
+///
+/// Checks that:
+/// - The number of format indices matches the number of arguments.
+/// - Every argument is used by the format string.
+/// - Automatic and explicit indices are not mixed.
+class FormatvStringCheck : public ClangTidyCheck {
+public:
+  FormatvStringCheck(StringRef Name, ClangTidyContext *Context);
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+  // Map from fully-qualified function name to the 0-based index of the format
+  // string parameter.
+  llvm::StringMap<unsigned> Functions;
+  const std::string AdditionalFunctions;
+};
+
+} // namespace clang::tidy::llvm_check
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_FORMATVSTRINGCHECK_H

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
@@ -10,7 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_FORMATVSTRINGCHECK_H
 
 #include "../ClangTidyCheck.h"
-#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 
 namespace clang::tidy::llvm_check {
 
@@ -38,9 +38,7 @@ public:
   }
 
 private:
-  // Map from fully-qualified function name to the 0-based index of the format
-  // string parameter.
-  llvm::StringMap<unsigned> Functions;
+  llvm::StringSet<> Functions;
   const std::string AdditionalFunctions;
 };
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
@@ -20,6 +20,9 @@ namespace clang::tidy::llvm_check {
 /// - The number of format indices matches the number of arguments.
 /// - Every argument is used by the format string.
 /// - Automatic and explicit indices are not mixed.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/llvm/formatv-string.html
 class FormatvStringCheck : public ClangTidyCheck {
 public:
   FormatvStringCheck(StringRef Name, ClangTidyContext *Context);
@@ -29,6 +32,10 @@ public:
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+  std::optional<TraversalKind> getCheckTraversalKind() const override {
+    return TK_IgnoreUnlessSpelledInSource;
+  }
 
 private:
   // Map from fully-qualified function name to the 0-based index of the format

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
@@ -10,7 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_FORMATVSTRINGCHECK_H
 
 #include "../ClangTidyCheck.h"
-#include "llvm/ADT/StringSet.h"
+#include <vector>
 
 namespace clang::tidy::llvm_check {
 
@@ -38,7 +38,7 @@ public:
   }
 
 private:
-  llvm::StringSet<> Functions;
+  std::vector<StringRef> Functions;
   const StringRef AdditionalFunctions;
 };
 

--- a/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/FormatvStringCheck.h
@@ -39,7 +39,7 @@ public:
 
 private:
   llvm::StringSet<> Functions;
-  const std::string AdditionalFunctions;
+  const StringRef AdditionalFunctions;
 };
 
 } // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../readability/ElseAfterReturnCheck.h"
 #include "../readability/NamespaceCommentCheck.h"
 #include "../readability/QualifiedAutoCheck.h"
+#include "FormatvStringCheck.h"
 #include "HeaderGuardCheck.h"
 #include "IncludeOrderCheck.h"
 #include "PreferIsaOrDynCastInConditionalsCheck.h"
@@ -32,6 +33,7 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<readability::ElseAfterReturnCheck>(
         "llvm-else-after-return");
+    CheckFactories.registerCheck<FormatvStringCheck>("llvm-formatv-string");
     CheckFactories.registerCheck<LLVMHeaderGuardCheck>("llvm-header-guard");
     CheckFactories.registerCheck<IncludeOrderCheck>("llvm-include-order");
     CheckFactories.registerCheck<readability::NamespaceCommentCheck>(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -125,6 +125,12 @@ New checks
   Finds functions where throwing exceptions is unsafe but the function is still
   marked as potentially throwing.
 
+- New :doc:`llvm-formatv-string
+  <clang-tidy/checks/llvm/formatv-string>` check.
+
+  Validates ``llvm::formatv`` format strings against the provided arguments,
+  diagnosing mismatched argument counts, unused arguments, and mixed index styles.
+
 - New :doc:`llvm-redundant-casting
   <clang-tidy/checks/llvm/redundant-casting>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -244,6 +244,7 @@ Clang-Tidy Checks
    :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes"
    :doc:`hicpp-multiway-paths-covered <hicpp/multiway-paths-covered>`,
    :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,
+   :doc:`llvm-formatv-string <llvm/formatv-string>`,
    :doc:`llvm-header-guard <llvm/header-guard>`,
    :doc:`llvm-include-order <llvm/include-order>`, "Yes"
    :doc:`llvm-namespace-comment <llvm/namespace-comment>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -10,18 +10,18 @@ This check diagnoses the following issues:
 
 - The number of replacement indices in the format string does not match the
   number of arguments provided.
-- A format string does not use an argument at a given index.
-- Automatic and explicit indices are mixed (e.g. ``{} {1}``).
+- A format string does not use one of the given arguments.
+- Mixing of automatic and explicit indices (e.g. ``{} {1}``).
 
 .. code-block:: c++
 
-  // Warning: requires 2 arguments, but 1 provided.
+  // warning: formatv() format string requires 2 arguments, but 1 argument was provided
   llvm::formatv("{0} {1}", x);
 
-  // Warning: mixes automatic and explicit indices.
+  // warning: formatv() format string mixes automatic and explicit indices
   llvm::formatv("{} {1}", x, y);
 
-  // Warning: format string does not use argument at index 1.
+  // warning: formatv() argument unused in format string
   llvm::formatv("{0} {2}", x, y, z);
 
   // OK.
@@ -42,7 +42,8 @@ Options
   fully qualified function name and `index` is the zero-based parameter
   position of the format string.
 
-  For example, to check `mylib::log(Level, const char *Fmt, ...)` where the
-  format string is the second parameter (index 1):
+  For example, to check `mylib::log(Level, const char *Fmt, ...)` set this
+  option to `mylib::log:1`. The value `1` indicates the format string is found
+  in the second parameter.
 
-  Default is empty string.
+  Default is the empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -45,16 +45,4 @@ Options
   For example, to check `mylib::log(Level, const char *Fmt, ...)` where the
   format string is the second parameter (index 1):
 
-  .. code-block:: yaml
-
-    CheckOptions:
-      llvm-formatv-string.AdditionalFunctions: "mylib::log:1"
-
-  Multiple entries are separated by semicolons:
-
-  .. code-block:: yaml
-
-    CheckOptions:
-      llvm-formatv-string.AdditionalFunctions: "mylib::log:1;lldb_private::Log::Format:2"
-
   Default is empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -1,0 +1,60 @@
+.. title:: clang-tidy - llvm-formatv-string
+
+llvm-formatv-string
+===================
+
+Validates ``llvm::formatv`` format strings against the arguments provided,
+similar to how the compiler validates ``printf`` format strings.
+
+This check diagnoses the following issues:
+
+- The number of replacement indices in the format string does not match the
+  number of arguments provided.
+- A format string does not use an argument at a given index.
+- Automatic and explicit indices are mixed (e.g. ``{} {1}``).
+
+.. code-block:: c++
+
+  // Warning: requires 2 arguments, but 1 provided.
+  llvm::formatv("{0} {1}", x);
+
+  // Warning: mixes automatic and explicit indices.
+  llvm::formatv("{} {1}", x, y);
+
+  // Warning: format string does not use argument at index 1.
+  llvm::formatv("{0} {2}", x, y, z);
+
+  // OK.
+  llvm::formatv("{0} {1}", x, y);
+  llvm::formatv("{} {}", x, y);
+  llvm::formatv("{0} {0}", x);
+
+The check only operates on calls where the format string is a string literal.
+Dynamic format strings are not diagnosed.
+
+Options
+-------
+
+.. option:: AdditionalFunctions
+
+  A semicolon-separated list of additional functions to check, beyond
+  ``llvm::formatv``. Each entry has the form ``name:index``, where ``name``
+  is the fully qualified function name and ``index`` is the 0-based parameter
+  position of the format string.
+
+  For example, to check ``mylib::log(Level, const char *Fmt, ...)`` where
+  the format string is the second parameter (index 1):
+
+  .. code-block:: yaml
+
+    CheckOptions:
+      llvm-formatv-string.AdditionalFunctions: "mylib::log:1"
+
+  Multiple entries are separated by semicolons:
+
+  .. code-block:: yaml
+
+    CheckOptions:
+      llvm-formatv-string.AdditionalFunctions: "mylib::log:1;lldb_private::Log::Format:2"
+
+  Default: empty.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -57,4 +57,4 @@ Options
     CheckOptions:
       llvm-formatv-string.AdditionalFunctions: "mylib::log:1;lldb_private::Log::Format:2"
 
-  Default: empty.
+  Default is empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -37,13 +37,13 @@ Options
 
 .. option:: AdditionalFunctions
 
-  A semicolon-separated list of additional functions to check, beyond
-  ``llvm::formatv``. Each entry has the form `name:index`, where `name` is the
-  fully qualified function name and `index` is the zero-based parameter
-  position of the format string.
+  A semicolon-separated list of additional fully qualified function names to
+  check, beyond ``llvm::formatv`` and ``llvm::createStringErrorV``. Each
+  function must be a variadic template whose last parameter is a parameter
+  pack. The format string is assumed to be the parameter immediately preceding
+  the pack.
 
-  For example, to check `mylib::log(Level, const char *Fmt, ...)` set this
-  option to `mylib::log:1`. The value `1` indicates the format string is found
-  in the second parameter.
+  For example, to check ``mylib::log(Level, const char *Fmt, Ts&&...)`` set
+  this option to ``mylib::log``.
 
   Default is the empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -38,8 +38,8 @@ Options
 .. option:: AdditionalFunctions
 
   A semicolon-separated list of additional functions to check, beyond
-  ``llvm::formatv``. Each entry has the form ``name:index``, where ``name``
-  is the fully qualified function name and ``index`` is the 0-based parameter
+  ``llvm::formatv``. Each entry has the form `name:index`, where `name` is the
+  fully qualified function name and `index` is the zero-based parameter
   position of the format string.
 
   For example, to check ``mylib::log(Level, const char *Fmt, ...)`` where

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -42,8 +42,8 @@ Options
   fully qualified function name and `index` is the zero-based parameter
   position of the format string.
 
-  For example, to check ``mylib::log(Level, const char *Fmt, ...)`` where
-  the format string is the second parameter (index 1):
+  For example, to check `mylib::log(Level, const char *Fmt, ...)` where the
+  format string is the second parameter (index 1):
 
   .. code-block:: yaml
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -4,7 +4,8 @@ llvm-formatv-string
 ===================
 
 Validates ``llvm::formatv`` format strings against the provided arguments,
-diagnosing mismatched argument counts, unused arguments, and mixed index styles.
+diagnosing mismatched argument counts, unused arguments, and mixed index
+styles.
 
 This check diagnoses the following issues:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -44,7 +44,7 @@ Options
   pack. The format string is assumed to be the parameter immediately preceding
   the pack.
 
-  For example, to check ``mylib::log(Level, const char *Fmt, Ts&&...)`` set
-  this option to `mylib::log`.
+  For example, to check ``::mylib::log(Level, const char *Fmt, Ts&&...)`` set
+  this option to `::mylib::log`.
 
   Default is the empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -15,13 +15,13 @@ This check diagnoses the following issues:
 
 .. code-block:: c++
 
-  // warning: formatv() format string requires 2 arguments, but 1 argument was provided
+  // warning: format string requires 2 arguments, but 1 argument was provided
   llvm::formatv("{0} {1}", x);
 
-  // warning: formatv() format string mixes automatic and explicit indices
+  // warning: format string mixes automatic and explicit indices
   llvm::formatv("{} {1}", x, y);
 
-  // warning: formatv() argument unused in format string
+  // warning: argument unused in format string
   llvm::formatv("{0} {2}", x, y, z);
 
   // OK.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/formatv-string.rst
@@ -3,8 +3,8 @@
 llvm-formatv-string
 ===================
 
-Validates ``llvm::formatv`` format strings against the arguments provided,
-similar to how the compiler validates ``printf`` format strings.
+Validates ``llvm::formatv`` format strings against the provided arguments,
+diagnosing mismatched argument counts, unused arguments, and mixed index styles.
 
 This check diagnoses the following issues:
 
@@ -44,6 +44,6 @@ Options
   the pack.
 
   For example, to check ``mylib::log(Level, const char *Fmt, Ts&&...)`` set
-  this option to ``mylib::log``.
+  this option to `mylib::log`.
 
   Default is the empty string.

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
@@ -1,0 +1,28 @@
+// RUN: %check_clang_tidy %s llvm-formatv-string %t -- \
+// RUN:   -config='{CheckOptions: {llvm-formatv-string.AdditionalFunctions: "mylib::log:1"}}'
+
+namespace llvm {
+
+template <typename... Ts>
+void formatv(const char *Fmt, Ts &&...Vals) {}
+
+} // namespace llvm
+
+namespace mylib {
+
+enum Level { Info, Error };
+
+template <typename... Ts>
+void log(Level L, const char *Fmt, Ts &&...Vals) {}
+
+} // namespace mylib
+
+void correct() {
+  mylib::log(mylib::Info, "{0} {1}", 1, 2);
+  mylib::log(mylib::Error, "{0}", 42);
+}
+
+void wrong_count() {
+  mylib::log(mylib::Info, "{0} {1}", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: formatv() format string requires 2 argument(s), but 1 argument(s) were provided
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
@@ -24,5 +24,5 @@ void correct() {
 
 void wrong_count() {
   mylib::log(mylib::Info, "{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: formatv() format string requires 2 argument(s), but 1 argument(s) were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: formatv() format string requires 2 arguments, but 1 argument was provided
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy %s llvm-formatv-string %t -- \
-// RUN:   -config='{CheckOptions: {llvm-formatv-string.AdditionalFunctions: "mylib::log:1"}}'
+// RUN:   -config='{CheckOptions: {llvm-formatv-string.AdditionalFunctions: "mylib::log"}}'
 
 namespace llvm {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-additional.cpp
@@ -24,5 +24,5 @@ void correct() {
 
 void wrong_count() {
   mylib::log(mylib::Info, "{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: format string requires 2 arguments, but 1 argument was provided
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
@@ -1,0 +1,25 @@
+// RUN: %check_clang_tidy %s llvm-formatv-string %t -- \
+// RUN:   -config='{CheckOptions: {llvm-formatv-string.AdditionalFunctions: "llvm::createStringErrorV"}}'
+
+namespace llvm {
+
+template <typename... Ts>
+void createStringErrorV(int EC, const char *Fmt, Ts &&...Vals) {}
+
+template <typename... Ts>
+void createStringErrorV(const char *Fmt, Ts &&...Vals) {}
+
+} // namespace llvm
+
+void correct() {
+  llvm::createStringErrorV(0, "{0} {1}", 1, 2);
+  llvm::createStringErrorV("{0}", 42);
+}
+
+void wrong_count() {
+  llvm::createStringErrorV(0, "{0} {1}", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+
+  llvm::createStringErrorV("{0} {1}", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
@@ -1,5 +1,4 @@
-// RUN: %check_clang_tidy %s llvm-formatv-string %t -- \
-// RUN:   -config='{CheckOptions: {llvm-formatv-string.AdditionalFunctions: "llvm::createStringErrorV"}}'
+// RUN: %check_clang_tidy %s llvm-formatv-string %t
 
 namespace llvm {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string-autodetect.cpp
@@ -17,8 +17,8 @@ void correct() {
 
 void wrong_count() {
   llvm::createStringErrorV(0, "{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: format string requires 2 arguments, but 1 argument was provided
 
   llvm::createStringErrorV("{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: format string requires 2 arguments, but 1 argument was provided
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -28,18 +28,18 @@ void correct() {
 
 void too_few_args() {
   llvm::formatv("{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 2 argument(s), but 1 argument(s) were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 2 arguments, but 1 argument was provided
 
   llvm::formatv("{0} {1} {2}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 3 argument(s), but 2 argument(s) were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 3 arguments, but 2 arguments were provided
 }
 
 void too_many_args() {
   llvm::formatv("{0}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 1 argument(s), but 2 argument(s) were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 1 argument, but 2 arguments were provided
 
   llvm::formatv("no replacements", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 0 argument(s), but 1 argument(s) were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 0 arguments, but 1 argument was provided
 }
 
 void mixed_indices() {
@@ -49,7 +49,7 @@ void mixed_indices() {
 
 void holes_in_indices() {
   llvm::formatv("{0} {2}", 1, 2, 3);
-  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() format string does not use argument at index 1
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() argument unused in format string
 }
 
 void non_literal_format_string(const char *fmt) {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -1,0 +1,58 @@
+// RUN: %check_clang_tidy %s llvm-formatv-string %t
+
+namespace llvm {
+
+template <typename... Ts>
+void formatv(const char *Fmt, Ts &&...Vals) {}
+
+template <typename... Ts>
+void formatv(bool Validate, const char *Fmt, Ts &&...Vals) {}
+
+} // namespace llvm
+
+void correct() {
+  llvm::formatv("{0}", 1);
+  llvm::formatv("{0} {1}", 1, 2);
+  llvm::formatv("{0} {0}", 1);
+  llvm::formatv("{1} {0}", 1, 2);
+  llvm::formatv("{0,10}", 1);
+  llvm::formatv("{0,-10}", 1);
+  llvm::formatv("{0:x}", 1);
+  llvm::formatv("{0,10:x}", 1);
+  llvm::formatv("no replacements");
+  llvm::formatv("escaped {{ braces }}");
+  llvm::formatv("{}", 1);
+  llvm::formatv("{} {}", 1, 2);
+  llvm::formatv(false, "{0}", 1);
+}
+
+void too_few_args() {
+  llvm::formatv("{0} {1}", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 2 argument(s), but 1 argument(s) were provided
+
+  llvm::formatv("{0} {1} {2}", 1, 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 3 argument(s), but 2 argument(s) were provided
+}
+
+void too_many_args() {
+  llvm::formatv("{0}", 1, 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 1 argument(s), but 2 argument(s) were provided
+
+  llvm::formatv("no replacements", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 0 argument(s), but 1 argument(s) were provided
+}
+
+void mixed_indices() {
+  llvm::formatv("{} {1}", 1, 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string mixes automatic and explicit indices
+}
+
+void holes_in_indices() {
+  llvm::formatv("{0} {2}", 1, 2, 3);
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() format string does not use argument at index 1
+}
+
+void non_literal_format_string(const char *fmt) {
+  // No warning for non-literal format strings.
+  llvm::formatv(fmt, 1, 2);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -56,3 +56,9 @@ void non_literal_format_string(const char *fmt) {
   // No warning for non-literal format strings.
   llvm::formatv(fmt, 1, 2);
 }
+
+void bool_overload() {
+  llvm::formatv(false, "{0} {1}", 1, 2);
+  llvm::formatv(true, "{0}", 1, 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: formatv() format string requires 1 argument, but 2 arguments were provided
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -43,10 +43,10 @@ void too_few_args() {
 
 void too_many_args() {
   llvm::formatv("{0}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 1 argument, but 2 arguments were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: argument unused in format string
 
   llvm::formatv("no replacements", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 0 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: argument unused in format string
 }
 
 void mixed_indices() {
@@ -61,6 +61,10 @@ void holes_in_indices() {
   llvm::formatv("{2}", 1, 2, 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: argument unused in format string
   // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: argument unused in format string
+
+  llvm::formatv("{1}", 10, 20, 30);
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: argument unused in format string
+  // CHECK-MESSAGES: :[[@LINE-2]]:32: warning: argument unused in format string
 }
 
 void non_literal_format_string(const char *fmt) {
@@ -71,7 +75,7 @@ void non_literal_format_string(const char *fmt) {
 void bool_overload() {
   llvm::formatv(false, "{0} {1}", 1, 2);
   llvm::formatv(true, "{0}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: format string requires 1 argument, but 2 arguments were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: argument unused in format string
 }
 
 void invalid_index() {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -27,6 +27,9 @@ void correct() {
 }
 
 void too_few_args() {
+  llvm::formatv("{0}");
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 1 argument, but 0 arguments were provided
+
   llvm::formatv("{0} {1}", 1);
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 2 arguments, but 1 argument was provided
 

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -19,6 +19,7 @@ void correct() {
   llvm::formatv("{0,-10}", 1);
   llvm::formatv("{0:x}", 1);
   llvm::formatv("{0,10:x}", 1);
+  llvm::formatv("{0:$[,]}", 1);
   llvm::formatv("no replacements");
   llvm::formatv("escaped {{ braces }}");
   llvm::formatv("{}", 1);

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -20,6 +20,9 @@ void correct() {
   llvm::formatv("{0:x}", 1);
   llvm::formatv("{0,10:x}", 1);
   llvm::formatv("{0:$[,]}", 1);
+  llvm::formatv("{ 0 }", 1);
+  llvm::formatv("{  0  :x}", 1);
+  llvm::formatv("{ 0 } { 1 }", 1, 2);
   llvm::formatv("no replacements");
   llvm::formatv("escaped {{ braces }}");
   llvm::formatv("{}", 1);

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -28,28 +28,28 @@ void correct() {
 
 void too_few_args() {
   llvm::formatv("{0} {1}", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 2 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 2 arguments, but 1 argument was provided
 
   llvm::formatv("{0} {1} {2}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 3 arguments, but 2 arguments were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 3 arguments, but 2 arguments were provided
 }
 
 void too_many_args() {
   llvm::formatv("{0}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 1 argument, but 2 arguments were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 1 argument, but 2 arguments were provided
 
   llvm::formatv("no replacements", 1);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string requires 0 arguments, but 1 argument was provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string requires 0 arguments, but 1 argument was provided
 }
 
 void mixed_indices() {
   llvm::formatv("{} {1}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: formatv() format string mixes automatic and explicit indices
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: format string mixes automatic and explicit indices
 }
 
 void holes_in_indices() {
   llvm::formatv("{0} {2}", 1, 2, 3);
-  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: formatv() argument unused in format string
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: argument unused in format string
 }
 
 void non_literal_format_string(const char *fmt) {
@@ -60,5 +60,10 @@ void non_literal_format_string(const char *fmt) {
 void bool_overload() {
   llvm::formatv(false, "{0} {1}", 1, 2);
   llvm::formatv(true, "{0}", 1, 2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: formatv() format string requires 1 argument, but 2 arguments were provided
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: format string requires 1 argument, but 2 arguments were provided
+}
+
+void invalid_index() {
+  llvm::formatv("{abc}", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid replacement index in format string
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/formatv-string.cpp
@@ -53,6 +53,10 @@ void mixed_indices() {
 void holes_in_indices() {
   llvm::formatv("{0} {2}", 1, 2, 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: argument unused in format string
+
+  llvm::formatv("{2}", 1, 2, 3);
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: argument unused in format string
+  // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: argument unused in format string
 }
 
 void non_literal_format_string(const char *fmt) {


### PR DESCRIPTION
Adds a clang-tidy check to perform some validation on `llvm::formatv` calls. Similar to the built in support Clang has for checking printf calls.

The validations are:
- The number of unique format indices matches the number of arguments.
- Every argument is used by the format string.
- Automatic and explicit indices are not mixed.

This includes a config option (`AdditionalFunctions`) to perform the same validation checks on other functions which take formatv inputs.

Assisted-by: claude