### PR TITLE
[ARM][MVE] Combine extract(bitcast(buildvec(extract)))

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -15659,6 +15659,35 @@ static SDValue PerformExtractEltCombine(SDNode *N,
                            DCI.DAG.getConstant(SubIdx, dl, MVT::i32));
   }
 
+  // extract(bitcast(BUILD_VECTOR(extract(bitcast(a)), ..))) -> extract(a)
+  if (ST->isLittle() && Op0.getOpcode() == ISD::BITCAST &&
+      Op0.getOperand(0).getOpcode() == ARMISD::BUILD_VECTOR &&
+      isa<ConstantSDNode>(N->getOperand(1)) &&
+      Op0.getScalarValueSizeInBits() <=
+          Op0.getOperand(0).getScalarValueSizeInBits()) {
+    unsigned Lane = N->getConstantOperandVal(1);
+    EVT ExtVT = Op0.getValueType();
+    EVT BVVT = Op0.getOperand(0).getValueType();
+    unsigned BVLane =
+        (Lane * BVVT.getVectorNumElements()) / ExtVT.getVectorNumElements();
+    assert(BVLane < Op0.getOperand(0).getNumOperands());
+    SDValue Ext = Op0.getOperand(0).getOperand(BVLane);
+    if (Ext.getOpcode() == ISD::EXTRACT_VECTOR_ELT &&
+        Ext.getOperand(0).getOpcode() == ISD::BITCAST &&
+        isa<ConstantSDNode>(Ext.getOperand(1)) &&
+        Ext.getOperand(0).getOperand(0).getValueType() == ExtVT) {
+      unsigned InnerLane = Ext.getConstantOperandVal(1);
+      unsigned BVSubLane = Lane - (BVLane * ExtVT.getVectorNumElements()) /
+                                      BVVT.getVectorNumElements();
+      unsigned FinalLane = (InnerLane * ExtVT.getVectorNumElements()) /
+                               BVVT.getVectorNumElements() +
+                           BVSubLane;
+      return DCI.DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, VT,
+                             Ext.getOperand(0).getOperand(0),
+                             DCI.DAG.getConstant(FinalLane, dl, MVT::i32));
+    }
+  }
+
   return SDValue();
 }
 

