### PR TITLE
[libc] cmake and config for wchar file entrypoints

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -396,6 +396,17 @@ set(TARGET_LIBC_ENTRYPOINTS
     # wchar.h entrypoints
     libc.src.wchar.wcslen
     libc.src.wchar.wctob
+    libc.src.wchar.fgetwc
+    libc.src.wchar.fgetws
+    libc.src.wchar.fputwc
+    libc.src.wchar.fputws
+    libc.src.wchar.fwide
+    libc.src.wchar.getwc
+    libc.src.wchar.getwchar
+    libc.src.wchar.putwc
+    libc.src.wchar.putwchar
+    libc.src.wchar.ungetwc
+
 
     # wctype.h entrypoints
     libc.src.wctype.iswalpha

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -400,6 +400,17 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.btowc
     libc.src.wchar.wcslen
     libc.src.wchar.wctob
+    libc.src.wchar.fgetwc
+    libc.src.wchar.fgetws
+    libc.src.wchar.fputwc
+    libc.src.wchar.fputws
+    libc.src.wchar.fwide
+    libc.src.wchar.getwc
+    libc.src.wchar.getwchar
+    libc.src.wchar.putwc
+    libc.src.wchar.putwchar
+    libc.src.wchar.ungetwc
+
 
     # wctype.h entrypoints
     libc.src.wctype.iswalpha

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -452,6 +452,17 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.wcstoll
     libc.src.wchar.wcstoul
     libc.src.wchar.wcstoull
+    libc.src.wchar.fgetwc
+    libc.src.wchar.fgetws
+    libc.src.wchar.fputwc
+    libc.src.wchar.fputws
+    libc.src.wchar.fwide
+    libc.src.wchar.getwc
+    libc.src.wchar.getwchar
+    libc.src.wchar.putwc
+    libc.src.wchar.putwchar
+    libc.src.wchar.ungetwc
+
 
     # wctype.h entrypoints
     libc.src.wctype.iswalpha

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -369,3 +369,71 @@ functions:
       - type: wchar_t *__restrict
       - type: const wchar_t *__restrict
       - type: size_t
+  - name: fgetwc
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: FILE *
+  - name: fgetws
+    standards:
+      - stdc
+    return_type: wchar_t *
+    arguments:
+      - type: wchar_t *__restrict
+      - type: int
+      - type: FILE *__restrict
+  - name: fputwc
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: wchar_t
+      - type: FILE *
+  - name: fputws
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: const wchar_t *__restrict
+      - type: FILE *__restrict
+  - name: fwide
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: FILE *
+      - type: int
+  - name: getwc
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: FILE *
+  - name: getwchar
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: void
+  - name: putwc
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: wchar_t
+      - type: FILE *
+  - name: putwchar
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: wchar_t
+  - name: ungetwc
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: wint_t
+      - type: FILE *
+

--- a/libc/src/stdio/generic/fgets.cpp
+++ b/libc/src/stdio/generic/fgets.cpp
@@ -29,6 +29,8 @@ LLVM_LIBC_FUNCTION(char *, fgets,
   // i is an int because it's frequently compared to count, which is also int.
   int i = 0;
 
+  // TODO: rewrite this logic. If there's an error it should return nullptr. See
+  // fgetws for example.
   for (; i < (count - 1) && c != '\n'; ++i) {
     auto result = stream->read_unlocked(&c, 1);
     size_t r = result.value;

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -557,12 +557,159 @@ add_entrypoint_object(
 add_entrypoint_object(
   wcsxfrm
   SRCS
-    wcsxfrm.cpp
+  wcsxfrm.cpp
   HDRS
-    wcsxfrm.h
+  wcsxfrm.h
   DEPENDS
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
     libc.src.__support.macros.config
     libc.src.__support.common
 )
+
+add_entrypoint_object(
+  fwide
+  SRCS
+    fwide.cpp
+  HDRS
+    fwide.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.src.__support.File.file
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  fputwc
+  SRCS
+    fputwc.cpp
+  HDRS
+    fputwc.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wint_t
+    libc.hdr.types.wchar_t
+    libc.hdr.wchar_macros
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  fgetwc
+  SRCS
+    fgetwc.cpp
+  HDRS
+    fgetwc.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wint_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  fputws
+  SRCS
+    fputws.cpp
+  HDRS
+    fputws.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wchar_t
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.string.string_utils
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  fgetws
+  SRCS
+    fgetws.cpp
+  HDRS
+    fgetws.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wchar_t
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  ungetwc
+  SRCS
+    ungetwc.cpp
+  HDRS
+    ungetwc.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wint_t
+    libc.src.__support.File.file
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  getwc
+  SRCS
+    getwc.cpp
+  HDRS
+    getwc.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wint_t
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  getwchar
+  SRCS
+    getwchar.cpp
+  HDRS
+    getwchar.h
+  DEPENDS
+    libc.src.stdio.stdin
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+)
+
+add_entrypoint_object(
+  putwc
+  SRCS
+    putwc.cpp
+  HDRS
+    putwc.h
+  DEPENDS
+    libc.hdr.types.FILE
+    libc.hdr.types.wint_t
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+    libc.src.__support.macros.null_check
+)
+
+add_entrypoint_object(
+  putwchar
+  SRCS
+    putwchar.cpp
+  HDRS
+    putwchar.h
+  DEPENDS
+    libc.src.stdio.stdout
+    libc.src.__support.File.file
+    libc.src.__support.libc_errno
+)
+
+
+
+
+
+
+
+
+
+

--- a/libc/src/wchar/fgetwc.cpp
+++ b/libc/src/wchar/fgetwc.cpp
@@ -1,0 +1,34 @@
+//===-- Implementation of fgetwc ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/fgetwc.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, fgetwc, (::FILE * stream)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+  auto *f = reinterpret_cast<File *>(stream);
+  wchar_t wc;
+  FileIOResult result = f->read(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/fgetwc.h
+++ b/libc/src/wchar/fgetwc.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for fgetwc ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_FGETWC_H
+#define LLVM_LIBC_SRC_WCHAR_FGETWC_H
+
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t fgetwc(::FILE *stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_FGETWC_H

--- a/libc/src/wchar/fgetws.cpp
+++ b/libc/src/wchar/fgetws.cpp
@@ -1,0 +1,63 @@
+//===-- Implementation of fgetws ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/fgetws.h"
+#include "hdr/types/FILE.h"
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wchar_t *, fgetws,
+                   (wchar_t *__restrict ws, int count,
+                    ::FILE *__restrict stream)) {
+  if (count <= 0)
+    return nullptr;
+
+  LIBC_CRASH_ON_NULLPTR(ws);
+  LIBC_CRASH_ON_NULLPTR(stream);
+
+  auto *f = reinterpret_cast<File *>(stream);
+
+  if (count == 1) {
+    ws[0] = L'\0';
+    return ws;
+  }
+
+  f->lock();
+
+  wchar_t *result = ws;
+  int chars_read = 0;
+  wchar_t c = L'\0';
+
+  for (; chars_read < count - 1 && c != '\n'; ++chars_read) {
+    auto read_res = f->read_unlocked(&c, 1);
+    if (read_res.has_error()) {
+      libc_errno = read_res.error;
+      result = nullptr;
+      break;
+    }
+    if (read_res.value < 1) {
+      if (chars_read == 0)
+        result = nullptr;
+      break;
+    }
+    ws[chars_read] = c;
+  }
+
+  if (result != nullptr)
+    ws[chars_read] = L'\0';
+
+  f->unlock();
+  return result;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/fgetws.h
+++ b/libc/src/wchar/fgetws.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for fgetws ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_FGETWS_H
+#define LLVM_LIBC_SRC_WCHAR_FGETWS_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wchar_t *fgetws(wchar_t *__restrict str, int count, ::FILE *__restrict stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_FGETWS_H

--- a/libc/src/wchar/fputwc.cpp
+++ b/libc/src/wchar/fputwc.cpp
@@ -1,0 +1,33 @@
+//===-- Implementation of fputwc ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/fputwc.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, fputwc, (wchar_t wc, ::FILE *stream)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+  auto *f = reinterpret_cast<File *>(stream);
+  FileIOResult result = f->write(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/fputwc.h
+++ b/libc/src/wchar/fputwc.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for fputwc ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_FPUTWC_H
+#define LLVM_LIBC_SRC_WCHAR_FPUTWC_H
+
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t fputwc(wchar_t wc, ::FILE *stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_FPUTWC_H

--- a/libc/src/wchar/fputws.cpp
+++ b/libc/src/wchar/fputws.cpp
@@ -1,0 +1,38 @@
+//===-- Implementation of fputws ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/fputws.h"
+#include "hdr/types/FILE.h"
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+#include "src/string/string_length.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, fputws,
+                   (const wchar_t *__restrict str, ::FILE *__restrict stream)) {
+  LIBC_CRASH_ON_NULLPTR(str);
+  LIBC_CRASH_ON_NULLPTR(stream);
+
+  size_t len = internal::string_length(str);
+
+  auto *f = reinterpret_cast<File *>(stream);
+  FileIOResult result = f->write(str, len);
+  if (result.has_error() || result.value < len) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return -1;
+  }
+
+  return static_cast<int>(result.value);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/fputws.h
+++ b/libc/src/wchar/fputws.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for fputws ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_FPUTWS_H
+#define LLVM_LIBC_SRC_WCHAR_FPUTWS_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int fputws(const wchar_t *__restrict str, ::FILE *__restrict stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_FPUTWS_H

--- a/libc/src/wchar/fwide.cpp
+++ b/libc/src/wchar/fwide.cpp
@@ -1,0 +1,38 @@
+//===-- Implementation of fwide -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/fwide.h"
+#include "hdr/types/FILE.h"
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, fwide, (::FILE * stream, int mode)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+  auto *f = reinterpret_cast<File *>(stream);
+
+  File::Orientation orient;
+  if (mode > 0) {
+    orient = f->try_set_orientation(File::Orientation::WIDE);
+  } else if (mode < 0) {
+    orient = f->try_set_orientation(File::Orientation::BYTE);
+  } else {
+    orient = f->get_orientation();
+  }
+
+  if (orient == File::Orientation::WIDE)
+    return 1;
+  if (orient == File::Orientation::BYTE)
+    return -1;
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/fwide.h
+++ b/libc/src/wchar/fwide.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for fwide -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_FWIDE_H
+#define LLVM_LIBC_SRC_WCHAR_FWIDE_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int fwide(::FILE *stream, int mode);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_FWIDE_H

--- a/libc/src/wchar/getwc.cpp
+++ b/libc/src/wchar/getwc.cpp
@@ -1,0 +1,34 @@
+//===-- Implementation of getwc -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/getwc.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, getwc, (::FILE * stream)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+  auto *f = reinterpret_cast<File *>(stream);
+  wchar_t wc;
+  FileIOResult result = f->read(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/getwc.h
+++ b/libc/src/wchar/getwc.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for getwc -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_GETWC_H
+#define LLVM_LIBC_SRC_WCHAR_GETWC_H
+
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t getwc(::FILE *stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_GETWC_H

--- a/libc/src/wchar/getwchar.cpp
+++ b/libc/src/wchar/getwchar.cpp
@@ -1,0 +1,33 @@
+//===-- Implementation of getwchar ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/getwchar.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/stdio/stdin.h" // For stdin
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, getwchar, ()) {
+  auto *f = reinterpret_cast<File *>(LIBC_NAMESPACE::stdin);
+  wchar_t wc;
+  FileIOResult result = f->read(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/getwchar.h
+++ b/libc/src/wchar/getwchar.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for getwchar --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_GETWCHAR_H
+#define LLVM_LIBC_SRC_WCHAR_GETWCHAR_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t getwchar();
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_GETWCHAR_H

--- a/libc/src/wchar/putwc.cpp
+++ b/libc/src/wchar/putwc.cpp
@@ -1,0 +1,33 @@
+//===-- Implementation of putwc -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/putwc.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, putwc, (wchar_t wc, ::FILE *stream)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+  auto *f = reinterpret_cast<File *>(stream);
+  FileIOResult result = f->write(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/putwc.h
+++ b/libc/src/wchar/putwc.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for putwc -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_PUTWC_H
+#define LLVM_LIBC_SRC_WCHAR_PUTWC_H
+
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t putwc(wchar_t wc, ::FILE *stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_PUTWC_H

--- a/libc/src/wchar/putwchar.cpp
+++ b/libc/src/wchar/putwchar.cpp
@@ -1,0 +1,32 @@
+//===-- Implementation of putwchar ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/putwchar.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/stdio/stdout.h" // For stdout
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, putwchar, (wchar_t wc)) {
+  auto *f = reinterpret_cast<File *>(LIBC_NAMESPACE::stdout);
+  FileIOResult result = f->write(&wc, 1);
+  if (result.has_error() || result.value < 1) {
+    if (result.has_error())
+      libc_errno = result.error;
+    return WEOF;
+  }
+  return static_cast<wint_t>(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/putwchar.h
+++ b/libc/src/wchar/putwchar.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for putwchar --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_PUTWCHAR_H
+#define LLVM_LIBC_SRC_WCHAR_PUTWCHAR_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t putwchar(wchar_t wc);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_PUTWCHAR_H

--- a/libc/src/wchar/ungetwc.cpp
+++ b/libc/src/wchar/ungetwc.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of ungetwc -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/ungetwc.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/File/file.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, ungetwc, (wint_t wc, ::FILE *stream)) {
+  LIBC_CRASH_ON_NULLPTR(stream);
+
+  auto *f = reinterpret_cast<File *>(stream);
+  return f->ungetwc(wc);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/ungetwc.h
+++ b/libc/src/wchar/ungetwc.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for ungetwc ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_UNGETWC_H
+#define LLVM_LIBC_SRC_WCHAR_UNGETWC_H
+
+#include "hdr/types/FILE.h"
+#include "hdr/types/wint_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t ungetwc(wint_t wc, ::FILE *stream);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_UNGETWC_H

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -537,3 +537,191 @@ add_libc_unittest(
   DEPENDS
     libc.src.wchar.wcsxfrm
 )
+
+add_libc_test(
+  fwide_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    fwide_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.wchar.fwide
+)
+
+add_libc_test(
+  fputwc_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    fputwc_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fread
+    libc.src.stdio.fwrite
+    libc.src.stdio.ferror
+    libc.src.wchar.fputwc
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  fgetwc_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    fgetwc_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.feof
+    libc.src.stdio.ferror
+    libc.src.stdio.fwrite
+    libc.src.wchar.fgetwc
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  fputws_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    fputws_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fread
+    libc.src.stdio.ferror
+    libc.src.wchar.fputws
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  fgetws_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    fgetws_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fwrite
+    libc.src.stdio.ferror
+    libc.src.wchar.fgetws
+    libc.src.wchar.fwide
+    libc.src.wchar.wcscmp
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  ungetwc_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    ungetwc_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fwrite
+    libc.src.stdio.feof
+    libc.src.stdio.ferror
+    libc.src.stdio.fseek
+    libc.src.wchar.fgetwc
+    libc.src.wchar.fwide
+    libc.src.wchar.ungetwc
+)
+
+add_libc_test(
+  getwc_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    getwc_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fwrite
+    libc.src.stdio.feof
+    libc.src.stdio.ferror
+    libc.src.wchar.getwc
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  getwchar_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    getwchar_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fwrite
+    libc.src.stdio.feof
+    libc.src.stdio.ferror
+    libc.src.stdio.stdin
+    libc.src.wchar.getwchar
+    libc.src.wchar.fwide
+    libc.src.wchar.ungetwc
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  putwc_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    putwc_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fread
+    libc.src.stdio.ferror
+    libc.src.wchar.putwc
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  putwchar_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    putwchar_test.cpp
+  DEPENDS
+    libc.include.stdio
+    libc.src.stdio.fopen
+    libc.src.stdio.fclose
+    libc.src.stdio.fread
+    libc.src.stdio.ferror
+    libc.src.stdio.stdout
+    libc.src.wchar.putwchar
+    libc.src.wchar.fwide
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/libc/test/src/wchar/fgetwc_test.cpp
+++ b/libc/test/src/wchar/fgetwc_test.cpp
@@ -1,0 +1,145 @@
+//===-- Unittests for fgetwc ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/feof.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fwrite.h"
+#include "src/wchar/fgetwc.h"
+#include "src/wchar/fwide.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcFgetwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcFgetwcTest, ReadASCII) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_ascii.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "abc"
+  constexpr char CONTENT[] = "abc";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'b'));
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'c'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwcTest, ReadUtf8) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_utf8.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "a¢€𐍈"
+  // a   -> 0x61 (1-byte)
+  // ¢   -> 0xC2 0xA2 (2-byte)
+  // €   -> 0xE2 0x82 0xAC (3-byte)
+  // 𐍈   -> 0xF0 0x90 0x8D 0x88 (4-byte)
+  constexpr unsigned char CONTENT[] = {0x61, 0xC2, 0xA2, 0xE2, 0x82,
+                                       0xAC, 0xF0, 0x90, 0x8D, 0x88};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'𐍈'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwcTest, EOFAndInvalidStream) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_eof.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write nothing, just close
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // EOF Test
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(WEOF));
+  EXPECT_NE(LIBC_NAMESPACE::feof(file), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open in write-only mode and try to read
+  file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwcTest, EncodingErrorEILSEQ) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_eilseq.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write an invalid UTF-8 sequence: 0x80 (stray continuation byte)
+  constexpr unsigned char CONTENT[] = {0x80};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Reading invalid sequence should fail with EILSEQ
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EILSEQ);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwcTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetwc_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Read wide char should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/fgetws_test.cpp
+++ b/libc/test/src/wchar/fgetws_test.cpp
@@ -1,0 +1,181 @@
+//===-- Unittests for fgetws ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/types/wint_t.h"
+#include "src/stdio/fclose.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fwrite.h"
+#include "src/wchar/fgetws.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/wcscmp.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcFgetwsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+// TODO: Refactor these tests to use standard wide-character string comparison
+// assert macros (e.g., EXPECT_STREQ for wchar_t) once they are supported
+// natively by the LLVM-libc test framework, instead of calling wcscmp.
+TEST_F(LlvmLibcFgetwsTest, ReadWideString) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_string.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write UTF-8 bytes for: "Hello, ¢€𐍈 world!\n"
+  constexpr unsigned char CONTENT[] = {
+      'H',  'e',  'l',  'l',  'o', ',', ' ', 0xC2, 0xA2, 0xE2, 0x82, 0xAC,
+      0xF0, 0x90, 0x8D, 0x88, ' ', 'w', 'o', 'r',  'l',  'd',  '!',  '\n'};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  wchar_t buffer[50] = {0};
+  wchar_t *result = LIBC_NAMESPACE::fgetws(buffer, 50, file);
+  ASSERT_FALSE(result == nullptr);
+  EXPECT_EQ(result, buffer);
+  EXPECT_EQ(LIBC_NAMESPACE::wcscmp(buffer, L"Hello, ¢€𐍈 world!\n"), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwsTest, ReadBounded) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_bounded.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "1234567890"
+  constexpr char CONTENT[] = "1234567890";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  wchar_t buffer[10] = {0};
+  // Read bounded by count = 5 (4 chars + null terminator)
+  wchar_t *result = LIBC_NAMESPACE::fgetws(buffer, 5, file);
+  ASSERT_FALSE(result == nullptr);
+  EXPECT_EQ(result, buffer);
+  EXPECT_EQ(LIBC_NAMESPACE::wcscmp(buffer, L"1234"), 0);
+
+  // Read bounded by count = 1 (writes only null terminator)
+  wchar_t buffer_one[5] = {L'x', L'y', L'z', L'\0'};
+  wchar_t *result_one = LIBC_NAMESPACE::fgetws(buffer_one, 1, file);
+  ASSERT_FALSE(result_one == nullptr);
+  EXPECT_EQ(result_one, buffer_one);
+  EXPECT_EQ(static_cast<wint_t>(buffer_one[0]), static_cast<wint_t>(L'\0'));
+  EXPECT_EQ(static_cast<wint_t>(buffer_one[1]),
+            static_cast<wint_t>(L'y')); // untouched
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwsTest, NewlineStops) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_newline.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "abc\ndef"
+  constexpr char CONTENT[] = "abc\ndef";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  wchar_t buffer[20] = {0};
+  wchar_t *result = LIBC_NAMESPACE::fgetws(buffer, 10, file);
+  ASSERT_FALSE(result == nullptr);
+  EXPECT_EQ(result, buffer);
+  EXPECT_EQ(LIBC_NAMESPACE::wcscmp(buffer, L"abc\n"), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwsTest, InvalidStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_invalid.test"));
+
+  // Create the file first
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open in write-only mode
+  file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Try to read from write-only stream
+  wchar_t buffer[10] = {0};
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fgetws(buffer, 5, file),
+            static_cast<wchar_t *>(nullptr));
+  ASSERT_ERRNO_EQ(EBADF);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwsTest, EncodingErrorEILSEQ) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_eilseq.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write an invalid UTF-8 sequence: 0x80 (stray continuation byte)
+  constexpr unsigned char CONTENT[] = {0x80};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Reading invalid sequence should fail with EILSEQ
+  wchar_t buffer[10] = {0};
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fgetws(buffer, 5, file),
+            static_cast<wchar_t *>(nullptr));
+  ASSERT_ERRNO_EQ(EILSEQ);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFgetwsTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fgetws_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Read wide string should fail and set errno to EINVAL
+  wchar_t buffer[10] = {0};
+  EXPECT_EQ(LIBC_NAMESPACE::fgetws(buffer, 5, file),
+            static_cast<wchar_t *>(nullptr));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/fputwc_test.cpp
+++ b/libc/test/src/wchar/fputwc_test.cpp
@@ -1,0 +1,146 @@
+//===-- Unittests for fputwc ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fread.h"
+#include "src/stdio/fwrite.h"
+#include "src/wchar/fputwc.h"
+#include "src/wchar/fwide.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcFputwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcFputwcTest, WriteASCII) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_ascii.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write 'a', 'b', 'c'
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'a', file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'b', file), static_cast<wint_t>(L'b'));
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'c', file), static_cast<wint_t>(L'c'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open again to read raw bytes
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  char buffer[10] = {0};
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 3, file), size_t(3));
+  EXPECT_STREQ(buffer, "abc");
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwcTest, WriteUtf8) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_utf8.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // 1-byte character: 'a' (L'a', 0x61) -> UTF-8: 0x61
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'a', file), static_cast<wint_t>(L'a'));
+
+  // 2-byte character: '¢' (L'¢', 0xA2) -> UTF-8: 0xC2 0xA2
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'¢', file), static_cast<wint_t>(L'¢'));
+
+  // 3-byte character: '€' (L'€', 0x20AC) -> UTF-8: 0xE2 0x82 0xAC
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'€', file), static_cast<wint_t>(L'€'));
+
+  // 4-byte character: '𐍈' (L'𐍈', 0x10348) -> UTF-8: 0xF0 0x90 0x8D 0x88
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'𐍈', file), static_cast<wint_t>(L'𐍈'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open again to read raw bytes
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[15] = {0};
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 10, file), size_t(10));
+
+  // Verify 1-byte
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>(0x61));
+
+  // Verify 2-byte
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>(0xC2));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>(0xA2));
+
+  // Verify 3-byte
+  EXPECT_EQ(buffer[3], static_cast<unsigned char>(0xE2));
+  EXPECT_EQ(buffer[4], static_cast<unsigned char>(0x82));
+  EXPECT_EQ(buffer[5], static_cast<unsigned char>(0xAC));
+
+  // Verify 4-byte
+  EXPECT_EQ(buffer[6], static_cast<unsigned char>(0xF0));
+  EXPECT_EQ(buffer[7], static_cast<unsigned char>(0x90));
+  EXPECT_EQ(buffer[8], static_cast<unsigned char>(0x8D));
+  EXPECT_EQ(buffer[9], static_cast<unsigned char>(0x88));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwcTest, EncodingErrorEILSEQ) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_eilseq.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Try to write an invalid wide character point (outside Unicode range)
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(static_cast<wchar_t>(0x110000), file),
+            static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EILSEQ);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwcTest, InvalidStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_invalid.test"));
+
+  // Create the file first
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open in read-only mode
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Try to write to read-only file
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'x', file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwcTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputwc_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Writing wide char should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::fputwc(L'a', file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/fputws_test.cpp
+++ b/libc/test/src/wchar/fputws_test.cpp
@@ -1,0 +1,151 @@
+//===-- Unittests for fputws ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "src/stdio/fclose.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fread.h"
+#include "src/wchar/fputws.h"
+#include "src/wchar/fwide.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcFputwsTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcFputwsTest, WriteWideString) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_string.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // String with 1, 2, 3, and 4-byte UTF-8 characters
+  // Hello, ¢€𐍈 world!\n
+  constexpr wchar_t STR[] = L"Hello, ¢€𐍈 world!\n";
+  EXPECT_GE(LIBC_NAMESPACE::fputws(STR, file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open to read raw bytes and verify UTF-8 mapping
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[50] = {0};
+  // Expecting 7 (Hello, ) + 2 (¢) + 3 (€) + 4 (𐍈) + 8 ( world!\n) = 24 bytes
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 24, file), size_t(24));
+
+  // "Hello, "
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>('H'));
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>('e'));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>('l'));
+  EXPECT_EQ(buffer[3], static_cast<unsigned char>('l'));
+  EXPECT_EQ(buffer[4], static_cast<unsigned char>('o'));
+  EXPECT_EQ(buffer[5], static_cast<unsigned char>(','));
+  EXPECT_EQ(buffer[6], static_cast<unsigned char>(' '));
+
+  // "¢"
+  EXPECT_EQ(buffer[7], static_cast<unsigned char>(0xC2));
+  EXPECT_EQ(buffer[8], static_cast<unsigned char>(0xA2));
+
+  // "€"
+  EXPECT_EQ(buffer[9], static_cast<unsigned char>(0xE2));
+  EXPECT_EQ(buffer[10], static_cast<unsigned char>(0x82));
+  EXPECT_EQ(buffer[11], static_cast<unsigned char>(0xAC));
+
+  // "𐍈"
+  EXPECT_EQ(buffer[12], static_cast<unsigned char>(0xF0));
+  EXPECT_EQ(buffer[13], static_cast<unsigned char>(0x90));
+  EXPECT_EQ(buffer[14], static_cast<unsigned char>(0x8D));
+  EXPECT_EQ(buffer[15], static_cast<unsigned char>(0x88));
+
+  // " world!\n"
+  EXPECT_EQ(buffer[16], static_cast<unsigned char>(' '));
+  EXPECT_EQ(buffer[17], static_cast<unsigned char>('w'));
+  EXPECT_EQ(buffer[18], static_cast<unsigned char>('o'));
+  EXPECT_EQ(buffer[19], static_cast<unsigned char>('r'));
+  EXPECT_EQ(buffer[20], static_cast<unsigned char>('l'));
+  EXPECT_EQ(buffer[21], static_cast<unsigned char>('d'));
+  EXPECT_EQ(buffer[22], static_cast<unsigned char>('!'));
+  EXPECT_EQ(buffer[23], static_cast<unsigned char>('\n'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwsTest, EmptyString) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_empty.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  EXPECT_GE(LIBC_NAMESPACE::fputws(L"", file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Verify nothing was written
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[5] = {0};
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 5, file), size_t(0));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwsTest, InvalidStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_invalid.test"));
+
+  // Create the file first
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open in read-only mode
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Try to write to read-only file
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_LT(LIBC_NAMESPACE::fputws(L"fail", file), 0);
+  ASSERT_ERRNO_EQ(EBADF);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwsTest, EncodingErrorEILSEQ) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_eilseq.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // String with invalid wide character point (outside Unicode range) which
+  // fails encoding
+  constexpr wchar_t STR[] = {static_cast<wchar_t>(0x110000), L'\0'};
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_LT(LIBC_NAMESPACE::fputws(STR, file), 0);
+  ASSERT_ERRNO_EQ(EILSEQ);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcFputwsTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fputws_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Writing wide string should fail and set errno to EINVAL
+  EXPECT_LT(LIBC_NAMESPACE::fputws(L"fail", file), 0);
+  ASSERT_ERRNO_EQ(EINVAL);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/fwide_test.cpp
+++ b/libc/test/src/wchar/fwide_test.cpp
@@ -1,0 +1,54 @@
+//===-- Unittests for fwide -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/fclose.h"
+#include "src/stdio/fopen.h"
+#include "src/wchar/fwide.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcFwideTest, QueryInitial) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("fwide_query.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Initial orientation should be unoriented (0)
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcFwideTest, OrientWide) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fwide_wide.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Setting mode > 0 should return > 0 (wide oriented)
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, 1), 0);
+
+  // Subsequent orientation queries/attempts should still return > 0
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, 0), 0);
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcFwideTest, OrientByte) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("fwide_byte.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Setting mode < 0 should return < 0 (byte oriented)
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Subsequent orientation queries/attempts should still return < 0
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, 0), 0);
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, 1), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/getwc_test.cpp
+++ b/libc/test/src/wchar/getwc_test.cpp
@@ -1,0 +1,122 @@
+//===-- Unittests for getwc -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/feof.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fwrite.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/getwc.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcGetwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcGetwcTest, ReadValidCharacters) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_valid.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "12"
+  constexpr char CONTENT[] = "12";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Initial orientation
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'1'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'2'));
+
+  // Stream orientation should now be wide
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcGetwcTest, ReadUtf8) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("getwc_utf8.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "a¢€𐍈"
+  constexpr unsigned char CONTENT[] = {0x61, 0xC2, 0xA2, 0xE2, 0x82,
+                                       0xAC, 0xF0, 0x90, 0x8D, 0x88};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(L'𐍈'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcGetwcTest, EndOfFile) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("getwc_eof.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Read past EOF
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(WEOF));
+  EXPECT_NE(LIBC_NAMESPACE::feof(file), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcGetwcTest, ReadError) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_readerr.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Try to read from write-only file
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcGetwcTest, ByteOrientedStreamFail) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwc_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Reading should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::getwc(file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/getwchar_test.cpp
+++ b/libc/test/src/wchar/getwchar_test.cpp
@@ -1,0 +1,183 @@
+//===-- Unittests for getwchar --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/feof.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fwrite.h"
+#include "src/stdio/stdin.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/getwchar.h"
+#include "src/wchar/ungetwc.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcGetwcharTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+// TODO: Analyze if redirecting stdin here works, and also if it's the right way
+// to approach this.
+
+TEST_F(LlvmLibcGetwcharTest, ReadValidWideCharacters) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_valid.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "12"
+  constexpr char CONTENT[] = "12";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Redirect stdin
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdin == nullptr);
+
+  // Verify unoriented
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdin, 0), 0);
+
+  // Read characters
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'1'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'2'));
+
+  // Orientation should be wide
+  EXPECT_GT(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdin, 0), 0);
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}
+
+TEST_F(LlvmLibcGetwcharTest, ReadUtf8) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_utf8.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "a¢€𐍈"
+  constexpr unsigned char CONTENT[] = {0x61, 0xC2, 0xA2, 0xE2, 0x82,
+                                       0xAC, 0xF0, 0x90, 0x8D, 0x88};
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT), file),
+            sizeof(CONTENT));
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Redirect stdin
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdin == nullptr);
+
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'𐍈'));
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}
+
+TEST_F(LlvmLibcGetwcharTest, EndOfFileBehavior) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_eof.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Redirect stdin
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdin == nullptr);
+
+  // Read past EOF
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(WEOF));
+  EXPECT_NE(LIBC_NAMESPACE::feof(LIBC_NAMESPACE::stdin), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::ferror(LIBC_NAMESPACE::stdin), 0);
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}
+
+TEST_F(LlvmLibcGetwcharTest, ReadError) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_readerr.test"));
+
+  // Redirect stdin using a write-only stream
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdin == nullptr);
+
+  // Try to read from write-only stream
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(LIBC_NAMESPACE::stdin), 0);
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}
+
+TEST_F(LlvmLibcGetwcharTest, ByteOrientedMisuse) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Redirect stdin
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = file;
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdin, -1), 0);
+
+  // Reading should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(LIBC_NAMESPACE::stdin), 0);
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}
+
+TEST_F(LlvmLibcGetwcharTest, InteractionWithUngetwc) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("getwchar_unget.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "1"
+  constexpr char CONTENT[] = "1";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Redirect stdin
+  ::FILE *original_stdin = LIBC_NAMESPACE::stdin;
+  LIBC_NAMESPACE::stdin = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdin == nullptr);
+
+  // Read '1'
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'1'));
+
+  // Push back 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'X', LIBC_NAMESPACE::stdin),
+            static_cast<wint_t>(L'X'));
+
+  // Read again -> should be 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::getwchar(), static_cast<wint_t>(L'X'));
+
+  // Restore stdin
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdin), 0);
+  LIBC_NAMESPACE::stdin = original_stdin;
+}

