### PR TITLE
[gn] Fix a benign bug in write_cmake_config.py

### DIFF
--- a/llvm/utils/gn/build/write_cmake_config.py
+++ b/llvm/utils/gn/build/write_cmake_config.py
@@ -109,7 +109,7 @@ def main():
         return 1
 
     def read(filename):
-        with open(args.output) as f:
+        with open(filename) as f:
             return f.read()
 
     if not os.path.exists(args.output) or read(args.output) != output:


### PR DESCRIPTION
A local read() function was ignoring its parameter and was instead always using the value that was passed in as parameter anyways.

No actual behavior change.