### PR TITLE
[AArch64][SVE] Use truncating stores whenever possible

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23900,25 +23900,25 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   if (T1.getOpcode() != ISD::TRUNCATE || T2.getOpcode() != ISD::TRUNCATE)
     return SDValue();
 
-  if (!T1.getValueType().isFixedLengthVector())
+  EVT LoMemVT = T1.getValueType();
+  EVT HiMemVT = T2.getValueType();
+  if (!LoMemVT.isFixedLengthVector())
     return SDValue();
 
   if (!T1.hasOneUse() || !T2.hasOneUse())
     return SDValue();
 
-  EVT LoMemVT = T1.getValueType();
-  EVT HiMemVT = T2.getValueType();
   unsigned LoBytes = LoMemVT.getStoreSize();
   unsigned HiBytes = HiMemVT.getStoreSize();
   Align LoAlign = ST->getAlign();
   Align HiAlign = commonAlignment(LoAlign, LoBytes);
 
-  if (!TLI.canCombineTruncStore(T1.getOperand(0).getValueType(),
-                                T1.getValueType(), LoAlign,
-                                ST->getAddressSpace(), LegalOperations) ||
-      !TLI.canCombineTruncStore(T2.getOperand(0).getValueType(),
-                                T2.getValueType(), HiAlign,
-                                ST->getAddressSpace(), LegalOperations))
+  if (!TLI.canCombineTruncStore(T1.getOperand(0).getValueType(), LoMemVT,
+                                LoAlign, ST->getAddressSpace(),
+                                LegalOperations) ||
+      !TLI.canCombineTruncStore(T2.getOperand(0).getValueType(), HiMemVT,
+                                HiAlign, ST->getAddressSpace(),
+                                LegalOperations))
     return SDValue();
 
   SDLoc DL(ST);
@@ -23932,10 +23932,10 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   MachineMemOperand *HiMMO =
       MF.getMachineMemOperand(ST->getMemOperand(), LoBytes, HiBytes);
 
-  SDValue LoSt = DAG.getTruncStore(Chain, DL, T1.getOperand(0), LoPtr,
-                                   T1.getValueType(), LoMMO);
-  SDValue HiSt = DAG.getTruncStore(Chain, DL, T2.getOperand(0), HiPtr,
-                                   T2.getValueType(), HiMMO);
+  SDValue LoSt =
+      DAG.getTruncStore(Chain, DL, T1.getOperand(0), LoPtr, LoMemVT, LoMMO);
+  SDValue HiSt =
+      DAG.getTruncStore(Chain, DL, T2.getOperand(0), HiPtr, HiMemVT, HiMMO);
 
   return DAG.getNode(ISD::TokenFactor, DL, MVT::Other, LoSt, HiSt);
 }

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -537,7 +537,7 @@ namespace {
     SDValue replaceStoreOfInsertLoad(StoreSDNode *ST);
 
     bool refineExtractVectorEltIntoMultipleNarrowExtractVectorElts(SDNode *N);
-
+    SDValue combineStoreConcatTruncVector(StoreSDNode *N);
     SDValue visitSTORE(SDNode *N);
     SDValue visitATOMIC_STORE(SDNode *N);
     SDValue visitLIFETIME_END(SDNode *N);
@@ -23878,6 +23878,74 @@ static SDValue foldToMaskedStore(StoreSDNode *Store, SelectionDAG &DAG,
                             Store->getAddressingMode());
 }
 
