### PR TITLE
[InstCombine] Fix vector icmp handling in alloc removal

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -3977,9 +3977,8 @@ Instruction *InstCombinerImpl::visitAllocSite(Instruction &MI) {
       Instruction *I = cast<Instruction>(&*User);
 
       if (ICmpInst *C = dyn_cast<ICmpInst>(I)) {
-        replaceInstUsesWith(*C,
-                            ConstantInt::get(Type::getInt1Ty(C->getContext()),
-                                             C->isFalseWhenEqual()));
+        replaceInstUsesWith(
+            *C, ConstantInt::get(C->getType(), C->isFalseWhenEqual()));
       } else if (auto *SI = dyn_cast<StoreInst>(I)) {
         for (auto *DVR : DVRs)
           if (DVR->isAddressOfVariable())

--- a/llvm/test/Transforms/InstCombine/compare-unescaped.ll
+++ b/llvm/test/Transforms/InstCombine/compare-unescaped.ll
@@ -395,6 +395,15 @@ define i1 @two_nonnull_mallocs_hidden() {
   ret i1 %cmp
 }
 
+define <4 x i1> @test_vector_icmp() {
+; CHECK-LABEL: @test_vector_icmp(
+; CHECK-NEXT:    ret <4 x i1> zeroinitializer
+;
+  %ptr = call ptr @malloc(i64 16)
+  %gep = getelementptr i8, ptr %ptr, <4 x i64> <i64 4, i64 8, i64 12, i64 16>
+  %cmp = icmp eq <4 x ptr> %gep, splat (ptr null)
+  ret <4 x i1> %cmp
+}
 
 !0 = !{}
 


### PR DESCRIPTION
A vector icmp can occur after #195486.