### PR TITLE
[mlir][linalg] Add splat transpose canonicalization patterns

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -91,13 +91,14 @@ static Operation *getSlice(OpBuilder &b, Location loc, Value source,
       .Default([&](Type t) -> Operation * { return nullptr; });
 }
 
-static TypedAttr getScalarConstantAttrFromDenseSplat(Value input) {
+static std::optional<TypedAttr>
+getScalarConstantAttrFromDenseSplat(Value input) {
   DenseElementsAttr splatAttr;
   matchPattern(input, m_Constant<DenseElementsAttr>(&splatAttr));
   if (!splatAttr || !splatAttr.isSplat())
-    return {};
+    return std::nullopt;
 
-  return dyn_cast<TypedAttr>(splatAttr.getSplatValue<Attribute>());
+  return splatAttr.getSplatValue<TypedAttr>();
 }
 
 //===----------------------------------------------------------------------===//
@@ -2134,14 +2135,6 @@ LogicalResult TransposeOp::fold(FoldAdaptor adaptor,
     return success();
   }
 
-  if (getInput().getType() == getInit().getType()) {
-    auto splatAttr = dyn_cast_if_present<DenseElementsAttr>(adaptor.getInput());
-    if (splatAttr && splatAttr.isSplat()) {
-      result.push_back(getInput());
-      return success();
-    }
-  }
-
   return failure();
 }
 
@@ -2178,17 +2171,15 @@ struct FoldTransposeSplatConstant : OpRewritePattern<linalg::TransposeOp> {
     if (!transposeOp.hasPureTensorSemantics())
       return failure();
 
-    TypedAttr splatValue =
+    auto splatValue =
         getScalarConstantAttrFromDenseSplat(transposeOp.getInput());
-    if (!splatValue)
+    if (!splatValue.has_value())
       return failure();
 
     auto resultType =
         cast<RankedTensorType>(transposeOp.getResult()[0].getType());
-    if (!resultType.hasStaticShape())
-      return failure();
 
-    auto resultAttr = DenseElementsAttr::get(resultType, splatValue);
+    auto resultAttr = DenseElementsAttr::get(resultType, splatValue.value());
     rewriter.replaceOpWithNewOp<arith::ConstantOp>(transposeOp, resultType,
                                                    resultAttr);
     return success();

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -30,6 +30,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
@@ -88,6 +89,15 @@ static Operation *getSlice(OpBuilder &b, Location loc, Value source,
                                          strides);
       })
       .Default([&](Type t) -> Operation * { return nullptr; });
+}
+
+static TypedAttr getScalarConstantAttrFromDenseSplat(Value input) {
+  DenseElementsAttr splatAttr;
+  matchPattern(input, m_Constant<DenseElementsAttr>(&splatAttr));
+  if (!splatAttr || !splatAttr.isSplat())
+    return {};
+
+  return dyn_cast<TypedAttr>(splatAttr.getSplatValue<Attribute>());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2124,6 +2134,14 @@ LogicalResult TransposeOp::fold(FoldAdaptor adaptor,
     return success();
   }
 
+  if (getInput().getType() == getInit().getType()) {
+    auto splatAttr = dyn_cast_if_present<DenseElementsAttr>(adaptor.getInput());
+    if (splatAttr && splatAttr.isSplat()) {
+      result.push_back(getInput());
+      return success();
+    }
+  }
+
   return failure();
 }
 
@@ -2146,6 +2164,33 @@ struct FoldTransposeWithTranspose : OpRewritePattern<linalg::TransposeOp> {
     rewriter.replaceOpWithNewOp<TransposeOp>(
         transposeOp, defTransposeOp.getInput(), transposeOp.getInit(),
         foldedPerms);
+    return success();
+  }
+};
+
+/// Rewrite a transpose of a dense splat constant into a dense splat constant of
+/// the transposed output shape.
+struct FoldTransposeSplatConstant : OpRewritePattern<linalg::TransposeOp> {
+  using OpRewritePattern<linalg::TransposeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::TransposeOp transposeOp,
+                                PatternRewriter &rewriter) const override {
+    if (!transposeOp.hasPureTensorSemantics())
+      return failure();
+
+    TypedAttr splatValue =
+        getScalarConstantAttrFromDenseSplat(transposeOp.getInput());
+    if (!splatValue)
+      return failure();
+
+    auto resultType =
+        cast<RankedTensorType>(transposeOp.getResult()[0].getType());
+    if (!resultType.hasStaticShape())
+      return failure();
+
+    auto resultAttr = DenseElementsAttr::get(resultType, splatValue);
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(transposeOp, resultType,
+                                                   resultAttr);
     return success();
   }
 };
