### PR TITLE
[LifetimeSafety] Warn on incorrectly placed `[[clang::lifetimebound]]` attributes

### DIFF
--- a/clang/docs/LifetimeSafety.rst
+++ b/clang/docs/LifetimeSafety.rst
@@ -467,6 +467,7 @@ enables only the high-confidence subset of these checks.
 * ``-Wlifetime-safety-validations``: Enables checks that validate existing lifetime annotations.
 
   * ``-Wlifetime-safety-noescape``: Warns when a parameter marked with ``[[clang::noescape]]`` escapes the function.
+  * ``-Wlifetime-safety-lifetimebound-violation``: Warns when a parameter marked with ``[[clang::lifetimebound]]`` is not returned from the function.
 
 Limitations
 ===========

--- a/clang/docs/LifetimeSafety.rst
+++ b/clang/docs/LifetimeSafety.rst
@@ -467,7 +467,7 @@ enables only the high-confidence subset of these checks.
 * ``-Wlifetime-safety-validations``: Enables checks that validate existing lifetime annotations.
 
   * ``-Wlifetime-safety-noescape``: Warns when a parameter marked with ``[[clang::noescape]]`` escapes the function.
-  * ``-Wlifetime-safety-lifetimebound-violation``: Warns when a parameter marked with ``[[clang::lifetimebound]]`` is not returned from the function.
+  * ``-Wlifetime-safety-lifetimebound-violation``: Warns when the analysis cannot verify that the return value can be lifetime bound to a parameter marked with ``[[clang::lifetimebound]]``.
 
 Limitations
 ===========

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -108,6 +108,8 @@ public:
   virtual void reportNoescapeViolation(const ParmVarDecl *ParmWithNoescape,
                                        const VarDecl *EscapeGlobal) {}
 
+  virtual void reportLifetimeboundViolation(const ParmVarDecl *VD) {}
+
   // Suggests lifetime bound annotations for implicit this.
   virtual void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
                                                   const CXXMethodDecl *MD,

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -108,6 +108,8 @@ public:
   virtual void reportNoescapeViolation(const ParmVarDecl *ParmWithNoescape,
                                        const VarDecl *EscapeGlobal) {}
 
