### PR TITLE
[DebugInfo][CodeView] Fix TypeTableCollection bounds check

### DIFF
--- a/llvm/lib/DebugInfo/CodeView/TypeTableCollection.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeTableCollection.cpp
@@ -52,7 +52,7 @@ StringRef TypeTableCollection::getTypeName(TypeIndex Index) {
 }
 
 bool TypeTableCollection::contains(TypeIndex Index) {
-  return Index.toArrayIndex() <= size();
+  return !Index.isSimple() && Index.toArrayIndex() < size();
 }
 
 uint32_t TypeTableCollection::size() { return Records.size(); }

--- a/llvm/unittests/DebugInfo/CodeView/RandomAccessVisitorTest.cpp
+++ b/llvm/unittests/DebugInfo/CodeView/RandomAccessVisitorTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h"
 #include "llvm/DebugInfo/CodeView/TypeRecord.h"
 #include "llvm/DebugInfo/CodeView/TypeRecordMapping.h"
+#include "llvm/DebugInfo/CodeView/TypeTableCollection.h"
 #include "llvm/DebugInfo/CodeView/TypeVisitorCallbacks.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryByteStream.h"
@@ -225,6 +226,20 @@ TEST_F(RandomAccessVisitorTest, MultipleVisits) {
   EXPECT_EQ(3u, TestState->Callbacks.count());
   for (const auto &I : enumerate(IndicesToVisit))
     EXPECT_TRUE(ValidateVisitedRecord(I.index(), I.value()));
+}
+
+TEST_F(RandomAccessVisitorTest, TypeTableCollectionDoesNotContainPastEnd) {
+  SmallVector<ArrayRef<uint8_t>> Records;
+  for (const CVType &Type : GlobalState->TypeVector)
+    Records.push_back(Type.data());
+  TypeTableCollection Types(Records);
+
+  EXPECT_TRUE(Types.contains(TypeIndex::fromArrayIndex(0)));
+  EXPECT_TRUE(Types.contains(
+      TypeIndex::fromArrayIndex(GlobalState->TypeVector.size() - 1)));
+  EXPECT_FALSE(Types.contains(
+      TypeIndex::fromArrayIndex(GlobalState->TypeVector.size())));
+  EXPECT_FALSE(Types.contains(TypeIndex::Int32()));
 }
 
 TEST_F(RandomAccessVisitorTest, DescendingWithinChunk) {


### PR DESCRIPTION
## Summary

`TypeTableCollection::contains()` had two issues:

- It used `Index.toArrayIndex() <= size()`, which incorrectly reported a one-past-the-end index as contained.
- It called `toArrayIndex()` unconditionally. `TypeIndex::toArrayIndex()` asserts `!isSimple()`, so passing a simple type index (e.g. `TypeIndex::Int32()`) would trip the assertion in builds with assertions enabled.

This change rejects simple types up front and tightens the bound to `<`, matching the contract used elsewhere in the file (e.g. `getNext()` and `getType()`, both of which use `< size()` / `< Records.size()`).

## Test plan

Added `RandomAccessVisitorTest.TypeTableCollectionDoesNotContainPastEnd` covering:
- the first record (in range)
- the last record (in range)
- one-past-the-end (out of range)
- a simple `TypeIndex::Int32()` (out of range, must not assert)

Run:

    build/unittests/DebugInfo/CodeView/DebugInfoCodeViewTests \
      --gtest_filter=RandomAccessVisitorTest.TypeTableCollectionDoesNotContainPastEnd