--- a/llvm/test/CodeGen/Thumb2/active_lane_mask.ll
+++ b/llvm/test/CodeGen/Thumb2/active_lane_mask.ll
@@ -119,12 +119,11 @@ define <7 x i32> @v7i32(i32 %index, i32 %TC, <7 x i32> %V1, <7 x i32> %V2) {
 ; CHECK-NEXT:    ldr r1, [sp, #24]
 ; CHECK-NEXT:    vmov q1[2], q1[0], r2, r1
 ; CHECK-NEXT:    vpsel q0, q1, q0
-; CHECK-NEXT:    vmov r1, s2
-; CHECK-NEXT:    vmov.f32 s2, s1
-; CHECK-NEXT:    vmov r3, s0
-; CHECK-NEXT:    vmov r2, s2
-; CHECK-NEXT:    strd r3, r2, [r0, #16]
-; CHECK-NEXT:    str r1, [r0, #24]
+; CHECK-NEXT:    vmov r1, s1
+; CHECK-NEXT:    vmov r2, s0
+; CHECK-NEXT:    vmov r3, s2
+; CHECK-NEXT:    strd r2, r1, [r0, #16]
+; CHECK-NEXT:    str r3, [r0, #24]
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:

--- a/llvm/test/CodeGen/Thumb2/mve-fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-fptosi-sat-vector.ll
@@ -185,9 +185,8 @@ define arm_aapcs_vfpcc <6 x i32> @test_signed_v6f32_v6i32(<6 x float> %f) {
 ; CHECK-MVEFP:       @ %bb.0:
 ; CHECK-MVEFP-NEXT:    vcvt.s32.f32 q1, q1
 ; CHECK-MVEFP-NEXT:    vcvt.s32.f32 q0, q0
-; CHECK-MVEFP-NEXT:    vmov.f32 s6, s5
+; CHECK-MVEFP-NEXT:    vmov r1, s5
 ; CHECK-MVEFP-NEXT:    vmov r2, s4
-; CHECK-MVEFP-NEXT:    vmov r1, s6
 ; CHECK-MVEFP-NEXT:    strd r2, r1, [r0, #16]
 ; CHECK-MVEFP-NEXT:    vstrw.32 q0, [r0]
 ; CHECK-MVEFP-NEXT:    bx lr
@@ -221,10 +220,9 @@ define arm_aapcs_vfpcc <7 x i32> @test_signed_v7f32_v7i32(<7 x float> %f) {
 ; CHECK-MVEFP:       @ %bb.0:
 ; CHECK-MVEFP-NEXT:    vcvt.s32.f32 q1, q1
 ; CHECK-MVEFP-NEXT:    vcvt.s32.f32 q0, q0
-; CHECK-MVEFP-NEXT:    vmov.f32 s10, s5
+; CHECK-MVEFP-NEXT:    vmov r1, s5
 ; CHECK-MVEFP-NEXT:    vmov r2, s4
 ; CHECK-MVEFP-NEXT:    vmov r3, s6
-; CHECK-MVEFP-NEXT:    vmov r1, s10
 ; CHECK-MVEFP-NEXT:    strd r2, r1, [r0, #16]
 ; CHECK-MVEFP-NEXT:    str r3, [r0, #24]
 ; CHECK-MVEFP-NEXT:    vstrw.32 q0, [r0]

--- a/llvm/test/CodeGen/Thumb2/mve-fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-fptoui-sat-vector.ll
@@ -172,9 +172,8 @@ define arm_aapcs_vfpcc <6 x i32> @test_unsigned_v6f32_v6i32(<6 x float> %f) {
 ; CHECK-MVEFP:       @ %bb.0:
 ; CHECK-MVEFP-NEXT:    vcvt.u32.f32 q1, q1
 ; CHECK-MVEFP-NEXT:    vcvt.u32.f32 q0, q0
-; CHECK-MVEFP-NEXT:    vmov.f32 s6, s5
+; CHECK-MVEFP-NEXT:    vmov r1, s5
 ; CHECK-MVEFP-NEXT:    vmov r2, s4
-; CHECK-MVEFP-NEXT:    vmov r1, s6
 ; CHECK-MVEFP-NEXT:    strd r2, r1, [r0, #16]
 ; CHECK-MVEFP-NEXT:    vstrw.32 q0, [r0]
 ; CHECK-MVEFP-NEXT:    bx lr
@@ -208,10 +207,9 @@ define arm_aapcs_vfpcc <7 x i32> @test_unsigned_v7f32_v7i32(<7 x float> %f) {
 ; CHECK-MVEFP:       @ %bb.0:
 ; CHECK-MVEFP-NEXT:    vcvt.u32.f32 q1, q1
 ; CHECK-MVEFP-NEXT:    vcvt.u32.f32 q0, q0
-; CHECK-MVEFP-NEXT:    vmov.f32 s10, s5
+; CHECK-MVEFP-NEXT:    vmov r1, s5
 ; CHECK-MVEFP-NEXT:    vmov r2, s4
 ; CHECK-MVEFP-NEXT:    vmov r3, s6
-; CHECK-MVEFP-NEXT:    vmov r1, s10
 ; CHECK-MVEFP-NEXT:    strd r2, r1, [r0, #16]
 ; CHECK-MVEFP-NEXT:    str r3, [r0, #24]
 ; CHECK-MVEFP-NEXT:    vstrw.32 q0, [r0]

--- a/llvm/test/CodeGen/Thumb2/mve-laneinterleaving-cost.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-laneinterleaving-cost.ll
@@ -4,54 +4,51 @@
 define arm_aapcs_vfpcc <4 x i32> @loads_i32(ptr %A, ptr %B, ptr %C) {
 ; CHECK-LABEL: loads_i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vldrw.u32 q2, [r1]
-; CHECK-NEXT:    vmov.i64 q1, #0xffffffff
-; CHECK-NEXT:    vmov.f32 s0, s10
-; CHECK-NEXT:    vmov.f32 s2, s11
-; CHECK-NEXT:    vand q0, q0, q1
-; CHECK-NEXT:    vmov.f32 s10, s9
-; CHECK-NEXT:    vmov r1, r3, d0
-; CHECK-NEXT:    vand q2, q2, q1
-; CHECK-NEXT:    vmov r4, r5, d1
-; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    vldrw.u32 q1, [r2]
-; CHECK-NEXT:    vmov lr, r12, d5
-; CHECK-NEXT:    vmov.f32 s12, s2
-; CHECK-NEXT:    vmov.f32 s2, s3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    vmov.f32 s12, s6
-; CHECK-NEXT:    vmov.f32 s6, s7
-; CHECK-NEXT:    asrs r2, r0, #31
-; CHECK-NEXT:    adds r0, r0, r1
-; CHECK-NEXT:    adc.w r1, r2, r3
-; CHECK-NEXT:    vmov r2, s12
-; CHECK-NEXT:    asrl r0, r1, r2
-; CHECK-NEXT:    vmov r1, s2
-; CHECK-NEXT:    vmov.f32 s2, s1
-; CHECK-NEXT:    adds r2, r1, r4
-; CHECK-NEXT:    asr.w r3, r1, #31
-; CHECK-NEXT:    adc.w r1, r3, r5
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    vldrw.u32 q3, [r1]
+; CHECK-NEXT:    vldrw.u32 q1, [r0]
+; CHECK-NEXT:    vmov.i64 q2, #0xffffffff
+; CHECK-NEXT:    vmov.f32 s0, s12
+; CHECK-NEXT:    vmov.f32 s2, s13
+; CHECK-NEXT:    vmov lr, r0, d2
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmov r1, r5, d1
+; CHECK-NEXT:    vmov.f32 s12, s14
+; CHECK-NEXT:    vmov.f32 s14, s15
+; CHECK-NEXT:    vand q2, q3, q2
+; CHECK-NEXT:    vmov r4, r3, d5
+; CHECK-NEXT:    asrs r6, r0, #31
+; CHECK-NEXT:    adds.w r12, r0, r1
+; CHECK-NEXT:    vmov r0, s7
+; CHECK-NEXT:    adc.w r1, r6, r5
+; CHECK-NEXT:    adds.w r8, r0, r4
+; CHECK-NEXT:    vmov r4, r6, d4
+; CHECK-NEXT:    asr.w r5, r0, #31
+; CHECK-NEXT:    adcs r5, r3
 ; CHECK-NEXT:    vmov r3, s6
-; CHECK-NEXT:    asrl r2, r1, r3
-; CHECK-NEXT:    vmov r4, r5, d4
-; CHECK-NEXT:    vmov r1, s2
-; CHECK-NEXT:    vmov.f32 s2, s5
-; CHECK-NEXT:    adds.w r6, r1, lr
-; CHECK-NEXT:    asr.w r3, r1, #31
-; CHECK-NEXT:    adc.w r1, r3, r12
-; CHECK-NEXT:    vmov r3, s2
-; CHECK-NEXT:    asrl r6, r1, r3
-; CHECK-NEXT:    vmov r1, s0
-; CHECK-NEXT:    adds r4, r4, r1
-; CHECK-NEXT:    asr.w r3, r1, #31
-; CHECK-NEXT:    adc.w r1, r3, r5
-; CHECK-NEXT:    vmov r3, s4
-; CHECK-NEXT:    asrl r4, r1, r3
-; CHECK-NEXT:    vmov q0[2], q0[0], r4, r0
-; CHECK-NEXT:    vmov q0[3], q0[1], r6, r2
-; CHECK-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov.f32 s8, s6
+; CHECK-NEXT:    vmov.f32 s2, s7
+; CHECK-NEXT:    vmov.f32 s6, s5
+; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    adds r4, r4, r3
+; CHECK-NEXT:    asr.w r7, r3, #31
+; CHECK-NEXT:    adc.w r3, r7, r6
+; CHECK-NEXT:    asrl r4, r3, r2
+; CHECK-NEXT:    asr.w r2, lr, #31
+; CHECK-NEXT:    vmov r3, r6, d0
+; CHECK-NEXT:    adds.w r0, lr, r3
+; CHECK-NEXT:    adc.w r3, r2, r6
+; CHECK-NEXT:    vmov r2, s4
+; CHECK-NEXT:    asrl r0, r3, r2
+; CHECK-NEXT:    vmov r2, s2
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r4
+; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    asrl r8, r5, r2
+; CHECK-NEXT:    asrl r12, r1, r0
+; CHECK-NEXT:    vmov q0[3], q0[1], r12, r8
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
 entry:
   %a = load <4 x i32>, ptr %A, align 4
   %b = load <4 x i32>, ptr %B, align 4
@@ -134,58 +131,51 @@ entry:
 define arm_aapcs_vfpcc void @load_store_i32(ptr %A, ptr %B, ptr %C, ptr %D) {
 ; CHECK-LABEL: load_store_i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r11, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-NEXT:    vldrw.u32 q1, [r1]
 ; CHECK-NEXT:    vmov.i64 q0, #0xffffffff
 ; CHECK-NEXT:    vmov.f32 s8, s6
 ; CHECK-NEXT:    vmov.f32 s10, s7
+; CHECK-NEXT:    vand q2, q2, q0
 ; CHECK-NEXT:    vmov.f32 s6, s5
-; CHECK-NEXT:    vand q4, q2, q0
-; CHECK-NEXT:    vand q2, q1, q0
-; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    vmov r4, r5, d9
+; CHECK-NEXT:    vmov r1, r12, d5
+; CHECK-NEXT:    vand q0, q1, q0
+; CHECK-NEXT:    vmov lr, r4, d4
+; CHECK-NEXT:    vldrw.u32 q2, [r0]
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
-; CHECK-NEXT:    vmov.f32 s12, s2
-; CHECK-NEXT:    vmov.f32 s2, s3
-; CHECK-NEXT:    vmov lr, r12, d8
-; CHECK-NEXT:    vmov.f32 s16, s6
-; CHECK-NEXT:    vmov.f32 s6, s7
-; CHECK-NEXT:    vmov r6, r1, d5
-; CHECK-NEXT:    vmov.f32 s10, s1
-; CHECK-NEXT:    vmov r0, s2
-; CHECK-NEXT:    vmov.f32 s2, s5
-; CHECK-NEXT:    adds.w r8, r0, r4
-; CHECK-NEXT:    asr.w r2, r0, #31
-; CHECK-NEXT:    adcs r5, r2
-; CHECK-NEXT:    vmov r2, s6
-; CHECK-NEXT:    asrl r8, r5, r2
+; CHECK-NEXT:    vmov r9, r8, d0
+; CHECK-NEXT:    vmov r0, s11
+; CHECK-NEXT:    vmov.f32 s0, s6
+; CHECK-NEXT:    vmov.f32 s6, s5
+; CHECK-NEXT:    asrs r2, r0, #31
+; CHECK-NEXT:    adds r0, r0, r1
+; CHECK-NEXT:    adc.w r11, r2, r12
 ; CHECK-NEXT:    vmov r2, s10
-; CHECK-NEXT:    vmov r5, r7, d4
-; CHECK-NEXT:    asrs r4, r2, #31
-; CHECK-NEXT:    adds r2, r2, r6
-; CHECK-NEXT:    adcs r1, r4
-; CHECK-NEXT:    vmov r4, s2
-; CHECK-NEXT:    asrl r2, r1, r4
-; CHECK-NEXT:    vmov r1, s12
-; CHECK-NEXT:    adds.w r6, r1, lr
-; CHECK-NEXT:    asr.w r4, r1, #31
-; CHECK-NEXT:    adc.w r1, r4, r12
-; CHECK-NEXT:    vmov r4, s16
-; CHECK-NEXT:    asrl r6, r1, r4
-; CHECK-NEXT:    vmov r1, s0
-; CHECK-NEXT:    adds r0, r1, r5
-; CHECK-NEXT:    asr.w r4, r1, #31
-; CHECK-NEXT:    adc.w r1, r4, r7
-; CHECK-NEXT:    vmov r7, s4
-; CHECK-NEXT:    asrl r0, r1, r7
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r6
-; CHECK-NEXT:    vmov q0[3], q0[1], r2, r8
+; CHECK-NEXT:    vmov.f32 s10, s7
+; CHECK-NEXT:    asrs r6, r2, #31
+; CHECK-NEXT:    adds.w r2, r2, lr
+; CHECK-NEXT:    adc.w r7, r6, r4
+; CHECK-NEXT:    vmov r4, r5, d4
+; CHECK-NEXT:    vmov r6, s0
+; CHECK-NEXT:    asrl r2, r7, r6
+; CHECK-NEXT:    adds.w r6, r4, r9
+; CHECK-NEXT:    asr.w r7, r4, #31
+; CHECK-NEXT:    vmov r4, s4
+; CHECK-NEXT:    adc.w r7, r7, r8
+; CHECK-NEXT:    asrl r6, r7, r4
+; CHECK-NEXT:    vmov r4, r1, d1
+; CHECK-NEXT:    vmov q0[2], q0[0], r6, r2
+; CHECK-NEXT:    asrs r2, r5, #31
+; CHECK-NEXT:    vmov r7, s10
+; CHECK-NEXT:    asrl r0, r11, r7
+; CHECK-NEXT:    adds r6, r5, r4
+; CHECK-NEXT:    adcs r1, r2
+; CHECK-NEXT:    vmov r2, s6
+; CHECK-NEXT:    asrl r6, r1, r2
+; CHECK-NEXT:    vmov q0[3], q0[1], r6, r0
 ; CHECK-NEXT:    vstrw.32 q0, [r3]
-; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
   %a = load <4 x i32>, ptr %A, align 4
   %b = load <4 x i32>, ptr %B, align 4
@@ -268,36 +258,32 @@ entry:
 define arm_aapcs_vfpcc void @load_one_store_i32(ptr %A, ptr %D) {
 ; CHECK-LABEL: load_one_store_i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, lr}
-; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
 ; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    vmov.f32 s4, s2
-; CHECK-NEXT:    vmov.f32 s2, s3
-; CHECK-NEXT:    vmov r2, s2
-; CHECK-NEXT:    vmov.f32 s2, s1
-; CHECK-NEXT:    adds.w r12, r2, r2
-; CHECK-NEXT:    asr.w r3, r2, #31
-; CHECK-NEXT:    adc.w r3, r3, r2, asr #31
-; CHECK-NEXT:    asrl r12, r3, r2
-; CHECK-NEXT:    vmov r3, s2
-; CHECK-NEXT:    adds r2, r3, r3
+; CHECK-NEXT:    vmov r0, s3
+; CHECK-NEXT:    vmov r2, r3, d0
+; CHECK-NEXT:    adds.w r12, r0, r0
+; CHECK-NEXT:    asr.w lr, r0, #31
+; CHECK-NEXT:    adc.w r5, lr, r0, asr #31
+; CHECK-NEXT:    asrl r12, r5, r0
+; CHECK-NEXT:    vmov r0, s2
+; CHECK-NEXT:    asr.w lr, r2, #31
+; CHECK-NEXT:    adds r4, r0, r0
+; CHECK-NEXT:    asr.w r5, r0, #31
+; CHECK-NEXT:    adc.w r5, r5, r0, asr #31
+; CHECK-NEXT:    adds r6, r3, r3
+; CHECK-NEXT:    asrl r4, r5, r0
 ; CHECK-NEXT:    asr.w r0, r3, #31
 ; CHECK-NEXT:    adc.w r5, r0, r3, asr #31
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    asrl r2, r5, r3
-; CHECK-NEXT:    adds r4, r0, r0
-; CHECK-NEXT:    asr.w r3, r0, #31
-; CHECK-NEXT:    adc.w r3, r3, r0, asr #31
-; CHECK-NEXT:    asrl r4, r3, r0
-; CHECK-NEXT:    vmov r0, s0
-; CHECK-NEXT:    adds r6, r0, r0
-; CHECK-NEXT:    asr.w r3, r0, #31
-; CHECK-NEXT:    adc.w r3, r3, r0, asr #31
-; CHECK-NEXT:    asrl r6, r3, r0
-; CHECK-NEXT:    vmov q0[2], q0[0], r6, r4
-; CHECK-NEXT:    vmov q0[3], q0[1], r2, r12
+; CHECK-NEXT:    adds r0, r2, r2
+; CHECK-NEXT:    adc.w r7, lr, r2, asr #31
+; CHECK-NEXT:    asrl r6, r5, r3
+; CHECK-NEXT:    asrl r0, r7, r2
+; CHECK-NEXT:    vmov q0[2], q0[0], r0, r4
+; CHECK-NEXT:    vmov q0[3], q0[1], r6, r12
 ; CHECK-NEXT:    vstrw.32 q0, [r1]
-; CHECK-NEXT:    pop {r4, r5, r6, pc}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 entry:
   %a = load <4 x i32>, ptr %A, align 4
   %sa = sext <4 x i32> %a to <4 x i64>

--- a/llvm/test/CodeGen/Thumb2/mve-satmul-loops.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-satmul-loops.ll
@@ -474,7 +474,6 @@ define arm_aapcs_vfpcc void @ssatmul_4t_q31(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK-NEXT:    vmov.f32 s28, s22
 ; CHECK-NEXT:    vmov.f32 s30, s23
 ; CHECK-NEXT:    vmullb.s32 q0, q7, q6
-; CHECK-NEXT:    vmov.f32 s18, s21
 ; CHECK-NEXT:    vmov r10, r5, d0
 ; CHECK-NEXT:    asrl r10, r5, #31
 ; CHECK-NEXT:    rsbs.w r7, r10, #-2147483648
@@ -488,7 +487,7 @@ define arm_aapcs_vfpcc void @ssatmul_4t_q31(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK-NEXT:    sbcs.w r3, r12, r7
 ; CHECK-NEXT:    vmov q0[3], q0[1], r5, r7
 ; CHECK-NEXT:    csetm r3, lt
-; CHECK-NEXT:    vmov r7, s18
+; CHECK-NEXT:    vmov r7, s21
 ; CHECK-NEXT:    bfi r4, r3, #8, #8
 ; CHECK-NEXT:    vmsr p0, r4
 ; CHECK-NEXT:    vpsel q0, q0, q2
@@ -507,7 +506,6 @@ define arm_aapcs_vfpcc void @ssatmul_4t_q31(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK-NEXT:    vmsr p0, r4
 ; CHECK-NEXT:    vmov r4, s20
 ; CHECK-NEXT:    vpsel q6, q0, q3
-; CHECK-NEXT:    vmov.f32 s2, s17
 ; CHECK-NEXT:    smull r10, r5, r4, r3
 ; CHECK-NEXT:    movs r4, #0
 ; CHECK-NEXT:    asrl r10, r5, #31
@@ -515,7 +513,7 @@ define arm_aapcs_vfpcc void @ssatmul_4t_q31(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK-NEXT:    sbcs.w r3, r12, r5
 ; CHECK-NEXT:    csetm r3, lt
 ; CHECK-NEXT:    bfi r4, r3, #0, #8
-; CHECK-NEXT:    vmov r3, s2
+; CHECK-NEXT:    vmov r3, s17
 ; CHECK-NEXT:    smull r6, r3, r7, r3
 ; CHECK-NEXT:    asrl r6, r3, #31
 ; CHECK-NEXT:    rsbs.w r7, r6, #-2147483648

--- a/llvm/test/CodeGen/Thumb2/mve-sext-masked-load.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-sext-masked-load.ll
@@ -51,41 +51,36 @@ entry:
 define arm_aapcs_vfpcc <4 x double> @foo_v4i32(ptr nocapture readonly %pSrc, i32 %blockSize, <4 x i32> %a) {
 ; CHECK-LABEL: foo_v4i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r7, lr}
-; CHECK-NEXT:    push {r7, lr}
+; CHECK-NEXT:    .save {r4, r5, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r7, lr}
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpt.s32 lt, q0, zr
-; CHECK-NEXT:    vldrwt.u32 q5, [r0]
-; CHECK-NEXT:    vmov.f32 s2, s23
-; CHECK-NEXT:    vmov.f32 s16, s22
-; CHECK-NEXT:    vmov r0, s2
+; CHECK-NEXT:    vldrwt.u32 q4, [r0]
+; CHECK-NEXT:    vmov r0, s19
 ; CHECK-NEXT:    asrs r1, r0, #31
 ; CHECK-NEXT:    bl __aeabi_l2d
-; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    vmov d9, r0, r1
+; CHECK-NEXT:    vmov r4, r5, d8
 ; CHECK-NEXT:    asrs r3, r2, #31
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    mov r1, r3
 ; CHECK-NEXT:    bl __aeabi_l2d
-; CHECK-NEXT:    vmov.f32 s2, s21
 ; CHECK-NEXT:    vmov d8, r0, r1
-; CHECK-NEXT:    vmov r2, s2
-; CHECK-NEXT:    asrs r3, r2, #31
-; CHECK-NEXT:    mov r0, r2
-; CHECK-NEXT:    mov r1, r3
+; CHECK-NEXT:    asrs r1, r5, #31
+; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    bl __aeabi_l2d
-; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    asrs r2, r4, #31
 ; CHECK-NEXT:    vmov d11, r0, r1
-; CHECK-NEXT:    asrs r3, r2, #31
-; CHECK-NEXT:    mov r0, r2
-; CHECK-NEXT:    mov r1, r3
+; CHECK-NEXT:    mov r0, r4
+; CHECK-NEXT:    mov r1, r2
 ; CHECK-NEXT:    bl __aeabi_l2d
 ; CHECK-NEXT:    vmov d10, r0, r1
 ; CHECK-NEXT:    vmov q1, q4
 ; CHECK-NEXT:    vmov q0, q5
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEXT:    pop {r7, pc}
+; CHECK-NEXT:    pop {r4, r5, r7, pc}
 entry:
   %active.lane.mask = icmp slt <4 x i32> %a, zeroinitializer
   %wide.masked.load = call <4 x i32> @llvm.masked.load.v4i32.p0(ptr %pSrc, i32 4, <4 x i1> %active.lane.mask, <4 x i32> undef)

--- a/llvm/test/CodeGen/Thumb2/mve-shuffle.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-shuffle.ll
@@ -1363,66 +1363,39 @@ entry:
 define arm_aapcs_vfpcc <8 x half> @shuffle3step_f16(<32 x half> %src) {
 ; CHECKFP16-LABEL: shuffle3step_f16:
 ; CHECKFP16:       @ %bb.0: @ %entry
-; CHECKFP16-NEXT:    .vsave {d8, d9, d10, d11}
-; CHECKFP16-NEXT:    vpush {d8, d9, d10, d11}
-; CHECKFP16-NEXT:    vmovx.f16 s13, s1
-; CHECKFP16-NEXT:    vmovx.f16 s16, s0
-; CHECKFP16-NEXT:    vins.f16 s0, s13
-; CHECKFP16-NEXT:    vmovx.f16 s13, s4
-; CHECKFP16-NEXT:    vmovx.f16 s15, s3
-; CHECKFP16-NEXT:    vins.f16 s3, s13
-; CHECKFP16-NEXT:    vmov q5, q0
-; CHECKFP16-NEXT:    vins.f16 s16, s2
-; CHECKFP16-NEXT:    vmovx.f16 s2, s2
-; CHECKFP16-NEXT:    vmovx.f16 s14, s6
-; CHECKFP16-NEXT:    vins.f16 s1, s2
-; CHECKFP16-NEXT:    vmovx.f16 s2, s5
-; CHECKFP16-NEXT:    vmovx.f16 s18, s16
-; CHECKFP16-NEXT:    vmovx.f16 s0, s20
-; CHECKFP16-NEXT:    vins.f16 s4, s2
-; CHECKFP16-NEXT:    vins.f16 s14, s8
-; CHECKFP16-NEXT:    vmovx.f16 s2, s8
-; CHECKFP16-NEXT:    vadd.f16 s0, s0, s18
-; CHECKFP16-NEXT:    vmovx.f16 s8, s1
-; CHECKFP16-NEXT:    vins.f16 s15, s5
-; CHECKFP16-NEXT:    vadd.f16 s8, s0, s8
-; CHECKFP16-NEXT:    vadd.f16 s0, s20, s16
-; CHECKFP16-NEXT:    vadd.f16 s0, s0, s1
-; CHECKFP16-NEXT:    vmovx.f16 s1, s3
-; CHECKFP16-NEXT:    vins.f16 s0, s8
+; CHECKFP16-NEXT:    vmov q3, q0
+; CHECKFP16-NEXT:    vmovx.f16 s0, s6
+; CHECKFP16-NEXT:    vadd.f16 s0, s6, s0
+; CHECKFP16-NEXT:    vmovx.f16 s6, s14
+; CHECKFP16-NEXT:    vadd.f16 s2, s0, s7
+; CHECKFP16-NEXT:    vmovx.f16 s0, s7
+; CHECKFP16-NEXT:    vadd.f16 s0, s0, s8
+; CHECKFP16-NEXT:    vmovx.f16 s8, s8
+; CHECKFP16-NEXT:    vadd.f16 s0, s0, s8
+; CHECKFP16-NEXT:    vmovx.f16 s8, s13
+; CHECKFP16-NEXT:    vins.f16 s2, s0
+; CHECKFP16-NEXT:    vmovx.f16 s0, s12
+; CHECKFP16-NEXT:    vadd.f16 s0, s12, s0
+; CHECKFP16-NEXT:    vadd.f16 s8, s8, s14
+; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
+; CHECKFP16-NEXT:    vadd.f16 s0, s0, s13
 ; CHECKFP16-NEXT:    vmovx.f16 s8, s15
-; CHECKFP16-NEXT:    vadd.f16 s8, s1, s8
-; CHECKFP16-NEXT:    vmovx.f16 s1, s4
-; CHECKFP16-NEXT:    vmovx.f16 s13, s7
-; CHECKFP16-NEXT:    vadd.f16 s8, s8, s1
-; CHECKFP16-NEXT:    vadd.f16 s1, s3, s15
-; CHECKFP16-NEXT:    vins.f16 s6, s13
-; CHECKFP16-NEXT:    vadd.f16 s1, s1, s4
-; CHECKFP16-NEXT:    vins.f16 s7, s2
-; CHECKFP16-NEXT:    vins.f16 s1, s8
-; CHECKFP16-NEXT:    vmovx.f16 s8, s6
-; CHECKFP16-NEXT:    vmovx.f16 s4, s14
-; CHECKFP16-NEXT:    vmovx.f16 s12, s9
-; CHECKFP16-NEXT:    vmovx.f16 s13, s10
-; CHECKFP16-NEXT:    vmovx.f16 s2, s11
-; CHECKFP16-NEXT:    vadd.f16 s4, s8, s4
-; CHECKFP16-NEXT:    vmovx.f16 s8, s7
-; CHECKFP16-NEXT:    vadd.f16 s6, s6, s14
-; CHECKFP16-NEXT:    vins.f16 s10, s2
-; CHECKFP16-NEXT:    vins.f16 s12, s11
-; CHECKFP16-NEXT:    vins.f16 s9, s13
-; CHECKFP16-NEXT:    vadd.f16 s2, s6, s7
-; CHECKFP16-NEXT:    vadd.f16 s4, s4, s8
-; CHECKFP16-NEXT:    vins.f16 s2, s4
-; CHECKFP16-NEXT:    vmovx.f16 s4, s12
-; CHECKFP16-NEXT:    vmovx.f16 s6, s9
-; CHECKFP16-NEXT:    vadd.f16 s4, s6, s4
-; CHECKFP16-NEXT:    vmovx.f16 s6, s10
+; CHECKFP16-NEXT:    vins.f16 s0, s6
+; CHECKFP16-NEXT:    vmovx.f16 s6, s4
+; CHECKFP16-NEXT:    vmovx.f16 s1, s5
+; CHECKFP16-NEXT:    vadd.f16 s6, s6, s5
+; CHECKFP16-NEXT:    vadd.f16 s8, s15, s8
+; CHECKFP16-NEXT:    vadd.f16 s6, s6, s1
+; CHECKFP16-NEXT:    vadd.f16 s1, s8, s4
+; CHECKFP16-NEXT:    vmovx.f16 s4, s10
+; CHECKFP16-NEXT:    vins.f16 s1, s6
+; CHECKFP16-NEXT:    vadd.f16 s4, s4, s11
+; CHECKFP16-NEXT:    vmovx.f16 s6, s11
 ; CHECKFP16-NEXT:    vadd.f16 s4, s4, s6
-; CHECKFP16-NEXT:    vadd.f16 s6, s9, s12
+; CHECKFP16-NEXT:    vmovx.f16 s6, s9
+; CHECKFP16-NEXT:    vadd.f16 s6, s9, s6
 ; CHECKFP16-NEXT:    vadd.f16 s3, s6, s10
 ; CHECKFP16-NEXT:    vins.f16 s3, s4
-; CHECKFP16-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECKFP16-NEXT:    bx lr
 ;
 ; CHECKFP-LABEL: shuffle3step_f16:
@@ -1476,91 +1449,53 @@ entry:
 define arm_aapcs_vfpcc <8 x half> @shuffle4step_f16(<32 x half> %src) {
 ; CHECKFP16-LABEL: shuffle4step_f16:
 ; CHECKFP16:       @ %bb.0: @ %entry
-; CHECKFP16-NEXT:    .vsave {d12, d13, d14, d15}
-; CHECKFP16-NEXT:    vpush {d12, d13, d14, d15}
-; CHECKFP16-NEXT:    .vsave {d8, d9, d10}
-; CHECKFP16-NEXT:    vpush {d8, d9, d10}
-; CHECKFP16-NEXT:    vmov q4, q3
-; CHECKFP16-NEXT:    vmovx.f16 s30, s9
-; CHECKFP16-NEXT:    vmovx.f16 s12, s11
-; CHECKFP16-NEXT:    vmovx.f16 s14, s17
-; CHECKFP16-NEXT:    vins.f16 s30, s12
-; CHECKFP16-NEXT:    vmovx.f16 s12, s19
-; CHECKFP16-NEXT:    vmovx.f16 s24, s1
-; CHECKFP16-NEXT:    vins.f16 s14, s12
-; CHECKFP16-NEXT:    vmovx.f16 s12, s3
-; CHECKFP16-NEXT:    vins.f16 s1, s3
-; CHECKFP16-NEXT:    vmovx.f16 s20, s5
-; CHECKFP16-NEXT:    vins.f16 s24, s12
-; CHECKFP16-NEXT:    vmovx.f16 s12, s7
-; CHECKFP16-NEXT:    vmov.f32 s28, s1
-; CHECKFP16-NEXT:    vins.f16 s20, s12
-; CHECKFP16-NEXT:    vmovx.f16 s12, s24
-; CHECKFP16-NEXT:    vmovx.f16 s1, s1
-; CHECKFP16-NEXT:    vins.f16 s5, s7
-; CHECKFP16-NEXT:    vadd.f16 s1, s1, s12
-; CHECKFP16-NEXT:    vmovx.f16 s12, s0
+; CHECKFP16-NEXT:    .vsave {d8}
+; CHECKFP16-NEXT:    vpush {d8}
+; CHECKFP16-NEXT:    vmovx.f16 s16, s3
+; CHECKFP16-NEXT:    vadd.f16 s3, s3, s16
+; CHECKFP16-NEXT:    vmovx.f16 s16, s2
+; CHECKFP16-NEXT:    vadd.f16 s2, s2, s16
+; CHECKFP16-NEXT:    vadd.f16 s2, s2, s3
+; CHECKFP16-NEXT:    vmovx.f16 s3, s1
+; CHECKFP16-NEXT:    vadd.f16 s1, s1, s3
+; CHECKFP16-NEXT:    vmovx.f16 s3, s0
+; CHECKFP16-NEXT:    vadd.f16 s0, s0, s3
+; CHECKFP16-NEXT:    vadd.f16 s0, s0, s1
+; CHECKFP16-NEXT:    vmovx.f16 s1, s6
 ; CHECKFP16-NEXT:    vins.f16 s0, s2
-; CHECKFP16-NEXT:    vmovx.f16 s2, s2
-; CHECKFP16-NEXT:    vmovx.f16 s26, s8
-; CHECKFP16-NEXT:    vins.f16 s8, s10
-; CHECKFP16-NEXT:    vmovx.f16 s7, s4
-; CHECKFP16-NEXT:    vins.f16 s12, s2
-; CHECKFP16-NEXT:    vmovx.f16 s2, s6
-; CHECKFP16-NEXT:    vins.f16 s4, s6
-; CHECKFP16-NEXT:    vins.f16 s7, s2
-; CHECKFP16-NEXT:    vmov.f32 s2, s8
-; CHECKFP16-NEXT:    vmovx.f16 s8, s0
-; CHECKFP16-NEXT:    vmovx.f16 s6, s12
-; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
-; CHECKFP16-NEXT:    vadd.f16 s8, s28, s24
-; CHECKFP16-NEXT:    vadd.f16 s0, s0, s12
-; CHECKFP16-NEXT:    vmovx.f16 s10, s10
-; CHECKFP16-NEXT:    vadd.f16 s0, s0, s8
+; CHECKFP16-NEXT:    vmovx.f16 s2, s7
 ; CHECKFP16-NEXT:    vadd.f16 s6, s6, s1
-; CHECKFP16-NEXT:    vmovx.f16 s3, s16
-; CHECKFP16-NEXT:    vins.f16 s26, s10
-; CHECKFP16-NEXT:    vmovx.f16 s10, s18
-; CHECKFP16-NEXT:    vins.f16 s0, s6
-; CHECKFP16-NEXT:    vmovx.f16 s6, s20
-; CHECKFP16-NEXT:    vmovx.f16 s8, s5
-; CHECKFP16-NEXT:    vins.f16 s3, s10
+; CHECKFP16-NEXT:    vadd.f16 s2, s7, s2
+; CHECKFP16-NEXT:    vmovx.f16 s1, s4
+; CHECKFP16-NEXT:    vadd.f16 s2, s6, s2
+; CHECKFP16-NEXT:    vmovx.f16 s6, s5
+; CHECKFP16-NEXT:    vadd.f16 s4, s4, s1
+; CHECKFP16-NEXT:    vadd.f16 s6, s5, s6
+; CHECKFP16-NEXT:    vadd.f16 s1, s4, s6
+; CHECKFP16-NEXT:    vmovx.f16 s4, s10
+; CHECKFP16-NEXT:    vins.f16 s1, s2
+; CHECKFP16-NEXT:    vmovx.f16 s2, s11
+; CHECKFP16-NEXT:    vadd.f16 s2, s11, s2
+; CHECKFP16-NEXT:    vadd.f16 s4, s10, s4
+; CHECKFP16-NEXT:    vmovx.f16 s6, s8
+; CHECKFP16-NEXT:    vadd.f16 s4, s4, s2
+; CHECKFP16-NEXT:    vmovx.f16 s2, s9
 ; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
-; CHECKFP16-NEXT:    vmovx.f16 s10, s4
-; CHECKFP16-NEXT:    vmovx.f16 s8, s7
-; CHECKFP16-NEXT:    vadd.f16 s8, s10, s8
-; CHECKFP16-NEXT:    vadd.f16 s4, s4, s7
-; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
-; CHECKFP16-NEXT:    vadd.f16 s8, s5, s20
-; CHECKFP16-NEXT:    vadd.f16 s1, s4, s8
-; CHECKFP16-NEXT:    vins.f16 s9, s11
-; CHECKFP16-NEXT:    vins.f16 s1, s6
-; CHECKFP16-NEXT:    vmovx.f16 s4, s30
-; CHECKFP16-NEXT:    vmovx.f16 s6, s9
-; CHECKFP16-NEXT:    vmovx.f16 s8, s2
-; CHECKFP16-NEXT:    vadd.f16 s4, s6, s4
-; CHECKFP16-NEXT:    vmovx.f16 s6, s26
-; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
-; CHECKFP16-NEXT:    vadd.f16 s2, s2, s26
-; CHECKFP16-NEXT:    vadd.f16 s4, s6, s4
-; CHECKFP16-NEXT:    vadd.f16 s6, s9, s30
-; CHECKFP16-NEXT:    vadd.f16 s2, s2, s6
-; CHECKFP16-NEXT:    vins.f16 s17, s19
-; CHECKFP16-NEXT:    vins.f16 s16, s18
+; CHECKFP16-NEXT:    vadd.f16 s2, s9, s2
+; CHECKFP16-NEXT:    vmovx.f16 s8, s12
+; CHECKFP16-NEXT:    vadd.f16 s2, s6, s2
+; CHECKFP16-NEXT:    vmovx.f16 s6, s14
 ; CHECKFP16-NEXT:    vins.f16 s2, s4
-; CHECKFP16-NEXT:    vmovx.f16 s4, s14
-; CHECKFP16-NEXT:    vmovx.f16 s6, s17
+; CHECKFP16-NEXT:    vmovx.f16 s4, s15
+; CHECKFP16-NEXT:    vadd.f16 s4, s15, s4
+; CHECKFP16-NEXT:    vadd.f16 s6, s14, s6
 ; CHECKFP16-NEXT:    vadd.f16 s4, s6, s4
-; CHECKFP16-NEXT:    vmovx.f16 s6, s3
-; CHECKFP16-NEXT:    vmovx.f16 s8, s16
-; CHECKFP16-NEXT:    vadd.f16 s6, s8, s6
-; CHECKFP16-NEXT:    vadd.f16 s8, s16, s3
-; CHECKFP16-NEXT:    vadd.f16 s4, s6, s4
-; CHECKFP16-NEXT:    vadd.f16 s6, s17, s14
+; CHECKFP16-NEXT:    vmovx.f16 s6, s13
+; CHECKFP16-NEXT:    vadd.f16 s6, s13, s6
+; CHECKFP16-NEXT:    vadd.f16 s8, s12, s8
 ; CHECKFP16-NEXT:    vadd.f16 s3, s8, s6
 ; CHECKFP16-NEXT:    vins.f16 s3, s4
-; CHECKFP16-NEXT:    vpop {d8, d9, d10}
-; CHECKFP16-NEXT:    vpop {d12, d13, d14, d15}
+; CHECKFP16-NEXT:    vpop {d8}
 ; CHECKFP16-NEXT:    bx lr
 ;
 ; CHECKFP-LABEL: shuffle4step_f16:

--- a/llvm/test/CodeGen/Thumb2/mve-vabdus.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vabdus.ll
@@ -373,49 +373,41 @@ define void @vabd_loop_s32(ptr nocapture readonly %x, ptr nocapture readonly %y,
 ; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:  .LBB17_1: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
-; CHECK-NEXT:    vmov.f32 s8, s6
-; CHECK-NEXT:    vmov r7, s4
-; CHECK-NEXT:    vmov.f32 s6, s7
-; CHECK-NEXT:    vmov r3, s8
-; CHECK-NEXT:    vldrw.u32 q2, [r1], #16
-; CHECK-NEXT:    vmov.f32 s12, s10
-; CHECK-NEXT:    vmov.f32 s10, s5
-; CHECK-NEXT:    vmov.f32 s14, s11
-; CHECK-NEXT:    vmov r4, s12
-; CHECK-NEXT:    asr.w r12, r3, #31
+; CHECK-NEXT:    vldrw.u32 q2, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q3, [r1], #16
+; CHECK-NEXT:    vmov r3, s10
+; CHECK-NEXT:    vmov r4, s14
 ; CHECK-NEXT:    subs.w r8, r3, r4
+; CHECK-NEXT:    asr.w r12, r3, #31
 ; CHECK-NEXT:    sbcs.w r4, r12, r4, asr #31
-; CHECK-NEXT:    vmov r4, s10
+; CHECK-NEXT:    vmov r7, r3, d6
+; CHECK-NEXT:    vmov r4, r5, d4
 ; CHECK-NEXT:    csetm r12, lt
-; CHECK-NEXT:    vmov.f32 s10, s9
-; CHECK-NEXT:    vmov r6, s10
-; CHECK-NEXT:    asrs r5, r4, #31
-; CHECK-NEXT:    subs r4, r4, r6
-; CHECK-NEXT:    sbcs.w r5, r5, r6, asr #31
-; CHECK-NEXT:    vmov r6, s8
+; CHECK-NEXT:    asrs r6, r5, #31
+; CHECK-NEXT:    subs r5, r5, r3
+; CHECK-NEXT:    sbcs.w r3, r6, r3, asr #31
 ; CHECK-NEXT:    csetm r9, lt
-; CHECK-NEXT:    vmov r5, s6
+; CHECK-NEXT:    subs r6, r4, r7
+; CHECK-NEXT:    asr.w r4, r4, #31
+; CHECK-NEXT:    vmov q1[2], q1[0], r6, r8
+; CHECK-NEXT:    sbcs.w r4, r4, r7, asr #31
+; CHECK-NEXT:    vmov r6, s15
+; CHECK-NEXT:    vmov r7, s11
+; CHECK-NEXT:    csetm r4, lt
 ; CHECK-NEXT:    subs r3, r7, r6
+; CHECK-NEXT:    vmov q1[3], q1[1], r5, r3
+; CHECK-NEXT:    mov.w r3, #0
+; CHECK-NEXT:    bfi r3, r4, #0, #4
 ; CHECK-NEXT:    asr.w r7, r7, #31
-; CHECK-NEXT:    vmov q2[2], q2[0], r3, r8
-; CHECK-NEXT:    vmov r3, s14
-; CHECK-NEXT:    sbcs.w r6, r7, r6, asr #31
-; CHECK-NEXT:    csetm r6, lt
-; CHECK-NEXT:    subs r7, r5, r3
-; CHECK-NEXT:    vmov q2[3], q2[1], r4, r7
-; CHECK-NEXT:    mov.w r4, #0
-; CHECK-NEXT:    bfi r4, r6, #0, #4
-; CHECK-NEXT:    asr.w r7, r5, #31
-; CHECK-NEXT:    sbcs.w r3, r7, r3, asr #31
-; CHECK-NEXT:    bfi r4, r9, #4, #4
-; CHECK-NEXT:    bfi r4, r12, #8, #4
-; CHECK-NEXT:    csetm r3, lt
-; CHECK-NEXT:    bfi r4, r3, #12, #4
-; CHECK-NEXT:    vmsr p0, r4
+; CHECK-NEXT:    sbcs.w r7, r7, r6, asr #31
+; CHECK-NEXT:    bfi r3, r9, #4, #4
+; CHECK-NEXT:    bfi r3, r12, #8, #4
+; CHECK-NEXT:    csetm r7, lt
+; CHECK-NEXT:    bfi r3, r7, #12, #4
+; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vsubt.i32 q2, q0, q2
-; CHECK-NEXT:    vstrb.8 q2, [r2], #16
+; CHECK-NEXT:    vsubt.i32 q1, q0, q1
+; CHECK-NEXT:    vstrb.8 q1, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB17_1
 ; CHECK-NEXT:  @ %bb.2: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, pc}

--- a/llvm/test/CodeGen/Thumb2/mve-vld3.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vld3.ll
@@ -7,20 +7,18 @@
 define void @vld3_v2i32(ptr %src, ptr %dst) {
 ; CHECK-LABEL: vld3_v2i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r7, lr}
-; CHECK-NEXT:    push {r7, lr}
+; CHECK-NEXT:    .save {r4, lr}
+; CHECK-NEXT:    push {r4, lr}
 ; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    ldrd r0, r2, [r0, #16]
-; CHECK-NEXT:    vmov.f32 s6, s3
-; CHECK-NEXT:    vmov r12, lr, d0
-; CHECK-NEXT:    vmov r3, s6
+; CHECK-NEXT:    ldrd r0, r4, [r0, #16]
+; CHECK-NEXT:    vmov r12, r3, d1
+; CHECK-NEXT:    vmov r2, lr, d0
 ; CHECK-NEXT:    add r0, r3
-; CHECK-NEXT:    add.w r3, r12, lr
-; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    vmov r2, s2
-; CHECK-NEXT:    add r2, r3
+; CHECK-NEXT:    add r0, r4
+; CHECK-NEXT:    add r2, lr
+; CHECK-NEXT:    add r2, r12
 ; CHECK-NEXT:    strd r2, r0, [r1]
-; CHECK-NEXT:    pop {r7, pc}
+; CHECK-NEXT:    pop {r4, pc}
 entry:
   %l1 = load <6 x i32>, ptr %src, align 4
   %s1 = shufflevector <6 x i32> %l1, <6 x i32> undef, <2 x i32> <i32 0, i32 3>
@@ -216,27 +214,20 @@ define void @vld3_v2i16(ptr %src, ptr %dst) {
 ; CHECK-NEXT:    .pad #8
 ; CHECK-NEXT:    sub sp, #8
 ; CHECK-NEXT:    vldrh.u32 q0, [r0]
-; CHECK-NEXT:    ldr r2, [r0, #8]
-; CHECK-NEXT:    mov r3, sp
-; CHECK-NEXT:    str r2, [sp]
-; CHECK-NEXT:    vmov.f32 s6, s3
-; CHECK-NEXT:    vmov.f32 s8, s1
-; CHECK-NEXT:    vmov r0, s6
-; CHECK-NEXT:    vldrh.u32 q1, [r3]
-; CHECK-NEXT:    vmov.f32 s6, s4
-; CHECK-NEXT:    vmov.f32 s4, s2
-; CHECK-NEXT:    vmov.f32 s2, s5
-; CHECK-NEXT:    vmov r2, s6
+; CHECK-NEXT:    ldr r0, [r0, #8]
+; CHECK-NEXT:    str r0, [sp]
+; CHECK-NEXT:    mov r0, sp
+; CHECK-NEXT:    vmov r2, r3, d0
+; CHECK-NEXT:    vldrh.u32 q1, [r0]
+; CHECK-NEXT:    vmov r0, r12, d2
+; CHECK-NEXT:    add r2, r3
+; CHECK-NEXT:    vmov r3, s2
+; CHECK-NEXT:    add r2, r3
+; CHECK-NEXT:    strh r2, [r1]
+; CHECK-NEXT:    vmov r2, s3
 ; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    vmov r2, s2
-; CHECK-NEXT:    add r0, r2
+; CHECK-NEXT:    add r0, r12
 ; CHECK-NEXT:    strh r0, [r1, #2]
-; CHECK-NEXT:    vmov r0, s8
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    vmov r2, s4
-; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    strh r0, [r1]
 ; CHECK-NEXT:    add sp, #8
 ; CHECK-NEXT:    bx lr
 entry:
@@ -1285,49 +1276,93 @@ entry:
 }
 
 define void @vld3_v8f16(ptr %src, ptr %dst) {
-; CHECK-LABEL: vld3_v8f16:
-; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    vldrw.u32 q2, [r0, #16]
-; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    vldrw.u32 q3, [r0, #32]
-; CHECK-NEXT:    vmov.f32 s5, s8
-; CHECK-NEXT:    vmovx.f16 s8, s8
-; CHECK-NEXT:    vmovx.f16 s17, s3
-; CHECK-NEXT:    vins.f16 s3, s8
-; CHECK-NEXT:    vmovx.f16 s8, s11
-; CHECK-NEXT:    vmovx.f16 s18, s10
-; CHECK-NEXT:    vmovx.f16 s16, s0
-; CHECK-NEXT:    vins.f16 s10, s8
-; CHECK-NEXT:    vmovx.f16 s6, s2
-; CHECK-NEXT:    vmov.f32 s4, s1
-; CHECK-NEXT:    vmovx.f16 s8, s14
-; CHECK-NEXT:    vmovx.f16 s19, s13
-; CHECK-NEXT:    vins.f16 s4, s6
-; CHECK-NEXT:    vmovx.f16 s6, s9
-; CHECK-NEXT:    vins.f16 s16, s2
-; CHECK-NEXT:    vmovx.f16 s2, s15
-; CHECK-NEXT:    vmovx.f16 s7, s12
-; CHECK-NEXT:    vins.f16 s18, s12
-; CHECK-NEXT:    vmovx.f16 s12, s1
-; CHECK-NEXT:    vins.f16 s13, s8
-; CHECK-NEXT:    vins.f16 s5, s6
-; CHECK-NEXT:    vmov.f32 s6, s11
-; CHECK-NEXT:    vins.f16 s14, s2
-; CHECK-NEXT:    vmov.f32 s1, s3
-; CHECK-NEXT:    vins.f16 s19, s15
-; CHECK-NEXT:    vins.f16 s17, s9
-; CHECK-NEXT:    vins.f16 s0, s12
-; CHECK-NEXT:    vmov.f32 s2, s10
-; CHECK-NEXT:    vmov.f32 s3, s13
-; CHECK-NEXT:    vins.f16 s6, s7
-; CHECK-NEXT:    vmov.f32 s7, s14
-; CHECK-NEXT:    vadd.f16 q0, q0, q4
-; CHECK-NEXT:    vadd.f16 q0, q0, q1
-; CHECK-NEXT:    vstrw.32 q0, [r1]
-; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    bx lr
+; CHECK-LV-LABEL: vld3_v8f16:
+; CHECK-LV:       @ %bb.0: @ %entry
+; CHECK-LV-NEXT:    .vsave {d8, d9}
+; CHECK-LV-NEXT:    vpush {d8, d9}
+; CHECK-LV-NEXT:    vldrw.u32 q1, [r0, #16]
+; CHECK-LV-NEXT:    vldrw.u32 q0, [r0, #32]
+; CHECK-LV-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-LV-NEXT:    vmovx.f16 s10, s6
+; CHECK-LV-NEXT:    vmov.f32 s18, s7
+; CHECK-LV-NEXT:    vins.f16 s10, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s0
+; CHECK-LV-NEXT:    vins.f16 s18, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s3
+; CHECK-LV-NEXT:    vmov.f32 s19, s2
+; CHECK-LV-NEXT:    vmovx.f16 s11, s1
+; CHECK-LV-NEXT:    vins.f16 s19, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s14
+; CHECK-LV-NEXT:    vins.f16 s11, s3
+; CHECK-LV-NEXT:    vmovx.f16 s3, s13
+; CHECK-LV-NEXT:    vins.f16 s13, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s4
+; CHECK-LV-NEXT:    vmovx.f16 s9, s15
+; CHECK-LV-NEXT:    vins.f16 s15, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s7
+; CHECK-LV-NEXT:    vmovx.f16 s8, s12
+; CHECK-LV-NEXT:    vins.f16 s6, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s2
+; CHECK-LV-NEXT:    vins.f16 s8, s14
+; CHECK-LV-NEXT:    vmovx.f16 s14, s5
+; CHECK-LV-NEXT:    vins.f16 s1, s0
+; CHECK-LV-NEXT:    vins.f16 s4, s14
+; CHECK-LV-NEXT:    vmov.f32 s16, s13
+; CHECK-LV-NEXT:    vins.f16 s9, s5
+; CHECK-LV-NEXT:    vmov.f32 s13, s15
+; CHECK-LV-NEXT:    vins.f16 s12, s3
+; CHECK-LV-NEXT:    vmov.f32 s14, s6
+; CHECK-LV-NEXT:    vmov.f32 s15, s1
+; CHECK-LV-NEXT:    vmov.f32 s17, s4
+; CHECK-LV-NEXT:    vadd.f16 q0, q3, q2
+; CHECK-LV-NEXT:    vadd.f16 q0, q0, q4
+; CHECK-LV-NEXT:    vstrw.32 q0, [r1]
+; CHECK-LV-NEXT:    vpop {d8, d9}
+; CHECK-LV-NEXT:    bx lr
+;
+; CHECK-LIS-LABEL: vld3_v8f16:
+; CHECK-LIS:       @ %bb.0: @ %entry
+; CHECK-LIS-NEXT:    .vsave {d8, d9}
+; CHECK-LIS-NEXT:    vpush {d8, d9}
+; CHECK-LIS-NEXT:    vldrw.u32 q2, [r0, #16]
+; CHECK-LIS-NEXT:    vldrw.u32 q0, [r0, #32]
+; CHECK-LIS-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-LIS-NEXT:    vmovx.f16 s6, s10
+; CHECK-LIS-NEXT:    vmov.f32 s18, s11
+; CHECK-LIS-NEXT:    vins.f16 s6, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s0
+; CHECK-LIS-NEXT:    vins.f16 s18, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s3
+; CHECK-LIS-NEXT:    vmov.f32 s19, s2
+; CHECK-LIS-NEXT:    vmovx.f16 s7, s1
+; CHECK-LIS-NEXT:    vins.f16 s19, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s14
+; CHECK-LIS-NEXT:    vins.f16 s7, s3
+; CHECK-LIS-NEXT:    vmovx.f16 s3, s13
+; CHECK-LIS-NEXT:    vins.f16 s13, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s8
+; CHECK-LIS-NEXT:    vmovx.f16 s5, s15
+; CHECK-LIS-NEXT:    vins.f16 s15, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s11
+; CHECK-LIS-NEXT:    vmovx.f16 s4, s12
+; CHECK-LIS-NEXT:    vins.f16 s10, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s2
+; CHECK-LIS-NEXT:    vins.f16 s4, s14
+; CHECK-LIS-NEXT:    vmovx.f16 s14, s9
+; CHECK-LIS-NEXT:    vins.f16 s1, s0
+; CHECK-LIS-NEXT:    vins.f16 s8, s14
+; CHECK-LIS-NEXT:    vmov.f32 s16, s13
+; CHECK-LIS-NEXT:    vins.f16 s5, s9
+; CHECK-LIS-NEXT:    vmov.f32 s13, s15
+; CHECK-LIS-NEXT:    vins.f16 s12, s3
+; CHECK-LIS-NEXT:    vmov.f32 s14, s10
+; CHECK-LIS-NEXT:    vmov.f32 s15, s1
+; CHECK-LIS-NEXT:    vmov.f32 s17, s8
+; CHECK-LIS-NEXT:    vadd.f16 q0, q3, q1
+; CHECK-LIS-NEXT:    vadd.f16 q0, q0, q4
+; CHECK-LIS-NEXT:    vstrw.32 q0, [r1]
+; CHECK-LIS-NEXT:    vpop {d8, d9}
+; CHECK-LIS-NEXT:    bx lr
 entry:
   %l1 = load <24 x half>, ptr %src, align 4
   %s1 = shufflevector <24 x half> %l1, <24 x half> undef, <8 x i32> <i32 0, i32 3, i32 6, i32 9, i32 12, i32 15, i32 18, i32 21>
@@ -1344,22 +1379,59 @@ define void @vld3_v16f16(ptr %src, ptr %dst) {
 ; CHECK-LV:       @ %bb.0: @ %entry
 ; CHECK-LV-NEXT:    .vsave {d8, d9}
 ; CHECK-LV-NEXT:    vpush {d8, d9}
-; CHECK-LV-NEXT:    vldrw.u32 q0, [r0, #48]
+; CHECK-LV-NEXT:    vldrw.u32 q0, [r0, #80]
 ; CHECK-LV-NEXT:    vldrw.u32 q2, [r0, #64]
-; CHECK-LV-NEXT:    vldrw.u32 q3, [r0, #80]
-; CHECK-LV-NEXT:    vmovx.f16 s6, s2
-; CHECK-LV-NEXT:    vmov.f32 s4, s1
-; CHECK-LV-NEXT:    vins.f16 s4, s6
-; CHECK-LV-NEXT:    vmovx.f16 s6, s9
-; CHECK-LV-NEXT:    vmov.f32 s5, s8
-; CHECK-LV-NEXT:    vmovx.f16 s7, s12
-; CHECK-LV-NEXT:    vins.f16 s5, s6
+; CHECK-LV-NEXT:    vldrw.u32 q3, [r0, #48]
+; CHECK-LV-NEXT:    vmovx.f16 s4, s0
 ; CHECK-LV-NEXT:    vmov.f32 s6, s11
-; CHECK-LV-NEXT:    vins.f16 s6, s7
-; CHECK-LV-NEXT:    vmovx.f16 s16, s15
-; CHECK-LV-NEXT:    vmov.f32 s7, s14
+; CHECK-LV-NEXT:    vins.f16 s6, s4
+; CHECK-LV-NEXT:    vmovx.f16 s4, s3
+; CHECK-LV-NEXT:    vmov.f32 s7, s2
+; CHECK-LV-NEXT:    vmovx.f16 s18, s10
+; CHECK-LV-NEXT:    vins.f16 s7, s4
+; CHECK-LV-NEXT:    vmovx.f16 s5, s14
+; CHECK-LV-NEXT:    vmov.f32 s4, s13
+; CHECK-LV-NEXT:    vins.f16 s18, s0
+; CHECK-LV-NEXT:    vins.f16 s4, s5
+; CHECK-LV-NEXT:    vmovx.f16 s16, s9
+; CHECK-LV-NEXT:    vmov.f32 s5, s8
+; CHECK-LV-NEXT:    vmovx.f16 s0, s13
+; CHECK-LV-NEXT:    vins.f16 s5, s16
+; CHECK-LV-NEXT:    vmovx.f16 s16, s12
+; CHECK-LV-NEXT:    vins.f16 s12, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s8
+; CHECK-LV-NEXT:    vmovx.f16 s17, s15
+; CHECK-LV-NEXT:    vins.f16 s15, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s11
+; CHECK-LV-NEXT:    vmovx.f16 s19, s1
+; CHECK-LV-NEXT:    vins.f16 s10, s0
+; CHECK-LV-NEXT:    vmovx.f16 s0, s2
+; CHECK-LV-NEXT:    vins.f16 s1, s0
+; CHECK-LV-NEXT:    vins.f16 s16, s14
+; CHECK-LV-NEXT:    vmov.f32 s13, s15
+; CHECK-LV-NEXT:    vins.f16 s19, s3
+; CHECK-LV-NEXT:    vins.f16 s17, s9
+; CHECK-LV-NEXT:    vmov.f32 s14, s10
+; CHECK-LV-NEXT:    vmov.f32 s15, s1
+; CHECK-LV-NEXT:    vldrw.u32 q2, [r0, #16]
+; CHECK-LV-NEXT:    vadd.f16 q0, q3, q4
+; CHECK-LV-NEXT:    vadd.f16 q3, q0, q1
+; CHECK-LV-NEXT:    vldrw.u32 q1, [r0, #32]
+; CHECK-LV-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-LV-NEXT:    vstrw.32 q3, [r1, #16]
+; CHECK-LV-NEXT:    vmovx.f16 s12, s4
+; CHECK-LV-NEXT:    vmov.f32 s14, s11
+; CHECK-LV-NEXT:    vins.f16 s14, s12
+; CHECK-LV-NEXT:    vmovx.f16 s12, s7
+; CHECK-LV-NEXT:    vmov.f32 s15, s6
+; CHECK-LV-NEXT:    vmovx.f16 s13, s2
+; CHECK-LV-NEXT:    vins.f16 s15, s12
+; CHECK-LV-NEXT:    vmov.f32 s12, s1
+; CHECK-LV-NEXT:    vins.f16 s12, s13
+; CHECK-LV-NEXT:    vmovx.f16 s16, s9
+; CHECK-LV-NEXT:    vmov.f32 s13, s8
 ; CHECK-LV-NEXT:    vmovx.f16 s17, s3
-; CHECK-LV-NEXT:    vins.f16 s7, s16
+; CHECK-LV-NEXT:    vins.f16 s13, s16
 ; CHECK-LV-NEXT:    vmovx.f16 s16, s0
 ; CHECK-LV-NEXT:    vins.f16 s16, s2
 ; CHECK-LV-NEXT:    vmovx.f16 s2, s1
@@ -1369,53 +1441,16 @@ define void @vld3_v16f16(ptr %src, ptr %dst) {
 ; CHECK-LV-NEXT:    vmovx.f16 s2, s11
 ; CHECK-LV-NEXT:    vmovx.f16 s18, s10
 ; CHECK-LV-NEXT:    vins.f16 s10, s2
-; CHECK-LV-NEXT:    vmovx.f16 s2, s14
-; CHECK-LV-NEXT:    vmovx.f16 s19, s13
-; CHECK-LV-NEXT:    vins.f16 s13, s2
+; CHECK-LV-NEXT:    vmovx.f16 s2, s6
+; CHECK-LV-NEXT:    vmovx.f16 s19, s5
+; CHECK-LV-NEXT:    vins.f16 s5, s2
 ; CHECK-LV-NEXT:    vmov.f32 s1, s3
-; CHECK-LV-NEXT:    vins.f16 s18, s12
-; CHECK-LV-NEXT:    vins.f16 s19, s15
+; CHECK-LV-NEXT:    vins.f16 s18, s4
+; CHECK-LV-NEXT:    vins.f16 s19, s7
 ; CHECK-LV-NEXT:    vins.f16 s17, s9
 ; CHECK-LV-NEXT:    vmov.f32 s2, s10
-; CHECK-LV-NEXT:    vmov.f32 s3, s13
-; CHECK-LV-NEXT:    vldrw.u32 q2, [r0, #16]
+; CHECK-LV-NEXT:    vmov.f32 s3, s5
 ; CHECK-LV-NEXT:    vadd.f16 q0, q0, q4
-; CHECK-LV-NEXT:    vadd.f16 q3, q0, q1
-; CHECK-LV-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-LV-NEXT:    vldrw.u32 q0, [r0, #32]
-; CHECK-LV-NEXT:    vstrw.32 q3, [r1, #16]
-; CHECK-LV-NEXT:    vmovx.f16 s14, s6
-; CHECK-LV-NEXT:    vmov.f32 s12, s5
-; CHECK-LV-NEXT:    vins.f16 s12, s14
-; CHECK-LV-NEXT:    vmovx.f16 s14, s9
-; CHECK-LV-NEXT:    vmov.f32 s13, s8
-; CHECK-LV-NEXT:    vmovx.f16 s18, s10
-; CHECK-LV-NEXT:    vins.f16 s13, s14
-; CHECK-LV-NEXT:    vmovx.f16 s15, s0
-; CHECK-LV-NEXT:    vmov.f32 s14, s11
-; CHECK-LV-NEXT:    vins.f16 s18, s0
-; CHECK-LV-NEXT:    vins.f16 s14, s15
-; CHECK-LV-NEXT:    vmovx.f16 s16, s3
-; CHECK-LV-NEXT:    vmov.f32 s15, s2
-; CHECK-LV-NEXT:    vmovx.f16 s0, s5
-; CHECK-LV-NEXT:    vins.f16 s15, s16
-; CHECK-LV-NEXT:    vmovx.f16 s16, s4
-; CHECK-LV-NEXT:    vins.f16 s4, s0
-; CHECK-LV-NEXT:    vmovx.f16 s0, s8
-; CHECK-LV-NEXT:    vmovx.f16 s17, s7
-; CHECK-LV-NEXT:    vins.f16 s7, s0
-; CHECK-LV-NEXT:    vmovx.f16 s0, s11
-; CHECK-LV-NEXT:    vmovx.f16 s19, s1
-; CHECK-LV-NEXT:    vins.f16 s10, s0
-; CHECK-LV-NEXT:    vmovx.f16 s0, s2
-; CHECK-LV-NEXT:    vins.f16 s1, s0
-; CHECK-LV-NEXT:    vins.f16 s16, s6
-; CHECK-LV-NEXT:    vmov.f32 s5, s7
-; CHECK-LV-NEXT:    vins.f16 s19, s3
-; CHECK-LV-NEXT:    vins.f16 s17, s9
-; CHECK-LV-NEXT:    vmov.f32 s6, s10
-; CHECK-LV-NEXT:    vmov.f32 s7, s1
-; CHECK-LV-NEXT:    vadd.f16 q0, q1, q4
 ; CHECK-LV-NEXT:    vadd.f16 q0, q0, q3
 ; CHECK-LV-NEXT:    vstrw.32 q0, [r1]
 ; CHECK-LV-NEXT:    vpop {d8, d9}
@@ -1425,79 +1460,79 @@ define void @vld3_v16f16(ptr %src, ptr %dst) {
 ; CHECK-LIS:       @ %bb.0: @ %entry
 ; CHECK-LIS-NEXT:    .vsave {d8, d9}
 ; CHECK-LIS-NEXT:    vpush {d8, d9}
-; CHECK-LIS-NEXT:    vldrw.u32 q0, [r0, #48]
+; CHECK-LIS-NEXT:    vldrw.u32 q0, [r0, #80]
 ; CHECK-LIS-NEXT:    vldrw.u32 q2, [r0, #64]
-; CHECK-LIS-NEXT:    vldrw.u32 q3, [r0, #80]
-; CHECK-LIS-NEXT:    vmovx.f16 s6, s2
-; CHECK-LIS-NEXT:    vmov.f32 s4, s1
-; CHECK-LIS-NEXT:    vins.f16 s4, s6
-; CHECK-LIS-NEXT:    vmovx.f16 s6, s9
-; CHECK-LIS-NEXT:    vmov.f32 s5, s8
-; CHECK-LIS-NEXT:    vmovx.f16 s7, s12
-; CHECK-LIS-NEXT:    vins.f16 s5, s6
+; CHECK-LIS-NEXT:    vldrw.u32 q3, [r0, #48]
+; CHECK-LIS-NEXT:    vmovx.f16 s4, s0
 ; CHECK-LIS-NEXT:    vmov.f32 s6, s11
-; CHECK-LIS-NEXT:    vins.f16 s6, s7
-; CHECK-LIS-NEXT:    vmovx.f16 s16, s15
-; CHECK-LIS-NEXT:    vmov.f32 s7, s14
-; CHECK-LIS-NEXT:    vmovx.f16 s17, s3
-; CHECK-LIS-NEXT:    vins.f16 s7, s16
-; CHECK-LIS-NEXT:    vmovx.f16 s16, s0
-; CHECK-LIS-NEXT:    vins.f16 s16, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s1
-; CHECK-LIS-NEXT:    vins.f16 s0, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s8
-; CHECK-LIS-NEXT:    vins.f16 s3, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s11
+; CHECK-LIS-NEXT:    vins.f16 s6, s4
+; CHECK-LIS-NEXT:    vmovx.f16 s4, s3
+; CHECK-LIS-NEXT:    vmov.f32 s7, s2
 ; CHECK-LIS-NEXT:    vmovx.f16 s18, s10
-; CHECK-LIS-NEXT:    vins.f16 s10, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s14
-; CHECK-LIS-NEXT:    vmovx.f16 s19, s13
-; CHECK-LIS-NEXT:    vins.f16 s13, s2
-; CHECK-LIS-NEXT:    vmov.f32 s1, s3
-; CHECK-LIS-NEXT:    vins.f16 s18, s12
-; CHECK-LIS-NEXT:    vins.f16 s19, s15
+; CHECK-LIS-NEXT:    vins.f16 s7, s4
+; CHECK-LIS-NEXT:    vmovx.f16 s5, s14
+; CHECK-LIS-NEXT:    vmov.f32 s4, s13
+; CHECK-LIS-NEXT:    vins.f16 s18, s0
+; CHECK-LIS-NEXT:    vins.f16 s4, s5
+; CHECK-LIS-NEXT:    vmovx.f16 s16, s9
+; CHECK-LIS-NEXT:    vmov.f32 s5, s8
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s13
+; CHECK-LIS-NEXT:    vins.f16 s5, s16
+; CHECK-LIS-NEXT:    vmovx.f16 s16, s12
+; CHECK-LIS-NEXT:    vins.f16 s12, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s8
+; CHECK-LIS-NEXT:    vmovx.f16 s17, s15
+; CHECK-LIS-NEXT:    vins.f16 s15, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s11
+; CHECK-LIS-NEXT:    vmovx.f16 s19, s1
+; CHECK-LIS-NEXT:    vins.f16 s10, s0
+; CHECK-LIS-NEXT:    vmovx.f16 s0, s2
+; CHECK-LIS-NEXT:    vins.f16 s1, s0
+; CHECK-LIS-NEXT:    vins.f16 s16, s14
+; CHECK-LIS-NEXT:    vmov.f32 s13, s15
+; CHECK-LIS-NEXT:    vins.f16 s19, s3
 ; CHECK-LIS-NEXT:    vins.f16 s17, s9
-; CHECK-LIS-NEXT:    vmov.f32 s2, s10
-; CHECK-LIS-NEXT:    vmov.f32 s3, s13
-; CHECK-LIS-NEXT:    vldrw.u32 q2, [r0, #16]
-; CHECK-LIS-NEXT:    vadd.f16 q0, q0, q4
-; CHECK-LIS-NEXT:    vadd.f16 q3, q0, q1
-; CHECK-LIS-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-LIS-NEXT:    vmov.f32 s14, s10
+; CHECK-LIS-NEXT:    vmov.f32 s15, s1
+; CHECK-LIS-NEXT:    vadd.f16 q0, q3, q4
+; CHECK-LIS-NEXT:    vldrw.u32 q3, [r0, #16]
+; CHECK-LIS-NEXT:    vadd.f16 q2, q0, q1
 ; CHECK-LIS-NEXT:    vldrw.u32 q1, [r0, #32]
-; CHECK-LIS-NEXT:    vstrw.32 q3, [r1, #16]
-; CHECK-LIS-NEXT:    vmovx.f16 s14, s2
-; CHECK-LIS-NEXT:    vmov.f32 s12, s1
-; CHECK-LIS-NEXT:    vins.f16 s12, s14
-; CHECK-LIS-NEXT:    vmovx.f16 s14, s9
-; CHECK-LIS-NEXT:    vmov.f32 s13, s8
-; CHECK-LIS-NEXT:    vmovx.f16 s15, s4
-; CHECK-LIS-NEXT:    vins.f16 s13, s14
-; CHECK-LIS-NEXT:    vmov.f32 s14, s11
-; CHECK-LIS-NEXT:    vins.f16 s14, s15
-; CHECK-LIS-NEXT:    vmovx.f16 s16, s7
-; CHECK-LIS-NEXT:    vmov.f32 s15, s6
+; CHECK-LIS-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-LIS-NEXT:    vstrw.32 q2, [r1, #16]
+; CHECK-LIS-NEXT:    vmovx.f16 s8, s4
+; CHECK-LIS-NEXT:    vmov.f32 s10, s15
+; CHECK-LIS-NEXT:    vins.f16 s10, s8
+; CHECK-LIS-NEXT:    vmovx.f16 s8, s7
+; CHECK-LIS-NEXT:    vmov.f32 s11, s6
+; CHECK-LIS-NEXT:    vmovx.f16 s9, s2
+; CHECK-LIS-NEXT:    vins.f16 s11, s8
+; CHECK-LIS-NEXT:    vmov.f32 s8, s1
+; CHECK-LIS-NEXT:    vins.f16 s8, s9
+; CHECK-LIS-NEXT:    vmovx.f16 s16, s13
+; CHECK-LIS-NEXT:    vmov.f32 s9, s12
 ; CHECK-LIS-NEXT:    vmovx.f16 s17, s3
-; CHECK-LIS-NEXT:    vins.f16 s15, s16
+; CHECK-LIS-NEXT:    vins.f16 s9, s16
 ; CHECK-LIS-NEXT:    vmovx.f16 s16, s0
 ; CHECK-LIS-NEXT:    vins.f16 s16, s2
 ; CHECK-LIS-NEXT:    vmovx.f16 s2, s1
 ; CHECK-LIS-NEXT:    vins.f16 s0, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s8
+; CHECK-LIS-NEXT:    vmovx.f16 s2, s12
 ; CHECK-LIS-NEXT:    vins.f16 s3, s2
-; CHECK-LIS-NEXT:    vmovx.f16 s2, s11
-; CHECK-LIS-NEXT:    vmovx.f16 s18, s10
-; CHECK-LIS-NEXT:    vins.f16 s10, s2
+; CHECK-LIS-NEXT:    vmovx.f16 s2, s15
+; CHECK-LIS-NEXT:    vmovx.f16 s18, s14
+; CHECK-LIS-NEXT:    vins.f16 s14, s2
 ; CHECK-LIS-NEXT:    vmovx.f16 s2, s6
 ; CHECK-LIS-NEXT:    vmovx.f16 s19, s5
 ; CHECK-LIS-NEXT:    vins.f16 s5, s2
 ; CHECK-LIS-NEXT:    vmov.f32 s1, s3
 ; CHECK-LIS-NEXT:    vins.f16 s18, s4
 ; CHECK-LIS-NEXT:    vins.f16 s19, s7
-; CHECK-LIS-NEXT:    vins.f16 s17, s9
-; CHECK-LIS-NEXT:    vmov.f32 s2, s10
+; CHECK-LIS-NEXT:    vins.f16 s17, s13
+; CHECK-LIS-NEXT:    vmov.f32 s2, s14
 ; CHECK-LIS-NEXT:    vmov.f32 s3, s5
 ; CHECK-LIS-NEXT:    vadd.f16 q0, q0, q4
-; CHECK-LIS-NEXT:    vadd.f16 q0, q0, q3
+; CHECK-LIS-NEXT:    vadd.f16 q0, q0, q2
 ; CHECK-LIS-NEXT:    vstrw.32 q0, [r1]
 ; CHECK-LIS-NEXT:    vpop {d8, d9}
 ; CHECK-LIS-NEXT:    bx lr

--- a/llvm/test/CodeGen/Thumb2/mve-vld4.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vld4.ll
@@ -6,28 +6,22 @@
 define void @vld4_v2i32(ptr %src, ptr %dst) {
 ; CHECK-LABEL: vld4_v2i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vldrw.u32 q1, [r0, #16]
+; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
+; CHECK-NEXT:    vldrw.u32 q0, [r0, #16]
+; CHECK-NEXT:    vmov r7, r3, d0
+; CHECK-NEXT:    vmov r12, lr, d1
 ; CHECK-NEXT:    vldrw.u32 q0, [r0]
-; CHECK-NEXT:    vmov.f32 s10, s7
-; CHECK-NEXT:    vmov r2, s6
-; CHECK-NEXT:    vmov.f32 s6, s5
-; CHECK-NEXT:    vmov r3, s4
-; CHECK-NEXT:    vmov.f32 s8, s3
-; CHECK-NEXT:    vmov.f32 s12, s1
-; CHECK-NEXT:    vmov r0, s10
-; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    vmov r2, s6
+; CHECK-NEXT:    vmov r0, r4, d1
+; CHECK-NEXT:    vmov r5, r6, d0
+; CHECK-NEXT:    add r3, r7
+; CHECK-NEXT:    add.w r2, r12, lr
 ; CHECK-NEXT:    add r2, r3
-; CHECK-NEXT:    vmov r3, s2
-; CHECK-NEXT:    add.w r12, r2, r0
-; CHECK-NEXT:    vmov r2, s8
-; CHECK-NEXT:    vmov r0, s0
-; CHECK-NEXT:    add r2, r3
-; CHECK-NEXT:    vmov r3, s12
+; CHECK-NEXT:    add r0, r4
+; CHECK-NEXT:    adds r3, r5, r6
 ; CHECK-NEXT:    add r0, r3
-; CHECK-NEXT:    add r0, r2
-; CHECK-NEXT:    strd r0, r12, [r1]
-; CHECK-NEXT:    bx lr
+; CHECK-NEXT:    strd r0, r2, [r1]
+; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 entry:
   %l1 = load <8 x i32>, ptr %src, align 4
   %s1 = shufflevector <8 x i32> %l1, <8 x i32> undef, <2 x i32> <i32 0, i32 4>

--- a/llvm/test/CodeGen/Thumb2/mve-vst3.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vst3.ll
@@ -1259,55 +1259,47 @@ define void @vst3_v8f16(ptr %src, ptr %dst) {
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
+; CHECK-NEXT:    vldrw.u32 q1, [r0, #32]
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
 ; CHECK-NEXT:    vldrw.u32 q3, [r0, #16]
-; CHECK-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-NEXT:    vmovx.f16 s0, s14
-; CHECK-NEXT:    vmov.f32 s8, s7
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    vins.f16 s8, s15
-; CHECK-NEXT:    vmov.16 q0[0], r2
-; CHECK-NEXT:    vmov.f32 s16, s4
-; CHECK-NEXT:    vmov.f32 s1, s8
-; CHECK-NEXT:    vmovx.f16 s8, s15
-; CHECK-NEXT:    vmov r2, s8
-; CHECK-NEXT:    vldrw.u32 q2, [r0, #32]
-; CHECK-NEXT:    vmov.16 q0[6], r2
-; CHECK-NEXT:    vins.f16 s16, s12
-; CHECK-NEXT:    vmovx.f16 s2, s10
-; CHECK-NEXT:    vins.f16 s0, s2
-; CHECK-NEXT:    vmovx.f16 s2, s7
-; CHECK-NEXT:    vmovx.f16 s7, s11
-; CHECK-NEXT:    vins.f16 s11, s2
-; CHECK-NEXT:    vmovx.f16 s2, s12
-; CHECK-NEXT:    vins.f16 s3, s7
-; CHECK-NEXT:    vmov r0, s2
-; CHECK-NEXT:    vmovx.f16 s2, s4
-; CHECK-NEXT:    vmovx.f16 s4, s8
-; CHECK-NEXT:    vmov.16 q4[4], r0
-; CHECK-NEXT:    vins.f16 s8, s2
-; CHECK-NEXT:    vmovx.f16 s2, s13
-; CHECK-NEXT:    vmov.f32 s7, s5
-; CHECK-NEXT:    vins.f16 s18, s4
-; CHECK-NEXT:    vmov.f32 s4, s6
-; CHECK-NEXT:    vins.f16 s7, s13
-; CHECK-NEXT:    vmov r0, s2
-; CHECK-NEXT:    vins.f16 s4, s14
-; CHECK-NEXT:    vmov.16 q3[2], r0
-; CHECK-NEXT:    vmovx.f16 s2, s5
-; CHECK-NEXT:    vmovx.f16 s12, s9
-; CHECK-NEXT:    vins.f16 s9, s2
-; CHECK-NEXT:    vmovx.f16 s2, s6
-; CHECK-NEXT:    vins.f16 s13, s12
-; CHECK-NEXT:    vins.f16 s10, s2
-; CHECK-NEXT:    vmov.f32 s2, s11
-; CHECK-NEXT:    vmov.f32 s12, s9
-; CHECK-NEXT:    vstrw.32 q0, [r1, #32]
-; CHECK-NEXT:    vmov.f32 s14, s4
-; CHECK-NEXT:    vmov.f32 s15, s10
-; CHECK-NEXT:    vmov.f32 s17, s8
-; CHECK-NEXT:    vstrw.32 q3, [r1, #16]
-; CHECK-NEXT:    vmov.f32 s19, s7
+; CHECK-NEXT:    vmovx.f16 s8, s3
+; CHECK-NEXT:    vmov.f32 s16, s7
+; CHECK-NEXT:    vins.f16 s16, s8
+; CHECK-NEXT:    vmovx.f16 s8, s14
+; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    vmovx.f16 s18, s6
+; CHECK-NEXT:    vmov.16 q2[0], r0
+; CHECK-NEXT:    vins.f16 s3, s15
+; CHECK-NEXT:    vins.f16 s8, s18
+; CHECK-NEXT:    vmovx.f16 s11, s4
+; CHECK-NEXT:    vmovx.f16 s18, s12
+; CHECK-NEXT:    vmovx.f16 s9, s0
+; CHECK-NEXT:    vins.f16 s0, s12
+; CHECK-NEXT:    vins.f16 s18, s11
+; CHECK-NEXT:    vmovx.f16 s12, s7
+; CHECK-NEXT:    vmovx.f16 s11, s15
+; CHECK-NEXT:    vins.f16 s11, s12
+; CHECK-NEXT:    vmovx.f16 s12, s1
+; CHECK-NEXT:    vmovx.f16 s7, s5
+; CHECK-NEXT:    vins.f16 s5, s12
+; CHECK-NEXT:    vmovx.f16 s12, s2
+; CHECK-NEXT:    vins.f16 s4, s9
+; CHECK-NEXT:    vins.f16 s1, s13
+; CHECK-NEXT:    vmovx.f16 s13, s13
+; CHECK-NEXT:    vins.f16 s6, s12
+; CHECK-NEXT:    vins.f16 s2, s14
+; CHECK-NEXT:    vmov.f32 s10, s16
+; CHECK-NEXT:    vins.f16 s13, s7
+; CHECK-NEXT:    vmov.f32 s9, s3
+; CHECK-NEXT:    vmov.f32 s17, s4
+; CHECK-NEXT:    vstrw.32 q2, [r1, #32]
+; CHECK-NEXT:    vmov.f32 s16, s0
+; CHECK-NEXT:    vmov.f32 s19, s1
+; CHECK-NEXT:    vmov.f32 s12, s5
 ; CHECK-NEXT:    vstrw.32 q4, [r1]
+; CHECK-NEXT:    vmov.f32 s14, s2
+; CHECK-NEXT:    vmov.f32 s15, s6
+; CHECK-NEXT:    vstrw.32 q3, [r1, #16]
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    bx lr
 entry:
@@ -1328,117 +1320,111 @@ define void @vst3_v16f16(ptr %src, ptr %dst) {
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #72
-; CHECK-NEXT:    sub sp, #72
-; CHECK-NEXT:    vldrw.u32 q5, [r0, #16]
-; CHECK-NEXT:    vldrw.u32 q1, [r0, #48]
-; CHECK-NEXT:    vldrw.u32 q2, [r0, #80]
-; CHECK-NEXT:    vldrw.u32 q7, [r0]
-; CHECK-NEXT:    vmov.f32 s0, s20
-; CHECK-NEXT:    vldrw.u32 q6, [r0, #32]
-; CHECK-NEXT:    vins.f16 s0, s4
-; CHECK-NEXT:    vmovx.f16 s2, s8
-; CHECK-NEXT:    vmov.f32 s12, s0
+; CHECK-NEXT:    .pad #96
+; CHECK-NEXT:    sub sp, #96
 ; CHECK-NEXT:    vldrw.u32 q4, [r0, #64]
-; CHECK-NEXT:    vmov.f32 s0, s21
-; CHECK-NEXT:    vstrw.32 q7, [sp, #8] @ 16-byte Spill
-; CHECK-NEXT:    vins.f16 s0, s5
-; CHECK-NEXT:    vstr s0, [sp, #68] @ 4-byte Spill
-; CHECK-NEXT:    vmovx.f16 s0, s4
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    vmovx.f16 s0, s20
-; CHECK-NEXT:    vmov.16 q3[4], r2
-; CHECK-NEXT:    vins.f16 s8, s0
-; CHECK-NEXT:    vmov.f32 s0, s29
-; CHECK-NEXT:    vins.f16 s14, s2
-; CHECK-NEXT:    vins.f16 s0, s25
-; CHECK-NEXT:    vstrw.32 q3, [sp, #48] @ 16-byte Spill
-; CHECK-NEXT:    vmov.f32 s12, s28
-; CHECK-NEXT:    vstr s0, [sp, #4] @ 4-byte Spill
-; CHECK-NEXT:    vmovx.f16 s0, s24
-; CHECK-NEXT:    vins.f16 s12, s24
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    vmovx.f16 s2, s16
-; CHECK-NEXT:    vmov.16 q3[4], r2
-; CHECK-NEXT:    vmovx.f16 s0, s28
-; CHECK-NEXT:    vins.f16 s14, s2
-; CHECK-NEXT:    vmovx.f16 s2, s26
-; CHECK-NEXT:    vins.f16 s16, s0
-; CHECK-NEXT:    vmov.f32 s0, s31
-; CHECK-NEXT:    vmov r0, s2
-; CHECK-NEXT:    vstrw.32 q3, [sp, #32] @ 16-byte Spill
-; CHECK-NEXT:    vins.f16 s0, s27
-; CHECK-NEXT:    vmov.16 q3[0], r0
-; CHECK-NEXT:    vmov.f32 s13, s0
-; CHECK-NEXT:    vmovx.f16 s0, s27
-; CHECK-NEXT:    vmov r0, s0
-; CHECK-NEXT:    vmovx.f16 s0, s18
-; CHECK-NEXT:    vmov.16 q3[6], r0
-; CHECK-NEXT:    vmovx.f16 s2, s19
-; CHECK-NEXT:    vins.f16 s12, s0
-; CHECK-NEXT:    vmovx.f16 s0, s31
-; CHECK-NEXT:    vins.f16 s19, s0
-; CHECK-NEXT:    vmovx.f16 s0, s6
-; CHECK-NEXT:    vmov.f32 s4, s23
-; CHECK-NEXT:    vins.f16 s15, s2
-; CHECK-NEXT:    vmov r0, s0
-; CHECK-NEXT:    vins.f16 s4, s7
-; CHECK-NEXT:    vmov.16 q0[0], r0
-; CHECK-NEXT:    vldrw.u32 q7, [sp, #32] @ 16-byte Reload
-; CHECK-NEXT:    vmov.f32 s1, s4
-; CHECK-NEXT:    vmovx.f16 s4, s7
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmovx.f16 s4, s11
-; CHECK-NEXT:    vmov.16 q0[6], r0
-; CHECK-NEXT:    vldr s31, [sp, #4] @ 4-byte Reload
-; CHECK-NEXT:    vmovx.f16 s2, s10
-; CHECK-NEXT:    vins.f16 s3, s4
-; CHECK-NEXT:    vins.f16 s0, s2
-; CHECK-NEXT:    vmovx.f16 s2, s23
-; CHECK-NEXT:    vins.f16 s11, s2
-; CHECK-NEXT:    vmov.f32 s2, s22
-; CHECK-NEXT:    vins.f16 s2, s6
-; CHECK-NEXT:    vmov.f32 s29, s16
-; CHECK-NEXT:    vstr s2, [sp, #28] @ 4-byte Spill
-; CHECK-NEXT:    vmovx.f16 s2, s5
-; CHECK-NEXT:    vmov r0, s2
-; CHECK-NEXT:    vstrw.32 q7, [r1]
-; CHECK-NEXT:    vmov.16 q1[2], r0
-; CHECK-NEXT:    vmov.f32 s2, s11
-; CHECK-NEXT:    vmovx.f16 s4, s21
-; CHECK-NEXT:    vmovx.f16 s6, s9
-; CHECK-NEXT:    vins.f16 s9, s4
-; CHECK-NEXT:    vmovx.f16 s4, s22
-; CHECK-NEXT:    vldrw.u32 q5, [sp, #8] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vldrw.u32 q5, [r0, #80]
+; CHECK-NEXT:    vldrw.u32 q6, [r0, #48]
+; CHECK-NEXT:    vmovx.f16 s4, s3
+; CHECK-NEXT:    vmov.f32 s10, s19
 ; CHECK-NEXT:    vins.f16 s10, s4
-; CHECK-NEXT:    vmovx.f16 s4, s25
+; CHECK-NEXT:    vldrw.u32 q1, [r0, #32]
+; CHECK-NEXT:    vmovx.f16 s12, s18
+; CHECK-NEXT:    vmov q7, q4
+; CHECK-NEXT:    vmovx.f16 s8, s6
+; CHECK-NEXT:    vmov q4, q1
+; CHECK-NEXT:    vins.f16 s3, s19
+; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    vldrw.u32 q4, [r0, #16]
+; CHECK-NEXT:    vstrw.32 q1, [sp, #64] @ 16-byte Spill
+; CHECK-NEXT:    vmov.16 q1[0], r2
+; CHECK-NEXT:    vstrw.32 q6, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    vmov.f32 s6, s10
+; CHECK-NEXT:    vmovx.f16 s8, s19
+; CHECK-NEXT:    vmov.f32 s10, s23
+; CHECK-NEXT:    vins.f16 s4, s12
+; CHECK-NEXT:    vins.f16 s10, s8
+; CHECK-NEXT:    vmovx.f16 s8, s26
+; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    vmovx.f16 s5, s22
+; CHECK-NEXT:    vmov.16 q3[0], r0
+; CHECK-NEXT:    vmovx.f16 s8, s31
+; CHECK-NEXT:    vins.f16 s12, s5
+; CHECK-NEXT:    vmov.f32 s14, s10
+; CHECK-NEXT:    vstrw.32 q3, [sp, #80] @ 16-byte Spill
+; CHECK-NEXT:    vmov q3, q6
+; CHECK-NEXT:    vldrw.u32 q6, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vins.f16 s19, s15
+; CHECK-NEXT:    vmovx.f16 s10, s12
+; CHECK-NEXT:    vmov.f32 s26, s30
+; CHECK-NEXT:    vmovx.f16 s7, s27
+; CHECK-NEXT:    vins.f16 s7, s8
+; CHECK-NEXT:    vmovx.f16 s8, s28
+; CHECK-NEXT:    vstrw.32 q1, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vmovx.f16 s6, s21
+; CHECK-NEXT:    vmovx.f16 s5, s13
+; CHECK-NEXT:    vmovx.f16 s4, s17
 ; CHECK-NEXT:    vins.f16 s5, s6
-; CHECK-NEXT:    vmov.f32 s11, s22
-; CHECK-NEXT:    vmovx.f16 s6, s17
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmovx.f16 s4, s21
-; CHECK-NEXT:    vins.f16 s11, s26
-; CHECK-NEXT:    vmov.16 q6[2], r0
-; CHECK-NEXT:    vins.f16 s17, s4
-; CHECK-NEXT:    vmovx.f16 s4, s22
-; CHECK-NEXT:    vldrw.u32 q5, [sp, #48] @ 16-byte Reload
-; CHECK-NEXT:    vins.f16 s18, s4
-; CHECK-NEXT:    vins.f16 s25, s6
-; CHECK-NEXT:    vldr s23, [sp, #68] @ 4-byte Reload
-; CHECK-NEXT:    vldr s6, [sp, #28] @ 4-byte Reload
-; CHECK-NEXT:    vmov.f32 s14, s19
-; CHECK-NEXT:    vmov.f32 s21, s8
+; CHECK-NEXT:    vins.f16 s21, s4
+; CHECK-NEXT:    vstrw.32 q1, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vmovx.f16 s4, s16
+; CHECK-NEXT:    vins.f16 s16, s12
+; CHECK-NEXT:    vins.f16 s17, s13
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vmovx.f16 s6, s20
+; CHECK-NEXT:    vins.f16 s20, s4
+; CHECK-NEXT:    vmovx.f16 s4, s0
+; CHECK-NEXT:    vins.f16 s10, s6
+; CHECK-NEXT:    vmovx.f16 s6, s12
+; CHECK-NEXT:    vmov.f32 s9, s20
+; CHECK-NEXT:    vins.f16 s28, s4
+; CHECK-NEXT:    vins.f16 s6, s8
+; CHECK-NEXT:    vstrw.32 q2, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmov.f64 d12, d14
+; CHECK-NEXT:    vmovx.f16 s4, s23
+; CHECK-NEXT:    vins.f16 s0, s12
+; CHECK-NEXT:    vmov.f32 s5, s28
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    vmovx.f16 s31, s11
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vins.f16 s31, s4
+; CHECK-NEXT:    vmovx.f16 s4, s18
+; CHECK-NEXT:    vins.f16 s22, s4
+; CHECK-NEXT:    vmovx.f16 s4, s1
+; CHECK-NEXT:    vmov.f32 s7, s1
+; CHECK-NEXT:    vmovx.f16 s8, s25
+; CHECK-NEXT:    vins.f16 s25, s4
+; CHECK-NEXT:    vmovx.f16 s4, s2
+; CHECK-NEXT:    vmov.f32 s29, s19
+; CHECK-NEXT:    vmovx.f16 s1, s13
+; CHECK-NEXT:    vins.f16 s26, s4
+; CHECK-NEXT:    vins.f16 s7, s13
+; CHECK-NEXT:    vins.f16 s2, s14
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vmov.f32 s4, s0
+; CHECK-NEXT:    vstrw.32 q7, [sp, #80] @ 16-byte Spill
+; CHECK-NEXT:    vmov.f32 s13, s3
+; CHECK-NEXT:    vins.f16 s1, s8
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmov.f32 s0, s25
+; CHECK-NEXT:    vmov.f32 s3, s26
+; CHECK-NEXT:    vins.f16 s18, s10
+; CHECK-NEXT:    vldrw.u32 q2, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q0, [r1, #16]
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    vmov.f32 s8, s16
+; CHECK-NEXT:    vmov.f32 s11, s17
 ; CHECK-NEXT:    vstrw.32 q3, [r1, #32]
-; CHECK-NEXT:    vmov.f32 s4, s9
-; CHECK-NEXT:    vstrw.32 q5, [r1, #48]
-; CHECK-NEXT:    vmov.f32 s7, s10
+; CHECK-NEXT:    vmov.f32 s17, s29
+; CHECK-NEXT:    vstrw.32 q2, [r1, #48]
+; CHECK-NEXT:    vmov.f32 s16, s21
 ; CHECK-NEXT:    vstrw.32 q0, [r1, #80]
-; CHECK-NEXT:    vmov.f32 s24, s17
-; CHECK-NEXT:    vstrw.32 q1, [r1, #64]
-; CHECK-NEXT:    vmov.f32 s26, s11
-; CHECK-NEXT:    vmov.f32 s27, s18
-; CHECK-NEXT:    vstrw.32 q6, [r1, #16]
-; CHECK-NEXT:    add sp, #72
+; CHECK-NEXT:    vmov.f32 s19, s22
+; CHECK-NEXT:    vstrw.32 q1, [r1]
+; CHECK-NEXT:    vstrw.32 q4, [r1, #64]
+; CHECK-NEXT:    add sp, #96
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
 entry:


### PR DESCRIPTION
Due to some of the lowering we have for buildvector to attempt to use fp lanes efficiently under arm, we can end up with
extract(bitcast(BUILD_VECTOR(extract(bitcast(a)), ..))) that we can convert into simpler extract(a).