--- a/libc/test/src/wchar/putwc_test.cpp
+++ b/libc/test/src/wchar/putwc_test.cpp
@@ -1,0 +1,134 @@
+//===-- Unittests for putwc -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fread.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/putwc.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcPutwcTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcPutwcTest, WriteASCII) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_ascii.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Initial orientation should be 0
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'a', file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'b', file), static_cast<wint_t>(L'b'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'c', file), static_cast<wint_t>(L'c'));
+
+  // Orientation should now be wide
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Read back raw bytes to verify
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[5] = {0};
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 3, file), size_t(3));
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>('a'));
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>('b'));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>('c'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcPutwcTest, WriteUtf8) {
+  auto FILENAME = libc_make_test_file_path(APPEND_LIBC_TEST("putwc_utf8.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // a   -> L'a' (1-byte)
+  // ¢   -> L'¢' (2-byte)
+  // €   -> L'€' (3-byte)
+  // 𐍈   -> L'𐍈' (4-byte)
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'a', file), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'¢', file), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'€', file), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'𐍈', file), static_cast<wint_t>(L'𐍈'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Read back raw bytes and verify strict UTF-8 sequences on disk
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[20] = {0};
+  // Expecting 1 + 2 + 3 + 4 = 10 bytes
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 10, file), size_t(10));
+
+  // a
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>(0x61));
+
+  // ¢
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>(0xC2));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>(0xA2));
+
+  // €
+  EXPECT_EQ(buffer[3], static_cast<unsigned char>(0xE2));
+  EXPECT_EQ(buffer[4], static_cast<unsigned char>(0x82));
+  EXPECT_EQ(buffer[5], static_cast<unsigned char>(0xAC));
+
+  // 𐍈
+  EXPECT_EQ(buffer[6], static_cast<unsigned char>(0xF0));
+  EXPECT_EQ(buffer[7], static_cast<unsigned char>(0x90));
+  EXPECT_EQ(buffer[8], static_cast<unsigned char>(0x8D));
+  EXPECT_EQ(buffer[9], static_cast<unsigned char>(0x88));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcPutwcTest, InvalidStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_invalid.test"));
+
+  // Create file
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open read-only
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'a', file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcPutwcTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwc_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Writing wide char should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::putwc(L'a', file), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(file), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}

