### PR TITLE
Revert "[DenseMap] Add memory barrier for sanitizers in getInlineBuckets/getLargeRep (#183457)"

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -1033,13 +1033,6 @@ private:
     // Note that this cast does not violate aliasing rules as we assert that
     // the memory's dynamic type is the small, inline bucket buffer, and the
     // 'storage' is a POD containing a char buffer.
-#if defined(__clang__) &&                                                      \
-    (defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__))
-    // Unless it's a sanitizer with container overflow detection. In this case
-    // some items in buckets can be partially poisoned, triggering sanitizer
-    // report on load.
-    __asm__ volatile("" ::: "memory");
-#endif
     return reinterpret_cast<const BucketT *>(&storage);
   }
 
@@ -1051,10 +1044,6 @@ private:
   const LargeRep *getLargeRep() const {
     assert(!Small);
     // Note, same rule about aliasing as with getInlineBuckets.
-#if defined(__clang__) &&                                                      \
-    (defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__))
-    __asm__ volatile("" ::: "memory");
-#endif
     return reinterpret_cast<const LargeRep *>(&storage);
   }
 


### PR DESCRIPTION
Revert #183457 and fixup #193695 as they are not needed after #194208.

Related issue #182720.

This reverts commit b5ac484470b9ceda96addcbc946f9ded4c5ef972.
This reverts commit 8d5b74db2d8f54da2609d18040504153c1afe5df.
