### PR TITLE
[Clang] Add macro for `__VULKAN__` environment

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -89,6 +89,8 @@ void BaseSPIRVTargetInfo::getTargetDefines(const LangOptions &Opts,
   DefineStd(Builder, "SPIRV", Opts);
   if (Opts.HLSL)
     DefineStd(Builder, "spirv", Opts);
+  if (getTriple().isVulkanOS())
+    Builder.defineMacro("__VULKAN__");
 }
 
 void SPIRVTargetInfo::getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Preprocessor/predefined-macros.c
+++ b/clang/test/Preprocessor/predefined-macros.c
@@ -238,6 +238,13 @@
 // CHECK-SPIRV64-NOT: #define __SPIRV32__ 1
 // CHECK-SPIRV64-NOT: #define __spirv__ 1
 
+// RUN: %clang_cc1 %s -E -dM -o - -x c -triple spirv64-unknown-vulkan \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV64-VULKAN
+// CHECK-SPIRV64-VULKAN-DAG: #define __SPIRV__ 1
+// CHECK-SPIRV64-VULKAN-DAG: #define __SPIRV64__ 1
+// CHECK-SPIRV64-VULKAN-DAG: #define __VULKAN__ 1
+// CHECK-SPIRV64-VULKAN-NOT: #define __SPIRV32__ 1
+
 // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv64-amd-amdhsa \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV64-AMDGCN
 // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv64-amd-amdhsa -fatomic-ignore-denormal-mode \


### PR DESCRIPTION
Summary:
Adds a macro like for `__LINUX__` or `__WIN32`. The intention here is to
let code differentiate between vulkan variants or not.
