### PR TITLE
[mlir][gpu] Reject conflicting async operands on gpu.launch_func

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1341,6 +1341,10 @@ LogicalResult LaunchFuncOp::verify() {
              << "expects types of the cluster dimensions must be the same";
   }
 
+  if (!getAsyncDependencies().empty() && getAsyncObject())
+    return emitOpError(
+        "cannot have both async dependencies and an explicit async object");
+
   return success();
 }
 

--- a/mlir/test/Dialect/GPU/invalid.mlir
+++ b/mlir/test/Dialect/GPU/invalid.mlir
@@ -224,6 +224,25 @@ module attributes {gpu.container_module} {
 
 module attributes {gpu.container_module} {
   gpu.module @kernels {
+    gpu.func @kernel_1() kernel {
+      gpu.return
+    }
+  }
+
+  func.func @launch_func_async_deps_and_async_object(%sz : index,
+                                                     %stream : !llvm.ptr) {
+    %dep = gpu.wait async
+    // expected-error@+1 {{cannot have both async dependencies and an explicit async object}}
+    %t = gpu.launch_func async [%dep] <%stream : !llvm.ptr> @kernels::@kernel_1
+        blocks in (%sz, %sz, %sz) threads in (%sz, %sz, %sz)
+    return
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
+  gpu.module @kernels {
     gpu.func @kernel_1(%arg1 : !llvm.ptr) {
       gpu.return
     }


### PR DESCRIPTION
Reject gpu.launch_func ops that have both async dependencies and an explicit async object.
