### PR TITLE
[OpenCL] Add warning for reserved 'long long' type

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11832,6 +11832,9 @@ def err_opencl_requires_extension : Error<
 def ext_opencl_double_without_pragma : Extension<
   "Clang permits use of type 'double' regardless pragma if 'cl_khr_fp64' is"
   " supported">;
+def warn_opencl_longlong : Warning<
+  "'long long' is a reserved data type in OpenCL C">,
+  InGroup<ReservedIdentifier>;
 def warn_opencl_generic_address_space_arg : Warning<
   "passing non-generic address space pointer to %0"
   " may cause dynamic conversion affecting performance">,

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1041,8 +1041,10 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       case TypeSpecifierWidth::LongLong:
         Result = Context.LongLongTy;
 
-        // 'long long' is a C99 or C++11 feature.
-        if (!S.getLangOpts().C99) {
+        if (S.getLangOpts().OpenCL) {
+          S.Diag(DS.getTypeSpecWidthLoc(), diag::warn_opencl_longlong);
+        } else if (!S.getLangOpts().C99) {
+          // 'long long' is a C99 or C++11 feature.
           if (S.getLangOpts().CPlusPlus)
             S.Diag(DS.getTypeSpecWidthLoc(),
                    S.getLangOpts().CPlusPlus11 ?
@@ -1066,8 +1068,10 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       case TypeSpecifierWidth::LongLong:
         Result = Context.UnsignedLongLongTy;
 
-        // 'long long' is a C99 or C++11 feature.
-        if (!S.getLangOpts().C99) {
+        if (S.getLangOpts().OpenCL) {
+          S.Diag(DS.getTypeSpecWidthLoc(), diag::warn_opencl_longlong);
+        } else if (!S.getLangOpts().C99) {
+          // 'long long' is a C99 or C++11 feature.
           if (S.getLangOpts().CPlusPlus)
             S.Diag(DS.getTypeSpecWidthLoc(),
                    S.getLangOpts().CPlusPlus11 ?

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1042,6 +1042,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
         Result = Context.LongLongTy;
 
         if (S.getLangOpts().OpenCL) {
+          // OpenCL v3.0 s6.3.4: 'long long' is a reserved data type.
           S.Diag(DS.getTypeSpecWidthLoc(), diag::warn_opencl_longlong);
         } else if (!S.getLangOpts().C99) {
           // 'long long' is a C99 or C++11 feature.
@@ -1069,6 +1070,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
         Result = Context.UnsignedLongLongTy;
 
         if (S.getLangOpts().OpenCL) {
+          // OpenCL v3.0 s6.3.4: 'long long' is a reserved data type.
           S.Diag(DS.getTypeSpecWidthLoc(), diag::warn_opencl_longlong);
         } else if (!S.getLangOpts().C99) {
           // 'long long' is a C99 or C++11 feature.

--- a/clang/test/Misc/languageOptsOpenCL.cl
+++ b/clang/test/Misc/languageOptsOpenCL.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -x cl %s -verify -triple spir-unknown-unknown
+// RUN: %clang_cc1 -x cl %s -verify -triple spir-unknown-unknown -Wno-reserved-identifier
 // expected-no-diagnostics
 
 // Test the forced language options for OpenCL are set correctly.
@@ -8,6 +8,8 @@ kernel void test() {
   int v1[(__alignof(int)== 4) ? 1 : -1];
   int v2[(sizeof(long) == 8) ? 1 : -1];
   int v3[(__alignof(long)== 8) ? 1 : -1];
+  int v4[(sizeof(long long) == 16) ? 1 : -1];
+  int v5[(__alignof(long long)== 16) ? 1 : -1];
   int v6[(sizeof(float) == 4) ? 1 : -1];
   int v7[(__alignof(float)== 4) ? 1 : -1];
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable

--- a/clang/test/Misc/languageOptsOpenCL.cl
+++ b/clang/test/Misc/languageOptsOpenCL.cl
@@ -8,8 +8,6 @@ kernel void test() {
   int v1[(__alignof(int)== 4) ? 1 : -1];
   int v2[(sizeof(long) == 8) ? 1 : -1];
   int v3[(__alignof(long)== 8) ? 1 : -1];
-  int v4[(sizeof(long long) == 16) ? 1 : -1];
-  int v5[(__alignof(long long)== 16) ? 1 : -1];
   int v6[(sizeof(float) == 4) ? 1 : -1];
   int v7[(__alignof(float)== 4) ? 1 : -1];
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable

--- a/clang/test/SemaOpenCL/fdeclare-opencl-builtins.cl
+++ b/clang/test/SemaOpenCL/fdeclare-opencl-builtins.cl
@@ -117,7 +117,7 @@ kernel void test_enum_args(volatile global atomic_int *global_p, global int *exp
 #endif
 
 #if defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200
-void test_typedef_args(clk_event_t evt, volatile atomic_flag *flg, global unsigned long long *values) {
+void test_typedef_args(clk_event_t evt, volatile atomic_flag *flg, global unsigned long *values) {
   capture_event_profiling_info(evt, CLK_PROFILING_COMMAND_EXEC_TIME, values);
 
   atomic_flag_clear(flg);

--- a/clang/test/SemaOpenCL/longlong.cl
+++ b/clang/test/SemaOpenCL/longlong.cl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 %s -cl-std=CL1.0 -verify -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CL1.2 -verify -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CL2.0 -verify -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CL3.0 -verify -fsyntax-only
+
+void kernel test_longlong() {
+  long long x = 0;          // expected-warning{{'long long' is a reserved data type in OpenCL C}}
+  unsigned long long y = 0; // expected-warning{{'long long' is a reserved data type in OpenCL C}}
+}

--- a/clang/test/SemaOpenCL/longlong.cl
+++ b/clang/test/SemaOpenCL/longlong.cl
@@ -2,8 +2,11 @@
 // RUN: %clang_cc1 %s -cl-std=CL1.2 -verify -fsyntax-only
 // RUN: %clang_cc1 %s -cl-std=CL2.0 -verify -fsyntax-only
 // RUN: %clang_cc1 %s -cl-std=CL3.0 -verify -fsyntax-only
+// RUN: %clang_cc1 %s -cl-std=CLC++ -verify -fsyntax-only
 
 void kernel test_longlong() {
   long long x = 0;          // expected-warning{{'long long' is a reserved data type in OpenCL C}}
   unsigned long long y = 0; // expected-warning{{'long long' is a reserved data type in OpenCL C}}
+  typedef long long longlong2 __attribute__((ext_vector_type(2))); // expected-warning{{'long long' is a reserved data type in OpenCL C}}
+  typedef unsigned long long ulonglong2 __attribute__((ext_vector_type(4))); // expected-warning{{'long long' is a reserved data type in OpenCL C}}
 }

--- a/clang/test/SemaSPIRV/BuiltIns/subgroup-errors.c
+++ b/clang/test/SemaSPIRV/BuiltIns/subgroup-errors.c
@@ -14,7 +14,6 @@ void ballot(_Bool c) {
 
 void shuffle() {
   int x = 0;
-  long long l = 0;
   float f = 0;
   int [[clang::ext_vector_type(1)]] v;
   (void)__builtin_spirv_subgroup_shuffle(x, x);


### PR DESCRIPTION
'long long' is a reserved data type in all versions of OpenCL C.

Relates to https://github.com/intel/intel-graphics-compiler/issues/405