### PR TITLE
[GlobalISel] Skip match table for opcodes with no combines

### DIFF
--- a/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table.td
+++ b/llvm/test/TableGen/GlobalISelCombinerEmitter/match-table.td
@@ -82,8 +82,25 @@ def MyCombiner: GICombiner<"GenMyCombiner", [
 // CHECK-NEXT:   return matchIConstant(State.MIs[0]->getOperand(1), 0);
 // CHECK-NEXT: }
 
-// Verify we reset MatchData on each tryCombineAll
+// Verify we gate on opcodes with generated combines and reset MatchData on each
+// tryCombineAll.
+// CHECK:      static bool GenMyCombiner_canMatchOpcode(unsigned Opc) {
+// CHECK-NEXT:   switch (Opc) {
+// CHECK-DAG:    case TargetOpcode::COPY:
+// CHECK-DAG:    case TargetOpcode::G_AND:
+// CHECK-DAG:    case TargetOpcode::G_STORE:
+// CHECK-DAG:    case TargetOpcode::G_TRUNC:
+// CHECK-DAG:    case TargetOpcode::G_SEXT:
+// CHECK-DAG:    case TargetOpcode::G_ZEXT:
+// CHECK:        return true;
+// CHECK-NEXT:   default:
+// CHECK-NEXT:     return false;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-EMPTY:
 // CHECK:      bool GenMyCombiner::tryCombineAll(MachineInstr &I) const {
+// CHECK-NEXT:   if (!GenMyCombiner_canMatchOpcode(I.getOpcode()))
+// CHECK-NEXT:     return false;
 // CHECK-NEXT:   const PredicateBitset AvailableFeatures = getAvailableFeatures();
 // CHECK-NEXT:   State.MIs.clear();
 // CHECK-NEXT:   State.MIs.push_back(&I);

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -2415,8 +2415,7 @@ class GICombinerEmitter final : public GlobalISelMatchTableExecutorEmitter {
   MatchTable buildMatchTable(MutableArrayRef<RuleMatcher> Rules);
 
   void emitRuleConfigImpl(raw_ostream &OS);
-  SmallSetVector<const CodeGenInstruction *, 32>
-  collectMatchOpcodes(ArrayRef<RuleMatcher> Rules) const;
+  void collectMatchOpcodes(ArrayRef<RuleMatcher> Rules);
   void emitCanMatchOpcodeFn(raw_ostream &OS, StringRef FnName) const;
 
   void emitAdditionalImpl(raw_ostream &OS) override;
@@ -2564,15 +2563,12 @@ void GICombinerEmitter::emitRuleConfigImpl(raw_ostream &OS) {
      << "}\n\n";
 }
 
-SmallSetVector<const CodeGenInstruction *, 32>
-GICombinerEmitter::collectMatchOpcodes(ArrayRef<RuleMatcher> Rules) const {
-  SmallSetVector<const CodeGenInstruction *, 32> Opcodes;
+void GICombinerEmitter::collectMatchOpcodes(ArrayRef<RuleMatcher> Rules) {
   for (const RuleMatcher &Rule : Rules) {
     for (const CodeGenInstruction *I :
          Rule.insnmatchers_front().getOpcodeMatcher().getAlternativeOpcodes())
-      Opcodes.insert(I);
+      MatchOpcodes.insert(I);
   }
-  return Opcodes;
 }
 
 void GICombinerEmitter::emitCanMatchOpcodeFn(raw_ostream &OS,
@@ -2822,7 +2818,7 @@ void GICombinerEmitter::run(raw_ostream &OS) {
     return false;
   });
 
-  MatchOpcodes = collectMatchOpcodes(Rules);
+  collectMatchOpcodes(Rules);
   const MatchTable Table = buildMatchTable(Rules);
 
   Timer.startTimer("Emit combiner");

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -41,6 +41,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
@@ -2404,6 +2405,9 @@ class GICombinerEmitter final : public GlobalISelMatchTableExecutorEmitter {
   // combine rule used to disable/enable it.
   std::vector<std::pair<unsigned, std::string>> AllCombineRules;
 
+  // Opcodes handled by the generated matcher.
+  SmallSetVector<const CodeGenInstruction *, 32> MatchOpcodes;
+
   // Keep track of all rules we've seen so far to ensure we don't process
   // the same rule twice.
   StringSet<> RulesSeen;
@@ -2411,6 +2415,9 @@ class GICombinerEmitter final : public GlobalISelMatchTableExecutorEmitter {
   MatchTable buildMatchTable(MutableArrayRef<RuleMatcher> Rules);
 
   void emitRuleConfigImpl(raw_ostream &OS);
+  SmallSetVector<const CodeGenInstruction *, 32>
+  collectMatchOpcodes(ArrayRef<RuleMatcher> Rules) const;
+  void emitCanMatchOpcodeFn(raw_ostream &OS, StringRef FnName) const;
 
   void emitAdditionalImpl(raw_ostream &OS) override;
 
@@ -2557,9 +2564,44 @@ void GICombinerEmitter::emitRuleConfigImpl(raw_ostream &OS) {
      << "}\n\n";
 }
 
+SmallSetVector<const CodeGenInstruction *, 32>
+GICombinerEmitter::collectMatchOpcodes(ArrayRef<RuleMatcher> Rules) const {
+  SmallSetVector<const CodeGenInstruction *, 32> Opcodes;
+  for (const RuleMatcher &Rule : Rules) {
+    for (const CodeGenInstruction *I :
+         Rule.insnmatchers_front().getOpcodeMatcher().getAlternativeOpcodes())
+      Opcodes.insert(I);
+  }
+  return Opcodes;
+}
+
+void GICombinerEmitter::emitCanMatchOpcodeFn(raw_ostream &OS,
+                                             StringRef FnName) const {
+  OS << "static bool " << FnName << "(unsigned Opc) {\n";
+  if (MatchOpcodes.empty()) {
+    OS << "  (void)Opc;\n"
+       << "  return false;\n"
+       << "}\n\n";
+    return;
+  }
+
+  OS << "  switch (Opc) {\n";
+  for (const CodeGenInstruction *I : MatchOpcodes)
+    OS << "  case " << I->Namespace << "::" << I->getName() << ":\n";
+  OS << "    return true;\n"
+     << "  default:\n"
+     << "    return false;\n"
+     << "  }\n"
+     << "}\n\n";
+}
+
 void GICombinerEmitter::emitAdditionalImpl(raw_ostream &OS) {
+  std::string CanMatchOpcodeFnName = (getClassName() + "_canMatchOpcode").str();
+  emitCanMatchOpcodeFn(OS, CanMatchOpcodeFnName);
   OS << "bool " << getClassName() << "::" << getCombineAllMethodName()
      << "(MachineInstr &I) const {\n"
+     << "  if (!" << CanMatchOpcodeFnName << "(I.getOpcode()))\n"
+     << "    return false;\n"
      << "  const PredicateBitset AvailableFeatures = "
         "getAvailableFeatures();\n"
      << "  State.MIs.clear();\n"
@@ -2780,6 +2822,7 @@ void GICombinerEmitter::run(raw_ostream &OS) {
     return false;
   });
 
+  MatchOpcodes = collectMatchOpcodes(Rules);
   const MatchTable Table = buildMatchTable(Rules);
 
   Timer.startTimer("Emit combiner");


### PR DESCRIPTION
Generate an opcode predicate for GICombiner matchers and use it to return from tryCombineAll before setting up matcher state and executing the match table.

The opcode list is collected from the generated rules, so the guard stays in sync with the match table and avoids match-table overhead for instructions the combiner cannot handle.

Improves CTMark geomean by -0.33% on stage1-aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=ed50ea52004259af958bb3e5636268342c49ee62&to=aea6e13cbc76c500a2e0aaedced716b9508811a7&stat=instructions%3Au

Also improves -O3 GISel geomean by -0.07%. Local results since this config isn't available on llvm-compile-time-tracker:
```
                 instructions:u                 diff
                            old           new
7zip               203476185395  203435124795 -0.02%
Bullet             103700835951  103694675411 -0.01%
ClamAV              52725697786   52671103456 -0.10%
SPASS               41611892042   41564657601 -0.11%
consumer-typeset    31700292250   31663189016 -0.12%
kimwitu++           39506799515   39520035914  0.03%
lencod              66874010678   66804617092 -0.10%
mafft               36550480158   36513382949 -0.10%
sqlite3             33262506697   33216990490 -0.14%
tramp3d-v4          76018141926   76024936414  0.01%
geomean             56941557756   56903973091 -0.07%
```
Assisted-by: codex