### PR TITLE
[libcxx] Remove _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -687,17 +687,10 @@ _LIBCPP_PUSH_MACROS
 // has been built with ASAN support in order to enable the container checks in std::string.
 // Within the <string> implementation, use `_LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS_FOR_STRING`
 // to determine whether ASAN container checks should be provided.
-//
-// The _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS macro disables ASAN instrumentation for a specific
-// function, allowing memory accesses that would normally trigger ASan errors to proceed without
-// crashing. This is useful for accessing parts of objects memory, which should not be accessed,
-// such as unused bytes in short strings, that should never be accessed by other parts of the program.
 #  if _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS && _LIBCPP_INSTRUMENTED_WITH_ASAN
 #    define _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS_FOR_STRING 1
-#    define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS __attribute__((__no_sanitize__("address")))
 #  else
 #    define _LIBCPP_ENABLE_ASAN_CONTAINER_CHECKS_FOR_STRING 0
-#    define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
 #  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
@@ -970,7 +963,7 @@ public:
     __annotate_new(0);
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string(const basic_string& __str)
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const basic_string& __str)
       : __alloc_(__alloc_traits::select_on_container_copy_construction(__str.__alloc_)) {
     if (!__str.__is_long()) {
       __rep_ = __str.__rep_;
@@ -979,7 +972,7 @@ public:
       __init_copy_ctor_external(std::__to_address(__str.__get_long_pointer()), __str.__get_long_size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
+  _LIBCPP_CONSTEXPR_SINCE_CXX20
   basic_string(const basic_string& __str, const allocator_type& __a)
       : __alloc_(__a) {
     if (!__str.__is_long()) {
@@ -996,15 +989,7 @@ public:
 #    else
       _NOEXCEPT
 #    endif
-      // Turning off ASan instrumentation for variable initialization with _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
-      // does not work consistently during initialization of __r_, so we instead unpoison __str's memory manually first.
-      // __str's memory needs to be unpoisoned only in the case where it's a short string.
-      : __rep_([](basic_string& __s) -> decltype(__s.__rep_)&& {
-          if (!__s.__is_long())
-            __s.__annotate_delete();
-          return std::move(__s.__rep_);
-        }(__str)),
-        __alloc_(std::move(__str.__alloc_)) {
+      : __rep_(std::move(__str.__rep_)), __alloc_(std::move(__str.__alloc_)) {
     __str.__rep_ = __rep();
     __str.__annotate_new(0);
     if (!__is_long())
@@ -1184,7 +1169,7 @@ public:
     return __self_view(typename __self_view::__assume_valid(), data(), size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string&
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   operator=(const basic_string& __str);
 
   template <class _Tp,
@@ -2096,7 +2081,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __invariants() const;
 
 private:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS bool
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
   __is_long() const _NOEXCEPT {
     if (__libcpp_is_constant_evaluated() && __builtin_constant_p(__rep_.__l.__is_long_)) {
       return __rep_.__l.__is_long_;
@@ -2165,14 +2150,14 @@ private:
   // internal buffer accessors
   // -------------------------
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __set_short_size(size_type __s) _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(__s < __min_cap, "__s should never be greater than or equal to the short string capacity");
     __rep_.__s.__size_    = __s;
     __rep_.__s.__is_long_ = false;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS size_type
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type
   __get_short_size() const _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(!__rep_.__s.__is_long_, "String has to be short when trying to get the short size");
     return __rep_.__s.__size_;
@@ -2209,12 +2194,12 @@ private:
     return __rep_.__l.__data_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS pointer
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer
   __get_short_pointer() _NOEXCEPT {
     return pointer_traits<pointer>::pointer_to(__rep_.__s.__data_[0]);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS const_pointer
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_pointer
   __get_short_pointer() const _NOEXCEPT {
     return pointer_traits<const_pointer>::pointer_to(__rep_.__s.__data_[0]);
   }
@@ -2459,7 +2444,7 @@ private:
 #  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __move_assign(basic_string& __str, false_type) noexcept(__alloc_traits::is_always_equal::value);
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __move_assign(basic_string& __str, true_type)
 #    if _LIBCPP_STD_VER >= 17
       noexcept;
@@ -2856,7 +2841,7 @@ basic_string<_CharT, _Traits, _Allocator>::operator=(value_type __c) {
 }
 
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS basic_string<_CharT, _Traits, _Allocator>&
+_LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::operator=(const basic_string& __str) {
   if (this == std::addressof(__str))
     return *this;
@@ -2888,7 +2873,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
 }
 
 template <class _CharT, class _Traits, class _Allocator>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, true_type)
 #    if _LIBCPP_STD_VER >= 17
     noexcept

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -972,9 +972,7 @@ public:
       __init_copy_ctor_external(std::__to_address(__str.__get_long_pointer()), __str.__get_long_size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20
-  basic_string(const basic_string& __str, const allocator_type& __a)
-      : __alloc_(__a) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const basic_string& __str, const allocator_type& __a) : __alloc_(__a) {
     if (!__str.__is_long()) {
       __rep_ = __str.__rep_;
       __annotate_new(__get_short_size());
@@ -1169,8 +1167,7 @@ public:
     return __self_view(typename __self_view::__assume_valid(), data(), size());
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
-  operator=(const basic_string& __str);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(const basic_string& __str);
 
   template <class _Tp,
             __enable_if_t<__can_be_converted_to_string_view_v<_CharT, _Traits, _Tp> &&
@@ -2081,8 +2078,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __invariants() const;
 
 private:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
-  __is_long() const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_long() const _NOEXCEPT {
     if (__libcpp_is_constant_evaluated() && __builtin_constant_p(__rep_.__l.__is_long_)) {
       return __rep_.__l.__is_long_;
     }
@@ -2150,15 +2146,13 @@ private:
   // internal buffer accessors
   // -------------------------
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-  __set_short_size(size_type __s) _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __set_short_size(size_type __s) _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(__s < __min_cap, "__s should never be greater than or equal to the short string capacity");
     __rep_.__s.__size_    = __s;
     __rep_.__s.__is_long_ = false;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type
-  __get_short_size() const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type __get_short_size() const _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(!__rep_.__s.__is_long_, "String has to be short when trying to get the short size");
     return __rep_.__s.__size_;
   }
@@ -2194,13 +2188,11 @@ private:
     return __rep_.__l.__data_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer
-  __get_short_pointer() _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer __get_short_pointer() _NOEXCEPT {
     return pointer_traits<pointer>::pointer_to(__rep_.__s.__data_[0]);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_pointer
-  __get_short_pointer() const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_pointer __get_short_pointer() const _NOEXCEPT {
     return pointer_traits<const_pointer>::pointer_to(__rep_.__s.__data_[0]);
   }
 
@@ -2444,8 +2436,7 @@ private:
 #  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __move_assign(basic_string& __str, false_type) noexcept(__alloc_traits::is_always_equal::value);
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-  __move_assign(basic_string& __str, true_type)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign(basic_string& __str, true_type)
 #    if _LIBCPP_STD_VER >= 17
       noexcept;
 #    else


### PR DESCRIPTION
This was only necessary for ASan container annotations for short strings. Remove it now that we do not support ASan container annotations on short strings to:
1. Not suppress Asan on other violations, e.g. std::string::size() on dead object.
2. Make the code a bit more clean.

Short string annotations were removed in  https://github.com/llvm/llvm-project/pull/194208.

