### PR TITLE
[clang] Stop simplifyConstraint at embedded NUL

### DIFF
--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -1072,6 +1072,9 @@ TargetInfo::simplifyConstraint(StringRef Constraint,
                                SmallVectorImpl<ConstraintInfo> *OutCons) const {
   std::string Result;
 
+  // Stop at '\0' to match the old behavior.
+  Constraint = Constraint.split('\0').first;
+
   for (const char *I = Constraint.begin(), *E = Constraint.end(); I < E; I++) {
     switch (*I) {
     default:

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -1072,7 +1072,7 @@ TargetInfo::simplifyConstraint(StringRef Constraint,
                                SmallVectorImpl<ConstraintInfo> *OutCons) const {
   std::string Result;
 
-  // Stop at '\0' to match the old behavior.
+  // Ignore embedded nulls to match prior (clang-21 and earlier) behavior
   Constraint = Constraint.split('\0').first;
 
   for (const char *I = Constraint.begin(), *E = Constraint.end(); I < E; I++) {

--- a/clang/test/CodeGen/inline-asm-constraint-embedded-null.c
+++ b/clang/test/CodeGen/inline-asm-constraint-embedded-null.c
@@ -1,0 +1,8 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -o - %s | FileCheck %s
+
+// Regression test for issue173900.
+
+// CHECK-LABEL: define {{.*}}void @f(
+// CHECK: call void asm sideeffect "", "f,{{[^"]*}}"(double 0.000000e+00)
+void f(void) { __asm__("" : : "f\0001"(0.0)); }


### PR DESCRIPTION
Resolves #173900.

#154905 switched simplifyConstraint from a C-style string to a StringRef, which silently changed behavior when encountering embedded NUL bytes. Truncate at the first '\0' to restore the old behavior.