### PR TITLE
[PassManager] Mark some codegen passes as required

### DIFF
--- a/llvm/include/llvm/CodeGen/AtomicExpand.h
+++ b/llvm/include/llvm/CodeGen/AtomicExpand.h
@@ -16,7 +16,7 @@ namespace llvm {
 class Function;
 class TargetMachine;
 
-class AtomicExpandPass : public OptionalPassInfoMixin<AtomicExpandPass> {
+class AtomicExpandPass : public RequiredPassInfoMixin<AtomicExpandPass> {
 private:
   const TargetMachine *TM;
 

--- a/llvm/include/llvm/CodeGen/DwarfEHPrepare.h
+++ b/llvm/include/llvm/CodeGen/DwarfEHPrepare.h
@@ -20,7 +20,7 @@ namespace llvm {
 
 class TargetMachine;
 
-class DwarfEHPreparePass : public OptionalPassInfoMixin<DwarfEHPreparePass> {
+class DwarfEHPreparePass : public RequiredPassInfoMixin<DwarfEHPreparePass> {
   const TargetMachine *TM;
 
 public:

--- a/llvm/include/llvm/CodeGen/GCMetadata.h
+++ b/llvm/include/llvm/CodeGen/GCMetadata.h
@@ -226,7 +226,7 @@ public:
 /// and custom intrinsic lowering.
 ///
 /// This pass requires `CollectorMetadataAnalysis`.
-class GCLoweringPass : public OptionalPassInfoMixin<GCLoweringPass> {
+class GCLoweringPass : public RequiredPassInfoMixin<GCLoweringPass> {
 public:
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };

--- a/llvm/include/llvm/CodeGen/IndirectBrExpand.h
+++ b/llvm/include/llvm/CodeGen/IndirectBrExpand.h
@@ -16,7 +16,7 @@ namespace llvm {
 class TargetMachine;
 
 class IndirectBrExpandPass
-    : public OptionalPassInfoMixin<IndirectBrExpandPass> {
+    : public RequiredPassInfoMixin<IndirectBrExpandPass> {
   const TargetMachine *TM;
 
 public:

--- a/llvm/include/llvm/CodeGen/InlineAsmPrepare.h
+++ b/llvm/include/llvm/CodeGen/InlineAsmPrepare.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class InlineAsmPreparePass
-    : public OptionalPassInfoMixin<InlineAsmPreparePass> {
+    : public RequiredPassInfoMixin<InlineAsmPreparePass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };

--- a/llvm/include/llvm/CodeGen/JMCInstrumenter.h
+++ b/llvm/include/llvm/CodeGen/JMCInstrumenter.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class JMCInstrumenterPass : public OptionalPassInfoMixin<JMCInstrumenterPass> {
+class JMCInstrumenterPass : public RequiredPassInfoMixin<JMCInstrumenterPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/CodeGen/LowerEmuTLS.h
+++ b/llvm/include/llvm/CodeGen/LowerEmuTLS.h
@@ -19,7 +19,7 @@
 
 namespace llvm {
 
-class LowerEmuTLSPass : public OptionalPassInfoMixin<LowerEmuTLSPass> {
+class LowerEmuTLSPass : public RequiredPassInfoMixin<LowerEmuTLSPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/CodeGen/MachineCFGPrinter.h
+++ b/llvm/include/llvm/CodeGen/MachineCFGPrinter.h
@@ -90,7 +90,7 @@ struct DOTGraphTraits<DOTMachineFuncInfo *> : public DefaultDOTGraphTraits {
   }
 };
 
-class MachineCFGPrinterPass : public PassInfoMixin<MachineCFGPrinterPass> {
+class MachineCFGPrinterPass : public RequiredPassInfoMixin<MachineCFGPrinterPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
@@ -47,7 +47,7 @@ public:
 };
 
 class FreeMachineFunctionPass
-    : public OptionalPassInfoMixin<FreeMachineFunctionPass> {
+    : public RequiredPassInfoMixin<FreeMachineFunctionPass> {
 public:
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };

--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -296,14 +296,14 @@ LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI,
                                             const TargetRegisterInfo *TRI);
 
 class FinalizeBundleTestPass
-    : public OptionalPassInfoMixin<FinalizeBundleTestPass> {
+    : public RequiredPassInfoMixin<FinalizeBundleTestPass> {
 public:
-  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                                 MachineFunctionAnalysisManager &MFAM);
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
 };
 
 class UnpackMachineBundlesPass
-    : public OptionalPassInfoMixin<UnpackMachineBundlesPass> {
+    : public RequiredPassInfoMixin<UnpackMachineBundlesPass> {
 
 public:
   UnpackMachineBundlesPass(

--- a/llvm/include/llvm/CodeGen/MachineStripDebug.h
+++ b/llvm/include/llvm/CodeGen/MachineStripDebug.h
@@ -22,7 +22,7 @@
 namespace llvm {
 
 class StripDebugMachineModulePass
-    : public OptionalPassInfoMixin<StripDebugMachineModulePass> {
+    : public RequiredPassInfoMixin<StripDebugMachineModulePass> {
 public:
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };

--- a/llvm/include/llvm/CodeGen/PreISelIntrinsicLowering.h
+++ b/llvm/include/llvm/CodeGen/PreISelIntrinsicLowering.h
@@ -21,7 +21,7 @@ class Module;
 class TargetMachine;
 
 struct PreISelIntrinsicLoweringPass
-    : OptionalPassInfoMixin<PreISelIntrinsicLoweringPass> {
+    : RequiredPassInfoMixin<PreISelIntrinsicLoweringPass> {
   const TargetMachine *TM;
 
   PreISelIntrinsicLoweringPass(const TargetMachine *TM) : TM(TM) {}

--- a/llvm/include/llvm/CodeGen/ProcessImplicitDefs.h
+++ b/llvm/include/llvm/CodeGen/ProcessImplicitDefs.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class ProcessImplicitDefsPass
-    : public OptionalPassInfoMixin<ProcessImplicitDefsPass> {
+    : public RequiredPassInfoMixin<ProcessImplicitDefsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/RegUsageInfoPropagate.h
+++ b/llvm/include/llvm/CodeGen/RegUsageInfoPropagate.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class RegUsageInfoPropagationPass
-    : public OptionalPassInfoMixin<RegUsageInfoPropagationPass> {
+    : public RequiredPassInfoMixin<RegUsageInfoPropagationPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
+++ b/llvm/include/llvm/CodeGen/ReplaceWithVeclib.h
@@ -21,7 +21,7 @@
 
 namespace llvm {
 class Function;
-struct ReplaceWithVeclib : public OptionalPassInfoMixin<ReplaceWithVeclib> {
+struct ReplaceWithVeclib : public RequiredPassInfoMixin<ReplaceWithVeclib> {
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 

--- a/llvm/include/llvm/CodeGen/SafeStack.h
+++ b/llvm/include/llvm/CodeGen/SafeStack.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class TargetMachine;
 
-class SafeStackPass : public OptionalPassInfoMixin<SafeStackPass> {
+class SafeStackPass : public RequiredPassInfoMixin<SafeStackPass> {
   const TargetMachine *TM;
 
 public:

--- a/llvm/include/llvm/CodeGen/ShadowStackGCLowering.h
+++ b/llvm/include/llvm/CodeGen/ShadowStackGCLowering.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class ShadowStackGCLoweringPass
-    : public OptionalPassInfoMixin<ShadowStackGCLoweringPass> {
+    : public RequiredPassInfoMixin<ShadowStackGCLoweringPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/CodeGen/SjLjEHPrepare.h
+++ b/llvm/include/llvm/CodeGen/SjLjEHPrepare.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class TargetMachine;
 
-class SjLjEHPreparePass : public OptionalPassInfoMixin<SjLjEHPreparePass> {
+class SjLjEHPreparePass : public RequiredPassInfoMixin<SjLjEHPreparePass> {
   const TargetMachine *TM;
 
 public:

--- a/llvm/include/llvm/CodeGen/StackColoring.h
+++ b/llvm/include/llvm/CodeGen/StackColoring.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class StackColoringPass : public OptionalPassInfoMixin<StackColoringPass> {
+class StackColoringPass : public RequiredPassInfoMixin<StackColoringPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/StackProtector.h
+++ b/llvm/include/llvm/CodeGen/StackProtector.h
@@ -82,7 +82,7 @@ public:
                                      SSPLayoutMap *Layout = nullptr);
 };
 
-class StackProtectorPass : public OptionalPassInfoMixin<StackProtectorPass> {
+class StackProtectorPass : public RequiredPassInfoMixin<StackProtectorPass> {
   const TargetMachine *TM;
 
 public:

--- a/llvm/include/llvm/CodeGen/WasmEHPrepare.h
+++ b/llvm/include/llvm/CodeGen/WasmEHPrepare.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class WasmEHPreparePass : public OptionalPassInfoMixin<WasmEHPreparePass> {
+class WasmEHPreparePass : public RequiredPassInfoMixin<WasmEHPreparePass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };

--- a/llvm/include/llvm/CodeGen/WinEHPrepare.h
+++ b/llvm/include/llvm/CodeGen/WinEHPrepare.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class WinEHPreparePass : public OptionalPassInfoMixin<WinEHPreparePass> {
+class WinEHPreparePass : public RequiredPassInfoMixin<WinEHPreparePass> {
   bool DemoteCatchSwitchPHIOnly;
 
 public:


### PR DESCRIPTION
These are required for lowering but were accidentally added as optional.