### PR TITLE
[clang] Add arm64_neon.h wrapper

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -55,6 +55,7 @@ set(arm_only_files
   )
 
 set(aarch64_only_files
+  arm64_neon.h
   arm64intr.h
   arm_neon_sve_bridge.h
   )

--- a/clang/lib/Headers/arm64_neon.h
+++ b/clang/lib/Headers/arm64_neon.h
@@ -1,0 +1,15 @@
+/*===---- arm64_neon.h - ARM64 NEON intrinsics -----------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ARM64_NEON_H
+#define __ARM64_NEON_H
+
+#include <arm_neon.h>
+
+#endif /* __ARM64_NEON_H */

--- a/clang/lib/Headers/arm64_neon.h
+++ b/clang/lib/Headers/arm64_neon.h
@@ -7,9 +7,15 @@
  *===-----------------------------------------------------------------------===
  */
 
+/* Only include this if we're compiling for the windows platform. */
+#ifndef _MSC_VER
+#include_next <arm64_neon.h>
+#else
+
 #ifndef __ARM64_NEON_H
 #define __ARM64_NEON_H
 
 #include <arm_neon.h>
 
 #endif /* __ARM64_NEON_H */
+#endif /* _MSC_VER */

--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -50,6 +50,12 @@ module _Builtin_intrinsics [system] [extern_c] {
 
     header "arm64intr.h"
     export *
+
+    explicit module neon {
+      requires neon
+      header "arm64_neon.h"
+      export *
+    }
   }
 
   explicit module intel {

--- a/clang/test/CodeGen/arm64-neon-header.c
+++ b/clang/test/CodeGen/arm64-neon-header.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple arm64-pc-windows-msvc -fms-compatibility \
-// RUN:     -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-pc-windows-msvc -target-feature +neon \
+// RUN:     -fms-compatibility -emit-llvm -o - %s | FileCheck %s
 
 #include <arm64_neon.h>
 

--- a/clang/test/CodeGen/arm64-neon-header.c
+++ b/clang/test/CodeGen/arm64-neon-header.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple arm64-pc-windows-msvc -target-feature +neon \
-// RUN:     -fms-compatibility -emit-llvm -o - %s | FileCheck %s
+// RUN:     -fms-compatibility -fms-compatibility-version=19.00 \
+// RUN:     -emit-llvm -o - %s | FileCheck %s
 
 #include <arm64_neon.h>
 

--- a/clang/test/CodeGen/arm64-neon-header.c
+++ b/clang/test/CodeGen/arm64-neon-header.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple arm64-pc-windows-msvc -fms-compatibility \
+// RUN:     -emit-llvm -o - %s | FileCheck %s
+
+#include <arm64_neon.h>
+
+// CHECK-LABEL: define{{.*}} @test_vld1q_s32_x4(
+// CHECK-NOT: neon_ld1m4_q32
+// CHECK: call { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld1x4.v4i32.p0(ptr {{.*}})
+// CHECK-NOT: neon_ld1m4_q32
+// CHECK: ret
+int32x4x4_t test_vld1q_s32_x4(int32_t const *a) {
+  return vld1q_s32_x4(a);
+}


### PR DESCRIPTION
Add an MSVC-compatible <arm64_neon.h> resource header that forwards to
Clang's generated <arm_neon.h>. This lets ARM64 Windows code using the
MSVC header name lower NEON intrinsics through Clang builtins instead of
eaving external neon_* calls such as neon_ld1m4_q32

Fixes #195683