+// store(concat_vector(truncate, truncate))
+// --> store(truncate)
+//     store(truncate)
+SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
+  if (!LegalTypes)
+    return SDValue();
+
+  if (ST->isTruncatingStore() || ST->isIndexed())
+    return SDValue();
+
+  SDValue Chain = ST->getChain();
+  SDValue Value = ST->getValue();
+  SDValue Ptr = ST->getBasePtr();
+
+  unsigned Opc = Value.getOpcode();
+  if (Opc != ISD::CONCAT_VECTORS)
+    return SDValue();
+
+  SDValue T1 = Value.getOperand(0);
+  SDValue T2 = Value.getOperand(1);
+  if (T1.getOpcode() != ISD::TRUNCATE || T2.getOpcode() != ISD::TRUNCATE)
+    return SDValue();
+
+  if (!T1.getValueType().isFixedLengthVector())
+    return SDValue();
+
+  if (!T1->hasOneUse() || !T2.hasOneUse())
+    return SDValue();
+
+  EVT LoVT = T1.getOperand(0).getValueType();
+  EVT HiVT = T2.getOperand(0).getValueType();
+  EVT LoMemVT = T1.getValueType();
+  EVT HiMemVT = T2.getValueType();
+  unsigned LoBytes = LoMemVT.getStoreSize();
+  unsigned HiBytes = HiMemVT.getStoreSize();
+  Align LoAlign = ST->getAlign();
+  Align HiAlign = commonAlignment(LoAlign, LoBytes);
+
+  if (!TLI.canCombineTruncStore(T1.getOperand(0).getValueType(),
+                                T1.getValueType(), LoAlign,
+                                ST->getAddressSpace(), LegalOperations))
+    return SDValue();
+
+  if (!TLI.canCombineTruncStore(T2.getOperand(0).getValueType(),
+                                T2.getValueType(), HiAlign,
+                                ST->getAddressSpace(), LegalOperations))
+    return SDValue();
+
+  SDLoc DL(ST);
+  SDValue LoPtr = Ptr;
+  SDValue HiPtr =
+      DAG.getMemBasePlusOffset(LoPtr, TypeSize::getFixed(LoBytes), DL);
+
+  MachinePointerInfo LoPI = ST->getPointerInfo();
+  MachinePointerInfo HiPI = ST->getPointerInfo().getWithOffset(LoBytes);
+
+  MachineFunction &MF = DAG.getMachineFunction();
+  MachineMemOperand *LoMMO =
+      MF.getMachineMemOperand(ST->getMemOperand(), 0, LoBytes);
+  MachineMemOperand *HiMMO =
+      MF.getMachineMemOperand(ST->getMemOperand(), LoBytes, HiBytes);
+
+  SDValue LoSt = DAG.getStore(Chain, DL, T1, LoPtr, LoMMO);
+  SDValue HiSt = DAG.getStore(Chain, DL, T2, HiPtr, HiMMO);
+
+  return DAG.getNode(ISD::TokenFactor, DL, MVT::Other, LoSt, HiSt);
+}
+
 SDValue DAGCombiner::visitSTORE(SDNode *N) {
   StoreSDNode *ST  = cast<StoreSDNode>(N);
   SDValue Chain = ST->getChain();
@@ -23944,6 +24012,9 @@ SDValue DAGCombiner::visitSTORE(SDNode *N) {
     }
     Chain = ST->getChain();
   }
