### PR TITLE
[SPIRV] Dummy implementation of the `returnaddress` and `frameaddress` intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -5136,6 +5136,15 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
       return selectMaskedScatter(I);
     return diagnoseUnsupported(
         I, "llvm.masked.scatter requires SPV_INTEL_masked_gather_scatter");
+  case Intrinsic::returnaddress:
+  case Intrinsic::frameaddress: {
+    // SPIR-V does not have a stack or return address. Lower to null.
+    auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpConstantNull))
+                   .addDef(ResVReg)
+                   .addUse(GR.getSPIRVTypeID(ResType));
+    MIB.constrainAllUses(TII, TRI, RBI);
+    return true;
+  }
   default: {
     std::string DiagMsg;
     raw_string_ostream OS(DiagMsg);

--- a/llvm/test/CodeGen/SPIRV/returnaddress.ll
+++ b/llvm/test/CodeGen/SPIRV/returnaddress.ll
@@ -1,0 +1,26 @@
+; RUN: llc -mtriple=spirv64-unknown-unknown -O0 < %s | FileCheck %s
+; RUN: llc -mtriple=spirv32-unknown-unknown -O0 < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown < %s -o - -filetype=obj | spirv-val %}
+
+; SPIR-V does not have a stack or return address concept.
+; llvm.returnaddress and llvm.frameaddress are lowered to null (OpConstantNull).
+
+declare ptr @llvm.returnaddress(i32)
+declare ptr @llvm.frameaddress(i32)
+
+; CHECK-DAG: %[[#PTR_TY:]] = OpTypePointer
+; CHECK-DAG: %[[#NULL:]] = OpConstantNull %[[#PTR_TY]]
+
+; CHECK: %[[#]] = OpFunction
+; CHECK: OpReturnValue %[[#NULL]]
+define ptr @test_returnaddress() {
+  %ret = call ptr @llvm.returnaddress(i32 0)
+  ret ptr %ret
+}
+
+; CHECK: %[[#]] = OpFunction
+; CHECK: OpReturnValue %[[#NULL]]
+define ptr @test_frameaddress() {
+  %ret = call ptr @llvm.frameaddress(i32 0)
+  ret ptr %ret
+}


### PR DESCRIPTION
The SPIR-V specification doesn't define any operations for the
return and frame address. The valid implementation in this case is to
produce a null pointer.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>