### PR TITLE
[Flang][OpenMP] Support declare reduction without initializer

### DIFF
--- a/flang/include/flang/Lower/ConvertVariable.h
+++ b/flang/include/flang/Lower/ConvertVariable.h
@@ -192,6 +192,15 @@ void genUnpackArray(Fortran::lower::AbstractConverter &converter,
                     mlir::Location loc, fir::FortranVariableOpInterface def,
                     const Fortran::semantics::Symbol &sym);
 
+/// Generate a scalar default initializer value for a derived type variable.
+/// Returns an SSA aggregate value with each component set to its default
+/// initialization (or zero if no default). This is a thin wrapper around
+/// the internal genDefaultInitializerValue utility, exposed for use by
+/// OpenMP reduction initialization.
+mlir::Value genScalarDefaultInitializerValue(
+    Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+    const Fortran::semantics::Symbol &sym, mlir::Type symTy);
+
 } // namespace lower
 } // namespace Fortran
 #endif // FORTRAN_LOWER_CONVERT_VARIABLE_H

--- a/flang/include/flang/Lower/Support/PrivateReductionUtils.h
+++ b/flang/include/flang/Lower/Support/PrivateReductionUtils.h
@@ -22,6 +22,7 @@ class Region;
 
 namespace Fortran {
 namespace semantics {
+class DerivedTypeSpec;
 class Symbol;
 } // namespace semantics
 } // namespace Fortran
@@ -70,6 +71,18 @@ fir::ShapeShiftOp getShapeShift(fir::FirOpBuilder &builder, mlir::Location loc,
                                 mlir::Value box,
                                 bool cannotHaveNonDefaultLowerBounds = false,
                                 bool useDefaultLowerBounds = false);
+
+/// Generate inline default initialization for a variable of the given type,
+/// storing the result into \p destRef. This handles:
+///   - Trivial types (integer, real, complex, logical): zero-initialized.
+///   - Fixed-length CHARACTER: zero-initialized.
+///   - Derived types with default component values: component-wise stores.
+///   - Derived types without defaults (trivial components only): zero-init.
+void genInlineTypeDefaultInit(
+    AbstractConverter &converter, fir::FirOpBuilder &builder,
+    mlir::Location loc, mlir::Type type, mlir::Value destRef,
+    const Fortran::semantics::DerivedTypeSpec *derivedTypeSpec = nullptr,
+    const Fortran::semantics::Symbol *sym = nullptr);
 
 } // namespace lower
 } // namespace Fortran

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -464,6 +464,16 @@ static mlir::Value genDefaultInitializerValue(
   return initialValue;
 }
 
+mlir::Value Fortran::lower::genScalarDefaultInitializerValue(
+    Fortran::lower::AbstractConverter &converter, mlir::Location loc,
+    const Fortran::semantics::Symbol &sym, mlir::Type symTy) {
+  Fortran::lower::StatementContext stmtCtx;
+  mlir::Value result =
+      genDefaultInitializerValue(converter, loc, sym, symTy, stmtCtx);
+  stmtCtx.finalizeAndPop();
+  return result;
+}
+
 /// Does this global already have an initializer ?
 static bool globalIsInitialized(fir::GlobalOp global) {
   return !global.getRegion().empty() || global.getInitVal();

--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -651,9 +651,7 @@ bool ClauseProcessor::processInitializer(
     };
     return true;
   }
