### PR TITLE
[RISCV][MC][NFC] Update IME vtype layout to match latest spec `riscv-isa-release-fa55752-2026-05-04`

### DIFF
--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -400,17 +400,17 @@ static unsigned getLambdaShift(unsigned XLen) {
 
 static unsigned getAltFmtAShift(unsigned XLen) {
   assertValidXLenForVType(XLen);
-  return XLen - 5;
+  return XLen - 6;
 }
 
 static unsigned getAltFmtBShift(unsigned XLen) {
   assertValidXLenForVType(XLen);
-  return XLen - 6;
+  return XLen - 7;
 }
 
 static unsigned getBSShift(unsigned XLen) {
   assertValidXLenForVType(XLen);
-  return XLen - 7;
+  return XLen - 5;
 }
 
 unsigned encodeLambda(unsigned Lambda) {

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -62,7 +62,7 @@ TEST(RISCVVType, IMEVTypeFields) {
   uint64_t RV32VType = RISCVVType::IME::addVTypeFields(
       BaseVType, /*XLen=*/32, /*Lambda=*/4, /*AltFmtA=*/true,
       /*AltFmtB=*/false, /*BlockSize16=*/true);
-  EXPECT_EQ(0x3a0000d0ULL, RV32VType);
+  EXPECT_EQ(0x3c0000d0ULL, RV32VType);
   EXPECT_EQ(0x7e000000ULL, RISCVVType::IME::getVTypeFieldsMask(32));
   EXPECT_EQ(3U, RISCVVType::IME::getLambdaEncoding(RV32VType, 32));
   EXPECT_EQ(4U, *RISCVVType::IME::getLambda(RV32VType, 32));
@@ -80,6 +80,22 @@ TEST(RISCVVType, IMEVTypeFields) {
   EXPECT_TRUE(RISCVVType::IME::isAltFmtA(RV64VType, 64));
   EXPECT_TRUE(RISCVVType::IME::isAltFmtB(RV64VType, 64));
   EXPECT_TRUE(RISCVVType::IME::isBlockSize16(RV64VType, 64));
+
+  uint64_t RV64AltFmtAOnly = RISCVVType::IME::addVTypeFields(
+      BaseVType, /*XLen=*/64, /*Lambda=*/0, /*AltFmtA=*/true,
+      /*AltFmtB=*/false, /*BlockSize16=*/false);
+  EXPECT_EQ(0x04000000000000d0ULL, RV64AltFmtAOnly);
+  EXPECT_TRUE(RISCVVType::IME::isAltFmtA(RV64AltFmtAOnly, 64));
+  EXPECT_FALSE(RISCVVType::IME::isAltFmtB(RV64AltFmtAOnly, 64));
+  EXPECT_FALSE(RISCVVType::IME::isBlockSize16(RV64AltFmtAOnly, 64));
+
+  uint64_t RV64BlockSizeOnly = RISCVVType::IME::addVTypeFields(
+      BaseVType, /*XLen=*/64, /*Lambda=*/0, /*AltFmtA=*/false,
+      /*AltFmtB=*/false, /*BlockSize16=*/true);
+  EXPECT_EQ(0x08000000000000d0ULL, RV64BlockSizeOnly);
+  EXPECT_FALSE(RISCVVType::IME::isAltFmtA(RV64BlockSizeOnly, 64));
+  EXPECT_FALSE(RISCVVType::IME::isAltFmtB(RV64BlockSizeOnly, 64));
+  EXPECT_TRUE(RISCVVType::IME::isBlockSize16(RV64BlockSizeOnly, 64));
 
   uint64_t DynamicLambda = RISCVVType::IME::addVTypeFields(
       BaseVType, /*XLen=*/64, /*Lambda=*/0, /*AltFmtA=*/false,


### PR DESCRIPTION
This updates the IME-specific vtype field layout to match the [latest IME spec, version riscv-isa-release-fa55752-2026-05-04](https://github.com/riscv/integrated-matrix-extension/blob/main/src/integrated-matrix.adoc#new-fields-in-the-vector-type-vtype-register). The latest spec places the IME fields as:

| Field         | New Position              | Change Description              |
|---------------|---------------------------|---------------------------------|
| `lambda[2:0]` | `vtype[XLEN-2:XLEN-4]`   | Unchanged                       |
| `bs`          | `vtype[XLEN-5]`          | Moved from `vtype[XLEN-7]`     |
| `altfmt_A`    | `vtype[XLEN-6]`          | Moved from `vtype[XLEN-5]`     |
| `altfmt_B`    | `vtype[XLEN-7]`          | Moved from `vtype[XLEN-6]`     |

Previously `bs`, `altfmt_A`, and `altfmt_B` followed the older ordering, which was first introduced in #193956. The new position of altfmt supports growing in the future for more datatypes.
This patch also updates tests to reflect field changes.

Currently this should be NFC since we didn't have any CodeGen implementation that involves vtype in IME.
