### PR TITLE
[Driver] Forward -v to clang-sycl-linker in SPIRV toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -184,6 +184,8 @@ void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // Use of --sycl-link will call the clang-sycl-linker instead of
     // the default linker (spirv-link).
     Linker = ToolChain.GetProgramPath("clang-sycl-linker");
+    if (Args.hasArg(options::OPT_v))
+      CmdArgs.push_back("-v");
   } else if (!llvm::sys::fs::can_execute(Linker) &&
              !C.getArgs().hasArg(clang::options::OPT__HASH_HASH_HASH)) {
     C.getDriver().Diag(clang::diag::err_drv_no_spv_tools) << getShortName();

--- a/clang/test/Driver/sycl-link-spirv-target.cpp
+++ b/clang/test/Driver/sycl-link-spirv-target.cpp
@@ -9,3 +9,9 @@
 // RUN:   -Xlinker --device-libs=lib1.bc,lib2.bc %t.bc 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=XLINKEROPTS
 // XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "-triple=spirv64" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"
+
+// Test that -v is forwarded to clang-sycl-linker when --sycl-link is used.
+// RUN: touch %t.bc
+// RUN: %clangxx -### --target=spirv64 --sycl-link -v %t.bc 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=VERBOSE
+// VERBOSE: "{{.*}}clang-sycl-linker{{.*}}" {{.*}}"-v"


### PR DESCRIPTION
The SPIRV linker job construction was not forwarding the -v (verbose) flag to clang-sycl-linker when --sycl-link is used. This is limited to the --sycl-link path because the default linker spir-link doesn't support -v flag.