### PR TITLE
[Clang][ItaniumMangle][NFC] Refactor FunctionTypeDepthState

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -243,42 +243,34 @@ class CXXNameMangler {
   unsigned SeqID = 0;
 
   class FunctionTypeDepthState {
-    unsigned Bits = 0;
-
-    enum { InResultTypeMask = 1 };
+    unsigned Depth : 31;
+    unsigned InFunctionDeclSuffix : 1;
 
   public:
-    FunctionTypeDepthState() = default;
+    FunctionTypeDepthState() : Depth(0), InFunctionDeclSuffix(0) {}
 
-    /// The number of function types we're inside.
-    unsigned getDepth() const {
-      return Bits >> 1;
-    }
-
-    /// True if we're in the return type of the innermost function type.
-    bool isInResultType() const {
-      return Bits & InResultTypeMask;
+    unsigned getNestingDepth(unsigned ParmDepth) const {
+      // ParmDepth does not include the declaring function prototype.
+      // FunctionTypeDepth does account for that.
+      assert(ParmDepth < Depth &&
+             "ParmVarDecl is not visible in current parameter environment");
+      return Depth - ParmDepth - InFunctionDeclSuffix;
     }
 
     FunctionTypeDepthState push() {
-      FunctionTypeDepthState tmp = *this;
-      Bits = (Bits & ~InResultTypeMask) + 2;
-      return tmp;
+      FunctionTypeDepthState Saved = *this;
+      ++Depth;
+      InFunctionDeclSuffix = 0;
+      return Saved;
     }
 
-    void enterResultType() {
-      Bits |= InResultTypeMask;
+    void pop(FunctionTypeDepthState Saved) {
+      assert(Depth == Saved.Depth + 1 && "unbalanced function type depth pop");
+      *this = Saved;
     }
 
-    void leaveResultType() {
-      Bits &= ~InResultTypeMask;
-    }
-
-    void pop(FunctionTypeDepthState saved) {
-      assert(getDepth() == saved.getDepth() + 1);
-      Bits = saved.Bits;
-    }
-
+    void enterFunctionDeclSuffix() { InFunctionDeclSuffix = 1; }
+    void leaveFunctionDeclSuffix() { InFunctionDeclSuffix = 0; }
   } FunctionTypeDepth;
 
   // abi_tag is a gcc attribute, taking one or more strings called "tags".
@@ -3752,9 +3744,9 @@ void CXXNameMangler::mangleType(const FunctionNoProtoType *T) {
 
   FunctionTypeDepthState saved = FunctionTypeDepth.push();
 
-  FunctionTypeDepth.enterResultType();
+  FunctionTypeDepth.enterFunctionDeclSuffix();
   mangleType(T->getReturnType());
-  FunctionTypeDepth.leaveResultType();
+  FunctionTypeDepth.leaveFunctionDeclSuffix();
 
   FunctionTypeDepth.pop(saved);
   Out << 'E';
@@ -3769,7 +3761,7 @@ void CXXNameMangler::mangleBareFunctionType(const FunctionProtoType *Proto,
 
   // <bare-function-type> ::= <signature type>+
   if (MangleReturnType) {
-    FunctionTypeDepth.enterResultType();
+    FunctionTypeDepth.enterFunctionDeclSuffix();
 
     // Mangle ns_returns_retained as an order-sensitive qualifier here.
     if (Proto->getExtInfo().getProducesResult() && FD == nullptr)
@@ -3784,7 +3776,7 @@ void CXXNameMangler::mangleBareFunctionType(const FunctionProtoType *Proto,
     }
     mangleType(ReturnTy);
 
-    FunctionTypeDepth.leaveResultType();
+    FunctionTypeDepth.leaveFunctionDeclSuffix();
   }
 
   if (Proto->getNumParams() == 0 && !Proto->isVariadic()) {
@@ -3821,7 +3813,7 @@ void CXXNameMangler::mangleBareFunctionType(const FunctionProtoType *Proto,
   }
 
   if (FD) {
-    FunctionTypeDepth.enterResultType();
+    FunctionTypeDepth.enterFunctionDeclSuffix();
     mangleRequiresClause(FD->getTrailingRequiresClause().ConstraintExpr);
   }
 
@@ -5716,7 +5708,7 @@ recurse:
       Out << '_';
 
       // The rest of the mangling is in the immediate scope of the parameters.
-      FunctionTypeDepth.enterResultType();
+      FunctionTypeDepth.enterFunctionDeclSuffix();
       for (const concepts::Requirement *Req : RE->getRequirements())
         mangleRequirement(RE->getExprLoc(), Req);
       FunctionTypeDepth.pop(saved);
@@ -6013,14 +6005,8 @@ void CXXNameMangler::mangleFunctionParam(const ParmVarDecl *parm) {
   unsigned parmIndex = parm->getFunctionScopeIndex();
 
   // Compute 'L'.
-  // parmDepth does not include the declaring function prototype.
-  // FunctionTypeDepth does account for that.
-  assert(parmDepth < FunctionTypeDepth.getDepth());
-  unsigned nestingDepth = FunctionTypeDepth.getDepth() - parmDepth;
-  if (FunctionTypeDepth.isInResultType())
-    nestingDepth--;
-
-  if (nestingDepth == 0) {
+  if (unsigned nestingDepth = FunctionTypeDepth.getNestingDepth(parmDepth);
+      nestingDepth == 0) {
     Out << "fp";
   } else {
     Out << "fL" << (nestingDepth - 1) << 'p';
@@ -7254,9 +7240,9 @@ CXXNameMangler::makeFunctionReturnTypeTags(const FunctionDecl *FD) {
   const FunctionProtoType *Proto =
       cast<FunctionProtoType>(FD->getType()->getAs<FunctionType>());
   FunctionTypeDepthState saved = TrackReturnTypeTags.FunctionTypeDepth.push();
-  TrackReturnTypeTags.FunctionTypeDepth.enterResultType();
+  TrackReturnTypeTags.FunctionTypeDepth.enterFunctionDeclSuffix();
   TrackReturnTypeTags.mangleType(Proto->getReturnType());
-  TrackReturnTypeTags.FunctionTypeDepth.leaveResultType();
+  TrackReturnTypeTags.FunctionTypeDepth.leaveFunctionDeclSuffix();
   TrackReturnTypeTags.FunctionTypeDepth.pop(saved);
 
   return TrackReturnTypeTags.AbiTagsRoot.getSortedUniqueUsedAbiTags();


### PR DESCRIPTION
This patch refactors `FunctionTypeDepthState` to use bit-fields and moves the
`getNestingDepth` logic into it. It also renames `{enter,leave}ResultType` to
`{enter,leave}FunctionDeclSuffix`, since the old names no longer match their
current role.