### PR TITLE
[clang] fix location information of CXXConstructorExpr AST node

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
@@ -265,3 +265,19 @@ Gaz hn3() {
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
   // CHECK-FIXES: return {x};
 }
+
+
+struct foo {};
+
+struct bar {
+  operator const foo&() const;
+};
+
+foo x() {
+  return bar();
+}
+
+foo y() {
+  auto b = bar();
+  return b;
+}

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -525,6 +525,7 @@ Bug Fixes in This Version
 - Clang now emits an error for friend declarations of lambda members. (#GH26540)
 - Fixed a crash caused by lambda capture handling in delayed default arguments. (#GH176534)
 - Fixed a crash when parsing invalid ``static_assert`` declarations with string-literal messages (#GH187690).
+- Fixed location information when creating `CXXConstructExpr` AST node (#GH185044).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7429,8 +7429,8 @@ static ExprResult CopyObject(Sema &S,
 
   // Actually perform the constructor call.
   CurInit = S.BuildCXXConstructExpr(
-      Loc, T, Best->FoundDecl, Constructor, Elidable, ConstructorArgs,
-      HadMultipleCandidates,
+      CurInitExpr->getBeginLoc(), T, Best->FoundDecl, Constructor, Elidable,
+      ConstructorArgs, HadMultipleCandidates,
       /*ListInit*/ false,
       /*StdInitListInit*/ false,
       /*ZeroInit*/ false, CXXConstructionKind::Complete, SourceRange());


### PR DESCRIPTION
The bug reveals itself in clang-tidy's modernize-return-braced-init-list check by showing incorrect location information

Fixes #185044

**I need help with below:**
- should the title of PR be `[clang-tidy]`? (I don't think so though)
- where exactly do I add tests in clang subproject? I've added two test cases in clang-tidy, but they don't fully test what changed here
- should there be a release notes entry in clang-tools-extra/docs/ReleaseNotes.rst as well?


**[EDIT]**: Seems like the CI is failing, I'll check tomorrow for why that is the case.