### PR TITLE
[SystemZ] Remove superfluous args in tests.

### DIFF
--- a/llvm/test/CodeGen/SystemZ/memcpy-03.ll
+++ b/llvm/test/CodeGen/SystemZ/memcpy-03.ll
@@ -6,7 +6,7 @@
 
 declare void @llvm.memcpy.p0.p0.i64(ptr nocapture, ptr nocapture, i64, i1) nounwind
 
-define void @fun1(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun1(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(1,%r2), 0(%r3)
@@ -15,7 +15,7 @@ define void @fun1(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun1_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun1_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun1_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(1,%r2), 0(%r3)
@@ -24,7 +24,7 @@ define void @fun1_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun2(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun2(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun2:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(2,%r2), 0(%r3)
@@ -33,7 +33,7 @@ define void @fun2(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun2_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun2_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun2_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(2,%r2), 0(%r3)
@@ -42,7 +42,7 @@ define void @fun2_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun3(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun3(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun3:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(3,%r2), 0(%r3)
@@ -51,7 +51,7 @@ define void @fun3(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun3_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun3_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun3_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(3,%r2), 0(%r3)
@@ -60,7 +60,7 @@ define void @fun3_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun4(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun4(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(4,%r2), 0(%r3)
@@ -69,7 +69,7 @@ define void @fun4(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun4_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun4_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun4_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(4,%r2), 0(%r3)
@@ -78,7 +78,7 @@ define void @fun4_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun5(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun5(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(5,%r2), 0(%r3)
@@ -87,7 +87,7 @@ define void @fun5(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun5_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun5_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun5_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(5,%r2), 0(%r3)
@@ -96,7 +96,7 @@ define void @fun5_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun6(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun6(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun6:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(6,%r2), 0(%r3)
@@ -105,7 +105,7 @@ define void @fun6(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun6_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun6_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun6_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(6,%r2), 0(%r3)
@@ -114,7 +114,7 @@ define void @fun6_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun7(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun7(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun7:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(7,%r2), 0(%r3)
@@ -123,7 +123,7 @@ define void @fun7(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun7_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun7_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun7_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(7,%r2), 0(%r3)
@@ -132,7 +132,7 @@ define void @fun7_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun8(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun8(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(8,%r2), 0(%r3)
@@ -141,7 +141,7 @@ define void @fun8(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun8_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun8_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun8_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(8,%r2), 0(%r3)
@@ -150,7 +150,7 @@ define void @fun8_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun9(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun9(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun9:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(9,%r2), 0(%r3)
@@ -159,7 +159,7 @@ define void @fun9(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun9_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun9_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun9_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(9,%r2), 0(%r3)
@@ -168,7 +168,7 @@ define void @fun9_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun10(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun10(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun10:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(10,%r2), 0(%r3)
@@ -177,7 +177,7 @@ define void @fun10(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun10_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun10_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun10_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(10,%r2), 0(%r3)
@@ -186,7 +186,7 @@ define void @fun10_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun11(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun11(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun11:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(11,%r2), 0(%r3)
@@ -195,7 +195,7 @@ define void @fun11(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun11_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun11_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun11_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(11,%r2), 0(%r3)
@@ -204,7 +204,7 @@ define void @fun11_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun12(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun12(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun12:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(12,%r2), 0(%r3)
@@ -213,7 +213,7 @@ define void @fun12(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun12_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun12_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun12_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(12,%r2), 0(%r3)
@@ -222,7 +222,7 @@ define void @fun12_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun13(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun13(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun13:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(13,%r2), 0(%r3)
@@ -231,7 +231,7 @@ define void @fun13(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun13_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun13_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun13_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(13,%r2), 0(%r3)
@@ -240,7 +240,7 @@ define void @fun13_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun14(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun14(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun14:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(14,%r2), 0(%r3)
@@ -249,7 +249,7 @@ define void @fun14(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun14_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun14_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun14_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(14,%r2), 0(%r3)
@@ -258,7 +258,7 @@ define void @fun14_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun15(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun15(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun15:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(15,%r2), 0(%r3)
@@ -267,7 +267,7 @@ define void @fun15(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun15_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun15_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun15_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(15,%r2), 0(%r3)
@@ -276,7 +276,7 @@ define void @fun15_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun16(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun16(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(16,%r2), 0(%r3)
@@ -285,7 +285,7 @@ define void @fun16(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun16_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun16_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun16_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(16,%r2), 0(%r3)
@@ -294,7 +294,7 @@ define void @fun16_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lb %r0, 16(%r3)
@@ -306,7 +306,7 @@ define void @fun17(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(17,%r2), 0(%r3)
@@ -315,7 +315,7 @@ define void @fun17_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17_unalignedSrc(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17_unalignedSrc(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17_unalignedSrc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(17,%r2), 0(%r3)
@@ -324,7 +324,7 @@ define void @fun17_unalignedSrc(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lh %r0, 16(%r3)
@@ -336,7 +336,7 @@ define void @fun18(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(18,%r2), 0(%r3)
@@ -345,7 +345,7 @@ define void @fun18_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18_unalignedDst(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18_unalignedDst(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18_unalignedDst:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(18,%r2), 0(%r3)
@@ -354,7 +354,7 @@ define void @fun18_unalignedDst(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun19(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun19(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun19:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 15(%r3)
@@ -366,7 +366,7 @@ define void @fun19(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun19_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun19_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun19_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(19,%r2), 0(%r3)
@@ -375,7 +375,7 @@ define void @fun19_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun20(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun20:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    l %r0, 16(%r3)
@@ -387,7 +387,7 @@ define void @fun20(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun20_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun20_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(20,%r2), 0(%r3)
@@ -396,7 +396,7 @@ define void @fun20_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20_localDst(ptr %Src, i8 %val) {
+define void @fun20_localDst(ptr %Src) {
 ; CHECK-LABEL: fun20_localDst:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    aghi %r15, -184
@@ -411,7 +411,7 @@ define void @fun20_localDst(ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun21(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun21(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun21:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lg %r0, 13(%r3)
@@ -423,7 +423,7 @@ define void @fun21(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun21_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun21_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun21_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(21,%r2), 0(%r3)
@@ -432,7 +432,7 @@ define void @fun21_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun22(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun22(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun22:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lg %r0, 14(%r3)
@@ -444,7 +444,7 @@ define void @fun22(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun22_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun22_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun22_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(22,%r2), 0(%r3)
@@ -453,7 +453,7 @@ define void @fun22_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun23(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun23(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun23:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lg %r0, 15(%r3)
@@ -465,7 +465,7 @@ define void @fun23(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun23_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun23_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun23_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(23,%r2), 0(%r3)
@@ -474,7 +474,7 @@ define void @fun23_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun24(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun24(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun24:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lg %r0, 16(%r3)
@@ -486,7 +486,7 @@ define void @fun24(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun24_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun24_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun24_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(24,%r2), 0(%r3)
@@ -495,7 +495,7 @@ define void @fun24_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun25(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun25(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun25:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(25,%r2), 0(%r3)
@@ -504,7 +504,7 @@ define void @fun25(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun25_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun25_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun25_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(25,%r2), 0(%r3)
@@ -513,7 +513,7 @@ define void @fun25_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun26(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun26(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun26:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(26,%r2), 0(%r3)
@@ -522,7 +522,7 @@ define void @fun26(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun26_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun26_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun26_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(26,%r2), 0(%r3)
@@ -531,7 +531,7 @@ define void @fun26_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun27(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun27(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun27:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(27,%r2), 0(%r3)
@@ -540,7 +540,7 @@ define void @fun27(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun27_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun27_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun27_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(27,%r2), 0(%r3)
@@ -549,7 +549,7 @@ define void @fun27_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun28(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun28(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun28:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(28,%r2), 0(%r3)
@@ -558,7 +558,7 @@ define void @fun28(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun28_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun28_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun28_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(28,%r2), 0(%r3)
@@ -567,7 +567,7 @@ define void @fun28_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun29(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun29(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun29:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(29,%r2), 0(%r3)
@@ -576,7 +576,7 @@ define void @fun29(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun29_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun29_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun29_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(29,%r2), 0(%r3)
@@ -585,7 +585,7 @@ define void @fun29_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun30(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun30(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun30:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(30,%r2), 0(%r3)
@@ -594,7 +594,7 @@ define void @fun30(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun30_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun30_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun30_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(30,%r2), 0(%r3)
@@ -603,7 +603,7 @@ define void @fun30_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun31(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun31(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun31:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(31,%r2), 0(%r3)
@@ -612,7 +612,7 @@ define void @fun31(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun31_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun31_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun31_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(31,%r2), 0(%r3)
@@ -621,7 +621,7 @@ define void @fun31_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun32(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun32(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 16(%r3), 3
@@ -633,7 +633,7 @@ define void @fun32(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun32_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun32_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun32_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(32,%r2), 0(%r3)
@@ -642,7 +642,7 @@ define void @fun32_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun33(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun33(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun33:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(33,%r2), 0(%r3)
@@ -651,7 +651,7 @@ define void @fun33(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun33_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun33_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun33_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mvc 0(33,%r2), 0(%r3)

--- a/llvm/test/CodeGen/SystemZ/memmove-01.ll
+++ b/llvm/test/CodeGen/SystemZ/memmove-01.ll
@@ -6,7 +6,7 @@
 
 declare void @llvm.memmove.p0.p0.i64(ptr nocapture, ptr nocapture, i64, i1) nounwind
 
-define void @fun1(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun1(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -22,7 +22,7 @@ define void @fun1(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun1_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun1_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun1_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -38,7 +38,7 @@ define void @fun1_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun2(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun2(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun2:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -54,7 +54,7 @@ define void @fun2(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun2_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun2_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun2_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -70,7 +70,7 @@ define void @fun2_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun3(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun3(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun3:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -86,7 +86,7 @@ define void @fun3(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun3_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun3_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun3_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -102,7 +102,7 @@ define void @fun3_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun4(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun4(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun4:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -118,7 +118,7 @@ define void @fun4(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun4_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun4_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun4_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -134,7 +134,7 @@ define void @fun4_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun5(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun5(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun5:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -150,7 +150,7 @@ define void @fun5(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun5_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun5_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun5_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -166,7 +166,7 @@ define void @fun5_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun6(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun6(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun6:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -182,7 +182,7 @@ define void @fun6(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun6_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun6_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun6_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -198,7 +198,7 @@ define void @fun6_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun7(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun7(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun7:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -214,7 +214,7 @@ define void @fun7(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun7_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun7_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun7_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -230,7 +230,7 @@ define void @fun7_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun8(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun8(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -246,7 +246,7 @@ define void @fun8(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun8_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun8_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun8_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -262,7 +262,7 @@ define void @fun8_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun9(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun9(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun9:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -278,7 +278,7 @@ define void @fun9(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun9_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun9_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun9_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -294,7 +294,7 @@ define void @fun9_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun10(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun10(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun10:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -310,7 +310,7 @@ define void @fun10(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun10_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun10_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun10_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -326,7 +326,7 @@ define void @fun10_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun11(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun11(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun11:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -342,7 +342,7 @@ define void @fun11(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun11_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun11_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun11_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -358,7 +358,7 @@ define void @fun11_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun12(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun12(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun12:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -374,7 +374,7 @@ define void @fun12(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun12_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun12_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun12_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -390,7 +390,7 @@ define void @fun12_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun13(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun13(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun13:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -406,7 +406,7 @@ define void @fun13(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun13_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun13_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun13_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -422,7 +422,7 @@ define void @fun13_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun14(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun14(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun14:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -438,7 +438,7 @@ define void @fun14(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun14_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun14_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun14_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -454,7 +454,7 @@ define void @fun14_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun15(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun15(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun15:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -470,7 +470,7 @@ define void @fun15(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun15_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun15_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun15_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -486,7 +486,7 @@ define void @fun15_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun16(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun16(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -502,7 +502,7 @@ define void @fun16(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun16_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun16_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun16_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -518,7 +518,7 @@ define void @fun16_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lb %r0, 16(%r3)
@@ -530,7 +530,7 @@ define void @fun17(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -546,7 +546,7 @@ define void @fun17_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun17_unalignedSrc(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun17_unalignedSrc(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun17_unalignedSrc:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -562,7 +562,7 @@ define void @fun17_unalignedSrc(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    lh %r0, 16(%r3)
@@ -574,7 +574,7 @@ define void @fun18(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -590,7 +590,7 @@ define void @fun18_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun18_unalignedDst(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun18_unalignedDst(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun18_unalignedDst:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -606,7 +606,7 @@ define void @fun18_unalignedDst(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun19(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun19(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun19:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -618,7 +618,7 @@ define void @fun19(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun19_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun19_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun19_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -634,7 +634,7 @@ define void @fun19_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun20(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun20:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -646,7 +646,7 @@ define void @fun20(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun20_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun20_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -662,7 +662,7 @@ define void @fun20_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun20_localDst(ptr %Src, i8 %val) {
+define void @fun20_localDst(ptr %Src) {
 ; CHECK-LABEL: fun20_localDst:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    aghi %r15, -184
@@ -677,7 +677,7 @@ define void @fun20_localDst(ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun21(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun21(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun21:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -689,7 +689,7 @@ define void @fun21(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun21_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun21_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun21_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -705,7 +705,7 @@ define void @fun21_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun22(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun22(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun22:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -717,7 +717,7 @@ define void @fun22(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun22_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun22_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun22_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -733,7 +733,7 @@ define void @fun22_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun23(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun23(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun23:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -745,7 +745,7 @@ define void @fun23(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun23_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun23_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun23_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -761,7 +761,7 @@ define void @fun23_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun24(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun24(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun24:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -773,7 +773,7 @@ define void @fun24(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun24_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun24_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun24_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -789,7 +789,7 @@ define void @fun24_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun25(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun25(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun25:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -805,7 +805,7 @@ define void @fun25(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun25_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun25_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun25_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -821,7 +821,7 @@ define void @fun25_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun26(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun26(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun26:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -837,7 +837,7 @@ define void @fun26(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun26_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun26_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun26_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -853,7 +853,7 @@ define void @fun26_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun27(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun27(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun27:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -869,7 +869,7 @@ define void @fun27(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun27_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun27_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun27_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -885,7 +885,7 @@ define void @fun27_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun28(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun28(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun28:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -901,7 +901,7 @@ define void @fun28(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun28_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun28_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun28_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -917,7 +917,7 @@ define void @fun28_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun29(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun29(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun29:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -933,7 +933,7 @@ define void @fun29(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun29_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun29_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun29_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -949,7 +949,7 @@ define void @fun29_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun30(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun30(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun30:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -965,7 +965,7 @@ define void @fun30(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun30_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun30_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun30_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -981,7 +981,7 @@ define void @fun30_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun31(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun31(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun31:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -997,7 +997,7 @@ define void @fun31(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun31_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun31_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun31_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -1013,7 +1013,7 @@ define void @fun31_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun32(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun32(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vl %v0, 0(%r3), 3
@@ -1025,7 +1025,7 @@ define void @fun32(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun32_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun32_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun32_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -1041,7 +1041,7 @@ define void @fun32_unaligned(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun33(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun33(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun33:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)
@@ -1057,7 +1057,7 @@ define void @fun33(ptr %Dst, ptr %Src, i8 %val) {
   ret void
 }
 
-define void @fun33_unaligned(ptr %Dst, ptr %Src, i8 %val) {
+define void @fun33_unaligned(ptr %Dst, ptr %Src) {
 ; CHECK-LABEL: fun33_unaligned:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    stmg %r14, %r15, 112(%r15)


### PR DESCRIPTION
The third %val argument only makes sense for memset, so remove from memcpy/memmove tests.