--- a/libc/test/src/wchar/putwchar_test.cpp
+++ b/libc/test/src/wchar/putwchar_test.cpp
@@ -1,0 +1,178 @@
+//===-- Unittests for putwchar --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fread.h"
+#include "src/stdio/stdout.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/putwchar.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcPutwcharTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcPutwcharTest, WriteASCII) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_ascii.test"));
+
+  // Redirect stdout
+  ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
+  LIBC_NAMESPACE::stdout = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdout == nullptr);
+
+  // Initial orientation
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdout, 0), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'a'), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'b'), static_cast<wint_t>(L'b'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'c'), static_cast<wint_t>(L'c'));
+
+  // Orientation should be wide
+  EXPECT_GT(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdout, 0), 0);
+
+  // Restore stdout
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdout), 0);
+  LIBC_NAMESPACE::stdout = original_stdout;
+
+  // Read back raw bytes to verify
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[5] = {0};
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 3, file), size_t(3));
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>('a'));
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>('b'));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>('c'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcPutwcharTest, WriteUtf8) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_utf8.test"));
+
+  // Redirect stdout
+  ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
+  LIBC_NAMESPACE::stdout = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdout == nullptr);
+
+  // a   -> L'a' (1-byte)
+  // ¢   -> L'¢' (2-byte)
+  // €   -> L'€' (3-byte)
+  // 𐍈   -> L'𐍈' (4-byte)
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'a'), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'¢'), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'€'), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'𐍈'), static_cast<wint_t>(L'𐍈'));
+
+  // Restore stdout
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdout), 0);
+  LIBC_NAMESPACE::stdout = original_stdout;
+
+  // Read back raw bytes and verify UTF-8 sequences exactly on disk
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  unsigned char buffer[20] = {0};
+  // Expecting 1 + 2 + 3 + 4 = 10 bytes
+  ASSERT_EQ(LIBC_NAMESPACE::fread(buffer, 1, 10, file), size_t(10));
+
+  // a
+  EXPECT_EQ(buffer[0], static_cast<unsigned char>(0x61));
+
+  // ¢
+  EXPECT_EQ(buffer[1], static_cast<unsigned char>(0xC2));
+  EXPECT_EQ(buffer[2], static_cast<unsigned char>(0xA2));
+
+  // €
+  EXPECT_EQ(buffer[3], static_cast<unsigned char>(0xE2));
+  EXPECT_EQ(buffer[4], static_cast<unsigned char>(0x82));
+  EXPECT_EQ(buffer[5], static_cast<unsigned char>(0xAC));
+
+  // 𐍈
+  EXPECT_EQ(buffer[6], static_cast<unsigned char>(0xF0));
+  EXPECT_EQ(buffer[7], static_cast<unsigned char>(0x90));
+  EXPECT_EQ(buffer[8], static_cast<unsigned char>(0x8D));
+  EXPECT_EQ(buffer[9], static_cast<unsigned char>(0x88));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST_F(LlvmLibcPutwcharTest, InvalidStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_invalid.test"));
+
+  // Create the file first
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Redirect stdout using a read-only file stream
+  ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
+  LIBC_NAMESPACE::stdout = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(LIBC_NAMESPACE::stdout == nullptr);
+
+  // Try to write to read-only stdout
+  ASSERT_ERRNO_SUCCESS();
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'a'), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EBADF);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(LIBC_NAMESPACE::stdout), 0);
+
+  // Restore stdout
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdout), 0);
+  LIBC_NAMESPACE::stdout = original_stdout;
+}
+
+TEST_F(LlvmLibcPutwcharTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("putwchar_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Redirect stdout
+  ::FILE *original_stdout = LIBC_NAMESPACE::stdout;
+  LIBC_NAMESPACE::stdout = file;
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(LIBC_NAMESPACE::stdout, -1), 0);
+
+  // Writing should fail and set errno to EINVAL
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'a'), static_cast<wint_t>(WEOF));
+  ASSERT_ERRNO_EQ(EINVAL);
+  EXPECT_NE(LIBC_NAMESPACE::ferror(LIBC_NAMESPACE::stdout), 0);
+
+  // Restore stdout
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(LIBC_NAMESPACE::stdout), 0);
+  LIBC_NAMESPACE::stdout = original_stdout;
+}
+
+TEST_F(LlvmLibcPutwcharTest, RealStdoutNoRedirection) {
+  // This test writes directly to the real un-redirected stdout.
+  // While it cannot be programmatically verified by the test runner,
+  // it is extremely useful for developers running tests manually in a terminal
+  // to visually verify characters are outputted correctly.
+
+  // Print: "putwchar test: [a¢€𐍈]\n"
+  constexpr wchar_t PREFIX[] = L"putwchar test: [";
+  for (size_t i = 0; PREFIX[i] != L'\0'; ++i) {
+    EXPECT_EQ(LIBC_NAMESPACE::putwchar(PREFIX[i]),
+              static_cast<wint_t>(PREFIX[i]));
+  }
+
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'a'), static_cast<wint_t>(L'a'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'¢'), static_cast<wint_t>(L'¢'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'€'), static_cast<wint_t>(L'€'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'𐍈'), static_cast<wint_t>(L'𐍈'));
+
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L']'), static_cast<wint_t>(L']'));
+  EXPECT_EQ(LIBC_NAMESPACE::putwchar(L'\n'), static_cast<wint_t>(L'\n'));
+}

