### PR TITLE
[Flang][OpenMP] Preserve MapInfoOp loc on descriptor base-address maps

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -347,13 +347,18 @@ class MapInfoFinalizationPass
   /// base address (BoxOffsetOp) and a MapInfoOp for it. The most
   /// important thing to note is that we normally move the bounds from
   /// the descriptor map onto the base address map.
+  ///
+  /// \p mapInfoOpLoc is the location of the MapInfoOp being expanded (the
+  /// descriptor map before this pass splits it). Lowering attaches a NameLoc
+  /// there for the Fortran map text. This is used with new Ops being
+  /// created by this function.
   mlir::omp::MapInfoOp
-  genBaseAddrMap(mlir::Value descriptor, mlir::OperandRange bounds,
-                 mlir::omp::ClauseMapFlags mapType, fir::FirOpBuilder &builder,
+  genBaseAddrMap(mlir::Location mapInfoOpLoc, mlir::Value descriptor,
+                 mlir::OperandRange bounds, mlir::omp::ClauseMapFlags mapType,
+                 fir::FirOpBuilder &builder,
                  mlir::FlatSymbolRefAttr mapperId = mlir::FlatSymbolRefAttr()) {
-    mlir::Location loc = descriptor.getLoc();
     mlir::Value baseAddrAddr = fir::BoxOffsetOp::create(
-        builder, loc, descriptor, fir::BoxFieldAttr::base_addr);
+        builder, mapInfoOpLoc, descriptor, fir::BoxFieldAttr::base_addr);
 
     mlir::Type underlyingVarType =
         llvm::cast<mlir::omp::PointerLikeType>(
@@ -365,7 +370,7 @@ class MapInfoFinalizationPass
 
     // Member of the descriptor pointing at the allocated data
     return mlir::omp::MapInfoOp::create(
-        builder, loc, baseAddrAddr.getType(), descriptor,
+        builder, mapInfoOpLoc, baseAddrAddr.getType(), descriptor,
         mlir::TypeAttr::get(underlyingVarType),
         builder.getAttr<mlir::omp::ClauseMapFlagsAttr>(mapType),
         builder.getAttr<mlir::omp::VariableCaptureKindAttr>(
@@ -603,7 +608,7 @@ class MapInfoFinalizationPass
       assert(mapMemberUsers.size() == 1 &&
              "OMPMapInfoFinalization currently only supports single users of a "
              "MapInfoOp");
-      auto baseAddr = genBaseAddrMap(descriptor, op.getBounds(),
+      auto baseAddr = genBaseAddrMap(op->getLoc(), descriptor, op.getBounds(),
                                      op.getMapType(), builder, mapperId);
       ParentAndPlacement mapUser = mapMemberUsers[0];
       adjustMemberIndices(memberIndices, mapUser.index);
@@ -617,7 +622,7 @@ class MapInfoFinalizationPass
       mapUser.parent.setMembersIndexAttr(
           builder.create2DI64ArrayAttr(memberIndices));
     } else if (!isHasDeviceAddrFlag) {
-      auto baseAddr = genBaseAddrMap(descriptor, op.getBounds(),
+      auto baseAddr = genBaseAddrMap(op->getLoc(), descriptor, op.getBounds(),
                                      op.getMapType(), builder, mapperId);
       newMembers.push_back(baseAddr);
       if (!op.getMembers().empty()) {

--- a/flang/test/Transforms/omp-map-info-finalization-name-loc.fir
+++ b/flang/test/Transforms/omp-map-info-finalization-name-loc.fir
@@ -1,0 +1,34 @@
+// RUN: fir-opt --omp-map-info-finalization --mlir-print-debuginfo %s | FileCheck %s
+
+#loc_decl = loc("omp-map-info-finalization-name-loc.fir":12:1)
+#loc_name = loc("arr(1:42)"(#loc_decl))
+
+func.func @preserve_name_loc_for_descriptor_base_member(%arg0: !fir.box<!fir.array<?xi32>>) {
+  %0 = fir.alloca !fir.box<!fir.heap<i32>>
+  %1 = fir.zero_bits !fir.heap<i32>
+  %2:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<intent_out>, uniq_name = "test"} : (!fir.box<!fir.array<?xi32>>) -> (!fir.box<!fir.array<?xi32>>, !fir.box<!fir.array<?xi32>>)
+  %3 = fir.embox %1 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+  fir.store %3 to %0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+  %4:2 = hlfir.declare %0 {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "test2"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+  %5 = fir.allocmem i32 {fir.must_be_heap = true}
+  %6 = fir.embox %5 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+  fir.store %6 to %4#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+  %c0 = arith.constant 1 : index
+  %c1 = arith.constant 0 : index
+  %c2 = arith.constant 10 : index
+  %dims:3 = fir.box_dims %2#1, %c1 : (!fir.box<!fir.array<?xi32>>, index) -> (index, index, index)
+  %bounds = omp.map.bounds lower_bound(%c1 : index) upper_bound(%c2 : index) extent(%dims#1 : index) stride(%dims#2 : index) start_idx(%c0 : index) {stride_in_bytes = true}
+  %7 = fir.box_addr %2#1 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
+  %8 = omp.map.info var_ptr(%4#1 : !fir.ref<!fir.box<!fir.heap<i32>>>, !fir.box<!fir.heap<i32>>) map_clauses(tofrom) capture(ByRef) -> !fir.ref<!fir.box<!fir.heap<i32>>> loc(#loc_name)
+  %9 = omp.map.info var_ptr(%7 : !fir.ref<!fir.array<?xi32>>, !fir.array<?xi32>) map_clauses(from) capture(ByRef) bounds(%bounds) -> !fir.ref<!fir.array<?xi32>>
+  omp.target map_entries(%8 -> %arg1, %9 -> %arg2 : !fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.array<?xi32>>) {
+    omp.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @preserve_name_loc_for_descriptor_base_member
+// CHECK: fir.box_offset {{.*}} base_addr : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.llvm_ptr<!fir.ref<i32>> loc(#loc[[LOCID:[0-9]+]])
+// CHECK: omp.map.info {{.*}} map_clauses(tofrom){{.*}} loc(#loc[[LOCID]])
+// CHECK: omp.map.info {{.*}} map_clauses(always, to){{.*}} members({{.*}}){{.*}} loc(#loc[[LOCID]])
+// CHECK: #loc[[LOCID]] = loc("arr(1:42)"({{.*}}))


### PR DESCRIPTION
This PR tries to fix another issue which was discovered after https://github.com/llvm/llvm-project/issues/195333 was fixed. Now when we run the same steps, we see the following output

```
omptarget device 0 info: Entering OpenMP data region with being_mapper at test.f90:18:9 with 5 arguments:
omptarget device 0 info: alloc(ptr(1:1024))[48] 
omptarget device 0 info: to(ptr(1:1024))[0] 
omptarget device 0 info: to(ptr(1:1024))[40] 
omptarget device 0 info: to(unknown)[8] 
omptarget device 0 info: to(unknown)[4096] 
```
Notice "unknown" in the last 2 lines. This happens because `MapInfoFinalization` splits box descriptor `omp.map.info` ops into a parent map and a base-address member map (fir.box_offset + inner map with var_ptr_ptr). The `genBaseAddrMap` used `descriptor.getLoc()` for those new ops, which dropped the `NameLoc` that lowering attaches for the Fortran map text. OpenMP-LLVM derives offload map names from that location, so the member map showed up as "unknown" while the parent still had the correct name.

To fix this, we now pass the expanded `MapInfoOp's` location (op->getLoc()) into `genBaseAddrMap` and use it for fir.box_offset and the inner `omp.map.info` so `NameLoc` is preserved.