### PR TITLE
[gn] Run `uvx black llvm/utils/gn/build/sync_source_dir.py`

### DIFF
--- a/llvm/utils/gn/build/sync_source_dir.py
+++ b/llvm/utils/gn/build/sync_source_dir.py
@@ -19,14 +19,14 @@ def read(filename):
 
 def main():
     parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--stamp", required=True,
-                        help="name of a file whose mtime is updated on run")
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--stamp", required=True, help="name of a file whose mtime is updated on run"
+    )
     parser.add_argument("--source-dir", required=True)
     parser.add_argument("--output-dir", required=True)
-    parser.add_argument("--except", dest="exceptions", action="append",
-                        default=[])
+    parser.add_argument("--except", dest="exceptions", action="append", default=[])
     parser.add_argument("rspfile")
     args = parser.parse_args()
 


### PR DESCRIPTION
Apparently "Check code formatting" doesn't block submission. Follow-up to #195948.