### PR TITLE
[NFC] Remove isRequired() from analyses

### DIFF
--- a/llvm/include/llvm/CodeGen/AssignmentTrackingAnalysis.h
+++ b/llvm/include/llvm/CodeGen/AssignmentTrackingAnalysis.h
@@ -131,8 +131,6 @@ public:
 
   bool runOnFunction(Function &F) override;
 
-  static bool isRequired() { return true; }
-
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();
   }

--- a/llvm/include/llvm/IR/Verifier.h
+++ b/llvm/include/llvm/IR/Verifier.h
@@ -118,7 +118,6 @@ public:
 
   LLVM_ABI Result run(Module &M, ModuleAnalysisManager &);
   LLVM_ABI Result run(Function &F, FunctionAnalysisManager &);
-  static bool isRequired() { return true; }
 };
 
 /// Create a verifier pass.


### PR DESCRIPTION
isRequired() isn't relevant for analyses.