-  TODO(converter.getCurrentLocation(),
-       "declare reduction without an initializer clause is not yet "
-       "supported");
+  return false;
 }
 
 bool ClauseProcessor::processMergeable(

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -30,6 +30,7 @@
 #include "flang/Lower/OpenMP/Clauses.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/StatementContext.h"
+#include "flang/Lower/Support/PrivateReductionUtils.h"
 #include "flang/Lower/Support/ReductionProcessor.h"
 #include "flang/Lower/SymbolMap.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
@@ -4251,18 +4252,24 @@ static ReductionProcessor::GenCombinerCBTy processReductionCombiner(
   return genCombinerCB;
 }
 
-// Checks that the reduction type is either a trivial type or a derived type of
-// trivial types.
+// Checks that the reduction type is either a trivial type, a fixed-length
+// character type, or a derived type composed of such types.
 static bool isSimpleReductionType(mlir::Type reductionType) {
   if (fir::isa_trivial(reductionType))
     return true;
+  // Fixed-length CHARACTER is not trivial but can be zero-initialized.
+  // Reject dynamic-length CHARACTER (len == unknownLen()).
+  if (auto charTy = mlir::dyn_cast<fir::CharacterType>(reductionType))
+    return charTy.getLen() != fir::CharacterType::unknownLen();
   if (auto recordTy = mlir::dyn_cast<fir::RecordType>(reductionType)) {
     for (auto [_, fieldType] : recordTy.getTypeList()) {
-      if (!fir::isa_trivial(fieldType))
+      if (!isSimpleReductionType(fieldType))
         return false;
     }
+    return true;
   }
-  return true;
+  // Reject array and descriptor-based types.
+  return false;
 }
 
 // Getting the type from a symbol compared to a DeclSpec is simpler since we do
@@ -4285,8 +4292,8 @@ getReductionType(lower::AbstractConverter &converter,
 
   if (!isSimpleReductionType(reductionType))
     TODO(converter.getCurrentLocation(),
-         "declare reduction currently only supports trival types or derived "
-         "types containing trivial types");
+         "declare reduction currently only supports trivial types, "
+         "fixed-length CHARACTER, or derived types containing them");
   return reductionType;
 }
 
@@ -4399,22 +4406,16 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
     ReductionProcessor::GenCombinerCBTy genCombinerCB =
         processReductionCombiner(converter, symTable, semaCtx, combiner,
                                  parserInst);
-    ReductionProcessor::GenInitValueCBTy genInitValueCB;
-    ClauseProcessor cp(converter, semaCtx, clauses);
     const parser::OmpStylizedInstance *parserInitInst = nullptr;
     if (initExpr) {
       assert(parserInitInstIt != initExpr->v.end() &&
              "Mismatched initializer instance count");
       parserInitInst = &*parserInitInstIt++;
     }
-    cp.processInitializer(symTable, genInitValueCB, parserInitInst);
-    mlir::Type redType =
-        isByRef
-            ? static_cast<mlir::Type>(fir::ReferenceType::get(reductionType))
-            : reductionType;
 
-    // Get the omp_out symbol from the combiner for finalization checks
-    // in populateByRefInitAndCleanupRegions.
+    // Get the omp_out symbol from the combiner. Used for finalization checks
+    // in populateByRefInitAndCleanupRegions and for generating default
+    // initialization via genScalarDefaultInitializerValue.
     const semantics::Symbol *reductionSym = nullptr;
     const auto &declList =
         std::get<std::list<parser::OmpStylizedDeclaration>>(parserInst.t);
@@ -4425,6 +4426,57 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
         break;
       }
     }
