### PR TITLE
Make it clear that log enable's output file is per channel not per category

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -867,7 +867,8 @@ let Command = "log enable" in {
   def log_file : Option<"file", "f">,
                  Group<1>,
                  Arg<"Filename">,
-                 Desc<"Set the destination file to log to.">;
+                 Desc<"Set the destination file that all the enabled "
+                      "categories in the specified log channel will log to.">;
   def log_handler : Option<"log-handler", "h">,
                     Group<1>,
                     EnumArg<"LogHandler">,


### PR DESCRIPTION
It is natural to try:

```
log enable -f file1 lldb step
log enable -f file2 lldb process

```
or whatever, and then be surprised that all the logs end up in `file2`...  The help on `log enable`'s `-f` option didn't specify what you were setting the file for.  This PR just changes the help text to be clear about the current state of things.