### PR TITLE
Reland "[Driver][HIP/SPIRV] Fix crash when llvm-link is executed" 

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -40,7 +40,8 @@ void AMDGCN::Linker::constructLLVMLinkCommand(
   ArgStringList LinkerInputs;
 
   for (auto Input : Inputs)
-    LinkerInputs.push_back(Input.getFilename());
+    if (Input.isFilename())
+      LinkerInputs.push_back(Input.getFilename());
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.

--- a/clang/test/Driver/hip-spirv-linker-crash.c
+++ b/clang/test/Driver/hip-spirv-linker-crash.c
@@ -1,0 +1,15 @@
+// Verify that SPIR-V compilation does not crash during the llvm-link step
+// due to extra args that are not meant to be forwarded there.
+//
+// RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
+// RUN:   -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
+// RUN:   | FileCheck %s
+//
+// RUN: %clang -### --target=spirv64-amd-amdhsa -use-spirv-backend \
+// RUN:   -Xlinker -mllvm -Xlinker -opt-bisect-limit=-1 %s 2>&1 \
+// RUN:   | FileCheck %s
+//
+// CHECK: "{{.*}}llvm-link"
+// CHECK-NOT: opt-bisect-limit
+// CHECK-NOT: -mllvm
+// CHECK-SAME: "-o" "{{.*}}.bc" "{{.*}}.bc"{{$}}


### PR DESCRIPTION
Originally reverted due to possible regression detected by buildbot. This PR relands https://github.com/llvm/llvm-project/pull/196074. Failures were due to flaky tests. 