### PR TITLE
[ObjectYAML][NFC] Extract BBAddrMap YAML types into shared namespace

### DIFF
--- a/llvm/include/llvm/ObjectYAML/BBAddrMapYAML.h
+++ b/llvm/include/llvm/ObjectYAML/BBAddrMapYAML.h
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the YAML representation of BB address maps
+/// (SHT_LLVM_BB_ADDR_MAP / .llvm_bb_addr_map). The types here are
+/// format-agnostic so they can be reused by ELFYAML and COFFYAML.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_OBJECTYAML_BBADDRMAPYAML_H
+#define LLVM_OBJECTYAML_BBADDRMAPYAML_H
+
+#include "llvm/Support/YAMLTraits.h"
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace llvm {
+namespace BBAddrMapYAML {
+
+struct BBAddrMapEntry {
+  struct BBEntry {
+    uint32_t ID;
+    llvm::yaml::Hex64 AddressOffset;
+    llvm::yaml::Hex64 Size;
+    llvm::yaml::Hex64 Metadata;
+    std::optional<std::vector<llvm::yaml::Hex64>> CallsiteEndOffsets;
+    std::optional<llvm::yaml::Hex64> Hash;
+  };
+  uint8_t Version;
+  llvm::yaml::Hex16 Feature;
+
+  struct BBRangeEntry {
+    llvm::yaml::Hex64 BaseAddress;
+    std::optional<uint64_t> NumBlocks;
+    std::optional<std::vector<BBEntry>> BBEntries;
+  };
+
+  std::optional<uint64_t> NumBBRanges;
+  std::optional<std::vector<BBRangeEntry>> BBRanges;
+
+  llvm::yaml::Hex64 getFunctionAddress() const {
+    if (!BBRanges || BBRanges->empty())
+      return 0;
+    return BBRanges->front().BaseAddress;
+  }
+
+  // Returns if any BB entries have non-empty callsite offsets.
+  bool hasAnyCallsiteEndOffsets() const {
+    if (!BBRanges)
+      return false;
+    for (const BBRangeEntry &BBR : *BBRanges) {
+      if (!BBR.BBEntries)
+        continue;
+      for (const BBEntry &BBE : *BBR.BBEntries)
+        if (BBE.CallsiteEndOffsets && !BBE.CallsiteEndOffsets->empty())
+          return true;
+    }
+    return false;
+  }
+};
+
+struct PGOAnalysisMapEntry {
+  struct PGOBBEntry {
+    struct SuccessorEntry {
+      uint32_t ID;
+      llvm::yaml::Hex32 BrProb;
+      std::optional<uint32_t> PostLinkBrFreq;
+    };
+    std::optional<uint64_t> BBFreq;
+    std::optional<uint32_t> PostLinkBBFreq;
+    std::optional<std::vector<SuccessorEntry>> Successors;
+  };
+  std::optional<uint64_t> FuncEntryCount;
+  std::optional<std::vector<PGOBBEntry>> PGOBBEntries;
+};
+
+} // end namespace BBAddrMapYAML
+} // end namespace llvm
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry::BBEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::PGOAnalysisMapEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(
+    llvm::BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry)
+
+namespace llvm {
+namespace yaml {
+
+template <> struct MappingTraits<BBAddrMapYAML::BBAddrMapEntry> {
+  static void mapping(IO &IO, BBAddrMapYAML::BBAddrMapEntry &E);
+};
+
+template <> struct MappingTraits<BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry> {
+  static void mapping(IO &IO, BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry &E);
+};
+
+template <> struct MappingTraits<BBAddrMapYAML::BBAddrMapEntry::BBEntry> {
+  static void mapping(IO &IO, BBAddrMapYAML::BBAddrMapEntry::BBEntry &E);
+};
+
+template <> struct MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry> {
+  static void mapping(IO &IO, BBAddrMapYAML::PGOAnalysisMapEntry &E);
+};
+
+template <> struct MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry> {
+  static void mapping(IO &IO,
+                      BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry &E);
+};
+
+template <>
+struct MappingTraits<
+    BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry> {
+  static void
+  mapping(IO &IO,
+          BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry &E);
+};
+
+} // end namespace yaml
+} // end namespace llvm
+
+#endif // LLVM_OBJECTYAML_BBADDRMAPYAML_H

