### PR TITLE
[modulemap] Fix module build after #189515

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -353,6 +353,8 @@ module LLVM_Transforms {
 
   // Requires DEBUG_TYPE to be defined by including file.
   exclude header "llvm/Transforms/Utils/InstructionWorklist.h"
+
+  textual header "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerIRValues.def"
 }
 
 extern module LLVM_Extern_Utils_DataTypes "module.extern.modulemap"
@@ -453,4 +455,5 @@ module LLVM_SandboxIR {
   module * { export * }
 
   textual header "llvm/SandboxIR/Values.def"
+  textual header "llvm/SandboxIR/ValuesDefFilesList.def"
 }

--- a/llvm/lib/IR/CMakeLists.txt
+++ b/llvm/lib/IR/CMakeLists.txt
@@ -91,6 +91,7 @@ add_llvm_component_library(LLVMCore
   ${LLVM_PTHREAD_LIB}
 
   DEPENDS
+  analysis_gen
   intrinsics_gen
 
   LINK_COMPONENTS


### PR DESCRIPTION
Mark newly added `.def` file as textual header to fix module include and
module cycle issue. Also added a missing CMake analysis_gen dependency
that might cause build failure.
