### PR TITLE
[Driver][HIP/SPIRV] Fix crash when llvm-link is executed.

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -39,8 +39,11 @@ void AMDGCN::Linker::constructLLVMLinkCommand(
 
   ArgStringList LinkerInputs;
 
-  for (auto Input : Inputs)
-    LinkerInputs.push_back(Input.getFilename());
+  for (auto Input : Inputs) {
+    if (Input.isFilename()) {
+      LinkerInputs.push_back(Input.getFilename());
+    }
+  }
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.

--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -39,11 +39,9 @@ void AMDGCN::Linker::constructLLVMLinkCommand(
 
   ArgStringList LinkerInputs;
 
-  for (auto Input : Inputs) {
-    if (Input.isFilename()) {
+  for (auto Input : Inputs)
+    if (Input.isFilename())
       LinkerInputs.push_back(Input.getFilename());
-    }
-  }
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.

--- a/clang/test/Driver/hip-spirv-linker-crash.c
+++ b/clang/test/Driver/hip-spirv-linker-crash.c
@@ -3,18 +3,13 @@
 //
 // RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
 // RUN:   -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-OPT
+// RUN:   | FileCheck %s
 //
 // RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
 // RUN:   -Xlinker -mllvm -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-MLLVM
+// RUN:   | FileCheck %s
 //
-// CHECK-LINKER-OPT: "{{.*}}llvm-link"
-// CHECK-LINKER-OPT-NOT: opt-bisect-limit
-// CHECK-LINKER-OPT-NOT: -mllvm
-// CHECK-LINKER-OPT-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}
-//
-// CHECK-LINKER-MLLVM: "{{.*}}llvm-link"
-// CHECK-LINKER-MLLVM-NOT: opt-bisect-limit
-// CHECK-LINKER-MLLVM-NOT: -mllvm
-// CHECK-LINKER-MLLVM-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}
+// CHECK: "{{.*}}llvm-link"
+// CHECK-NOT: opt-bisect-limit
+// CHECK-NOT: -mllvm
+// CHECK-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}

--- a/clang/test/Driver/hip-spirv-linker-crash.c
+++ b/clang/test/Driver/hip-spirv-linker-crash.c
@@ -1,0 +1,16 @@
+// Verify that SPIR-V compilation does not crash during the llvm-link step
+// due to extra args that are not meant to be forwarded there.
+//
+// RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
+// RUN:   -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-OPT
+//
+// RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
+// RUN:   -Xlinker -mllvm -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-MLLVM
+//
+// CHECK-LINKER-OPT: "{{.*}}llvm-link"
+// CHECK-LINKER-OPT-SAME: "-o" "{{.*}}" "{{.*}}"{{$}}
+//
+// CHECK-LINKER-MLLVM: "{{.*}}llvm-link"
+// CHECK-LINKER-MLLVM-SAME: "-o" "{{.*}}" "{{.*}}"{{$}}

--- a/clang/test/Driver/hip-spirv-linker-crash.c
+++ b/clang/test/Driver/hip-spirv-linker-crash.c
@@ -10,7 +10,11 @@
 // RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-MLLVM
 //
 // CHECK-LINKER-OPT: "{{.*}}llvm-link"
+// CHECK-LINKER-OPT-NOT: opt-bisect-limit
+// CHECK-LINKER-OPT-NOT: -mllvm
 // CHECK-LINKER-OPT-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}
 //
 // CHECK-LINKER-MLLVM: "{{.*}}llvm-link"
+// CHECK-LINKER-MLLVM-NOT: opt-bisect-limit
+// CHECK-LINKER-MLLVM-NOT: -mllvm
 // CHECK-LINKER-MLLVM-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}

--- a/clang/test/Driver/hip-spirv-linker-crash.c
+++ b/clang/test/Driver/hip-spirv-linker-crash.c
@@ -10,7 +10,7 @@
 // RUN:   | FileCheck %s --check-prefix=CHECK-LINKER-MLLVM
 //
 // CHECK-LINKER-OPT: "{{.*}}llvm-link"
-// CHECK-LINKER-OPT-SAME: "-o" "{{.*}}" "{{.*}}"{{$}}
+// CHECK-LINKER-OPT-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}
 //
 // CHECK-LINKER-MLLVM: "{{.*}}llvm-link"
-// CHECK-LINKER-MLLVM-SAME: "-o" "{{.*}}" "{{.*}}"{{$}}
+// CHECK-LINKER-MLLVM-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}


### PR DESCRIPTION
There is a design limitation (see [InputInfo](https://github.com/llvm/llvm-project/blob/f08b4fff52cdd3fc8fdd962080da089497c00fcc/clang/include/clang/Driver/InputInfo.h#L23)) that is forwarding flags to `llvm-link` when it shouldn't happen. This commit fixes this issue by sanitizing the arguments forwarded to `llvm-link`.

This may happen when `clang-linker-wrapper` eventually calls `clang`, which adds the `-Xlinker` flags. Crash reproducer is here: https://gcc.godbolt.org/z/rxvWcvan3.

The fix is based on @MrSidims' old PR (#183492).

The error started manifesting by default after the switch to the new driver, and the issue has been in the new driver since commit https://github.com/llvm/llvm-project/commit/4c6f398b866030c17fd94dcdca04f4df03c5214c. However, the problem could potentially be triggered by any call to `clang`, regardless of the `clang-linker-wrapper`. 