### PR TITLE
[UniformityAnalysis] Rename public api's in UA (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -1292,12 +1292,13 @@ GenericUniformityInfo<ContextT>::getFunction() const {
 /// A default-constructed instance (no analysis computed) reports everything
 /// as uniform, which is conservatively correct for non-divergent targets.
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergent(ConstValueRefT V) const {
+bool GenericUniformityInfo<ContextT>::isDivergentDef(ConstValueRefT V) const {
   return DA && DA->isDivergent(V);
 }
 
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergent(const InstructionT *I) const {
+bool GenericUniformityInfo<ContextT>::isDivergentDef(
+    const InstructionT *I) const {
   return DA && DA->isDivergent(*I);
 }
 

--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -1292,18 +1292,18 @@ GenericUniformityInfo<ContextT>::getFunction() const {
 /// A default-constructed instance (no analysis computed) reports everything
 /// as uniform, which is conservatively correct for non-divergent targets.
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergentDef(ConstValueRefT V) const {
+bool GenericUniformityInfo<ContextT>::isDivergentAtDef(ConstValueRefT V) const {
   return DA && DA->isDivergent(V);
 }
 
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergentDef(
+bool GenericUniformityInfo<ContextT>::isDivergentAtDef(
     const InstructionT *I) const {
   return DA && DA->isDivergent(*I);
 }
 
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergentUse(const UseT &U) const {
+bool GenericUniformityInfo<ContextT>::isDivergentAtUse(const UseT &U) const {
   return DA && DA->isDivergentUse(U);
 }
 

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -74,6 +74,9 @@ public:
   /// divergent.
   bool isDivergentUse(const UseT &U) const;
 
+  /// \brief Whether \p U is uniform/non-divergent at its use.
+  bool isUniformUse(const UseT &U) const { return !isDivergentUse(U); }
+
   bool hasDivergentTerminator(const BlockT &B);
 
   void print(raw_ostream &Out) const;

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -58,17 +58,17 @@ public:
   const FunctionT &getFunction() const;
 
   /// Whether \p V is divergent at its definition.
-  bool isDivergent(ConstValueRefT V) const;
+  bool isDivergentDef(ConstValueRefT V) const;
 
-  /// Whether \p V is uniform/non-divergent.
-  bool isUniform(ConstValueRefT V) const { return !isDivergent(V); }
+  /// Whether \p V is uniform/non-divergent at its definition.
+  bool isUniformDef(ConstValueRefT V) const { return !isDivergentDef(V); }
 
   // Similar queries for InstructionT. These accept a pointer argument so that
   // in LLVM IR, they overload the equivalent queries for Value*. For example,
   // if querying whether a CondBrInst is divergent, it should not be treated as
   // a Value in LLVM IR.
-  bool isUniform(const InstructionT *I) const { return !isDivergent(I); };
-  bool isDivergent(const InstructionT *I) const;
+  bool isUniformDef(const InstructionT *I) const { return !isDivergentDef(I); };
+  bool isDivergentDef(const InstructionT *I) const;
 
   /// \brief Whether \p U is divergent. Uses of a uniform value can be
   /// divergent.

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -58,24 +58,26 @@ public:
   const FunctionT &getFunction() const;
 
   /// Whether \p V is divergent at its definition.
-  bool isDivergentDef(ConstValueRefT V) const;
+  bool isDivergentAtDef(ConstValueRefT V) const;
 
   /// Whether \p V is uniform/non-divergent at its definition.
-  bool isUniformDef(ConstValueRefT V) const { return !isDivergentDef(V); }
+  bool isUniformAtDef(ConstValueRefT V) const { return !isDivergentAtDef(V); }
 
   // Similar queries for InstructionT. These accept a pointer argument so that
   // in LLVM IR, they overload the equivalent queries for Value*. For example,
   // if querying whether a CondBrInst is divergent, it should not be treated as
   // a Value in LLVM IR.
-  bool isUniformDef(const InstructionT *I) const { return !isDivergentDef(I); };
-  bool isDivergentDef(const InstructionT *I) const;
+  bool isUniformAtDef(const InstructionT *I) const {
+    return !isDivergentAtDef(I);
+  };
+  bool isDivergentAtDef(const InstructionT *I) const;
 
-  /// \brief Whether \p U is divergent. Uses of a uniform value can be
-  /// divergent.
-  bool isDivergentUse(const UseT &U) const;
+  /// \brief Whether \p U is divergent at its use. Uses of a uniform value can
+  /// be divergent.
+  bool isDivergentAtUse(const UseT &U) const;
 
   /// \brief Whether \p U is uniform/non-divergent at its use.
-  bool isUniformUse(const UseT &U) const { return !isDivergentUse(U); }
+  bool isUniformAtUse(const UseT &U) const { return !isDivergentAtUse(U); }
 
   bool hasDivergentTerminator(const BlockT &B);
 

--- a/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
@@ -385,7 +385,7 @@ Register FunctionLoweringInfo::CreateRegs(Type *Ty, bool isDivergent) {
 }
 
 Register FunctionLoweringInfo::CreateRegs(const Value *V) {
-  return CreateRegs(V->getType(), UA && UA->isDivergent(V) &&
+  return CreateRegs(V->getType(), UA && UA->isDivergentDef(V) &&
                                       !TLI->requiresUniformRegister(*MF, V));
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
@@ -385,7 +385,7 @@ Register FunctionLoweringInfo::CreateRegs(Type *Ty, bool isDivergent) {
 }
 
 Register FunctionLoweringInfo::CreateRegs(const Value *V) {
-  return CreateRegs(V->getType(), UA && UA->isDivergentDef(V) &&
+  return CreateRegs(V->getType(), UA && UA->isDivergentAtDef(V) &&
                                       !TLI->requiresUniformRegister(*MF, V));
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
@@ -60,13 +60,13 @@ public:
 } // End anonymous namespace
 
 void AMDGPUAnnotateUniformValues::visitCondBrInst(CondBrInst &I) {
-  if (UA->isUniform(&I))
+  if (UA->isUniformDef(&I))
     setUniformMetadata(&I);
 }
 
 void AMDGPUAnnotateUniformValues::visitLoadInst(LoadInst &I) {
   Value *Ptr = I.getPointerOperand();
-  if (!UA->isUniform(Ptr))
+  if (!UA->isUniformDef(Ptr))
     return;
   Instruction *PtrI = dyn_cast<Instruction>(Ptr);
   if (PtrI)

--- a/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
@@ -60,13 +60,13 @@ public:
 } // End anonymous namespace
 
 void AMDGPUAnnotateUniformValues::visitCondBrInst(CondBrInst &I) {
-  if (UA->isUniformDef(&I))
+  if (UA->isUniformAtDef(&I))
     setUniformMetadata(&I);
 }
 
 void AMDGPUAnnotateUniformValues::visitLoadInst(LoadInst &I) {
   Value *Ptr = I.getPointerOperand();
-  if (!UA->isUniformDef(Ptr))
+  if (!UA->isUniformAtDef(Ptr))
     return;
   Instruction *PtrI = dyn_cast<Instruction>(Ptr);
   if (PtrI)

--- a/llvm/lib/Target/AMDGPU/AMDGPUAtomicOptimizer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAtomicOptimizer.cpp
@@ -223,11 +223,11 @@ void AMDGPUAtomicOptimizerImpl::visitAtomicRMWInst(AtomicRMWInst &I) {
 
   // If the pointer operand is divergent, then each lane is doing an atomic
   // operation on a different address, and we cannot optimize that.
-  if (UA.isDivergentUse(I.getOperandUse(PtrIdx))) {
+  if (UA.isDivergentAtUse(I.getOperandUse(PtrIdx))) {
     return;
   }
 
-  bool ValDivergent = UA.isDivergentUse(I.getOperandUse(ValIdx));
+  bool ValDivergent = UA.isDivergentAtUse(I.getOperandUse(ValIdx));
 
   // If the value operand is divergent, each lane is contributing a different
   // value to the atomic calculation. We can only optimize divergent values if
@@ -311,7 +311,7 @@ void AMDGPUAtomicOptimizerImpl::visitIntrinsicInst(IntrinsicInst &I) {
 
   const unsigned ValIdx = 0;
 
-  const bool ValDivergent = UA.isDivergentUse(I.getOperandUse(ValIdx));
+  const bool ValDivergent = UA.isDivergentAtUse(I.getOperandUse(ValIdx));
 
   // If the value operand is divergent, each lane is contributing a different
   // value to the atomic calculation. We can only optimize divergent values if
@@ -328,7 +328,7 @@ void AMDGPUAtomicOptimizerImpl::visitIntrinsicInst(IntrinsicInst &I) {
   // If any of the other arguments to the intrinsic are divergent, we can't
   // optimize the operation.
   for (unsigned Idx = 1; Idx < I.getNumOperands(); Idx++) {
-    if (UA.isDivergentUse(I.getOperandUse(Idx)))
+    if (UA.isDivergentAtUse(I.getOperandUse(Idx)))
       return;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -318,7 +318,7 @@ bool AMDGPUCodeGenPrepareImpl::canWidenScalarExtLoad(LoadInst &I) const {
   int TySize = DL.getTypeSizeInBits(Ty);
   Align Alignment = DL.getValueOrABITypeAlignment(I.getAlign(), Ty);
 
-  return I.isSimple() && TySize < 32 && Alignment >= 4 && UA.isUniform(&I);
+  return I.isSimple() && TySize < 32 && Alignment >= 4 && UA.isUniformDef(&I);
 }
 
 unsigned
@@ -370,7 +370,7 @@ bool AMDGPUCodeGenPrepareImpl::replaceMulWithMul24(BinaryOperator &I) const {
     return false;
 
   // Prefer scalar if this could be s_mul_i32
-  if (UA.isUniform(&I))
+  if (UA.isUniformDef(&I))
     return false;
 
   Value *LHS = I.getOperand(0);

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -318,7 +318,7 @@ bool AMDGPUCodeGenPrepareImpl::canWidenScalarExtLoad(LoadInst &I) const {
   int TySize = DL.getTypeSizeInBits(Ty);
   Align Alignment = DL.getValueOrABITypeAlignment(I.getAlign(), Ty);
 
-  return I.isSimple() && TySize < 32 && Alignment >= 4 && UA.isUniformDef(&I);
+  return I.isSimple() && TySize < 32 && Alignment >= 4 && UA.isUniformAtDef(&I);
 }
 
 unsigned
@@ -370,7 +370,7 @@ bool AMDGPUCodeGenPrepareImpl::replaceMulWithMul24(BinaryOperator &I) const {
     return false;
 
   // Prefer scalar if this could be s_mul_i32
-  if (UA.isUniformDef(&I))
+  if (UA.isUniformAtDef(&I))
     return false;
 
   Value *LHS = I.getOperand(0);

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -111,7 +111,7 @@ void DivergenceLoweringHelper::getCandidatesForLowering(
       if (MI.getOpcode() != TargetOpcode::G_PHI)
         continue;
       Register Dst = MI.getOperand(0).getReg();
-      if (MRI->getType(Dst) == S1 && MUI->isDivergent(Dst))
+      if (MRI->getType(Dst) == S1 && MUI->isDivergentDef(Dst))
         Vreg1Phis.push_back(&MI);
     }
   }
@@ -207,7 +207,7 @@ bool DivergenceLoweringHelper::lowerTemporalDivergence() {
   DenseMap<Register, Register> TDCache;
 
   for (auto [Reg, UseInst, _] : MUI->getTemporalDivergenceList()) {
-    if (MRI->getType(Reg) == LLT::scalar(1) || MUI->isDivergent(Reg) ||
+    if (MRI->getType(Reg) == LLT::scalar(1) || MUI->isDivergentDef(Reg) ||
         ILMA.isS32S64LaneMask(Reg))
       continue;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -111,7 +111,7 @@ void DivergenceLoweringHelper::getCandidatesForLowering(
       if (MI.getOpcode() != TargetOpcode::G_PHI)
         continue;
       Register Dst = MI.getOperand(0).getReg();
-      if (MRI->getType(Dst) == S1 && MUI->isDivergentDef(Dst))
+      if (MRI->getType(Dst) == S1 && MUI->isDivergentAtDef(Dst))
         Vreg1Phis.push_back(&MI);
     }
   }
@@ -207,7 +207,7 @@ bool DivergenceLoweringHelper::lowerTemporalDivergence() {
   DenseMap<Register, Register> TDCache;
 
   for (auto [Reg, UseInst, _] : MUI->getTemporalDivergenceList()) {
-    if (MRI->getType(Reg) == LLT::scalar(1) || MUI->isDivergentDef(Reg) ||
+    if (MRI->getType(Reg) == LLT::scalar(1) || MUI->isDivergentAtDef(Reg) ||
         ILMA.isS32S64LaneMask(Reg))
       continue;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
@@ -493,7 +493,7 @@ bool AMDGPULateCodeGenPrepare::canWidenScalarExtLoad(LoadInst &LI) const {
   if (LI.getAlign() < DL.getABITypeAlign(Ty))
     return false;
   // It should be uniform, i.e. a scalar load.
-  return UA.isUniform(&LI);
+  return UA.isUniformDef(&LI);
 }
 
 bool AMDGPULateCodeGenPrepare::visitLoadInst(LoadInst &LI) {

--- a/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
@@ -493,7 +493,7 @@ bool AMDGPULateCodeGenPrepare::canWidenScalarExtLoad(LoadInst &LI) const {
   if (LI.getAlign() < DL.getABITypeAlign(Ty))
     return false;
   // It should be uniform, i.e. a scalar load.
-  return UA.isUniformDef(&LI);
+  return UA.isUniformAtDef(&LI);
 }
 
 bool AMDGPULateCodeGenPrepare::visitLoadInst(LoadInst &LI) {

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -99,57 +99,59 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
   case B512:
     return MRI.getType(Reg).getSizeInBits() == 512;
   case DivAnyTy:
-    return MUI.isDivergent(Reg);
+    return MUI.isDivergentDef(Reg);
   case UniS1:
-    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isUniformDef(Reg);
   case UniS16:
-    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isUniformDef(Reg);
   case UniS32:
-    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isUniformDef(Reg);
   case UniS64:
-    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isUniformDef(Reg);
   case UniS128:
-    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isUniformDef(Reg);
   case UniP0:
-    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isUniformDef(Reg);
   case UniP1:
-    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isUniformDef(Reg);
   case UniP2:
-    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isUniformDef(Reg);
   case UniP3:
-    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isUniformDef(Reg);
   case UniP4:
-    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isUniformDef(Reg);
   case UniP5:
-    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isUniformDef(Reg);
   case UniP8:
-    return MRI.getType(Reg) == LLT::pointer(8, 128) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::pointer(8, 128) && MUI.isUniformDef(Reg);
   case UniPtr32:
-    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isUniform(Reg);
+    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isUniformDef(Reg);
   case UniPtr64:
-    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isUniform(Reg);
+    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isUniformDef(Reg);
   case UniPtr128:
-    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isUniform(Reg);
+    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isUniformDef(Reg);
   case UniV2S16:
-    return MRI.getType(Reg) == LLT::fixed_vector(2, 16) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(2, 16) &&
+           MUI.isUniformDef(Reg);
   case UniV2S32:
-    return MRI.getType(Reg) == LLT::fixed_vector(2, 32) && MUI.isUniform(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(2, 32) &&
+           MUI.isUniformDef(Reg);
   case UniB32:
-    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isUniformDef(Reg);
   case UniB64:
-    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isUniformDef(Reg);
   case UniB96:
-    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isUniformDef(Reg);
   case UniB128:
-    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isUniformDef(Reg);
   case UniB160:
-    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isUniformDef(Reg);
   case UniB256:
-    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isUniformDef(Reg);
   case UniB512:
-    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isUniform(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isUniformDef(Reg);
   case UniBRC: {
-    if (!MUI.isUniform(Reg))
+    if (!MUI.isUniformDef(Reg))
       return false;
     // Check if there is SGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
@@ -160,59 +162,64 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
     return LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize);
   }
   case DivS1:
-    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isDivergentDef(Reg);
   case DivS16:
-    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isDivergentDef(Reg);
   case DivS32:
-    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isDivergentDef(Reg);
   case DivS64:
-    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isDivergentDef(Reg);
   case DivS128:
-    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isDivergentDef(Reg);
   case DivP0:
-    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isDivergentDef(Reg);
   case DivP1:
-    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isDivergentDef(Reg);
   case DivP2:
-    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isDivergentDef(Reg);
   case DivP3:
-    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isDivergentDef(Reg);
   case DivP4:
-    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isDivergentDef(Reg);
   case DivP5:
-    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isDivergentDef(Reg);
   case DivPtr32:
-    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isDivergent(Reg);
+    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isDivergentDef(Reg);
   case DivPtr64:
-    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isDivergent(Reg);
+    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isDivergentDef(Reg);
   case DivPtr128:
-    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isDivergent(Reg);
+    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isDivergentDef(Reg);
   case DivV2S16:
-    return MRI.getType(Reg) == LLT::fixed_vector(2, 16) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(2, 16) &&
+           MUI.isDivergentDef(Reg);
   case DivV2S32:
-    return MRI.getType(Reg) == LLT::fixed_vector(2, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(2, 32) &&
+           MUI.isDivergentDef(Reg);
   case DivV3S32:
-    return MRI.getType(Reg) == LLT::fixed_vector(3, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(3, 32) &&
+           MUI.isDivergentDef(Reg);
   case DivV4S16:
-    return MRI.getType(Reg) == LLT::fixed_vector(4, 16) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(4, 16) &&
+           MUI.isDivergentDef(Reg);
   case DivV6S32:
-    return MRI.getType(Reg) == LLT::fixed_vector(6, 32) && MUI.isDivergent(Reg);
+    return MRI.getType(Reg) == LLT::fixed_vector(6, 32) &&
+           MUI.isDivergentDef(Reg);
   case DivB32:
-    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isDivergentDef(Reg);
   case DivB64:
-    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isDivergentDef(Reg);
   case DivB96:
-    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isDivergentDef(Reg);
   case DivB128:
-    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isDivergentDef(Reg);
   case DivB160:
-    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isDivergentDef(Reg);
   case DivB256:
-    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isDivergentDef(Reg);
   case DivB512:
-    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isDivergent(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isDivergentDef(Reg);
   case DivBRC: {
-    if (!MUI.isDivergent(Reg))
+    if (!MUI.isDivergentDef(Reg))
       return false;
     // Check if there is VGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
@@ -317,7 +324,7 @@ SetOfRulesForOpcode::findMappingForMI(const MachineInstr &MI,
       Slot = getFastPredicateSlot(LLTToId(MRI.getType(Reg)));
 
     if (Slot != -1)
-      return MUI.isUniform(Reg) ? &Uni[Slot] : &Div[Slot];
+      return MUI.isUniformDef(Reg) ? &Uni[Slot] : &Div[Slot];
   }
 
   // Slow search for more complex rules.

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -99,59 +99,59 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
   case B512:
     return MRI.getType(Reg).getSizeInBits() == 512;
   case DivAnyTy:
-    return MUI.isDivergentDef(Reg);
+    return MUI.isDivergentAtDef(Reg);
   case UniS1:
-    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isUniformAtDef(Reg);
   case UniS16:
-    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isUniformAtDef(Reg);
   case UniS32:
-    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isUniformAtDef(Reg);
   case UniS64:
-    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isUniformAtDef(Reg);
   case UniS128:
-    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isUniformAtDef(Reg);
   case UniP0:
-    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isUniformAtDef(Reg);
   case UniP1:
-    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isUniformAtDef(Reg);
   case UniP2:
-    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isUniformAtDef(Reg);
   case UniP3:
-    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isUniformAtDef(Reg);
   case UniP4:
-    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isUniformAtDef(Reg);
   case UniP5:
-    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isUniformAtDef(Reg);
   case UniP8:
-    return MRI.getType(Reg) == LLT::pointer(8, 128) && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(8, 128) && MUI.isUniformAtDef(Reg);
   case UniPtr32:
-    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isUniformDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isUniformAtDef(Reg);
   case UniPtr64:
-    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isUniformDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isUniformAtDef(Reg);
   case UniPtr128:
-    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isUniformDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isUniformAtDef(Reg);
   case UniV2S16:
     return MRI.getType(Reg) == LLT::fixed_vector(2, 16) &&
-           MUI.isUniformDef(Reg);
+           MUI.isUniformAtDef(Reg);
   case UniV2S32:
     return MRI.getType(Reg) == LLT::fixed_vector(2, 32) &&
-           MUI.isUniformDef(Reg);
+           MUI.isUniformAtDef(Reg);
   case UniB32:
-    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isUniformAtDef(Reg);
   case UniB64:
-    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isUniformAtDef(Reg);
   case UniB96:
-    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isUniformAtDef(Reg);
   case UniB128:
-    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isUniformAtDef(Reg);
   case UniB160:
-    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isUniformAtDef(Reg);
   case UniB256:
-    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isUniformAtDef(Reg);
   case UniB512:
-    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isUniformDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isUniformAtDef(Reg);
   case UniBRC: {
-    if (!MUI.isUniformDef(Reg))
+    if (!MUI.isUniformAtDef(Reg))
       return false;
     // Check if there is SGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
@@ -162,64 +162,64 @@ bool matchUniformityAndLLT(Register Reg, UniformityLLTOpPredicateID UniID,
     return LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize);
   }
   case DivS1:
-    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(1) && MUI.isDivergentAtDef(Reg);
   case DivS16:
-    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(16) && MUI.isDivergentAtDef(Reg);
   case DivS32:
-    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(32) && MUI.isDivergentAtDef(Reg);
   case DivS64:
-    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(64) && MUI.isDivergentAtDef(Reg);
   case DivS128:
-    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::scalar(128) && MUI.isDivergentAtDef(Reg);
   case DivP0:
-    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(0, 64) && MUI.isDivergentAtDef(Reg);
   case DivP1:
-    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(1, 64) && MUI.isDivergentAtDef(Reg);
   case DivP2:
-    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(2, 32) && MUI.isDivergentAtDef(Reg);
   case DivP3:
-    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(3, 32) && MUI.isDivergentAtDef(Reg);
   case DivP4:
-    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(4, 64) && MUI.isDivergentAtDef(Reg);
   case DivP5:
-    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg) == LLT::pointer(5, 32) && MUI.isDivergentAtDef(Reg);
   case DivPtr32:
-    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isDivergentDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 32) && MUI.isDivergentAtDef(Reg);
   case DivPtr64:
-    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isDivergentDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 64) && MUI.isDivergentAtDef(Reg);
   case DivPtr128:
-    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isDivergentDef(Reg);
+    return isAnyPtr(MRI.getType(Reg), 128) && MUI.isDivergentAtDef(Reg);
   case DivV2S16:
     return MRI.getType(Reg) == LLT::fixed_vector(2, 16) &&
-           MUI.isDivergentDef(Reg);
+           MUI.isDivergentAtDef(Reg);
   case DivV2S32:
     return MRI.getType(Reg) == LLT::fixed_vector(2, 32) &&
-           MUI.isDivergentDef(Reg);
+           MUI.isDivergentAtDef(Reg);
   case DivV3S32:
     return MRI.getType(Reg) == LLT::fixed_vector(3, 32) &&
-           MUI.isDivergentDef(Reg);
+           MUI.isDivergentAtDef(Reg);
   case DivV4S16:
     return MRI.getType(Reg) == LLT::fixed_vector(4, 16) &&
-           MUI.isDivergentDef(Reg);
+           MUI.isDivergentAtDef(Reg);
   case DivV6S32:
     return MRI.getType(Reg) == LLT::fixed_vector(6, 32) &&
-           MUI.isDivergentDef(Reg);
+           MUI.isDivergentAtDef(Reg);
   case DivB32:
-    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 32 && MUI.isDivergentAtDef(Reg);
   case DivB64:
-    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 64 && MUI.isDivergentAtDef(Reg);
   case DivB96:
-    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 96 && MUI.isDivergentAtDef(Reg);
   case DivB128:
-    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 128 && MUI.isDivergentAtDef(Reg);
   case DivB160:
-    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 160 && MUI.isDivergentAtDef(Reg);
   case DivB256:
-    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 256 && MUI.isDivergentAtDef(Reg);
   case DivB512:
-    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isDivergentDef(Reg);
+    return MRI.getType(Reg).getSizeInBits() == 512 && MUI.isDivergentAtDef(Reg);
   case DivBRC: {
-    if (!MUI.isDivergentDef(Reg))
+    if (!MUI.isDivergentAtDef(Reg))
       return false;
     // Check if there is VGPR register class of same size as the LLT.
     const SIRegisterInfo *TRI =
@@ -324,7 +324,7 @@ SetOfRulesForOpcode::findMappingForMI(const MachineInstr &MI,
       Slot = getFastPredicateSlot(LLTToId(MRI.getType(Reg)));
 
     if (Slot != -1)
-      return MUI.isUniformDef(Reg) ? &Uni[Slot] : &Div[Slot];
+      return MUI.isUniformAtDef(Reg) ? &Uni[Slot] : &Div[Slot];
   }
 
   // Slow search for more complex rules.

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
@@ -111,7 +111,7 @@ public:
 
   const RegisterBank *getRegBankToAssign(Register Reg) {
     if (!isTemporalDivergenceCopy(Reg) &&
-        (MUI.isUniform(Reg) || ILMA.isS32S64LaneMask(Reg)))
+        (MUI.isUniformDef(Reg) || ILMA.isS32S64LaneMask(Reg)))
       return SgprRB;
     if (MRI.getType(Reg) == LLT::scalar(1))
       return VccRB;

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankSelect.cpp
@@ -111,7 +111,7 @@ public:
 
   const RegisterBank *getRegBankToAssign(Register Reg) {
     if (!isTemporalDivergenceCopy(Reg) &&
-        (MUI.isUniformDef(Reg) || ILMA.isS32S64LaneMask(Reg)))
+        (MUI.isUniformAtDef(Reg) || ILMA.isS32S64LaneMask(Reg)))
       return SgprRB;
     if (MRI.getType(Reg) == LLT::scalar(1))
       return VccRB;

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
@@ -102,7 +102,7 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
   SmallVector<PHINode *> ToBeDeleted;
   for (auto &BB : F) {
     for (auto &PHI : BB.phis()) {
-      if (UA.isDivergent(&PHI))
+      if (UA.isDivergentDef(&PHI))
         continue;
 
       // The unique incoming value except undef/poison for the PHI node.
@@ -144,7 +144,7 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
       // TODO: We should still be able to replace undef value if the unique
       // value is a Constant.
       if (!UniqueDefinedIncoming || Undefs.empty() ||
-          !UA.isDivergent(DominateBB->getTerminator()))
+          !UA.isDivergentDef(DominateBB->getTerminator()))
         continue;
 
       // We only replace the undef when DominateBB truly dominates all the

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
@@ -102,7 +102,7 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
   SmallVector<PHINode *> ToBeDeleted;
   for (auto &BB : F) {
     for (auto &PHI : BB.phis()) {
-      if (UA.isDivergentDef(&PHI))
+      if (UA.isDivergentAtDef(&PHI))
         continue;
 
       // The unique incoming value except undef/poison for the PHI node.
@@ -144,7 +144,7 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
       // TODO: We should still be able to replace undef value if the unique
       // value is a Constant.
       if (!UniqueDefinedIncoming || Undefs.empty() ||
-          !UA.isDivergentDef(DominateBB->getTerminator()))
+          !UA.isDivergentAtDef(DominateBB->getTerminator()))
         continue;
 
       // We only replace the undef when DominateBB truly dominates all the

--- a/llvm/lib/Target/AMDGPU/AMDGPUUniformIntrinsicCombine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUniformIntrinsicCombine.cpp
@@ -49,7 +49,7 @@ isDivergentUseWithNew(const Use &U, const UniformityInfo &UI,
   Value *V = U.get();
   if (auto It = Tracker.find(V); It != Tracker.end())
     return !It->second; // divergent if marked false
-  return UI.isDivergentUse(U);
+  return UI.isDivergentAtUse(U);
 }
 
 /// Optimizes uniform intrinsics calls if their operand can be proven uniform.

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
@@ -123,7 +123,7 @@ static bool isUniformlyReached(const UniformityInfo &UA, BasicBlock &BB) {
 
   while (!Stack.empty()) {
     BasicBlock *Top = Stack.pop_back_val();
-    if (!UA.isUniform(Top->getTerminator()))
+    if (!UA.isUniformDef(Top->getTerminator()))
       return false;
 
     for (BasicBlock *Pred : predecessors(Top)) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
@@ -123,7 +123,7 @@ static bool isUniformlyReached(const UniformityInfo &UA, BasicBlock &BB) {
 
   while (!Stack.empty()) {
     BasicBlock *Top = Stack.pop_back_val();
-    if (!UA.isUniformDef(Top->getTerminator()))
+    if (!UA.isUniformAtDef(Top->getTerminator()))
       return false;
 
     for (BasicBlock *Pred : predecessors(Top)) {

--- a/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
+++ b/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
@@ -128,7 +128,7 @@ void SIAnnotateControlFlow::initialize(const GCNSubtarget &ST) {
 /// Is the branch condition uniform or did the StructurizeCFG pass
 /// consider it as such?
 bool SIAnnotateControlFlow::isUniform(CondBrInst *T) {
-  return UA->isUniform(T) || T->hasMetadata("structurizecfg.uniform");
+  return UA->isUniformDef(T) || T->hasMetadata("structurizecfg.uniform");
 }
 
 /// Is BB the last block saved on the stack ?

--- a/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
+++ b/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
@@ -128,7 +128,7 @@ void SIAnnotateControlFlow::initialize(const GCNSubtarget &ST) {
 /// Is the branch condition uniform or did the StructurizeCFG pass
 /// consider it as such?
 bool SIAnnotateControlFlow::isUniform(CondBrInst *T) {
-  return UA->isUniformDef(T) || T->hasMetadata("structurizecfg.uniform");
+  return UA->isUniformAtDef(T) || T->hasMetadata("structurizecfg.uniform");
 }
 
 /// Is BB the last block saved on the stack ?

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -19790,7 +19790,7 @@ bool SITargetLowering::isSDNodeSourceOfDivergence(const SDNode *N,
       return !TRI->isSGPRReg(MRI, Reg);
 
     if (const Value *V = FLI->getValueFromVirtualReg(R->getReg()))
-      return UA->isDivergent(V);
+      return UA->isDivergentDef(V);
 
     assert(Reg == FLI->DemoteRegister || isCopyFromRegOfInlineAsm(N));
     return !TRI->isSGPRReg(MRI, Reg);

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -19790,7 +19790,7 @@ bool SITargetLowering::isSDNodeSourceOfDivergence(const SDNode *N,
       return !TRI->isSGPRReg(MRI, Reg);
 
     if (const Value *V = FLI->getValueFromVirtualReg(R->getReg()))
-      return UA->isDivergentDef(V);
+      return UA->isDivergentAtDef(V);
 
     assert(Reg == FLI->DemoteRegister || isCopyFromRegOfInlineAsm(N));
     return !TRI->isSGPRReg(MRI, Reg);

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -780,7 +780,7 @@ static bool isSCEVUniform(const SCEV *S, UniformityInfo &UI) {
   if (isa<SCEVConstant>(S))
     return true;
   if (auto *U = dyn_cast<SCEVUnknown>(S))
-    return UI.isUniform(U->getValue());
+    return UI.isUniformDef(U->getValue());
   for (const SCEV *Op : S->operands()) {
     if (!isSCEVUniform(Op, UI))
       return false;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -780,7 +780,7 @@ static bool isSCEVUniform(const SCEV *S, UniformityInfo &UI) {
   if (isa<SCEVConstant>(S))
     return true;
   if (auto *U = dyn_cast<SCEVUnknown>(S))
-    return UI.isUniformDef(U->getValue());
+    return UI.isUniformAtDef(U->getValue());
   for (const SCEV *Op : S->operands()) {
     if (!isSCEVUniform(Op, UI))
       return false;

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -1302,7 +1302,7 @@ static bool hasOnlyUniformBranches(Region *R, unsigned UniformMDKindID,
       if (!Br)
         continue;
 
-      if (!UA.isUniform(Br))
+      if (!UA.isUniformDef(Br))
         return false;
 
       // One of our direct children is conditional.

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -1302,7 +1302,7 @@ static bool hasOnlyUniformBranches(Region *R, unsigned UniformMDKindID,
       if (!Br)
         continue;
 
-      if (!UA.isUniformDef(Br))
+      if (!UA.isUniformAtDef(Br))
         return false;
 
       // One of our direct children is conditional.

--- a/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
@@ -80,9 +80,9 @@ TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
   // Existing values from the analysis are uniform (kernel args are inreg).
   Instruction *AddInst = &*F->getEntryBlock().begin();
   ASSERT_TRUE(isa<BinaryOperator>(AddInst));
-  EXPECT_FALSE(UI.isDivergent(AddInst)) << "%add should be uniform";
-  EXPECT_FALSE(UI.isDivergent(F->getArg(0))) << "%a should be uniform";
-  EXPECT_FALSE(UI.isDivergent(F->getArg(1))) << "%b should be uniform";
+  EXPECT_FALSE(UI.isDivergentDef(AddInst)) << "%add should be uniform";
+  EXPECT_FALSE(UI.isDivergentDef(F->getArg(0))) << "%a should be uniform";
+  EXPECT_FALSE(UI.isDivergentDef(F->getArg(1))) << "%b should be uniform";
 
   // Create a new instruction after analysis. It was not present during
   // analysis, so it is not in UniformValues and must be conservatively
@@ -90,6 +90,6 @@ TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
   IRBuilder<> Builder(AddInst->getNextNode());
   Value *NewInst = Builder.CreateMul(F->getArg(0), F->getArg(1), "new_mul");
 
-  EXPECT_TRUE(UI.isDivergent(NewInst))
+  EXPECT_TRUE(UI.isDivergentDef(NewInst))
       << "New instruction created after analysis must be reported divergent";
 }

--- a/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
@@ -80,9 +80,9 @@ TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
   // Existing values from the analysis are uniform (kernel args are inreg).
   Instruction *AddInst = &*F->getEntryBlock().begin();
   ASSERT_TRUE(isa<BinaryOperator>(AddInst));
-  EXPECT_FALSE(UI.isDivergentDef(AddInst)) << "%add should be uniform";
-  EXPECT_FALSE(UI.isDivergentDef(F->getArg(0))) << "%a should be uniform";
-  EXPECT_FALSE(UI.isDivergentDef(F->getArg(1))) << "%b should be uniform";
+  EXPECT_FALSE(UI.isDivergentAtDef(AddInst)) << "%add should be uniform";
+  EXPECT_FALSE(UI.isDivergentAtDef(F->getArg(0))) << "%a should be uniform";
+  EXPECT_FALSE(UI.isDivergentAtDef(F->getArg(1))) << "%b should be uniform";
 
   // Create a new instruction after analysis. It was not present during
   // analysis, so it is not in UniformValues and must be conservatively
@@ -90,6 +90,6 @@ TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
   IRBuilder<> Builder(AddInst->getNextNode());
   Value *NewInst = Builder.CreateMul(F->getArg(0), F->getArg(1), "new_mul");
 
-  EXPECT_TRUE(UI.isDivergentDef(NewInst))
+  EXPECT_TRUE(UI.isDivergentAtDef(NewInst))
       << "New instruction created after analysis must be reported divergent";
 }


### PR DESCRIPTION
Rename isUniform to isUniformDef and isDivergent to isDivergentDef on GenericUniformityInfo. The existing names are ambiguous.

REF: https://github.com/llvm/llvm-project/pull/175167#discussion_r3199029395