### PR TITLE
[clang][NFC] Mark CWG1336 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg13xx.cpp
+++ b/clang/test/CXX/drs/cwg13xx.cpp
@@ -296,6 +296,25 @@ namespace cwg1330 { // cwg1330: 4 c++11
 
 // cwg1334: sup 1719
 
+namespace cwg1336 { // cwg1336: 3.1
+#if __cplusplus >= 201103L
+struct A {
+  A(int, int);
+};
+
+struct B {
+  explicit B(int, int); // #cwg1336-B-ctor
+};
+
+void f() {
+  A a = {1, 2};
+  B b = {1, 2};
+  // expected-error@-1 {{chosen constructor is explicit in copy-initialization}}
+  //   expected-note@#cwg1336-B-ctor {{explicit constructor declared here}}
+}
+#endif
+} // namespace cwg1336
+
 namespace cwg1340 { // cwg1340: 2.9
 struct A;
 struct B;

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -9129,7 +9129,7 @@
     <td>[<a href="https://wg21.link/class.conv.ctor">class.conv.ctor</a>]</td>
     <td>CD3</td>
     <td>Definition of &#8220;converting constructor&#8221;</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.1</td>
   </tr>
   <tr id="1337">
     <td><a href="https://cplusplus.github.io/CWG/issues/1337.html">1337</a></td>


### PR DESCRIPTION
[CWG1336](https://wg21.link/cwg1336) clarifies that, as long as it isn't explicit, a constructor is still a converting constructor even if it has multiple arguments. Clang seems to implement this since 3.1: https://godbolt.org/z/919zdMd3h (I checked a few versions following 3.1 as well, and didn't notice any regressions).