### PR TITLE
[lldb] Fix misconstructed FromErrorStringWithFormatv format strings

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -1915,7 +1915,7 @@ public:
           auto report_error = [this, elem_counter,
                                counter](const char *err_txt) -> bool {
             m_args_error = Status::FromErrorStringWithFormatv(
-                "Element {} of arguments list element {}: {}.", elem_counter,
+                "element {} of arguments list element {}: {}", elem_counter,
                 counter, err_txt);
             return false;
           };

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -1915,9 +1915,8 @@ public:
           auto report_error = [this, elem_counter,
                                counter](const char *err_txt) -> bool {
             m_args_error = Status::FromErrorStringWithFormatv(
-                "Element {0} of arguments "
-                "list element {1}: %s.",
-                elem_counter, counter, err_txt);
+                "Element {} of arguments list element {}: {}.", elem_counter,
+                counter, err_txt);
             return false;
           };
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3485,7 +3485,7 @@ public:
           m_cached = value;
         } else {
           return Status::FromErrorStringWithFormatv(
-              "invalid boolean value '%s' passed for -c option", option_arg);
+              "invalid boolean value '{}' passed for -c option", option_arg);
         }
         break;
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -488,8 +488,8 @@ public:
 
       if (!write_error.Success()) {
         err = Status::FromErrorStringWithFormatv(
-            "couldn't write the contents of reference variable {0} to memory: "
-            "{0}",
+            "couldn't write the contents of reference variable {} to memory: "
+            "{}",
             GetName(), write_error.AsCString());
         return;
       }


### PR DESCRIPTION
Fix mistakes in `FromErrorStringWithFormatv` format strings. Uses https://github.com/llvm/llvm-project/pull/195974