### PR TITLE
[MC][DXContainer] Handle empty PSV index sequences

### DIFF
--- a/llvm/lib/MC/DXContainerPSVInfo.cpp
+++ b/llvm/lib/MC/DXContainerPSVInfo.cpp
@@ -20,11 +20,13 @@ static constexpr size_t npos = StringRef::npos;
 
 static size_t FindSequence(ArrayRef<uint32_t> Buffer,
                            ArrayRef<uint32_t> Sequence) {
+  if (Sequence.empty())
+    return 0;
   if (Buffer.size() < Sequence.size())
     return npos;
   for (size_t Idx = 0; Idx <= Buffer.size() - Sequence.size(); ++Idx) {
-    if (0 == memcmp(static_cast<const void *>(&Buffer[Idx]),
-                    static_cast<const void *>(Sequence.begin()),
+    if (0 == memcmp(static_cast<const void *>(Buffer.data() + Idx),
+                    static_cast<const void *>(Sequence.data()),
                     Sequence.size() * sizeof(uint32_t)))
       return Idx;
   }

--- a/llvm/unittests/Object/DXContainerTest.cpp
+++ b/llvm/unittests/Object/DXContainerTest.cpp
@@ -1296,3 +1296,34 @@ TEST(DXCFile, PSVv2EntryNameNotInStringTable) {
   EXPECT_EQ(StrTab.size(), 4u);
   EXPECT_TRUE(llvm::all_of(StrTab, [](char C) { return C == '\0'; }));
 }
+
+TEST(DXCFile, PSVSignatureElementEmptyIndices) {
+  mcdxbc::PSVRuntimeInfo PSV;
+  PSV.BaseData.ShaderStage =
+      static_cast<uint8_t>(Triple::EnvironmentType::Vertex - Triple::Pixel);
+  PSV.InputElements.push_back(
+      mcdxbc::PSVSignatureElement{"POSITION",
+                                  {},
+                                  0,
+                                  0,
+                                  0,
+                                  false,
+                                  dxbc::PSV::SemanticKind::Arbitrary,
+                                  dxbc::PSV::ComponentType::Float32,
+                                  dxbc::PSV::InterpolationMode::Linear,
+                                  0,
+                                  0});
+
+  PSV.finalize(Triple::EnvironmentType::Vertex, 1);
+
+  SmallVector<char> Buffer;
+  raw_svector_ostream OS(Buffer);
+  PSV.write(OS, 1);
+
+  DirectX::PSVRuntimeInfo ParsedPSV(StringRef(Buffer.data(), Buffer.size()));
+  ASSERT_THAT_ERROR(ParsedPSV.parse(static_cast<uint16_t>(
+                        Triple::EnvironmentType::Vertex - Triple::Pixel)),
+                    Succeeded());
+  ASSERT_EQ(ParsedPSV.getSigInputElements().size(), 1u);
+  EXPECT_EQ((*ParsedPSV.getSigInputElements().begin()).Rows, 0u);
+}


### PR DESCRIPTION
## Summary

`FindSequence()` in `DXContainerPSVInfo.cpp` formed pointers via `&Buffer[Idx]` and `Sequence.begin()`. Both are undefined behavior when the underlying `ArrayRef` is empty (or when `Idx == Buffer.size()` at the past-the-end iteration), even though the subsequent `memcmp` length is zero.

This patch:

- Returns `0` immediately when `Sequence` is empty, matching the conventional "empty pattern matches at position 0" semantics (cf. `std::search`). The caller in `ProcessElementList` writes `Rows = Indices.size()`, so a zero offset is harmless when the sequence is empty.
- Replaces `&Buffer[Idx]` / `Sequence.begin()` with `Buffer.data() + Idx` / `Sequence.data()`, which are well-defined for past-the-end pointer arithmetic and for empty containers.

No functional change for non-empty inputs.

## Test plan

Added `DXCFile.PSVSignatureElementEmptyIndices`, which builds a `PSVRuntimeInfo` containing an input signature element with no semantic indices, finalizes/writes it, parses it back, and verifies the round trip succeeds with `Rows == 0`.

Run:

    build/unittests/Object/ObjectTests \
      --gtest_filter=DXCFile.PSVSignatureElementEmptyIndices
