### PR TITLE
Revert "[ASan][ADT] Don't scribble with ASan"

### DIFF
--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -35,7 +35,6 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLForwardCompat.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemAlloc.h"
 #include "llvm/Support/type_traits.h"
 #include <cstring>
@@ -310,10 +309,8 @@ protected:
     // Clear the old callback and inline flag to get back to as-if-null.
     RHS.CallbackAndInlineFlag = {};
 
-#if !defined(NDEBUG) && !LLVM_ADDRESS_SANITIZER_BUILD
-    // In debug builds without ASan, we also scribble across the rest of the
-    // storage. Scribbling under AddressSanitizer (ASan) is disabled to prevent
-    // overwriting poisoned objects (e.g., annotated short strings).
+#ifndef NDEBUG
+    // In debug builds, we also scribble across the rest of the storage.
     memset(RHS.getInlineStorage(), 0xAD, InlineStorageSize);
 #endif
   }


### PR DESCRIPTION
Reverts llvm/llvm-project#79066

This is no longer necessary now that we have gotten rid of ASan short string annotations in libc++ (#194208).