### PR TITLE
[CMake][NFC] Remove dead code add_llvm_external_project(libclc)

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -53,9 +53,6 @@ add_llvm_implicit_projects()
 
 add_llvm_external_project(polly)
 
-# libclc depends on clang
-add_llvm_external_project(libclc)
-
 # Add subprojects specified using LLVM_EXTERNAL_PROJECTS
 foreach(p ${LLVM_EXTERNAL_PROJECTS})
   add_llvm_external_project(${p})


### PR DESCRIPTION
It was added in 72f9881c3ffcf. libclc has now switched to runtime build.