### PR TITLE
[clang][AMDGPU] Reject malformed target IDs with empty components

### DIFF
--- a/clang/lib/Basic/TargetID.cpp
+++ b/clang/lib/Basic/TargetID.cpp
@@ -89,6 +89,8 @@ parseTargetIDWithFormatCheckingOnly(llvm::StringRef TargetID,
 
   while (!Features.empty()) {
     auto Splits = Features.split(':');
+    if (Splits.first.empty())
+      return std::nullopt;
     auto Sign = Splits.first.back();
     auto Feature = Splits.first.drop_back();
     if (Sign != '+' && Sign != '-')

--- a/clang/test/Driver/amdgpu-invalid-target-id.s
+++ b/clang/test/Driver/amdgpu-invalid-target-id.s
@@ -39,3 +39,9 @@
 // RUN:   %s 2>&1 | FileCheck -check-prefix=NOCOLON %s
 
 // NOCOLON: error: invalid target ID 'gfx900+xnack'
+
+// RUN: not %clang -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx900::xnack+ -nostdlib \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=EXTRACOL %s
+
+// EXTRACOL: error: invalid target ID 'gfx900::xnack+'

--- a/clang/test/Driver/amdgpu-invalid-target-id.s
+++ b/clang/test/Driver/amdgpu-invalid-target-id.s
@@ -40,7 +40,7 @@
 
 // NOCOLON: error: invalid target ID 'gfx900+xnack'
 
-// RUN: not %clang -target amdgcn-amd-amdhsa \
+// RUN: not %clang --target=amdgcn-amd-amdhsa \
 // RUN:   -mcpu=gfx900::xnack+ -nostdlib \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=EXTRACOL %s
 


### PR DESCRIPTION
Fixes #196078

An extra colon in `-mcpu` (e.g. `gfx900::xnack+`) produced an empty feature component and triggered an assertion in `StringRef::back()`.

Return `std::nullopt` for malformed target IDs instead.