@@ -2210,7 +2255,8 @@ struct SwapTransposeWithBroadcast : OpRewritePattern<linalg::TransposeOp> {
 
 void TransposeOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                               MLIRContext *context) {
-  results.add<FoldTransposeWithTranspose, SwapTransposeWithBroadcast>(context);
+  results.add<FoldTransposeWithTranspose, FoldTransposeSplatConstant,
+              SwapTransposeWithBroadcast>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Linalg/canonicalize.mlir
+++ b/mlir/test/Dialect/Linalg/canonicalize.mlir
@@ -1271,18 +1271,23 @@ func.func @transpose_splat_constant_to_dense(%init: tensor<3x2xf32>) -> tensor<3
 
 // -----
 
-// CHECK-LABEL: @transpose_splat_constant_same_type
-//       CHECK:   %[[CST:.+]] = arith.constant dense<1.000000e+00> : tensor<2x2xf32>
-//   CHECK-NOT:   linalg.fill
+// CHECK-LABEL: @transpose_splat_constant_same_shape_permutations
+//       CHECK:   %[[CST:.+]] = arith.constant dense<1.000000e+00> : tensor<3x3x3xf32>
 //   CHECK-NOT:   linalg.transpose
-//       CHECK:   return %[[CST]] : tensor<2x2xf32>
-func.func @transpose_splat_constant_same_type(%init: tensor<2x2xf32>) -> tensor<2x2xf32> {
-  %cst = arith.constant dense<1.000000e+00> : tensor<2x2xf32>
-  %transpose = linalg.transpose
-      ins(%cst:tensor<2x2xf32>)
-      outs(%init:tensor<2x2xf32>)
-      permutation = [1, 0]
-  func.return %transpose : tensor<2x2xf32>
+//       CHECK:   return %[[CST]], %[[CST]] : tensor<3x3x3xf32>, tensor<3x3x3xf32>
+func.func @transpose_splat_constant_same_shape_permutations(
+    %init0: tensor<3x3x3xf32>,
+    %init1: tensor<3x3x3xf32>) -> (tensor<3x3x3xf32>, tensor<3x3x3xf32>) {
+  %cst = arith.constant dense<1.000000e+00> : tensor<3x3x3xf32>
+  %transpose0 = linalg.transpose
+      ins(%cst:tensor<3x3x3xf32>)
+      outs(%init0:tensor<3x3x3xf32>)
+      permutation = [0, 1, 2]
+  %transpose1 = linalg.transpose
+      ins(%cst:tensor<3x3x3xf32>)
+      outs(%init1:tensor<3x3x3xf32>)
+      permutation = [2, 0, 1]
+  func.return %transpose0, %transpose1 : tensor<3x3x3xf32>, tensor<3x3x3xf32>
 }
 
 // -----

--- a/mlir/test/Dialect/Linalg/canonicalize.mlir
+++ b/mlir/test/Dialect/Linalg/canonicalize.mlir
@@ -1256,6 +1256,52 @@ func.func @transpose_identity_perm(%input: tensor<16x32x64xf32>,
 
 // -----
 
+// CHECK-LABEL: @transpose_splat_constant_to_dense
+//       CHECK:   %[[CST:.+]] = arith.constant dense<1.000000e+00> : tensor<3x2xf32>
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   return %[[CST]] : tensor<3x2xf32>
+func.func @transpose_splat_constant_to_dense(%init: tensor<3x2xf32>) -> tensor<3x2xf32> {
+  %cst = arith.constant dense<1.000000e+00> : tensor<2x3xf32>
+  %transpose = linalg.transpose
+      ins(%cst:tensor<2x3xf32>)
+      outs(%init:tensor<3x2xf32>)
+      permutation = [1, 0]
+  func.return %transpose : tensor<3x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @transpose_splat_constant_same_type
+//       CHECK:   %[[CST:.+]] = arith.constant dense<1.000000e+00> : tensor<2x2xf32>
+//   CHECK-NOT:   linalg.fill
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   return %[[CST]] : tensor<2x2xf32>
+func.func @transpose_splat_constant_same_type(%init: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %cst = arith.constant dense<1.000000e+00> : tensor<2x2xf32>
+  %transpose = linalg.transpose
+      ins(%cst:tensor<2x2xf32>)
+      outs(%init:tensor<2x2xf32>)
+      permutation = [1, 0]
+  func.return %transpose : tensor<2x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @transpose_non_splat_constant
+//       CHECK:   %[[CST:.+]] = arith.constant dense<{{\[}}[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf32>
+//       CHECK:   %[[TRANSPOSE:.+]] = linalg.transpose ins(%[[CST]] : tensor<2x3xf32>) outs({{.*}} : tensor<3x2xf32>) permutation = [1, 0]
+//       CHECK:   return %[[TRANSPOSE]] : tensor<3x2xf32>
+func.func @transpose_non_splat_constant(%init: tensor<3x2xf32>) -> tensor<3x2xf32> {
+  %cst = arith.constant dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf32>
+  %transpose = linalg.transpose
+      ins(%cst:tensor<2x3xf32>)
+      outs(%init:tensor<3x2xf32>)
+      permutation = [1, 0]
+  func.return %transpose : tensor<3x2xf32>
+}
+
+// -----
+
 func.func @transpose_transpose_cancel(%input: tensor<5x4x3xf32>,
                                       %init1: tensor<4x3x5xf32>,
                                       %init2: tensor<5x4x3xf32>) -> tensor<5x4x3xf32> {


### PR DESCRIPTION
All elements in a dense splat are identical, transposing it only changes the shape, but still maintaining the value. Add a pattern where it would replace the `linalg.transpose` of a splat constant with a `arith.constant` of the transposed result shape.

Assisted-by: Cursor (GPT-5.5)