### PR TITLE
[PowerPC] Hardcode LDAT/LWAT_CSNE constant immediate

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -314,9 +314,9 @@ def LDAT : X_RD5_RS5_IM5<31, 614, (outs g8prc:$RST), (ins g8prc:$RSTi, ptr_rc_no
            RegConstraint<"$RSTi = $RST">;
 
 let hasExtraSrcRegAllocReq = 1, mayStore = 1,
-      isCodeGenOnly = 1, hasNoSchedulingInfo = 1 in
-def LDAT_CSNE : X_RD5_RS5_IM5<31, 614, (outs g8rc:$RST), (ins ptr_rc_nor0:$RA, u5imm:$RB),
-                         "ldat $RST, $RA, $RB", IIC_LdStLoad>,
+      isCodeGenOnly = 1, hasNoSchedulingInfo = 1, RB = 16 in
+def LDAT_CSNE : X_RD5_RS5_IM5<31, 614, (outs g8rc:$RST), (ins ptr_rc_nor0:$RA),
+                         "ldat $RST, $RA, 16", IIC_LdStLoad>,
            Requires<[IsISA3_0]>;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -5921,7 +5921,6 @@ bool PPCInstrInfo::expandAMOCSNEPseudo(MachineInstr &MI) const {
 
   BuildMI(MBB, MI, DL, get(IsLDAT ? PPC::LDAT_CSNE : PPC::LWAT_CSNE), PPC::X8)
       .addReg(ScratchReg)
-      .addImm(16)
       .addReg(PPC::X9, RegState::Implicit)
       .addReg(PPC::X10, RegState::Implicit);
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2095,10 +2095,10 @@ def LWAT : X_RD5_RS5_IM5<31, 582, (outs g8prc:$RST), (ins g8prc:$RSTi, ptr_rc_no
            Requires<[IsISA3_0]>,
            RegConstraint<"$RSTi = $RST">;
 
-let hasExtraSrcRegAllocReq = 1, mayLoad = 1,
-       mayStore = 1, isCodeGenOnly = 1, hasNoSchedulingInfo = 1 in
-def LWAT_CSNE : X_RD5_RS5_IM5<31, 582, (outs g8rc:$RST), (ins ptr_rc_nor0:$RA, u5imm:$RB),
-                         "lwat $RST, $RA, $RB", IIC_LdStLoad>,
+let hasExtraSrcRegAllocReq = 1, mayLoad = 1, mayStore = 1,
+       isCodeGenOnly = 1, hasNoSchedulingInfo = 1, RB = 16 in
+def LWAT_CSNE : X_RD5_RS5_IM5<31, 582, (outs g8rc:$RST), (ins ptr_rc_nor0:$RA),
+                         "lwat $RST, $RA, 16", IIC_LdStLoad>,
            Requires<[IsISA3_0]>;
 
 def LWAT_PSEUDO : PPCCustomInserterPseudo<


### PR DESCRIPTION
The FC field in LDAT/LWAT_CSNE instructions is always 16, so hardcode it in the TableGen definition instead of passing it as an explicit operand.