+
+    ReductionProcessor::GenInitValueCBTy genInitValueCB;
+    ClauseProcessor cp(converter, semaCtx, clauses);
+    if (!cp.processInitializer(symTable, genInitValueCB, parserInitInst)) {
+      // No initializer clause provided. Per OpenMP, initialize as
+      // default-initialized using the shared inline init helper.
+      const semantics::DerivedTypeSpec *derivedTypeSpec = nullptr;
+      if (const semantics::DeclTypeSpec *declTypeSpec = typeSpec.declTypeSpec)
+        derivedTypeSpec = declTypeSpec->AsDerived();
+
+      mlir::Type unwrappedType = fir::unwrapRefType(reductionType);
+      if (fir::isa_trivial(unwrappedType)) {
+        // Trivial types return the zero value directly (by-value init).
+        genInitValueCB = [](fir::FirOpBuilder &builder, mlir::Location loc,
+                            mlir::Type type, mlir::Value,
+                            mlir::Value) -> mlir::Value {
+          mlir::Type ty = fir::unwrapRefType(type);
+          if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(ty))
+            ty = seqTy.getEleTy();
+          else if (auto boxTy = mlir::dyn_cast<fir::BaseBoxType>(ty)) {
+            auto eleTy = fir::unwrapRefType(boxTy.getEleTy());
+            if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(eleTy))
+              ty = seqTy.getEleTy();
+            else
+              ty = eleTy;
+          }
+          return fir::ZeroOp::create(builder, loc, ty);
+        };
+      } else if (mlir::isa<fir::CharacterType>(unwrappedType) ||
+                 fir::isa_derived(unwrappedType)) {
+        // CHARACTER and derived types use by-ref init via the shared helper.
+        genInitValueCB = [&converter, derivedTypeSpec, reductionSym](
+                             fir::FirOpBuilder &builder, mlir::Location loc,
+                             mlir::Type type, mlir::Value,
+                             mlir::Value) -> mlir::Value {
+          mlir::Block *initBlock = builder.getInsertionBlock();
+          mlir::Value privVar = initBlock->getArgument(1);
+          lower::genInlineTypeDefaultInit(converter, builder, loc, type,
+                                          privVar, derivedTypeSpec,
+                                          reductionSym);
+          return mlir::Value{};
+        };
+      } else {
+        llvm_unreachable(
+            "unhandled type in declare reduction without initializer");
+      }
+    }
+    mlir::Type redType =
+        isByRef
+            ? static_cast<mlir::Type>(fir::ReferenceType::get(reductionType))
+            : reductionType;
 
     ReductionProcessor::createDeclareReductionHelper<
         mlir::omp::DeclareReductionOp>(

--- a/flang/lib/Lower/Support/PrivateReductionUtils.cpp
+++ b/flang/lib/Lower/Support/PrivateReductionUtils.cpp
@@ -28,6 +28,7 @@
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Semantics/symbol.h"
+#include "flang/Semantics/type.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Location.h"
 #include "llvm/Support/CommandLine.h"
@@ -662,6 +663,14 @@ void PopulateInitAndCleanupRegionsHelper::initAndCleanupUnboxedDerivedType(
       builder.setInsertionPointToEnd(initBlock);
     fir::StoreOp::create(builder, loc, scalarInitValue, allocatedPrivVarArg);
   }
+  // For reductions, the init callback handles initialization, either inline
+  // component-wise stores or explicit initializer clause.
+  if (isReduction(kind)) {
+    if (needsInitialization && fir::isa_derived(valType) &&
+        fir::isRecordWithDescriptorMember(valType))
+      TODO(loc, "reduction of derived type requiring runtime initialization");
+    needsInitialization = false;
+  }
   mlir::Type boxedTy = fir::BoxType::get(valType);
   mlir::Value newBox =
       fir::EmboxOp::create(builder, loc, boxedTy, allocatedPrivVarArg);
@@ -795,4 +804,43 @@ void Fortran::lower::populateByRefInitAndCleanupRegions(
       if (load.use_empty())
         load.erase();
   }
+}
+
+void Fortran::lower::genInlineTypeDefaultInit(
+    Fortran::lower::AbstractConverter &converter, fir::FirOpBuilder &builder,
+    mlir::Location loc, mlir::Type type, mlir::Value destRef,
+    const Fortran::semantics::DerivedTypeSpec *derivedTypeSpec,
+    const Fortran::semantics::Symbol *sym) {
+  mlir::Type unwrappedType = fir::unwrapRefType(type);
+
+  if (fir::isa_trivial(unwrappedType) ||
+      mlir::isa<fir::CharacterType>(unwrappedType)) {
+    // Trivial types and fixed-length CHARACTER: zero-initialize.
+    mlir::Value zero = fir::ZeroOp::create(builder, loc, unwrappedType);
+    fir::StoreOp::create(builder, loc, zero, destRef);
+    return;
+  }
+
+  if (fir::isa_derived(unwrappedType)) {
+    bool hasDefaults =
+        derivedTypeSpec && derivedTypeSpec->HasDefaultInitialization(
+                               /*ignoreAllocatable=*/false,
+                               /*ignorePointer=*/true);
+    if (hasDefaults) {
+      assert(sym && "derived type has default initialization but no symbol "
+                    "provided; default values would be lost");
+      // Reuse the existing default-initializer infrastructure from
+      // ConvertVariable to build an SSA aggregate value, then store it.
+      mlir::Value initVal = Fortran::lower::genScalarDefaultInitializerValue(
+          converter, loc, *sym, unwrappedType);
+      fir::StoreOp::create(builder, loc, initVal, destRef);
+    } else {
+      // Derived type without defaults: zero-initialize the whole record.
+      mlir::Value zero = fir::ZeroOp::create(builder, loc, unwrappedType);
+      fir::StoreOp::create(builder, loc, zero, destRef);
+    }
+    return;
+  }
+
+  llvm_unreachable("unhandled type in genInlineTypeDefaultInit");
 }

