### PR TITLE
[RegAllocFast] Eliminate dead copies

### DIFF
--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -1715,9 +1715,11 @@ void RegAllocFastImpl::allocateInstruction(MachineInstr &MI) {
   }
 
   LLVM_DEBUG(dbgs() << "<< " << MI);
-  if (MI.isCopy() && MI.getOperand(0).getReg() == MI.getOperand(1).getReg() &&
+  if (MI.isCopy() &&
+      (MI.getOperand(0).getReg() == MI.getOperand(1).getReg() ||
+       MI.getOperand(0).isDead()) &&
       MI.getNumOperands() == 2) {
-    LLVM_DEBUG(dbgs() << "Mark identity copy for removal\n");
+    LLVM_DEBUG(dbgs() << "Mark unnecessary copy for removal: " << MI);
     Coalesced.push_back(&MI);
   }
 }

--- a/llvm/test/CodeGen/AArch64/fast-isel-atomic-fallback.ll
+++ b/llvm/test/CodeGen/AArch64/fast-isel-atomic-fallback.ll
@@ -36,7 +36,6 @@ define i32 @cmpxchg_cstexpr_addr(i32 %cmp, i32 %new, ptr %ps) #0 {
 ; CHECK-NEXT:  LBB1_3:
 ; CHECK-NEXT:    subs w8, w0, w8
 ; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    ; kill: def $w1 killed $w8
 ; CHECK-NEXT:    str w8, [x2]
 ; CHECK-NEXT:    ret
   %tmp0 = cmpxchg ptr inttoptr (i32 ptrtoint (ptr @g to i32) to ptr), i32 %cmp, i32 %new seq_cst seq_cst

