### PR TITLE
[SSAF] Fix -Wunused-variable

### DIFF
--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -347,7 +347,7 @@ public:
       if (!ContributorName)
         llvm::reportFatalInternalError(makeEntityNameErr(Ctx, CD));
 
-      auto [_, InsertionSucceeded] = SummaryBuilder.addSummary(
+      [[maybe_unused]] auto [_, InsertionSucceeded] = SummaryBuilder.addSummary(
           addEntity(*ContributorName), std::move(*EntitySummary));
 
       assert(InsertionSucceeded && "duplicated contributor extraction");


### PR DESCRIPTION
Add [[maybe_unused]] given the operation is side effecting/returns
multiple values.