### PR TITLE
[clang][ssaf] Validate plugin path before in `loadPlugins`

### DIFF
--- a/clang/lib/ScalableStaticAnalysisFramework/Tool/Utils.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Tool/Utils.cpp
@@ -136,6 +136,10 @@ llvm::StringRef clang::ssaf::getToolName() { return ToolName; }
 
 void clang::ssaf::loadPlugins(llvm::ArrayRef<std::string> Paths) {
   for (const std::string &PluginPath : Paths) {
+    if (!fs::exists(PluginPath)) {
+      fail(ErrorMessages::FailedToLoadPlugin, PluginPath,
+           ErrorMessages::PathDoesNotExist);
+    }
     std::string ErrMsg;
     if (llvm::sys::DynamicLibrary::LoadLibraryPermanently(PluginPath.c_str(),
                                                           &ErrMsg)) {

--- a/clang/test/Analysis/Scalable/ssaf-analyzer/cli-errors.test
+++ b/clang/test/Analysis/Scalable/ssaf-analyzer/cli-errors.test
@@ -26,7 +26,7 @@
 // RUN: not clang-ssaf-analyzer --load /nonexistent/path/plugin.so \
 // RUN:   %S/Inputs/lu.json -o %t/plugin-err.json 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=BAD-PLUGIN
-// BAD-PLUGIN: clang-ssaf-analyzer: error: failed to load plugin '/nonexistent/path/plugin.so':
+// BAD-PLUGIN: clang-ssaf-analyzer: error: failed to load plugin '/nonexistent/path/plugin.so': Path does not exist
 
 // ============================================================================
 // Error: empty analysis name


### PR DESCRIPTION
This change validates that plugin paths exist before loading them, producing a clean error message instead of relying on dlopen failure behavior. This fixes test failure on HWSan (aarch64-linux) where dlopen of a nonexistent `.so` triggers a sanitizer crash before the error message is written.