--- a/llvm/include/llvm/ObjectYAML/BBAddrMapYAML.h
+++ b/llvm/include/llvm/ObjectYAML/BBAddrMapYAML.h
@@ -88,7 +88,8 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry::BBEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::PGOAnalysisMapEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(
+    llvm::BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(
     llvm::BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry)
 
@@ -111,7 +112,8 @@ template <> struct MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry> {
   static void mapping(IO &IO, BBAddrMapYAML::PGOAnalysisMapEntry &E);
 };
 
-template <> struct MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry> {
+template <>
+struct MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry> {
   static void mapping(IO &IO,
                       BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry &E);
 };

--- a/llvm/include/llvm/ObjectYAML/ELFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/ELFYAML.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Object/ELFTypes.h"
+#include "llvm/ObjectYAML/BBAddrMapYAML.h"
 #include "llvm/ObjectYAML/DWARFYAML.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/YAMLTraits.h"
@@ -154,63 +155,6 @@ struct SectionOrType {
 struct DynamicEntry {
   ELF_DYNTAG Tag;
   llvm::yaml::Hex64 Val;
-};
-
-struct BBAddrMapEntry {
-  struct BBEntry {
-    uint32_t ID;
-    llvm::yaml::Hex64 AddressOffset;
-    llvm::yaml::Hex64 Size;
-    llvm::yaml::Hex64 Metadata;
-    std::optional<std::vector<llvm::yaml::Hex64>> CallsiteEndOffsets;
-    std::optional<llvm::yaml::Hex64> Hash;
-  };
-  uint8_t Version;
-  llvm::yaml::Hex16 Feature;
-
-  struct BBRangeEntry {
-    llvm::yaml::Hex64 BaseAddress;
-    std::optional<uint64_t> NumBlocks;
-    std::optional<std::vector<BBEntry>> BBEntries;
-  };
-
-  std::optional<uint64_t> NumBBRanges;
-  std::optional<std::vector<BBRangeEntry>> BBRanges;
-
-  llvm::yaml::Hex64 getFunctionAddress() const {
-    if (!BBRanges || BBRanges->empty())
-      return 0;
-    return BBRanges->front().BaseAddress;
-  }
-
-  // Returns if any BB entries have non-empty callsite offsets.
-  bool hasAnyCallsiteEndOffsets() const {
-    if (!BBRanges)
-      return false;
-    for (const ELFYAML::BBAddrMapEntry::BBRangeEntry &BBR : *BBRanges) {
-      if (!BBR.BBEntries)
-        continue;
-      for (const ELFYAML::BBAddrMapEntry::BBEntry &BBE : *BBR.BBEntries)
-        if (BBE.CallsiteEndOffsets && !BBE.CallsiteEndOffsets->empty())
-          return true;
-    }
-    return false;
-  }
-};
-
-struct PGOAnalysisMapEntry {
-  struct PGOBBEntry {
-    struct SuccessorEntry {
-      uint32_t ID;
-      llvm::yaml::Hex32 BrProb;
-      std::optional<uint32_t> PostLinkBrFreq;
-    };
-    std::optional<uint64_t> BBFreq;
-    std::optional<uint32_t> PostLinkBBFreq;
-    std::optional<std::vector<SuccessorEntry>> Successors;
-  };
-  std::optional<uint64_t> FuncEntryCount;
-  std::optional<std::vector<PGOBBEntry>> PGOBBEntries;
 };
 
 struct StackSizeEntry {
@@ -359,8 +303,8 @@ struct SectionHeaderTable : Chunk {
 };
 
 struct BBAddrMapSection : Section {
-  std::optional<std::vector<BBAddrMapEntry>> Entries;
-  std::optional<std::vector<PGOAnalysisMapEntry>> PGOAnalyses;
+  std::optional<std::vector<BBAddrMapYAML::BBAddrMapEntry>> Entries;
+  std::optional<std::vector<BBAddrMapYAML::PGOAnalysisMapEntry>> PGOAnalyses;
 
   BBAddrMapSection() : Section(ChunkKind::BBAddrMap) {}
 
@@ -780,13 +724,6 @@ bool shouldAllocateFileSpace(ArrayRef<ProgramHeader> Phdrs,
 } // end namespace llvm
 
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::StackSizeEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::BBAddrMapEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::BBAddrMapEntry::BBEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::BBAddrMapEntry::BBRangeEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::PGOAnalysisMapEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::PGOAnalysisMapEntry::PGOBBEntry)
-LLVM_YAML_IS_SEQUENCE_VECTOR(
-    llvm::ELFYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::DynamicEntry)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::LinkerOption)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::ELFYAML::CallGraphEntryWeight)
@@ -945,33 +882,6 @@ struct MappingTraits<ELFYAML::Symbol> {
 
 template <> struct MappingTraits<ELFYAML::StackSizeEntry> {
   static void mapping(IO &IO, ELFYAML::StackSizeEntry &Rel);
-};
-
-template <> struct MappingTraits<ELFYAML::BBAddrMapEntry> {
-  static void mapping(IO &IO, ELFYAML::BBAddrMapEntry &E);
-};
-
-template <> struct MappingTraits<ELFYAML::BBAddrMapEntry::BBRangeEntry> {
-  static void mapping(IO &IO, ELFYAML::BBAddrMapEntry::BBRangeEntry &E);
-};
-
-template <> struct MappingTraits<ELFYAML::BBAddrMapEntry::BBEntry> {
-  static void mapping(IO &IO, ELFYAML::BBAddrMapEntry::BBEntry &E);
-};
-
-template <> struct MappingTraits<ELFYAML::PGOAnalysisMapEntry> {
-  static void mapping(IO &IO, ELFYAML::PGOAnalysisMapEntry &Rel);
-};
-
-template <> struct MappingTraits<ELFYAML::PGOAnalysisMapEntry::PGOBBEntry> {
-  static void mapping(IO &IO, ELFYAML::PGOAnalysisMapEntry::PGOBBEntry &Rel);
-};
-
-template <>
-struct MappingTraits<ELFYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry> {
-  static void
-  mapping(IO &IO,
-          ELFYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry &Rel);
 };
 
 template <> struct MappingTraits<ELFYAML::GnuHashHeader> {

--- a/llvm/lib/ObjectYAML/BBAddrMapYAML.cpp
+++ b/llvm/lib/ObjectYAML/BBAddrMapYAML.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines the YAMLIO mappings for the format-agnostic BB address
+/// map YAML types declared in BBAddrMapYAML.h.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ObjectYAML/BBAddrMapYAML.h"
+
+namespace llvm {
+namespace yaml {
+
+void MappingTraits<BBAddrMapYAML::BBAddrMapEntry>::mapping(
+    IO &IO, BBAddrMapYAML::BBAddrMapEntry &E) {
+  assert(IO.getContext() && "The IO context is not initialized");
+  IO.mapRequired("Version", E.Version);
+  IO.mapOptional("Feature", E.Feature, Hex16(0));
+  IO.mapOptional("NumBBRanges", E.NumBBRanges);
+  IO.mapOptional("BBRanges", E.BBRanges);
+}
+
+void MappingTraits<BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry>::mapping(
+    IO &IO, BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry &E) {
+  IO.mapOptional("BaseAddress", E.BaseAddress, Hex64(0));
+  IO.mapOptional("NumBlocks", E.NumBlocks);
+  IO.mapOptional("BBEntries", E.BBEntries);
+}
+
+void MappingTraits<BBAddrMapYAML::BBAddrMapEntry::BBEntry>::mapping(
+    IO &IO, BBAddrMapYAML::BBAddrMapEntry::BBEntry &E) {
+  assert(IO.getContext() && "The IO context is not initialized");
+  IO.mapOptional("ID", E.ID);
+  IO.mapRequired("AddressOffset", E.AddressOffset);
+  IO.mapRequired("Size", E.Size);
+  IO.mapRequired("Metadata", E.Metadata);
+  IO.mapOptional("CallsiteEndOffsets", E.CallsiteEndOffsets);
+  IO.mapOptional("Hash", E.Hash);
+}
+
+void MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry>::mapping(
+    IO &IO, BBAddrMapYAML::PGOAnalysisMapEntry &E) {
+  assert(IO.getContext() && "The IO context is not initialized");
+  IO.mapOptional("FuncEntryCount", E.FuncEntryCount);
+  IO.mapOptional("PGOBBEntries", E.PGOBBEntries);
+}
+
+void MappingTraits<BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry>::mapping(
+    IO &IO, BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry &E) {
+  assert(IO.getContext() && "The IO context is not initialized");
+  IO.mapOptional("BBFreq", E.BBFreq);
+  IO.mapOptional("PostLinkBBFreq", E.PostLinkBBFreq);
+  IO.mapOptional("Successors", E.Successors);
+}
+
+void MappingTraits<
+    BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry>::
+    mapping(IO &IO,
+            BBAddrMapYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry &E) {
+  assert(IO.getContext() && "The IO context is not initialized");
+  IO.mapRequired("ID", E.ID);
+  IO.mapRequired("BrProb", E.BrProb);
+  IO.mapOptional("PostLinkBrFreq", E.PostLinkBrFreq);
+}
+
+} // end namespace yaml
+} // end namespace llvm

--- a/llvm/lib/ObjectYAML/CMakeLists.txt
+++ b/llvm/lib/ObjectYAML/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_llvm_component_library(LLVMObjectYAML
   ArchiveEmitter.cpp
   ArchiveYAML.cpp
+  BBAddrMapYAML.cpp
   CodeViewYAMLDebugSections.cpp
   CodeViewYAMLSymbols.cpp
   CodeViewYAMLTypeHashing.cpp

--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1453,7 +1453,7 @@ void ELFState<ELFT>::writeSectionContent(
     return;
   }
 
-  const std::vector<ELFYAML::PGOAnalysisMapEntry> *PGOAnalyses = nullptr;
+  const std::vector<BBAddrMapYAML::PGOAnalysisMapEntry> *PGOAnalyses = nullptr;
   if (Section.PGOAnalyses) {
     if (Section.Entries->size() != Section.PGOAnalyses->size())
       WithColor::warning() << "PGOAnalyses must be the same length as Entries "
@@ -1504,7 +1504,7 @@ void ELFState<ELFT>::writeSectionContent(
     uint64_t TotalNumBlocks = 0;
     bool EmitCallsiteEndOffsets =
         FeatureOrErr->CallsiteEndOffsets || E.hasAnyCallsiteEndOffsets();
-    for (const ELFYAML::BBAddrMapEntry::BBRangeEntry &BBR : *E.BBRanges) {
+    for (const BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry &BBR : *E.BBRanges) {
       // Write the base address of the range.
       CBA.write<uintX_t>(BBR.BaseAddress, ELFT::Endianness);
       // Write number of BBEntries (number of basic blocks in this basic block
@@ -1516,7 +1516,7 @@ void ELFState<ELFT>::writeSectionContent(
       // Write all BBEntries in this BBRange.
       if (!BBR.BBEntries || FeatureOrErr->OmitBBEntries)
         continue;
-      for (const ELFYAML::BBAddrMapEntry::BBEntry &BBE : *BBR.BBEntries) {
+      for (const BBAddrMapYAML::BBAddrMapEntry::BBEntry &BBE : *BBR.BBEntries) {
         ++TotalNumBlocks;
         if (Section.Type == llvm::ELF::SHT_LLVM_BB_ADDR_MAP && E.Version > 1)
           SHeader.sh_size += CBA.writeULEB128(BBE.ID);
@@ -1542,7 +1542,7 @@ void ELFState<ELFT>::writeSectionContent(
     }
     if (!PGOAnalyses)
       continue;
-    const ELFYAML::PGOAnalysisMapEntry &PGOEntry = PGOAnalyses->at(Idx);
+    const BBAddrMapYAML::PGOAnalysisMapEntry &PGOEntry = PGOAnalyses->at(Idx);
 
     if (PGOEntry.FuncEntryCount)
       SHeader.sh_size += CBA.writeULEB128(*PGOEntry.FuncEntryCount);

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -1815,57 +1815,6 @@ void MappingTraits<ELFYAML::StackSizeEntry>::mapping(
   IO.mapRequired("Size", E.Size);
 }
 
-void MappingTraits<ELFYAML::BBAddrMapEntry>::mapping(
-    IO &IO, ELFYAML::BBAddrMapEntry &E) {
-  assert(IO.getContext() && "The IO context is not initialized");
-  IO.mapRequired("Version", E.Version);
-  IO.mapOptional("Feature", E.Feature, Hex16(0));
-  IO.mapOptional("NumBBRanges", E.NumBBRanges);
-  IO.mapOptional("BBRanges", E.BBRanges);
-}
-
-void MappingTraits<ELFYAML::BBAddrMapEntry::BBRangeEntry>::mapping(
-    IO &IO, ELFYAML::BBAddrMapEntry::BBRangeEntry &E) {
-  IO.mapOptional("BaseAddress", E.BaseAddress, Hex64(0));
-  IO.mapOptional("NumBlocks", E.NumBlocks);
-  IO.mapOptional("BBEntries", E.BBEntries);
-}
-
-void MappingTraits<ELFYAML::BBAddrMapEntry::BBEntry>::mapping(
-    IO &IO, ELFYAML::BBAddrMapEntry::BBEntry &E) {
-  assert(IO.getContext() && "The IO context is not initialized");
-  IO.mapOptional("ID", E.ID);
-  IO.mapRequired("AddressOffset", E.AddressOffset);
-  IO.mapRequired("Size", E.Size);
-  IO.mapRequired("Metadata", E.Metadata);
-  IO.mapOptional("CallsiteEndOffsets", E.CallsiteEndOffsets);
-  IO.mapOptional("Hash", E.Hash);
-}
-
-void MappingTraits<ELFYAML::PGOAnalysisMapEntry>::mapping(
-    IO &IO, ELFYAML::PGOAnalysisMapEntry &E) {
-  assert(IO.getContext() && "The IO context is not initialized");
-  IO.mapOptional("FuncEntryCount", E.FuncEntryCount);
-  IO.mapOptional("PGOBBEntries", E.PGOBBEntries);
-}
-
-void MappingTraits<ELFYAML::PGOAnalysisMapEntry::PGOBBEntry>::mapping(
-    IO &IO, ELFYAML::PGOAnalysisMapEntry::PGOBBEntry &E) {
-  assert(IO.getContext() && "The IO context is not initialized");
-  IO.mapOptional("BBFreq", E.BBFreq);
-  IO.mapOptional("PostLinkBBFreq", E.PostLinkBBFreq);
-  IO.mapOptional("Successors", E.Successors);
-}
-
-void MappingTraits<ELFYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry>::
-    mapping(IO &IO,
-            ELFYAML::PGOAnalysisMapEntry::PGOBBEntry::SuccessorEntry &E) {
-  assert(IO.getContext() && "The IO context is not initialized");
-  IO.mapRequired("ID", E.ID);
-  IO.mapRequired("BrProb", E.BrProb);
-  IO.mapOptional("PostLinkBrFreq", E.PostLinkBrFreq);
-}
-
 void MappingTraits<ELFYAML::GnuHashHeader>::mapping(IO &IO,
                                                     ELFYAML::GnuHashHeader &E) {
   assert(IO.getContext() && "The IO context is not initialized");

--- a/llvm/tools/obj2yaml/elf2yaml.cpp
+++ b/llvm/tools/obj2yaml/elf2yaml.cpp
@@ -892,9 +892,9 @@ ELFDumper<ELFT>::dumpBBAddrMapSection(const Elf_Shdr *Shdr) {
   unsigned AddressSize = ELFT::Is64Bits ? 8 : 4;
   DataExtractor Data(Content, Obj.isLE());
 
-  std::vector<ELFYAML::BBAddrMapEntry> Entries;
+  std::vector<BBAddrMapYAML::BBAddrMapEntry> Entries;
   bool HasAnyPGOAnalysisMapEntry = false;
-  std::vector<ELFYAML::PGOAnalysisMapEntry> PGOAnalyses;
+  std::vector<BBAddrMapYAML::PGOAnalysisMapEntry> PGOAnalyses;
   DataExtractor::Cursor Cur(0);
   uint8_t Version = 0;
   uint16_t Feature = 0;
@@ -921,7 +921,7 @@ ELFDumper<ELFT>::dumpBBAddrMapSection(const Elf_Shdr *Shdr) {
       Address = Data.getUnsigned(Cur, AddressSize);
       NumBlocks = Data.getULEB128(Cur);
     }
-    std::vector<ELFYAML::BBAddrMapEntry::BBRangeEntry> BBRanges;
+    std::vector<BBAddrMapYAML::BBAddrMapEntry::BBRangeEntry> BBRanges;
     uint64_t BaseAddress = 0;
     for (uint64_t BBRangeN = 0; Cur && BBRangeN != NumBBRanges; ++BBRangeN) {
       if (FeatureOrErr->MultiBBRange) {
@@ -931,7 +931,7 @@ ELFDumper<ELFT>::dumpBBAddrMapSection(const Elf_Shdr *Shdr) {
         BaseAddress = Address;
       }
 
-      std::vector<ELFYAML::BBAddrMapEntry::BBEntry> BBEntries;
+      std::vector<BBAddrMapYAML::BBAddrMapEntry::BBEntry> BBEntries;
       // Read the specified number of BB entries, or until decoding fails.
       for (uint64_t BlockIndex = 0; Cur && BlockIndex < NumBlocks;
            ++BlockIndex) {
@@ -960,7 +960,7 @@ ELFDumper<ELFT>::dumpBBAddrMapSection(const Elf_Shdr *Shdr) {
     Entries.push_back(
         {Version, Feature, /*NumBBRanges=*/{}, std::move(BBRanges)});
 
-    ELFYAML::PGOAnalysisMapEntry &PGOAnalysis = PGOAnalyses.emplace_back();
+    BBAddrMapYAML::PGOAnalysisMapEntry &PGOAnalysis = PGOAnalyses.emplace_back();
     if (FeatureOrErr->hasPGOAnalysis()) {
       HasAnyPGOAnalysisMapEntry = true;
 

--- a/llvm/tools/obj2yaml/elf2yaml.cpp
+++ b/llvm/tools/obj2yaml/elf2yaml.cpp
@@ -960,7 +960,8 @@ ELFDumper<ELFT>::dumpBBAddrMapSection(const Elf_Shdr *Shdr) {
     Entries.push_back(
         {Version, Feature, /*NumBBRanges=*/{}, std::move(BBRanges)});
 
-    BBAddrMapYAML::PGOAnalysisMapEntry &PGOAnalysis = PGOAnalyses.emplace_back();
+    BBAddrMapYAML::PGOAnalysisMapEntry &PGOAnalysis =
+        PGOAnalyses.emplace_back();
     if (FeatureOrErr->hasPGOAnalysis()) {
       HasAnyPGOAnalysisMapEntry = true;
 


### PR DESCRIPTION
Move BBAddrMapEntry and PGOAnalysisMapEntry out of namespace ELFYAML
into a new format-agnostic namespace BBAddrMapYAML so that COFF
YAML support can reuse the same schema and MappingTraits.