### PR TITLE
[LLVM][AsmWriter] Fix ConstantFP zeroinitializer check

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1643,7 +1643,7 @@ static void writeConstantInternal(raw_ostream &Out, const Constant *CV,
     Type *Ty = CFP->getType();
 
     if (Ty->isVectorTy()) {
-      if (CFP->isPosZero()) {
+      if (CFP->getValue().bitcastToAPInt().isZero()) {
         Out << "zeroinitializer";
         return;
       }

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -90,11 +90,10 @@ bool Constant::isNullValue() const {
   if (const ConstantByte *CB = dyn_cast<ConstantByte>(this))
     return CB->isZero();
 
-  // +0.0 is null.
   if (const ConstantFP *CFP = dyn_cast<ConstantFP>(this))
     // ppc_fp128 determine isZero using high order double only
-    // Should check the bitwise value to make sure all bits are zero.
-    return CFP->isExactlyValue(+0.0);
+    // so check the bitwise value to make sure all bits are zero.
+    return CFP->getValue().bitcastToAPInt().isZero();
 
   // constant zero is zero for aggregates, cpnull is null for pointers, none for
   // tokens.

--- a/llvm/test/Assembler/constant-splat.ll
+++ b/llvm/test/Assembler/constant-splat.ll
@@ -36,7 +36,7 @@
 ; CHECK: @constant.splat.ppc_fp128 = constant <1 x ppc_fp128> splat (ppc_fp128 -0.000000e+00)
 @constant.splat.ppc_fp128 = constant <1 x ppc_fp128> splat (ppc_fp128 0xM80000000000000000000000000000000)
 
-; CHECK: @constant.splat.ppc_fp128.zero.1 = constant <1 x ppc_fp128> zeroinitializer
+; CHECK: @constant.splat.ppc_fp128.zero.1 = constant <1 x ppc_fp128> splat (ppc_fp128 f0x00000000000000010000000000000000)
 @constant.splat.ppc_fp128.zero.1 = constant <1 x ppc_fp128> splat (ppc_fp128 f0x00000000000000010000000000000000)
 
 ; CHECK: @constant.splat.global.ptr = constant <4 x ptr> <ptr @my_global, ptr @my_global, ptr @my_global, ptr @my_global>

--- a/llvm/test/Assembler/constant-splat.ll
+++ b/llvm/test/Assembler/constant-splat.ll
@@ -36,6 +36,9 @@
 ; CHECK: @constant.splat.ppc_fp128 = constant <1 x ppc_fp128> splat (ppc_fp128 -0.000000e+00)
 @constant.splat.ppc_fp128 = constant <1 x ppc_fp128> splat (ppc_fp128 0xM80000000000000000000000000000000)
 
+; CHECK: @constant.splat.ppc_fp128.zero.1 = constant <1 x ppc_fp128> zeroinitializer
+@constant.splat.ppc_fp128.zero.1 = constant <1 x ppc_fp128> splat (ppc_fp128 f0x00000000000000010000000000000000)
+
 ; CHECK: @constant.splat.global.ptr = constant <4 x ptr> <ptr @my_global, ptr @my_global, ptr @my_global, ptr @my_global>
 @constant.splat.global.ptr = constant <4 x ptr> splat (ptr @my_global)
 


### PR DESCRIPTION
It turns out ppc_fp128 has a value where isPosZero() returns true but isNullValue() returns false.

I wondered if DoubleAPFloat might be wrong but when trying to "fix" it I found more and more places that do not care about the second double, so I reverted to this localised fix.  The change to `Constant::isNullValue()` is not required, but given the comment I figured it was worth keeping the related code consistent.