### PR TITLE
[lldb-dap] Make lldbDAP an OBJECT library (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -1,8 +1,10 @@
-# We need to include the llvm components we depend on manually, as liblldb does
-# not re-export those.
-set(LLVM_LINK_COMPONENTS Support)
-
-add_lldb_library(lldbDAP
+# lldbDAP is an OBJECT library: a collection of compiled object files that is
+# shared between the lldb-dap tool and the DAPTests unit test, with no declared
+# link dependencies of its own. Each consumer lists its own LINK_LIBS and
+# LINK_COMPONENTS, avoiding transitive propagation of static LLVM components
+# that would collide with symbols re-exported by liblldb when
+# LLDB_EXPORT_ALL_SYMBOLS is ON.
+add_lldb_library(lldbDAP OBJECT
   Breakpoint.cpp
   BreakpointBase.cpp
   ClientLauncher.cpp
@@ -73,13 +75,6 @@ add_lldb_library(lldbDAP
   Protocol/ProtocolEvents.cpp
   Protocol/ProtocolTypes.cpp
   Protocol/ProtocolRequests.cpp
-
-  LINK_COMPONENTS
-    Option
-    Support
-  LINK_LIBS
-    liblldb
-    lldbHost
   )
 
 target_include_directories(lldbDAP

--- a/lldb/tools/lldb-dap/tool/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/tool/CMakeLists.txt
@@ -2,16 +2,18 @@ set(LLVM_TARGET_DEFINITIONS Options.td)
 tablegen(LLVM Options.inc -gen-opt-parser-defs)
 add_public_tablegen_target(LLDBDAPOptionsTableGen)
 
-set(LLDB_DAP_LINK_LIBS lldbDAP)
+set(LLDB_DAP_LINK_LIBS lldbDAP liblldb lldbHost)
 
 if(WIN32)
   list(APPEND LLDB_DAP_LINK_LIBS lldbHostPythonPathSetup)
-  list(APPEND LLDB_DAP_LINK_LIBS liblldb)
 endif()
 
 add_lldb_tool(lldb-dap
   lldb-dap.cpp
 
+  LINK_COMPONENTS
+    Option
+    Support
   LINK_LIBS
     ${LLDB_DAP_LINK_LIBS}
   )

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -22,11 +22,14 @@ add_lldb_unittest(DAPTests
 
   LINK_COMPONENTS
     Support
+
   LINK_LIBS
-    liblldb
     lldbDAP
+    lldbHost
+    lldbUtility
     lldbUtilityHelpers
     LLVMTestingSupport
+    liblldb
   )
 
 set(test_inputs


### PR DESCRIPTION
Convert lldbDAP from a static library to an OBJECT library and move its LINK_COMPONENTS (Option, Support) and LINK_LIBS (liblldb, lldbHost) to its consumers (the lldb-dap tool and the DAPTests unit test).

This avoids transitive propagation of LLVM's static components through lldbDAP, which would otherwise collide with the same symbols re-exported by liblldb when LLDB_EXPORT_ALL_SYMBOLS is enabled, breaking llvm::Error's RTTI (e.g. ErrorInfoBase::ID) across library boundaries.

Extracted from #189718 for easier reviewing.