### PR TITLE
[lldb] Strip metadata bits on function pointer in IndirectCallEdge::GetCallee

### DIFF
--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -235,11 +235,12 @@ Function *IndirectCallEdge::GetCallee(ModuleList &images,
     return nullptr;
   }
 
-  if (auto *process = exe_ctx.GetProcessPtr())
+  if (auto *process = exe_ctx.GetProcessPtr()) {
     raw_addr = process->FixCodeAddress(raw_addr);
-  else
+  } else { 
     LLDB_LOG(log, "IndirectCallEdge: No Process available, unable to call "
                   "FixCodeAddress on function pointer");
+  }
 
   Address callee_addr;
   if (!exe_ctx.GetTargetPtr()->ResolveLoadAddress(raw_addr, callee_addr)) {

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -237,7 +237,7 @@ Function *IndirectCallEdge::GetCallee(ModuleList &images,
 
   if (auto *process = exe_ctx.GetProcessPtr()) {
     raw_addr = process->FixCodeAddress(raw_addr);
-  } else { 
+  } else {
     LLDB_LOG(log, "IndirectCallEdge: No Process available, unable to call "
                   "FixCodeAddress on function pointer");
   }

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -235,6 +235,12 @@ Function *IndirectCallEdge::GetCallee(ModuleList &images,
     return nullptr;
   }
 
+  if (auto *process = exe_ctx.GetProcessPtr())
+    raw_addr = process->FixCodeAddress(raw_addr);
+  else
+    LLDB_LOG(log, "IndirectCallEdge: No Process available, unable to call "
+                  "FixCodeAddress on function pointer");
+
   Address callee_addr;
   if (!exe_ctx.GetTargetPtr()->ResolveLoadAddress(raw_addr, callee_addr)) {
     LLDB_LOG(log, "IndirectCallEdge: Could not resolve callee's load address");


### PR DESCRIPTION
IndirectCallEdge::GetCallee calculates the raw address of a function pointer and tries to resolve a load address for it. If the function pointer has metadata bits in it (e.g. a signed pointer in arm64e) then the resolution will fail.