--- a/libc/test/src/wchar/ungetwc_test.cpp
+++ b/libc/test/src/wchar/ungetwc_test.cpp
@@ -1,0 +1,208 @@
+//===-- Unittests for ungetwc ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/stdio_macros.h" // For SEEK_CUR
+#include "hdr/wchar_macros.h" // For WEOF
+#include "src/stdio/fclose.h"
+#include "src/stdio/feof.h"
+#include "src/stdio/ferror.h"
+#include "src/stdio/fopen.h"
+#include "src/stdio/fseek.h"
+#include "src/stdio/fwrite.h"
+#include "src/wchar/fgetwc.h"
+#include "src/wchar/fwide.h"
+#include "src/wchar/ungetwc.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcUngetwcTest, PushBackAndRead) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_push.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "12"
+  constexpr char CONTENT[] = "12";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  // Open for reading
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Read first char -> '1'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'1'));
+
+  // Push back 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'X', file), static_cast<wint_t>(L'X'));
+
+  // Read again -> should get 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'X'));
+
+  // Read again -> should get '2'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'2'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, PushBackWEOF) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_weof.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Push back WEOF should do nothing and return WEOF
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(WEOF, file), static_cast<wint_t>(WEOF));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, ByteModeFailure) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_bytemode.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Orient to byte mode
+  EXPECT_LT(LIBC_NAMESPACE::fwide(file, -1), 0);
+
+  // Push back should fail
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'a', file), static_cast<wint_t>(WEOF));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, OrientUnorientedStream) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_orient.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Verify initial unoriented state
+  EXPECT_EQ(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  // Push back a char
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'A', file), static_cast<wint_t>(L'A'));
+
+  // Verify stream is now wide-oriented
+  EXPECT_GT(LIBC_NAMESPACE::fwide(file, 0), 0);
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, ClearEofIndicator) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_cleareof.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "1"
+  constexpr char CONTENT[] = "1";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Read '1'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'1'));
+
+  // Read past EOF
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(WEOF));
+  EXPECT_NE(LIBC_NAMESPACE::feof(file), 0);
+
+  // ungetwc should clear EOF indicator
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'1', file), static_cast<wint_t>(L'1'));
+  EXPECT_EQ(LIBC_NAMESPACE::feof(file), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::ferror(file), 0); // error remains unmodified
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, DiscardOnFilePositioning) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_discard.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "12"
+  constexpr char CONTENT[] = "12";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Read first char -> '1'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'1'));
+
+  // Push back 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'X', file), static_cast<wint_t>(L'X'));
+
+  // Seek to absolute position 1 (after '1') to discard pushed-back char
+  EXPECT_EQ(LIBC_NAMESPACE::fseek(file, 1, SEEK_SET), 0);
+
+  // Read again -> should get '2' instead of 'X'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'2'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, LifoMultiplePushbacks) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_lifo.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w+");
+  ASSERT_FALSE(file == nullptr);
+
+  // Push back 'X' then 'Y'
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'X', file), static_cast<wint_t>(L'X'));
+  // If multiple push-backs are supported, verify LIFO ordering
+  wint_t second_push = LIBC_NAMESPACE::ungetwc(L'Y', file);
+  if (second_push == static_cast<wint_t>(L'Y')) {
+    EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'Y'));
+    EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'X'));
+  } else {
+    // Only one push-back supported on this platform/implementation
+    EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'X'));
+  }
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}
+
+TEST(LlvmLibcUngetwcTest, PushbackAtStartOfFile) {
+  auto FILENAME =
+      libc_make_test_file_path(APPEND_LIBC_TEST("ungetwc_start.test"));
+  ::FILE *file = LIBC_NAMESPACE::fopen(FILENAME, "w");
+  ASSERT_FALSE(file == nullptr);
+
+  // Write "1"
+  constexpr char CONTENT[] = "1";
+  ASSERT_EQ(LIBC_NAMESPACE::fwrite(CONTENT, 1, sizeof(CONTENT) - 1, file),
+            sizeof(CONTENT) - 1);
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+
+  file = LIBC_NAMESPACE::fopen(FILENAME, "r");
+  ASSERT_FALSE(file == nullptr);
+
+  // Push back 'Z' at the very beginning without prior reads
+  EXPECT_EQ(LIBC_NAMESPACE::ungetwc(L'Z', file), static_cast<wint_t>(L'Z'));
+
+  // Read first char -> should be 'Z'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'Z'));
+
+  // Read next char -> should be '1'
+  EXPECT_EQ(LIBC_NAMESPACE::fgetwc(file), static_cast<wint_t>(L'1'));
+
+  ASSERT_EQ(LIBC_NAMESPACE::fclose(file), 0);
+}


### PR DESCRIPTION
Add CMake and config files for wide character file entrypoints. Part 11/11.

Previous parts:
https://github.com/llvm/llvm-project/pull/196157
https://github.com/llvm/llvm-project/pull/196158
https://github.com/llvm/llvm-project/pull/196159
https://github.com/llvm/llvm-project/pull/196160
https://github.com/llvm/llvm-project/pull/196161
https://github.com/llvm/llvm-project/pull/196162
https://github.com/llvm/llvm-project/pull/196163
https://github.com/llvm/llvm-project/pull/196164
https://github.com/llvm/llvm-project/pull/196165
https://github.com/llvm/llvm-project/pull/196166

Assisted by Gemini