+  // Reports misuse of [[clang::lifetimebound]] when parameter doesn't escape
+  // through return.
   virtual void reportLifetimeboundViolation(const ParmVarDecl *VD) {}
 
   // Suggests lifetime bound annotations for implicit this.

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -626,7 +626,7 @@ Warning to detect invalidation of references.
 
 def LifetimeSafetyLifetimeboundViolation : DiagGroup<"lifetime-safety-lifetimebound-violation"> {
   code Documentation = [{
-Warning to detect lifetimebound violations introduced by marking parameter as lifetimebound but not actually returning it.
+Warning to detect lifetimebound violations introduced by marking parameter as lifetimebound but not returning it in any way.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -626,7 +626,7 @@ Warning to detect invalidation of references.
 
 def LifetimeSafetyLifetimeboundViolation : DiagGroup<"lifetime-safety-lifetimebound-violation"> {
   code Documentation = [{
-Warning to detect lifetimebound violations introduced by marking parameter as lifetimebound but not returning it in any way.
+Detects parameters marked as [[clang::lifetimebound]] that do not escape through the return value.
   }];
 }
 
@@ -635,8 +635,7 @@ def LifetimeSafetyPermissive : DiagGroup<"lifetime-safety-permissive",
                                          LifetimeSafetyReturnStackAddr,
                                          LifetimeSafetyDanglingField,
                                          LifetimeSafetyDanglingGlobal,
-                                         LifetimeSafetyUseAfterFree,
-                                         LifetimeSafetyLifetimeboundViolation]>;
+                                         LifetimeSafetyUseAfterFree]>;
 
 def LifetimeSafetyStrict : DiagGroup<"lifetime-safety-strict",
                                     [LifetimeSafetyPermissive,
@@ -673,10 +672,10 @@ Detects misuse of [[clang::noescape]] annotation where the parameter escapes (fo
 }
 
 def LifetimeSafetyValidations : DiagGroup<"lifetime-safety-validations",
-                                          [LifetimeSafetyNoescape]> {
+                                          [LifetimeSafetyNoescape, LifetimeSafetyLifetimeboundViolation]> {
   code Documentation = [{
 Verify function implementations adhere to the annotated lifetime contracts through lifetime safety
-like verifying [[clang::noescape]] and [[clang::lifetimebound]] (upcoming).
+like verifying [[clang::noescape]] and [[clang::lifetimebound]].
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -624,12 +624,19 @@ Warning to detect invalidation of references.
   }];
 }
 
+def LifetimeSafetyLifetimeboundViolation : DiagGroup<"lifetime-safety-lifetimebound-violation"> {
+  code Documentation = [{
+Warning to detect lifetimebound violations introduced by marking parameter as lifetimebound but not actually returning it.
+  }];
+}
+
 def LifetimeSafetyPermissive : DiagGroup<"lifetime-safety-permissive",
                                          [LifetimeSafetyUseAfterScope,
                                          LifetimeSafetyReturnStackAddr,
                                          LifetimeSafetyDanglingField,
                                          LifetimeSafetyDanglingGlobal,
-                                         LifetimeSafetyUseAfterFree]>;
+                                         LifetimeSafetyUseAfterFree,
+                                         LifetimeSafetyLifetimeboundViolation]>;
 
 def LifetimeSafetyStrict : DiagGroup<"lifetime-safety-strict",
                                     [LifetimeSafetyPermissive,

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -626,8 +626,8 @@ Warning to detect invalidation of references.
 
 def LifetimeSafetyLifetimeboundViolation : DiagGroup<"lifetime-safety-lifetimebound-violation"> {
   code Documentation = [{
-Detects parameters marked as [[clang::lifetimebound]] for which we could not verify that the return value can be lifetime bound to them.
-This may contain false-positives, e.g. when we fail to track origin propagation for the return value.
+Detects parameters marked as [[clang::lifetimebound]] for which the analysis could not verify that the return value can be lifetime bound to the parameter.
+This warning may produce false-positives diagnostics when it cannot fully model the code.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -673,7 +673,8 @@ Detects misuse of [[clang::noescape]] annotation where the parameter escapes (fo
 }
 
 def LifetimeSafetyValidations : DiagGroup<"lifetime-safety-validations",
-                                          [LifetimeSafetyNoescape, LifetimeSafetyLifetimeboundViolation]> {
+                                          [LifetimeSafetyNoescape,
+                                           LifetimeSafetyLifetimeboundViolation]> {
   code Documentation = [{
 Verify function implementations adhere to the annotated lifetime contracts through lifetime safety
 like verifying [[clang::noescape]] and [[clang::lifetimebound]].

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -626,7 +626,8 @@ Warning to detect invalidation of references.
 
 def LifetimeSafetyLifetimeboundViolation : DiagGroup<"lifetime-safety-lifetimebound-violation"> {
   code Documentation = [{
-Detects parameters marked as [[clang::lifetimebound]] that do not escape through the return value.
+Detects parameters marked as [[clang::lifetimebound]] for which we could not verify that the return value can be lifetime bound to them.
+This may contain false-positives, e.g. when we fail to track origin propagation for the return value.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11004,7 +11004,7 @@ def warn_lifetime_safety_dangling_global_moved
       DefaultIgnore;
 
 def warn_lifetime_safety_param_lifetimebound_violation
-    : Warning<"parameter is marked as [[clang::lifetimebound]] but doesn't escape">,
+    : Warning<"parameter is marked as [[clang::lifetimebound]] but isn't returned">,
       InGroup<LifetimeSafetyLifetimeboundViolation>,
       DefaultIgnore;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11003,6 +11003,11 @@ def warn_lifetime_safety_dangling_global_moved
       InGroup<LifetimeSafetyDanglingGlobalMoved>,
       DefaultIgnore;
 
+def warn_lifetime_safety_param_lifetimebound_violation
+    : Warning<"parameter is marked as [[clang::lifetimebound]] but doesn't escape">,
+      InGroup<LifetimeSafetyLifetimeboundViolation>,
+      DefaultIgnore;
+
 def note_lifetime_safety_used_here : Note<"later used here">;
 def note_lifetime_safety_invalidated_here : Note<"invalidated here">;
 def note_lifetime_safety_destroyed_here : Note<"destroyed here">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11004,7 +11004,7 @@ def warn_lifetime_safety_dangling_global_moved
       DefaultIgnore;
 
 def warn_lifetime_safety_param_lifetimebound_violation
-    : Warning<"parameter is marked as [[clang::lifetimebound]] but isn't returned">,
+    : Warning<"could not verify that the return value can be lifetime bound to '%0'">,
       InGroup<LifetimeSafetyLifetimeboundViolation>,
       DefaultIgnore;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11004,7 +11004,7 @@ def warn_lifetime_safety_dangling_global_moved
       DefaultIgnore;
 
 def warn_lifetime_safety_param_lifetimebound_violation
-    : Warning<"could not verify that the return value can be lifetime bound to '%0'">,
+    : Warning<"could not verify that the return value can be lifetime bound to %select{an unnamed parameter|'%1'}0">,
       InGroup<LifetimeSafetyLifetimeboundViolation>,
       DefaultIgnore;
 

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -367,12 +367,13 @@ public:
       return;
     for (const ParmVarDecl *PVD : cast<FunctionDecl>(FD)->parameters()) {
       if (!PVD->hasAttr<LifetimeBoundAttr>())
-        return;
+        continue;
       if (!PVD->getAttr<LifetimeBoundAttr>()->isImplicit() &&
           !VerifiedLiftimeboundEscapes.contains(PVD))
         SemaHelper->reportLifetimeboundViolation(PVD);
     }
   }
+
   void inferAnnotations() {
     for (auto [Target, EscapeTarget] : AnnotationWarningsMap) {
       if (const auto *MD = Target.dyn_cast<const CXXMethodDecl *>()) {

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -60,6 +60,7 @@ private:
   llvm::DenseMap<LoanID, PendingWarning> FinalWarningsMap;
   llvm::DenseMap<AnnotationTarget, EscapingTarget> AnnotationWarningsMap;
   llvm::DenseMap<const ParmVarDecl *, EscapingTarget> NoescapeWarningsMap;
+  llvm::DenseSet<const ParmVarDecl *> VerifiedLiftimeboundEscapes;
   const LoanPropagationAnalysis &LoanPropagation;
   const MovedLoansAnalysis &MovedLoans;
   const LiveOriginsAnalysis &LiveOrigins;
@@ -101,6 +102,7 @@ public:
     issuePendingWarnings();
     suggestAnnotations();
     reportNoescapeViolations();
+    reportLifetimeboundViolations();
     //  Annotation inference is currently guarded by a frontend flag. In the
     //  future, this might be replaced by a design that differentiates between
     //  explicit and inferred findings with separate warning groups.
@@ -137,6 +139,8 @@ public:
         else if (auto *FieldEsc = dyn_cast<FieldEscapeFact>(OEF);
                  FieldEsc && isa<CXXConstructorDecl>(FD))
           AnnotationWarningsMap.try_emplace(PVD, FieldEsc->getFieldDecl());
+      } else {
+        VerifiedLiftimeboundEscapes.insert(PVD);
       }
       // TODO: Suggest lifetime_capture_by(this) for parameter escaping to a
       // field!
@@ -358,6 +362,17 @@ public:
     }
   }
 
+  void reportLifetimeboundViolations() {
+    if (!isa<FunctionDecl>(FD))
+      return;
+    for (const ParmVarDecl *PVD : cast<FunctionDecl>(FD)->parameters()) {
+      if (!PVD->hasAttr<LifetimeBoundAttr>())
+        return;
+      if (!PVD->getAttr<LifetimeBoundAttr>()->isImplicit() &&
+          !VerifiedLiftimeboundEscapes.contains(PVD))
+        SemaHelper->reportLifetimeboundViolation(PVD);
+    }
+  }
   void inferAnnotations() {
     for (auto [Target, EscapeTarget] : AnnotationWarningsMap) {
       if (const auto *MD = Target.dyn_cast<const CXXMethodDecl *>()) {

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -368,8 +368,11 @@ public:
     for (const ParmVarDecl *PVD : cast<FunctionDecl>(FD)->parameters()) {
       if (!PVD->hasAttr<LifetimeBoundAttr>())
         continue;
-      if (!PVD->getAttr<LifetimeBoundAttr>()->isImplicit() &&
-          !VerifiedLiftimeboundEscapes.contains(PVD))
+      bool isImplicit = PVD->getAttr<LifetimeBoundAttr>()->isImplicit();
+      bool Escapes = VerifiedLiftimeboundEscapes.contains(PVD);
+      if (isImplicit && !Escapes && !isInStlNamespace(FD))
+        assert(false && "Implicit lifetimebound parameters should be verified");
+      if (!isImplicit && !Escapes)
         SemaHelper->reportLifetimeboundViolation(PVD);
     }
   }

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -131,16 +131,17 @@ public:
       // obscures the lifetime relationship (e.g., shared_ptr from unique_ptr).
       if (IsMoved)
         return;
-      // Otherwise, suggest lifetimebound for parameter escaping through return
-      // or a field in constructor.
-      if (!PVD->hasAttr<LifetimeBoundAttr>()) {
+      if (PVD->hasAttr<LifetimeBoundAttr>()) {
+        // Track that this lifetimebound parameter correctly escapes.
+        VerifiedLiftimeboundEscapes.insert(PVD);
+      } else {
+        // Otherwise, suggest lifetimebound for parameter escaping through
+        // return or a field in constructor.
         if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
           AnnotationWarningsMap.try_emplace(PVD, ReturnEsc->getReturnExpr());
         else if (auto *FieldEsc = dyn_cast<FieldEscapeFact>(OEF);
                  FieldEsc && isa<CXXConstructorDecl>(FD))
           AnnotationWarningsMap.try_emplace(PVD, FieldEsc->getFieldDecl());
-      } else {
-        VerifiedLiftimeboundEscapes.insert(PVD);
       }
       // TODO: Suggest lifetime_capture_by(this) for parameter escaping to a
       // field!
@@ -370,8 +371,9 @@ public:
         continue;
       bool isImplicit = PVD->getAttr<LifetimeBoundAttr>()->isImplicit();
       bool Escapes = VerifiedLiftimeboundEscapes.contains(PVD);
-      if (isImplicit && !Escapes && !isInStlNamespace(FD))
-        assert(false && "Implicit lifetimebound parameters should be verified");
+      assert((!isImplicit || Escapes || isInStlNamespace(FD)) &&
+             "Implicit lifetimebound parameters "
+             "should escape through return");
       if (!isImplicit && !Escapes)
         SemaHelper->reportLifetimeboundViolation(PVD);
     }

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -35,7 +35,10 @@ inline bool IsLifetimeSafetyDiagnosticEnabled(Sema &S, const Decl *D) {
          !Diags.isIgnored(diag::warn_lifetime_safety_invalidation,
                           D->getBeginLoc()) ||
          !Diags.isIgnored(diag::warn_lifetime_safety_noescape_escapes,
-                          D->getBeginLoc());
+                          D->getBeginLoc()) ||
+         !Diags.isIgnored(
+             diag::warn_lifetime_safety_param_lifetimebound_violation,
+             D->getBeginLoc());
 }
 
 class LifetimeSafetySemaHelperImpl : public LifetimeSafetySemaHelper {

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -172,6 +172,13 @@ public:
           << EscapeField->getSourceRange();
   }
 
+  void reportLifetimeboundViolation(
+      const ParmVarDecl *ParmWithLifetimebound) override {
+    S.Diag(ParmWithLifetimebound->getLocation(),
+           diag::warn_lifetime_safety_param_lifetimebound_violation)
+        << ParmWithLifetimebound->getSourceRange();
+  }
+
   void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
                                           const CXXMethodDecl *MD,
                                           const Expr *EscapeExpr) override {

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -24,21 +24,24 @@ namespace clang::lifetimes {
 
 inline bool IsLifetimeSafetyDiagnosticEnabled(Sema &S, const Decl *D) {
   DiagnosticsEngine &Diags = S.getDiagnostics();
-  return !Diags.isIgnored(diag::warn_lifetime_safety_use_after_scope,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(diag::warn_lifetime_safety_use_after_scope_moved,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(diag::warn_lifetime_safety_return_stack_addr,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(diag::warn_lifetime_safety_return_stack_addr_moved,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(diag::warn_lifetime_safety_invalidation,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(diag::warn_lifetime_safety_noescape_escapes,
-                          D->getBeginLoc()) ||
-         !Diags.isIgnored(
-             diag::warn_lifetime_safety_param_lifetimebound_violation,
-             D->getBeginLoc());
+  constexpr unsigned DiagIDs[] = {
+      diag::warn_lifetime_safety_use_after_scope,
+      diag::warn_lifetime_safety_use_after_scope_moved,
+      diag::warn_lifetime_safety_use_after_free,
+      diag::warn_lifetime_safety_return_stack_addr,
+      diag::warn_lifetime_safety_return_stack_addr_moved,
+      diag::warn_lifetime_safety_invalidation,
+      diag::warn_lifetime_safety_dangling_field,
+      diag::warn_lifetime_safety_dangling_field_moved,
+      diag::warn_lifetime_safety_dangling_global,
+      diag::warn_lifetime_safety_dangling_global_moved,
+      diag::warn_lifetime_safety_noescape_escapes,
+      diag::warn_lifetime_safety_param_lifetimebound_violation,
+  };
+  for (unsigned DiagID : DiagIDs)
+    if (!Diags.isIgnored(DiagID, D->getBeginLoc()))
+      return true;
+  return false;
 }
 
 class LifetimeSafetySemaHelperImpl : public LifetimeSafetySemaHelper {
@@ -177,10 +180,11 @@ public:
 
   void reportLifetimeboundViolation(
       const ParmVarDecl *ParmWithLifetimebound) override {
+    StringRef ParamName = ParmWithLifetimebound->getName();
+    bool HasName = ParamName.size() > 0;
     S.Diag(ParmWithLifetimebound->getLocation(),
            diag::warn_lifetime_safety_param_lifetimebound_violation)
-        << ParmWithLifetimebound->getName()
-        << ParmWithLifetimebound->getSourceRange();
+        << HasName << ParamName << ParmWithLifetimebound->getSourceRange();
   }
 
   void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -179,6 +179,7 @@ public:
       const ParmVarDecl *ParmWithLifetimebound) override {
     S.Diag(ParmWithLifetimebound->getLocation(),
            diag::warn_lifetime_safety_param_lifetimebound_violation)
+        << ParmWithLifetimebound->getName()
         << ParmWithLifetimebound->getSourceRange();
   }
 

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -1,0 +1,80 @@
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-all -verify %s
+
+#include "Inputs/lifetime-analysis.h"
+
+struct [[gsl::Owner]] MyObj {
+  int id;
+  ~MyObj() {}  // Non-trivial destructor
+};
+
+struct [[gsl::Pointer()]] View {
+  View(const MyObj &); // Borrows from MyObj
+  View();
+  void use() const;
+};
+
+bool cond();
+
+View not_lb(const MyObj &obj);
+
+View lb(const MyObj &obj [[clang::lifetimebound]]);
+
+View return_through_unannotated_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  return not_lb(obj);
+}
+
+View return_through_lifetimebound_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return lb(obj);
+}
+
+View lb2(const MyObj &obj [[clang::lifetimebound]]) {
+  return lb(obj);
+}
+
+View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  return not_lb(obj);
+}
+
+View return_through_alias(const MyObj &obj [[clang::lifetimebound]]) {
+  const MyObj &alias = obj;
+  return alias;
+}
+
+View return_alias_through_unannotated_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  const MyObj &alias = obj;
+  return not_lb(alias);
+}
+
+View return_through_two_lifetimebound_calls(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return lb2(obj);
+}
+
+View not_lb_view(View v);
+
+View lb_view(View v [[clang::lifetimebound]]);
+
+View return_through_nested_broken_chain(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  return not_lb_view(lb_view(View(obj)));
+}
+
+View return_constructed_view_through_unannotated_forwarder(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  return not_lb_view(View(obj));
+}
+
+View return_constructed_view_through_lifetimebound_forwarder(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return lb_view(View(obj));
+}
+
+View verify_each_annotated_param_independently(
+    const MyObj &a [[clang::lifetimebound]],
+    const MyObj &b [[clang::lifetimebound]], // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  return cond() ? a : not_lb(b);
+}

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-all -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-lifetimebound-violation -verify %s
 
 #include "Inputs/lifetime-analysis.h"
 

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -20,7 +20,7 @@ View not_lb(const MyObj &obj);
 View lb(const MyObj &obj [[clang::lifetimebound]]);
 
 View return_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   return not_lb(obj);
 }
 
@@ -33,7 +33,7 @@ View lb2(const MyObj &obj [[clang::lifetimebound]]) {
   return lb(obj);
 }
 
-View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   return not_lb(obj);
 }
 
@@ -43,7 +43,7 @@ View return_through_alias(const MyObj &obj [[clang::lifetimebound]]) {
 }
 
 View return_alias_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   const MyObj &alias = obj;
   return not_lb(alias);
 }
@@ -58,12 +58,12 @@ View not_lb_view(View v);
 View lb_view(View v [[clang::lifetimebound]]);
 
 View return_through_nested_broken_chain(
-    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   return not_lb_view(lb_view(View(obj)));
 }
 
 View return_constructed_view_through_unannotated_forwarder(
-    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   return not_lb_view(View(obj));
 }
 
@@ -74,7 +74,7 @@ View return_constructed_view_through_lifetimebound_forwarder(
 
 View verify_each_annotated_param_independently(
     const MyObj &a [[clang::lifetimebound]],
-    const MyObj &b [[clang::lifetimebound]], // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &b [[clang::lifetimebound]], // expected-warning {{could not verify that the return value can be lifetime bound to 'b'}}
+    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'c'}}
   return cond() ? a : not_lb(b);
 }

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -29,10 +29,6 @@ View return_through_lifetimebound_passthrough(
   return lb(obj);
 }
 
-View lb2(const MyObj &obj [[clang::lifetimebound]]) {
-  return lb(obj);
-}
-
 View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
   return not_lb(obj);
 }
@@ -48,14 +44,15 @@ View return_alias_through_unannotated_passthrough(
   return not_lb(alias);
 }
 
-View return_through_two_lifetimebound_calls(
-    const MyObj &obj [[clang::lifetimebound]]) {
-  return lb2(obj);
-}
-
 View not_lb_view(View v);
 
 View lb_view(View v [[clang::lifetimebound]]);
+
+
+View return_through_two_lifetimebound_calls(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return lb_view(lb(obj));
+}
 
 View return_through_nested_broken_chain(
     const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
@@ -77,4 +74,16 @@ View verify_each_annotated_param_independently(
     const MyObj &b [[clang::lifetimebound]], // expected-warning {{could not verify that the return value can be lifetime bound to 'b'}}
     const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'c'}}
   return cond() ? a : not_lb(b);
+}
+
+View unnamed_lifetimebound_param(
+    [[clang::lifetimebound]] const MyObj &) { // expected-warning {{could not verify that the return value can be lifetime bound to an unnamed parameter}}
+  return View();
+}
+
+// FIXME: Should warn on declaration, not definiton
+View annotated_decl_but_not_def_not_returned(const MyObj &obj [[clang::lifetimebound]]);
+
+View annotated_decl_but_not_def_not_returned(const MyObj &obj) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
+  return not_lb(obj);
 }

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3269,7 +3269,7 @@ void uaf_via_lifetimebound() {
 namespace GH126600 {
 struct [[gsl::Pointer]] function_ref {
   template <typename Callable>
-  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {} // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {}
   void (*ref)();
 };
 
@@ -3279,80 +3279,8 @@ struct [[gsl::Pointer]] function_ref {
 // avoid this warning for non-capturing lambdas.
 void assign_non_capturing_to_function_ref(function_ref &r) {
   r = []() {}; // expected-warning {{object whose reference is captured does not live long enough}} \
-               // expected-note {{destroyed here}} function-note {{requested here}}
+               // expected-note {{destroyed here}}
   (void)r; // expected-note {{later used here}}
 }
 
 } // namespace GH126600
-
-namespace LifetimeboundReturnVerification {
-
-bool cond();
-
-View drop_lb(const MyObj &obj) { return obj; }
-
-View keep_lb(const MyObj &obj [[clang::lifetimebound]]) {
-  return obj;
-}
-
-View return_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  return drop_lb(obj);
-}
-
-View return_through_lifetimebound_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) {
-  return keep_lb(obj);
-}
-
-View keep_lb2(const MyObj &obj [[clang::lifetimebound]]) {
-  return keep_lb(obj);
-}
-
-View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  return drop_lb(obj);
-}
-
-View return_through_alias(const MyObj &obj [[clang::lifetimebound]]) {
-  const MyObj &alias = obj;
-  return alias;
-}
-
-View return_alias_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  const MyObj &alias = obj;
-  return drop_lb(alias);
-}
-
-View return_through_two_lifetimebound_calls(
-    const MyObj &obj [[clang::lifetimebound]]) {
-  return keep_lb2(obj);
-}
-
-View fwd_view(View v) { return v; }
-
-View fwd_view_lb(View v [[clang::lifetimebound]]) { return v; }
-
-View return_through_nested_broken_chain(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  return fwd_view(fwd_view_lb(View(obj)));
-}
-
-View return_constructed_view_through_unannotated_forwarder(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  return fwd_view(View(obj));
-}
-
-View return_constructed_view_through_lifetimebound_forwarder(
-    const MyObj &obj [[clang::lifetimebound]]) {
-  return fwd_view_lb(View(obj));
-}
-
-View verify_each_annotated_param_independently(
-    const MyObj &a [[clang::lifetimebound]],
-    const MyObj &b [[clang::lifetimebound]], // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
-  return cond() ? a : drop_lb(b);
-}
-
-} // namespace LifetimeboundReturnVerification

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3329,14 +3329,14 @@ View return_through_two_lifetimebound_calls(
   return keep_lb2(obj);
 }
 
-View return_through_broken_chain(
-    const MyObj &obj [[clang::lifetimebound]]) {
-  return lose_lb(obj);
-}
-
 View fwd_view(View v) { return v; }
 
 View fwd_view_lb(View v [[clang::lifetimebound]]) { return v; }
+
+View return_through_nested_broken_chain(
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  return fwd_view(fwd_view_lb(View(obj)));
+}
 
 View return_constructed_view_through_unannotated_forwarder(
     const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3269,7 +3269,7 @@ void uaf_via_lifetimebound() {
 namespace GH126600 {
 struct [[gsl::Pointer]] function_ref {
   template <typename Callable>
-  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {} // expected-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {} // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   void (*ref)();
 };
 
@@ -3296,7 +3296,7 @@ View keep_lb(const MyObj &obj [[clang::lifetimebound]]) {
 }
 
 View return_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   return drop_lb(obj);
 }
 
@@ -3309,7 +3309,7 @@ View keep_lb2(const MyObj &obj [[clang::lifetimebound]]) {
   return keep_lb(obj);
 }
 
-View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   return drop_lb(obj);
 }
 
@@ -3319,7 +3319,7 @@ View return_through_alias(const MyObj &obj [[clang::lifetimebound]]) {
 }
 
 View return_alias_through_unannotated_passthrough(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   const MyObj &alias = obj;
   return drop_lb(alias);
 }
@@ -3334,12 +3334,12 @@ View fwd_view(View v) { return v; }
 View fwd_view_lb(View v [[clang::lifetimebound]]) { return v; }
 
 View return_through_nested_broken_chain(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   return fwd_view(fwd_view_lb(View(obj)));
 }
 
 View return_constructed_view_through_unannotated_forwarder(
-    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   return fwd_view(View(obj));
 }
 
@@ -3350,8 +3350,8 @@ View return_constructed_view_through_lifetimebound_forwarder(
 
 View verify_each_annotated_param_independently(
     const MyObj &a [[clang::lifetimebound]],
-    const MyObj &b [[clang::lifetimebound]], // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
-    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &b [[clang::lifetimebound]], // function-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
+    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but isn't returned}}
   return cond() ? a : drop_lb(b);
 }
 

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3284,3 +3284,75 @@ void assign_non_capturing_to_function_ref(function_ref &r) {
 }
 
 } // namespace GH126600
+
+namespace LifetimeboundReturnVerification {
+
+bool cond();
+
+View drop_lb(const MyObj &obj) { return obj; }
+
+View keep_lb(const MyObj &obj [[clang::lifetimebound]]) {
+  return obj;
+}
+
+View return_through_unannotated_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  return drop_lb(obj);
+}
+
+View return_through_lifetimebound_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return keep_lb(obj);
+}
+
+View keep_lb2(const MyObj &obj [[clang::lifetimebound]]) {
+  return keep_lb(obj);
+}
+
+View lose_lb(const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  return drop_lb(obj);
+}
+
+View return_through_alias(const MyObj &obj [[clang::lifetimebound]]) {
+  const MyObj &alias = obj;
+  return alias;
+}
+
+View return_alias_through_unannotated_passthrough(
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  const MyObj &alias = obj;
+  return drop_lb(alias);
+}
+
+View return_through_two_lifetimebound_calls(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return keep_lb2(obj);
+}
+
+View return_through_broken_chain(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return lose_lb(obj);
+}
+
+View fwd_view(View v) { return v; }
+
+View fwd_view_lb(View v [[clang::lifetimebound]]) { return v; }
+
+View return_constructed_view_through_unannotated_forwarder(
+    const MyObj &obj [[clang::lifetimebound]]) { // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  return fwd_view(View(obj));
+}
+
+View return_constructed_view_through_lifetimebound_forwarder(
+    const MyObj &obj [[clang::lifetimebound]]) {
+  return fwd_view_lb(View(obj));
+}
+
+View verify_each_annotated_param_independently(
+    const MyObj &a [[clang::lifetimebound]],
+    const MyObj &b [[clang::lifetimebound]], // function-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+    const MyObj &c [[clang::lifetimebound]]) { // expected-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
+  return cond() ? a : drop_lb(b);
+}
+
+} // namespace LifetimeboundReturnVerification

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -3269,7 +3269,7 @@ void uaf_via_lifetimebound() {
 namespace GH126600 {
 struct [[gsl::Pointer]] function_ref {
   template <typename Callable>
-  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {}
+  function_ref(Callable &&callable [[clang::lifetimebound]]) : ref(callable) {} // expected-warning {{parameter is marked as [[clang::lifetimebound]] but doesn't escape}}
   void (*ref)();
 };
 
@@ -3279,7 +3279,7 @@ struct [[gsl::Pointer]] function_ref {
 // avoid this warning for non-capturing lambdas.
 void assign_non_capturing_to_function_ref(function_ref &r) {
   r = []() {}; // expected-warning {{object whose reference is captured does not live long enough}} \
-               // expected-note {{destroyed here}}
+               // expected-note {{destroyed here}} function-note {{requested here}}
   (void)r; // expected-note {{later used here}}
 }
 


### PR DESCRIPTION
Adds new warning that is emitted when parameter is marked as `[[clang::lifetimebound]]` but is not returned in one way or another (tracked via `OriginEscapeFact`).

Closes #182935