### PR TITLE
[BOLT][AArch64] Refuse to run memcpy1 specialization

### DIFF
--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1958,8 +1958,10 @@ std::set<size_t> SpecializeMemcpy1::getCallSitesToOptimize(
 }
 
 Error SpecializeMemcpy1::runOnFunctions(BinaryContext &BC) {
-  if (!BC.isX86())
-    return Error::success();
+  if (!BC.isX86()) {
+    BC.errs() << "BOLT-ERROR: " << getName() << " is currently supported only on X86\n";
+    exit(1);
+  }
 
   uint64_t NumSpecialized = 0;
   uint64_t NumSpecializedDyno = 0;

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1959,7 +1959,8 @@ std::set<size_t> SpecializeMemcpy1::getCallSitesToOptimize(
 
 Error SpecializeMemcpy1::runOnFunctions(BinaryContext &BC) {
   if (!BC.isX86()) {
-    BC.errs() << "BOLT-ERROR: " << getName() << " is currently supported only on X86\n";
+    BC.errs() << "BOLT-ERROR: " << getName()
+              << " is currently supported only on X86\n";
     exit(1);
   }
 

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -7,11 +7,13 @@ RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-pre
 RUN: not llvm-bolt %t -o %t.bolt --three-way-branch 2>&1 | FileCheck %s --check-prefix=CHECK-THREE-WAY
 RUN: not llvm-bolt %t -o %t.bolt --jt-footprint-reduction 2>&1 | FileCheck %s --check-prefix=CHECK-JT-FOOTPRINT-REDUCTION
 RUN: not llvm-bolt %t -o %t.bolt --indirect-call-promotion=all 2>&1 | FileCheck %s --check-prefix=CHECK-INDIRECT-CALL-PROMOTION
+RUN: not llvm-bolt %t -o %t.bolt --memcpy1-spec=main 2>&1 | FileCheck %s --check-prefix=CHECK-MEMCPY1-SPEC
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86
 CHECK-THREE-WAY: BOLT-ERROR: three way branch is supported only on X86
 CHECK-JT-FOOTPRINT-REDUCTION: BOLT-ERROR: jt-footprint-reduction is supported only on X86
 CHECK-INDIRECT-CALL-PROMOTION: BOLT-ERROR: indirect-call-promotion is supported only on X86
+CHECK-MEMCPY1-SPEC: BOLT-ERROR: specialize-memcpy is currently supported only on X86
 
 // Passes specific to X86 arch
 RUN: not llvm-bolt %t -o %t.bolt --cmov-conversion 2>&1 | FileCheck %s --check-prefix=CHECK-CMOV-CONV


### PR DESCRIPTION
SpecializeMemcpy1 (`--memcpy1-spec=main`) is implemented only for X86. It does not crash but would be useful to inform the user that it is a no-op.

- Guard against non-X86
- Add error to unsupported-passes.test