--- a/flang/test/Lower/OpenMP/Todo/omp-declare-reduction-advanced-types.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declare-reduction-advanced-types.f90
@@ -8,7 +8,7 @@ module mymod
      integer(4)::val
      integer(4)::otherval
   end type advancedtype
-  !CHECK: not yet implemented: declare reduction currently only supports trival types or derived types containing trivial types
+  !CHECK: not yet implemented: declare reduction currently only supports trivial types, fixed-length CHARACTER, or derived types containing them
   !$omp declare reduction(myreduction: advancedtype: omp_out = omp_in) initializer(omp_priv = omp_orig)
 end module mymod
 

--- a/flang/test/Lower/OpenMP/Todo/reduction-character-dynamic-length.f90
+++ b/flang/test/Lower/OpenMP/Todo/reduction-character-dynamic-length.f90
@@ -1,7 +1,8 @@
-! RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
-! RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck -check-prefix=BBC %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck -check-prefix=FC1 %s
 
-! CHECK: not yet implemented: OpenMP reduction allocation for dynamic length character
+! BBC: not yet implemented: declare reduction currently only supports trivial types, fixed-length CHARACTER, or derived types containing them
+! FC1: not yet implemented: declare reduction currently only supports trivial types, fixed-length CHARACTER, or derived types containing them
 subroutine test_dynamic_length(n)
   integer, intent(in) :: n
   character(len=n) :: var

