### PR TITLE
[TableGen][GlobalISel] Skip REG_SEQUENCE with incompatible subreg index

### DIFF
--- a/llvm/test/TableGen/GlobalISelEmitter/RegSequenceBadSubReg.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/RegSequenceBadSubReg.td
@@ -1,0 +1,14 @@
+// RUN: llvm-tblgen -warn-on-skipped-patterns -gen-global-isel -I %p/../../../include %s -I %p/../Common -o /dev/null 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+include "GlobalISelEmitterCommon.td"
+
+// A REG_SEQUENCE whose super register class has no subclass containing the
+// requested subreg index used to crash the GlobalISel emitter on an empty
+// std::optional dereference. It now skips the pattern with failedImport.
+
+def bogus_sub : SubRegIndex<32>;
+
+// CHECK: warning: Skipped pattern: REG_SEQUENCE subreg index is incompatible with inferred reg class
+def : Pat<(i32 (add GPR32:$a, GPR32:$b)),
+          (REG_SEQUENCE GPR32, GPR32:$a, bogus_sub, GPR32:$b, bogus_sub)>;

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -1936,6 +1936,9 @@ Error GlobalISelEmitter::constrainOperands(action_iterator InsertPt,
 
       const auto SrcRCDstRCPair =
           SuperClass->getMatchingSubClassWithSubRegs(CGRegs, SubIdx);
+      if (!SrcRCDstRCPair)
+        return failedImport("REG_SEQUENCE subreg index is incompatible "
+                            "with inferred reg class");
 
       M.insertAction<ConstrainOperandToRegClassAction>(InsertPt, InsnID, I,
                                                        *SrcRCDstRCPair->second);


### PR DESCRIPTION
The REG_SEQUENCE branch of GlobalISelEmitter::constrainOperands called SuperClass->getMatchingSubClassWithSubRegs(...) and dereferenced the returned SrcRCDstRCPair unconditionally, aborting on a libstdc++ optional assertion when incorrect subreg index was passed.

Add the missing guard so the malformed pattern is reported via failedImport (a skipped pattern) instead of crashing tblgen.

Assisted by Claude.

Fixes https://github.com/llvm/llvm-project/issues/172690