### PR TITLE
[Clang][Sema] Fix source range for FieldDecl copy initialization

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-member-init.cpp
@@ -268,14 +268,14 @@ struct D2 {
 // Direct in-class initialization with default constructor (assign)
 struct D3 {
   S f3 = {};
-  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: initializer for member 'f3' is redundant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: initializer for member 'f3' is redundant
   // CHECK-FIXES: S f3;
 };
 
 // Direct in-class initialization with constructor with default argument (assign)
 struct D4 {
   T f4 = {};
-  // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: initializer for member 'f4' is redundant
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: initializer for member 'f4' is redundant
   // CHECK-FIXES: T f4;
 };
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4210,7 +4210,8 @@ ExprResult Sema::ConvertMemberDefaultInitExpression(FieldDecl *FD,
           ? InitializationKind::CreateDirectList(InitExpr->getBeginLoc(),
                                                  InitExpr->getBeginLoc(),
                                                  InitExpr->getEndLoc())
-          : InitializationKind::CreateCopy(InitExpr->getBeginLoc(), InitLoc);
+          : InitializationKind::CreateCopy(InitExpr->getBeginLoc(),
+                                           SourceLocation());
   InitializationSequence Seq(*this, Entity, Kind, InitExpr);
   return Seq.Perform(*this, Entity, Kind, InitExpr);
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4211,7 +4211,7 @@ ExprResult Sema::ConvertMemberDefaultInitExpression(FieldDecl *FD,
                                                  InitExpr->getBeginLoc(),
                                                  InitExpr->getEndLoc())
           : InitializationKind::CreateCopy(InitExpr->getBeginLoc(),
-                                           SourceLocation());
+                                           InitExpr->getBeginLoc());
   InitializationSequence Seq(*this, Entity, Kind, InitExpr);
   return Seq.Perform(*this, Entity, Kind, InitExpr);
 }

--- a/clang/test/AST/sourceranges.cpp
+++ b/clang/test/AST/sourceranges.cpp
@@ -180,6 +180,53 @@ namespace in_class_init {
   };
 }
 
+// CHECK-1Z: NamespaceDecl {{.*}} field_copy_init
+namespace field_copy_init {
+  struct D {};
+
+  // CHECK-1Z: CXXRecordDecl {{.*}} struct S definition
+  struct S {
+    D d0;
+
+    // CHECK-1Z: FieldDecl {{.*}} d1 'D'
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:12> 'D'
+    D d1 = d0;
+
+    // CHECK-1Z: FieldDecl {{.*}} d2 'D'
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:12, col:15> 'D'
+    D d2 = {d0};
+
+    // CHECK-1Z: FieldDecl {{.*}} d3 'D'
+    // CHECK-1Z-NEXT: CXXTemporaryObjectExpr {{.*}} <col:12, col:16> 'D'
+    D d3 = D{d0};
+
+    // CHECK-1Z: FieldDecl {{.*}} d4 'D'
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:9, col:12> 'D'
+    D d4{d0};
+  };
+
+  // CHECK-1Z: FunctionDecl {{.*}} fn 'void ()'
+  void fn() {
+    D d0;
+
+    // CHECK-1Z: VarDecl {{.*}} d1 'D' cinit
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:12> 'D'
+    D d1 = d0;
+
+    // CHECK-1Z: VarDecl {{.*}} d2 'D' cinit
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:12, col:15> 'D'
+    D d2 = {d0};
+
+    // CHECK-1Z: VarDecl {{.*}} d3 'D' cinit
+    // CHECK-1Z-NEXT: CXXTemporaryObjectExpr {{.*}} <col:12, col:16> 'D'
+    D d3 = D{d0};
+
+    // CHECK-1Z: VarDecl {{.*}} d4 'D' listinit
+    // CHECK-1Z-NEXT: CXXConstructExpr {{.*}} <col:7, col:12> 'D'
+    D d4{d0};
+  }
+}
+
 // CHECK-1Z: NamespaceDecl {{.*}} delegating_constructor_init
 namespace delegating_constructor_init {
   struct A {};


### PR DESCRIPTION
For non-static data member copy initialization, Clang used the location of the '=' token as the construction location for the synthesized CXXConstructExpr. This caused the expression source range for cases like 'D d = d0;' to include '= d0', unlike the corresponding VarDecl case.

Use an invalid equal location for member default initializer copy-initialization so the constructed expression range begins at the initializer expression itself.

Fixes #190816.