--- a/llvm/test/CodeGen/AArch64/swifterror.ll
+++ b/llvm/test/CodeGen/AArch64/swifterror.ll
@@ -183,7 +183,6 @@ define float @caller(ptr %error_ref) {
 ; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #8] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #16] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
-; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB1_2: ; %handler
 ; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #16] ; 8-byte Reload
@@ -368,7 +367,6 @@ define float @caller2(ptr %error_ref) {
 ; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
-; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB2_4: ; %handler
 ; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
@@ -606,7 +604,6 @@ define float @foo_loop(ptr swifterror %error_ptr_ref, i32 %cc, float %cc2) {
 ; CHECK-O0-ARM64_32-NEXT:    mov w0, w8
 ; CHECK-O0-ARM64_32-NEXT:    bl _malloc
 ; CHECK-O0-ARM64_32-NEXT:    mov x9, x0
-; CHECK-O0-ARM64_32-NEXT:    ; kill: def $x0 killed $x9
 ; CHECK-O0-ARM64_32-NEXT:    mov x0, x9
 ; CHECK-O0-ARM64_32-NEXT:    mov w8, #1 ; =0x1
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9, #8]
@@ -863,7 +860,6 @@ define float @caller3(ptr %error_ref) {
 ; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #8] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
-; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB6_2: ; %handler
 ; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #8] ; 8-byte Reload
@@ -1223,7 +1219,6 @@ define float @caller4(ptr %error_ref) {
 ; CHECK-O0-ARM64_32-NEXT:    ldr x9, [sp, #16] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldr x8, [sp, #24] ; 8-byte Reload
 ; CHECK-O0-ARM64_32-NEXT:    ldrb w8, [x8, #8]
-; CHECK-O0-ARM64_32-NEXT:    ; kill: def $w0 killed $w8
 ; CHECK-O0-ARM64_32-NEXT:    strb w8, [x9]
 ; CHECK-O0-ARM64_32-NEXT:  LBB8_2: ; %handler
 ; CHECK-O0-ARM64_32-NEXT:    ldr x0, [sp, #24] ; 8-byte Reload

--- a/llvm/test/CodeGen/AMDGPU/div_i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/div_i128.ll
@@ -1417,29 +1417,23 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_writelane_b32 v31, s8, 0
 ; GFX9-G-O0-NEXT:    v_writelane_b32 v31, s9, 1
 ; GFX9-G-O0-NEXT:    s_mov_b64 s[6:7], 0x7f
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr0_vgpr1 killed $vgpr3_vgpr4 killed $exec
 ; GFX9-G-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v5
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v1, v6
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9-G-O0-NEXT:    v_ashrrev_i32_e64 v11, v2, v7
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-G-O0-NEXT:    v_ashrrev_i32_e64 v9, v0, v1
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr0_vgpr1 killed $vgpr12_vgpr13 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v14
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v1, v15
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9-G-O0-NEXT:    v_ashrrev_i32_e64 v10, v2, v7
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s4
@@ -1702,7 +1696,6 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[9:10], v0, v[2:3]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[0:1], v0, v[4:5]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr2 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr3 killed $vgpr3 killed $vgpr2_vgpr3 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s4
@@ -1811,7 +1804,6 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[2:3], v2, v[0:1]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v4, s10
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[4:5], v4, v[14:15]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr7 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s11, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s11
@@ -1819,10 +1811,8 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr5 killed $vgpr5 killed $vgpr4_vgpr5 killed $exec
 ; GFX9-G-O0-NEXT:    v_or_b32_e64 v7, v0, v1
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr0_vgpr1 killed $vgpr22_vgpr23 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v24
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v1, v25
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s11, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s11
@@ -1838,7 +1828,6 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[25:26], v0, v[2:3]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s10
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[0:1], v0, v[14:15]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr14 killed $vgpr2 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr3 killed $vgpr3 killed $vgpr2_vgpr3 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s10, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s10
@@ -3746,7 +3735,6 @@ define i128 @v_udiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[9:10], v0, v[2:3]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[0:1], v0, v[4:5]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr2 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr3 killed $vgpr3 killed $vgpr2_vgpr3 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s4
@@ -3855,7 +3843,6 @@ define i128 @v_udiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[2:3], v2, v[0:1]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v4, s10
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[4:5], v4, v[20:21]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr7 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s11, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s11
@@ -3863,10 +3850,8 @@ define i128 @v_udiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr5 killed $vgpr5 killed $vgpr4_vgpr5 killed $exec
 ; GFX9-G-O0-NEXT:    v_or_b32_e64 v7, v0, v1
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr0_vgpr1 killed $vgpr12_vgpr13 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v14
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v1, v15
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s11, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s11
@@ -3882,7 +3867,6 @@ define i128 @v_udiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[22:23], v0, v[2:3]
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s10
 ; GFX9-G-O0-NEXT:    v_lshlrev_b64 v[0:1], v0, v[12:13]
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr12 killed $vgpr2 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr3 killed $vgpr3 killed $vgpr2_vgpr3 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s10, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v2, s10
@@ -4395,10 +4379,8 @@ define i128 @v_sdiv_i128_v_pow2k(i128 %lhs) {
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v10, v2
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v11, v3
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr0_vgpr1 killed $vgpr8_vgpr9 killed $exec
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, v10
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v1, v11
-; GFX9-G-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr0 killed $exec
 ; GFX9-G-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr0_vgpr1 killed $exec
 ; GFX9-G-O0-NEXT:    s_mov_b32 s4, 31
 ; GFX9-G-O0-NEXT:    v_mov_b32_e32 v0, s4

--- a/llvm/test/CodeGen/AMDGPU/extract_vector_dynelt.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract_vector_dynelt.ll
@@ -2810,7 +2810,7 @@ define float @float32_extelt_vec(i32 %sel) {
 ; GCN-O0:       ; %bb.0: ; %entry
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v63, off, s[0:3], s32 offset:204 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v63, off, s[0:3], s32 offset:200 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -2972,7 +2972,6 @@ define float @float32_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v63, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v63, 3
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:196 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
@@ -3012,7 +3011,6 @@ define float @float32_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:200 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:196 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v63, s6, 2
@@ -3031,7 +3029,7 @@ define float @float32_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v63, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:200 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:196 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v62, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
@@ -3048,7 +3046,7 @@ define float @float32_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:204 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:200 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -3132,25 +3130,25 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0:       ; %bb.0: ; %entry
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:284 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:288 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:276 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:280 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v34, s36, 0
-; GCN-O0-NEXT:    v_writelane_b32 v34, s37, 1
-; GCN-O0-NEXT:    v_writelane_b32 v34, s38, 2
-; GCN-O0-NEXT:    v_writelane_b32 v34, s39, 3
-; GCN-O0-NEXT:    v_writelane_b32 v34, s48, 4
-; GCN-O0-NEXT:    v_writelane_b32 v34, s49, 5
-; GCN-O0-NEXT:    v_writelane_b32 v34, s50, 6
-; GCN-O0-NEXT:    v_writelane_b32 v34, s51, 7
-; GCN-O0-NEXT:    v_writelane_b32 v34, s52, 8
-; GCN-O0-NEXT:    v_writelane_b32 v34, s53, 9
-; GCN-O0-NEXT:    v_writelane_b32 v34, s54, 10
-; GCN-O0-NEXT:    v_writelane_b32 v34, s55, 11
-; GCN-O0-NEXT:    v_writelane_b32 v34, s64, 12
-; GCN-O0-NEXT:    v_writelane_b32 v34, s65, 13
-; GCN-O0-NEXT:    v_writelane_b32 v34, s66, 14
-; GCN-O0-NEXT:    v_writelane_b32 v34, s67, 15
+; GCN-O0-NEXT:    v_writelane_b32 v33, s36, 0
+; GCN-O0-NEXT:    v_writelane_b32 v33, s37, 1
+; GCN-O0-NEXT:    v_writelane_b32 v33, s38, 2
+; GCN-O0-NEXT:    v_writelane_b32 v33, s39, 3
+; GCN-O0-NEXT:    v_writelane_b32 v33, s48, 4
+; GCN-O0-NEXT:    v_writelane_b32 v33, s49, 5
+; GCN-O0-NEXT:    v_writelane_b32 v33, s50, 6
+; GCN-O0-NEXT:    v_writelane_b32 v33, s51, 7
+; GCN-O0-NEXT:    v_writelane_b32 v33, s52, 8
+; GCN-O0-NEXT:    v_writelane_b32 v33, s53, 9
+; GCN-O0-NEXT:    v_writelane_b32 v33, s54, 10
+; GCN-O0-NEXT:    v_writelane_b32 v33, s55, 11
+; GCN-O0-NEXT:    v_writelane_b32 v33, s64, 12
+; GCN-O0-NEXT:    v_writelane_b32 v33, s65, 13
+; GCN-O0-NEXT:    v_writelane_b32 v33, s66, 14
+; GCN-O0-NEXT:    v_writelane_b32 v33, s67, 15
 ; GCN-O0-NEXT:    s_mov_b32 s4, 0x40301999
 ; GCN-O0-NEXT:    s_mov_b32 s40, 0x9999999a
 ; GCN-O0-NEXT:    s_mov_b32 s6, s40
@@ -3159,8 +3157,8 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_mov_b32 s5, s6
 ; GCN-O0-NEXT:    s_mov_b32 s6, 0x402e3333
 ; GCN-O0-NEXT:    s_mov_b32 s22, 0x33333333
-; GCN-O0-NEXT:    ; implicit-def: $vgpr35 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v35, s22, 0
+; GCN-O0-NEXT:    ; implicit-def: $vgpr34 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v34, s22, 0
 ; GCN-O0-NEXT:    s_mov_b32 s8, s22
 ; GCN-O0-NEXT:    s_mov_b32 s9, s6
 ; GCN-O0-NEXT:    s_mov_b32 s6, s9
@@ -3269,38 +3267,38 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_mov_b32 s65, s6
 ; GCN-O0-NEXT:    s_mov_b32 s66, s5
 ; GCN-O0-NEXT:    s_mov_b32 s67, s4
-; GCN-O0-NEXT:    v_writelane_b32 v35, s36, 1
-; GCN-O0-NEXT:    v_writelane_b32 v35, s37, 2
-; GCN-O0-NEXT:    v_writelane_b32 v35, s38, 3
-; GCN-O0-NEXT:    v_writelane_b32 v35, s39, 4
-; GCN-O0-NEXT:    v_writelane_b32 v35, s40, 5
-; GCN-O0-NEXT:    v_writelane_b32 v35, s41, 6
-; GCN-O0-NEXT:    v_writelane_b32 v35, s42, 7
-; GCN-O0-NEXT:    v_writelane_b32 v35, s43, 8
-; GCN-O0-NEXT:    v_writelane_b32 v35, s44, 9
-; GCN-O0-NEXT:    v_writelane_b32 v35, s45, 10
-; GCN-O0-NEXT:    v_writelane_b32 v35, s46, 11
-; GCN-O0-NEXT:    v_writelane_b32 v35, s47, 12
-; GCN-O0-NEXT:    v_writelane_b32 v35, s48, 13
-; GCN-O0-NEXT:    v_writelane_b32 v35, s49, 14
-; GCN-O0-NEXT:    v_writelane_b32 v35, s50, 15
-; GCN-O0-NEXT:    v_writelane_b32 v35, s51, 16
-; GCN-O0-NEXT:    v_writelane_b32 v35, s52, 17
-; GCN-O0-NEXT:    v_writelane_b32 v35, s53, 18
-; GCN-O0-NEXT:    v_writelane_b32 v35, s54, 19
-; GCN-O0-NEXT:    v_writelane_b32 v35, s55, 20
-; GCN-O0-NEXT:    v_writelane_b32 v35, s56, 21
-; GCN-O0-NEXT:    v_writelane_b32 v35, s57, 22
-; GCN-O0-NEXT:    v_writelane_b32 v35, s58, 23
-; GCN-O0-NEXT:    v_writelane_b32 v35, s59, 24
-; GCN-O0-NEXT:    v_writelane_b32 v35, s60, 25
-; GCN-O0-NEXT:    v_writelane_b32 v35, s61, 26
-; GCN-O0-NEXT:    v_writelane_b32 v35, s62, 27
-; GCN-O0-NEXT:    v_writelane_b32 v35, s63, 28
-; GCN-O0-NEXT:    v_writelane_b32 v35, s64, 29
-; GCN-O0-NEXT:    v_writelane_b32 v35, s65, 30
-; GCN-O0-NEXT:    v_writelane_b32 v35, s66, 31
-; GCN-O0-NEXT:    v_writelane_b32 v35, s67, 32
+; GCN-O0-NEXT:    v_writelane_b32 v34, s36, 1
+; GCN-O0-NEXT:    v_writelane_b32 v34, s37, 2
+; GCN-O0-NEXT:    v_writelane_b32 v34, s38, 3
+; GCN-O0-NEXT:    v_writelane_b32 v34, s39, 4
+; GCN-O0-NEXT:    v_writelane_b32 v34, s40, 5
+; GCN-O0-NEXT:    v_writelane_b32 v34, s41, 6
+; GCN-O0-NEXT:    v_writelane_b32 v34, s42, 7
+; GCN-O0-NEXT:    v_writelane_b32 v34, s43, 8
+; GCN-O0-NEXT:    v_writelane_b32 v34, s44, 9
+; GCN-O0-NEXT:    v_writelane_b32 v34, s45, 10
+; GCN-O0-NEXT:    v_writelane_b32 v34, s46, 11
+; GCN-O0-NEXT:    v_writelane_b32 v34, s47, 12
+; GCN-O0-NEXT:    v_writelane_b32 v34, s48, 13
+; GCN-O0-NEXT:    v_writelane_b32 v34, s49, 14
+; GCN-O0-NEXT:    v_writelane_b32 v34, s50, 15
+; GCN-O0-NEXT:    v_writelane_b32 v34, s51, 16
+; GCN-O0-NEXT:    v_writelane_b32 v34, s52, 17
+; GCN-O0-NEXT:    v_writelane_b32 v34, s53, 18
+; GCN-O0-NEXT:    v_writelane_b32 v34, s54, 19
+; GCN-O0-NEXT:    v_writelane_b32 v34, s55, 20
+; GCN-O0-NEXT:    v_writelane_b32 v34, s56, 21
+; GCN-O0-NEXT:    v_writelane_b32 v34, s57, 22
+; GCN-O0-NEXT:    v_writelane_b32 v34, s58, 23
+; GCN-O0-NEXT:    v_writelane_b32 v34, s59, 24
+; GCN-O0-NEXT:    v_writelane_b32 v34, s60, 25
+; GCN-O0-NEXT:    v_writelane_b32 v34, s61, 26
+; GCN-O0-NEXT:    v_writelane_b32 v34, s62, 27
+; GCN-O0-NEXT:    v_writelane_b32 v34, s63, 28
+; GCN-O0-NEXT:    v_writelane_b32 v34, s64, 29
+; GCN-O0-NEXT:    v_writelane_b32 v34, s65, 30
+; GCN-O0-NEXT:    v_writelane_b32 v34, s66, 31
+; GCN-O0-NEXT:    v_writelane_b32 v34, s67, 32
 ; GCN-O0-NEXT:    s_mov_b32 s4, 2
 ; GCN-O0-NEXT:    v_mul_lo_u32 v0, v0, s4
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
@@ -3372,21 +3370,20 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    buffer_store_dword v30, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    v_writelane_b32 v35, s4, 33
-; GCN-O0-NEXT:    v_writelane_b32 v35, s5, 34
+; GCN-O0-NEXT:    v_writelane_b32 v34, s4, 33
+; GCN-O0-NEXT:    v_writelane_b32 v34, s5, 34
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB21_1: ; =>This Inner Loop Header: Depth=1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v35, 35
-; GCN-O0-NEXT:    v_readlane_b32 s5, v35, 36
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v34, 35
+; GCN-O0-NEXT:    v_readlane_b32 s5, v34, 36
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -3426,61 +3423,60 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v35, s6, 35
-; GCN-O0-NEXT:    v_writelane_b32 v35, s7, 36
+; GCN-O0-NEXT:    v_writelane_b32 v34, s6, 35
+; GCN-O0-NEXT:    v_writelane_b32 v34, s7, 36
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB21_1
 ; GCN-O0-NEXT:  ; %bb.2:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v35, 33
-; GCN-O0-NEXT:    v_readlane_b32 s5, v35, 34
+; GCN-O0-NEXT:    v_readlane_b32 s4, v34, 33
+; GCN-O0-NEXT:    v_readlane_b32 s5, v34, 34
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s36, v35, 1
-; GCN-O0-NEXT:    v_readlane_b32 s37, v35, 2
-; GCN-O0-NEXT:    v_readlane_b32 s38, v35, 3
-; GCN-O0-NEXT:    v_readlane_b32 s39, v35, 4
-; GCN-O0-NEXT:    v_readlane_b32 s40, v35, 5
-; GCN-O0-NEXT:    v_readlane_b32 s41, v35, 6
-; GCN-O0-NEXT:    v_readlane_b32 s42, v35, 7
-; GCN-O0-NEXT:    v_readlane_b32 s43, v35, 8
-; GCN-O0-NEXT:    v_readlane_b32 s44, v35, 9
-; GCN-O0-NEXT:    v_readlane_b32 s45, v35, 10
-; GCN-O0-NEXT:    v_readlane_b32 s46, v35, 11
-; GCN-O0-NEXT:    v_readlane_b32 s47, v35, 12
-; GCN-O0-NEXT:    v_readlane_b32 s48, v35, 13
-; GCN-O0-NEXT:    v_readlane_b32 s49, v35, 14
-; GCN-O0-NEXT:    v_readlane_b32 s50, v35, 15
-; GCN-O0-NEXT:    v_readlane_b32 s51, v35, 16
-; GCN-O0-NEXT:    v_readlane_b32 s52, v35, 17
-; GCN-O0-NEXT:    v_readlane_b32 s53, v35, 18
-; GCN-O0-NEXT:    v_readlane_b32 s54, v35, 19
-; GCN-O0-NEXT:    v_readlane_b32 s55, v35, 20
-; GCN-O0-NEXT:    v_readlane_b32 s56, v35, 21
-; GCN-O0-NEXT:    v_readlane_b32 s57, v35, 22
-; GCN-O0-NEXT:    v_readlane_b32 s58, v35, 23
-; GCN-O0-NEXT:    v_readlane_b32 s59, v35, 24
-; GCN-O0-NEXT:    v_readlane_b32 s60, v35, 25
-; GCN-O0-NEXT:    v_readlane_b32 s61, v35, 26
-; GCN-O0-NEXT:    v_readlane_b32 s62, v35, 27
-; GCN-O0-NEXT:    v_readlane_b32 s63, v35, 28
-; GCN-O0-NEXT:    v_readlane_b32 s64, v35, 29
-; GCN-O0-NEXT:    v_readlane_b32 s65, v35, 30
-; GCN-O0-NEXT:    v_readlane_b32 s66, v35, 31
-; GCN-O0-NEXT:    v_readlane_b32 s67, v35, 32
+; GCN-O0-NEXT:    v_readlane_b32 s36, v34, 1
+; GCN-O0-NEXT:    v_readlane_b32 s37, v34, 2
+; GCN-O0-NEXT:    v_readlane_b32 s38, v34, 3
+; GCN-O0-NEXT:    v_readlane_b32 s39, v34, 4
+; GCN-O0-NEXT:    v_readlane_b32 s40, v34, 5
+; GCN-O0-NEXT:    v_readlane_b32 s41, v34, 6
+; GCN-O0-NEXT:    v_readlane_b32 s42, v34, 7
+; GCN-O0-NEXT:    v_readlane_b32 s43, v34, 8
+; GCN-O0-NEXT:    v_readlane_b32 s44, v34, 9
+; GCN-O0-NEXT:    v_readlane_b32 s45, v34, 10
+; GCN-O0-NEXT:    v_readlane_b32 s46, v34, 11
+; GCN-O0-NEXT:    v_readlane_b32 s47, v34, 12
+; GCN-O0-NEXT:    v_readlane_b32 s48, v34, 13
+; GCN-O0-NEXT:    v_readlane_b32 s49, v34, 14
+; GCN-O0-NEXT:    v_readlane_b32 s50, v34, 15
+; GCN-O0-NEXT:    v_readlane_b32 s51, v34, 16
+; GCN-O0-NEXT:    v_readlane_b32 s52, v34, 17
+; GCN-O0-NEXT:    v_readlane_b32 s53, v34, 18
+; GCN-O0-NEXT:    v_readlane_b32 s54, v34, 19
+; GCN-O0-NEXT:    v_readlane_b32 s55, v34, 20
+; GCN-O0-NEXT:    v_readlane_b32 s56, v34, 21
+; GCN-O0-NEXT:    v_readlane_b32 s57, v34, 22
+; GCN-O0-NEXT:    v_readlane_b32 s58, v34, 23
+; GCN-O0-NEXT:    v_readlane_b32 s59, v34, 24
+; GCN-O0-NEXT:    v_readlane_b32 s60, v34, 25
+; GCN-O0-NEXT:    v_readlane_b32 s61, v34, 26
+; GCN-O0-NEXT:    v_readlane_b32 s62, v34, 27
+; GCN-O0-NEXT:    v_readlane_b32 s63, v34, 28
+; GCN-O0-NEXT:    v_readlane_b32 s64, v34, 29
+; GCN-O0-NEXT:    v_readlane_b32 s65, v34, 30
+; GCN-O0-NEXT:    v_readlane_b32 s66, v34, 31
+; GCN-O0-NEXT:    v_readlane_b32 s67, v34, 32
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s36
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s37
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s38
@@ -3513,86 +3509,85 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    v_mov_b32_e32 v29, s65
 ; GCN-O0-NEXT:    v_mov_b32_e32 v30, s66
 ; GCN-O0-NEXT:    v_mov_b32_e32 v31, s67
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:172 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:176 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:180 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:184 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:188 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:192 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:196 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:200 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:204 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:208 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:212 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:216 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v18, off, s[0:3], s32 offset:220 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:224 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:228 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v21, off, s[0:3], s32 offset:232 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v22, off, s[0:3], s32 offset:236 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v23, off, s[0:3], s32 offset:240 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v24, off, s[0:3], s32 offset:244 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v25, off, s[0:3], s32 offset:248 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:252 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:256 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v28, off, s[0:3], s32 offset:260 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:264 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v30, off, s[0:3], s32 offset:268 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:272 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:172 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:176 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:180 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:184 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:188 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:192 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:196 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:200 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:204 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:208 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:212 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v18, off, s[0:3], s32 offset:216 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:220 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:224 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v21, off, s[0:3], s32 offset:228 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v22, off, s[0:3], s32 offset:232 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v23, off, s[0:3], s32 offset:236 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v24, off, s[0:3], s32 offset:240 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v25, off, s[0:3], s32 offset:244 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:248 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:252 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v28, off, s[0:3], s32 offset:256 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:260 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v30, off, s[0:3], s32 offset:264 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:268 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    v_writelane_b32 v35, s4, 37
-; GCN-O0-NEXT:    v_writelane_b32 v35, s5, 38
+; GCN-O0-NEXT:    v_writelane_b32 v34, s4, 37
+; GCN-O0-NEXT:    v_writelane_b32 v34, s5, 38
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB21_4: ; =>This Inner Loop Header: Depth=1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v35, 39
-; GCN-O0-NEXT:    v_readlane_b32 s5, v35, 40
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:276 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:152 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:156 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:160 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:164 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:168 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:172 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:176 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:180 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:184 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:196 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:200 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:204 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:208 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:212 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:216 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:220 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:224 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:228 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:232 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:236 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:240 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:244 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:248 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:252 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:256 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:260 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:264 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:268 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:272 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v34, 39
+; GCN-O0-NEXT:    v_readlane_b32 s5, v34, 40
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:152 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:156 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:160 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:164 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:168 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:172 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:176 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:180 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:184 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:196 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:200 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:204 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:208 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:212 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:216 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:220 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:224 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:228 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:232 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:236 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:240 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:244 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:248 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:252 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:256 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:260 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:264 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:268 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readfirstlane_b32 s6, v32
@@ -3600,27 +3595,26 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:280 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:276 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:272 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v35, s6, 39
-; GCN-O0-NEXT:    v_writelane_b32 v35, s7, 40
+; GCN-O0-NEXT:    v_writelane_b32 v34, s6, 39
+; GCN-O0-NEXT:    v_writelane_b32 v34, s7, 40
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB21_4
 ; GCN-O0-NEXT:  ; %bb.5:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[78:79], -1
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[78:79]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v35, 37
-; GCN-O0-NEXT:    v_readlane_b32 s5, v35, 38
+; GCN-O0-NEXT:    v_readlane_b32 s4, v34, 37
+; GCN-O0-NEXT:    v_readlane_b32 s5, v34, 38
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.6:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:280 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:272 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 def $vgpr1_vgpr2 killed $exec
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(1)
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, v0
@@ -3629,25 +3623,25 @@ define double @double16_extelt_vec(i32 %sel) {
 ; GCN-O0-NEXT:    s_mov_b32 s4, 32
 ; GCN-O0-NEXT:    v_lshrrev_b64 v[1:2], s4, v[1:2]
 ; GCN-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 killed $vgpr1_vgpr2 killed $exec
-; GCN-O0-NEXT:    v_readlane_b32 s67, v34, 15
-; GCN-O0-NEXT:    v_readlane_b32 s66, v34, 14
-; GCN-O0-NEXT:    v_readlane_b32 s65, v34, 13
-; GCN-O0-NEXT:    v_readlane_b32 s64, v34, 12
-; GCN-O0-NEXT:    v_readlane_b32 s55, v34, 11
-; GCN-O0-NEXT:    v_readlane_b32 s54, v34, 10
-; GCN-O0-NEXT:    v_readlane_b32 s53, v34, 9
-; GCN-O0-NEXT:    v_readlane_b32 s52, v34, 8
-; GCN-O0-NEXT:    v_readlane_b32 s51, v34, 7
-; GCN-O0-NEXT:    v_readlane_b32 s50, v34, 6
-; GCN-O0-NEXT:    v_readlane_b32 s49, v34, 5
-; GCN-O0-NEXT:    v_readlane_b32 s48, v34, 4
-; GCN-O0-NEXT:    v_readlane_b32 s39, v34, 3
-; GCN-O0-NEXT:    v_readlane_b32 s38, v34, 2
-; GCN-O0-NEXT:    v_readlane_b32 s37, v34, 1
-; GCN-O0-NEXT:    v_readlane_b32 s36, v34, 0
+; GCN-O0-NEXT:    v_readlane_b32 s67, v33, 15
+; GCN-O0-NEXT:    v_readlane_b32 s66, v33, 14
+; GCN-O0-NEXT:    v_readlane_b32 s65, v33, 13
+; GCN-O0-NEXT:    v_readlane_b32 s64, v33, 12
+; GCN-O0-NEXT:    v_readlane_b32 s55, v33, 11
+; GCN-O0-NEXT:    v_readlane_b32 s54, v33, 10
+; GCN-O0-NEXT:    v_readlane_b32 s53, v33, 9
+; GCN-O0-NEXT:    v_readlane_b32 s52, v33, 8
+; GCN-O0-NEXT:    v_readlane_b32 s51, v33, 7
+; GCN-O0-NEXT:    v_readlane_b32 s50, v33, 6
+; GCN-O0-NEXT:    v_readlane_b32 s49, v33, 5
+; GCN-O0-NEXT:    v_readlane_b32 s48, v33, 4
+; GCN-O0-NEXT:    v_readlane_b32 s39, v33, 3
+; GCN-O0-NEXT:    v_readlane_b32 s38, v33, 2
+; GCN-O0-NEXT:    v_readlane_b32 s37, v33, 1
+; GCN-O0-NEXT:    v_readlane_b32 s36, v33, 0
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:284 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:288 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:276 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:280 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -3673,14 +3667,13 @@ define i32 @extract_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -3688,22 +3681,21 @@ define i32 @extract_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr5 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v5, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v5, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr4 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v4, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v4, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB22_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 3
-; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v4, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v4, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -3714,28 +3706,27 @@ define i32 @extract_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v5, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v5, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    v_writelane_b32 v4, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v4, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB22_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v4, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v4, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -3761,7 +3752,6 @@ define i32 @extract_dyn_inreg_i32_3(<3 x i32> inreg %arg, i32 inreg %idx) {
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -3789,14 +3779,13 @@ define float @extract_dyn_float_3(<3 x float> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -3804,22 +3793,21 @@ define float @extract_dyn_float_3(<3 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr5 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v5, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v5, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr4 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v4, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v4, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB24_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 3
-; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v4, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v4, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -3830,28 +3818,27 @@ define float @extract_dyn_float_3(<3 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v5, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v5, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    v_writelane_b32 v4, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v4, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB24_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v4, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v4, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -3881,7 +3868,6 @@ define float @extract_dyn_inreg_float_3(<3 x float> inreg %arg, i32 inreg %idx) 
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -3915,7 +3901,7 @@ define i32 @extract_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -3924,7 +3910,6 @@ define i32 @extract_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -3936,22 +3921,21 @@ define i32 @extract_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr7 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v7, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v7, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr6 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v6, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v6, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB26_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 3
-; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v6, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v6, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -3964,28 +3948,27 @@ define i32 @extract_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v7, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v7, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    v_writelane_b32 v6, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v6, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB26_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v6, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v6, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4017,7 +4000,6 @@ define i32 @extract_dyn_inreg_i32_5(<5 x i32> inreg %arg, i32 inreg %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4053,7 +4035,7 @@ define float @extract_dyn_float_5(<5 x float> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -4062,7 +4044,6 @@ define float @extract_dyn_float_5(<5 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4074,22 +4055,21 @@ define float @extract_dyn_float_5(<5 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr7 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v7, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v7, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr6 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v6, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v6, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB28_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 3
-; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v6, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v6, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -4102,28 +4082,27 @@ define float @extract_dyn_float_5(<5 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v7, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v7, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    v_writelane_b32 v6, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v6, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB28_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v6, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v6, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4163,7 +4142,6 @@ define float @extract_dyn_inreg_float_5(<5 x float> inreg %arg, i32 inreg %idx) 
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4202,7 +4180,7 @@ define i32 @extract_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0: ; %entry
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -4212,7 +4190,6 @@ define i32 @extract_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4226,22 +4203,21 @@ define i32 @extract_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr8 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v8, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v8, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr7 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v7, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v7, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB30_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 3
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -4255,28 +4231,27 @@ define i32 @extract_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v8, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v8, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    v_writelane_b32 v7, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v7, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB30_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4312,7 +4287,6 @@ define i32 @extract_dyn_inreg_i32_6(<6 x i32> inreg %arg, i32 inreg %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4353,7 +4327,7 @@ define float @extract_dyn_float_6(<6 x float> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0: ; %entry
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -4363,7 +4337,6 @@ define float @extract_dyn_float_6(<6 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4377,22 +4350,21 @@ define float @extract_dyn_float_6(<6 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr8 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v8, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v8, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr7 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v7, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v7, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB32_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 3
-; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -4406,28 +4378,27 @@ define float @extract_dyn_float_6(<6 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v8, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v8, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    v_writelane_b32 v7, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v7, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB32_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v7, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v7, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4473,7 +4444,6 @@ define float @extract_dyn_inreg_float_6(<6 x float> inreg %arg, i32 inreg %idx) 
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4517,7 +4487,7 @@ define i32 @extract_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -4528,7 +4498,6 @@ define i32 @extract_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4544,22 +4513,21 @@ define i32 @extract_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr9 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v9, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v9, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr8 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v8, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v8, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB34_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 3
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -4574,28 +4542,27 @@ define i32 @extract_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v9, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v9, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    v_writelane_b32 v8, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v8, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB34_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4633,7 +4600,6 @@ define i32 @extract_dyn_inreg_i32_7(<7 x i32> inreg %arg, i32 inreg %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4677,7 +4643,7 @@ define float @extract_dyn_float_7(<7 x float> inreg %arg, i32 %idx) {
 ; GCN-O0:       ; %bb.0:
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b32 s4, s16
@@ -4688,7 +4654,6 @@ define float @extract_dyn_float_7(<7 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -4704,22 +4669,21 @@ define float @extract_dyn_float_7(<7 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr9 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v9, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v9, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    ; implicit-def: $vgpr8 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v8, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v8, s5, 1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr0
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB36_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 3
-; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -4734,28 +4698,27 @@ define float @extract_dyn_float_7(<7 x float> inreg %arg, i32 %idx) {
 ; GCN-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 m0, s6
 ; GCN-O0-NEXT:    v_movrels_b32_e32 v0, v0
-; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v9, s6, 2
-; GCN-O0-NEXT:    v_writelane_b32 v9, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    v_writelane_b32 v8, s6, 2
+; GCN-O0-NEXT:    v_writelane_b32 v8, s7, 3
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB36_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v8, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v8, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
-; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -4805,7 +4768,6 @@ define float @extract_dyn_inreg_float_7(<7 x float> inreg %arg, i32 inreg %idx) 
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6

--- a/llvm/test/CodeGen/AMDGPU/fix-crash-valu-hazard.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-crash-valu-hazard.ll
@@ -32,7 +32,6 @@ define amdgpu_ps void @global_load_lds_dword_saddr(ptr addrspace(1) inreg nocapt
 ; GFX90A-NEXT:    s_mov_b32 s2, s0
 ; GFX90A-NEXT:    ; kill: def $sgpr2 killed $sgpr2 def $sgpr2_sgpr3
 ; GFX90A-NEXT:    s_mov_b32 s3, s1
-; GFX90A-NEXT:    ; kill: def $sgpr0_sgpr1 killed $sgpr2_sgpr3
 ; GFX90A-NEXT:    s_getpc_b64 s[0:1]
 ; GFX90A-NEXT:    s_add_u32 s0, s0, G@gotpcrel32@lo+4
 ; GFX90A-NEXT:    s_addc_u32 s1, s1, G@gotpcrel32@hi+12

--- a/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
@@ -1628,7 +1628,6 @@ define amdgpu_kernel void @extract_neg_offset_vgpr(ptr addrspace(1) %out) {
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
 ; NOOPT-NEXT:    v_readlane_b32 s0, v31, 6
 ; NOOPT-NEXT:    v_readlane_b32 s1, v31, 7
-; NOOPT-NEXT:    buffer_load_dword v17, off, s[20:23], 0 offset:72 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v0, off, s[20:23], 0 offset:4 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v1, off, s[20:23], 0 offset:8 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v2, off, s[20:23], 0 offset:12 ; 4-byte Folded Reload
@@ -1652,7 +1651,6 @@ define amdgpu_kernel void @extract_neg_offset_vgpr(ptr addrspace(1) %out) {
 ; NOOPT-NEXT:    s_and_saveexec_b64 s[0:1], s[0:1]
 ; NOOPT-NEXT:    s_add_i32 m0, s2, 0xfffffe00
 ; NOOPT-NEXT:    v_movrels_b32_e32 v0, v0
-; NOOPT-NEXT:    buffer_store_dword v0, off, s[20:23], 0 offset:76 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    buffer_store_dword v0, off, s[20:23], 0 offset:72 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 s[2:3], s[0:1]
 ; NOOPT-NEXT:    v_writelane_b32 v31, s2, 6
@@ -1680,7 +1678,7 @@ define amdgpu_kernel void @extract_neg_offset_vgpr(ptr addrspace(1) %out) {
 ; NOOPT-NEXT:    v_readlane_b32 s1, v31, 1
 ; NOOPT-NEXT:    v_readlane_b32 s2, v31, 2
 ; NOOPT-NEXT:    v_readlane_b32 s3, v31, 3
-; NOOPT-NEXT:    buffer_load_dword v0, off, s[20:23], 0 offset:76 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v0, off, s[20:23], 0 offset:72 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
 ; NOOPT-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; NOOPT-NEXT:    s_endpgm
@@ -5197,11 +5195,11 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_mov_b32 s5, s8
 ; NOOPT-NEXT:    s_mov_b32 s6, s3
 ; NOOPT-NEXT:    s_mov_b32 s7, s2
-; NOOPT-NEXT:    ; implicit-def: $vgpr18 : SGPR spill to VGPR lane
-; NOOPT-NEXT:    v_writelane_b32 v18, s4, 0
-; NOOPT-NEXT:    v_writelane_b32 v18, s5, 1
-; NOOPT-NEXT:    v_writelane_b32 v18, s6, 2
-; NOOPT-NEXT:    v_writelane_b32 v18, s7, 3
+; NOOPT-NEXT:    ; implicit-def: $vgpr17 : SGPR spill to VGPR lane
+; NOOPT-NEXT:    v_writelane_b32 v17, s4, 0
+; NOOPT-NEXT:    v_writelane_b32 v17, s5, 1
+; NOOPT-NEXT:    v_writelane_b32 v17, s6, 2
+; NOOPT-NEXT:    v_writelane_b32 v17, s7, 3
 ; NOOPT-NEXT:    v_mov_b32_e32 v2, 0
 ; NOOPT-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; NOOPT-NEXT:    v_mov_b32_e32 v1, v2
@@ -5209,7 +5207,7 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
 ; NOOPT-NEXT:    v_lshl_b64 v[0:1], v[0:1], s3
 ; NOOPT-NEXT:    s_mov_b32 s4, 0
-; NOOPT-NEXT:    v_writelane_b32 v18, s4, 4
+; NOOPT-NEXT:    v_writelane_b32 v17, s4, 4
 ; NOOPT-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5
 ; NOOPT-NEXT:    s_mov_b32 s5, s2
 ; NOOPT-NEXT:    ; kill: def $sgpr0_sgpr1 killed $sgpr0_sgpr1 def $sgpr0_sgpr1_sgpr2_sgpr3
@@ -5250,22 +5248,22 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_mov_b32 s13, s18
 ; NOOPT-NEXT:    s_mov_b32 s14, s17
 ; NOOPT-NEXT:    s_mov_b32 s15, s16
-; NOOPT-NEXT:    v_writelane_b32 v18, s0, 5
-; NOOPT-NEXT:    v_writelane_b32 v18, s1, 6
-; NOOPT-NEXT:    v_writelane_b32 v18, s2, 7
-; NOOPT-NEXT:    v_writelane_b32 v18, s3, 8
-; NOOPT-NEXT:    v_writelane_b32 v18, s4, 9
-; NOOPT-NEXT:    v_writelane_b32 v18, s5, 10
-; NOOPT-NEXT:    v_writelane_b32 v18, s6, 11
-; NOOPT-NEXT:    v_writelane_b32 v18, s7, 12
-; NOOPT-NEXT:    v_writelane_b32 v18, s8, 13
-; NOOPT-NEXT:    v_writelane_b32 v18, s9, 14
-; NOOPT-NEXT:    v_writelane_b32 v18, s10, 15
-; NOOPT-NEXT:    v_writelane_b32 v18, s11, 16
-; NOOPT-NEXT:    v_writelane_b32 v18, s12, 17
-; NOOPT-NEXT:    v_writelane_b32 v18, s13, 18
-; NOOPT-NEXT:    v_writelane_b32 v18, s14, 19
-; NOOPT-NEXT:    v_writelane_b32 v18, s15, 20
+; NOOPT-NEXT:    v_writelane_b32 v17, s0, 5
+; NOOPT-NEXT:    v_writelane_b32 v17, s1, 6
+; NOOPT-NEXT:    v_writelane_b32 v17, s2, 7
+; NOOPT-NEXT:    v_writelane_b32 v17, s3, 8
+; NOOPT-NEXT:    v_writelane_b32 v17, s4, 9
+; NOOPT-NEXT:    v_writelane_b32 v17, s5, 10
+; NOOPT-NEXT:    v_writelane_b32 v17, s6, 11
+; NOOPT-NEXT:    v_writelane_b32 v17, s7, 12
+; NOOPT-NEXT:    v_writelane_b32 v17, s8, 13
+; NOOPT-NEXT:    v_writelane_b32 v17, s9, 14
+; NOOPT-NEXT:    v_writelane_b32 v17, s10, 15
+; NOOPT-NEXT:    v_writelane_b32 v17, s11, 16
+; NOOPT-NEXT:    v_writelane_b32 v17, s12, 17
+; NOOPT-NEXT:    v_writelane_b32 v17, s13, 18
+; NOOPT-NEXT:    v_writelane_b32 v17, s14, 19
+; NOOPT-NEXT:    v_writelane_b32 v17, s15, 20
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
 ; NOOPT-NEXT:    v_mov_b32_e32 v0, s0
 ; NOOPT-NEXT:    v_mov_b32_e32 v1, s1
@@ -5300,22 +5298,21 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    buffer_store_dword v14, off, s[36:39], 0 offset:60 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    buffer_store_dword v15, off, s[36:39], 0 offset:64 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 s[0:1], exec
-; NOOPT-NEXT:    v_writelane_b32 v18, s0, 21
-; NOOPT-NEXT:    v_writelane_b32 v18, s1, 22
+; NOOPT-NEXT:    v_writelane_b32 v17, s0, 21
+; NOOPT-NEXT:    v_writelane_b32 v17, s1, 22
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_store_dword v18, off, s[36:39], 0 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v17, off, s[36:39], 0 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    ; implicit-def: $vgpr0
 ; NOOPT-NEXT:    ; implicit-def: $sgpr0_sgpr1
 ; NOOPT-NEXT:  .LBB16_1: ; =>This Inner Loop Header: Depth=1
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 23
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 24
-; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 offset:80 ; 4-byte Folded Reload
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 23
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 24
 ; NOOPT-NEXT:    buffer_load_dword v0, off, s[36:39], 0 offset:4 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v1, off, s[36:39], 0 offset:8 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v2, off, s[36:39], 0 offset:12 ; 4-byte Folded Reload
@@ -5339,51 +5336,50 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_and_saveexec_b64 s[0:1], s[0:1]
 ; NOOPT-NEXT:    s_mov_b32 m0, s2
 ; NOOPT-NEXT:    v_movrels_b32_e32 v0, v0
-; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:84 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:80 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 s[2:3], s[0:1]
-; NOOPT-NEXT:    v_writelane_b32 v18, s2, 23
-; NOOPT-NEXT:    v_writelane_b32 v18, s3, 24
+; NOOPT-NEXT:    v_writelane_b32 v17, s2, 23
+; NOOPT-NEXT:    v_writelane_b32 v17, s3, 24
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_store_dword v18, off, s[36:39], 0 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v17, off, s[36:39], 0 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_xor_b64 exec, exec, s[0:1]
 ; NOOPT-NEXT:    s_cbranch_execnz .LBB16_1
 ; NOOPT-NEXT:  ; %bb.2:
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 21
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 22
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 21
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 22
 ; NOOPT-NEXT:    s_mov_b64 exec, s[0:1]
 ; NOOPT-NEXT:  ; %bb.3:
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    ;;#ASMSTART
 ; NOOPT-NEXT:    s_mov_b32 s4, 17
 ; NOOPT-NEXT:    ;;#ASMEND
 ; NOOPT-NEXT:    s_mov_b32 s16, s4
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 5
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 6
-; NOOPT-NEXT:    v_readlane_b32 s2, v18, 7
-; NOOPT-NEXT:    v_readlane_b32 s3, v18, 8
-; NOOPT-NEXT:    v_readlane_b32 s4, v18, 9
-; NOOPT-NEXT:    v_readlane_b32 s5, v18, 10
-; NOOPT-NEXT:    v_readlane_b32 s6, v18, 11
-; NOOPT-NEXT:    v_readlane_b32 s7, v18, 12
-; NOOPT-NEXT:    v_readlane_b32 s8, v18, 13
-; NOOPT-NEXT:    v_readlane_b32 s9, v18, 14
-; NOOPT-NEXT:    v_readlane_b32 s10, v18, 15
-; NOOPT-NEXT:    v_readlane_b32 s11, v18, 16
-; NOOPT-NEXT:    v_readlane_b32 s12, v18, 17
-; NOOPT-NEXT:    v_readlane_b32 s13, v18, 18
-; NOOPT-NEXT:    v_readlane_b32 s14, v18, 19
-; NOOPT-NEXT:    v_readlane_b32 s15, v18, 20
-; NOOPT-NEXT:    v_writelane_b32 v18, s16, 25
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 5
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 6
+; NOOPT-NEXT:    v_readlane_b32 s2, v17, 7
+; NOOPT-NEXT:    v_readlane_b32 s3, v17, 8
+; NOOPT-NEXT:    v_readlane_b32 s4, v17, 9
+; NOOPT-NEXT:    v_readlane_b32 s5, v17, 10
+; NOOPT-NEXT:    v_readlane_b32 s6, v17, 11
+; NOOPT-NEXT:    v_readlane_b32 s7, v17, 12
+; NOOPT-NEXT:    v_readlane_b32 s8, v17, 13
+; NOOPT-NEXT:    v_readlane_b32 s9, v17, 14
+; NOOPT-NEXT:    v_readlane_b32 s10, v17, 15
+; NOOPT-NEXT:    v_readlane_b32 s11, v17, 16
+; NOOPT-NEXT:    v_readlane_b32 s12, v17, 17
+; NOOPT-NEXT:    v_readlane_b32 s13, v17, 18
+; NOOPT-NEXT:    v_readlane_b32 s14, v17, 19
+; NOOPT-NEXT:    v_readlane_b32 s15, v17, 20
+; NOOPT-NEXT:    v_writelane_b32 v17, s16, 25
 ; NOOPT-NEXT:    v_mov_b32_e32 v0, s0
 ; NOOPT-NEXT:    v_mov_b32_e32 v1, s1
 ; NOOPT-NEXT:    v_mov_b32_e32 v2, s2
@@ -5400,55 +5396,54 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    v_mov_b32_e32 v13, s13
 ; NOOPT-NEXT:    v_mov_b32_e32 v14, s14
 ; NOOPT-NEXT:    v_mov_b32_e32 v15, s15
-; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:88 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v1, off, s[36:39], 0 offset:92 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v2, off, s[36:39], 0 offset:96 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v3, off, s[36:39], 0 offset:100 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v4, off, s[36:39], 0 offset:104 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v5, off, s[36:39], 0 offset:108 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v6, off, s[36:39], 0 offset:112 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v7, off, s[36:39], 0 offset:116 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v8, off, s[36:39], 0 offset:120 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v9, off, s[36:39], 0 offset:124 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v10, off, s[36:39], 0 offset:128 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v11, off, s[36:39], 0 offset:132 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v12, off, s[36:39], 0 offset:136 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v13, off, s[36:39], 0 offset:140 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v14, off, s[36:39], 0 offset:144 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v15, off, s[36:39], 0 offset:148 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:84 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v1, off, s[36:39], 0 offset:88 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v2, off, s[36:39], 0 offset:92 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v3, off, s[36:39], 0 offset:96 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v4, off, s[36:39], 0 offset:100 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v5, off, s[36:39], 0 offset:104 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v6, off, s[36:39], 0 offset:108 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v7, off, s[36:39], 0 offset:112 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v8, off, s[36:39], 0 offset:116 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v9, off, s[36:39], 0 offset:120 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v10, off, s[36:39], 0 offset:124 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v11, off, s[36:39], 0 offset:128 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v12, off, s[36:39], 0 offset:132 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v13, off, s[36:39], 0 offset:136 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v14, off, s[36:39], 0 offset:140 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v15, off, s[36:39], 0 offset:144 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 s[0:1], exec
-; NOOPT-NEXT:    v_writelane_b32 v18, s0, 26
-; NOOPT-NEXT:    v_writelane_b32 v18, s1, 27
+; NOOPT-NEXT:    v_writelane_b32 v17, s0, 26
+; NOOPT-NEXT:    v_writelane_b32 v17, s1, 27
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_store_dword v18, off, s[36:39], 0 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v17, off, s[36:39], 0 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    ; implicit-def: $vgpr0
 ; NOOPT-NEXT:    ; implicit-def: $sgpr0_sgpr1
 ; NOOPT-NEXT:  .LBB16_4: ; =>This Inner Loop Header: Depth=1
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 28
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 29
-; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 offset:152 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v0, off, s[36:39], 0 offset:88 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v1, off, s[36:39], 0 offset:92 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v2, off, s[36:39], 0 offset:96 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v3, off, s[36:39], 0 offset:100 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v4, off, s[36:39], 0 offset:104 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v5, off, s[36:39], 0 offset:108 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v6, off, s[36:39], 0 offset:112 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v7, off, s[36:39], 0 offset:116 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v8, off, s[36:39], 0 offset:120 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v9, off, s[36:39], 0 offset:124 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v10, off, s[36:39], 0 offset:128 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v11, off, s[36:39], 0 offset:132 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v12, off, s[36:39], 0 offset:136 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v13, off, s[36:39], 0 offset:140 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v14, off, s[36:39], 0 offset:144 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v15, off, s[36:39], 0 offset:148 ; 4-byte Folded Reload
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 28
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 29
+; NOOPT-NEXT:    buffer_load_dword v0, off, s[36:39], 0 offset:84 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v1, off, s[36:39], 0 offset:88 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v2, off, s[36:39], 0 offset:92 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v3, off, s[36:39], 0 offset:96 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v4, off, s[36:39], 0 offset:100 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v5, off, s[36:39], 0 offset:104 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v6, off, s[36:39], 0 offset:108 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v7, off, s[36:39], 0 offset:112 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v8, off, s[36:39], 0 offset:116 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v9, off, s[36:39], 0 offset:120 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v10, off, s[36:39], 0 offset:124 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v11, off, s[36:39], 0 offset:128 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v12, off, s[36:39], 0 offset:132 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v13, off, s[36:39], 0 offset:136 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v14, off, s[36:39], 0 offset:140 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v15, off, s[36:39], 0 offset:144 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    buffer_load_dword v16, off, s[36:39], 0 offset:68 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
 ; NOOPT-NEXT:    v_readfirstlane_b32 s2, v16
@@ -5456,38 +5451,37 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_and_saveexec_b64 s[0:1], s[0:1]
 ; NOOPT-NEXT:    s_mov_b32 m0, s2
 ; NOOPT-NEXT:    v_movrels_b32_e32 v0, v0
-; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:156 ; 4-byte Folded Spill
-; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:152 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v0, off, s[36:39], 0 offset:148 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 s[2:3], s[0:1]
-; NOOPT-NEXT:    v_writelane_b32 v18, s2, 28
-; NOOPT-NEXT:    v_writelane_b32 v18, s3, 29
+; NOOPT-NEXT:    v_writelane_b32 v17, s2, 28
+; NOOPT-NEXT:    v_writelane_b32 v17, s3, 29
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_store_dword v18, off, s[36:39], 0 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v17, off, s[36:39], 0 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_xor_b64 exec, exec, s[0:1]
 ; NOOPT-NEXT:    s_cbranch_execnz .LBB16_4
 ; NOOPT-NEXT:  ; %bb.5:
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 26
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 27
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 26
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 27
 ; NOOPT-NEXT:    s_mov_b64 exec, s[0:1]
 ; NOOPT-NEXT:  ; %bb.6:
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 4
-; NOOPT-NEXT:    v_readlane_b32 s4, v18, 0
-; NOOPT-NEXT:    v_readlane_b32 s5, v18, 1
-; NOOPT-NEXT:    v_readlane_b32 s6, v18, 2
-; NOOPT-NEXT:    v_readlane_b32 s7, v18, 3
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 4
+; NOOPT-NEXT:    v_readlane_b32 s4, v17, 0
+; NOOPT-NEXT:    v_readlane_b32 s5, v17, 1
+; NOOPT-NEXT:    v_readlane_b32 s6, v17, 2
+; NOOPT-NEXT:    v_readlane_b32 s7, v17, 3
 ; NOOPT-NEXT:    buffer_load_dword v0, off, s[36:39], 0 offset:76 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v1, off, s[36:39], 0 offset:156 ; 4-byte Folded Reload
-; NOOPT-NEXT:    buffer_load_dword v2, off, s[36:39], 0 offset:84 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v1, off, s[36:39], 0 offset:148 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v2, off, s[36:39], 0 offset:80 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
 ; NOOPT-NEXT:    buffer_store_dword v2, off, s[4:7], 0
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
@@ -5495,10 +5489,10 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
 ; NOOPT-NEXT:    v_cmp_eq_u32_e64 s[2:3], v0, s0
 ; NOOPT-NEXT:    s_mov_b64 s[0:1], exec
-; NOOPT-NEXT:    v_writelane_b32 v18, s0, 30
-; NOOPT-NEXT:    v_writelane_b32 v18, s1, 31
+; NOOPT-NEXT:    v_writelane_b32 v17, s0, 30
+; NOOPT-NEXT:    v_writelane_b32 v17, s1, 31
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
-; NOOPT-NEXT:    buffer_store_dword v18, off, s[36:39], 0 ; 4-byte Folded Spill
+; NOOPT-NEXT:    buffer_store_dword v17, off, s[36:39], 0 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_and_b64 s[0:1], s[0:1], s[2:3]
 ; NOOPT-NEXT:    s_mov_b64 exec, s[0:1]
@@ -5506,10 +5500,10 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:  ; %bb.7: ; %bb1
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s4, v18, 25
+; NOOPT-NEXT:    v_readlane_b32 s4, v17, 25
 ; NOOPT-NEXT:    ; implicit-def: $sgpr0_sgpr1
 ; NOOPT-NEXT:    s_mov_b32 s7, s1
 ; NOOPT-NEXT:    ; implicit-def: $sgpr0_sgpr1
@@ -5526,11 +5520,11 @@ define amdgpu_kernel void @extract_vgpr_offset_multiple_in_block(ptr addrspace(1
 ; NOOPT-NEXT:  .LBB16_8: ; %bb2
 ; NOOPT-NEXT:    s_or_saveexec_b64 s[28:29], -1
 ; NOOPT-NEXT:    s_waitcnt expcnt(0)
-; NOOPT-NEXT:    buffer_load_dword v18, off, s[36:39], 0 ; 4-byte Folded Reload
+; NOOPT-NEXT:    buffer_load_dword v17, off, s[36:39], 0 ; 4-byte Folded Reload
 ; NOOPT-NEXT:    s_mov_b64 exec, s[28:29]
 ; NOOPT-NEXT:    s_waitcnt vmcnt(0)
-; NOOPT-NEXT:    v_readlane_b32 s0, v18, 30
-; NOOPT-NEXT:    v_readlane_b32 s1, v18, 31
+; NOOPT-NEXT:    v_readlane_b32 s0, v17, 30
+; NOOPT-NEXT:    v_readlane_b32 s1, v17, 31
 ; NOOPT-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; NOOPT-NEXT:    s_endpgm
 ;
@@ -9863,7 +9857,6 @@ define amdgpu_cs void @insert_or_disj_index(ptr addrspace(1) %out, ptr addrspace
 ; NOOPT-NEXT:    v_mov_b32_e32 v1, v2
 ; NOOPT-NEXT:    buffer_store_dword v0, off, s[16:19], 0 offset:136 ; 4-byte Folded Spill
 ; NOOPT-NEXT:    buffer_store_dword v1, off, s[16:19], 0 offset:140 ; 4-byte Folded Spill
-; NOOPT-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10_sgpr11 killed $sgpr4_sgpr5_sgpr6_sgpr7
 ; NOOPT-NEXT:    s_waitcnt expcnt(1)
 ; NOOPT-NEXT:    v_mov_b32_e32 v0, s1
 ; NOOPT-NEXT:    buffer_load_dword v0, v0, s[4:7], s0 offen

--- a/llvm/test/CodeGen/AMDGPU/indirect-addressing-term.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-addressing-term.ll
@@ -82,7 +82,6 @@ define amdgpu_kernel void @extract_w_offset_vgpr(ptr addrspace(1) %out) {
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   $sgpr0_sgpr1 = SI_SPILL_S64_RESTORE %stack.2, implicit $exec, implicit $sgpr32 :: (load (s64) from %stack.2, align 4, addrspace 5)
-  ; GCN-NEXT:   dead [[COPY18:%[0-9]+]]:vgpr_32 = COPY [[DEF]]
   ; GCN-NEXT:   renamable $sgpr2 = V_READFIRSTLANE_B32 [[COPY]](s32), implicit $exec
   ; GCN-NEXT:   renamable $sgpr0_sgpr1 = V_CMP_EQ_U32_e64 $sgpr2, [[COPY]](s32), implicit $exec
   ; GCN-NEXT:   renamable $sgpr0_sgpr1 = S_AND_SAVEEXEC_B64 killed renamable $sgpr0_sgpr1, implicit-def $exec, implicit-def dead $scc, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
@@ -8177,11 +8177,11 @@ define amdgpu_ps <32 x float> @float32_inselt_vec(<32 x float> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    v_mov_b32_e32 v32, 1.0
 ; GCN-O0-NEXT:    buffer_store_dword v32, off, s[8:11], 0 offset:132 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[0:1], exec
-; GCN-O0-NEXT:    ; implicit-def: $vgpr64 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v64, s0, 0
-; GCN-O0-NEXT:    v_writelane_b32 v64, s1, 1
+; GCN-O0-NEXT:    ; implicit-def: $vgpr63 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v63, s0, 0
+; GCN-O0-NEXT:    v_writelane_b32 v63, s1, 1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v64, off, s[8:11], 0 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v63, off, s[8:11], 0 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[8:11], 0 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[8:11], 0 offset:8 ; 4-byte Folded Spill
@@ -8218,11 +8218,11 @@ define amdgpu_ps <32 x float> @float32_inselt_vec(<32 x float> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr0_sgpr1
 ; GCN-O0-NEXT:  .LBB22_1: ; =>This Inner Loop Header: Depth=1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v64, off, s[8:11], 0 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v63, off, s[8:11], 0 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s0, v64, 2
-; GCN-O0-NEXT:    v_readlane_b32 s1, v64, 3
+; GCN-O0-NEXT:    v_readlane_b32 s0, v63, 2
+; GCN-O0-NEXT:    v_readlane_b32 s1, v63, 3
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[8:11], 0 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[8:11], 0 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[8:11], 0 offset:12 ; 4-byte Folded Reload
@@ -8328,20 +8328,20 @@ define amdgpu_ps <32 x float> @float32_inselt_vec(<32 x float> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    buffer_store_dword v30, off, s[8:11], 0 offset:124 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v31, off, s[8:11], 0 offset:128 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[2:3], s[0:1]
-; GCN-O0-NEXT:    v_writelane_b32 v64, s2, 2
-; GCN-O0-NEXT:    v_writelane_b32 v64, s3, 3
+; GCN-O0-NEXT:    v_writelane_b32 v63, s2, 2
+; GCN-O0-NEXT:    v_writelane_b32 v63, s3, 3
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v64, off, s[8:11], 0 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v63, off, s[8:11], 0 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[0:1]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB22_1
 ; GCN-O0-NEXT:  ; %bb.2:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v64, off, s[8:11], 0 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v63, off, s[8:11], 0 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s0, v64, 0
-; GCN-O0-NEXT:    v_readlane_b32 s1, v64, 1
+; GCN-O0-NEXT:    v_readlane_b32 s0, v63, 0
+; GCN-O0-NEXT:    v_readlane_b32 s1, v63, 1
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[0:1]
 ; GCN-O0-NEXT:  ; %bb.3:
 ; GCN-O0-NEXT:    buffer_load_dword v31, off, s[8:11], 0 offset:268 ; 4-byte Folded Reload
@@ -8464,7 +8464,7 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0:       ; %bb.0: ; %entry
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    v_mov_b32_e32 v17, v15
 ; GCN-O0-NEXT:    v_mov_b32_e32 v18, v14
@@ -8517,16 +8517,16 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    v_mul_lo_u32 v16, v16, s4
 ; GCN-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], 1.0
-; GCN-O0-NEXT:    ; implicit-def: $vgpr33 : SGPR spill to VGPR lane
-; GCN-O0-NEXT:    v_writelane_b32 v33, s4, 0
-; GCN-O0-NEXT:    v_writelane_b32 v33, s5, 1
+; GCN-O0-NEXT:    ; implicit-def: $vgpr32 : SGPR spill to VGPR lane
+; GCN-O0-NEXT:    v_writelane_b32 v32, s4, 0
+; GCN-O0-NEXT:    v_writelane_b32 v32, s5, 1
 ; GCN-O0-NEXT:    v_mov_b32_e32 v16, s4
 ; GCN-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    v_writelane_b32 v33, s4, 2
-; GCN-O0-NEXT:    v_writelane_b32 v33, s5, 3
+; GCN-O0-NEXT:    v_writelane_b32 v32, s4, 2
+; GCN-O0-NEXT:    v_writelane_b32 v32, s5, 3
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
@@ -8547,11 +8547,11 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB23_1: ; =>This Inner Loop Header: Depth=1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v33, 4
-; GCN-O0-NEXT:    v_readlane_b32 s5, v33, 5
+; GCN-O0-NEXT:    v_readlane_b32 s4, v32, 4
+; GCN-O0-NEXT:    v_readlane_b32 s5, v32, 5
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
@@ -8609,28 +8609,28 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v33, s6, 4
-; GCN-O0-NEXT:    v_writelane_b32 v33, s7, 5
+; GCN-O0-NEXT:    v_writelane_b32 v32, s6, 4
+; GCN-O0-NEXT:    v_writelane_b32 v32, s7, 5
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB23_1
 ; GCN-O0-NEXT:  ; %bb.2:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v33, 2
-; GCN-O0-NEXT:    v_readlane_b32 s5, v33, 3
+; GCN-O0-NEXT:    v_readlane_b32 s4, v32, 2
+; GCN-O0-NEXT:    v_readlane_b32 s5, v32, 3
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.3:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v33, 0
-; GCN-O0-NEXT:    v_readlane_b32 s5, v33, 1
+; GCN-O0-NEXT:    v_readlane_b32 s4, v32, 0
+; GCN-O0-NEXT:    v_readlane_b32 s5, v32, 1
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
@@ -8656,10 +8656,10 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    v_mov_b32_e32 v16, s4
 ; GCN-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:268 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
-; GCN-O0-NEXT:    v_writelane_b32 v33, s4, 6
-; GCN-O0-NEXT:    v_writelane_b32 v33, s5, 7
+; GCN-O0-NEXT:    v_writelane_b32 v32, s4, 6
+; GCN-O0-NEXT:    v_writelane_b32 v32, s5, 7
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:204 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:208 ; 4-byte Folded Spill
@@ -8680,11 +8680,11 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB23_4: ; =>This Inner Loop Header: Depth=1
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v33, 8
-; GCN-O0-NEXT:    v_readlane_b32 s5, v33, 9
+; GCN-O0-NEXT:    v_readlane_b32 s4, v32, 8
+; GCN-O0-NEXT:    v_readlane_b32 s5, v32, 9
 ; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:204 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:208 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:212 ; 4-byte Folded Reload
@@ -8742,20 +8742,20 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:260 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:264 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
-; GCN-O0-NEXT:    v_writelane_b32 v33, s6, 8
-; GCN-O0-NEXT:    v_writelane_b32 v33, s7, 9
+; GCN-O0-NEXT:    v_writelane_b32 v32, s6, 8
+; GCN-O0-NEXT:    v_writelane_b32 v32, s7, 9
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB23_4
 ; GCN-O0-NEXT:  ; %bb.5:
 ; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s4, v33, 6
-; GCN-O0-NEXT:    v_readlane_b32 s5, v33, 7
+; GCN-O0-NEXT:    v_readlane_b32 s4, v32, 6
+; GCN-O0-NEXT:    v_readlane_b32 s5, v32, 7
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:  ; %bb.6:
 ; GCN-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:276 ; 4-byte Folded Reload
@@ -8806,7 +8806,7 @@ define <8 x double> @double8_inselt_vec(<8 x double> %vec, i32 %sel) {
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_mov_b32_e32 v15, v30
 ; GCN-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; GCN-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -8844,7 +8844,6 @@ define <3 x i32> @insert_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -8852,17 +8851,17 @@ define <3 x i32> @insert_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr5 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB24_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 3
@@ -8886,15 +8885,15 @@ define <3 x i32> @insert_dyn_i32_3(<3 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB24_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 1
@@ -8944,7 +8943,6 @@ define <3 x i32> @insert_dyn_inreg_i32_3(<3 x i32> inreg %arg, i32 inreg %idx, i
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v4, s6
@@ -8987,7 +8985,6 @@ define <3 x float> @insert_dyn_float_3(<3 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -8995,17 +8992,17 @@ define <3 x float> @insert_dyn_float_3(<3 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr5 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB26_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 3
@@ -9029,15 +9026,15 @@ define <3 x float> @insert_dyn_float_3(<3 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v5, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB26_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[10:11], -1
 ; GCN-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v5, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v5, 1
@@ -9087,7 +9084,6 @@ define <3 x float> @insert_dyn_inreg_float_3(<3 x float> inreg %arg, i32 inreg %
 ; GCN-O0-NEXT:    ; kill: def $sgpr4 killed $sgpr4 def $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    s_mov_b32 s5, s17
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
-; GCN-O0-NEXT:    ; kill: def $sgpr8_sgpr9_sgpr10 killed $sgpr4_sgpr5_sgpr6
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v4, s6
@@ -9138,7 +9134,6 @@ define <5 x i32> @insert_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -9148,9 +9143,9 @@ define <5 x i32> @insert_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr9 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -9158,9 +9153,9 @@ define <5 x i32> @insert_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB28_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 3
@@ -9190,15 +9185,15 @@ define <5 x i32> @insert_dyn_i32_5(<5 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB28_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 1
@@ -9264,7 +9259,6 @@ define <5 x i32> @insert_dyn_inreg_i32_5(<5 x i32> inreg %arg, i32 inreg %idx, i
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v4, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v5, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v6, s6
@@ -9319,7 +9313,6 @@ define <5 x float> @insert_dyn_float_5(<5 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -9329,9 +9322,9 @@ define <5 x float> @insert_dyn_float_5(<5 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr9 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -9339,9 +9332,9 @@ define <5 x float> @insert_dyn_float_5(<5 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB30_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 3
@@ -9371,15 +9364,15 @@ define <5 x float> @insert_dyn_float_5(<5 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v9, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB30_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v9, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v9, 1
@@ -9445,7 +9438,6 @@ define <5 x float> @insert_dyn_inreg_float_5(<5 x float> inreg %arg, i32 inreg %
 ; GCN-O0-NEXT:    s_mov_b32 s6, s18
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v4, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v5, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v6, s6
@@ -9504,7 +9496,6 @@ define <6 x i32> @insert_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -9515,9 +9506,9 @@ define <6 x i32> @insert_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr11 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -9526,9 +9517,9 @@ define <6 x i32> @insert_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB32_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v11, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v11, 3
@@ -9561,15 +9552,15 @@ define <6 x i32> @insert_dyn_i32_6(<6 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB32_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v11, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v11, 1
@@ -9643,7 +9634,6 @@ define <6 x i32> @insert_dyn_inreg_i32_6(<6 x i32> inreg %arg, i32 inreg %idx, i
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v10, s9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v9, s8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v8, s7
@@ -9704,7 +9694,6 @@ define <6 x float> @insert_dyn_float_6(<6 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -9715,9 +9704,9 @@ define <6 x float> @insert_dyn_float_6(<6 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr11 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -9726,9 +9715,9 @@ define <6 x float> @insert_dyn_float_6(<6 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB34_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v11, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v11, 3
@@ -9761,15 +9750,15 @@ define <6 x float> @insert_dyn_float_6(<6 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v11, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB34_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[22:23], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[12:13], -1
 ; GCN-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[22:23]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v11, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v11, 1
@@ -9843,7 +9832,6 @@ define <6 x float> @insert_dyn_inreg_float_6(<6 x float> inreg %arg, i32 inreg %
 ; GCN-O0-NEXT:    s_mov_b32 s7, s19
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v10, s9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v9, s8
 ; GCN-O0-NEXT:    v_mov_b32_e32 v8, s7
@@ -9908,7 +9896,6 @@ define <7 x i32> @insert_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -9920,9 +9907,9 @@ define <7 x i32> @insert_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr13 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -9932,9 +9919,9 @@ define <7 x i32> @insert_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB36_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v13, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v13, 3
@@ -9970,15 +9957,15 @@ define <7 x i32> @insert_dyn_i32_7(<7 x i32> inreg %arg, i32 %idx, i32 %val) {
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB36_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v13, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v13, 1
@@ -10060,7 +10047,6 @@ define <7 x i32> @insert_dyn_inreg_i32_7(<7 x i32> inreg %arg, i32 inreg %idx, i
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v12, s10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v11, s9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v10, s8
@@ -10127,7 +10113,6 @@ define <7 x float> @insert_dyn_float_7(<7 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -10139,9 +10124,9 @@ define <7 x float> @insert_dyn_float_7(<7 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    ; implicit-def: $vgpr13 : SGPR spill to VGPR lane
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s4, 0
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s5, 1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
@@ -10151,9 +10136,9 @@ define <7 x float> @insert_dyn_float_7(<7 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GCN-O0-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GCN-O0-NEXT:  .LBB38_1: ; =>This Inner Loop Header: Depth=1
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v13, 2
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v13, 3
@@ -10189,15 +10174,15 @@ define <7 x float> @insert_dyn_float_7(<7 x float> inreg %arg, i32 %idx, float %
 ; GCN-O0-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s6, 2
 ; GCN-O0-NEXT:    v_writelane_b32 v13, s7, 3
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; GCN-O0-NEXT:    s_cbranch_execnz .LBB38_1
 ; GCN-O0-NEXT:  ; %bb.2:
-; GCN-O0-NEXT:    s_or_saveexec_b64 s[26:27], -1
+; GCN-O0-NEXT:    s_or_saveexec_b64 s[14:15], -1
 ; GCN-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
-; GCN-O0-NEXT:    s_mov_b64 exec, s[26:27]
+; GCN-O0-NEXT:    s_mov_b64 exec, s[14:15]
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    v_readlane_b32 s4, v13, 0
 ; GCN-O0-NEXT:    v_readlane_b32 s5, v13, 1
@@ -10279,7 +10264,6 @@ define <7 x float> @insert_dyn_inreg_float_7(<7 x float> inreg %arg, i32 inreg %
 ; GCN-O0-NEXT:    s_mov_b32 s8, s20
 ; GCN-O0-NEXT:    s_mov_b32 s9, s21
 ; GCN-O0-NEXT:    s_mov_b32 s10, s22
-; GCN-O0-NEXT:    ; kill: def $sgpr12_sgpr13_sgpr14_sgpr15_sgpr16_sgpr17_sgpr18 killed $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v12, s10
 ; GCN-O0-NEXT:    v_mov_b32_e32 v11, s9
 ; GCN-O0-NEXT:    v_mov_b32_e32 v10, s8

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-buffer-atomics.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-buffer-atomics.ll
@@ -20,7 +20,6 @@ define void @buffer_fat_ptr_agent_atomic_add_noret_i32(ptr addrspace(7) inreg %p
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_atomic_add_u32 v0, v1, s[0:3], null offen
@@ -48,7 +47,6 @@ define i32 @buffer_fat_ptr_agent_atomic_add_ret_i32(ptr addrspace(7) inreg %ptr,
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_atomic_add_u32 v0, v1, s[0:3], null offen th:TH_ATOMIC_RETURN
@@ -70,7 +68,6 @@ define void @raw_buffer_atomic_add_v2f16_noret(<2 x half> %val, <4 x i32> inreg 
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_atomic_pk_add_f16 v0, v1, s[0:3], s16 offen
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
@@ -90,7 +87,6 @@ define <2 x half> @raw_buffer_atomic_add_v2f16_ret(<2 x half> %val, <4 x i32> in
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_atomic_pk_add_f16 v0, v1, s[0:3], s16 offen th:TH_ATOMIC_RETURN
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
@@ -115,7 +111,6 @@ define float @struct_buffer_atomic_add_v2f16_ret(<2 x half> %val, <4 x i32> inre
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3 killed $exec
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v3, v1
@@ -144,7 +139,6 @@ define void @struct_buffer_atomic_add_v2f16_noret(<2 x half> %val, <4 x i32> inr
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3 killed $exec
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v3, v1
@@ -167,7 +161,6 @@ define void @raw_buffer_store_i32(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    buffer_store_b32 v0, off, s[0:3], null
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
   call void @llvm.amdgcn.raw.buffer.store.i32(i32 %v, <4 x i32> %rsrc, i32 0, i32 0, i32 0)
@@ -186,7 +179,6 @@ define void @raw_buffer_store_i32_volatile(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_store_b32 v0, off, s[0:3], null scope:SCOPE_SYS
 ; GFX1250-NEXT:    s_wait_storecnt 0x0
@@ -207,7 +199,6 @@ define void @struct_buffer_store_i32(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    buffer_store_b32 v0, v1, s[0:3], null idxen
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
@@ -227,7 +218,6 @@ define void @struct_buffer_store_i32_volatile(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_store_b32 v0, v1, s[0:3], null idxen scope:SCOPE_SYS
@@ -249,7 +239,6 @@ define i32 @raw_buffer_load_i32(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    buffer_load_b32 v0, off, s[0:3], null
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
@@ -270,7 +259,6 @@ define i32 @raw_buffer_load_i32_volatile(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    buffer_load_b32 v0, off, s[0:3], null
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
@@ -290,7 +278,6 @@ define i32 @struct_buffer_load_i32(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], null idxen
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
@@ -312,7 +299,6 @@ define i32 @struct_buffer_load_i32_volatile(<4 x i32> inreg %rsrc, i32 %v) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s6
 ; GFX1250-NEXT:    s_mov_b32 s2, s5
 ; GFX1250-NEXT:    s_mov_b32 s3, s4
-; GFX1250-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], null idxen
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
@@ -340,7 +326,6 @@ define void @buffer_fat_ptr_store_i32(ptr addrspace(7) inreg %ptr, i32 %val) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX1250-NEXT:    buffer_store_b32 v0, v1, s[0:3], null offen
 ; GFX1250-NEXT:    s_set_pc_i64 s[30:31]
@@ -367,7 +352,6 @@ define void @buffer_fat_ptr_store_i32_volatile(ptr addrspace(7) inreg %ptr, i32 
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_store_b32 v0, v1, s[0:3], null offen scope:SCOPE_SYS
@@ -396,7 +380,6 @@ define i32 @buffer_fat_ptr_load_i32(ptr addrspace(7) inreg %ptr) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s16
 ; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen
 ; GFX1250-NEXT:    s_wait_loadcnt 0x0
@@ -424,7 +407,6 @@ define i32 @buffer_fat_ptr_load_i32_volatile(ptr addrspace(7) inreg %ptr) {
 ; GFX1250-NEXT:    s_mov_b32 s1, s10
 ; GFX1250-NEXT:    s_mov_b32 s2, s9
 ; GFX1250-NEXT:    s_mov_b32 s3, s8
-; GFX1250-NEXT:    ; kill: def $sgpr8 killed $sgpr16
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s16
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    buffer_load_b32 v0, v0, s[0:3], null offen scope:SCOPE_SYS

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-agent.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-agent.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_agent_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_agent_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_agent_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -702,8 +696,6 @@ define amdgpu_kernel void @local_agent_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -958,7 +950,6 @@ define amdgpu_kernel void @local_agent_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1163,7 +1154,6 @@ define amdgpu_kernel void @local_agent_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1368,7 +1358,6 @@ define amdgpu_kernel void @local_agent_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1598,7 +1587,6 @@ define amdgpu_kernel void @local_agent_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1828,7 +1816,6 @@ define amdgpu_kernel void @local_agent_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2033,7 +2020,6 @@ define amdgpu_kernel void @local_agent_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2255,7 +2241,6 @@ define amdgpu_kernel void @local_agent_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2485,7 +2470,6 @@ define amdgpu_kernel void @local_agent_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2732,7 +2716,6 @@ define amdgpu_kernel void @local_agent_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2979,7 +2962,6 @@ define amdgpu_kernel void @local_agent_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3235,7 +3217,6 @@ define amdgpu_kernel void @local_agent_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3516,7 +3497,6 @@ define amdgpu_kernel void @local_agent_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3799,7 +3779,6 @@ define amdgpu_kernel void @local_agent_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4061,7 +4040,6 @@ define amdgpu_kernel void @local_agent_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4340,7 +4318,6 @@ define amdgpu_kernel void @local_agent_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4627,7 +4604,6 @@ define amdgpu_kernel void @local_agent_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4931,7 +4907,6 @@ define amdgpu_kernel void @local_agent_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5235,7 +5210,6 @@ define amdgpu_kernel void @local_agent_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5514,7 +5488,6 @@ define amdgpu_kernel void @local_agent_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5793,7 +5766,6 @@ define amdgpu_kernel void @local_agent_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6097,7 +6069,6 @@ define amdgpu_kernel void @local_agent_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6401,7 +6372,6 @@ define amdgpu_kernel void @local_agent_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6705,7 +6675,6 @@ define amdgpu_kernel void @local_agent_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7009,7 +6978,6 @@ define amdgpu_kernel void @local_agent_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7313,7 +7281,6 @@ define amdgpu_kernel void @local_agent_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7617,7 +7584,6 @@ define amdgpu_kernel void @local_agent_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7921,7 +7887,6 @@ define amdgpu_kernel void @local_agent_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -8225,7 +8190,6 @@ define amdgpu_kernel void @local_agent_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8534,7 +8498,6 @@ define amdgpu_kernel void @local_agent_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8848,7 +8811,6 @@ define amdgpu_kernel void @local_agent_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9182,7 +9144,6 @@ define amdgpu_kernel void @local_agent_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9521,7 +9482,6 @@ define amdgpu_kernel void @local_agent_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9860,7 +9820,6 @@ define amdgpu_kernel void @local_agent_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10174,7 +10133,6 @@ define amdgpu_kernel void @local_agent_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10488,7 +10446,6 @@ define amdgpu_kernel void @local_agent_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10827,7 +10784,6 @@ define amdgpu_kernel void @local_agent_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11166,7 +11122,6 @@ define amdgpu_kernel void @local_agent_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11505,7 +11460,6 @@ define amdgpu_kernel void @local_agent_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11844,7 +11798,6 @@ define amdgpu_kernel void @local_agent_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12183,7 +12136,6 @@ define amdgpu_kernel void @local_agent_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12522,7 +12474,6 @@ define amdgpu_kernel void @local_agent_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12861,7 +12812,6 @@ define amdgpu_kernel void @local_agent_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -13198,8 +13148,6 @@ define amdgpu_kernel void @local_agent_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13424,8 +13372,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13650,8 +13596,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13876,8 +13820,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -14102,7 +14044,6 @@ define amdgpu_kernel void @local_agent_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14307,7 +14248,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14512,7 +14452,6 @@ define amdgpu_kernel void @local_agent_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14717,7 +14656,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14922,7 +14860,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15127,7 +15064,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15332,7 +15268,6 @@ define amdgpu_kernel void @local_agent_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15537,7 +15472,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15742,7 +15676,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15947,7 +15880,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16198,7 +16130,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16449,7 +16380,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16702,7 +16632,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16964,7 +16893,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17226,7 +17154,6 @@ define amdgpu_kernel void @local_agent_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17488,7 +17415,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17750,7 +17676,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18012,7 +17937,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18274,7 +18198,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18536,7 +18459,6 @@ define amdgpu_kernel void @local_agent_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18798,7 +18720,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19060,7 +18981,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19322,7 +19242,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19584,7 +19503,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19846,7 +19764,6 @@ define amdgpu_kernel void @local_agent_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20108,7 +20025,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20370,7 +20286,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20632,7 +20547,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20941,7 +20855,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21250,7 +21163,6 @@ define amdgpu_kernel void @local_agent_one_as_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21559,7 +21471,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21868,7 +21779,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22177,7 +22087,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22486,7 +22395,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22795,7 +22703,6 @@ define amdgpu_kernel void @local_agent_one_as_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23104,7 +23011,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23413,7 +23319,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23722,7 +23627,6 @@ define amdgpu_kernel void @local_agent_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24031,7 +23935,6 @@ define amdgpu_kernel void @local_agent_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24340,7 +24243,6 @@ define amdgpu_kernel void @local_agent_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24649,7 +24551,6 @@ define amdgpu_kernel void @local_agent_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24958,7 +24859,6 @@ define amdgpu_kernel void @local_agent_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-cluster.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-cluster.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_cluster_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_cluster_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_cluster_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -702,8 +696,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -958,7 +950,6 @@ define amdgpu_kernel void @local_cluster_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1163,7 +1154,6 @@ define amdgpu_kernel void @local_cluster_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1368,7 +1358,6 @@ define amdgpu_kernel void @local_cluster_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1598,7 +1587,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1828,7 +1816,6 @@ define amdgpu_kernel void @local_cluster_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2033,7 +2020,6 @@ define amdgpu_kernel void @local_cluster_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2255,7 +2241,6 @@ define amdgpu_kernel void @local_cluster_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2485,7 +2470,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2732,7 +2716,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2979,7 +2962,6 @@ define amdgpu_kernel void @local_cluster_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3235,7 +3217,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3516,7 +3497,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3799,7 +3779,6 @@ define amdgpu_kernel void @local_cluster_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4061,7 +4040,6 @@ define amdgpu_kernel void @local_cluster_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4340,7 +4318,6 @@ define amdgpu_kernel void @local_cluster_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4627,7 +4604,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4931,7 +4907,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5235,7 +5210,6 @@ define amdgpu_kernel void @local_cluster_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5514,7 +5488,6 @@ define amdgpu_kernel void @local_cluster_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5793,7 +5766,6 @@ define amdgpu_kernel void @local_cluster_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6097,7 +6069,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6401,7 +6372,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6705,7 +6675,6 @@ define amdgpu_kernel void @local_cluster_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7009,7 +6978,6 @@ define amdgpu_kernel void @local_cluster_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7313,7 +7281,6 @@ define amdgpu_kernel void @local_cluster_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7617,7 +7584,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7921,7 +7887,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -8225,7 +8190,6 @@ define amdgpu_kernel void @local_cluster_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8534,7 +8498,6 @@ define amdgpu_kernel void @local_cluster_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8848,7 +8811,6 @@ define amdgpu_kernel void @local_cluster_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9182,7 +9144,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9521,7 +9482,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9860,7 +9820,6 @@ define amdgpu_kernel void @local_cluster_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10174,7 +10133,6 @@ define amdgpu_kernel void @local_cluster_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10488,7 +10446,6 @@ define amdgpu_kernel void @local_cluster_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10827,7 +10784,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11166,7 +11122,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11505,7 +11460,6 @@ define amdgpu_kernel void @local_cluster_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11844,7 +11798,6 @@ define amdgpu_kernel void @local_cluster_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12183,7 +12136,6 @@ define amdgpu_kernel void @local_cluster_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12522,7 +12474,6 @@ define amdgpu_kernel void @local_cluster_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12861,7 +12812,6 @@ define amdgpu_kernel void @local_cluster_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -13198,8 +13148,6 @@ define amdgpu_kernel void @local_cluster_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13424,8 +13372,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13650,8 +13596,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13876,8 +13820,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -14102,7 +14044,6 @@ define amdgpu_kernel void @local_cluster_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14307,7 +14248,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14512,7 +14452,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14717,7 +14656,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14922,7 +14860,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15127,7 +15064,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15332,7 +15268,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15537,7 +15472,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15742,7 +15676,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15947,7 +15880,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16198,7 +16130,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16449,7 +16380,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16702,7 +16632,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16964,7 +16893,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17226,7 +17154,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17488,7 +17415,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17750,7 +17676,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18012,7 +17937,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18274,7 +18198,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18536,7 +18459,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18798,7 +18720,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19060,7 +18981,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19322,7 +19242,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19584,7 +19503,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19846,7 +19764,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20108,7 +20025,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20370,7 +20286,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20632,7 +20547,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20941,7 +20855,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21250,7 +21163,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21559,7 +21471,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21868,7 +21779,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22177,7 +22087,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22486,7 +22395,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22795,7 +22703,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23104,7 +23011,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23413,7 +23319,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23722,7 +23627,6 @@ define amdgpu_kernel void @local_cluster_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24031,7 +23935,6 @@ define amdgpu_kernel void @local_cluster_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24340,7 +24243,6 @@ define amdgpu_kernel void @local_cluster_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24649,7 +24551,6 @@ define amdgpu_kernel void @local_cluster_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24958,7 +24859,6 @@ define amdgpu_kernel void @local_cluster_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-nontemporal.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-nontemporal.ll
@@ -20,7 +20,6 @@ define amdgpu_kernel void @local_nontemporal_load_0(
 ; GFX6-NEXT:    s_mov_b64 s[4:5], s[8:9]
 ; GFX6-NEXT:    s_load_dword s8, s[4:5], 0x0
 ; GFX6-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr8
 ; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x2
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s11, s5
@@ -263,7 +262,6 @@ define amdgpu_kernel void @local_nontemporal_load_1(
 ; GFX6-NEXT:    s_mov_b64 s[4:5], s[8:9]
 ; GFX6-NEXT:    s_load_dword s8, s[4:5], 0x0
 ; GFX6-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr8
 ; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x2
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s11, s5
@@ -543,7 +541,6 @@ define amdgpu_kernel void @local_nontemporal_store_0(
 ; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[8:9], 0x0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_load_dwordx2 s[6:7], s[8:9], 0x0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[6:7], 0x0
@@ -764,7 +761,6 @@ define amdgpu_kernel void @local_nontemporal_store_1(
 ; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[8:9], 0x0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_load_dwordx2 s[6:7], s[8:9], 0x0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[6:7], 0x0
@@ -1012,7 +1008,6 @@ define amdgpu_kernel void @local_nontemporal_volatile_load(
 ; GFX6-NEXT:    s_mov_b64 s[4:5], s[8:9]
 ; GFX6-NEXT:    s_load_dword s8, s[4:5], 0x0
 ; GFX6-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr8
 ; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x2
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s11, s5

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-singlethread.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-singlethread.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_singlethread_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_singlethread_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -697,8 +691,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -923,7 +915,6 @@ define amdgpu_kernel void @local_singlethread_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1128,7 +1119,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1333,7 +1323,6 @@ define amdgpu_kernel void @local_singlethread_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1538,7 +1527,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1743,7 +1731,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1948,7 +1935,6 @@ define amdgpu_kernel void @local_singlethread_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2153,7 +2139,6 @@ define amdgpu_kernel void @local_singlethread_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2358,7 +2343,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2563,7 +2547,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2768,7 +2751,6 @@ define amdgpu_kernel void @local_singlethread_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3019,7 +3001,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3270,7 +3251,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3523,7 +3503,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -3785,7 +3764,6 @@ define amdgpu_kernel void @local_singlethread_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4047,7 +4025,6 @@ define amdgpu_kernel void @local_singlethread_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4309,7 +4286,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4571,7 +4547,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4833,7 +4808,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5095,7 +5069,6 @@ define amdgpu_kernel void @local_singlethread_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5357,7 +5330,6 @@ define amdgpu_kernel void @local_singlethread_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5619,7 +5591,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5881,7 +5852,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6143,7 +6113,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6405,7 +6374,6 @@ define amdgpu_kernel void @local_singlethread_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6667,7 +6635,6 @@ define amdgpu_kernel void @local_singlethread_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6929,7 +6896,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7191,7 +7157,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7453,7 +7418,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -7762,7 +7726,6 @@ define amdgpu_kernel void @local_singlethread_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8071,7 +8034,6 @@ define amdgpu_kernel void @local_singlethread_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8380,7 +8342,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8689,7 +8650,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8998,7 +8958,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9307,7 +9266,6 @@ define amdgpu_kernel void @local_singlethread_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9616,7 +9574,6 @@ define amdgpu_kernel void @local_singlethread_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9925,7 +9882,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10234,7 +10190,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10543,7 +10498,6 @@ define amdgpu_kernel void @local_singlethread_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10852,7 +10806,6 @@ define amdgpu_kernel void @local_singlethread_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11161,7 +11114,6 @@ define amdgpu_kernel void @local_singlethread_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11470,7 +11422,6 @@ define amdgpu_kernel void @local_singlethread_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11779,7 +11730,6 @@ define amdgpu_kernel void @local_singlethread_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12086,8 +12036,6 @@ define amdgpu_kernel void @local_singlethread_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12312,8 +12260,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12538,8 +12484,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12764,8 +12708,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12990,7 +12932,6 @@ define amdgpu_kernel void @local_singlethread_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13195,7 +13136,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13400,7 +13340,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13605,7 +13544,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13810,7 +13748,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14015,7 +13952,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14220,7 +14156,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14425,7 +14360,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14630,7 +14564,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14835,7 +14768,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15086,7 +15018,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15337,7 +15268,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15590,7 +15520,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_monotonic_cmpxchg
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -15852,7 +15781,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16114,7 +16042,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16376,7 +16303,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16638,7 +16564,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16900,7 +16825,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17162,7 +17086,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17424,7 +17347,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17686,7 +17608,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17948,7 +17869,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18210,7 +18130,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18472,7 +18391,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18734,7 +18652,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18996,7 +18913,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19258,7 +19174,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19520,7 +19435,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_monotonic_ret_cmp
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -19829,7 +19743,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_monotonic_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20138,7 +20051,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_monotonic_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20447,7 +20359,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_monotonic_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20756,7 +20667,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_monotonic_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21065,7 +20975,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_acquire_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21374,7 +21283,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_acquire_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21683,7 +21591,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_acquire_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21992,7 +21899,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_acquire_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22301,7 +22207,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_acquire_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22610,7 +22515,6 @@ define amdgpu_kernel void @local_singlethread_one_as_monotonic_seq_cst_ret_cmpxc
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22919,7 +22823,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acquire_seq_cst_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23228,7 +23131,6 @@ define amdgpu_kernel void @local_singlethread_one_as_release_seq_cst_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23537,7 +23439,6 @@ define amdgpu_kernel void @local_singlethread_one_as_acq_rel_seq_cst_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23846,7 +23747,6 @@ define amdgpu_kernel void @local_singlethread_one_as_seq_cst_seq_cst_ret_cmpxchg
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-system.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-system.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_system_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_system_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_system_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -702,8 +696,6 @@ define amdgpu_kernel void @local_system_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -958,7 +950,6 @@ define amdgpu_kernel void @local_system_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1163,7 +1154,6 @@ define amdgpu_kernel void @local_system_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1368,7 +1358,6 @@ define amdgpu_kernel void @local_system_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1598,7 +1587,6 @@ define amdgpu_kernel void @local_system_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1828,7 +1816,6 @@ define amdgpu_kernel void @local_system_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2033,7 +2020,6 @@ define amdgpu_kernel void @local_system_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2255,7 +2241,6 @@ define amdgpu_kernel void @local_system_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2485,7 +2470,6 @@ define amdgpu_kernel void @local_system_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2732,7 +2716,6 @@ define amdgpu_kernel void @local_system_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2979,7 +2962,6 @@ define amdgpu_kernel void @local_system_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3235,7 +3217,6 @@ define amdgpu_kernel void @local_system_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3516,7 +3497,6 @@ define amdgpu_kernel void @local_system_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3799,7 +3779,6 @@ define amdgpu_kernel void @local_system_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4061,7 +4040,6 @@ define amdgpu_kernel void @local_system_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4340,7 +4318,6 @@ define amdgpu_kernel void @local_system_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4627,7 +4604,6 @@ define amdgpu_kernel void @local_system_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4931,7 +4907,6 @@ define amdgpu_kernel void @local_system_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5235,7 +5210,6 @@ define amdgpu_kernel void @local_system_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5514,7 +5488,6 @@ define amdgpu_kernel void @local_system_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5793,7 +5766,6 @@ define amdgpu_kernel void @local_system_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6097,7 +6069,6 @@ define amdgpu_kernel void @local_system_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6401,7 +6372,6 @@ define amdgpu_kernel void @local_system_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6705,7 +6675,6 @@ define amdgpu_kernel void @local_system_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7009,7 +6978,6 @@ define amdgpu_kernel void @local_system_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7313,7 +7281,6 @@ define amdgpu_kernel void @local_system_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7617,7 +7584,6 @@ define amdgpu_kernel void @local_system_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7921,7 +7887,6 @@ define amdgpu_kernel void @local_system_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -8225,7 +8190,6 @@ define amdgpu_kernel void @local_system_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8534,7 +8498,6 @@ define amdgpu_kernel void @local_system_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8848,7 +8811,6 @@ define amdgpu_kernel void @local_system_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9182,7 +9144,6 @@ define amdgpu_kernel void @local_system_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9521,7 +9482,6 @@ define amdgpu_kernel void @local_system_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9860,7 +9820,6 @@ define amdgpu_kernel void @local_system_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10174,7 +10133,6 @@ define amdgpu_kernel void @local_system_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10488,7 +10446,6 @@ define amdgpu_kernel void @local_system_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10827,7 +10784,6 @@ define amdgpu_kernel void @local_system_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11166,7 +11122,6 @@ define amdgpu_kernel void @local_system_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11505,7 +11460,6 @@ define amdgpu_kernel void @local_system_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11844,7 +11798,6 @@ define amdgpu_kernel void @local_system_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12183,7 +12136,6 @@ define amdgpu_kernel void @local_system_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12522,7 +12474,6 @@ define amdgpu_kernel void @local_system_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12861,7 +12812,6 @@ define amdgpu_kernel void @local_system_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -13198,8 +13148,6 @@ define amdgpu_kernel void @local_system_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13424,8 +13372,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13650,8 +13596,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13876,8 +13820,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -14102,7 +14044,6 @@ define amdgpu_kernel void @local_system_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14307,7 +14248,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14512,7 +14452,6 @@ define amdgpu_kernel void @local_system_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14717,7 +14656,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14922,7 +14860,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15127,7 +15064,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15332,7 +15268,6 @@ define amdgpu_kernel void @local_system_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15537,7 +15472,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15742,7 +15676,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15947,7 +15880,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16198,7 +16130,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16449,7 +16380,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16702,7 +16632,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16964,7 +16893,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17226,7 +17154,6 @@ define amdgpu_kernel void @local_system_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17488,7 +17415,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17750,7 +17676,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18012,7 +17937,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18274,7 +18198,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18536,7 +18459,6 @@ define amdgpu_kernel void @local_system_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18798,7 +18720,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19060,7 +18981,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19322,7 +19242,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19584,7 +19503,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19846,7 +19764,6 @@ define amdgpu_kernel void @local_system_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20108,7 +20025,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20370,7 +20286,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20632,7 +20547,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20941,7 +20855,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21250,7 +21163,6 @@ define amdgpu_kernel void @local_system_one_as_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21559,7 +21471,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21868,7 +21779,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22177,7 +22087,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22486,7 +22395,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22795,7 +22703,6 @@ define amdgpu_kernel void @local_system_one_as_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23104,7 +23011,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23413,7 +23319,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23722,7 +23627,6 @@ define amdgpu_kernel void @local_system_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24031,7 +23935,6 @@ define amdgpu_kernel void @local_system_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24340,7 +24243,6 @@ define amdgpu_kernel void @local_system_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24649,7 +24551,6 @@ define amdgpu_kernel void @local_system_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24958,7 +24859,6 @@ define amdgpu_kernel void @local_system_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-volatile.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-volatile.ll
@@ -16,7 +16,6 @@ define amdgpu_kernel void @local_volatile_load_0(
 ; GFX6-NEXT:    s_mov_b64 s[0:1], s[4:5]
 ; GFX6-NEXT:    s_load_dword s4, s[0:1], 0x9
 ; GFX6-NEXT:    s_load_dwordx2 s[2:3], s[0:1], 0xb
-; GFX6-NEXT:    ; kill: def $sgpr2 killed $sgpr4
 ; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[0:1], 0xb
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s7, s1
@@ -199,7 +198,6 @@ define amdgpu_kernel void @local_volatile_load_1(
 ; GFX6-NEXT:    s_mov_b64 s[0:1], s[4:5]
 ; GFX6-NEXT:    s_load_dword s4, s[0:1], 0x9
 ; GFX6-NEXT:    s_load_dwordx2 s[2:3], s[0:1], 0xb
-; GFX6-NEXT:    ; kill: def $sgpr2 killed $sgpr4
 ; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[0:1], 0xb
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s7, s1
@@ -407,7 +405,6 @@ define amdgpu_kernel void @local_volatile_store_0(
 ; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s1, s[4:5], 0xb
-; GFX6-NEXT:    ; kill: def $sgpr0 killed $sgpr1
 ; GFX6-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s0, s[2:3], 0x0
@@ -568,7 +565,6 @@ define amdgpu_kernel void @local_volatile_store_1(
 ; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s1, s[4:5], 0xb
-; GFX6-NEXT:    ; kill: def $sgpr0 killed $sgpr1
 ; GFX6-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s0, s[2:3], 0x0
@@ -747,8 +743,6 @@ define amdgpu_kernel void @local_volatile_workgroup_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s1, s[4:5], 0x9
 ; GFX6-NEXT:    s_load_dword s0, s[4:5], 0xa
-; GFX6-NEXT:    ; kill: def $sgpr2 killed $sgpr0
-; GFX6-NEXT:    ; kill: def $sgpr2 killed $sgpr1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s1
@@ -916,7 +910,6 @@ define amdgpu_kernel void @local_volatile_workgroup_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s0, s[4:5], 0x9
 ; GFX6-NEXT:    s_load_dword s1, s[4:5], 0xa
-; GFX6-NEXT:    ; kill: def $sgpr0 killed $sgpr1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s0, s[4:5], 0x9
 ; GFX6-NEXT:    s_mov_b32 m0, -1

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-wavefront.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-wavefront.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_wavefront_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_wavefront_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -697,8 +691,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -923,7 +915,6 @@ define amdgpu_kernel void @local_wavefront_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1128,7 +1119,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1333,7 +1323,6 @@ define amdgpu_kernel void @local_wavefront_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1538,7 +1527,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1743,7 +1731,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1948,7 +1935,6 @@ define amdgpu_kernel void @local_wavefront_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2153,7 +2139,6 @@ define amdgpu_kernel void @local_wavefront_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2358,7 +2343,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2563,7 +2547,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2768,7 +2751,6 @@ define amdgpu_kernel void @local_wavefront_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3019,7 +3001,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3270,7 +3251,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3523,7 +3503,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -3785,7 +3764,6 @@ define amdgpu_kernel void @local_wavefront_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4047,7 +4025,6 @@ define amdgpu_kernel void @local_wavefront_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4309,7 +4286,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4571,7 +4547,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4833,7 +4808,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5095,7 +5069,6 @@ define amdgpu_kernel void @local_wavefront_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5357,7 +5330,6 @@ define amdgpu_kernel void @local_wavefront_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5619,7 +5591,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5881,7 +5852,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6143,7 +6113,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6405,7 +6374,6 @@ define amdgpu_kernel void @local_wavefront_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6667,7 +6635,6 @@ define amdgpu_kernel void @local_wavefront_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6929,7 +6896,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7191,7 +7157,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7453,7 +7418,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -7762,7 +7726,6 @@ define amdgpu_kernel void @local_wavefront_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8071,7 +8034,6 @@ define amdgpu_kernel void @local_wavefront_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8380,7 +8342,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8689,7 +8650,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8998,7 +8958,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9307,7 +9266,6 @@ define amdgpu_kernel void @local_wavefront_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9616,7 +9574,6 @@ define amdgpu_kernel void @local_wavefront_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9925,7 +9882,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10234,7 +10190,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10543,7 +10498,6 @@ define amdgpu_kernel void @local_wavefront_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10852,7 +10806,6 @@ define amdgpu_kernel void @local_wavefront_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11161,7 +11114,6 @@ define amdgpu_kernel void @local_wavefront_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11470,7 +11422,6 @@ define amdgpu_kernel void @local_wavefront_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11779,7 +11730,6 @@ define amdgpu_kernel void @local_wavefront_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12086,8 +12036,6 @@ define amdgpu_kernel void @local_wavefront_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12312,8 +12260,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12538,8 +12484,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12764,8 +12708,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -12990,7 +12932,6 @@ define amdgpu_kernel void @local_wavefront_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13195,7 +13136,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13400,7 +13340,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13605,7 +13544,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -13810,7 +13748,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14015,7 +13952,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14220,7 +14156,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14425,7 +14360,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14630,7 +14564,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14835,7 +14768,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15086,7 +15018,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15337,7 +15268,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15590,7 +15520,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -15852,7 +15781,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16114,7 +16042,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16376,7 +16303,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16638,7 +16564,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16900,7 +16825,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17162,7 +17086,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17424,7 +17347,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17686,7 +17608,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17948,7 +17869,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18210,7 +18130,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18472,7 +18391,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18734,7 +18652,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18996,7 +18913,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19258,7 +19174,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19520,7 +19435,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_monotonic_ret_cmpxch
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -19829,7 +19743,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20138,7 +20051,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20447,7 +20359,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20756,7 +20667,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21065,7 +20975,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21374,7 +21283,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21683,7 +21591,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21992,7 +21899,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22301,7 +22207,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22610,7 +22515,6 @@ define amdgpu_kernel void @local_wavefront_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22919,7 +22823,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23228,7 +23131,6 @@ define amdgpu_kernel void @local_wavefront_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23537,7 +23439,6 @@ define amdgpu_kernel void @local_wavefront_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23846,7 +23747,6 @@ define amdgpu_kernel void @local_wavefront_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-workgroup.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-local-workgroup.ll
@@ -19,8 +19,6 @@ define amdgpu_kernel void @local_workgroup_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -245,8 +243,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -471,8 +467,6 @@ define amdgpu_kernel void @local_workgroup_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -702,8 +696,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -958,7 +950,6 @@ define amdgpu_kernel void @local_workgroup_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1163,7 +1154,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1368,7 +1358,6 @@ define amdgpu_kernel void @local_workgroup_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1598,7 +1587,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -1828,7 +1816,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2033,7 +2020,6 @@ define amdgpu_kernel void @local_workgroup_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2255,7 +2241,6 @@ define amdgpu_kernel void @local_workgroup_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2485,7 +2470,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2732,7 +2716,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -2979,7 +2962,6 @@ define amdgpu_kernel void @local_workgroup_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3235,7 +3217,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3516,7 +3497,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -3799,7 +3779,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4061,7 +4040,6 @@ define amdgpu_kernel void @local_workgroup_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4340,7 +4318,6 @@ define amdgpu_kernel void @local_workgroup_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4627,7 +4604,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -4931,7 +4907,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5235,7 +5210,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5514,7 +5488,6 @@ define amdgpu_kernel void @local_workgroup_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -5793,7 +5766,6 @@ define amdgpu_kernel void @local_workgroup_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6097,7 +6069,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6401,7 +6372,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -6705,7 +6675,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7009,7 +6978,6 @@ define amdgpu_kernel void @local_workgroup_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7313,7 +7281,6 @@ define amdgpu_kernel void @local_workgroup_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7617,7 +7584,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -7921,7 +7887,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -8225,7 +8190,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8534,7 +8498,6 @@ define amdgpu_kernel void @local_workgroup_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -8848,7 +8811,6 @@ define amdgpu_kernel void @local_workgroup_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9182,7 +9144,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9521,7 +9482,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -9860,7 +9820,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10174,7 +10133,6 @@ define amdgpu_kernel void @local_workgroup_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10488,7 +10446,6 @@ define amdgpu_kernel void @local_workgroup_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -10827,7 +10784,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11166,7 +11122,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11505,7 +11460,6 @@ define amdgpu_kernel void @local_workgroup_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -11844,7 +11798,6 @@ define amdgpu_kernel void @local_workgroup_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12183,7 +12136,6 @@ define amdgpu_kernel void @local_workgroup_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12522,7 +12474,6 @@ define amdgpu_kernel void @local_workgroup_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -12861,7 +12812,6 @@ define amdgpu_kernel void @local_workgroup_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -13198,8 +13148,6 @@ define amdgpu_kernel void @local_workgroup_one_as_unordered_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13424,8 +13372,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13650,8 +13596,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -13876,8 +13820,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_load(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr4
-; GFX6-NEXT:    ; kill: def $sgpr6 killed $sgpr5
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s5
@@ -14102,7 +14044,6 @@ define amdgpu_kernel void @local_workgroup_one_as_unordered_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14307,7 +14248,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14512,7 +14452,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14717,7 +14656,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_store(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -14922,7 +14860,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15127,7 +15064,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15332,7 +15268,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15537,7 +15472,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15742,7 +15676,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr5
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -15947,7 +15880,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16198,7 +16130,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16449,7 +16380,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_ret_atomicrmw(
 ; GFX6:       ; %bb.0: ; %entry
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x0
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_mov_b32 m0, -1
@@ -16702,7 +16632,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -16964,7 +16893,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17226,7 +17154,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17488,7 +17415,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -17750,7 +17676,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18012,7 +17937,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18274,7 +18198,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18536,7 +18459,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -18798,7 +18720,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19060,7 +18981,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_acquire_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19322,7 +19242,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19584,7 +19503,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -19846,7 +19764,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20108,7 +20025,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20370,7 +20286,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr4 killed $sgpr6
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s4, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
@@ -20632,7 +20547,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_monotonic_ret_cmpxch
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -20941,7 +20855,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21250,7 +21163,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21559,7 +21471,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -21868,7 +21779,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22177,7 +22087,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22486,7 +22395,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -22795,7 +22703,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23104,7 +23011,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23413,7 +23319,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -23722,7 +23627,6 @@ define amdgpu_kernel void @local_workgroup_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24031,7 +23935,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24340,7 +24243,6 @@ define amdgpu_kernel void @local_workgroup_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24649,7 +24551,6 @@ define amdgpu_kernel void @local_workgroup_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2
@@ -24958,7 +24859,6 @@ define amdgpu_kernel void @local_workgroup_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x2
-; GFX6-NEXT:    ; kill: def $sgpr5 killed $sgpr4
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_load_dword s5, s[8:9], 0x1
 ; GFX6-NEXT:    s_load_dword s6, s[8:9], 0x2

--- a/llvm/test/CodeGen/AMDGPU/mubuf-legalize-operands-non-ptr-intrinsics.ll
+++ b/llvm/test/CodeGen/AMDGPU/mubuf-legalize-operands-non-ptr-intrinsics.ll
@@ -484,69 +484,66 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0:       ; %bb.0: ; %entry
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v12, v9
-; W64-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v12, v8
-; W64-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v12, v3
+; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v13, v4
+; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_mov_b32_e32 v6, v3
 ; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
-; W64-O0-NEXT:    v_mov_b32_e32 v13, v2
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
-; W64-O0-NEXT:    v_mov_b32_e32 v14, v1
-; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5_vgpr6_vgpr7 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v7, v2
+; W64-O0-NEXT:    v_mov_b32_e32 v8, v1
+; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_mov_b32_e32 v2, v0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; W64-O0-NEXT:    ; kill: def $vgpr13 killed $vgpr13 def $vgpr13_vgpr14_vgpr15_vgpr16 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v14, v5
+; W64-O0-NEXT:    s_waitcnt vmcnt(3)
+; W64-O0-NEXT:    v_mov_b32_e32 v15, v4
 ; W64-O0-NEXT:    s_waitcnt vmcnt(2)
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v3
-; W64-O0-NEXT:    s_waitcnt vmcnt(1)
-; W64-O0-NEXT:    v_mov_b32_e32 v6, v2
-; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_mov_b32_e32 v7, v1
-; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v16, v3
+; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v1, v14
-; W64-O0-NEXT:    v_mov_b32_e32 v2, v13
-; W64-O0-NEXT:    v_mov_b32_e32 v3, v12
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3_vgpr4_vgpr5 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v3, v8
+; W64-O0-NEXT:    v_mov_b32_e32 v4, v7
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v6
+; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr11 killed $vgpr11 def $vgpr11_vgpr12 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v12, v9
-; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 def $vgpr1_vgpr2 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v2, v12
+; W64-O0-NEXT:    s_waitcnt vmcnt(9)
+; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v9, v10
-; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v1, v10
+; W64-O0-NEXT:    s_waitcnt vmcnt(10)
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b32 s4, 0
-; W64-O0-NEXT:    ; implicit-def: $vgpr15 : SGPR spill to VGPR lane
-; W64-O0-NEXT:    v_writelane_b32 v15, s4, 0
+; W64-O0-NEXT:    ; implicit-def: $vgpr17 : SGPR spill to VGPR lane
+; W64-O0-NEXT:    v_writelane_b32 v17, s4, 0
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
-; W64-O0-NEXT:    v_writelane_b32 v15, s4, 1
-; W64-O0-NEXT:    v_writelane_b32 v15, s5, 2
+; W64-O0-NEXT:    v_writelane_b32 v17, s4, 1
+; W64-O0-NEXT:    v_writelane_b32 v17, s5, 2
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
@@ -571,53 +568,53 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    s_mov_b32 s9, s12
 ; W64-O0-NEXT:    s_mov_b32 s10, s7
 ; W64-O0-NEXT:    s_mov_b32 s11, s6
-; W64-O0-NEXT:    v_writelane_b32 v15, s8, 3
-; W64-O0-NEXT:    v_writelane_b32 v15, s9, 4
-; W64-O0-NEXT:    v_writelane_b32 v15, s10, 5
-; W64-O0-NEXT:    v_writelane_b32 v15, s11, 6
+; W64-O0-NEXT:    v_writelane_b32 v17, s8, 3
+; W64-O0-NEXT:    v_writelane_b32 v17, s9, 4
+; W64-O0-NEXT:    v_writelane_b32 v17, s10, 5
+; W64-O0-NEXT:    v_writelane_b32 v17, s11, 6
 ; W64-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
-; W64-O0-NEXT:    v_writelane_b32 v15, s4, 7
-; W64-O0-NEXT:    v_writelane_b32 v15, s5, 8
+; W64-O0-NEXT:    v_writelane_b32 v17, s4, 7
+; W64-O0-NEXT:    v_writelane_b32 v17, s5, 8
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB1_1 Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v15, 7
-; W64-O0-NEXT:    v_readlane_b32 s5, v15, 8
-; W64-O0-NEXT:    v_readlane_b32 s8, v15, 3
-; W64-O0-NEXT:    v_readlane_b32 s9, v15, 4
-; W64-O0-NEXT:    v_readlane_b32 s10, v15, 5
-; W64-O0-NEXT:    v_readlane_b32 s11, v15, 6
-; W64-O0-NEXT:    v_readlane_b32 s6, v15, 0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_readlane_b32 s4, v17, 7
+; W64-O0-NEXT:    v_readlane_b32 s5, v17, 8
+; W64-O0-NEXT:    v_readlane_b32 s8, v17, 3
+; W64-O0-NEXT:    v_readlane_b32 s9, v17, 4
+; W64-O0-NEXT:    v_readlane_b32 s10, v17, 5
+; W64-O0-NEXT:    v_readlane_b32 s11, v17, 6
+; W64-O0-NEXT:    v_readlane_b32 s6, v17, 0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB1_1
 ; W64-O0-NEXT:  ; %bb.3:
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v15, 1
-; W64-O0-NEXT:    v_readlane_b32 s5, v15, 2
+; W64-O0-NEXT:    v_readlane_b32 s4, v17, 1
+; W64-O0-NEXT:    v_readlane_b32 s5, v17, 2
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
-; W64-O0-NEXT:    v_writelane_b32 v15, s4, 9
-; W64-O0-NEXT:    v_writelane_b32 v15, s5, 10
+; W64-O0-NEXT:    v_writelane_b32 v17, s4, 9
+; W64-O0-NEXT:    v_writelane_b32 v17, s5, 10
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  .LBB1_4: ; =>This Inner Loop Header: Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -642,48 +639,48 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    s_mov_b32 s9, s12
 ; W64-O0-NEXT:    s_mov_b32 s10, s7
 ; W64-O0-NEXT:    s_mov_b32 s11, s6
-; W64-O0-NEXT:    v_writelane_b32 v15, s8, 11
-; W64-O0-NEXT:    v_writelane_b32 v15, s9, 12
-; W64-O0-NEXT:    v_writelane_b32 v15, s10, 13
-; W64-O0-NEXT:    v_writelane_b32 v15, s11, 14
+; W64-O0-NEXT:    v_writelane_b32 v17, s8, 11
+; W64-O0-NEXT:    v_writelane_b32 v17, s9, 12
+; W64-O0-NEXT:    v_writelane_b32 v17, s10, 13
+; W64-O0-NEXT:    v_writelane_b32 v17, s11, 14
 ; W64-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
-; W64-O0-NEXT:    v_writelane_b32 v15, s4, 15
-; W64-O0-NEXT:    v_writelane_b32 v15, s5, 16
+; W64-O0-NEXT:    v_writelane_b32 v17, s4, 15
+; W64-O0-NEXT:    v_writelane_b32 v17, s5, 16
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  ; %bb.5: ; in Loop: Header=BB1_4 Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v15, 15
-; W64-O0-NEXT:    v_readlane_b32 s5, v15, 16
-; W64-O0-NEXT:    v_readlane_b32 s8, v15, 11
-; W64-O0-NEXT:    v_readlane_b32 s9, v15, 12
-; W64-O0-NEXT:    v_readlane_b32 s10, v15, 13
-; W64-O0-NEXT:    v_readlane_b32 s11, v15, 14
-; W64-O0-NEXT:    v_readlane_b32 s6, v15, 0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_readlane_b32 s4, v17, 15
+; W64-O0-NEXT:    v_readlane_b32 s5, v17, 16
+; W64-O0-NEXT:    v_readlane_b32 s8, v17, 11
+; W64-O0-NEXT:    v_readlane_b32 s9, v17, 12
+; W64-O0-NEXT:    v_readlane_b32 s10, v17, 13
+; W64-O0-NEXT:    v_readlane_b32 s11, v17, 14
+; W64-O0-NEXT:    v_readlane_b32 s6, v17, 0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB1_4
 ; W64-O0-NEXT:  ; %bb.6:
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v15, 9
-; W64-O0-NEXT:    v_readlane_b32 s5, v15, 10
+; W64-O0-NEXT:    v_readlane_b32 s4, v17, 9
+; W64-O0-NEXT:    v_readlane_b32 s5, v17, 10
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
@@ -692,7 +689,7 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    global_store_dword v[0:1], v2, off
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -1000,45 +997,45 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0:       ; %bb.0: ; %entry
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v8, v11
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v8, v5
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v4
+; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; W64-O0-NEXT:    s_nop 0
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    v_mov_b32_e32 v9, v3
-; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    v_mov_b32_e32 v10, v2
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    v_mov_b32_e32 v11, v1
-; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5_vgpr6_vgpr7 killed $exec
-; W64-O0-NEXT:    s_waitcnt vmcnt(2)
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v3
-; W64-O0-NEXT:    s_waitcnt vmcnt(1)
-; W64-O0-NEXT:    v_mov_b32_e32 v6, v2
-; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_mov_b32_e32 v7, v1
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v1, v11
-; W64-O0-NEXT:    v_mov_b32_e32 v2, v10
-; W64-O0-NEXT:    v_mov_b32_e32 v3, v9
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v1, v8
+; W64-O0-NEXT:    v_mov_b32_e32 v2, v6
+; W64-O0-NEXT:    v_mov_b32_e32 v3, v7
+; W64-O0-NEXT:    ; kill: def $vgpr5 killed $vgpr5 def $vgpr5_vgpr6_vgpr7_vgpr8 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v6, v11
+; W64-O0-NEXT:    v_mov_b32_e32 v7, v10
+; W64-O0-NEXT:    v_mov_b32_e32 v8, v9
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v9, v12
-; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v12
+; W64-O0-NEXT:    s_waitcnt vmcnt(6)
+; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; W64-O0-NEXT:    s_waitcnt vmcnt(6)
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    ;;#ASMSTART
 ; W64-O0-NEXT:    s_mov_b32 s4, 17
 ; W64-O0-NEXT:    ;;#ASMEND
@@ -1109,7 +1106,7 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB2_1
 ; W64-O0-NEXT:  ; %bb.3:
@@ -1121,13 +1118,13 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s7, v13, 3
 ; W64-O0-NEXT:    s_mov_b64 exec, s[6:7]
 ; W64-O0-NEXT:    v_readlane_b32 s4, v13, 1
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b32 s5, 0x3ff
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    v_and_b32_e64 v1, v1, s5
 ; W64-O0-NEXT:    v_cmp_eq_u32_e64 s[6:7], v1, s4
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
 ; W64-O0-NEXT:    v_writelane_b32 v13, s4, 10
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 11
@@ -1146,7 +1143,7 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_mov_b32 s5, 0
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 12
 ; W64-O0-NEXT:    v_mov_b32_e32 v0, s4
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
 ; W64-O0-NEXT:    v_writelane_b32 v13, s4, 13
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 14
@@ -1202,12 +1199,12 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s10, v13, 17
 ; W64-O0-NEXT:    v_readlane_b32 s11, v13, 18
 ; W64-O0-NEXT:    v_readlane_b32 s6, v13, 12
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB2_5
 ; W64-O0-NEXT:  ; %bb.7:
@@ -1218,9 +1215,9 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s4, v13, 13
 ; W64-O0-NEXT:    v_readlane_b32 s5, v13, 14
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; W64-O0-NEXT:  .LBB2_8: ; %bb2
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
 ; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
@@ -1231,12 +1228,12 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    global_store_dword v[0:1], v2, off
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/rem_i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/rem_i128.ll
@@ -2892,12 +2892,9 @@ define i128 @v_urem_i128_v_pow2k(i128 %lhs) {
 ; GFX9-O0-LABEL: v_urem_i128_v_pow2k:
 ; GFX9-O0:       ; %bb.0:
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v4, v3
 ; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3 killed $exec
-; GFX9-O0-NEXT:    ; kill: def $vgpr3 killed $vgpr4 killed $exec
 ; GFX9-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 def $vgpr1_vgpr2 killed $exec
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v2, v0

--- a/llvm/test/CodeGen/AMDGPU/vgpr-large-tuple-alloc-error.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-large-tuple-alloc-error.ll
@@ -13,202 +13,194 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX900-LABEL: test_tuple:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; GFX900-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; GFX900-NEXT:    v_mov_b32_e32 v33, v30
-; GFX900-NEXT:    v_mov_b32_e32 v34, v29
-; GFX900-NEXT:    v_mov_b32_e32 v35, v28
-; GFX900-NEXT:    v_mov_b32_e32 v36, v27
-; GFX900-NEXT:    v_mov_b32_e32 v37, v26
-; GFX900-NEXT:    v_mov_b32_e32 v38, v25
-; GFX900-NEXT:    v_mov_b32_e32 v39, v24
-; GFX900-NEXT:    v_mov_b32_e32 v48, v23
-; GFX900-NEXT:    v_mov_b32_e32 v49, v22
-; GFX900-NEXT:    v_mov_b32_e32 v50, v21
-; GFX900-NEXT:    v_mov_b32_e32 v51, v20
-; GFX900-NEXT:    v_mov_b32_e32 v52, v19
-; GFX900-NEXT:    v_mov_b32_e32 v53, v18
-; GFX900-NEXT:    v_mov_b32_e32 v54, v17
-; GFX900-NEXT:    v_mov_b32_e32 v55, v16
-; GFX900-NEXT:    v_mov_b32_e32 v40, v15
-; GFX900-NEXT:    v_mov_b32_e32 v41, v14
-; GFX900-NEXT:    v_mov_b32_e32 v42, v13
-; GFX900-NEXT:    v_mov_b32_e32 v43, v12
-; GFX900-NEXT:    v_mov_b32_e32 v44, v11
-; GFX900-NEXT:    v_mov_b32_e32 v45, v10
-; GFX900-NEXT:    v_mov_b32_e32 v46, v9
-; GFX900-NEXT:    v_mov_b32_e32 v47, v8
-; GFX900-NEXT:    v_mov_b32_e32 v56, v7
-; GFX900-NEXT:    v_mov_b32_e32 v57, v6
-; GFX900-NEXT:    v_mov_b32_e32 v58, v5
-; GFX900-NEXT:    v_mov_b32_e32 v59, v4
-; GFX900-NEXT:    v_mov_b32_e32 v60, v3
-; GFX900-NEXT:    v_mov_b32_e32 v61, v2
-; GFX900-NEXT:    v_mov_b32_e32 v62, v1
-; GFX900-NEXT:    buffer_load_dword v32, off, s[0:3], s32
+; GFX900-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX900-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX900-NEXT:    v_mov_b32_e32 v32, v30
+; GFX900-NEXT:    v_mov_b32_e32 v33, v29
+; GFX900-NEXT:    v_mov_b32_e32 v34, v28
+; GFX900-NEXT:    v_mov_b32_e32 v35, v27
+; GFX900-NEXT:    v_mov_b32_e32 v36, v26
+; GFX900-NEXT:    v_mov_b32_e32 v37, v25
+; GFX900-NEXT:    v_mov_b32_e32 v38, v24
+; GFX900-NEXT:    v_mov_b32_e32 v39, v23
+; GFX900-NEXT:    v_mov_b32_e32 v48, v22
+; GFX900-NEXT:    v_mov_b32_e32 v49, v21
+; GFX900-NEXT:    v_mov_b32_e32 v50, v20
+; GFX900-NEXT:    v_mov_b32_e32 v51, v19
+; GFX900-NEXT:    v_mov_b32_e32 v52, v18
+; GFX900-NEXT:    v_mov_b32_e32 v53, v17
+; GFX900-NEXT:    v_mov_b32_e32 v54, v16
+; GFX900-NEXT:    v_mov_b32_e32 v55, v15
+; GFX900-NEXT:    v_mov_b32_e32 v40, v14
+; GFX900-NEXT:    v_mov_b32_e32 v41, v13
+; GFX900-NEXT:    v_mov_b32_e32 v42, v12
+; GFX900-NEXT:    v_mov_b32_e32 v43, v11
+; GFX900-NEXT:    v_mov_b32_e32 v44, v10
+; GFX900-NEXT:    v_mov_b32_e32 v45, v9
+; GFX900-NEXT:    v_mov_b32_e32 v46, v8
+; GFX900-NEXT:    v_mov_b32_e32 v47, v7
+; GFX900-NEXT:    v_mov_b32_e32 v56, v6
+; GFX900-NEXT:    v_mov_b32_e32 v57, v5
+; GFX900-NEXT:    v_mov_b32_e32 v58, v4
+; GFX900-NEXT:    v_mov_b32_e32 v59, v3
+; GFX900-NEXT:    v_mov_b32_e32 v60, v2
+; GFX900-NEXT:    v_mov_b32_e32 v61, v1
+; GFX900-NEXT:    buffer_load_dword v1, off, s[0:3], s32
 ; GFX900-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 killed $exec
-; GFX900-NEXT:    v_mov_b32_e32 v1, v62
-; GFX900-NEXT:    v_mov_b32_e32 v2, v61
-; GFX900-NEXT:    v_mov_b32_e32 v3, v60
-; GFX900-NEXT:    v_mov_b32_e32 v4, v59
-; GFX900-NEXT:    v_mov_b32_e32 v5, v58
-; GFX900-NEXT:    v_mov_b32_e32 v6, v57
-; GFX900-NEXT:    v_mov_b32_e32 v7, v56
-; GFX900-NEXT:    v_mov_b32_e32 v8, v47
-; GFX900-NEXT:    v_mov_b32_e32 v9, v46
-; GFX900-NEXT:    v_mov_b32_e32 v10, v45
-; GFX900-NEXT:    v_mov_b32_e32 v11, v44
-; GFX900-NEXT:    v_mov_b32_e32 v12, v43
-; GFX900-NEXT:    v_mov_b32_e32 v13, v42
-; GFX900-NEXT:    v_mov_b32_e32 v14, v41
-; GFX900-NEXT:    v_mov_b32_e32 v15, v40
-; GFX900-NEXT:    v_mov_b32_e32 v16, v55
-; GFX900-NEXT:    v_mov_b32_e32 v17, v54
-; GFX900-NEXT:    v_mov_b32_e32 v18, v53
-; GFX900-NEXT:    v_mov_b32_e32 v19, v52
-; GFX900-NEXT:    v_mov_b32_e32 v20, v51
-; GFX900-NEXT:    v_mov_b32_e32 v21, v50
-; GFX900-NEXT:    v_mov_b32_e32 v22, v49
-; GFX900-NEXT:    v_mov_b32_e32 v23, v48
-; GFX900-NEXT:    v_mov_b32_e32 v24, v39
-; GFX900-NEXT:    v_mov_b32_e32 v25, v38
-; GFX900-NEXT:    v_mov_b32_e32 v26, v37
-; GFX900-NEXT:    v_mov_b32_e32 v27, v36
-; GFX900-NEXT:    v_mov_b32_e32 v28, v35
-; GFX900-NEXT:    v_mov_b32_e32 v29, v34
-; GFX900-NEXT:    v_mov_b32_e32 v30, v33
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_mov_b32_e32 v31, v32
+; GFX900-NEXT:    v_mov_b32_e32 v1, v61
+; GFX900-NEXT:    v_mov_b32_e32 v2, v60
+; GFX900-NEXT:    v_mov_b32_e32 v3, v59
+; GFX900-NEXT:    v_mov_b32_e32 v4, v58
+; GFX900-NEXT:    v_mov_b32_e32 v5, v57
+; GFX900-NEXT:    v_mov_b32_e32 v6, v56
+; GFX900-NEXT:    v_mov_b32_e32 v7, v47
+; GFX900-NEXT:    v_mov_b32_e32 v8, v46
+; GFX900-NEXT:    v_mov_b32_e32 v9, v45
+; GFX900-NEXT:    v_mov_b32_e32 v10, v44
+; GFX900-NEXT:    v_mov_b32_e32 v11, v43
+; GFX900-NEXT:    v_mov_b32_e32 v12, v42
+; GFX900-NEXT:    v_mov_b32_e32 v13, v41
+; GFX900-NEXT:    v_mov_b32_e32 v14, v40
+; GFX900-NEXT:    v_mov_b32_e32 v15, v55
+; GFX900-NEXT:    v_mov_b32_e32 v16, v54
+; GFX900-NEXT:    v_mov_b32_e32 v17, v53
+; GFX900-NEXT:    v_mov_b32_e32 v18, v52
+; GFX900-NEXT:    v_mov_b32_e32 v19, v51
+; GFX900-NEXT:    v_mov_b32_e32 v20, v50
+; GFX900-NEXT:    v_mov_b32_e32 v21, v49
+; GFX900-NEXT:    v_mov_b32_e32 v22, v48
+; GFX900-NEXT:    v_mov_b32_e32 v23, v39
+; GFX900-NEXT:    v_mov_b32_e32 v24, v38
+; GFX900-NEXT:    v_mov_b32_e32 v25, v37
+; GFX900-NEXT:    v_mov_b32_e32 v26, v36
+; GFX900-NEXT:    v_mov_b32_e32 v27, v35
+; GFX900-NEXT:    v_mov_b32_e32 v28, v34
+; GFX900-NEXT:    v_mov_b32_e32 v29, v33
 ; GFX900-NEXT:    v_mov_b32_e32 v0, 0
-; GFX900-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
-; GFX900-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; GFX900-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX906-LABEL: test_tuple:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX906-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; GFX906-NEXT:    v_mov_b32_e32 v33, v30
-; GFX906-NEXT:    v_mov_b32_e32 v34, v29
-; GFX906-NEXT:    v_mov_b32_e32 v35, v28
-; GFX906-NEXT:    v_mov_b32_e32 v36, v27
-; GFX906-NEXT:    v_mov_b32_e32 v37, v26
-; GFX906-NEXT:    v_mov_b32_e32 v38, v25
-; GFX906-NEXT:    v_mov_b32_e32 v39, v24
-; GFX906-NEXT:    v_mov_b32_e32 v48, v23
-; GFX906-NEXT:    v_mov_b32_e32 v49, v22
-; GFX906-NEXT:    v_mov_b32_e32 v50, v21
-; GFX906-NEXT:    v_mov_b32_e32 v51, v20
-; GFX906-NEXT:    v_mov_b32_e32 v52, v19
-; GFX906-NEXT:    v_mov_b32_e32 v53, v18
-; GFX906-NEXT:    v_mov_b32_e32 v54, v17
-; GFX906-NEXT:    v_mov_b32_e32 v55, v16
-; GFX906-NEXT:    v_mov_b32_e32 v40, v15
-; GFX906-NEXT:    v_mov_b32_e32 v41, v14
-; GFX906-NEXT:    v_mov_b32_e32 v42, v13
-; GFX906-NEXT:    v_mov_b32_e32 v43, v12
-; GFX906-NEXT:    v_mov_b32_e32 v44, v11
-; GFX906-NEXT:    v_mov_b32_e32 v45, v10
-; GFX906-NEXT:    v_mov_b32_e32 v46, v9
-; GFX906-NEXT:    v_mov_b32_e32 v47, v8
-; GFX906-NEXT:    v_mov_b32_e32 v56, v7
-; GFX906-NEXT:    v_mov_b32_e32 v57, v6
-; GFX906-NEXT:    v_mov_b32_e32 v58, v5
-; GFX906-NEXT:    v_mov_b32_e32 v59, v4
-; GFX906-NEXT:    v_mov_b32_e32 v60, v3
-; GFX906-NEXT:    v_mov_b32_e32 v61, v2
-; GFX906-NEXT:    v_mov_b32_e32 v62, v1
-; GFX906-NEXT:    buffer_load_dword v32, off, s[0:3], s32
+; GFX906-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; GFX906-NEXT:    v_mov_b32_e32 v32, v30
+; GFX906-NEXT:    v_mov_b32_e32 v33, v29
+; GFX906-NEXT:    v_mov_b32_e32 v34, v28
+; GFX906-NEXT:    v_mov_b32_e32 v35, v27
+; GFX906-NEXT:    v_mov_b32_e32 v36, v26
+; GFX906-NEXT:    v_mov_b32_e32 v37, v25
+; GFX906-NEXT:    v_mov_b32_e32 v38, v24
+; GFX906-NEXT:    v_mov_b32_e32 v39, v23
+; GFX906-NEXT:    v_mov_b32_e32 v48, v22
+; GFX906-NEXT:    v_mov_b32_e32 v49, v21
+; GFX906-NEXT:    v_mov_b32_e32 v50, v20
+; GFX906-NEXT:    v_mov_b32_e32 v51, v19
+; GFX906-NEXT:    v_mov_b32_e32 v52, v18
+; GFX906-NEXT:    v_mov_b32_e32 v53, v17
+; GFX906-NEXT:    v_mov_b32_e32 v54, v16
+; GFX906-NEXT:    v_mov_b32_e32 v55, v15
+; GFX906-NEXT:    v_mov_b32_e32 v40, v14
+; GFX906-NEXT:    v_mov_b32_e32 v41, v13
+; GFX906-NEXT:    v_mov_b32_e32 v42, v12
+; GFX906-NEXT:    v_mov_b32_e32 v43, v11
+; GFX906-NEXT:    v_mov_b32_e32 v44, v10
+; GFX906-NEXT:    v_mov_b32_e32 v45, v9
+; GFX906-NEXT:    v_mov_b32_e32 v46, v8
+; GFX906-NEXT:    v_mov_b32_e32 v47, v7
+; GFX906-NEXT:    v_mov_b32_e32 v56, v6
+; GFX906-NEXT:    v_mov_b32_e32 v57, v5
+; GFX906-NEXT:    v_mov_b32_e32 v58, v4
+; GFX906-NEXT:    v_mov_b32_e32 v59, v3
+; GFX906-NEXT:    v_mov_b32_e32 v60, v2
+; GFX906-NEXT:    v_mov_b32_e32 v61, v1
+; GFX906-NEXT:    buffer_load_dword v1, off, s[0:3], s32
 ; GFX906-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 killed $exec
-; GFX906-NEXT:    v_mov_b32_e32 v1, v62
-; GFX906-NEXT:    v_mov_b32_e32 v2, v61
-; GFX906-NEXT:    v_mov_b32_e32 v3, v60
-; GFX906-NEXT:    v_mov_b32_e32 v4, v59
-; GFX906-NEXT:    v_mov_b32_e32 v5, v58
-; GFX906-NEXT:    v_mov_b32_e32 v6, v57
-; GFX906-NEXT:    v_mov_b32_e32 v7, v56
-; GFX906-NEXT:    v_mov_b32_e32 v8, v47
-; GFX906-NEXT:    v_mov_b32_e32 v9, v46
-; GFX906-NEXT:    v_mov_b32_e32 v10, v45
-; GFX906-NEXT:    v_mov_b32_e32 v11, v44
-; GFX906-NEXT:    v_mov_b32_e32 v12, v43
-; GFX906-NEXT:    v_mov_b32_e32 v13, v42
-; GFX906-NEXT:    v_mov_b32_e32 v14, v41
-; GFX906-NEXT:    v_mov_b32_e32 v15, v40
-; GFX906-NEXT:    v_mov_b32_e32 v16, v55
-; GFX906-NEXT:    v_mov_b32_e32 v17, v54
-; GFX906-NEXT:    v_mov_b32_e32 v18, v53
-; GFX906-NEXT:    v_mov_b32_e32 v19, v52
-; GFX906-NEXT:    v_mov_b32_e32 v20, v51
-; GFX906-NEXT:    v_mov_b32_e32 v21, v50
-; GFX906-NEXT:    v_mov_b32_e32 v22, v49
-; GFX906-NEXT:    v_mov_b32_e32 v23, v48
-; GFX906-NEXT:    v_mov_b32_e32 v24, v39
-; GFX906-NEXT:    v_mov_b32_e32 v25, v38
-; GFX906-NEXT:    v_mov_b32_e32 v26, v37
-; GFX906-NEXT:    v_mov_b32_e32 v27, v36
-; GFX906-NEXT:    v_mov_b32_e32 v28, v35
-; GFX906-NEXT:    v_mov_b32_e32 v29, v34
-; GFX906-NEXT:    v_mov_b32_e32 v30, v33
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
-; GFX906-NEXT:    v_mov_b32_e32 v31, v32
+; GFX906-NEXT:    v_mov_b32_e32 v1, v61
+; GFX906-NEXT:    v_mov_b32_e32 v2, v60
+; GFX906-NEXT:    v_mov_b32_e32 v3, v59
+; GFX906-NEXT:    v_mov_b32_e32 v4, v58
+; GFX906-NEXT:    v_mov_b32_e32 v5, v57
+; GFX906-NEXT:    v_mov_b32_e32 v6, v56
+; GFX906-NEXT:    v_mov_b32_e32 v7, v47
+; GFX906-NEXT:    v_mov_b32_e32 v8, v46
+; GFX906-NEXT:    v_mov_b32_e32 v9, v45
+; GFX906-NEXT:    v_mov_b32_e32 v10, v44
+; GFX906-NEXT:    v_mov_b32_e32 v11, v43
+; GFX906-NEXT:    v_mov_b32_e32 v12, v42
+; GFX906-NEXT:    v_mov_b32_e32 v13, v41
+; GFX906-NEXT:    v_mov_b32_e32 v14, v40
+; GFX906-NEXT:    v_mov_b32_e32 v15, v55
+; GFX906-NEXT:    v_mov_b32_e32 v16, v54
+; GFX906-NEXT:    v_mov_b32_e32 v17, v53
+; GFX906-NEXT:    v_mov_b32_e32 v18, v52
+; GFX906-NEXT:    v_mov_b32_e32 v19, v51
+; GFX906-NEXT:    v_mov_b32_e32 v20, v50
+; GFX906-NEXT:    v_mov_b32_e32 v21, v49
+; GFX906-NEXT:    v_mov_b32_e32 v22, v48
+; GFX906-NEXT:    v_mov_b32_e32 v23, v39
+; GFX906-NEXT:    v_mov_b32_e32 v24, v38
+; GFX906-NEXT:    v_mov_b32_e32 v25, v37
+; GFX906-NEXT:    v_mov_b32_e32 v26, v36
+; GFX906-NEXT:    v_mov_b32_e32 v27, v35
+; GFX906-NEXT:    v_mov_b32_e32 v28, v34
+; GFX906-NEXT:    v_mov_b32_e32 v29, v33
 ; GFX906-NEXT:    v_mov_b32_e32 v0, 0
-; GFX906-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -229,73 +221,69 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX908-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_write_b32 a13, v61 ; Reload Reuse
-; GFX908-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
-; GFX908-NEXT:    v_mov_b32_e32 v33, v30
-; GFX908-NEXT:    v_mov_b32_e32 v34, v29
-; GFX908-NEXT:    v_mov_b32_e32 v35, v28
-; GFX908-NEXT:    v_mov_b32_e32 v36, v27
-; GFX908-NEXT:    v_mov_b32_e32 v37, v26
-; GFX908-NEXT:    v_mov_b32_e32 v38, v25
-; GFX908-NEXT:    v_mov_b32_e32 v39, v24
-; GFX908-NEXT:    v_mov_b32_e32 v48, v23
-; GFX908-NEXT:    v_mov_b32_e32 v49, v22
-; GFX908-NEXT:    v_mov_b32_e32 v50, v21
-; GFX908-NEXT:    v_mov_b32_e32 v51, v20
-; GFX908-NEXT:    v_mov_b32_e32 v52, v19
-; GFX908-NEXT:    v_mov_b32_e32 v53, v18
-; GFX908-NEXT:    v_mov_b32_e32 v54, v17
-; GFX908-NEXT:    v_mov_b32_e32 v55, v16
-; GFX908-NEXT:    v_mov_b32_e32 v40, v15
-; GFX908-NEXT:    v_mov_b32_e32 v41, v14
-; GFX908-NEXT:    v_mov_b32_e32 v42, v13
-; GFX908-NEXT:    v_mov_b32_e32 v43, v12
-; GFX908-NEXT:    v_mov_b32_e32 v44, v11
-; GFX908-NEXT:    v_mov_b32_e32 v45, v10
-; GFX908-NEXT:    v_mov_b32_e32 v46, v9
-; GFX908-NEXT:    v_mov_b32_e32 v47, v8
-; GFX908-NEXT:    v_mov_b32_e32 v56, v7
-; GFX908-NEXT:    v_mov_b32_e32 v57, v6
-; GFX908-NEXT:    v_mov_b32_e32 v58, v5
-; GFX908-NEXT:    v_mov_b32_e32 v59, v4
-; GFX908-NEXT:    v_mov_b32_e32 v60, v3
-; GFX908-NEXT:    v_mov_b32_e32 v61, v2
-; GFX908-NEXT:    v_mov_b32_e32 v62, v1
-; GFX908-NEXT:    buffer_load_dword v32, off, s[0:3], s32
+; GFX908-NEXT:    v_mov_b32_e32 v32, v30
+; GFX908-NEXT:    v_mov_b32_e32 v33, v29
+; GFX908-NEXT:    v_mov_b32_e32 v34, v28
+; GFX908-NEXT:    v_mov_b32_e32 v35, v27
+; GFX908-NEXT:    v_mov_b32_e32 v36, v26
+; GFX908-NEXT:    v_mov_b32_e32 v37, v25
+; GFX908-NEXT:    v_mov_b32_e32 v38, v24
+; GFX908-NEXT:    v_mov_b32_e32 v39, v23
+; GFX908-NEXT:    v_mov_b32_e32 v48, v22
+; GFX908-NEXT:    v_mov_b32_e32 v49, v21
+; GFX908-NEXT:    v_mov_b32_e32 v50, v20
+; GFX908-NEXT:    v_mov_b32_e32 v51, v19
+; GFX908-NEXT:    v_mov_b32_e32 v52, v18
+; GFX908-NEXT:    v_mov_b32_e32 v53, v17
+; GFX908-NEXT:    v_mov_b32_e32 v54, v16
+; GFX908-NEXT:    v_mov_b32_e32 v55, v15
+; GFX908-NEXT:    v_mov_b32_e32 v40, v14
+; GFX908-NEXT:    v_mov_b32_e32 v41, v13
+; GFX908-NEXT:    v_mov_b32_e32 v42, v12
+; GFX908-NEXT:    v_mov_b32_e32 v43, v11
+; GFX908-NEXT:    v_mov_b32_e32 v44, v10
+; GFX908-NEXT:    v_mov_b32_e32 v45, v9
+; GFX908-NEXT:    v_mov_b32_e32 v46, v8
+; GFX908-NEXT:    v_mov_b32_e32 v47, v7
+; GFX908-NEXT:    v_mov_b32_e32 v56, v6
+; GFX908-NEXT:    v_mov_b32_e32 v57, v5
+; GFX908-NEXT:    v_mov_b32_e32 v58, v4
+; GFX908-NEXT:    v_mov_b32_e32 v59, v3
+; GFX908-NEXT:    v_mov_b32_e32 v60, v2
+; GFX908-NEXT:    v_mov_b32_e32 v61, v1
+; GFX908-NEXT:    buffer_load_dword v1, off, s[0:3], s32
 ; GFX908-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 killed $exec
-; GFX908-NEXT:    v_mov_b32_e32 v1, v62
-; GFX908-NEXT:    v_mov_b32_e32 v2, v61
-; GFX908-NEXT:    v_mov_b32_e32 v3, v60
-; GFX908-NEXT:    v_mov_b32_e32 v4, v59
-; GFX908-NEXT:    v_mov_b32_e32 v5, v58
-; GFX908-NEXT:    v_mov_b32_e32 v6, v57
-; GFX908-NEXT:    v_mov_b32_e32 v7, v56
-; GFX908-NEXT:    v_mov_b32_e32 v8, v47
-; GFX908-NEXT:    v_mov_b32_e32 v9, v46
-; GFX908-NEXT:    v_mov_b32_e32 v10, v45
-; GFX908-NEXT:    v_mov_b32_e32 v11, v44
-; GFX908-NEXT:    v_mov_b32_e32 v12, v43
-; GFX908-NEXT:    v_mov_b32_e32 v13, v42
-; GFX908-NEXT:    v_mov_b32_e32 v14, v41
-; GFX908-NEXT:    v_mov_b32_e32 v15, v40
-; GFX908-NEXT:    v_mov_b32_e32 v16, v55
-; GFX908-NEXT:    v_mov_b32_e32 v17, v54
-; GFX908-NEXT:    v_mov_b32_e32 v18, v53
-; GFX908-NEXT:    v_mov_b32_e32 v19, v52
-; GFX908-NEXT:    v_mov_b32_e32 v20, v51
-; GFX908-NEXT:    v_mov_b32_e32 v21, v50
-; GFX908-NEXT:    v_mov_b32_e32 v22, v49
-; GFX908-NEXT:    v_mov_b32_e32 v23, v48
-; GFX908-NEXT:    v_mov_b32_e32 v24, v39
-; GFX908-NEXT:    v_mov_b32_e32 v25, v38
-; GFX908-NEXT:    v_mov_b32_e32 v26, v37
-; GFX908-NEXT:    v_mov_b32_e32 v27, v36
-; GFX908-NEXT:    v_mov_b32_e32 v28, v35
-; GFX908-NEXT:    v_mov_b32_e32 v29, v34
-; GFX908-NEXT:    v_mov_b32_e32 v30, v33
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
-; GFX908-NEXT:    v_mov_b32_e32 v31, v32
+; GFX908-NEXT:    v_mov_b32_e32 v1, v61
+; GFX908-NEXT:    v_mov_b32_e32 v2, v60
+; GFX908-NEXT:    v_mov_b32_e32 v3, v59
+; GFX908-NEXT:    v_mov_b32_e32 v4, v58
+; GFX908-NEXT:    v_mov_b32_e32 v5, v57
+; GFX908-NEXT:    v_mov_b32_e32 v6, v56
+; GFX908-NEXT:    v_mov_b32_e32 v7, v47
+; GFX908-NEXT:    v_mov_b32_e32 v8, v46
+; GFX908-NEXT:    v_mov_b32_e32 v9, v45
+; GFX908-NEXT:    v_mov_b32_e32 v10, v44
+; GFX908-NEXT:    v_mov_b32_e32 v11, v43
+; GFX908-NEXT:    v_mov_b32_e32 v12, v42
+; GFX908-NEXT:    v_mov_b32_e32 v13, v41
+; GFX908-NEXT:    v_mov_b32_e32 v14, v40
+; GFX908-NEXT:    v_mov_b32_e32 v15, v55
+; GFX908-NEXT:    v_mov_b32_e32 v16, v54
+; GFX908-NEXT:    v_mov_b32_e32 v17, v53
+; GFX908-NEXT:    v_mov_b32_e32 v18, v52
+; GFX908-NEXT:    v_mov_b32_e32 v19, v51
+; GFX908-NEXT:    v_mov_b32_e32 v20, v50
+; GFX908-NEXT:    v_mov_b32_e32 v21, v49
+; GFX908-NEXT:    v_mov_b32_e32 v22, v48
+; GFX908-NEXT:    v_mov_b32_e32 v23, v39
+; GFX908-NEXT:    v_mov_b32_e32 v24, v38
+; GFX908-NEXT:    v_mov_b32_e32 v25, v37
+; GFX908-NEXT:    v_mov_b32_e32 v26, v36
+; GFX908-NEXT:    v_mov_b32_e32 v27, v35
+; GFX908-NEXT:    v_mov_b32_e32 v28, v34
+; GFX908-NEXT:    v_mov_b32_e32 v29, v33
 ; GFX908-NEXT:    v_mov_b32_e32 v0, 0
-; GFX908-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v60, a12 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v59, a11 ; Reload Reuse
@@ -329,73 +317,69 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX90a-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_write_b32 a13, v61 ; Reload Reuse
-; GFX90a-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
-; GFX90a-NEXT:    v_mov_b32_e32 v33, v30
-; GFX90a-NEXT:    v_mov_b32_e32 v34, v29
-; GFX90a-NEXT:    v_mov_b32_e32 v35, v28
-; GFX90a-NEXT:    v_mov_b32_e32 v36, v27
-; GFX90a-NEXT:    v_mov_b32_e32 v37, v26
-; GFX90a-NEXT:    v_mov_b32_e32 v38, v25
-; GFX90a-NEXT:    v_mov_b32_e32 v39, v24
-; GFX90a-NEXT:    v_mov_b32_e32 v48, v23
-; GFX90a-NEXT:    v_mov_b32_e32 v49, v22
-; GFX90a-NEXT:    v_mov_b32_e32 v50, v21
-; GFX90a-NEXT:    v_mov_b32_e32 v51, v20
-; GFX90a-NEXT:    v_mov_b32_e32 v52, v19
-; GFX90a-NEXT:    v_mov_b32_e32 v53, v18
-; GFX90a-NEXT:    v_mov_b32_e32 v54, v17
-; GFX90a-NEXT:    v_mov_b32_e32 v55, v16
-; GFX90a-NEXT:    v_mov_b32_e32 v40, v15
-; GFX90a-NEXT:    v_mov_b32_e32 v41, v14
-; GFX90a-NEXT:    v_mov_b32_e32 v42, v13
-; GFX90a-NEXT:    v_mov_b32_e32 v43, v12
-; GFX90a-NEXT:    v_mov_b32_e32 v44, v11
-; GFX90a-NEXT:    v_mov_b32_e32 v45, v10
-; GFX90a-NEXT:    v_mov_b32_e32 v46, v9
-; GFX90a-NEXT:    v_mov_b32_e32 v47, v8
-; GFX90a-NEXT:    v_mov_b32_e32 v56, v7
-; GFX90a-NEXT:    v_mov_b32_e32 v57, v6
-; GFX90a-NEXT:    v_mov_b32_e32 v58, v5
-; GFX90a-NEXT:    v_mov_b32_e32 v59, v4
-; GFX90a-NEXT:    v_mov_b32_e32 v60, v3
-; GFX90a-NEXT:    v_mov_b32_e32 v61, v2
-; GFX90a-NEXT:    v_mov_b32_e32 v62, v1
-; GFX90a-NEXT:    buffer_load_dword v32, off, s[0:3], s32
+; GFX90a-NEXT:    v_mov_b32_e32 v32, v30
+; GFX90a-NEXT:    v_mov_b32_e32 v33, v29
+; GFX90a-NEXT:    v_mov_b32_e32 v34, v28
+; GFX90a-NEXT:    v_mov_b32_e32 v35, v27
+; GFX90a-NEXT:    v_mov_b32_e32 v36, v26
+; GFX90a-NEXT:    v_mov_b32_e32 v37, v25
+; GFX90a-NEXT:    v_mov_b32_e32 v38, v24
+; GFX90a-NEXT:    v_mov_b32_e32 v39, v23
+; GFX90a-NEXT:    v_mov_b32_e32 v48, v22
+; GFX90a-NEXT:    v_mov_b32_e32 v49, v21
+; GFX90a-NEXT:    v_mov_b32_e32 v50, v20
+; GFX90a-NEXT:    v_mov_b32_e32 v51, v19
+; GFX90a-NEXT:    v_mov_b32_e32 v52, v18
+; GFX90a-NEXT:    v_mov_b32_e32 v53, v17
+; GFX90a-NEXT:    v_mov_b32_e32 v54, v16
+; GFX90a-NEXT:    v_mov_b32_e32 v55, v15
+; GFX90a-NEXT:    v_mov_b32_e32 v40, v14
+; GFX90a-NEXT:    v_mov_b32_e32 v41, v13
+; GFX90a-NEXT:    v_mov_b32_e32 v42, v12
+; GFX90a-NEXT:    v_mov_b32_e32 v43, v11
+; GFX90a-NEXT:    v_mov_b32_e32 v44, v10
+; GFX90a-NEXT:    v_mov_b32_e32 v45, v9
+; GFX90a-NEXT:    v_mov_b32_e32 v46, v8
+; GFX90a-NEXT:    v_mov_b32_e32 v47, v7
+; GFX90a-NEXT:    v_mov_b32_e32 v56, v6
+; GFX90a-NEXT:    v_mov_b32_e32 v57, v5
+; GFX90a-NEXT:    v_mov_b32_e32 v58, v4
+; GFX90a-NEXT:    v_mov_b32_e32 v59, v3
+; GFX90a-NEXT:    v_mov_b32_e32 v60, v2
+; GFX90a-NEXT:    v_mov_b32_e32 v61, v1
+; GFX90a-NEXT:    buffer_load_dword v1, off, s[0:3], s32
 ; GFX90a-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 killed $exec
-; GFX90a-NEXT:    v_mov_b32_e32 v1, v62
-; GFX90a-NEXT:    v_mov_b32_e32 v2, v61
-; GFX90a-NEXT:    v_mov_b32_e32 v3, v60
-; GFX90a-NEXT:    v_mov_b32_e32 v4, v59
-; GFX90a-NEXT:    v_mov_b32_e32 v5, v58
-; GFX90a-NEXT:    v_mov_b32_e32 v6, v57
-; GFX90a-NEXT:    v_mov_b32_e32 v7, v56
-; GFX90a-NEXT:    v_mov_b32_e32 v8, v47
-; GFX90a-NEXT:    v_mov_b32_e32 v9, v46
-; GFX90a-NEXT:    v_mov_b32_e32 v10, v45
-; GFX90a-NEXT:    v_mov_b32_e32 v11, v44
-; GFX90a-NEXT:    v_mov_b32_e32 v12, v43
-; GFX90a-NEXT:    v_mov_b32_e32 v13, v42
-; GFX90a-NEXT:    v_mov_b32_e32 v14, v41
-; GFX90a-NEXT:    v_mov_b32_e32 v15, v40
-; GFX90a-NEXT:    v_mov_b32_e32 v16, v55
-; GFX90a-NEXT:    v_mov_b32_e32 v17, v54
-; GFX90a-NEXT:    v_mov_b32_e32 v18, v53
-; GFX90a-NEXT:    v_mov_b32_e32 v19, v52
-; GFX90a-NEXT:    v_mov_b32_e32 v20, v51
-; GFX90a-NEXT:    v_mov_b32_e32 v21, v50
-; GFX90a-NEXT:    v_mov_b32_e32 v22, v49
-; GFX90a-NEXT:    v_mov_b32_e32 v23, v48
-; GFX90a-NEXT:    v_mov_b32_e32 v24, v39
-; GFX90a-NEXT:    v_mov_b32_e32 v25, v38
-; GFX90a-NEXT:    v_mov_b32_e32 v26, v37
-; GFX90a-NEXT:    v_mov_b32_e32 v27, v36
-; GFX90a-NEXT:    v_mov_b32_e32 v28, v35
-; GFX90a-NEXT:    v_mov_b32_e32 v29, v34
-; GFX90a-NEXT:    v_mov_b32_e32 v30, v33
 ; GFX90a-NEXT:    s_waitcnt vmcnt(0)
-; GFX90a-NEXT:    v_mov_b32_e32 v31, v32
+; GFX90a-NEXT:    v_mov_b32_e32 v1, v61
+; GFX90a-NEXT:    v_mov_b32_e32 v2, v60
+; GFX90a-NEXT:    v_mov_b32_e32 v3, v59
+; GFX90a-NEXT:    v_mov_b32_e32 v4, v58
+; GFX90a-NEXT:    v_mov_b32_e32 v5, v57
+; GFX90a-NEXT:    v_mov_b32_e32 v6, v56
+; GFX90a-NEXT:    v_mov_b32_e32 v7, v47
+; GFX90a-NEXT:    v_mov_b32_e32 v8, v46
+; GFX90a-NEXT:    v_mov_b32_e32 v9, v45
+; GFX90a-NEXT:    v_mov_b32_e32 v10, v44
+; GFX90a-NEXT:    v_mov_b32_e32 v11, v43
+; GFX90a-NEXT:    v_mov_b32_e32 v12, v42
+; GFX90a-NEXT:    v_mov_b32_e32 v13, v41
+; GFX90a-NEXT:    v_mov_b32_e32 v14, v40
+; GFX90a-NEXT:    v_mov_b32_e32 v15, v55
+; GFX90a-NEXT:    v_mov_b32_e32 v16, v54
+; GFX90a-NEXT:    v_mov_b32_e32 v17, v53
+; GFX90a-NEXT:    v_mov_b32_e32 v18, v52
+; GFX90a-NEXT:    v_mov_b32_e32 v19, v51
+; GFX90a-NEXT:    v_mov_b32_e32 v20, v50
+; GFX90a-NEXT:    v_mov_b32_e32 v21, v49
+; GFX90a-NEXT:    v_mov_b32_e32 v22, v48
+; GFX90a-NEXT:    v_mov_b32_e32 v23, v39
+; GFX90a-NEXT:    v_mov_b32_e32 v24, v38
+; GFX90a-NEXT:    v_mov_b32_e32 v25, v37
+; GFX90a-NEXT:    v_mov_b32_e32 v26, v36
+; GFX90a-NEXT:    v_mov_b32_e32 v27, v35
+; GFX90a-NEXT:    v_mov_b32_e32 v28, v34
+; GFX90a-NEXT:    v_mov_b32_e32 v29, v33
 ; GFX90a-NEXT:    v_mov_b32_e32 v0, 0
-; GFX90a-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v60, a12 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v59, a11 ; Reload Reuse

--- a/llvm/test/CodeGen/AMDGPU/wwm-reserved-spill.ll
+++ b/llvm/test/CodeGen/AMDGPU/wwm-reserved-spill.ll
@@ -569,7 +569,6 @@ define amdgpu_gfx void @strict_wwm_call_i64(ptr addrspace(8) inreg %tmp14, i64 i
 ; GFX9-O0-NEXT:    v_writelane_b32 v11, s43, 3
 ; GFX9-O0-NEXT:    ; kill: def $sgpr34 killed $sgpr34 def $sgpr34_sgpr35
 ; GFX9-O0-NEXT:    s_mov_b32 s35, s9
-; GFX9-O0-NEXT:    ; kill: def $sgpr36_sgpr37 killed $sgpr34_sgpr35
 ; GFX9-O0-NEXT:    s_mov_b32 s38, s35
 ; GFX9-O0-NEXT:    s_mov_b64 s[36:37], 0
 ; GFX9-O0-NEXT:    s_mov_b32 s40, s37
@@ -724,7 +723,6 @@ define amdgpu_gfx void @strict_wwm_amdgpu_cs_main(<4 x i32> inreg %desc, i32 %in
 ; GFX9-O0-NEXT:    s_mov_b32 s37, s5
 ; GFX9-O0-NEXT:    s_mov_b32 s38, s6
 ; GFX9-O0-NEXT:    s_mov_b32 s39, s7
-; GFX9-O0-NEXT:    ; kill: def $sgpr40_sgpr41_sgpr42_sgpr43 killed $sgpr36_sgpr37_sgpr38_sgpr39
 ; GFX9-O0-NEXT:    s_mov_b32 s34, 5
 ; GFX9-O0-NEXT:    v_lshlrev_b32_e64 v0, s34, v0
 ; GFX9-O0-NEXT:    s_mov_b32 s34, 0
@@ -889,42 +887,41 @@ define amdgpu_gfx <32 x i32> @strict_wwm_callee_saves(<32 x i32> inreg %keep, pt
 ; GFX9-O0:       ; %bb.0:
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-O0-NEXT:    s_xor_saveexec_b64 s[34:35], -1
-; GFX9-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    s_nop 0
-; GFX9-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    s_mov_b64 exec, s[34:35]
-; GFX9-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
+; GFX9-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:16
+; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:16
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v36, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:12
+; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:12
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v37, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:8
+; GFX9-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:8
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v38, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v39, off, s[0:3], s32 offset:4
+; GFX9-O0-NEXT:    buffer_store_dword v36, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:4
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32
+; GFX9-O0-NEXT:    buffer_store_dword v37, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v38, off, s[0:3], s32
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v38, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v2, s6
@@ -951,29 +948,26 @@ define amdgpu_gfx <32 x i32> @strict_wwm_callee_saves(<32 x i32> inreg %keep, pt
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v25, s29
-; GFX9-O0-NEXT:    v_mov_b32_e32 v26, v40
-; GFX9-O0-NEXT:    v_mov_b32_e32 v27, v39
-; GFX9-O0-NEXT:    v_mov_b32_e32 v28, v38
-; GFX9-O0-NEXT:    v_mov_b32_e32 v29, v37
-; GFX9-O0-NEXT:    v_mov_b32_e32 v30, v36
-; GFX9-O0-NEXT:    ; kill: def $vgpr31 killed $vgpr35 killed $exec
-; GFX9-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    v_mov_b32_e32 v26, v38
+; GFX9-O0-NEXT:    v_mov_b32_e32 v27, v37
+; GFX9-O0-NEXT:    v_mov_b32_e32 v28, v36
+; GFX9-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3 killed $exec
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(4)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v3, v5
@@ -1118,12 +1112,11 @@ define amdgpu_gfx <32 x i32> @strict_wwm_callee_saves(<32 x i32> inreg %keep, pt
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v25, s29
-; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    s_xor_saveexec_b64 s[34:35], -1
-; GFX9-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-O0-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/wwm-reserved.ll
+++ b/llvm/test/CodeGen/AMDGPU/wwm-reserved.ll
@@ -733,7 +733,6 @@ define amdgpu_cs void @_amdgpu_cs_main(<4 x i32> inreg %desc, i32 %index) {
 ; GFX9-O0-NEXT:    s_mov_b32 s1, s6
 ; GFX9-O0-NEXT:    s_mov_b32 s2, s5
 ; GFX9-O0-NEXT:    s_mov_b32 s3, s4
-; GFX9-O0-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX9-O0-NEXT:    s_mov_b32 s4, 5
 ; GFX9-O0-NEXT:    v_lshlrev_b32_e64 v0, s4, v0
 ; GFX9-O0-NEXT:    s_mov_b32 s4, 0
@@ -1592,7 +1591,6 @@ define amdgpu_cs void @strict_wwm_amdgpu_cs_main(<4 x i32> inreg %desc, i32 %ind
 ; GFX9-O0-NEXT:    s_mov_b32 s1, s6
 ; GFX9-O0-NEXT:    s_mov_b32 s2, s5
 ; GFX9-O0-NEXT:    s_mov_b32 s3, s4
-; GFX9-O0-NEXT:    ; kill: def $sgpr4_sgpr5_sgpr6_sgpr7 killed $sgpr0_sgpr1_sgpr2_sgpr3
 ; GFX9-O0-NEXT:    s_mov_b32 s4, 5
 ; GFX9-O0-NEXT:    v_lshlrev_b32_e64 v0, s4, v0
 ; GFX9-O0-NEXT:    s_mov_b32 s4, 0

--- a/llvm/test/CodeGen/ARM/legalize-bitcast.ll
+++ b/llvm/test/CodeGen/ARM/legalize-bitcast.ll
@@ -41,8 +41,6 @@ bb.1:
 define i16 @int_to_vec(i80 %in) {
 ; CHECK-LABEL: int_to_vec:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    @ kill: def $r2 killed $r1
-; CHECK-NEXT:    @ kill: def $r2 killed $r0
 ; CHECK-NEXT:    lsl r0, r0, #16
 ; CHECK-NEXT:    orr r0, r0, r1, lsr #16
 ; CHECK-NEXT:    @ implicit-def: $d18

--- a/llvm/test/CodeGen/LoongArch/spill-ra-without-kill.ll
+++ b/llvm/test/CodeGen/LoongArch/spill-ra-without-kill.ll
@@ -19,7 +19,6 @@ define dso_local ptr @f(i32 noundef signext %i) "frame-pointer"="all" {
 ; CHECK-NEXT:    addi.d $fp, $sp, 48
 ; CHECK-NEXT:    .cfi_def_cfa 22, 0
 ; CHECK-NEXT:    st.d $ra, $fp, -40 # 8-byte Folded Spill
-; CHECK-NEXT:    # kill: def $r5 killed $r4
 ; CHECK-NEXT:    st.w $a0, $fp, -28
 ; CHECK-NEXT:    pcalau12i $a0, %pc_hi20(calls)
 ; CHECK-NEXT:    addi.d $a2, $a0, %pc_lo12(calls)

--- a/llvm/test/CodeGen/Mips/atomic-min-max.ll
+++ b/llvm/test/CodeGen/Mips/atomic-min-max.ll
@@ -1007,7 +1007,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -1049,7 +1048,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -1101,7 +1099,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -1143,7 +1140,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -1183,7 +1179,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -1224,7 +1219,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -1266,7 +1260,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -1307,7 +1300,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -1348,7 +1340,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -1387,7 +1378,6 @@ define i16 @test_max_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -1599,7 +1589,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -1641,7 +1630,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -1693,7 +1681,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -1735,7 +1722,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -1775,7 +1761,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -1816,7 +1801,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -1858,7 +1842,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -1899,7 +1882,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -1940,7 +1922,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -1979,7 +1960,6 @@ define i16 @test_min_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -2190,7 +2170,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -2232,7 +2211,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -2283,7 +2261,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -2325,7 +2302,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -2365,7 +2341,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -2406,7 +2381,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -2447,7 +2421,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -2488,7 +2461,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -2529,7 +2501,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -2568,7 +2539,6 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -2779,7 +2749,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -2821,7 +2790,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -2872,7 +2840,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -2914,7 +2881,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -2954,7 +2920,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -2995,7 +2960,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -3036,7 +3000,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -3077,7 +3040,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -3118,7 +3080,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -3157,7 +3118,6 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -3369,7 +3329,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -3411,7 +3370,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -3463,7 +3421,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -3505,7 +3462,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -3545,7 +3501,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -3586,7 +3541,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -3628,7 +3582,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -3669,7 +3622,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -3710,7 +3662,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -3749,7 +3700,6 @@ define i8 @test_max_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -3960,7 +3910,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -4002,7 +3951,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -4054,7 +4002,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -4096,7 +4043,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -4136,7 +4082,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -4177,7 +4122,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -4219,7 +4163,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -4260,7 +4203,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -4301,7 +4243,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -4340,7 +4281,6 @@ define i8 @test_min_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -4551,7 +4491,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -4593,7 +4532,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -4644,7 +4582,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -4686,7 +4623,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -4726,7 +4662,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -4767,7 +4702,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -4808,7 +4742,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -4849,7 +4782,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -4890,7 +4822,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -4929,7 +4860,6 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1
@@ -5140,7 +5070,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS:       # %bb.0: # %entry
 ; MIPS-NEXT:    addiu $sp, $sp, -8
 ; MIPS-NEXT:    .cfi_def_cfa_offset 8
-; MIPS-NEXT:    # kill: def $at killed $a1
 ; MIPS-NEXT:    sync
 ; MIPS-NEXT:    addiu $1, $zero, -4
 ; MIPS-NEXT:    and $6, $4, $1
@@ -5182,7 +5111,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS2:       # %bb.0: # %entry
 ; MIPS2-NEXT:    addiu $sp, $sp, -8
 ; MIPS2-NEXT:    .cfi_def_cfa_offset 8
-; MIPS2-NEXT:    # kill: def $at killed $a1
 ; MIPS2-NEXT:    sync
 ; MIPS2-NEXT:    addiu $1, $zero, -4
 ; MIPS2-NEXT:    and $6, $4, $1
@@ -5233,7 +5161,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSR6:       # %bb.0: # %entry
 ; MIPSR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSR6-NEXT:    # kill: def $at killed $a1
 ; MIPSR6-NEXT:    sync
 ; MIPSR6-NEXT:    addiu $1, $zero, -4
 ; MIPSR6-NEXT:    and $6, $4, $1
@@ -5275,7 +5202,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MM:       # %bb.0: # %entry
 ; MM-NEXT:    addiu $sp, $sp, -8
 ; MM-NEXT:    .cfi_def_cfa_offset 8
-; MM-NEXT:    # kill: def $at killed $a1
 ; MM-NEXT:    sync
 ; MM-NEXT:    addiu $1, $zero, -4
 ; MM-NEXT:    and $6, $4, $1
@@ -5315,7 +5241,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    addiu $sp, $sp, -8
 ; MMR6-NEXT:    .cfi_def_cfa_offset 8
-; MMR6-NEXT:    # kill: def $at killed $a1
 ; MMR6-NEXT:    sync
 ; MMR6-NEXT:    addiu $1, $zero, -4
 ; MMR6-NEXT:    and $6, $4, $1
@@ -5356,7 +5281,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -8
 ; MIPS32-NEXT:    .cfi_def_cfa_offset 8
-; MIPS32-NEXT:    # kill: def $at killed $a1
 ; MIPS32-NEXT:    sync
 ; MIPS32-NEXT:    addiu $1, $zero, -4
 ; MIPS32-NEXT:    and $6, $4, $1
@@ -5397,7 +5321,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSEL:       # %bb.0: # %entry
 ; MIPSEL-NEXT:    addiu $sp, $sp, -8
 ; MIPSEL-NEXT:    .cfi_def_cfa_offset 8
-; MIPSEL-NEXT:    # kill: def $at killed $a1
 ; MIPSEL-NEXT:    sync
 ; MIPSEL-NEXT:    addiu $1, $zero, -4
 ; MIPSEL-NEXT:    and $6, $4, $1
@@ -5438,7 +5361,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPSELR6:       # %bb.0: # %entry
 ; MIPSELR6-NEXT:    addiu $sp, $sp, -8
 ; MIPSELR6-NEXT:    .cfi_def_cfa_offset 8
-; MIPSELR6-NEXT:    # kill: def $at killed $a1
 ; MIPSELR6-NEXT:    sync
 ; MIPSELR6-NEXT:    addiu $1, $zero, -4
 ; MIPSELR6-NEXT:    and $6, $4, $1
@@ -5479,7 +5401,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMEL:       # %bb.0: # %entry
 ; MMEL-NEXT:    addiu $sp, $sp, -8
 ; MMEL-NEXT:    .cfi_def_cfa_offset 8
-; MMEL-NEXT:    # kill: def $at killed $a1
 ; MMEL-NEXT:    sync
 ; MMEL-NEXT:    addiu $1, $zero, -4
 ; MMEL-NEXT:    and $6, $4, $1
@@ -5518,7 +5439,6 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MMELR6:       # %bb.0: # %entry
 ; MMELR6-NEXT:    addiu $sp, $sp, -8
 ; MMELR6-NEXT:    .cfi_def_cfa_offset 8
-; MMELR6-NEXT:    # kill: def $at killed $a1
 ; MMELR6-NEXT:    sync
 ; MMELR6-NEXT:    addiu $1, $zero, -4
 ; MMELR6-NEXT:    and $6, $4, $1

--- a/llvm/test/CodeGen/Mips/atomic.ll
+++ b/llvm/test/CodeGen/Mips/atomic.ll
@@ -2379,7 +2379,6 @@ define signext i8 @AtomicLoadAdd8(i8 signext %incr) nounwind {
 ; MIPS32R6O0-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; MIPS32R6O0-NEXT:    addiu $sp, $sp, -8
 ; MIPS32R6O0-NEXT:    addu $1, $2, $25
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a0
 ; MIPS32R6O0-NEXT:    lw $1, %got(y)($1)
 ; MIPS32R6O0-NEXT:    addiu $2, $zero, -4
 ; MIPS32R6O0-NEXT:    and $5, $1, $2
@@ -2883,7 +2882,6 @@ define signext i8 @AtomicLoadSub8(i8 signext %incr) nounwind {
 ; MIPS32R6O0-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; MIPS32R6O0-NEXT:    addiu $sp, $sp, -8
 ; MIPS32R6O0-NEXT:    addu $1, $2, $25
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a0
 ; MIPS32R6O0-NEXT:    lw $1, %got(y)($1)
 ; MIPS32R6O0-NEXT:    addiu $2, $zero, -4
 ; MIPS32R6O0-NEXT:    and $5, $1, $2
@@ -3392,7 +3390,6 @@ define signext i8 @AtomicLoadNand8(i8 signext %incr) nounwind {
 ; MIPS32R6O0-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; MIPS32R6O0-NEXT:    addiu $sp, $sp, -8
 ; MIPS32R6O0-NEXT:    addu $1, $2, $25
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a0
 ; MIPS32R6O0-NEXT:    lw $1, %got(y)($1)
 ; MIPS32R6O0-NEXT:    addiu $2, $zero, -4
 ; MIPS32R6O0-NEXT:    and $5, $1, $2
@@ -3904,7 +3901,6 @@ define signext i8 @AtomicSwap8(i8 signext %newval) nounwind {
 ; MIPS32R6O0-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; MIPS32R6O0-NEXT:    addiu $sp, $sp, -8
 ; MIPS32R6O0-NEXT:    addu $1, $2, $25
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a0
 ; MIPS32R6O0-NEXT:    lw $1, %got(y)($1)
 ; MIPS32R6O0-NEXT:    addiu $2, $zero, -4
 ; MIPS32R6O0-NEXT:    and $5, $1, $2
@@ -4420,8 +4416,6 @@ define signext i8 @AtomicCmpSwap8(i8 signext %oldval, i8 signext %newval) nounwi
 ; MIPS32R6O0-NEXT:    addu $3, $2, $25
 ; MIPS32R6O0-NEXT:    move $1, $5
 ; MIPS32R6O0-NEXT:    move $2, $4
-; MIPS32R6O0-NEXT:    # kill: def $a1 killed $at
-; MIPS32R6O0-NEXT:    # kill: def $a0 killed $v0
 ; MIPS32R6O0-NEXT:    lw $3, %got(y)($3)
 ; MIPS32R6O0-NEXT:    addiu $4, $zero, -4
 ; MIPS32R6O0-NEXT:    and $4, $3, $4
@@ -4994,8 +4988,6 @@ define i1 @AtomicCmpSwapRes8(ptr %ptr, i8 signext %oldval, i8 signext %newval) n
 ; MIPS32R6O0-NEXT:    move $2, $5
 ; MIPS32R6O0-NEXT:    sw $2, 0($sp) # 4-byte Folded Spill
 ; MIPS32R6O0-NEXT:    move $3, $4
-; MIPS32R6O0-NEXT:    # kill: def $a2 killed $at
-; MIPS32R6O0-NEXT:    # kill: def $a1 killed $v0
 ; MIPS32R6O0-NEXT:    addiu $4, $zero, -4
 ; MIPS32R6O0-NEXT:    and $4, $3, $4
 ; MIPS32R6O0-NEXT:    andi $3, $3, 3
@@ -5537,7 +5529,6 @@ define signext i16 @AtomicLoadAdd16(i16 signext %incr) nounwind {
 ; MIPS32R6O0-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; MIPS32R6O0-NEXT:    addiu $sp, $sp, -8
 ; MIPS32R6O0-NEXT:    addu $1, $2, $25
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a0
 ; MIPS32R6O0-NEXT:    lw $1, %got(z)($1)
 ; MIPS32R6O0-NEXT:    addiu $2, $zero, -4
 ; MIPS32R6O0-NEXT:    and $5, $1, $2
@@ -6071,9 +6062,6 @@ define {i16, i1} @foo(ptr %addr, i16 %l, i16 %r, i16 %new) {
 ; MIPS32R6O0-NEXT:    .cfi_def_cfa_offset 8
 ; MIPS32R6O0-NEXT:    move $1, $7
 ; MIPS32R6O0-NEXT:    move $3, $4
-; MIPS32R6O0-NEXT:    # kill: def $a3 killed $at
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a2
-; MIPS32R6O0-NEXT:    # kill: def $v0 killed $a1
 ; MIPS32R6O0-NEXT:    addu $2, $5, $6
 ; MIPS32R6O0-NEXT:    sw $2, 0($sp) # 4-byte Folded Spill
 ; MIPS32R6O0-NEXT:    sync

--- a/llvm/test/CodeGen/Mips/implicit-sret.ll
+++ b/llvm/test/CodeGen/Mips/implicit-sret.ll
@@ -38,7 +38,6 @@ start:
 define internal { i32, i128, i64 } @implicit_sret_impl() unnamed_addr nounwind {
 ; CHECK-LABEL: implicit_sret_impl:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $at_64 killed $a0_64
 ; CHECK-NEXT:    daddiu $1, $zero, 20
 ; CHECK-NEXT:    sd $1, 24($4)
 ; CHECK-NEXT:    daddiu $1, $zero, 0
@@ -84,7 +83,6 @@ start:
 define internal { i32, i32, i32, i32, i32, i32 } @implicit_sret_impl2() unnamed_addr nounwind {
 ; CHECK-LABEL: implicit_sret_impl2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $at_64 killed $a0_64
 ; CHECK-NEXT:    addiu $1, $zero, 6
 ; CHECK-NEXT:    sw $1, 20($4)
 ; CHECK-NEXT:    addiu $1, $zero, 5

--- a/llvm/test/CodeGen/PowerPC/aix-p9-insert-extract.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-p9-insert-extract.ll
@@ -1739,7 +1739,6 @@ define <8 x i16> @insert_halfword_0(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_0:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 0
@@ -1772,7 +1771,6 @@ define <8 x i16> @insert_halfword_1(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_1:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 2
@@ -1805,7 +1803,6 @@ define <8 x i16> @insert_halfword_2(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_2:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 4
@@ -1838,7 +1835,6 @@ define <8 x i16> @insert_halfword_3(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_3:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 6
@@ -1871,7 +1867,6 @@ define <8 x i16> @insert_halfword_4(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_4:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 8
@@ -1904,7 +1899,6 @@ define <8 x i16> @insert_halfword_5(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_5:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 10
@@ -1937,7 +1931,6 @@ define <8 x i16> @insert_halfword_6(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_6:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 12
@@ -1970,7 +1963,6 @@ define <8 x i16> @insert_halfword_7(<8 x i16> %a, i16 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_halfword_7:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinserth 2, 3, 14
@@ -2005,7 +1997,6 @@ define <16 x i8> @insert_byte_0(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_0:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 0
@@ -2038,7 +2029,6 @@ define <16 x i8> @insert_byte_1(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_1:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 1
@@ -2071,7 +2061,6 @@ define <16 x i8> @insert_byte_2(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_2:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 2
@@ -2104,7 +2093,6 @@ define <16 x i8> @insert_byte_3(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_3:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 3
@@ -2137,7 +2125,6 @@ define <16 x i8> @insert_byte_4(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_4:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 4
@@ -2170,7 +2157,6 @@ define <16 x i8> @insert_byte_5(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_5:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 5
@@ -2203,7 +2189,6 @@ define <16 x i8> @insert_byte_6(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_6:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 6
@@ -2236,7 +2221,6 @@ define <16 x i8> @insert_byte_7(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_7:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 7
@@ -2269,7 +2253,6 @@ define <16 x i8> @insert_byte_8(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_8:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 8
@@ -2302,7 +2285,6 @@ define <16 x i8> @insert_byte_9(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_9:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 9
@@ -2335,7 +2317,6 @@ define <16 x i8> @insert_byte_10(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_10:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 10
@@ -2368,7 +2349,6 @@ define <16 x i8> @insert_byte_11(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_11:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 11
@@ -2401,7 +2381,6 @@ define <16 x i8> @insert_byte_12(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_12:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 12
@@ -2434,7 +2413,6 @@ define <16 x i8> @insert_byte_13(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_13:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 13
@@ -2467,7 +2445,6 @@ define <16 x i8> @insert_byte_14(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_14:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 14
@@ -2500,7 +2477,6 @@ define <16 x i8> @insert_byte_15(<16 x i8> %a, i8 %b) {
 ;
 ; CHECK-32-O0-LABEL: insert_byte_15:
 ; CHECK-32-O0:       # %bb.0: # %entry
-; CHECK-32-O0-NEXT:    # kill: def $r4 killed $r3
 ; CHECK-32-O0-NEXT:    mtfprwz 0, 3
 ; CHECK-32-O0-NEXT:    xscpsgndp 35, 0, 0
 ; CHECK-32-O0-NEXT:    vinsertb 2, 3, 15

--- a/llvm/test/CodeGen/PowerPC/aix-small-local-dynamic-tls-types.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-small-local-dynamic-tls-types.ll
@@ -2056,7 +2056,6 @@ define i32 @testDouble2() {
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    bla .__tls_get_mod[PR]
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    la r3, internal_tlv_double[TL]@ld(r3)
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    lfd f0, 0(r3)
-; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    # kill: def $f1 killed $f0
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    xscvdpsxws f0, f0
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    addi r3, r1, 52
 ; SMALL-LOCAL-DYNAMIC-SMALLCM64-O0-NEXT:    stfiwx f0, 0, r3
@@ -2077,7 +2076,6 @@ define i32 @testDouble2() {
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    bla .__tls_get_mod[PR]
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    la r3, internal_tlv_double[TL]@ld(r3)
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    lfd f0, 0(r3)
-; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    # kill: def $f1 killed $f0
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    xscvdpsxws f0, f0
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    addi r3, r1, 52
 ; SMALL-LOCAL-DYNAMIC-LARGECM64-O0-NEXT:    stfiwx f0, 0, r3

--- a/llvm/test/CodeGen/PowerPC/aix-tls-le-ldst-O0.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-le-ldst-O0.ll
@@ -120,7 +120,6 @@ define void @storeLongLong(i64 noundef %x) {
 ; SMALL32-O0-NEXT:    stw r0, 40(r1)
 ; SMALL32-O0-NEXT:    mr r5, r4
 ; SMALL32-O0-NEXT:    stw r3, 28(r1) # 4-byte Folded Spill
-; SMALL32-O0-NEXT:    # kill: def $r4 killed $r5
 ; SMALL32-O0-NEXT:    lwz r6, L..C1(r2) # target-flags(ppc-tprel) @TLLongLong
 ; SMALL32-O0-NEXT:    bla .__get_tpointer[PR]
 ; SMALL32-O0-NEXT:    mr r4, r3
@@ -140,7 +139,6 @@ define void @storeLongLong(i64 noundef %x) {
 ; LARGE32-O0-NEXT:    stw r0, 40(r1)
 ; LARGE32-O0-NEXT:    mr r5, r4
 ; LARGE32-O0-NEXT:    stw r3, 28(r1) # 4-byte Folded Spill
-; LARGE32-O0-NEXT:    # kill: def $r4 killed $r5
 ; LARGE32-O0-NEXT:    addis r3, L..C1@u(r2)
 ; LARGE32-O0-NEXT:    lwz r6, L..C1@l(r3)
 ; LARGE32-O0-NEXT:    bla .__get_tpointer[PR]
@@ -434,7 +432,6 @@ define i32 @loadDouble() {
 ; SMALL64-O0-NEXT:    ld r3, L..C2(r2) # target-flags(ppc-tprel) @TLDouble
 ; SMALL64-O0-NEXT:    add r3, r13, r3
 ; SMALL64-O0-NEXT:    lfd f0, 0(r3)
-; SMALL64-O0-NEXT:    # kill: def $f1 killed $f0
 ; SMALL64-O0-NEXT:    xscvdpsxws f0, f0
 ; SMALL64-O0-NEXT:    addi r3, r1, -12
 ; SMALL64-O0-NEXT:    stfiwx f0, 0, r3
@@ -448,7 +445,6 @@ define i32 @loadDouble() {
 ; LARGE64-O0-NEXT:    ld r3, L..C2@l(r3)
 ; LARGE64-O0-NEXT:    add r3, r13, r3
 ; LARGE64-O0-NEXT:    lfd f0, 0(r3)
-; LARGE64-O0-NEXT:    # kill: def $f1 killed $f0
 ; LARGE64-O0-NEXT:    xscvdpsxws f0, f0
 ; LARGE64-O0-NEXT:    addi r3, r1, -12
 ; LARGE64-O0-NEXT:    stfiwx f0, 0, r3
@@ -497,7 +493,6 @@ define i32 @loadDouble() {
 ; SMALL-LOCAL-EXEC-SMALLCM64:       # %bb.0: # %entry
 ; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    la r3, TLDouble[UL]@le(r13)
 ; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    lfd f0, 0(r3)
-; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    # kill: def $f1 killed $f0
 ; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    xscvdpsxws f0, f0
 ; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    addi r3, r1, -12
 ; SMALL-LOCAL-EXEC-SMALLCM64-NEXT:    stfiwx f0, 0, r3
@@ -509,7 +504,6 @@ define i32 @loadDouble() {
 ; SMALL-LOCAL-EXEC-LARGECM64:       # %bb.0: # %entry
 ; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    la r3, TLDouble[UL]@le(r13)
 ; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    lfd f0, 0(r3)
-; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    # kill: def $f1 killed $f0
 ; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    xscvdpsxws f0, f0
 ; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    addi r3, r1, -12
 ; SMALL-LOCAL-EXEC-LARGECM64-NEXT:    stfiwx f0, 0, r3

--- a/llvm/test/CodeGen/PowerPC/ppcsoftops.ll
+++ b/llvm/test/CodeGen/PowerPC/ppcsoftops.ll
@@ -219,10 +219,6 @@ define dso_local zeroext i32 @func(double noundef %0, double noundef %1) #0 {
 ; PPC-NEXT:    mflr 0
 ; PPC-NEXT:    stwu 1, -32(1)
 ; PPC-NEXT:    stw 0, 36(1)
-; PPC-NEXT:    # kill: def $r7 killed $r6
-; PPC-NEXT:    # kill: def $r7 killed $r5
-; PPC-NEXT:    # kill: def $r7 killed $r4
-; PPC-NEXT:    # kill: def $r7 killed $r3
 ; PPC-NEXT:    stw 4, 28(1)
 ; PPC-NEXT:    stw 3, 24(1)
 ; PPC-NEXT:    stw 6, 20(1)
@@ -323,8 +319,6 @@ define zeroext i1 @ppcf128_soften(ppc_fp128 %a) #0 {
 ; PPC-NEXT:    stw 5, 12(1) # 4-byte Folded Spill
 ; PPC-NEXT:    mr 5, 3
 ; PPC-NEXT:    lwz 3, 12(1) # 4-byte Folded Reload
-; PPC-NEXT:    # kill: def $r4 killed $r3
-; PPC-NEXT:    # kill: def $r4 killed $r5
 ; PPC-NEXT:    xoris 4, 5, 65520
 ; PPC-NEXT:    or 4, 3, 4
 ; PPC-NEXT:    cntlzw 4, 4

--- a/llvm/test/CodeGen/RISCV/constpool-known-bits.ll
+++ b/llvm/test/CodeGen/RISCV/constpool-known-bits.ll
@@ -5,7 +5,6 @@
 define i64 @test(i32 noundef signext %c, i32 noundef signext %d) {
 ; NOPIC-LABEL: test:
 ; NOPIC:       # %bb.0: # %entry
-; NOPIC-NEXT:    # kill: def $x11 killed $x10
 ; NOPIC-NEXT:    slli a0, a0, 32
 ; NOPIC-NEXT:    srli a1, a0, 32
 ; NOPIC-NEXT:    lui a0, %hi(.LCPI0_0)
@@ -27,7 +26,6 @@ define i64 @test(i32 noundef signext %c, i32 noundef signext %d) {
 ;
 ; PIC-LABEL: test:
 ; PIC:       # %bb.0: # %entry
-; PIC-NEXT:    # kill: def $x11 killed $x10
 ; PIC-NEXT:    slli a0, a0, 32
 ; PIC-NEXT:    srli a1, a0, 32
 ; PIC-NEXT:  .Lpcrel_hi0:

--- a/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rv32-spill-vector-csr.ll
@@ -41,13 +41,12 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ; SPILL-O0-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O0-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O0-NEXT:    call puts
-; SPILL-O0-NEXT:    addi a1, sp, 16
-; SPILL-O0-NEXT:    vl1r.v v10, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-NEXT:    csrr a1, vlenb
-; SPILL-O0-NEXT:    add a1, sp, a1
-; SPILL-O0-NEXT:    addi a1, a1, 16
-; SPILL-O0-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-NEXT:    # kill: def $x11 killed $x10
+; SPILL-O0-NEXT:    addi a0, sp, 16
+; SPILL-O0-NEXT:    vl1r.v v10, (a0) # vscale x 8-byte Folded Reload
+; SPILL-O0-NEXT:    csrr a0, vlenb
+; SPILL-O0-NEXT:    add a0, sp, a0
+; SPILL-O0-NEXT:    addi a0, a0, 16
+; SPILL-O0-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O0-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; SPILL-O0-NEXT:    # implicit-def: $v8
 ; SPILL-O0-NEXT:    vsetvli zero, a0, e64, m1, tu, ma
@@ -167,13 +166,12 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ; SPILL-O0-VSETVLI-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O0-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O0-VSETVLI-NEXT:    call puts
-; SPILL-O0-VSETVLI-NEXT:    addi a1, sp, 16
-; SPILL-O0-VSETVLI-NEXT:    vl1r.v v10, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-VSETVLI-NEXT:    csrr a1, vlenb
-; SPILL-O0-VSETVLI-NEXT:    add a1, sp, a1
-; SPILL-O0-VSETVLI-NEXT:    addi a1, a1, 16
-; SPILL-O0-VSETVLI-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-VSETVLI-NEXT:    # kill: def $x11 killed $x10
+; SPILL-O0-VSETVLI-NEXT:    addi a0, sp, 16
+; SPILL-O0-VSETVLI-NEXT:    vl1r.v v10, (a0) # vscale x 8-byte Folded Reload
+; SPILL-O0-VSETVLI-NEXT:    csrr a0, vlenb
+; SPILL-O0-VSETVLI-NEXT:    add a0, sp, a0
+; SPILL-O0-VSETVLI-NEXT:    addi a0, a0, 16
+; SPILL-O0-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O0-VSETVLI-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; SPILL-O0-VSETVLI-NEXT:    # implicit-def: $v8
 ; SPILL-O0-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, tu, ma

--- a/llvm/test/CodeGen/RISCV/rvv/rv64-spill-vector-csr.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rv64-spill-vector-csr.ll
@@ -40,13 +40,12 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ; SPILL-O0-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O0-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O0-NEXT:    call puts
-; SPILL-O0-NEXT:    addi a1, sp, 32
-; SPILL-O0-NEXT:    vl1r.v v10, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-NEXT:    csrr a1, vlenb
-; SPILL-O0-NEXT:    add a1, sp, a1
-; SPILL-O0-NEXT:    addi a1, a1, 32
-; SPILL-O0-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-NEXT:    # kill: def $x11 killed $x10
+; SPILL-O0-NEXT:    addi a0, sp, 32
+; SPILL-O0-NEXT:    vl1r.v v10, (a0) # vscale x 8-byte Folded Reload
+; SPILL-O0-NEXT:    csrr a0, vlenb
+; SPILL-O0-NEXT:    add a0, sp, a0
+; SPILL-O0-NEXT:    addi a0, a0, 32
+; SPILL-O0-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O0-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; SPILL-O0-NEXT:    # implicit-def: $v8
 ; SPILL-O0-NEXT:    vsetvli zero, a0, e64, m1, tu, ma
@@ -175,13 +174,12 @@ define <vscale x 1 x double> @foo(<vscale x 1 x double> %a, <vscale x 1 x double
 ; SPILL-O0-VSETVLI-NEXT:    lui a0, %hi(.L.str)
 ; SPILL-O0-VSETVLI-NEXT:    addi a0, a0, %lo(.L.str)
 ; SPILL-O0-VSETVLI-NEXT:    call puts
-; SPILL-O0-VSETVLI-NEXT:    addi a1, sp, 32
-; SPILL-O0-VSETVLI-NEXT:    vl1r.v v10, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-VSETVLI-NEXT:    csrr a1, vlenb
-; SPILL-O0-VSETVLI-NEXT:    add a1, sp, a1
-; SPILL-O0-VSETVLI-NEXT:    addi a1, a1, 32
-; SPILL-O0-VSETVLI-NEXT:    vl1r.v v9, (a1) # vscale x 8-byte Folded Reload
-; SPILL-O0-VSETVLI-NEXT:    # kill: def $x11 killed $x10
+; SPILL-O0-VSETVLI-NEXT:    addi a0, sp, 32
+; SPILL-O0-VSETVLI-NEXT:    vl1r.v v10, (a0) # vscale x 8-byte Folded Reload
+; SPILL-O0-VSETVLI-NEXT:    csrr a0, vlenb
+; SPILL-O0-VSETVLI-NEXT:    add a0, sp, a0
+; SPILL-O0-VSETVLI-NEXT:    addi a0, a0, 32
+; SPILL-O0-VSETVLI-NEXT:    vl1r.v v9, (a0) # vscale x 8-byte Folded Reload
 ; SPILL-O0-VSETVLI-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; SPILL-O0-VSETVLI-NEXT:    # implicit-def: $v8
 ; SPILL-O0-VSETVLI-NEXT:    vsetvli zero, a0, e64, m1, tu, ma

--- a/llvm/test/CodeGen/RISCV/xcvalu.ll
+++ b/llvm/test/CodeGen/RISCV/xcvalu.ll
@@ -68,7 +68,6 @@ define i32 @umax(i32 %a, i32 %b) {
 define i32 @exths(i16 %a) {
 ; CHECK-LABEL: exths:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $x11 killed $x10
 ; CHECK-NEXT:    cv.exths a0, a0
 ; CHECK-NEXT:    ret
   %1 = sext i16 %a to i32
@@ -78,7 +77,6 @@ define i32 @exths(i16 %a) {
 define i32 @exthz(i16 %a) {
 ; CHECK-LABEL: exthz:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $x11 killed $x10
 ; CHECK-NEXT:    cv.exthz a0, a0
 ; CHECK-NEXT:    ret
   %1 = zext i16 %a to i32
@@ -88,7 +86,6 @@ define i32 @exthz(i16 %a) {
 define i32 @extbs(i8 %a) {
 ; CHECK-LABEL: extbs:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $x11 killed $x10
 ; CHECK-NEXT:    cv.extbs a0, a0
 ; CHECK-NEXT:    ret
   %1 = sext i8 %a to i32
@@ -98,7 +95,6 @@ define i32 @extbs(i8 %a) {
 define i32 @extbz(i8 %a) {
 ; CHECK-LABEL: extbz:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $x11 killed $x10
 ; CHECK-NEXT:    cv.extbz a0, a0
 ; CHECK-NEXT:    ret
   %1 = zext i8 %a to i32

--- a/llvm/test/CodeGen/X86/AMX/amx-configO0toO0.ll
+++ b/llvm/test/CodeGen/X86/AMX/amx-configO0toO0.ll
@@ -382,7 +382,6 @@ define dso_local void @test_api(i32 %cond, i16 signext %row, i16 signext %col) #
 ; AVX512-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %cx # 2-byte Reload
 ; AVX512-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; AVX512-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
-; AVX512-NEXT:    # kill: def $r8 killed $rax
 ; AVX512-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; AVX512-NEXT:    vmovdqa64 {{[0-9]+}}(%rsp), %zmm0
 ; AVX512-NEXT:    vmovaps %zmm0, {{[-0-9]+}}(%r{{[sb]}}p) # 64-byte Spill
@@ -598,7 +597,6 @@ define dso_local void @test_api(i32 %cond, i16 signext %row, i16 signext %col) #
 ; AVX512-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %si # 2-byte Reload
 ; AVX512-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %dx # 2-byte Reload
 ; AVX512-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; AVX512-NEXT:    # kill: def $rdi killed $rax
 ; AVX512-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; AVX512-NEXT:    vmovdqa64 {{[0-9]+}}(%rsp), %zmm0
 ; AVX512-NEXT:    vmovdqa64 {{[0-9]+}}(%rsp), %zmm1

--- a/llvm/test/CodeGen/X86/avx512-mask-zext-bugfix.ll
+++ b/llvm/test/CodeGen/X86/avx512-mask-zext-bugfix.ll
@@ -38,9 +38,7 @@ define void @test_xmm(i32 %shift, i32 %mulp, <2 x i64> %a,ptr %arraydecay,ptr %f
 ; CHECK-NEXT:    callq _check_mask16
 ; CHECK-NEXT:    vmovaps {{[-0-9]+}}(%r{{[sb]}}p), %xmm0 ## 16-byte Reload
 ; CHECK-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdi ## 8-byte Reload
-; CHECK-NEXT:    vpmovd2m %xmm0, %k0
-; CHECK-NEXT:    ## kill: def $k1 killed $k0
-; CHECK-NEXT:    kmovd %k0, %eax
+; CHECK-NEXT:    vmovmskps %xmm0, %eax
 ; CHECK-NEXT:    ## kill: def $al killed $al killed $eax
 ; CHECK-NEXT:    movzbl %al, %eax
 ; CHECK-NEXT:    ## kill: def $ax killed $ax killed $eax

--- a/llvm/test/CodeGen/X86/avxneconvert-intrinsics-shared.ll
+++ b/llvm/test/CodeGen/X86/avxneconvert-intrinsics-shared.ll
@@ -8,7 +8,6 @@ define <8 x bfloat> @test_int_x86_vcvtneps2bf16128(<4 x float> %A) {
 ; AVX512BF16-COMMON-LABEL: test_int_x86_vcvtneps2bf16128:
 ; AVX512BF16-COMMON:       # %bb.0:
 ; AVX512BF16-COMMON-NEXT:    {vex} vcvtneps2bf16 %xmm0, %xmm0 # encoding: [0xc4,0xe2,0x7a,0x72,0xc0]
-; AVX512BF16-COMMON-NEXT:    # kill: def $xmm1 killed $xmm0
 ; AVX512BF16-COMMON-NEXT:    ret{{[l|q]}} # encoding: [0xc3]
 ;
 ; AVX512BF16-LABEL: test_int_x86_vcvtneps2bf16128:
@@ -24,7 +23,6 @@ define <8 x bfloat> @test_int_x86_vcvtneps2bf16256(<8 x float> %A) {
 ; AVX512BF16-COMMON-LABEL: test_int_x86_vcvtneps2bf16256:
 ; AVX512BF16-COMMON:       # %bb.0:
 ; AVX512BF16-COMMON-NEXT:    {vex} vcvtneps2bf16 %ymm0, %xmm0 # encoding: [0xc4,0xe2,0x7e,0x72,0xc0]
-; AVX512BF16-COMMON-NEXT:    # kill: def $xmm1 killed $xmm0
 ; AVX512BF16-COMMON-NEXT:    vzeroupper # encoding: [0xc5,0xf8,0x77]
 ; AVX512BF16-COMMON-NEXT:    ret{{[l|q]}} # encoding: [0xc3]
 ;

--- a/llvm/test/CodeGen/X86/bug47278.mir
+++ b/llvm/test/CodeGen/X86/bug47278.mir
@@ -15,9 +15,6 @@ body:             |
     ; CHECK: renamable $edx = MOVZX32rm8 renamable $eax, 1, $noreg, 0, $noreg :: (load (s8) from `ptr undef` + 20, align 4, basealign 16)
     ; CHECK: dead renamable $ecx = MOV32rm renamable $eax, 1, $noreg, 0, $noreg :: (load (s32) from `ptr undef` + 12, basealign 16)
     ; CHECK: renamable $al = MOV8rm killed renamable $eax, 1, $noreg, 0, $noreg :: (load (s8) from `ptr undef`, align 4)
-    ; CHECK: dead renamable $ecx = COPY renamable $edx
-    ; CHECK: dead renamable $ecx = COPY renamable $edx
-    ; CHECK: dead renamable $ecx = COPY renamable $edx
     ; CHECK: renamable $esi = IMPLICIT_DEF
     ; CHECK: renamable $ecx = IMPLICIT_DEF
     ; CHECK: renamable $ecx = CMOV32rr renamable $ecx, killed renamable $esi, 2, implicit undef $eflags

--- a/llvm/test/CodeGen/X86/huge-stack.ll
+++ b/llvm/test/CodeGen/X86/huge-stack.ll
@@ -50,7 +50,6 @@ define ptr @scavenge_spill() unnamed_addr #0 {
 ; CHECK-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; CHECK-NEXT:    leaq 46(%rsp), %rdi
 ; CHECK-NEXT:    callq baz@PLT
-; CHECK-NEXT:    # kill: def $rcx killed $rax
 ; CHECK-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; CHECK-NEXT:    movabsq $25769803816, %rcx # imm = 0x600000028
 ; CHECK-NEXT:    addq %rcx, %rsp

--- a/llvm/test/CodeGen/X86/pcsections-atomics.ll
+++ b/llvm/test/CodeGen/X86/pcsections-atomics.ll
@@ -2566,15 +2566,11 @@ define void @atomic8_cas_monotonic(ptr %a) {
 ; O0-NEXT:    movb $1, %cl
 ; O0-NEXT:  .Lpcsection75:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
+; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
 ; O0-NEXT:  .Lpcsection76:
-; O0-NEXT:    # kill: def $dl killed $al
+; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
 ; O0-NEXT:  .Lpcsection77:
-; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection78:
-; O0-NEXT:    # kill: def $dl killed $al
-; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection79:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -2670,17 +2666,13 @@ define void @atomic8_cas_acquire(ptr %a) {
 ; O0-NEXT:    movb $42, %al
 ; O0-NEXT:    movb %al, {{[-0-9]+}}(%r{{[sb]}}p) # 1-byte Spill
 ; O0-NEXT:    movb $1, %cl
+; O0-NEXT:  .Lpcsection78:
+; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
+; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
+; O0-NEXT:  .Lpcsection79:
+; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
+; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
 ; O0-NEXT:  .Lpcsection80:
-; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection81:
-; O0-NEXT:    # kill: def $dl killed $al
-; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection82:
-; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection83:
-; O0-NEXT:    # kill: def $dl killed $al
-; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection84:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -2776,17 +2768,13 @@ define void @atomic8_cas_release(ptr %a) {
 ; O0-NEXT:    movb $42, %al
 ; O0-NEXT:    movb %al, {{[-0-9]+}}(%r{{[sb]}}p) # 1-byte Spill
 ; O0-NEXT:    movb $1, %cl
-; O0-NEXT:  .Lpcsection85:
+; O0-NEXT:  .Lpcsection81:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection86:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection87:
+; O0-NEXT:  .Lpcsection82:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection88:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection89:
+; O0-NEXT:  .Lpcsection83:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -2882,17 +2870,13 @@ define void @atomic8_cas_acq_rel(ptr %a) {
 ; O0-NEXT:    movb $42, %al
 ; O0-NEXT:    movb %al, {{[-0-9]+}}(%r{{[sb]}}p) # 1-byte Spill
 ; O0-NEXT:    movb $1, %cl
-; O0-NEXT:  .Lpcsection90:
+; O0-NEXT:  .Lpcsection84:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection91:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection92:
+; O0-NEXT:  .Lpcsection85:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection93:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection94:
+; O0-NEXT:  .Lpcsection86:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -2988,17 +2972,13 @@ define void @atomic8_cas_seq_cst(ptr %a) {
 ; O0-NEXT:    movb $42, %al
 ; O0-NEXT:    movb %al, {{[-0-9]+}}(%r{{[sb]}}p) # 1-byte Spill
 ; O0-NEXT:    movb $1, %cl
-; O0-NEXT:  .Lpcsection95:
+; O0-NEXT:  .Lpcsection87:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection96:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection97:
+; O0-NEXT:  .Lpcsection88:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
-; O0-NEXT:  .Lpcsection98:
-; O0-NEXT:    # kill: def $dl killed $al
 ; O0-NEXT:    movb {{[-0-9]+}}(%r{{[sb]}}p), %al # 1-byte Reload
-; O0-NEXT:  .Lpcsection99:
+; O0-NEXT:  .Lpcsection89:
 ; O0-NEXT:    lock cmpxchgb %cl, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3091,7 +3071,7 @@ define i16 @atomic16_load_unordered(ptr %a) {
 ; O0-LABEL: atomic16_load_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection100:
+; O0-NEXT:  .Lpcsection90:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3138,7 +3118,7 @@ define i16 @atomic16_load_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_load_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection101:
+; O0-NEXT:  .Lpcsection91:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3185,7 +3165,7 @@ define i16 @atomic16_load_acquire(ptr %a) {
 ; O0-LABEL: atomic16_load_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection102:
+; O0-NEXT:  .Lpcsection92:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3232,7 +3212,7 @@ define i16 @atomic16_load_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_load_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection103:
+; O0-NEXT:  .Lpcsection93:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3279,7 +3259,7 @@ define void @atomic16_store_unordered(ptr %a) {
 ; O0-LABEL: atomic16_store_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection104:
+; O0-NEXT:  .Lpcsection94:
 ; O0-NEXT:    movw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3326,7 +3306,7 @@ define void @atomic16_store_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_store_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection105:
+; O0-NEXT:  .Lpcsection95:
 ; O0-NEXT:    movw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3373,7 +3353,7 @@ define void @atomic16_store_release(ptr %a) {
 ; O0-LABEL: atomic16_store_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection106:
+; O0-NEXT:  .Lpcsection96:
 ; O0-NEXT:    movw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3421,7 +3401,7 @@ define void @atomic16_store_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection107:
+; O0-NEXT:  .Lpcsection97:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3473,7 +3453,7 @@ define void @atomic16_xchg_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection108:
+; O0-NEXT:  .Lpcsection98:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3524,7 +3504,7 @@ define void @atomic16_add_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_add_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection109:
+; O0-NEXT:  .Lpcsection99:
 ; O0-NEXT:    lock addw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3571,7 +3551,7 @@ define void @atomic16_sub_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_sub_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection110:
+; O0-NEXT:  .Lpcsection100:
 ; O0-NEXT:    lock subw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3618,7 +3598,7 @@ define void @atomic16_and_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_and_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection111:
+; O0-NEXT:  .Lpcsection101:
 ; O0-NEXT:    lock andw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3665,7 +3645,7 @@ define void @atomic16_or_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_or_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection112:
+; O0-NEXT:  .Lpcsection102:
 ; O0-NEXT:    lock orw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3712,7 +3692,7 @@ define void @atomic16_xor_monotonic(ptr %a) {
 ; O0-LABEL: atomic16_xor_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection113:
+; O0-NEXT:  .Lpcsection103:
 ; O0-NEXT:    lock xorw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3760,30 +3740,30 @@ define void @atomic16_nand_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection114:
+; O0-NEXT:  .Lpcsection104:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:  .LBB64_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; O0-NEXT:  .Lpcsection115:
+; O0-NEXT:  .Lpcsection105:
 ; O0-NEXT:    # implicit-def: $edx
 ; O0-NEXT:    movw %ax, %dx
-; O0-NEXT:  .Lpcsection116:
+; O0-NEXT:  .Lpcsection106:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection117:
+; O0-NEXT:  .Lpcsection107:
 ; O0-NEXT:    orl $65493, %edx # imm = 0xFFD5
-; O0-NEXT:  .Lpcsection118:
+; O0-NEXT:  .Lpcsection108:
 ; O0-NEXT:    # kill: def $dx killed $dx killed $edx
-; O0-NEXT:  .Lpcsection119:
+; O0-NEXT:  .Lpcsection109:
 ; O0-NEXT:    lock cmpxchgw %dx, (%rcx)
-; O0-NEXT:  .Lpcsection120:
+; O0-NEXT:  .Lpcsection110:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection121:
+; O0-NEXT:  .Lpcsection111:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; O0-NEXT:  .Lpcsection122:
+; O0-NEXT:  .Lpcsection112:
 ; O0-NEXT:    jne .LBB64_2
 ; O0-NEXT:    jmp .LBB64_1
 ; O0-NEXT:  .LBB64_2: # %atomicrmw.end
@@ -3901,7 +3881,7 @@ define void @atomic16_xchg_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection123:
+; O0-NEXT:  .Lpcsection113:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3952,7 +3932,7 @@ define void @atomic16_add_acquire(ptr %a) {
 ; O0-LABEL: atomic16_add_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection124:
+; O0-NEXT:  .Lpcsection114:
 ; O0-NEXT:    lock addw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -3999,7 +3979,7 @@ define void @atomic16_sub_acquire(ptr %a) {
 ; O0-LABEL: atomic16_sub_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection125:
+; O0-NEXT:  .Lpcsection115:
 ; O0-NEXT:    lock subw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4046,7 +4026,7 @@ define void @atomic16_and_acquire(ptr %a) {
 ; O0-LABEL: atomic16_and_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection126:
+; O0-NEXT:  .Lpcsection116:
 ; O0-NEXT:    lock andw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4093,7 +4073,7 @@ define void @atomic16_or_acquire(ptr %a) {
 ; O0-LABEL: atomic16_or_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection127:
+; O0-NEXT:  .Lpcsection117:
 ; O0-NEXT:    lock orw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4140,7 +4120,7 @@ define void @atomic16_xor_acquire(ptr %a) {
 ; O0-LABEL: atomic16_xor_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection128:
+; O0-NEXT:  .Lpcsection118:
 ; O0-NEXT:    lock xorw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4188,30 +4168,30 @@ define void @atomic16_nand_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection129:
+; O0-NEXT:  .Lpcsection119:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:  .LBB71_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; O0-NEXT:  .Lpcsection130:
+; O0-NEXT:  .Lpcsection120:
 ; O0-NEXT:    # implicit-def: $edx
 ; O0-NEXT:    movw %ax, %dx
-; O0-NEXT:  .Lpcsection131:
+; O0-NEXT:  .Lpcsection121:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection132:
+; O0-NEXT:  .Lpcsection122:
 ; O0-NEXT:    orl $65493, %edx # imm = 0xFFD5
-; O0-NEXT:  .Lpcsection133:
+; O0-NEXT:  .Lpcsection123:
 ; O0-NEXT:    # kill: def $dx killed $dx killed $edx
-; O0-NEXT:  .Lpcsection134:
+; O0-NEXT:  .Lpcsection124:
 ; O0-NEXT:    lock cmpxchgw %dx, (%rcx)
-; O0-NEXT:  .Lpcsection135:
+; O0-NEXT:  .Lpcsection125:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection136:
+; O0-NEXT:  .Lpcsection126:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; O0-NEXT:  .Lpcsection137:
+; O0-NEXT:  .Lpcsection127:
 ; O0-NEXT:    jne .LBB71_2
 ; O0-NEXT:    jmp .LBB71_1
 ; O0-NEXT:  .LBB71_2: # %atomicrmw.end
@@ -4329,7 +4309,7 @@ define void @atomic16_xchg_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection138:
+; O0-NEXT:  .Lpcsection128:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4380,7 +4360,7 @@ define void @atomic16_add_release(ptr %a) {
 ; O0-LABEL: atomic16_add_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection139:
+; O0-NEXT:  .Lpcsection129:
 ; O0-NEXT:    lock addw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4427,7 +4407,7 @@ define void @atomic16_sub_release(ptr %a) {
 ; O0-LABEL: atomic16_sub_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection140:
+; O0-NEXT:  .Lpcsection130:
 ; O0-NEXT:    lock subw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4474,7 +4454,7 @@ define void @atomic16_and_release(ptr %a) {
 ; O0-LABEL: atomic16_and_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection141:
+; O0-NEXT:  .Lpcsection131:
 ; O0-NEXT:    lock andw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4521,7 +4501,7 @@ define void @atomic16_or_release(ptr %a) {
 ; O0-LABEL: atomic16_or_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection142:
+; O0-NEXT:  .Lpcsection132:
 ; O0-NEXT:    lock orw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4568,7 +4548,7 @@ define void @atomic16_xor_release(ptr %a) {
 ; O0-LABEL: atomic16_xor_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection143:
+; O0-NEXT:  .Lpcsection133:
 ; O0-NEXT:    lock xorw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4616,30 +4596,30 @@ define void @atomic16_nand_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection144:
+; O0-NEXT:  .Lpcsection134:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:  .LBB78_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; O0-NEXT:  .Lpcsection145:
+; O0-NEXT:  .Lpcsection135:
 ; O0-NEXT:    # implicit-def: $edx
 ; O0-NEXT:    movw %ax, %dx
-; O0-NEXT:  .Lpcsection146:
+; O0-NEXT:  .Lpcsection136:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection147:
+; O0-NEXT:  .Lpcsection137:
 ; O0-NEXT:    orl $65493, %edx # imm = 0xFFD5
-; O0-NEXT:  .Lpcsection148:
+; O0-NEXT:  .Lpcsection138:
 ; O0-NEXT:    # kill: def $dx killed $dx killed $edx
-; O0-NEXT:  .Lpcsection149:
+; O0-NEXT:  .Lpcsection139:
 ; O0-NEXT:    lock cmpxchgw %dx, (%rcx)
-; O0-NEXT:  .Lpcsection150:
+; O0-NEXT:  .Lpcsection140:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection151:
+; O0-NEXT:  .Lpcsection141:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; O0-NEXT:  .Lpcsection152:
+; O0-NEXT:  .Lpcsection142:
 ; O0-NEXT:    jne .LBB78_2
 ; O0-NEXT:    jmp .LBB78_1
 ; O0-NEXT:  .LBB78_2: # %atomicrmw.end
@@ -4757,7 +4737,7 @@ define void @atomic16_xchg_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection153:
+; O0-NEXT:  .Lpcsection143:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4808,7 +4788,7 @@ define void @atomic16_add_acq_rel(ptr %a) {
 ; O0-LABEL: atomic16_add_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection154:
+; O0-NEXT:  .Lpcsection144:
 ; O0-NEXT:    lock addw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4855,7 +4835,7 @@ define void @atomic16_sub_acq_rel(ptr %a) {
 ; O0-LABEL: atomic16_sub_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection155:
+; O0-NEXT:  .Lpcsection145:
 ; O0-NEXT:    lock subw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4902,7 +4882,7 @@ define void @atomic16_and_acq_rel(ptr %a) {
 ; O0-LABEL: atomic16_and_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection156:
+; O0-NEXT:  .Lpcsection146:
 ; O0-NEXT:    lock andw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4949,7 +4929,7 @@ define void @atomic16_or_acq_rel(ptr %a) {
 ; O0-LABEL: atomic16_or_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection157:
+; O0-NEXT:  .Lpcsection147:
 ; O0-NEXT:    lock orw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -4996,7 +4976,7 @@ define void @atomic16_xor_acq_rel(ptr %a) {
 ; O0-LABEL: atomic16_xor_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection158:
+; O0-NEXT:  .Lpcsection148:
 ; O0-NEXT:    lock xorw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5044,30 +5024,30 @@ define void @atomic16_nand_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection159:
+; O0-NEXT:  .Lpcsection149:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:  .LBB85_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; O0-NEXT:  .Lpcsection160:
+; O0-NEXT:  .Lpcsection150:
 ; O0-NEXT:    # implicit-def: $edx
 ; O0-NEXT:    movw %ax, %dx
-; O0-NEXT:  .Lpcsection161:
+; O0-NEXT:  .Lpcsection151:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection162:
+; O0-NEXT:  .Lpcsection152:
 ; O0-NEXT:    orl $65493, %edx # imm = 0xFFD5
-; O0-NEXT:  .Lpcsection163:
+; O0-NEXT:  .Lpcsection153:
 ; O0-NEXT:    # kill: def $dx killed $dx killed $edx
-; O0-NEXT:  .Lpcsection164:
+; O0-NEXT:  .Lpcsection154:
 ; O0-NEXT:    lock cmpxchgw %dx, (%rcx)
-; O0-NEXT:  .Lpcsection165:
+; O0-NEXT:  .Lpcsection155:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection166:
+; O0-NEXT:  .Lpcsection156:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; O0-NEXT:  .Lpcsection167:
+; O0-NEXT:  .Lpcsection157:
 ; O0-NEXT:    jne .LBB85_2
 ; O0-NEXT:    jmp .LBB85_1
 ; O0-NEXT:  .LBB85_2: # %atomicrmw.end
@@ -5185,7 +5165,7 @@ define void @atomic16_xchg_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movw $42, %ax
-; O0-NEXT:  .Lpcsection168:
+; O0-NEXT:  .Lpcsection158:
 ; O0-NEXT:    xchgw %ax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5236,7 +5216,7 @@ define void @atomic16_add_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_add_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection169:
+; O0-NEXT:  .Lpcsection159:
 ; O0-NEXT:    lock addw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5283,7 +5263,7 @@ define void @atomic16_sub_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_sub_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection170:
+; O0-NEXT:  .Lpcsection160:
 ; O0-NEXT:    lock subw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5330,7 +5310,7 @@ define void @atomic16_and_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_and_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection171:
+; O0-NEXT:  .Lpcsection161:
 ; O0-NEXT:    lock andw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5377,7 +5357,7 @@ define void @atomic16_or_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_or_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection172:
+; O0-NEXT:  .Lpcsection162:
 ; O0-NEXT:    lock orw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5424,7 +5404,7 @@ define void @atomic16_xor_seq_cst(ptr %a) {
 ; O0-LABEL: atomic16_xor_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection173:
+; O0-NEXT:  .Lpcsection163:
 ; O0-NEXT:    lock xorw $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5472,30 +5452,30 @@ define void @atomic16_nand_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection174:
+; O0-NEXT:  .Lpcsection164:
 ; O0-NEXT:    movw (%rdi), %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:  .LBB92_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; O0-NEXT:  .Lpcsection175:
+; O0-NEXT:  .Lpcsection165:
 ; O0-NEXT:    # implicit-def: $edx
 ; O0-NEXT:    movw %ax, %dx
-; O0-NEXT:  .Lpcsection176:
+; O0-NEXT:  .Lpcsection166:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection177:
+; O0-NEXT:  .Lpcsection167:
 ; O0-NEXT:    orl $65493, %edx # imm = 0xFFD5
-; O0-NEXT:  .Lpcsection178:
+; O0-NEXT:  .Lpcsection168:
 ; O0-NEXT:    # kill: def $dx killed $dx killed $edx
-; O0-NEXT:  .Lpcsection179:
+; O0-NEXT:  .Lpcsection169:
 ; O0-NEXT:    lock cmpxchgw %dx, (%rcx)
-; O0-NEXT:  .Lpcsection180:
+; O0-NEXT:  .Lpcsection170:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection181:
+; O0-NEXT:  .Lpcsection171:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; O0-NEXT:  .Lpcsection182:
+; O0-NEXT:  .Lpcsection172:
 ; O0-NEXT:    jne .LBB92_2
 ; O0-NEXT:    jmp .LBB92_1
 ; O0-NEXT:  .LBB92_2: # %atomicrmw.end
@@ -5615,17 +5595,13 @@ define void @atomic16_cas_monotonic(ptr %a) {
 ; O0-NEXT:    movw $42, %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:    movw $1, %cx
-; O0-NEXT:  .Lpcsection183:
+; O0-NEXT:  .Lpcsection173:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection184:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection185:
+; O0-NEXT:  .Lpcsection174:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection186:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection187:
+; O0-NEXT:  .Lpcsection175:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5709,17 +5685,13 @@ define void @atomic16_cas_acquire(ptr %a) {
 ; O0-NEXT:    movw $42, %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:    movw $1, %cx
-; O0-NEXT:  .Lpcsection188:
+; O0-NEXT:  .Lpcsection176:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection189:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection190:
+; O0-NEXT:  .Lpcsection177:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection191:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection192:
+; O0-NEXT:  .Lpcsection178:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5803,17 +5775,13 @@ define void @atomic16_cas_release(ptr %a) {
 ; O0-NEXT:    movw $42, %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:    movw $1, %cx
-; O0-NEXT:  .Lpcsection193:
+; O0-NEXT:  .Lpcsection179:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection194:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection195:
+; O0-NEXT:  .Lpcsection180:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection196:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection197:
+; O0-NEXT:  .Lpcsection181:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5897,17 +5865,13 @@ define void @atomic16_cas_acq_rel(ptr %a) {
 ; O0-NEXT:    movw $42, %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:    movw $1, %cx
-; O0-NEXT:  .Lpcsection198:
+; O0-NEXT:  .Lpcsection182:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection199:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection200:
+; O0-NEXT:  .Lpcsection183:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection201:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection202:
+; O0-NEXT:  .Lpcsection184:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -5991,17 +5955,13 @@ define void @atomic16_cas_seq_cst(ptr %a) {
 ; O0-NEXT:    movw $42, %ax
 ; O0-NEXT:    movw %ax, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
 ; O0-NEXT:    movw $1, %cx
-; O0-NEXT:  .Lpcsection203:
+; O0-NEXT:  .Lpcsection185:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection204:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection205:
+; O0-NEXT:  .Lpcsection186:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
-; O0-NEXT:  .Lpcsection206:
-; O0-NEXT:    # kill: def $dx killed $ax
 ; O0-NEXT:    movw {{[-0-9]+}}(%r{{[sb]}}p), %ax # 2-byte Reload
-; O0-NEXT:  .Lpcsection207:
+; O0-NEXT:  .Lpcsection187:
 ; O0-NEXT:    lock cmpxchgw %cx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6082,7 +6042,7 @@ define i32 @atomic32_load_unordered(ptr %a) {
 ; O0-LABEL: atomic32_load_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection208:
+; O0-NEXT:  .Lpcsection188:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6129,7 +6089,7 @@ define i32 @atomic32_load_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_load_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection209:
+; O0-NEXT:  .Lpcsection189:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6176,7 +6136,7 @@ define i32 @atomic32_load_acquire(ptr %a) {
 ; O0-LABEL: atomic32_load_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection210:
+; O0-NEXT:  .Lpcsection190:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6223,7 +6183,7 @@ define i32 @atomic32_load_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_load_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection211:
+; O0-NEXT:  .Lpcsection191:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6270,7 +6230,7 @@ define void @atomic32_store_unordered(ptr %a) {
 ; O0-LABEL: atomic32_store_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection212:
+; O0-NEXT:  .Lpcsection192:
 ; O0-NEXT:    movl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6317,7 +6277,7 @@ define void @atomic32_store_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_store_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection213:
+; O0-NEXT:  .Lpcsection193:
 ; O0-NEXT:    movl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6364,7 +6324,7 @@ define void @atomic32_store_release(ptr %a) {
 ; O0-LABEL: atomic32_store_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection214:
+; O0-NEXT:  .Lpcsection194:
 ; O0-NEXT:    movl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6412,7 +6372,7 @@ define void @atomic32_store_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection215:
+; O0-NEXT:  .Lpcsection195:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6464,7 +6424,7 @@ define void @atomic32_xchg_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection216:
+; O0-NEXT:  .Lpcsection196:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6515,7 +6475,7 @@ define void @atomic32_add_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_add_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection217:
+; O0-NEXT:  .Lpcsection197:
 ; O0-NEXT:    lock addl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6562,7 +6522,7 @@ define void @atomic32_sub_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_sub_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection218:
+; O0-NEXT:  .Lpcsection198:
 ; O0-NEXT:    lock subl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6609,7 +6569,7 @@ define void @atomic32_and_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_and_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection219:
+; O0-NEXT:  .Lpcsection199:
 ; O0-NEXT:    lock andl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6656,7 +6616,7 @@ define void @atomic32_or_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_or_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection220:
+; O0-NEXT:  .Lpcsection200:
 ; O0-NEXT:    lock orl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6703,7 +6663,7 @@ define void @atomic32_xor_monotonic(ptr %a) {
 ; O0-LABEL: atomic32_xor_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection221:
+; O0-NEXT:  .Lpcsection201:
 ; O0-NEXT:    lock xorl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6751,7 +6711,7 @@ define void @atomic32_nand_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection222:
+; O0-NEXT:  .Lpcsection202:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:  .LBB112_1: # %atomicrmw.start
@@ -6759,18 +6719,18 @@ define void @atomic32_nand_monotonic(ptr %a) {
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %edx
-; O0-NEXT:  .Lpcsection223:
+; O0-NEXT:  .Lpcsection203:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection224:
+; O0-NEXT:  .Lpcsection204:
 ; O0-NEXT:    orl $-43, %edx
-; O0-NEXT:  .Lpcsection225:
+; O0-NEXT:  .Lpcsection205:
 ; O0-NEXT:    lock cmpxchgl %edx, (%rcx)
-; O0-NEXT:  .Lpcsection226:
+; O0-NEXT:  .Lpcsection206:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection227:
+; O0-NEXT:  .Lpcsection207:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; O0-NEXT:  .Lpcsection228:
+; O0-NEXT:  .Lpcsection208:
 ; O0-NEXT:    jne .LBB112_2
 ; O0-NEXT:    jmp .LBB112_1
 ; O0-NEXT:  .LBB112_2: # %atomicrmw.end
@@ -6872,7 +6832,7 @@ define void @atomic32_xchg_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection229:
+; O0-NEXT:  .Lpcsection209:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6923,7 +6883,7 @@ define void @atomic32_add_acquire(ptr %a) {
 ; O0-LABEL: atomic32_add_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection230:
+; O0-NEXT:  .Lpcsection210:
 ; O0-NEXT:    lock addl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -6970,7 +6930,7 @@ define void @atomic32_sub_acquire(ptr %a) {
 ; O0-LABEL: atomic32_sub_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection231:
+; O0-NEXT:  .Lpcsection211:
 ; O0-NEXT:    lock subl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7017,7 +6977,7 @@ define void @atomic32_and_acquire(ptr %a) {
 ; O0-LABEL: atomic32_and_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection232:
+; O0-NEXT:  .Lpcsection212:
 ; O0-NEXT:    lock andl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7064,7 +7024,7 @@ define void @atomic32_or_acquire(ptr %a) {
 ; O0-LABEL: atomic32_or_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection233:
+; O0-NEXT:  .Lpcsection213:
 ; O0-NEXT:    lock orl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7111,7 +7071,7 @@ define void @atomic32_xor_acquire(ptr %a) {
 ; O0-LABEL: atomic32_xor_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection234:
+; O0-NEXT:  .Lpcsection214:
 ; O0-NEXT:    lock xorl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7159,7 +7119,7 @@ define void @atomic32_nand_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection235:
+; O0-NEXT:  .Lpcsection215:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:  .LBB119_1: # %atomicrmw.start
@@ -7167,18 +7127,18 @@ define void @atomic32_nand_acquire(ptr %a) {
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %edx
-; O0-NEXT:  .Lpcsection236:
+; O0-NEXT:  .Lpcsection216:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection237:
+; O0-NEXT:  .Lpcsection217:
 ; O0-NEXT:    orl $-43, %edx
-; O0-NEXT:  .Lpcsection238:
+; O0-NEXT:  .Lpcsection218:
 ; O0-NEXT:    lock cmpxchgl %edx, (%rcx)
-; O0-NEXT:  .Lpcsection239:
+; O0-NEXT:  .Lpcsection219:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection240:
+; O0-NEXT:  .Lpcsection220:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; O0-NEXT:  .Lpcsection241:
+; O0-NEXT:  .Lpcsection221:
 ; O0-NEXT:    jne .LBB119_2
 ; O0-NEXT:    jmp .LBB119_1
 ; O0-NEXT:  .LBB119_2: # %atomicrmw.end
@@ -7280,7 +7240,7 @@ define void @atomic32_xchg_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection242:
+; O0-NEXT:  .Lpcsection222:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7331,7 +7291,7 @@ define void @atomic32_add_release(ptr %a) {
 ; O0-LABEL: atomic32_add_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection243:
+; O0-NEXT:  .Lpcsection223:
 ; O0-NEXT:    lock addl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7378,7 +7338,7 @@ define void @atomic32_sub_release(ptr %a) {
 ; O0-LABEL: atomic32_sub_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection244:
+; O0-NEXT:  .Lpcsection224:
 ; O0-NEXT:    lock subl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7425,7 +7385,7 @@ define void @atomic32_and_release(ptr %a) {
 ; O0-LABEL: atomic32_and_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection245:
+; O0-NEXT:  .Lpcsection225:
 ; O0-NEXT:    lock andl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7472,7 +7432,7 @@ define void @atomic32_or_release(ptr %a) {
 ; O0-LABEL: atomic32_or_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection246:
+; O0-NEXT:  .Lpcsection226:
 ; O0-NEXT:    lock orl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7519,7 +7479,7 @@ define void @atomic32_xor_release(ptr %a) {
 ; O0-LABEL: atomic32_xor_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection247:
+; O0-NEXT:  .Lpcsection227:
 ; O0-NEXT:    lock xorl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7567,7 +7527,7 @@ define void @atomic32_nand_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection248:
+; O0-NEXT:  .Lpcsection228:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:  .LBB126_1: # %atomicrmw.start
@@ -7575,18 +7535,18 @@ define void @atomic32_nand_release(ptr %a) {
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %edx
-; O0-NEXT:  .Lpcsection249:
+; O0-NEXT:  .Lpcsection229:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection250:
+; O0-NEXT:  .Lpcsection230:
 ; O0-NEXT:    orl $-43, %edx
-; O0-NEXT:  .Lpcsection251:
+; O0-NEXT:  .Lpcsection231:
 ; O0-NEXT:    lock cmpxchgl %edx, (%rcx)
-; O0-NEXT:  .Lpcsection252:
+; O0-NEXT:  .Lpcsection232:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection253:
+; O0-NEXT:  .Lpcsection233:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; O0-NEXT:  .Lpcsection254:
+; O0-NEXT:  .Lpcsection234:
 ; O0-NEXT:    jne .LBB126_2
 ; O0-NEXT:    jmp .LBB126_1
 ; O0-NEXT:  .LBB126_2: # %atomicrmw.end
@@ -7688,7 +7648,7 @@ define void @atomic32_xchg_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection255:
+; O0-NEXT:  .Lpcsection235:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7739,7 +7699,7 @@ define void @atomic32_add_acq_rel(ptr %a) {
 ; O0-LABEL: atomic32_add_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection256:
+; O0-NEXT:  .Lpcsection236:
 ; O0-NEXT:    lock addl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7786,7 +7746,7 @@ define void @atomic32_sub_acq_rel(ptr %a) {
 ; O0-LABEL: atomic32_sub_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection257:
+; O0-NEXT:  .Lpcsection237:
 ; O0-NEXT:    lock subl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7833,7 +7793,7 @@ define void @atomic32_and_acq_rel(ptr %a) {
 ; O0-LABEL: atomic32_and_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection258:
+; O0-NEXT:  .Lpcsection238:
 ; O0-NEXT:    lock andl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7880,7 +7840,7 @@ define void @atomic32_or_acq_rel(ptr %a) {
 ; O0-LABEL: atomic32_or_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection259:
+; O0-NEXT:  .Lpcsection239:
 ; O0-NEXT:    lock orl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7927,7 +7887,7 @@ define void @atomic32_xor_acq_rel(ptr %a) {
 ; O0-LABEL: atomic32_xor_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection260:
+; O0-NEXT:  .Lpcsection240:
 ; O0-NEXT:    lock xorl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -7975,7 +7935,7 @@ define void @atomic32_nand_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection261:
+; O0-NEXT:  .Lpcsection241:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:  .LBB133_1: # %atomicrmw.start
@@ -7983,18 +7943,18 @@ define void @atomic32_nand_acq_rel(ptr %a) {
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %edx
-; O0-NEXT:  .Lpcsection262:
+; O0-NEXT:  .Lpcsection242:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection263:
+; O0-NEXT:  .Lpcsection243:
 ; O0-NEXT:    orl $-43, %edx
-; O0-NEXT:  .Lpcsection264:
+; O0-NEXT:  .Lpcsection244:
 ; O0-NEXT:    lock cmpxchgl %edx, (%rcx)
-; O0-NEXT:  .Lpcsection265:
+; O0-NEXT:  .Lpcsection245:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection266:
+; O0-NEXT:  .Lpcsection246:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; O0-NEXT:  .Lpcsection267:
+; O0-NEXT:  .Lpcsection247:
 ; O0-NEXT:    jne .LBB133_2
 ; O0-NEXT:    jmp .LBB133_1
 ; O0-NEXT:  .LBB133_2: # %atomicrmw.end
@@ -8096,7 +8056,7 @@ define void @atomic32_xchg_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection268:
+; O0-NEXT:  .Lpcsection248:
 ; O0-NEXT:    xchgl %eax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8147,7 +8107,7 @@ define void @atomic32_add_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_add_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection269:
+; O0-NEXT:  .Lpcsection249:
 ; O0-NEXT:    lock addl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8194,7 +8154,7 @@ define void @atomic32_sub_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_sub_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection270:
+; O0-NEXT:  .Lpcsection250:
 ; O0-NEXT:    lock subl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8241,7 +8201,7 @@ define void @atomic32_and_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_and_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection271:
+; O0-NEXT:  .Lpcsection251:
 ; O0-NEXT:    lock andl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8288,7 +8248,7 @@ define void @atomic32_or_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_or_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection272:
+; O0-NEXT:  .Lpcsection252:
 ; O0-NEXT:    lock orl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8335,7 +8295,7 @@ define void @atomic32_xor_seq_cst(ptr %a) {
 ; O0-LABEL: atomic32_xor_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection273:
+; O0-NEXT:  .Lpcsection253:
 ; O0-NEXT:    lock xorl $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8383,7 +8343,7 @@ define void @atomic32_nand_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection274:
+; O0-NEXT:  .Lpcsection254:
 ; O0-NEXT:    movl (%rdi), %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:  .LBB140_1: # %atomicrmw.start
@@ -8391,18 +8351,18 @@ define void @atomic32_nand_seq_cst(ptr %a) {
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %edx
-; O0-NEXT:  .Lpcsection275:
+; O0-NEXT:  .Lpcsection255:
 ; O0-NEXT:    notl %edx
-; O0-NEXT:  .Lpcsection276:
+; O0-NEXT:  .Lpcsection256:
 ; O0-NEXT:    orl $-43, %edx
-; O0-NEXT:  .Lpcsection277:
+; O0-NEXT:  .Lpcsection257:
 ; O0-NEXT:    lock cmpxchgl %edx, (%rcx)
-; O0-NEXT:  .Lpcsection278:
+; O0-NEXT:  .Lpcsection258:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection279:
+; O0-NEXT:  .Lpcsection259:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; O0-NEXT:  .Lpcsection280:
+; O0-NEXT:  .Lpcsection260:
 ; O0-NEXT:    jne .LBB140_2
 ; O0-NEXT:    jmp .LBB140_1
 ; O0-NEXT:  .LBB140_2: # %atomicrmw.end
@@ -8506,17 +8466,13 @@ define void @atomic32_cas_monotonic(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection281:
+; O0-NEXT:  .Lpcsection261:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection282:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection283:
+; O0-NEXT:  .Lpcsection262:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection284:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection285:
+; O0-NEXT:  .Lpcsection263:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8612,17 +8568,13 @@ define void @atomic32_cas_acquire(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection286:
+; O0-NEXT:  .Lpcsection264:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection287:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection288:
+; O0-NEXT:  .Lpcsection265:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection289:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection290:
+; O0-NEXT:  .Lpcsection266:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8718,17 +8670,13 @@ define void @atomic32_cas_release(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection291:
+; O0-NEXT:  .Lpcsection267:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection292:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection293:
+; O0-NEXT:  .Lpcsection268:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection294:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection295:
+; O0-NEXT:  .Lpcsection269:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8824,17 +8772,13 @@ define void @atomic32_cas_acq_rel(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection296:
+; O0-NEXT:  .Lpcsection270:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection297:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection298:
+; O0-NEXT:  .Lpcsection271:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection299:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection300:
+; O0-NEXT:  .Lpcsection272:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -8930,17 +8874,13 @@ define void @atomic32_cas_seq_cst(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movl %eax, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection301:
+; O0-NEXT:  .Lpcsection273:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection302:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection303:
+; O0-NEXT:  .Lpcsection274:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
-; O0-NEXT:  .Lpcsection304:
-; O0-NEXT:    # kill: def $edx killed $eax
 ; O0-NEXT:    movl {{[-0-9]+}}(%r{{[sb]}}p), %eax # 4-byte Reload
-; O0-NEXT:  .Lpcsection305:
+; O0-NEXT:  .Lpcsection275:
 ; O0-NEXT:    lock cmpxchgl %ecx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9033,7 +8973,7 @@ define i64 @atomic64_load_unordered(ptr %a) {
 ; O0-LABEL: atomic64_load_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection306:
+; O0-NEXT:  .Lpcsection276:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9080,7 +9020,7 @@ define i64 @atomic64_load_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_load_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection307:
+; O0-NEXT:  .Lpcsection277:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9127,7 +9067,7 @@ define i64 @atomic64_load_acquire(ptr %a) {
 ; O0-LABEL: atomic64_load_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection308:
+; O0-NEXT:  .Lpcsection278:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9174,7 +9114,7 @@ define i64 @atomic64_load_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_load_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection309:
+; O0-NEXT:  .Lpcsection279:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9221,7 +9161,7 @@ define ptr @atomic64_load_seq_cst_ptr_ty(ptr %a) {
 ; O0-LABEL: atomic64_load_seq_cst_ptr_ty:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection310:
+; O0-NEXT:  .Lpcsection280:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9268,7 +9208,7 @@ define void @atomic64_store_unordered(ptr %a) {
 ; O0-LABEL: atomic64_store_unordered:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection311:
+; O0-NEXT:  .Lpcsection281:
 ; O0-NEXT:    movq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9315,7 +9255,7 @@ define void @atomic64_store_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_store_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection312:
+; O0-NEXT:  .Lpcsection282:
 ; O0-NEXT:    movq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9362,7 +9302,7 @@ define void @atomic64_store_release(ptr %a) {
 ; O0-LABEL: atomic64_store_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection313:
+; O0-NEXT:  .Lpcsection283:
 ; O0-NEXT:    movq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9410,7 +9350,7 @@ define void @atomic64_store_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection314:
+; O0-NEXT:  .Lpcsection284:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9461,7 +9401,7 @@ define void @atomic64_store_seq_cst_ptr_ty(ptr %a, ptr %v) {
 ; O0-LABEL: atomic64_store_seq_cst_ptr_ty:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection315:
+; O0-NEXT:  .Lpcsection285:
 ; O0-NEXT:    xchgq %rsi, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9509,7 +9449,7 @@ define void @atomic64_xchg_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection316:
+; O0-NEXT:  .Lpcsection286:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9560,7 +9500,7 @@ define void @atomic64_add_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_add_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection317:
+; O0-NEXT:  .Lpcsection287:
 ; O0-NEXT:    lock addq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9607,7 +9547,7 @@ define void @atomic64_sub_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_sub_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection318:
+; O0-NEXT:  .Lpcsection288:
 ; O0-NEXT:    lock subq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9654,7 +9594,7 @@ define void @atomic64_and_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_and_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection319:
+; O0-NEXT:  .Lpcsection289:
 ; O0-NEXT:    lock andq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9701,7 +9641,7 @@ define void @atomic64_or_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_or_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection320:
+; O0-NEXT:  .Lpcsection290:
 ; O0-NEXT:    lock orq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9748,7 +9688,7 @@ define void @atomic64_xor_monotonic(ptr %a) {
 ; O0-LABEL: atomic64_xor_monotonic:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection321:
+; O0-NEXT:  .Lpcsection291:
 ; O0-NEXT:    lock xorq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9796,7 +9736,7 @@ define void @atomic64_nand_monotonic(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection322:
+; O0-NEXT:  .Lpcsection292:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:  .LBB162_1: # %atomicrmw.start
@@ -9804,21 +9744,21 @@ define void @atomic64_nand_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %esi
-; O0-NEXT:  .Lpcsection323:
+; O0-NEXT:  .Lpcsection293:
 ; O0-NEXT:    notl %esi
-; O0-NEXT:  .Lpcsection324:
+; O0-NEXT:  .Lpcsection294:
 ; O0-NEXT:    # implicit-def: $rdx
 ; O0-NEXT:    movl %esi, %edx
-; O0-NEXT:  .Lpcsection325:
+; O0-NEXT:  .Lpcsection295:
 ; O0-NEXT:    orq $-43, %rdx
-; O0-NEXT:  .Lpcsection326:
+; O0-NEXT:  .Lpcsection296:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rcx)
-; O0-NEXT:  .Lpcsection327:
+; O0-NEXT:  .Lpcsection297:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection328:
+; O0-NEXT:  .Lpcsection298:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection329:
+; O0-NEXT:  .Lpcsection299:
 ; O0-NEXT:    jne .LBB162_2
 ; O0-NEXT:    jmp .LBB162_1
 ; O0-NEXT:  .LBB162_2: # %atomicrmw.end
@@ -9920,7 +9860,7 @@ define void @atomic64_xchg_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection330:
+; O0-NEXT:  .Lpcsection300:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -9971,7 +9911,7 @@ define void @atomic64_add_acquire(ptr %a) {
 ; O0-LABEL: atomic64_add_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection331:
+; O0-NEXT:  .Lpcsection301:
 ; O0-NEXT:    lock addq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10018,7 +9958,7 @@ define void @atomic64_sub_acquire(ptr %a) {
 ; O0-LABEL: atomic64_sub_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection332:
+; O0-NEXT:  .Lpcsection302:
 ; O0-NEXT:    lock subq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10065,7 +10005,7 @@ define void @atomic64_and_acquire(ptr %a) {
 ; O0-LABEL: atomic64_and_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection333:
+; O0-NEXT:  .Lpcsection303:
 ; O0-NEXT:    lock andq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10112,7 +10052,7 @@ define void @atomic64_or_acquire(ptr %a) {
 ; O0-LABEL: atomic64_or_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection334:
+; O0-NEXT:  .Lpcsection304:
 ; O0-NEXT:    lock orq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10159,7 +10099,7 @@ define void @atomic64_xor_acquire(ptr %a) {
 ; O0-LABEL: atomic64_xor_acquire:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection335:
+; O0-NEXT:  .Lpcsection305:
 ; O0-NEXT:    lock xorq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10207,7 +10147,7 @@ define void @atomic64_nand_acquire(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection336:
+; O0-NEXT:  .Lpcsection306:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:  .LBB169_1: # %atomicrmw.start
@@ -10215,21 +10155,21 @@ define void @atomic64_nand_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %esi
-; O0-NEXT:  .Lpcsection337:
+; O0-NEXT:  .Lpcsection307:
 ; O0-NEXT:    notl %esi
-; O0-NEXT:  .Lpcsection338:
+; O0-NEXT:  .Lpcsection308:
 ; O0-NEXT:    # implicit-def: $rdx
 ; O0-NEXT:    movl %esi, %edx
-; O0-NEXT:  .Lpcsection339:
+; O0-NEXT:  .Lpcsection309:
 ; O0-NEXT:    orq $-43, %rdx
-; O0-NEXT:  .Lpcsection340:
+; O0-NEXT:  .Lpcsection310:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rcx)
-; O0-NEXT:  .Lpcsection341:
+; O0-NEXT:  .Lpcsection311:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection342:
+; O0-NEXT:  .Lpcsection312:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection343:
+; O0-NEXT:  .Lpcsection313:
 ; O0-NEXT:    jne .LBB169_2
 ; O0-NEXT:    jmp .LBB169_1
 ; O0-NEXT:  .LBB169_2: # %atomicrmw.end
@@ -10331,7 +10271,7 @@ define void @atomic64_xchg_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection344:
+; O0-NEXT:  .Lpcsection314:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10382,7 +10322,7 @@ define void @atomic64_add_release(ptr %a) {
 ; O0-LABEL: atomic64_add_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection345:
+; O0-NEXT:  .Lpcsection315:
 ; O0-NEXT:    lock addq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10429,7 +10369,7 @@ define void @atomic64_sub_release(ptr %a) {
 ; O0-LABEL: atomic64_sub_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection346:
+; O0-NEXT:  .Lpcsection316:
 ; O0-NEXT:    lock subq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10476,7 +10416,7 @@ define void @atomic64_and_release(ptr %a) {
 ; O0-LABEL: atomic64_and_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection347:
+; O0-NEXT:  .Lpcsection317:
 ; O0-NEXT:    lock andq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10523,7 +10463,7 @@ define void @atomic64_or_release(ptr %a) {
 ; O0-LABEL: atomic64_or_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection348:
+; O0-NEXT:  .Lpcsection318:
 ; O0-NEXT:    lock orq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10570,7 +10510,7 @@ define void @atomic64_xor_release(ptr %a) {
 ; O0-LABEL: atomic64_xor_release:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection349:
+; O0-NEXT:  .Lpcsection319:
 ; O0-NEXT:    lock xorq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10618,7 +10558,7 @@ define void @atomic64_nand_release(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection350:
+; O0-NEXT:  .Lpcsection320:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:  .LBB176_1: # %atomicrmw.start
@@ -10626,21 +10566,21 @@ define void @atomic64_nand_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %esi
-; O0-NEXT:  .Lpcsection351:
+; O0-NEXT:  .Lpcsection321:
 ; O0-NEXT:    notl %esi
-; O0-NEXT:  .Lpcsection352:
+; O0-NEXT:  .Lpcsection322:
 ; O0-NEXT:    # implicit-def: $rdx
 ; O0-NEXT:    movl %esi, %edx
-; O0-NEXT:  .Lpcsection353:
+; O0-NEXT:  .Lpcsection323:
 ; O0-NEXT:    orq $-43, %rdx
-; O0-NEXT:  .Lpcsection354:
+; O0-NEXT:  .Lpcsection324:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rcx)
-; O0-NEXT:  .Lpcsection355:
+; O0-NEXT:  .Lpcsection325:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection356:
+; O0-NEXT:  .Lpcsection326:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection357:
+; O0-NEXT:  .Lpcsection327:
 ; O0-NEXT:    jne .LBB176_2
 ; O0-NEXT:    jmp .LBB176_1
 ; O0-NEXT:  .LBB176_2: # %atomicrmw.end
@@ -10742,7 +10682,7 @@ define void @atomic64_xchg_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection358:
+; O0-NEXT:  .Lpcsection328:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10793,7 +10733,7 @@ define void @atomic64_add_acq_rel(ptr %a) {
 ; O0-LABEL: atomic64_add_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection359:
+; O0-NEXT:  .Lpcsection329:
 ; O0-NEXT:    lock addq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10840,7 +10780,7 @@ define void @atomic64_sub_acq_rel(ptr %a) {
 ; O0-LABEL: atomic64_sub_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection360:
+; O0-NEXT:  .Lpcsection330:
 ; O0-NEXT:    lock subq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10887,7 +10827,7 @@ define void @atomic64_and_acq_rel(ptr %a) {
 ; O0-LABEL: atomic64_and_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection361:
+; O0-NEXT:  .Lpcsection331:
 ; O0-NEXT:    lock andq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10934,7 +10874,7 @@ define void @atomic64_or_acq_rel(ptr %a) {
 ; O0-LABEL: atomic64_or_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection362:
+; O0-NEXT:  .Lpcsection332:
 ; O0-NEXT:    lock orq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -10981,7 +10921,7 @@ define void @atomic64_xor_acq_rel(ptr %a) {
 ; O0-LABEL: atomic64_xor_acq_rel:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection363:
+; O0-NEXT:  .Lpcsection333:
 ; O0-NEXT:    lock xorq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11029,7 +10969,7 @@ define void @atomic64_nand_acq_rel(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection364:
+; O0-NEXT:  .Lpcsection334:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:  .LBB183_1: # %atomicrmw.start
@@ -11037,21 +10977,21 @@ define void @atomic64_nand_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %esi
-; O0-NEXT:  .Lpcsection365:
+; O0-NEXT:  .Lpcsection335:
 ; O0-NEXT:    notl %esi
-; O0-NEXT:  .Lpcsection366:
+; O0-NEXT:  .Lpcsection336:
 ; O0-NEXT:    # implicit-def: $rdx
 ; O0-NEXT:    movl %esi, %edx
-; O0-NEXT:  .Lpcsection367:
+; O0-NEXT:  .Lpcsection337:
 ; O0-NEXT:    orq $-43, %rdx
-; O0-NEXT:  .Lpcsection368:
+; O0-NEXT:  .Lpcsection338:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rcx)
-; O0-NEXT:  .Lpcsection369:
+; O0-NEXT:  .Lpcsection339:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection370:
+; O0-NEXT:  .Lpcsection340:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection371:
+; O0-NEXT:  .Lpcsection341:
 ; O0-NEXT:    jne .LBB183_2
 ; O0-NEXT:    jmp .LBB183_1
 ; O0-NEXT:  .LBB183_2: # %atomicrmw.end
@@ -11153,7 +11093,7 @@ define void @atomic64_xchg_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
 ; O0-NEXT:    movl $42, %eax
-; O0-NEXT:  .Lpcsection372:
+; O0-NEXT:  .Lpcsection342:
 ; O0-NEXT:    xchgq %rax, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11204,7 +11144,7 @@ define void @atomic64_add_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_add_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection373:
+; O0-NEXT:  .Lpcsection343:
 ; O0-NEXT:    lock addq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11251,7 +11191,7 @@ define void @atomic64_sub_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_sub_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection374:
+; O0-NEXT:  .Lpcsection344:
 ; O0-NEXT:    lock subq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11298,7 +11238,7 @@ define void @atomic64_and_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_and_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection375:
+; O0-NEXT:  .Lpcsection345:
 ; O0-NEXT:    lock andq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11345,7 +11285,7 @@ define void @atomic64_or_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_or_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection376:
+; O0-NEXT:  .Lpcsection346:
 ; O0-NEXT:    lock orq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11392,7 +11332,7 @@ define void @atomic64_xor_seq_cst(ptr %a) {
 ; O0-LABEL: atomic64_xor_seq_cst:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection377:
+; O0-NEXT:  .Lpcsection347:
 ; O0-NEXT:    lock xorq $42, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11440,7 +11380,7 @@ define void @atomic64_nand_seq_cst(ptr %a) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo, %rax
-; O0-NEXT:  .Lpcsection378:
+; O0-NEXT:  .Lpcsection348:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:  .LBB190_1: # %atomicrmw.start
@@ -11448,21 +11388,21 @@ define void @atomic64_nand_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movl %eax, %esi
-; O0-NEXT:  .Lpcsection379:
+; O0-NEXT:  .Lpcsection349:
 ; O0-NEXT:    notl %esi
-; O0-NEXT:  .Lpcsection380:
+; O0-NEXT:  .Lpcsection350:
 ; O0-NEXT:    # implicit-def: $rdx
 ; O0-NEXT:    movl %esi, %edx
-; O0-NEXT:  .Lpcsection381:
+; O0-NEXT:  .Lpcsection351:
 ; O0-NEXT:    orq $-43, %rdx
-; O0-NEXT:  .Lpcsection382:
+; O0-NEXT:  .Lpcsection352:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rcx)
-; O0-NEXT:  .Lpcsection383:
+; O0-NEXT:  .Lpcsection353:
 ; O0-NEXT:    sete %cl
-; O0-NEXT:  .Lpcsection384:
+; O0-NEXT:  .Lpcsection354:
 ; O0-NEXT:    testb $1, %cl
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection385:
+; O0-NEXT:  .Lpcsection355:
 ; O0-NEXT:    jne .LBB190_2
 ; O0-NEXT:    jmp .LBB190_1
 ; O0-NEXT:  .LBB190_2: # %atomicrmw.end
@@ -11566,17 +11506,13 @@ define void @atomic64_cas_monotonic(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection386:
+; O0-NEXT:  .Lpcsection356:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection387:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection388:
+; O0-NEXT:  .Lpcsection357:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection389:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection390:
+; O0-NEXT:  .Lpcsection358:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11672,17 +11608,13 @@ define void @atomic64_cas_acquire(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection391:
+; O0-NEXT:  .Lpcsection359:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection392:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection393:
+; O0-NEXT:  .Lpcsection360:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection394:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection395:
+; O0-NEXT:  .Lpcsection361:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11778,17 +11710,13 @@ define void @atomic64_cas_release(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection396:
+; O0-NEXT:  .Lpcsection362:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection397:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection398:
+; O0-NEXT:  .Lpcsection363:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection399:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection400:
+; O0-NEXT:  .Lpcsection364:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11884,17 +11812,13 @@ define void @atomic64_cas_acq_rel(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection401:
+; O0-NEXT:  .Lpcsection365:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection402:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection403:
+; O0-NEXT:  .Lpcsection366:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection404:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection405:
+; O0-NEXT:  .Lpcsection367:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -11990,17 +11914,13 @@ define void @atomic64_cas_seq_cst(ptr %a) {
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movl $1, %ecx
-; O0-NEXT:  .Lpcsection406:
+; O0-NEXT:  .Lpcsection368:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection407:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection408:
+; O0-NEXT:  .Lpcsection369:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
-; O0-NEXT:  .Lpcsection409:
-; O0-NEXT:    # kill: def $rdx killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
-; O0-NEXT:  .Lpcsection410:
+; O0-NEXT:  .Lpcsection370:
 ; O0-NEXT:    lock cmpxchgq %rcx, (%rdi)
 ; O0-NEXT:    movq $3, foo
 ; O0-NEXT:    retq
@@ -12094,7 +12014,7 @@ define void @atomic64_cas_seq_cst_ptr_ty(ptr %a, ptr %v1, ptr %v2) {
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq %rsi, %rax
 ; O0-NEXT:    movq foo(%rip), %rcx
-; O0-NEXT:  .Lpcsection411:
+; O0-NEXT:  .Lpcsection371:
 ; O0-NEXT:    lock cmpxchgq %rdx, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -12144,9 +12064,9 @@ entry:
 define i64 @atomic_use_cond(ptr %a) {
 ; O0-LABEL: atomic_use_cond:
 ; O0:       # %bb.0: # %entry
-; O0-NEXT:  .Lpcsection412:
+; O0-NEXT:  .Lpcsection372:
 ; O0-NEXT:    lock decq (%rdi)
-; O0-NEXT:  .Lpcsection413:
+; O0-NEXT:  .Lpcsection373:
 ; O0-NEXT:    sete %al
 ; O0-NEXT:    testb $1, %al
 ; O0-NEXT:    je .LBB197_2
@@ -12223,13 +12143,13 @@ define i128 @atomic128_load_unordered(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection414:
+; O0-NEXT:  .Lpcsection374:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ebx
 ; O0-NEXT:    movq %rbx, %rax
 ; O0-NEXT:    movq %rbx, %rdx
 ; O0-NEXT:    movq %rbx, %rcx
-; O0-NEXT:  .Lpcsection415:
+; O0-NEXT:  .Lpcsection375:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo(%rip)
 ; O0-NEXT:    popq %rbx
@@ -12324,13 +12244,13 @@ define i128 @atomic128_load_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection416:
+; O0-NEXT:  .Lpcsection376:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ebx
 ; O0-NEXT:    movq %rbx, %rax
 ; O0-NEXT:    movq %rbx, %rdx
 ; O0-NEXT:    movq %rbx, %rcx
-; O0-NEXT:  .Lpcsection417:
+; O0-NEXT:  .Lpcsection377:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo(%rip)
 ; O0-NEXT:    popq %rbx
@@ -12425,13 +12345,13 @@ define i128 @atomic128_load_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection418:
+; O0-NEXT:  .Lpcsection378:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ebx
 ; O0-NEXT:    movq %rbx, %rax
 ; O0-NEXT:    movq %rbx, %rdx
 ; O0-NEXT:    movq %rbx, %rcx
-; O0-NEXT:  .Lpcsection419:
+; O0-NEXT:  .Lpcsection379:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo(%rip)
 ; O0-NEXT:    popq %rbx
@@ -12526,13 +12446,13 @@ define i128 @atomic128_load_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection420:
+; O0-NEXT:  .Lpcsection380:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ebx
 ; O0-NEXT:    movq %rbx, %rax
 ; O0-NEXT:    movq %rbx, %rdx
 ; O0-NEXT:    movq %rbx, %rcx
-; O0-NEXT:  .Lpcsection421:
+; O0-NEXT:  .Lpcsection381:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo(%rip)
 ; O0-NEXT:    popq %rbx
@@ -12624,7 +12544,7 @@ define ptr @atomic128_load_seq_cst_ptr_ty(ptr %a) {
 ; O0-LABEL: atomic128_load_seq_cst_ptr_ty:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection422:
+; O0-NEXT:  .Lpcsection382:
 ; O0-NEXT:    movq (%rdi), %rax
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -12675,30 +12595,30 @@ define void @atomic128_store_unordered(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection423:
+; O0-NEXT:  .Lpcsection383:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection424:
+; O0-NEXT:  .Lpcsection384:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection425:
+; O0-NEXT:  .Lpcsection385:
 ; O0-NEXT:    jmp .LBB203_1
 ; O0-NEXT:  .LBB203_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection426:
+; O0-NEXT:  .Lpcsection386:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection427:
+; O0-NEXT:  .Lpcsection387:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection428:
+; O0-NEXT:  .Lpcsection388:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection429:
+; O0-NEXT:  .Lpcsection389:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection430:
+; O0-NEXT:  .Lpcsection390:
 ; O0-NEXT:    jne .LBB203_1
 ; O0-NEXT:    jmp .LBB203_2
 ; O0-NEXT:  .LBB203_2: # %atomicrmw.end
@@ -12812,30 +12732,30 @@ define void @atomic128_store_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection431:
+; O0-NEXT:  .Lpcsection391:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection432:
+; O0-NEXT:  .Lpcsection392:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection433:
+; O0-NEXT:  .Lpcsection393:
 ; O0-NEXT:    jmp .LBB204_1
 ; O0-NEXT:  .LBB204_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection434:
+; O0-NEXT:  .Lpcsection394:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection435:
+; O0-NEXT:  .Lpcsection395:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection436:
+; O0-NEXT:  .Lpcsection396:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection437:
+; O0-NEXT:  .Lpcsection397:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection438:
+; O0-NEXT:  .Lpcsection398:
 ; O0-NEXT:    jne .LBB204_1
 ; O0-NEXT:    jmp .LBB204_2
 ; O0-NEXT:  .LBB204_2: # %atomicrmw.end
@@ -12949,30 +12869,30 @@ define void @atomic128_store_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection439:
+; O0-NEXT:  .Lpcsection399:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection440:
+; O0-NEXT:  .Lpcsection400:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection441:
+; O0-NEXT:  .Lpcsection401:
 ; O0-NEXT:    jmp .LBB205_1
 ; O0-NEXT:  .LBB205_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection442:
+; O0-NEXT:  .Lpcsection402:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection443:
+; O0-NEXT:  .Lpcsection403:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection444:
+; O0-NEXT:  .Lpcsection404:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection445:
+; O0-NEXT:  .Lpcsection405:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection446:
+; O0-NEXT:  .Lpcsection406:
 ; O0-NEXT:    jne .LBB205_1
 ; O0-NEXT:    jmp .LBB205_2
 ; O0-NEXT:  .LBB205_2: # %atomicrmw.end
@@ -13086,30 +13006,30 @@ define void @atomic128_store_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection447:
+; O0-NEXT:  .Lpcsection407:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection448:
+; O0-NEXT:  .Lpcsection408:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection449:
+; O0-NEXT:  .Lpcsection409:
 ; O0-NEXT:    jmp .LBB206_1
 ; O0-NEXT:  .LBB206_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection450:
+; O0-NEXT:  .Lpcsection410:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection451:
+; O0-NEXT:  .Lpcsection411:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection452:
+; O0-NEXT:  .Lpcsection412:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection453:
+; O0-NEXT:  .Lpcsection413:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection454:
+; O0-NEXT:  .Lpcsection414:
 ; O0-NEXT:    jne .LBB206_1
 ; O0-NEXT:    jmp .LBB206_2
 ; O0-NEXT:  .LBB206_2: # %atomicrmw.end
@@ -13221,7 +13141,7 @@ define void @atomic128_store_seq_cst_ptr_ty(ptr %a, ptr %v) {
 ; O0-LABEL: atomic128_store_seq_cst_ptr_ty:
 ; O0:       # %bb.0: # %entry
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection455:
+; O0-NEXT:  .Lpcsection415:
 ; O0-NEXT:    xchgq %rsi, (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    retq
@@ -13272,30 +13192,30 @@ define void @atomic128_xchg_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection456:
+; O0-NEXT:  .Lpcsection416:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection457:
+; O0-NEXT:  .Lpcsection417:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection458:
+; O0-NEXT:  .Lpcsection418:
 ; O0-NEXT:    jmp .LBB208_1
 ; O0-NEXT:  .LBB208_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection459:
+; O0-NEXT:  .Lpcsection419:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection460:
+; O0-NEXT:  .Lpcsection420:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection461:
+; O0-NEXT:  .Lpcsection421:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection462:
+; O0-NEXT:  .Lpcsection422:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection463:
+; O0-NEXT:  .Lpcsection423:
 ; O0-NEXT:    jne .LBB208_1
 ; O0-NEXT:    jmp .LBB208_2
 ; O0-NEXT:  .LBB208_2: # %atomicrmw.end
@@ -13426,13 +13346,13 @@ define void @atomic128_add_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection464:
+; O0-NEXT:  .Lpcsection424:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection465:
+; O0-NEXT:  .Lpcsection425:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection466:
+; O0-NEXT:  .Lpcsection426:
 ; O0-NEXT:    jmp .LBB209_1
 ; O0-NEXT:  .LBB209_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -13440,16 +13360,16 @@ define void @atomic128_add_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection467:
+; O0-NEXT:  .Lpcsection427:
 ; O0-NEXT:    addq $42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection468:
+; O0-NEXT:  .Lpcsection428:
 ; O0-NEXT:    adcq $0, %rcx
-; O0-NEXT:  .Lpcsection469:
+; O0-NEXT:  .Lpcsection429:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection470:
+; O0-NEXT:  .Lpcsection430:
 ; O0-NEXT:    jne .LBB209_1
 ; O0-NEXT:    jmp .LBB209_2
 ; O0-NEXT:  .LBB209_2: # %atomicrmw.end
@@ -13588,13 +13508,13 @@ define void @atomic128_sub_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection471:
+; O0-NEXT:  .Lpcsection431:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection472:
+; O0-NEXT:  .Lpcsection432:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection473:
+; O0-NEXT:  .Lpcsection433:
 ; O0-NEXT:    jmp .LBB210_1
 ; O0-NEXT:  .LBB210_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -13602,16 +13522,16 @@ define void @atomic128_sub_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection474:
+; O0-NEXT:  .Lpcsection434:
 ; O0-NEXT:    addq $-42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection475:
+; O0-NEXT:  .Lpcsection435:
 ; O0-NEXT:    adcq $-1, %rcx
-; O0-NEXT:  .Lpcsection476:
+; O0-NEXT:  .Lpcsection436:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection477:
+; O0-NEXT:  .Lpcsection437:
 ; O0-NEXT:    jne .LBB210_1
 ; O0-NEXT:    jmp .LBB210_2
 ; O0-NEXT:  .LBB210_2: # %atomicrmw.end
@@ -13750,13 +13670,13 @@ define void @atomic128_and_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection478:
+; O0-NEXT:  .Lpcsection438:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection479:
+; O0-NEXT:  .Lpcsection439:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection480:
+; O0-NEXT:  .Lpcsection440:
 ; O0-NEXT:    jmp .LBB211_1
 ; O0-NEXT:  .LBB211_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -13764,18 +13684,18 @@ define void @atomic128_and_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection481:
+; O0-NEXT:  .Lpcsection441:
 ; O0-NEXT:    andl $42, %ecx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection482:
+; O0-NEXT:  .Lpcsection442:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection483:
+; O0-NEXT:  .Lpcsection443:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection484:
+; O0-NEXT:  .Lpcsection444:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection485:
+; O0-NEXT:  .Lpcsection445:
 ; O0-NEXT:    jne .LBB211_1
 ; O0-NEXT:    jmp .LBB211_2
 ; O0-NEXT:  .LBB211_2: # %atomicrmw.end
@@ -13910,13 +13830,13 @@ define void @atomic128_or_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection486:
+; O0-NEXT:  .Lpcsection446:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection487:
+; O0-NEXT:  .Lpcsection447:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection488:
+; O0-NEXT:  .Lpcsection448:
 ; O0-NEXT:    jmp .LBB212_1
 ; O0-NEXT:  .LBB212_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -13924,14 +13844,14 @@ define void @atomic128_or_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection489:
+; O0-NEXT:  .Lpcsection449:
 ; O0-NEXT:    orq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection490:
+; O0-NEXT:  .Lpcsection450:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection491:
+; O0-NEXT:  .Lpcsection451:
 ; O0-NEXT:    jne .LBB212_1
 ; O0-NEXT:    jmp .LBB212_2
 ; O0-NEXT:  .LBB212_2: # %atomicrmw.end
@@ -14062,13 +13982,13 @@ define void @atomic128_xor_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection492:
+; O0-NEXT:  .Lpcsection452:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection493:
+; O0-NEXT:  .Lpcsection453:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection494:
+; O0-NEXT:  .Lpcsection454:
 ; O0-NEXT:    jmp .LBB213_1
 ; O0-NEXT:  .LBB213_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -14076,14 +13996,14 @@ define void @atomic128_xor_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection495:
+; O0-NEXT:  .Lpcsection455:
 ; O0-NEXT:    xorq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection496:
+; O0-NEXT:  .Lpcsection456:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection497:
+; O0-NEXT:  .Lpcsection457:
 ; O0-NEXT:    jne .LBB213_1
 ; O0-NEXT:    jmp .LBB213_2
 ; O0-NEXT:  .LBB213_2: # %atomicrmw.end
@@ -14214,13 +14134,13 @@ define void @atomic128_nand_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection498:
+; O0-NEXT:  .Lpcsection458:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection499:
+; O0-NEXT:  .Lpcsection459:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection500:
+; O0-NEXT:  .Lpcsection460:
 ; O0-NEXT:    jmp .LBB214_1
 ; O0-NEXT:  .LBB214_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -14228,20 +14148,20 @@ define void @atomic128_nand_monotonic(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection501:
+; O0-NEXT:  .Lpcsection461:
 ; O0-NEXT:    notl %ecx
-; O0-NEXT:  .Lpcsection502:
+; O0-NEXT:  .Lpcsection462:
 ; O0-NEXT:    # implicit-def: $rbx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection503:
+; O0-NEXT:  .Lpcsection463:
 ; O0-NEXT:    orq $-43, %rbx
-; O0-NEXT:  .Lpcsection504:
+; O0-NEXT:  .Lpcsection464:
 ; O0-NEXT:    movq $-1, %rcx
-; O0-NEXT:  .Lpcsection505:
+; O0-NEXT:  .Lpcsection465:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection506:
+; O0-NEXT:  .Lpcsection466:
 ; O0-NEXT:    jne .LBB214_1
 ; O0-NEXT:    jmp .LBB214_2
 ; O0-NEXT:  .LBB214_2: # %atomicrmw.end
@@ -14384,30 +14304,30 @@ define void @atomic128_xchg_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection507:
+; O0-NEXT:  .Lpcsection467:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection508:
+; O0-NEXT:  .Lpcsection468:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection509:
+; O0-NEXT:  .Lpcsection469:
 ; O0-NEXT:    jmp .LBB215_1
 ; O0-NEXT:  .LBB215_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection510:
+; O0-NEXT:  .Lpcsection470:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection511:
+; O0-NEXT:  .Lpcsection471:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection512:
+; O0-NEXT:  .Lpcsection472:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection513:
+; O0-NEXT:  .Lpcsection473:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection514:
+; O0-NEXT:  .Lpcsection474:
 ; O0-NEXT:    jne .LBB215_1
 ; O0-NEXT:    jmp .LBB215_2
 ; O0-NEXT:  .LBB215_2: # %atomicrmw.end
@@ -14538,13 +14458,13 @@ define void @atomic128_add_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection515:
+; O0-NEXT:  .Lpcsection475:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection516:
+; O0-NEXT:  .Lpcsection476:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection517:
+; O0-NEXT:  .Lpcsection477:
 ; O0-NEXT:    jmp .LBB216_1
 ; O0-NEXT:  .LBB216_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -14552,16 +14472,16 @@ define void @atomic128_add_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection518:
+; O0-NEXT:  .Lpcsection478:
 ; O0-NEXT:    addq $42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection519:
+; O0-NEXT:  .Lpcsection479:
 ; O0-NEXT:    adcq $0, %rcx
-; O0-NEXT:  .Lpcsection520:
+; O0-NEXT:  .Lpcsection480:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection521:
+; O0-NEXT:  .Lpcsection481:
 ; O0-NEXT:    jne .LBB216_1
 ; O0-NEXT:    jmp .LBB216_2
 ; O0-NEXT:  .LBB216_2: # %atomicrmw.end
@@ -14700,13 +14620,13 @@ define void @atomic128_sub_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection522:
+; O0-NEXT:  .Lpcsection482:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection523:
+; O0-NEXT:  .Lpcsection483:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection524:
+; O0-NEXT:  .Lpcsection484:
 ; O0-NEXT:    jmp .LBB217_1
 ; O0-NEXT:  .LBB217_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -14714,16 +14634,16 @@ define void @atomic128_sub_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection525:
+; O0-NEXT:  .Lpcsection485:
 ; O0-NEXT:    addq $-42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection526:
+; O0-NEXT:  .Lpcsection486:
 ; O0-NEXT:    adcq $-1, %rcx
-; O0-NEXT:  .Lpcsection527:
+; O0-NEXT:  .Lpcsection487:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection528:
+; O0-NEXT:  .Lpcsection488:
 ; O0-NEXT:    jne .LBB217_1
 ; O0-NEXT:    jmp .LBB217_2
 ; O0-NEXT:  .LBB217_2: # %atomicrmw.end
@@ -14862,13 +14782,13 @@ define void @atomic128_and_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection529:
+; O0-NEXT:  .Lpcsection489:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection530:
+; O0-NEXT:  .Lpcsection490:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection531:
+; O0-NEXT:  .Lpcsection491:
 ; O0-NEXT:    jmp .LBB218_1
 ; O0-NEXT:  .LBB218_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -14876,18 +14796,18 @@ define void @atomic128_and_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection532:
+; O0-NEXT:  .Lpcsection492:
 ; O0-NEXT:    andl $42, %ecx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection533:
+; O0-NEXT:  .Lpcsection493:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection534:
+; O0-NEXT:  .Lpcsection494:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection535:
+; O0-NEXT:  .Lpcsection495:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection536:
+; O0-NEXT:  .Lpcsection496:
 ; O0-NEXT:    jne .LBB218_1
 ; O0-NEXT:    jmp .LBB218_2
 ; O0-NEXT:  .LBB218_2: # %atomicrmw.end
@@ -15022,13 +14942,13 @@ define void @atomic128_or_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection537:
+; O0-NEXT:  .Lpcsection497:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection538:
+; O0-NEXT:  .Lpcsection498:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection539:
+; O0-NEXT:  .Lpcsection499:
 ; O0-NEXT:    jmp .LBB219_1
 ; O0-NEXT:  .LBB219_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15036,14 +14956,14 @@ define void @atomic128_or_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection540:
+; O0-NEXT:  .Lpcsection500:
 ; O0-NEXT:    orq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection541:
+; O0-NEXT:  .Lpcsection501:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection542:
+; O0-NEXT:  .Lpcsection502:
 ; O0-NEXT:    jne .LBB219_1
 ; O0-NEXT:    jmp .LBB219_2
 ; O0-NEXT:  .LBB219_2: # %atomicrmw.end
@@ -15174,13 +15094,13 @@ define void @atomic128_xor_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection543:
+; O0-NEXT:  .Lpcsection503:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection544:
+; O0-NEXT:  .Lpcsection504:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection545:
+; O0-NEXT:  .Lpcsection505:
 ; O0-NEXT:    jmp .LBB220_1
 ; O0-NEXT:  .LBB220_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15188,14 +15108,14 @@ define void @atomic128_xor_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection546:
+; O0-NEXT:  .Lpcsection506:
 ; O0-NEXT:    xorq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection547:
+; O0-NEXT:  .Lpcsection507:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection548:
+; O0-NEXT:  .Lpcsection508:
 ; O0-NEXT:    jne .LBB220_1
 ; O0-NEXT:    jmp .LBB220_2
 ; O0-NEXT:  .LBB220_2: # %atomicrmw.end
@@ -15326,13 +15246,13 @@ define void @atomic128_nand_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection549:
+; O0-NEXT:  .Lpcsection509:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection550:
+; O0-NEXT:  .Lpcsection510:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection551:
+; O0-NEXT:  .Lpcsection511:
 ; O0-NEXT:    jmp .LBB221_1
 ; O0-NEXT:  .LBB221_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15340,20 +15260,20 @@ define void @atomic128_nand_acquire(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection552:
+; O0-NEXT:  .Lpcsection512:
 ; O0-NEXT:    notl %ecx
-; O0-NEXT:  .Lpcsection553:
+; O0-NEXT:  .Lpcsection513:
 ; O0-NEXT:    # implicit-def: $rbx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection554:
+; O0-NEXT:  .Lpcsection514:
 ; O0-NEXT:    orq $-43, %rbx
-; O0-NEXT:  .Lpcsection555:
+; O0-NEXT:  .Lpcsection515:
 ; O0-NEXT:    movq $-1, %rcx
-; O0-NEXT:  .Lpcsection556:
+; O0-NEXT:  .Lpcsection516:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection557:
+; O0-NEXT:  .Lpcsection517:
 ; O0-NEXT:    jne .LBB221_1
 ; O0-NEXT:    jmp .LBB221_2
 ; O0-NEXT:  .LBB221_2: # %atomicrmw.end
@@ -15496,30 +15416,30 @@ define void @atomic128_xchg_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection558:
+; O0-NEXT:  .Lpcsection518:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection559:
+; O0-NEXT:  .Lpcsection519:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection560:
+; O0-NEXT:  .Lpcsection520:
 ; O0-NEXT:    jmp .LBB222_1
 ; O0-NEXT:  .LBB222_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection561:
+; O0-NEXT:  .Lpcsection521:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection562:
+; O0-NEXT:  .Lpcsection522:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection563:
+; O0-NEXT:  .Lpcsection523:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection564:
+; O0-NEXT:  .Lpcsection524:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection565:
+; O0-NEXT:  .Lpcsection525:
 ; O0-NEXT:    jne .LBB222_1
 ; O0-NEXT:    jmp .LBB222_2
 ; O0-NEXT:  .LBB222_2: # %atomicrmw.end
@@ -15649,13 +15569,13 @@ define void @atomic128_add_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection566:
+; O0-NEXT:  .Lpcsection526:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection567:
+; O0-NEXT:  .Lpcsection527:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection568:
+; O0-NEXT:  .Lpcsection528:
 ; O0-NEXT:    jmp .LBB223_1
 ; O0-NEXT:  .LBB223_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15663,16 +15583,16 @@ define void @atomic128_add_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection569:
+; O0-NEXT:  .Lpcsection529:
 ; O0-NEXT:    addq $42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection570:
+; O0-NEXT:  .Lpcsection530:
 ; O0-NEXT:    adcq $0, %rcx
-; O0-NEXT:  .Lpcsection571:
+; O0-NEXT:  .Lpcsection531:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection572:
+; O0-NEXT:  .Lpcsection532:
 ; O0-NEXT:    jne .LBB223_1
 ; O0-NEXT:    jmp .LBB223_2
 ; O0-NEXT:  .LBB223_2: # %atomicrmw.end
@@ -15811,13 +15731,13 @@ define void @atomic128_sub_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection573:
+; O0-NEXT:  .Lpcsection533:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection574:
+; O0-NEXT:  .Lpcsection534:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection575:
+; O0-NEXT:  .Lpcsection535:
 ; O0-NEXT:    jmp .LBB224_1
 ; O0-NEXT:  .LBB224_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15825,16 +15745,16 @@ define void @atomic128_sub_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection576:
+; O0-NEXT:  .Lpcsection536:
 ; O0-NEXT:    addq $-42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection577:
+; O0-NEXT:  .Lpcsection537:
 ; O0-NEXT:    adcq $-1, %rcx
-; O0-NEXT:  .Lpcsection578:
+; O0-NEXT:  .Lpcsection538:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection579:
+; O0-NEXT:  .Lpcsection539:
 ; O0-NEXT:    jne .LBB224_1
 ; O0-NEXT:    jmp .LBB224_2
 ; O0-NEXT:  .LBB224_2: # %atomicrmw.end
@@ -15973,13 +15893,13 @@ define void @atomic128_and_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection580:
+; O0-NEXT:  .Lpcsection540:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection581:
+; O0-NEXT:  .Lpcsection541:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection582:
+; O0-NEXT:  .Lpcsection542:
 ; O0-NEXT:    jmp .LBB225_1
 ; O0-NEXT:  .LBB225_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -15987,18 +15907,18 @@ define void @atomic128_and_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection583:
+; O0-NEXT:  .Lpcsection543:
 ; O0-NEXT:    andl $42, %ecx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection584:
+; O0-NEXT:  .Lpcsection544:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection585:
+; O0-NEXT:  .Lpcsection545:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection586:
+; O0-NEXT:  .Lpcsection546:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection587:
+; O0-NEXT:  .Lpcsection547:
 ; O0-NEXT:    jne .LBB225_1
 ; O0-NEXT:    jmp .LBB225_2
 ; O0-NEXT:  .LBB225_2: # %atomicrmw.end
@@ -16133,13 +16053,13 @@ define void @atomic128_or_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection588:
+; O0-NEXT:  .Lpcsection548:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection589:
+; O0-NEXT:  .Lpcsection549:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection590:
+; O0-NEXT:  .Lpcsection550:
 ; O0-NEXT:    jmp .LBB226_1
 ; O0-NEXT:  .LBB226_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -16147,14 +16067,14 @@ define void @atomic128_or_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection591:
+; O0-NEXT:  .Lpcsection551:
 ; O0-NEXT:    orq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection592:
+; O0-NEXT:  .Lpcsection552:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection593:
+; O0-NEXT:  .Lpcsection553:
 ; O0-NEXT:    jne .LBB226_1
 ; O0-NEXT:    jmp .LBB226_2
 ; O0-NEXT:  .LBB226_2: # %atomicrmw.end
@@ -16285,13 +16205,13 @@ define void @atomic128_xor_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection594:
+; O0-NEXT:  .Lpcsection554:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection595:
+; O0-NEXT:  .Lpcsection555:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection596:
+; O0-NEXT:  .Lpcsection556:
 ; O0-NEXT:    jmp .LBB227_1
 ; O0-NEXT:  .LBB227_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -16299,14 +16219,14 @@ define void @atomic128_xor_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection597:
+; O0-NEXT:  .Lpcsection557:
 ; O0-NEXT:    xorq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection598:
+; O0-NEXT:  .Lpcsection558:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection599:
+; O0-NEXT:  .Lpcsection559:
 ; O0-NEXT:    jne .LBB227_1
 ; O0-NEXT:    jmp .LBB227_2
 ; O0-NEXT:  .LBB227_2: # %atomicrmw.end
@@ -16437,13 +16357,13 @@ define void @atomic128_nand_release(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection600:
+; O0-NEXT:  .Lpcsection560:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection601:
+; O0-NEXT:  .Lpcsection561:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection602:
+; O0-NEXT:  .Lpcsection562:
 ; O0-NEXT:    jmp .LBB228_1
 ; O0-NEXT:  .LBB228_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -16451,20 +16371,20 @@ define void @atomic128_nand_release(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection603:
+; O0-NEXT:  .Lpcsection563:
 ; O0-NEXT:    notl %ecx
-; O0-NEXT:  .Lpcsection604:
+; O0-NEXT:  .Lpcsection564:
 ; O0-NEXT:    # implicit-def: $rbx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection605:
+; O0-NEXT:  .Lpcsection565:
 ; O0-NEXT:    orq $-43, %rbx
-; O0-NEXT:  .Lpcsection606:
+; O0-NEXT:  .Lpcsection566:
 ; O0-NEXT:    movq $-1, %rcx
-; O0-NEXT:  .Lpcsection607:
+; O0-NEXT:  .Lpcsection567:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection608:
+; O0-NEXT:  .Lpcsection568:
 ; O0-NEXT:    jne .LBB228_1
 ; O0-NEXT:    jmp .LBB228_2
 ; O0-NEXT:  .LBB228_2: # %atomicrmw.end
@@ -16607,30 +16527,30 @@ define void @atomic128_xchg_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection609:
+; O0-NEXT:  .Lpcsection569:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection610:
+; O0-NEXT:  .Lpcsection570:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection611:
+; O0-NEXT:  .Lpcsection571:
 ; O0-NEXT:    jmp .LBB229_1
 ; O0-NEXT:  .LBB229_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection612:
+; O0-NEXT:  .Lpcsection572:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection613:
+; O0-NEXT:  .Lpcsection573:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection614:
+; O0-NEXT:  .Lpcsection574:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection615:
+; O0-NEXT:  .Lpcsection575:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection616:
+; O0-NEXT:  .Lpcsection576:
 ; O0-NEXT:    jne .LBB229_1
 ; O0-NEXT:    jmp .LBB229_2
 ; O0-NEXT:  .LBB229_2: # %atomicrmw.end
@@ -16761,13 +16681,13 @@ define void @atomic128_add_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection617:
+; O0-NEXT:  .Lpcsection577:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection618:
+; O0-NEXT:  .Lpcsection578:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection619:
+; O0-NEXT:  .Lpcsection579:
 ; O0-NEXT:    jmp .LBB230_1
 ; O0-NEXT:  .LBB230_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -16775,16 +16695,16 @@ define void @atomic128_add_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection620:
+; O0-NEXT:  .Lpcsection580:
 ; O0-NEXT:    addq $42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection621:
+; O0-NEXT:  .Lpcsection581:
 ; O0-NEXT:    adcq $0, %rcx
-; O0-NEXT:  .Lpcsection622:
+; O0-NEXT:  .Lpcsection582:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection623:
+; O0-NEXT:  .Lpcsection583:
 ; O0-NEXT:    jne .LBB230_1
 ; O0-NEXT:    jmp .LBB230_2
 ; O0-NEXT:  .LBB230_2: # %atomicrmw.end
@@ -16923,13 +16843,13 @@ define void @atomic128_sub_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection624:
+; O0-NEXT:  .Lpcsection584:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection625:
+; O0-NEXT:  .Lpcsection585:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection626:
+; O0-NEXT:  .Lpcsection586:
 ; O0-NEXT:    jmp .LBB231_1
 ; O0-NEXT:  .LBB231_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -16937,16 +16857,16 @@ define void @atomic128_sub_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection627:
+; O0-NEXT:  .Lpcsection587:
 ; O0-NEXT:    addq $-42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection628:
+; O0-NEXT:  .Lpcsection588:
 ; O0-NEXT:    adcq $-1, %rcx
-; O0-NEXT:  .Lpcsection629:
+; O0-NEXT:  .Lpcsection589:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection630:
+; O0-NEXT:  .Lpcsection590:
 ; O0-NEXT:    jne .LBB231_1
 ; O0-NEXT:    jmp .LBB231_2
 ; O0-NEXT:  .LBB231_2: # %atomicrmw.end
@@ -17085,13 +17005,13 @@ define void @atomic128_and_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection631:
+; O0-NEXT:  .Lpcsection591:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection632:
+; O0-NEXT:  .Lpcsection592:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection633:
+; O0-NEXT:  .Lpcsection593:
 ; O0-NEXT:    jmp .LBB232_1
 ; O0-NEXT:  .LBB232_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -17099,18 +17019,18 @@ define void @atomic128_and_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection634:
+; O0-NEXT:  .Lpcsection594:
 ; O0-NEXT:    andl $42, %ecx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection635:
+; O0-NEXT:  .Lpcsection595:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection636:
+; O0-NEXT:  .Lpcsection596:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection637:
+; O0-NEXT:  .Lpcsection597:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection638:
+; O0-NEXT:  .Lpcsection598:
 ; O0-NEXT:    jne .LBB232_1
 ; O0-NEXT:    jmp .LBB232_2
 ; O0-NEXT:  .LBB232_2: # %atomicrmw.end
@@ -17245,13 +17165,13 @@ define void @atomic128_or_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection639:
+; O0-NEXT:  .Lpcsection599:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection640:
+; O0-NEXT:  .Lpcsection600:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection641:
+; O0-NEXT:  .Lpcsection601:
 ; O0-NEXT:    jmp .LBB233_1
 ; O0-NEXT:  .LBB233_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -17259,14 +17179,14 @@ define void @atomic128_or_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection642:
+; O0-NEXT:  .Lpcsection602:
 ; O0-NEXT:    orq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection643:
+; O0-NEXT:  .Lpcsection603:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection644:
+; O0-NEXT:  .Lpcsection604:
 ; O0-NEXT:    jne .LBB233_1
 ; O0-NEXT:    jmp .LBB233_2
 ; O0-NEXT:  .LBB233_2: # %atomicrmw.end
@@ -17397,13 +17317,13 @@ define void @atomic128_xor_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection645:
+; O0-NEXT:  .Lpcsection605:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection646:
+; O0-NEXT:  .Lpcsection606:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection647:
+; O0-NEXT:  .Lpcsection607:
 ; O0-NEXT:    jmp .LBB234_1
 ; O0-NEXT:  .LBB234_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -17411,14 +17331,14 @@ define void @atomic128_xor_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection648:
+; O0-NEXT:  .Lpcsection608:
 ; O0-NEXT:    xorq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection649:
+; O0-NEXT:  .Lpcsection609:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection650:
+; O0-NEXT:  .Lpcsection610:
 ; O0-NEXT:    jne .LBB234_1
 ; O0-NEXT:    jmp .LBB234_2
 ; O0-NEXT:  .LBB234_2: # %atomicrmw.end
@@ -17549,13 +17469,13 @@ define void @atomic128_nand_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection651:
+; O0-NEXT:  .Lpcsection611:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection652:
+; O0-NEXT:  .Lpcsection612:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection653:
+; O0-NEXT:  .Lpcsection613:
 ; O0-NEXT:    jmp .LBB235_1
 ; O0-NEXT:  .LBB235_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -17563,20 +17483,20 @@ define void @atomic128_nand_acq_rel(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection654:
+; O0-NEXT:  .Lpcsection614:
 ; O0-NEXT:    notl %ecx
-; O0-NEXT:  .Lpcsection655:
+; O0-NEXT:  .Lpcsection615:
 ; O0-NEXT:    # implicit-def: $rbx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection656:
+; O0-NEXT:  .Lpcsection616:
 ; O0-NEXT:    orq $-43, %rbx
-; O0-NEXT:  .Lpcsection657:
+; O0-NEXT:  .Lpcsection617:
 ; O0-NEXT:    movq $-1, %rcx
-; O0-NEXT:  .Lpcsection658:
+; O0-NEXT:  .Lpcsection618:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection659:
+; O0-NEXT:  .Lpcsection619:
 ; O0-NEXT:    jne .LBB235_1
 ; O0-NEXT:    jmp .LBB235_2
 ; O0-NEXT:  .LBB235_2: # %atomicrmw.end
@@ -17719,30 +17639,30 @@ define void @atomic128_xchg_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection660:
+; O0-NEXT:  .Lpcsection620:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection661:
+; O0-NEXT:  .Lpcsection621:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection662:
+; O0-NEXT:  .Lpcsection622:
 ; O0-NEXT:    jmp .LBB236_1
 ; O0-NEXT:  .LBB236_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rdx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
-; O0-NEXT:  .Lpcsection663:
+; O0-NEXT:  .Lpcsection623:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection664:
+; O0-NEXT:  .Lpcsection624:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection665:
+; O0-NEXT:  .Lpcsection625:
 ; O0-NEXT:    movl $42, %ebx
-; O0-NEXT:  .Lpcsection666:
+; O0-NEXT:  .Lpcsection626:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection667:
+; O0-NEXT:  .Lpcsection627:
 ; O0-NEXT:    jne .LBB236_1
 ; O0-NEXT:    jmp .LBB236_2
 ; O0-NEXT:  .LBB236_2: # %atomicrmw.end
@@ -17873,13 +17793,13 @@ define void @atomic128_add_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection668:
+; O0-NEXT:  .Lpcsection628:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection669:
+; O0-NEXT:  .Lpcsection629:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection670:
+; O0-NEXT:  .Lpcsection630:
 ; O0-NEXT:    jmp .LBB237_1
 ; O0-NEXT:  .LBB237_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -17887,16 +17807,16 @@ define void @atomic128_add_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection671:
+; O0-NEXT:  .Lpcsection631:
 ; O0-NEXT:    addq $42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection672:
+; O0-NEXT:  .Lpcsection632:
 ; O0-NEXT:    adcq $0, %rcx
-; O0-NEXT:  .Lpcsection673:
+; O0-NEXT:  .Lpcsection633:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection674:
+; O0-NEXT:  .Lpcsection634:
 ; O0-NEXT:    jne .LBB237_1
 ; O0-NEXT:    jmp .LBB237_2
 ; O0-NEXT:  .LBB237_2: # %atomicrmw.end
@@ -18035,13 +17955,13 @@ define void @atomic128_sub_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection675:
+; O0-NEXT:  .Lpcsection635:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection676:
+; O0-NEXT:  .Lpcsection636:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection677:
+; O0-NEXT:  .Lpcsection637:
 ; O0-NEXT:    jmp .LBB238_1
 ; O0-NEXT:  .LBB238_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -18049,16 +17969,16 @@ define void @atomic128_sub_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection678:
+; O0-NEXT:  .Lpcsection638:
 ; O0-NEXT:    addq $-42, %rbx
 ; O0-NEXT:    movq %rdx, %rcx
-; O0-NEXT:  .Lpcsection679:
+; O0-NEXT:  .Lpcsection639:
 ; O0-NEXT:    adcq $-1, %rcx
-; O0-NEXT:  .Lpcsection680:
+; O0-NEXT:  .Lpcsection640:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection681:
+; O0-NEXT:  .Lpcsection641:
 ; O0-NEXT:    jne .LBB238_1
 ; O0-NEXT:    jmp .LBB238_2
 ; O0-NEXT:  .LBB238_2: # %atomicrmw.end
@@ -18197,13 +18117,13 @@ define void @atomic128_and_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection682:
+; O0-NEXT:  .Lpcsection642:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection683:
+; O0-NEXT:  .Lpcsection643:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection684:
+; O0-NEXT:  .Lpcsection644:
 ; O0-NEXT:    jmp .LBB239_1
 ; O0-NEXT:  .LBB239_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -18211,18 +18131,18 @@ define void @atomic128_and_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection685:
+; O0-NEXT:  .Lpcsection645:
 ; O0-NEXT:    andl $42, %ecx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection686:
+; O0-NEXT:  .Lpcsection646:
 ; O0-NEXT:    xorl %ecx, %ecx
-; O0-NEXT:  .Lpcsection687:
+; O0-NEXT:  .Lpcsection647:
 ; O0-NEXT:    # kill: def $rcx killed $ecx
-; O0-NEXT:  .Lpcsection688:
+; O0-NEXT:  .Lpcsection648:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection689:
+; O0-NEXT:  .Lpcsection649:
 ; O0-NEXT:    jne .LBB239_1
 ; O0-NEXT:    jmp .LBB239_2
 ; O0-NEXT:  .LBB239_2: # %atomicrmw.end
@@ -18357,13 +18277,13 @@ define void @atomic128_or_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection690:
+; O0-NEXT:  .Lpcsection650:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection691:
+; O0-NEXT:  .Lpcsection651:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection692:
+; O0-NEXT:  .Lpcsection652:
 ; O0-NEXT:    jmp .LBB240_1
 ; O0-NEXT:  .LBB240_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -18371,14 +18291,14 @@ define void @atomic128_or_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection693:
+; O0-NEXT:  .Lpcsection653:
 ; O0-NEXT:    orq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection694:
+; O0-NEXT:  .Lpcsection654:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection695:
+; O0-NEXT:  .Lpcsection655:
 ; O0-NEXT:    jne .LBB240_1
 ; O0-NEXT:    jmp .LBB240_2
 ; O0-NEXT:  .LBB240_2: # %atomicrmw.end
@@ -18509,13 +18429,13 @@ define void @atomic128_xor_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection696:
+; O0-NEXT:  .Lpcsection656:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection697:
+; O0-NEXT:  .Lpcsection657:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection698:
+; O0-NEXT:  .Lpcsection658:
 ; O0-NEXT:    jmp .LBB241_1
 ; O0-NEXT:  .LBB241_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -18523,14 +18443,14 @@ define void @atomic128_xor_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movq %rax, %rbx
-; O0-NEXT:  .Lpcsection699:
+; O0-NEXT:  .Lpcsection659:
 ; O0-NEXT:    xorq $42, %rbx
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection700:
+; O0-NEXT:  .Lpcsection660:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection701:
+; O0-NEXT:  .Lpcsection661:
 ; O0-NEXT:    jne .LBB241_1
 ; O0-NEXT:    jmp .LBB241_2
 ; O0-NEXT:  .LBB241_2: # %atomicrmw.end
@@ -18661,13 +18581,13 @@ define void @atomic128_nand_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq %rdi, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection702:
+; O0-NEXT:  .Lpcsection662:
 ; O0-NEXT:    movq (%rdi), %rax
-; O0-NEXT:  .Lpcsection703:
+; O0-NEXT:  .Lpcsection663:
 ; O0-NEXT:    movq 8(%rdi), %rdx
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection704:
+; O0-NEXT:  .Lpcsection664:
 ; O0-NEXT:    jmp .LBB242_1
 ; O0-NEXT:  .LBB242_1: # %atomicrmw.start
 ; O0-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -18675,20 +18595,20 @@ define void @atomic128_nand_seq_cst(ptr %a) {
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rsi # 8-byte Reload
 ; O0-NEXT:    movl %eax, %ecx
-; O0-NEXT:  .Lpcsection705:
+; O0-NEXT:  .Lpcsection665:
 ; O0-NEXT:    notl %ecx
-; O0-NEXT:  .Lpcsection706:
+; O0-NEXT:  .Lpcsection666:
 ; O0-NEXT:    # implicit-def: $rbx
 ; O0-NEXT:    movl %ecx, %ebx
-; O0-NEXT:  .Lpcsection707:
+; O0-NEXT:  .Lpcsection667:
 ; O0-NEXT:    orq $-43, %rbx
-; O0-NEXT:  .Lpcsection708:
+; O0-NEXT:  .Lpcsection668:
 ; O0-NEXT:    movq $-1, %rcx
-; O0-NEXT:  .Lpcsection709:
+; O0-NEXT:  .Lpcsection669:
 ; O0-NEXT:    lock cmpxchg16b (%rsi)
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rdx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection710:
+; O0-NEXT:  .Lpcsection670:
 ; O0-NEXT:    jne .LBB242_1
 ; O0-NEXT:    jmp .LBB242_2
 ; O0-NEXT:  .LBB242_2: # %atomicrmw.end
@@ -18830,34 +18750,30 @@ define void @atomic128_cas_monotonic(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection711:
+; O0-NEXT:  .Lpcsection671:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ecx
 ; O0-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection712:
+; O0-NEXT:  .Lpcsection672:
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection713:
+; O0-NEXT:  .Lpcsection673:
 ; O0-NEXT:    movl $1, %ebx
 ; O0-NEXT:    movq %rbx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection714:
+; O0-NEXT:  .Lpcsection674:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection715:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection716:
+; O0-NEXT:  .Lpcsection675:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection717:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection718:
+; O0-NEXT:  .Lpcsection676:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    popq %rbx
@@ -19027,34 +18943,30 @@ define void @atomic128_cas_acquire(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection719:
+; O0-NEXT:  .Lpcsection677:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ecx
 ; O0-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection720:
+; O0-NEXT:  .Lpcsection678:
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection721:
+; O0-NEXT:  .Lpcsection679:
 ; O0-NEXT:    movl $1, %ebx
 ; O0-NEXT:    movq %rbx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection722:
+; O0-NEXT:  .Lpcsection680:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection723:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection724:
+; O0-NEXT:  .Lpcsection681:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection725:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection726:
+; O0-NEXT:  .Lpcsection682:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    popq %rbx
@@ -19224,34 +19136,30 @@ define void @atomic128_cas_release(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection727:
+; O0-NEXT:  .Lpcsection683:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ecx
 ; O0-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection728:
+; O0-NEXT:  .Lpcsection684:
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection729:
+; O0-NEXT:  .Lpcsection685:
 ; O0-NEXT:    movl $1, %ebx
 ; O0-NEXT:    movq %rbx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection730:
+; O0-NEXT:  .Lpcsection686:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection731:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection732:
+; O0-NEXT:  .Lpcsection687:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection733:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection734:
+; O0-NEXT:  .Lpcsection688:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    popq %rbx
@@ -19421,34 +19329,30 @@ define void @atomic128_cas_acq_rel(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection735:
+; O0-NEXT:  .Lpcsection689:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ecx
 ; O0-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection736:
+; O0-NEXT:  .Lpcsection690:
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection737:
+; O0-NEXT:  .Lpcsection691:
 ; O0-NEXT:    movl $1, %ebx
 ; O0-NEXT:    movq %rbx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection738:
+; O0-NEXT:  .Lpcsection692:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection739:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection740:
+; O0-NEXT:  .Lpcsection693:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection741:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection742:
+; O0-NEXT:  .Lpcsection694:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $1, foo
 ; O0-NEXT:    popq %rbx
@@ -19618,34 +19522,30 @@ define void @atomic128_cas_seq_cst(ptr %a) {
 ; O0-NEXT:    .cfi_def_cfa_offset 16
 ; O0-NEXT:    .cfi_offset %rbx, -16
 ; O0-NEXT:    movq foo(%rip), %rax
-; O0-NEXT:  .Lpcsection743:
+; O0-NEXT:  .Lpcsection695:
 ; O0-NEXT:    xorl %eax, %eax
 ; O0-NEXT:    movl %eax, %ecx
 ; O0-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection744:
+; O0-NEXT:  .Lpcsection696:
 ; O0-NEXT:    movl $42, %eax
 ; O0-NEXT:    movq %rax, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; O0-NEXT:  .Lpcsection745:
+; O0-NEXT:  .Lpcsection697:
 ; O0-NEXT:    movl $1, %ebx
 ; O0-NEXT:    movq %rbx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection746:
+; O0-NEXT:  .Lpcsection698:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection747:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection748:
+; O0-NEXT:  .Lpcsection699:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rbx # 8-byte Reload
-; O0-NEXT:  .Lpcsection749:
-; O0-NEXT:    # kill: def $rsi killed $rax
 ; O0-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rax # 8-byte Reload
 ; O0-NEXT:    movq %rcx, %rdx
-; O0-NEXT:  .Lpcsection750:
+; O0-NEXT:  .Lpcsection700:
 ; O0-NEXT:    lock cmpxchg16b (%rdi)
 ; O0-NEXT:    movq $3, foo
 ; O0-NEXT:    popq %rbx

--- a/llvm/test/CodeGen/X86/pr32451.ll
+++ b/llvm/test/CodeGen/X86/pr32451.ll
@@ -16,7 +16,6 @@ define ptr @japi1_convert_690(ptr, ptr, i32) {
 ; CHECK-NEXT:    calll julia.gc_root_decl@PLT
 ; CHECK-NEXT:    movl %eax, {{[-0-9]+}}(%e{{[sb]}}p) # 4-byte Spill
 ; CHECK-NEXT:    calll jl_get_ptls_states@PLT
-; CHECK-NEXT:    # kill: def $ecx killed $eax
 ; CHECK-NEXT:    movl {{[-0-9]+}}(%e{{[sb]}}p), %eax # 4-byte Reload
 ; CHECK-NEXT:    movl 4(%eax), %eax
 ; CHECK-NEXT:    movb (%eax), %al

--- a/llvm/test/CodeGen/X86/pr41678.ll
+++ b/llvm/test/CodeGen/X86/pr41678.ll
@@ -28,7 +28,6 @@ define void @b() {
 ; CHECK-NEXT:    .cfi_def_cfa_offset 6
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    # kill: def $k0 killed $k6
 ; CHECK-NEXT:    kmovw %k6, (%esp)
 ; CHECK-NEXT:    addl $2, %esp
 ; CHECK-NEXT:    .cfi_def_cfa_offset 4


### PR DESCRIPTION
github issue: https://github.com/llvm/llvm-project/issues/168201

This patch extends copy elimination in **RegAllocFast** to catch an additional class of redundant copies. Previously, only identity copies (where source and destination registers are the same) were marked for removal.

Now, we check whether the current instruction is dead and remove it if it is.
The change:

- Updates the copy-elimination condition to include dead destination operands.

- Improves debug output to be more generic.

This reduces unnecessary instructions and can lead to slightly better codegen by eliminating dead copies earlier in the fast register allocation pass.