### PR TITLE
[Clang] Permit `vulkan` as an OS for the SPIRV target architecture

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -697,18 +697,19 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     return std::make_unique<SPIRVTargetInfo>(Triple, Opts);
   }
   case llvm::Triple::spirv32: {
-    if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar) ||
+    if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar &&
+         os != llvm::Triple::Vulkan) ||
         Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
     return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
   }
   case llvm::Triple::spirv64: {
-    if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar) ||
-        Triple.getEnvironment() != llvm::Triple::UnknownEnvironment) {
-      if (os == llvm::Triple::OSType::AMDHSA)
-        return std::make_unique<SPIRV64AMDGCNTargetInfo>(Triple, Opts);
+    if (os == llvm::Triple::OSType::AMDHSA)
+      return std::make_unique<SPIRV64AMDGCNTargetInfo>(Triple, Opts);
+    if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar &&
+         os != llvm::Triple::Vulkan) ||
+        Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
-    }
     if (Triple.getVendor() == llvm::Triple::Intel)
       return std::make_unique<SPIRV64IntelTargetInfo>(Triple, Opts);
     return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -379,8 +379,9 @@ public:
     assert(Triple.getArch() == llvm::Triple::spirv32 &&
            "Invalid architecture for 32-bit SPIR-V.");
     assert((getTriple().getOS() == llvm::Triple::UnknownOS ||
-            getTriple().getOS() == llvm::Triple::ChipStar) &&
-           "32-bit SPIR-V target must use unknown or chipstar OS");
+            getTriple().getOS() == llvm::Triple::ChipStar ||
+            getTriple().getOS() == llvm::Triple::Vulkan) &&
+           "32-bit SPIR-V target must use unknown, chipstar, or vulkan OS");
     assert(getTriple().getEnvironment() == llvm::Triple::UnknownEnvironment &&
            "32-bit SPIR-V target must use unknown environment type");
     PointerWidth = PointerAlign = 32;
@@ -403,8 +404,9 @@ public:
     assert(Triple.getArch() == llvm::Triple::spirv64 &&
            "Invalid architecture for 64-bit SPIR-V.");
     assert((getTriple().getOS() == llvm::Triple::UnknownOS ||
-            getTriple().getOS() == llvm::Triple::ChipStar) &&
-           "64-bit SPIR-V target must use unknown or chipstar OS");
+            getTriple().getOS() == llvm::Triple::ChipStar ||
+            getTriple().getOS() == llvm::Triple::Vulkan) &&
+           "64-bit SPIR-V target must use unknown, chipstar, or vulkan OS");
     assert(getTriple().getEnvironment() == llvm::Triple::UnknownEnvironment &&
            "64-bit SPIR-V target must use unknown environment type");
     PointerWidth = PointerAlign = 64;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7166,10 +7166,12 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
       break;
     case llvm::Triple::Vulkan:
     case llvm::Triple::ShaderModel:
-      if (usesInput(Args, types::isHLSL))
-        TC = std::make_unique<toolchains::HLSLToolChain>(*this, Target, Args);
-      else if (Target.isSPIRV())
+      if ((Target.getArch() == llvm::Triple::spirv32 ||
+           Target.getArch() == llvm::Triple::spirv64) &&
+          !usesInput(Args, types::isHLSL))
         TC = std::make_unique<toolchains::SPIRVToolChain>(*this, Target, Args);
+      else
+        TC = std::make_unique<toolchains::HLSLToolChain>(*this, Target, Args);
       break;
     case llvm::Triple::ChipStar:
       TC = std::make_unique<toolchains::HIPSPVToolChain>(*this, Target, Args);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7166,7 +7166,10 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
       break;
     case llvm::Triple::Vulkan:
     case llvm::Triple::ShaderModel:
-      TC = std::make_unique<toolchains::HLSLToolChain>(*this, Target, Args);
+      if (usesInput(Args, types::isHLSL))
+        TC = std::make_unique<toolchains::HLSLToolChain>(*this, Target, Args);
+      else if (Target.isSPIRV())
+        TC = std::make_unique<toolchains::SPIRVToolChain>(*this, Target, Args);
       break;
     case llvm::Triple::ChipStar:
       TC = std::make_unique<toolchains::HIPSPVToolChain>(*this, Target, Args);

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -260,3 +260,7 @@
 // RUN: %clang_cc1 -triple spirv64-amd-amdhsa -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=AMDGPUSPIRV64
 // AMDGPUSPIRV64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n32:64-S32-G1-P4-A0"
+
+// RUN: %clang_cc1 -triple spirv64-unknown-vulkan -o - -emit-llvm %s | \
+// RUN: FileCheck %s -check-prefix=SPIRV64VULKAN
+// SPIRV64VULKAN: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -5,11 +5,12 @@
 // RUN: %clang -### --target=spirv64 -x clcpp -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64-unknown-vulkan -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64VK %s
+// RUN: %clang -### --target=spirv64-unknown-vulkan1.3 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64VK %s
 
 // SPV64: "-cc1" "-triple" "spirv64"
 // SPV64-SAME: "-o" {{".*o"}}
 
-// SPV64VK: "-cc1" "-triple" "spirv64-unknown-vulkan"
+// SPV64VK: "-cc1" "-triple" "spirv64-unknown-vulkan{{(1\.3)?}}"
 // SPV64VK-SAME: "-o" {{".*o"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -c %s 2>&1 | FileCheck --check-prefix=SPV32 %s

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -4,9 +4,13 @@
 // RUN: %clang -### --target=spirv64 -x ir -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64 -x clcpp -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
+// RUN: %clang -### --target=spirv64-unknown-vulkan -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64VK %s
 
 // SPV64: "-cc1" "-triple" "spirv64"
 // SPV64-SAME: "-o" {{".*o"}}
+
+// SPV64VK: "-cc1" "-triple" "spirv64-unknown-vulkan"
+// SPV64VK-SAME: "-o" {{".*o"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -c %s 2>&1 | FileCheck --check-prefix=SPV32 %s
 // RUN: %clang -### --target=spirv32 %s 2>&1 | FileCheck --check-prefix=SPV32 %s


### PR DESCRIPTION
Summary:
This is currently rejected in two places, the toolchain creation and the
target itself. For the target we just permit it in the same way we alloe
things like 'amdhsa'. For the driver, the current handling just assumed
everything with 'vulkan' was HLSL. This shouldn't be true so we check
the source file type, and only push through actual HLSL files.

This is intended to more canonically support the 'CLSPV' target that
google has.
