### PR TITLE
[libc][stdlib] Use structure bindings instead of output params

### DIFF
--- a/libc/src/stdlib/environ_internal.cpp
+++ b/libc/src/stdlib/environ_internal.cpp
@@ -91,21 +91,21 @@ cpp::optional<size_t> EnvironmentManager::find_var(cpp::string_view name) {
 // Helper: allocate new storage and ownership arrays of the given capacity,
 // copy the first `copy_count` entries from old_storage/old_ownership, and
 // initialize the remaining ownership slots to default (not-owned).
-// Returns false on allocation failure; on failure the old arrays are untouched.
-bool EnvironmentManager::alloc_and_copy(size_t new_capacity, char **old_storage,
-                                        EnvStringOwnership *old_ownership,
-                                        size_t copy_count, char **&out_storage,
-                                        EnvStringOwnership *&out_ownership) {
+// Returns nullopt on allocation failure; the old arrays are untouched.
+cpp::optional<EnvironmentManager::AllocResult>
+EnvironmentManager::alloc_and_copy(size_t new_capacity, char **old_storage,
+                                   EnvStringOwnership *old_ownership,
+                                   size_t copy_count) {
   AllocChecker ac;
   char **new_storage = new (ac) char *[new_capacity + 1];
   if (!ac)
-    return false;
+    return cpp::nullopt;
 
   EnvStringOwnership *new_ownership =
       new (ac) EnvStringOwnership[new_capacity + 1];
   if (!ac) {
     delete[] new_storage;
-    return false;
+    return cpp::nullopt;
   }
 
   for (size_t i = 0; i < copy_count; i++) {
@@ -114,9 +114,7 @@ bool EnvironmentManager::alloc_and_copy(size_t new_capacity, char **old_storage,
   }
   new_storage[copy_count] = nullptr;
 
-  out_storage = new_storage;
-  out_ownership = new_ownership;
-  return true;
+  return AllocResult{new_storage, new_ownership};
 }
 
 bool EnvironmentManager::ensure_capacity(size_t needed) {
@@ -131,12 +129,11 @@ bool EnvironmentManager::ensure_capacity(size_t needed) {
                               ? MIN_ENVIRON_CAPACITY
                               : needed * ENVIRON_GROWTH_FACTOR;
 
-    char **new_storage = nullptr;
-    EnvStringOwnership *new_ownership = nullptr;
-    if (!alloc_and_copy(new_capacity, old_env, nullptr, count, new_storage,
-                        new_ownership))
+    auto result = alloc_and_copy(new_capacity, old_env, nullptr, count);
+    if (!result)
       return false;
 
+    auto [new_storage, new_ownership] = *result;
     storage = new_storage;
     ownership = new_ownership;
     capacity = new_capacity;
@@ -156,15 +153,14 @@ bool EnvironmentManager::ensure_capacity(size_t needed) {
   // manager in an inconsistent state.
   size_t new_capacity = needed * ENVIRON_GROWTH_FACTOR;
 
-  char **new_storage = nullptr;
-  EnvStringOwnership *new_ownership = nullptr;
-  if (!alloc_and_copy(new_capacity, storage, ownership, count, new_storage,
-                      new_ownership))
+  auto result = alloc_and_copy(new_capacity, storage, ownership, count);
+  if (!result)
     return false;
 
   delete[] storage;
   delete[] ownership;
 
+  auto [new_storage, new_ownership] = *result;
   storage = new_storage;
   ownership = new_ownership;
   capacity = new_capacity;

--- a/libc/src/stdlib/environ_internal.h
+++ b/libc/src/stdlib/environ_internal.h
@@ -88,13 +88,20 @@ class EnvironmentManager {
   // success, false on allocation failure.
   bool ensure_capacity(size_t needed);
 
+  // Result of a successful environment storage allocation.
+  struct AllocResult {
+    char **storage;
+    EnvStringOwnership *ownership;
+  };
+
   // Helper: allocate new storage and ownership arrays of the given capacity,
   // copy the first `copy_count` entries from old_storage/old_ownership, and
   // initialize the remaining ownership slots to default (not-owned).
-  // Returns false on allocation failure.
-  bool alloc_and_copy(size_t new_capacity, char **old_storage,
-                      EnvStringOwnership *old_ownership, size_t copy_count,
-                      char **&out_storage, EnvStringOwnership *&out_ownership);
+  // Returns nullopt on allocation failure; the old arrays are untouched.
+  cpp::optional<AllocResult> alloc_and_copy(size_t new_capacity,
+                                            char **old_storage,
+                                            EnvStringOwnership *old_ownership,
+                                            size_t copy_count);
 
 public:
   // Get the singleton instance of the environment manager.


### PR DESCRIPTION
Refactored alloc_and_copy to return cpp::optional<AllocResult> instead of using reference-to-pointer output parameters. The combination of char **& parameters with array new/delete is known to trigger a segfault in GCC 12's waccess GIMPLE pass.

The AllocResult struct holds the two allocated arrays (storage and ownership). Call sites use structured bindings to unpack the result after checking for nullopt.

Hopefully fixes the build failure in PR #195260 on the libc-x86_64-debian-gcc-fullbuild-dbg builder.

Assisted-by: Automated tooling, human reviewed.