### PR TITLE
[AArch64] Avoid raw_svector_ostream for SubtargetMap keys

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -19,6 +19,7 @@
 #include "AArch64TargetTransformInfo.h"
 #include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "TargetInfo/AArch64TargetInfo.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/CSEConfigBase.h"
@@ -461,11 +462,21 @@ AArch64TargetMachine::getSubtargetImpl(const Function &F) const {
   }
 
   SmallString<512> Key;
-  raw_svector_ostream(Key) << "SVEMin" << MinSVEVectorSize << "SVEMax"
-                           << MaxSVEVectorSize << "IsStreaming=" << IsStreaming
-                           << "IsStreamingCompatible=" << IsStreamingCompatible
-                           << CPU << TuneCPU << FS
-                           << "HasMinSize=" << HasMinSize;
+  // This lookup is hot during repeated TTI queries, so build the key directly
+  // instead of formatting through raw_svector_ostream.
+  Key += "SVEMin";
+  Key += utostr(MinSVEVectorSize);
+  Key += "SVEMax";
+  Key += utostr(MaxSVEVectorSize);
+  Key += "IsStreaming=";
+  Key += utostr(IsStreaming);
+  Key += "IsStreamingCompatible=";
+  Key += utostr(IsStreamingCompatible);
+  Key += CPU;
+  Key += TuneCPU;
+  Key += FS;
+  Key += "HasMinSize=";
+  Key += utostr(HasMinSize);
 
   auto &I = SubtargetMap[Key];
   if (!I) {


### PR DESCRIPTION
AArch64TargetMachine::getSubtargetImpl builds a StringMap key on every subtarget lookup. This showed up through repeated TTI queries while profiling sqlite on aarch64-O0-g.

Building the key directly with SmallString appends and utostr instead of raw_svector_ostream improves compile-time.

We used to do this until 07e7168048b1.

CTMark geomean:
- stage1-aarch64-O3: -0.16%
- stage1-aarch64-O0-g: -0.18%

https://llvm-compile-time-tracker.com/compare.php?from=c9d713aa48a714d20b8502d06b9feb24829e6f22&to=e7ff83884193ee70cf3a69778b891fb729e0bcba&stat=instructions%3Au

Assisted-by: codex