+
+  if (SDValue R = combineStoreConcatTruncVector(ST))
+    return R;
 
   // FIXME: is there such a thing as a truncating indexed store?
   if (ST->isTruncatingStore() && ST->isUnindexed() &&

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23890,7 +23890,6 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
 
   SDValue Chain = ST->getChain();
   SDValue Value = ST->getValue();
-  SDValue Ptr = ST->getBasePtr();
 
   unsigned Opc = Value.getOpcode();
   if (Opc != ISD::CONCAT_VECTORS)
@@ -23907,8 +23906,6 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   if (!T1->hasOneUse() || !T2.hasOneUse())
     return SDValue();
 
-  EVT LoVT = T1.getOperand(0).getValueType();
-  EVT HiVT = T2.getOperand(0).getValueType();
   EVT LoMemVT = T1.getValueType();
   EVT HiMemVT = T2.getValueType();
   unsigned LoBytes = LoMemVT.getStoreSize();
@@ -23918,21 +23915,16 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
 
   if (!TLI.canCombineTruncStore(T1.getOperand(0).getValueType(),
                                 T1.getValueType(), LoAlign,
-                                ST->getAddressSpace(), LegalOperations))
-    return SDValue();
-
-  if (!TLI.canCombineTruncStore(T2.getOperand(0).getValueType(),
+                                ST->getAddressSpace(), LegalOperations) ||
+      !TLI.canCombineTruncStore(T2.getOperand(0).getValueType(),
                                 T2.getValueType(), HiAlign,
                                 ST->getAddressSpace(), LegalOperations))
     return SDValue();
 
   SDLoc DL(ST);
-  SDValue LoPtr = Ptr;
+  SDValue LoPtr = ST->getBasePtr();
   SDValue HiPtr =
       DAG.getMemBasePlusOffset(LoPtr, TypeSize::getFixed(LoBytes), DL);
-
-  MachinePointerInfo LoPI = ST->getPointerInfo();
-  MachinePointerInfo HiPI = ST->getPointerInfo().getWithOffset(LoBytes);
 
   MachineFunction &MF = DAG.getMachineFunction();
   MachineMemOperand *LoMMO =

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23885,14 +23885,15 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   if (!LegalTypes)
     return SDValue();
 
-  if (ST->isTruncatingStore() || ST->isIndexed())
+  if (!ST->isSimple() || ST->isTruncatingStore() || ST->isIndexed())
     return SDValue();
 
   SDValue Chain = ST->getChain();
   SDValue Value = ST->getValue();
 
   unsigned Opc = Value.getOpcode();
-  if (Opc != ISD::CONCAT_VECTORS)
+  if (Opc != ISD::CONCAT_VECTORS || Value.getNumOperands() != 2 ||
+      !Value->hasOneUse())
     return SDValue();
 
   SDValue T1 = Value.getOperand(0);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -23889,22 +23889,21 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
     return SDValue();
 
   SDValue Chain = ST->getChain();
-  SDValue Value = ST->getValue();
+  SDValue ConcatVec = ST->getValue();
 
-  unsigned Opc = Value.getOpcode();
-  if (Opc != ISD::CONCAT_VECTORS || Value.getNumOperands() != 2 ||
-      !Value->hasOneUse())
+  if (ConcatVec.getOpcode() != ISD::CONCAT_VECTORS ||
+      ConcatVec.getNumOperands() != 2 || !ConcatVec->hasOneUse())
     return SDValue();
 
-  SDValue T1 = Value.getOperand(0);
-  SDValue T2 = Value.getOperand(1);
+  SDValue T1 = ConcatVec.getOperand(0);
+  SDValue T2 = ConcatVec.getOperand(1);
   if (T1.getOpcode() != ISD::TRUNCATE || T2.getOpcode() != ISD::TRUNCATE)
     return SDValue();
 
   if (!T1.getValueType().isFixedLengthVector())
     return SDValue();
 
-  if (!T1->hasOneUse() || !T2.hasOneUse())
+  if (!T1.hasOneUse() || !T2.hasOneUse())
     return SDValue();
 
   EVT LoMemVT = T1.getValueType();
@@ -23925,7 +23924,7 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   SDLoc DL(ST);
   SDValue LoPtr = ST->getBasePtr();
   SDValue HiPtr =
-      DAG.getMemBasePlusOffset(LoPtr, TypeSize::getFixed(LoBytes), DL);
+      DAG.getObjectPtrOffset(DL, LoPtr, TypeSize::getFixed(LoBytes));
 
   MachineFunction &MF = DAG.getMachineFunction();
   MachineMemOperand *LoMMO =
@@ -23933,14 +23932,16 @@ SDValue DAGCombiner::combineStoreConcatTruncVector(StoreSDNode *ST) {
   MachineMemOperand *HiMMO =
       MF.getMachineMemOperand(ST->getMemOperand(), LoBytes, HiBytes);
 
-  SDValue LoSt = DAG.getStore(Chain, DL, T1, LoPtr, LoMMO);
-  SDValue HiSt = DAG.getStore(Chain, DL, T2, HiPtr, HiMMO);
+  SDValue LoSt = DAG.getTruncStore(Chain, DL, T1.getOperand(0), LoPtr,
+                                   T1.getValueType(), LoMMO);
+  SDValue HiSt = DAG.getTruncStore(Chain, DL, T2.getOperand(0), HiPtr,
+                                   T2.getValueType(), HiMMO);
 
   return DAG.getNode(ISD::TokenFactor, DL, MVT::Other, LoSt, HiSt);
 }
 
 SDValue DAGCombiner::visitSTORE(SDNode *N) {
-  StoreSDNode *ST  = cast<StoreSDNode>(N);
+  StoreSDNode *ST = cast<StoreSDNode>(N);
   SDValue Chain = ST->getChain();
   SDValue Value = ST->getValue();
   SDValue Ptr   = ST->getBasePtr();

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-trunc-stores.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-trunc-stores.ll
@@ -92,12 +92,8 @@ define void @store_trunc_v8i64i16(ptr %ap, ptr %dest) #0 {
 ; VBITS_GE_256-NEXT:    mov x8, #4 // =0x4
 ; VBITS_GE_256-NEXT:    ld1d { z0.d }, p0/z, [x0, x8, lsl #3]
 ; VBITS_GE_256-NEXT:    ld1d { z1.d }, p0/z, [x0]
-; VBITS_GE_256-NEXT:    uzp1 z0.s, z0.s, z0.s
-; VBITS_GE_256-NEXT:    uzp1 z1.s, z1.s, z1.s
-; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
-; VBITS_GE_256-NEXT:    uzp1 z1.h, z1.h, z1.h
-; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
-; VBITS_GE_256-NEXT:    str q1, [x1]
+; VBITS_GE_256-NEXT:    st1h { z0.d }, p0, [x1, x8, lsl #1]
+; VBITS_GE_256-NEXT:    st1h { z1.d }, p0, [x1]
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: store_trunc_v8i64i16:
@@ -119,12 +115,8 @@ define void @store_trunc_v8i64i32(ptr %ap, ptr %dest) #0 {
 ; VBITS_GE_256-NEXT:    mov x8, #4 // =0x4
 ; VBITS_GE_256-NEXT:    ld1d { z0.d }, p0/z, [x0, x8, lsl #3]
 ; VBITS_GE_256-NEXT:    ld1d { z1.d }, p0/z, [x0]
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl4
-; VBITS_GE_256-NEXT:    uzp1 z0.s, z0.s, z0.s
-; VBITS_GE_256-NEXT:    uzp1 z1.s, z1.s, z1.s
-; VBITS_GE_256-NEXT:    splice z1.s, p0, z1.s, z0.s
-; VBITS_GE_256-NEXT:    ptrue p0.s, vl8
-; VBITS_GE_256-NEXT:    st1w { z1.s }, p0, [x1]
+; VBITS_GE_256-NEXT:    st1w { z0.d }, p0, [x1, x8, lsl #2]
+; VBITS_GE_256-NEXT:    st1w { z1.d }, p0, [x1]
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: store_trunc_v8i64i32:
@@ -147,12 +139,9 @@ define void @store_trunc_v16i32i8(ptr %ap, ptr %dest) #0 {
 ; VBITS_GE_256-NEXT:    mov x8, #8 // =0x8
 ; VBITS_GE_256-NEXT:    ld1w { z0.s }, p0/z, [x0, x8, lsl #2]
 ; VBITS_GE_256-NEXT:    ld1w { z1.s }, p0/z, [x0]
-; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
-; VBITS_GE_256-NEXT:    uzp1 z1.h, z1.h, z1.h
-; VBITS_GE_256-NEXT:    uzp1 z0.b, z0.b, z0.b
-; VBITS_GE_256-NEXT:    uzp1 z1.b, z1.b, z1.b
-; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
-; VBITS_GE_256-NEXT:    str q1, [x1]
+; VBITS_GE_256-NEXT:    mov w8, #8 // =0x8
+; VBITS_GE_256-NEXT:    st1b { z0.s }, p0, [x1, x8]
+; VBITS_GE_256-NEXT:    st1b { z1.s }, p0, [x1]
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: store_trunc_v16i32i8:
@@ -174,12 +163,8 @@ define void @store_trunc_v16i32i16(ptr %ap, ptr %dest) #0 {
 ; VBITS_GE_256-NEXT:    mov x8, #8 // =0x8
 ; VBITS_GE_256-NEXT:    ld1w { z0.s }, p0/z, [x0, x8, lsl #2]
 ; VBITS_GE_256-NEXT:    ld1w { z1.s }, p0/z, [x0]
-; VBITS_GE_256-NEXT:    ptrue p0.h, vl8
-; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
-; VBITS_GE_256-NEXT:    uzp1 z1.h, z1.h, z1.h
-; VBITS_GE_256-NEXT:    splice z1.h, p0, z1.h, z0.h
-; VBITS_GE_256-NEXT:    ptrue p0.h, vl16
-; VBITS_GE_256-NEXT:    st1h { z1.h }, p0, [x1]
+; VBITS_GE_256-NEXT:    st1h { z0.s }, p0, [x1, x8, lsl #1]
+; VBITS_GE_256-NEXT:    st1h { z1.s }, p0, [x1]
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: store_trunc_v16i32i16:
@@ -201,12 +186,9 @@ define void @store_trunc_v32i16i8(ptr %ap, ptr %dest) #0 {
 ; VBITS_GE_256-NEXT:    mov x8, #16 // =0x10
 ; VBITS_GE_256-NEXT:    ld1h { z0.h }, p0/z, [x0, x8, lsl #1]
 ; VBITS_GE_256-NEXT:    ld1h { z1.h }, p0/z, [x0]
-; VBITS_GE_256-NEXT:    ptrue p0.b, vl16
-; VBITS_GE_256-NEXT:    uzp1 z0.b, z0.b, z0.b
-; VBITS_GE_256-NEXT:    uzp1 z1.b, z1.b, z1.b
-; VBITS_GE_256-NEXT:    splice z1.b, p0, z1.b, z0.b
-; VBITS_GE_256-NEXT:    ptrue p0.b, vl32
-; VBITS_GE_256-NEXT:    st1b { z1.b }, p0, [x1]
+; VBITS_GE_256-NEXT:    mov w8, #16 // =0x10
+; VBITS_GE_256-NEXT:    st1b { z0.h }, p0, [x1, x8]
+; VBITS_GE_256-NEXT:    st1b { z1.h }, p0, [x1]
 ; VBITS_GE_256-NEXT:    ret
 ;
 ; VBITS_GE_512-LABEL: store_trunc_v32i16i8:

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-trunc-stores.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-trunc-stores.ll
@@ -85,7 +85,6 @@ define void @store_trunc_v32i64i8(ptr %ap, ptr %dest) vscale_range(16,0) #0 {
 }
 
 define void @store_trunc_v8i64i16(ptr %ap, ptr %dest) #0 {
-; Currently does not use the truncating store
 ; VBITS_GE_256-LABEL: store_trunc_v8i64i16:
 ; VBITS_GE_256:       // %bb.0:
 ; VBITS_GE_256-NEXT:    ptrue p0.d, vl4

--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-avx2.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-avx2.ll
@@ -1363,14 +1363,10 @@ define <4 x i16> @PR176951(<32 x i64> %shuffle, <16 x i16> %0, <16 x i1> %cmp) n
 ; X86-AVX512-NEXT:    subl $64, %esp
 ; X86-AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm3 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero,mem[8],zero,mem[9],zero,mem[10],zero,mem[11],zero,mem[12],zero,mem[13],zero,mem[14],zero,mem[15],zero
 ; X86-AVX512-NEXT:    vmovdqa64 8(%ebp), %zmm4
-; X86-AVX512-NEXT:    vpmovqd %zmm0, %ymm0
-; X86-AVX512-NEXT:    vpmovqd %zmm1, %ymm1
-; X86-AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; X86-AVX512-NEXT:    vpmovqd %zmm2, %ymm1
-; X86-AVX512-NEXT:    vpmovqd %zmm4, %ymm2
-; X86-AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
-; X86-AVX512-NEXT:    vmovdqa64 %zmm1, 64
-; X86-AVX512-NEXT:    vmovdqa64 %zmm0, 0
+; X86-AVX512-NEXT:    vpmovqd %zmm1, 32
+; X86-AVX512-NEXT:    vpmovqd %zmm0, 0
+; X86-AVX512-NEXT:    vpmovqd %zmm4, 96
+; X86-AVX512-NEXT:    vpmovqd %zmm2, 64
 ; X86-AVX512-NEXT:    vpsllw $15, %xmm3, %xmm0
 ; X86-AVX512-NEXT:    vpsraw $15, %xmm0, %xmm0
 ; X86-AVX512-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[10,11,u,u,8,9,8,9,6,7,u,u,10,11,14,15]
@@ -1420,14 +1416,10 @@ define <4 x i16> @PR176951(<32 x i64> %shuffle, <16 x i16> %0, <16 x i1> %cmp) n
 ;
 ; X64-AVX512-LABEL: PR176951:
 ; X64-AVX512:       # %bb.0:
-; X64-AVX512-NEXT:    vpmovqd %zmm0, %ymm0
-; X64-AVX512-NEXT:    vpmovqd %zmm1, %ymm1
-; X64-AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; X64-AVX512-NEXT:    vpmovqd %zmm2, %ymm1
-; X64-AVX512-NEXT:    vpmovqd %zmm3, %ymm2
-; X64-AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
-; X64-AVX512-NEXT:    vmovdqa64 %zmm1, 64
-; X64-AVX512-NEXT:    vmovdqa64 %zmm0, 0
+; X64-AVX512-NEXT:    vpmovqd %zmm1, 32
+; X64-AVX512-NEXT:    vpmovqd %zmm0, 0
+; X64-AVX512-NEXT:    vpmovqd %zmm3, 96
+; X64-AVX512-NEXT:    vpmovqd %zmm2, 64
 ; X64-AVX512-NEXT:    vpmovzxbw {{.*#+}} xmm0 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero
 ; X64-AVX512-NEXT:    vpsllw $15, %xmm0, %xmm0
 ; X64-AVX512-NEXT:    vpsraw $15, %xmm0, %xmm0


### PR DESCRIPTION
For fixed length SVE and fixed length vectors x/y, fold

```
store(concat_vector(truncate(x), truncate(y)))
-->  store(truncate(x))
     store(truncate(y))
```