--- a/flang/test/Lower/OpenMP/declare-reduction-no-initializer-derived.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-no-initializer-derived.f90
@@ -1,0 +1,97 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! Test declare reduction without initializer clause for derived types
+! with default component initialization.
+
+! CHECK-LABEL: omp.declare_reduction @add_reduction_byref_rec__QMtypesTshape
+! CHECK-SAME:    : !fir.ref<!fir.type<_QMtypesTshape{center:!fir.type<_QMtypesTpoint{x:f32,y:f32}>,radius:f32}>>
+! CHECK:       init {
+! CHECK:       ^bb0(%{{.*}}: !fir.ref<!fir.type<_QMtypesTshape{{.*}}>>, %[[PRIV:.*]]: !fir.ref<!fir.type<_QMtypesTshape{{.*}}>>):
+! CHECK:         %[[UNDEF:.*]] = fir.undefined !fir.type<_QMtypesTshape{{.*}}>
+! CHECK:         fir.zero_bits !fir.type<_QMtypesTpoint{x:f32,y:f32}>
+! CHECK:         fir.insert_value %[[UNDEF]], {{.*}}["center"
+! CHECK:         arith.constant 0.000000e+00 : f32
+! CHECK:         fir.insert_value {{.*}}["radius"
+! CHECK:         fir.store {{.*}} to %[[PRIV]]
+! CHECK:         omp.yield(%[[PRIV]]
+! CHECK:       } combiner {
+
+! CHECK-LABEL: omp.declare_reduction @add_reduction_byref_rec__QMtypesTpoint
+! CHECK-SAME:    : !fir.ref<!fir.type<_QMtypesTpoint{x:f32,y:f32}>>
+! CHECK:       init {
+! CHECK:       ^bb0(%{{.*}}: !fir.ref<!fir.type<_QMtypesTpoint{{.*}}>>, %[[PRIV2:.*]]: !fir.ref<!fir.type<_QMtypesTpoint{{.*}}>>):
+! CHECK:         fir.zero_bits !fir.type<_QMtypesTpoint{x:f32,y:f32}>
+! CHECK:         fir.store
+! CHECK:         omp.yield(%[[PRIV2]]
+! CHECK:       } combiner {
+
+! CHECK-LABEL: func.func @_QQmain
+! CHECK:       omp.wsloop {{.*}} reduction(byref @add_reduction_byref_rec__QMtypesTpoint
+! CHECK:       omp.wsloop {{.*}} reduction(byref @add_reduction_byref_rec__QMtypesTshape
+
+module types
+  implicit none
+
+  type :: point
+    real :: x , y
+  end type point
+
+  ! Nested derived type — tests recursive isSimpleReductionType
+  type :: shape
+    type(point) :: center
+    real :: radius = 0.0
+  end type shape
+
+  interface operator(+)
+    module procedure add_points, add_shapes
+  end interface
+
+contains
+
+  pure function add_points(a, b) result(res)
+    type(point), intent(in) :: a, b
+    type(point) :: res
+    res%x = a%x + b%x
+    res%y = a%y + b%y
+  end function
+
+  pure function add_shapes(a, b) result(res)
+    type(shape), intent(in) :: a, b
+    type(shape) :: res
+    res%center = add_points(a%center, b%center)
+    res%radius = a%radius + b%radius
+  end function
+
+end module types
+
+program test_no_init_derived
+  use types
+  implicit none
+
+  type(point) :: p
+  type(shape) :: s
+  integer :: i
+
+  !$omp declare reduction(+: point: omp_out = omp_out + omp_in)
+  !$omp declare reduction(+: shape: omp_out = omp_out + omp_in)
+
+  p = point(0.0, 0.0)
+  s = shape(point(0.0, 0.0), 0.0)
+
+  ! Test point reduction without initializer
+  !$omp parallel do reduction(+: p)
+  do i = 1, 10
+    p = p + point(1.0, 2.0)
+  end do
+  !$omp end parallel do
+
+  ! Test nested shape reduction without initializer
+  !$omp parallel do reduction(+: s)
+  do i = 1, 10
+    s = s + shape(point(1.0, 2.0), 3.0)
+  end do
+  !$omp end parallel do
+
+  print *, p%x, p%y
+  print *, s%center%x, s%center%y, s%radius
+end program

--- a/flang/test/Lower/OpenMP/declare-reduction-no-initializer-intrinsic.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-no-initializer-intrinsic.f90
@@ -1,0 +1,83 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! Test declare reduction without initializer clause for intrinsic types.
+! Without an initializer, the private variable should be zero-initialized.
+
+! CHECK-DAG: omp.declare_reduction @char_max : !fir.ref<!fir.char<1,10>>
+! CHECK:       init {
+! CHECK:       %[[CHZERO:.*]] = fir.zero_bits !fir.char<1,10>
+! CHECK:       fir.store %[[CHZERO]]
+! CHECK:       } combiner {
+
+! CHECK-DAG: omp.declare_reduction @add_reduction_z32 : complex<f32> init {
+! CHECK:       %[[CZERO:.*]] = fir.zero_bits complex<f32>
+! CHECK:       omp.yield(%[[CZERO]] : complex<f32>)
+! CHECK:     } combiner {
+! CHECK:       fir.addc
+! CHECK:     }
+
+! CHECK-DAG: omp.declare_reduction @add_reduction_f32 : f32 init {
+! CHECK:       %[[FZERO:.*]] = fir.zero_bits f32
+! CHECK:       omp.yield(%[[FZERO]] : f32)
+! CHECK:     } combiner {
+! CHECK:       arith.addf
+! CHECK:     }
+
+! CHECK-DAG: omp.declare_reduction @add_reduction_i32 : i32 init {
+! CHECK:       %[[IZERO:.*]] = fir.zero_bits i32
+! CHECK:       omp.yield(%[[IZERO]] : i32)
+! CHECK:     } combiner {
+! CHECK:       arith.addi
+! CHECK:     }
+
+program test_no_init_intrinsic
+  implicit none
+  integer :: a, i
+  real :: r
+  complex :: c
+  character(len=10) :: s
+
+  !$omp declare reduction(+: integer: omp_out = omp_out + omp_in)
+  !$omp declare reduction(+: real: omp_out = omp_out + omp_in)
+  !$omp declare reduction(+: complex: omp_out = omp_out + omp_in)
+  !$omp declare reduction(char_max: character(len=10): omp_out = max(omp_out, omp_in))
+
+  a = 0
+  r = 0.0
+  c = (0.0, 0.0)
+  s = "aaa"
+
+  ! Test integer reduction without initializer
+  ! CHECK: omp.wsloop {{.*}} reduction(@add_reduction_i32
+  !$omp parallel do reduction(+: a)
+  do i = 1, 10
+    a = a + i
+  end do
+  !$omp end parallel do
+
+  ! Test real reduction without initializer
+  ! CHECK: omp.wsloop {{.*}} reduction(@add_reduction_f32
+  !$omp parallel do reduction(+: r)
+  do i = 1, 10
+    r = r + real(i)
+  end do
+  !$omp end parallel do
+
+  ! Test complex reduction without initializer
+  ! CHECK: omp.wsloop {{.*}} reduction(@add_reduction_z32
+  !$omp parallel do reduction(+: c)
+  do i = 1, 10
+    c = c + cmplx(real(i), 0.0)
+  end do
+  !$omp end parallel do
+
+  ! Test fixed-length character reduction without initializer
+  ! CHECK: omp.wsloop {{.*}} reduction(byref @char_max
+  !$omp parallel do reduction(char_max: s)
+  do i = 1, 10
+    continue
+  end do
+  !$omp end parallel do
+
+  print *, a, r, c, s
+end program

--- a/flang/test/Lower/OpenMP/declare-reduction-no-initializer-target-derived.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-no-initializer-target-derived.f90
@@ -1,0 +1,56 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! Test declare reduction without initializer clause for derived type with
+! default component values, used in a target offload region.
+! The init region must initialize components using the type's default values.
+
+! CHECK-LABEL: omp.declare_reduction @add_pts
+! CHECK-SAME:    : !fir.ref<!fir.type<_QFTpoint{x:f32,y:f32}>>
+! CHECK:       init {
+! CHECK:       ^bb0(%{{.*}}: !fir.ref<!fir.type<_QFTpoint{{.*}}>>,
+! CHECK-SAME:       %[[PRIV:.*]]: !fir.ref<!fir.type<_QFTpoint{{.*}}>>):
+! CHECK-NOT:     fir.call @_FortranAInitialize
+! CHECK:         %[[UNDEF:.*]] = fir.undefined !fir.type<_QFTpoint{{.*}}>
+! CHECK:         fir.zero_bits f32
+! CHECK:         fir.insert_value %[[UNDEF]], {{.*}}["x"
+! CHECK:         arith.constant 0.000000e+00 : f32
+! CHECK:         fir.insert_value {{.*}}["y"
+! CHECK:         fir.store {{.*}} to %[[PRIV]]
+! CHECK:         omp.yield(%[[PRIV]]
+! CHECK:       } combiner {
+
+program main
+    implicit none
+
+    type :: Point
+        real :: x
+        real :: y = 0.0
+    end type Point
+
+    integer :: i
+    type(Point) :: total
+
+    !$omp declare reduction(add_pts : Point : &
+    !$omp&   merge_points(omp_out, omp_in))
+
+    total = Point(0.0, 0.0)
+
+    !$omp target teams distribute parallel do reduction(add_pts: total) map(tofrom: total)
+    do i = 1, 100
+        total%x = total%x + 1.0
+        total%y = total%y + 2.0
+    end do
+    !$omp end target teams distribute parallel do
+
+    print *, "Final Point X:", total%x
+    print *, "Final Point Y:", total%y
+
+contains
+    subroutine merge_points(out_p, in_p)
+        !$omp declare target
+        type(Point), intent(inout) :: out_p
+        type(Point), intent(in)    :: in_p
+        out_p%x = out_p%x + in_p%x
+        out_p%y = out_p%y + in_p%y
+    end subroutine
+end program main

--- a/flang/test/Lower/OpenMP/declare-reduction-no-initializer-unsupported.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-no-initializer-unsupported.f90
@@ -1,0 +1,40 @@
+! RUN: split-file %s %t
+! RUN: not %flang_fc1 -emit-hlfir -fopenmp %t/dyn_char.f90 -o - 2>&1 | FileCheck -check-prefix=DYN-CHAR %s
+! RUN: not %flang_fc1 -emit-hlfir -fopenmp %t/non_trivial.f90 -o - 2>&1 | FileCheck -check-prefix=NON-TRIVIAL %s
+
+! Test that unsupported types in declare reduction without initializer
+! produce a TODO diagnostic rather than crashing.
+
+! DYN-CHAR: not yet implemented: declare reduction currently only supports trivial types, fixed-length CHARACTER, or derived types containing them
+! NON-TRIVIAL: not yet implemented: declare reduction currently only supports trivial types, fixed-length CHARACTER, or derived types containing them
+
+!--- dyn_char.f90
+subroutine dyn_char(s, n)
+  integer, intent(in) :: n
+  character(len=n) :: s
+  integer :: i
+
+  !$omp declare reduction(char_max: character(len=n): omp_out = max(omp_out, omp_in))
+
+  !$omp parallel do reduction(char_max: s)
+  do i = 1, 4
+    s = s
+  end do
+end subroutine
+
+!--- non_trivial.f90
+subroutine non_trivial(x)
+  type :: alloc_type
+    integer, allocatable :: data(:)
+  end type
+
+  type(alloc_type) :: x
+  integer :: i
+
+  !$omp declare reduction(my_add: alloc_type: omp_out%data = omp_out%data + omp_in%data)
+
+  !$omp parallel do reduction(my_add: x)
+  do i = 1, 4
+    x%data(i) = x%data(i) + 1
+  end do
+end subroutine

--- a/flang/test/Lower/OpenMP/declare-reduction-target-intrinsic.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-target-intrinsic.f90
@@ -1,0 +1,73 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s
+
+! Test user-defined declare reduction with intrinsic types on target device.
+! These should generate inline constant initialization (no runtime calls),
+! so they work on GPU targets without requiring the device Fortran runtime.
+
+! CHECK-LABEL: omp.declare_reduction @addc : complex<f32> init {
+! CHECK:         %[[CZERO:.*]] = fir.zero_bits complex<f32>
+! CHECK:         omp.yield(%[[CZERO]] : complex<f32>)
+! CHECK:       } combiner {
+! CHECK:         fir.addc
+! CHECK:       }
+
+! CHECK-LABEL: omp.declare_reduction @addr : f32 init {
+! CHECK:         %[[FZERO:.*]] = fir.zero_bits f32
+! CHECK:         omp.yield(%[[FZERO]] : f32)
+! CHECK:       } combiner {
+! CHECK:         arith.addf
+! CHECK:       }
+
+! CHECK-LABEL: omp.declare_reduction @addi : i32 init {
+! CHECK:         %[[IZERO:.*]] = fir.zero_bits i32
+! CHECK:         omp.yield(%[[IZERO]] : i32)
+! CHECK:       } combiner {
+! CHECK:         arith.addi
+! CHECK:       }
+
+! CHECK: omp.target
+! CHECK:   omp.teams reduction(@addi
+! CHECK:     omp.wsloop reduction(@addi
+
+! CHECK: omp.target
+! CHECK:   omp.teams reduction(@addr
+! CHECK:     omp.wsloop reduction(@addr
+
+! CHECK: omp.target
+! CHECK:   omp.teams reduction(@addc
+! CHECK:     omp.wsloop reduction(@addc
+
+program test_target_named_reduction
+  implicit none
+  integer :: a, i
+  real :: r
+  complex :: c
+
+  !$omp declare reduction(addi: integer: omp_out = omp_out + omp_in)
+  !$omp declare reduction(addr: real: omp_out = omp_out + omp_in)
+  !$omp declare reduction(addc: complex: omp_out = omp_out + omp_in)
+
+  a = 0
+  r = 0.0
+  c = (0.0, 0.0)
+
+  !$omp target teams distribute parallel do reduction(addi: a) map(tofrom: a)
+  do i = 1, 10
+    a = a + i
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target teams distribute parallel do reduction(addr: r) map(tofrom: r)
+  do i = 1, 10
+    r = r + real(i)
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target teams distribute parallel do reduction(addc: c) map(tofrom: c)
+  do i = 1, 10
+    c = c + cmplx(real(i), 0.0)
+  end do
+  !$omp end target teams distribute parallel do
+
+  print *, "Int:", a, " Real:", r, " Complex:", c
+end program


### PR DESCRIPTION
For declare reduction without an explicit initializer clause, the init callback now handles initialization inline rather than relying on the _FortranAInitialize runtime call, which is available on the device runtime but has known issues on GPU targets.

The initialization logic first checks whether an initializer clause is present. If one is provided, it is used directly. Otherwise, for derived types, the code checks whether the type has default component initialization. If it does, each component is initialized inline: components with explicit default values use those values, components that are themselves derived types with defaults are recursively initialized, and components without any default are zero-initialized.

Derived types with allocatable components that require runtime initialization are guarded by a TODO.

Assisted by: Claude Opus 4.6