### PR TITLE
[clang][test] Make libclang CrashTests use threadsafe gtest death-test style

### DIFF
--- a/clang/unittests/libclang/CrashTests/LibclangCrashTest.cpp
+++ b/clang/unittests/libclang/CrashTests/LibclangCrashTest.cpp
@@ -12,6 +12,11 @@
 #include <string>
 
 TEST_F(LibclangParseTest, InstallAbortingLLVMFatalErrorHandler) {
+  // gtest death-tests execute in a sub-process (fork), which invalidates
+  // any signpost handles and would cause spurious crashes if used. Use the
+  // "threadsafe" style of death-test to work around this.
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+
   clang_toggleCrashRecovery(0);
   clang_install_aborting_llvm_fatal_error_handler();
 
@@ -24,6 +29,11 @@ TEST_F(LibclangParseTest, InstallAbortingLLVMFatalErrorHandler) {
 }
 
 TEST_F(LibclangParseTest, UninstallAbortingLLVMFatalErrorHandler) {
+  // gtest death-tests execute in a sub-process (fork), which invalidates
+  // any signpost handles and would cause spurious crashes if used. Use the
+  // "threadsafe" style of death-test to work around this.
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+
   clang_toggleCrashRecovery(0);
   clang_install_aborting_llvm_fatal_error_handler();
   clang_uninstall_llvm_fatal_error_handler();


### PR DESCRIPTION
The EXPECT_DEATH calls in LibclangCrashTest.cpp can occasionally crash on
macOS CI with the following stack:

  Result: died but not with expected error.
    Expected: contains regular expression "ERROR"
  [ DEATH ]  0  libclangCrashTests       llvm::sys::PrintStackTrace
  [ DEATH ]  2  libclangCrashTests       SignalHandler
  [ DEATH ]  3  libsystem_platform.dylib _sigtramp
  [ DEATH ]  4  libsystem_trace.dylib    _os_log_find
  [ DEATH ]  5  libsystem_trace.dylib    os_log_create
  [ DEATH ]  6  libclang.dylib           llvm::SignpostEmitter::SignpostEmitter
  [ DEATH ]  7  libclang.dylib           llvm::TimerGlobals::TimerGlobals
  [ DEATH ] 13  libclang.dylib           clang::SourceManager::SourceManager

Switch both death-tests in LibclangCrashTest.cpp to the "threadsafe"
style, which re-execs the unit-test binary for the child and therefore
starts from a fresh libsystem_trace state. This matches the mitigation
applied to LLDB's MemoryDeathTest in cb6dd90d2871 / #181127.

rdar://176052229
