### PR TITLE
[MLIR][ODS] Add strict property assembly format mode

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -748,6 +748,10 @@ The available directives are as follows:
         printed as part of the attribute dictionary unless a `prop-dict` is
         present.
     -   Discardable attributes are always part of the `attr-dict`.
+    -   For dialects that set `useStrictPropertiesInAssemblyFormat`,
+        `attr-dict` only carries discardable attributes for property-backed
+        operations. Inherent attributes must be bound directly in the format or
+        covered by `prop-dict`.
 
 *   `attr-dict-with-keyword`
 
@@ -1091,6 +1095,9 @@ to:
     directives.
 1.  Unless all non-attribute properties appear in the format, the `prop-dict`
     directive must be present.
+1.  For dialects that set `useStrictPropertiesInAssemblyFormat`, every inherent
+    attribute and property must either appear in the format or be covered by the
+    `prop-dict` directive.
 1.  The `attr-dict` directive must always be present.
 1.  Must not contain overlapping information; e.g. multiple instances of
     'attr-dict', types, operands, etc.

--- a/mlir/docs/DefiningDialects/_index.md
+++ b/mlir/docs/DefiningDialects/_index.md
@@ -272,6 +272,26 @@ void *MyDialect::getRegisteredInterfaceForOp(TypeID typeID, StringAttr opName);
 For a more detail description of the expected usages of this hook, view the detailed 
 [interface documentation](../Interfaces.md/#dialect-fallback-for-opinterface).
 
+### Strict Property Assembly Formats
+
+Dialects can set `useStrictPropertiesInAssemblyFormat` to require declarative
+assembly formats for property-backed operations to account for all inherent
+attributes and properties:
+
+```tablegen
+def MyDialect : Dialect {
+  let useStrictPropertiesInAssemblyFormat = 1;
+}
+```
+
+This mode is disabled by default for now. When enabled, an operation format must
+either bind every inherent attribute and property directly in the format or
+include the `prop-dict` directive. Generated parsers also reject inherent
+attributes that arrive through `attr-dict`, so `attr-dict` only carries
+discardable attributes for these formats. See the
+[declarative assembly format](Operations.md/#declarative-assembly-format)
+documentation for the corresponding format requirements.
+
 ### Default Attribute/Type Parsers and Printers 
 
 When a dialect registers an Attribute or Type, it must also override the respective

--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -23,6 +23,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def Affine_Dialect : Dialect {
   let name = "affine";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::affine";
   let hasConstantMaterializer = 1;
   let dependentDialects = ["arith::ArithDialect", "ub::UBDialect"];

--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -25,6 +25,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def Affine_Dialect : Dialect {
   let name = "affine";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::affine";
   let hasConstantMaterializer = 1;
   let dependentDialects = ["arith::ArithDialect", "ub::UBDialect"];

--- a/mlir/include/mlir/Dialect/ArmNeon/ArmNeon.td
+++ b/mlir/include/mlir/Dialect/ArmNeon/ArmNeon.td
@@ -23,6 +23,7 @@ include "mlir/IR/OpBase.td"
 
 def ArmNeon_Dialect : Dialect {
   let name = "arm_neon";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::arm_neon";
 
   // Note: this does not need to depend on LLVMDialect as long as functions in

--- a/mlir/include/mlir/Dialect/ArmSME/IR/ArmSME.td
+++ b/mlir/include/mlir/Dialect/ArmSME/IR/ArmSME.td
@@ -23,6 +23,7 @@ include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 
 def ArmSME_Dialect : Dialect {
   let name = "arm_sme";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::arm_sme";
   let summary = "Basic dialect to target Arm SME architectures";
   let description = [{

--- a/mlir/include/mlir/Dialect/ArmSVE/IR/ArmSVE.td
+++ b/mlir/include/mlir/Dialect/ArmSVE/IR/ArmSVE.td
@@ -22,6 +22,7 @@ include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 
 def ArmSVE_Dialect : Dialect {
   let name = "arm_sve";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::arm_sve";
   let summary = "Basic dialect to target Arm SVE architectures";
   let description = [{

--- a/mlir/include/mlir/Dialect/Complex/IR/ComplexBase.td
+++ b/mlir/include/mlir/Dialect/Complex/IR/ComplexBase.td
@@ -14,6 +14,7 @@ include "mlir/IR/OpBase.td"
 
 def Complex_Dialect : Dialect {
   let name = "complex";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::complex";
   let description = [{
     The complex dialect is intended to hold complex numbers creation and

--- a/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
+++ b/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
@@ -76,6 +76,7 @@ def DLTI_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 def HasDefaultDLTIDataLayout : NativeOpTrait<"HasDefaultDLTIDataLayout"> {

--- a/mlir/include/mlir/Dialect/IRDL/IR/IRDL.td
+++ b/mlir/include/mlir/Dialect/IRDL/IR/IRDL.td
@@ -74,6 +74,7 @@ def IRDL_Dialect : Dialect {
 
   let name = "irdl";
   let cppNamespace = "::mlir::irdl";
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 #endif // MLIR_DIALECT_IRDL_IR_IRDL

--- a/mlir/include/mlir/Dialect/Index/IR/IndexDialect.td
+++ b/mlir/include/mlir/Dialect/Index/IR/IndexDialect.td
@@ -83,6 +83,7 @@ def IndexDialect : Dialect {
 
   let hasConstantMaterializer = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 #endif // INDEX_DIALECT

--- a/mlir/include/mlir/Dialect/LLVMIR/VCIXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/VCIXOps.td
@@ -31,6 +31,7 @@ def VCIX_Dialect : Dialect {
   let name = "vcix";
   let cppNamespace = "::mlir::vcix";
   let dependentDialects = ["LLVM::LLVMDialect"];
+  let useStrictPropertiesInAssemblyFormat = 1;
   let description = [{
      The SiFive Vector Coprocessor Interface (VCIX) provides a flexible mechanism
      to extend application processors with custom coprocessors and

--- a/mlir/include/mlir/Dialect/LLVMIR/XeVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/XeVMOps.td
@@ -37,6 +37,7 @@ def XeVM_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 class XeVM_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgBase.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgBase.td
@@ -43,6 +43,7 @@ def Linalg_Dialect : Dialect {
     "tensor::TensorDialect",
   ];
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
   let hasCanonicalizer = 1;
   let hasOperationAttrVerify = 1;
   let hasConstantMaterializer = 1;

--- a/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramBase.td
+++ b/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramBase.td
@@ -13,6 +13,7 @@ include "mlir/IR/OpBase.td"
 
 def MLProgram_Dialect : Dialect {
   let name = "ml_program";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::ml_program";
   let description = [{
     The MLProgram dialect contains structural operations and types for

--- a/mlir/include/mlir/Dialect/MPI/IR/MPI.td
+++ b/mlir/include/mlir/Dialect/MPI/IR/MPI.td
@@ -15,6 +15,7 @@ include "mlir/IR/EnumAttr.td"
 
 def MPI_Dialect : Dialect {
   let name = "mpi";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::mpi";
   let description = [{
     This dialect models the Message Passing Interface (MPI), version 

--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrDialect.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrDialect.td
@@ -20,6 +20,7 @@ include "mlir/IR/OpBase.td"
 
 def Ptr_Dialect : Dialect {
   let name = "ptr";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let summary = "Pointer dialect";
   let description = [{
     The pointer dialect provides types and operations for representing and

--- a/mlir/include/mlir/Dialect/Quant/IR/QuantBase.td
+++ b/mlir/include/mlir/Dialect/Quant/IR/QuantBase.td
@@ -17,6 +17,7 @@ include "mlir/IR/OpBase.td"
 
 def Quant_Dialect : Dialect {
   let name = "quant";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let description = [{
     The `quant` dialect offers a framework for defining and manipulating
     quantized values. Central to this framework is the `!quant.uniform` data

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -27,6 +27,7 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 def SCF_Dialect : Dialect {
   let name = "scf";
   let cppNamespace = "::mlir::scf";
+  let useStrictPropertiesInAssemblyFormat = 1;
 
   let description = [{
     The `scf` (structured control flow) dialect contains operations that

--- a/mlir/include/mlir/Dialect/SMT/IR/SMTDialect.td
+++ b/mlir/include/mlir/Dialect/SMT/IR/SMTDialect.td
@@ -13,6 +13,7 @@ include "mlir/IR/DialectBase.td"
 
 def SMTDialect : Dialect {
   let name = "smt";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let summary = "a dialect that models satisfiability modulo theories";
   let cppNamespace = "mlir::smt";
 

--- a/mlir/include/mlir/Dialect/Shard/IR/ShardBase.td
+++ b/mlir/include/mlir/Dialect/Shard/IR/ShardBase.td
@@ -21,6 +21,7 @@ include "mlir/IR/EnumAttr.td"
 
 def Shard_Dialect : Dialect {
   let name = "shard";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::shard";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorBase.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorBase.td
@@ -13,6 +13,7 @@ include "mlir/IR/OpBase.td"
 
 def Tensor_Dialect : Dialect {
   let name = "tensor";
+  let useStrictPropertiesInAssemblyFormat = 1;
   let cppNamespace = "::mlir::tensor";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/UB/IR/UBOps.td
+++ b/mlir/include/mlir/Dialect/UB/IR/UBOps.td
@@ -20,6 +20,7 @@ def UB_Dialect : Dialect {
 
   let hasConstantMaterializer = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 }
 
 // Base class for UB dialect attributes.

--- a/mlir/include/mlir/IR/DialectBase.td
+++ b/mlir/include/mlir/IR/DialectBase.td
@@ -55,6 +55,12 @@ class Dialect {
   // dialect declaration.
   code extraClassDeclaration = "";
 
+  // If this dialect should require declarative parsers for property-backed
+  // operations to bind every inherent attribute and property directly in the
+  // custom assembly format, or otherwise cover them with `prop-dict`. This
+  // stricter mode is disabled by default for now.
+  bit useStrictPropertiesInAssemblyFormat = 0;
+
   // If this dialect overrides the hook for materializing constants.
   bit hasConstantMaterializer = 0;
 

--- a/mlir/include/mlir/TableGen/Dialect.h
+++ b/mlir/include/mlir/TableGen/Dialect.h
@@ -54,6 +54,10 @@ public:
   // Returns the dialects extra class declaration code.
   std::optional<StringRef> getExtraClassDeclaration() const;
 
+  /// Returns true if this dialect uses strict properties in declarative
+  /// assembly formats.
+  bool useStrictPropertiesInAssemblyFormat() const;
+
   /// Returns true if this dialect has a canonicalizer.
   bool hasCanonicalizer() const;
 

--- a/mlir/lib/TableGen/Dialect.cpp
+++ b/mlir/lib/TableGen/Dialect.cpp
@@ -62,6 +62,10 @@ std::optional<StringRef> Dialect::getExtraClassDeclaration() const {
   return value.empty() ? std::optional<StringRef>() : value;
 }
 
+bool Dialect::useStrictPropertiesInAssemblyFormat() const {
+  return def->getValueAsBit("useStrictPropertiesInAssemblyFormat");
+}
+
 bool Dialect::hasCanonicalizer() const {
   return def->getValueAsBit("hasCanonicalizer");
 }

--- a/mlir/test/mlir-tblgen/op-format-invalid.td
+++ b/mlir/test/mlir-tblgen/op-format-invalid.td
@@ -8,8 +8,16 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 def TestDialect : Dialect {
   let name = "test";
 }
+def TestStrictPropertiesDialect : Dialect {
+  let name = "test_strict_properties";
+  let useStrictPropertiesInAssemblyFormat = 1;
+}
 class TestFormat_Op<string fmt, list<Trait> traits = []>
     : Op<TestDialect, "format_op", traits> {
+  let assemblyFormat = fmt;
+}
+class TestStrictPropertiesFormat_Op<string fmt, list<Trait> traits = []>
+    : Op<TestStrictPropertiesDialect, "format_op", traits> {
   let assemblyFormat = fmt;
 }
 
@@ -36,6 +44,24 @@ def DirectiveAttrDictInvalidC : TestFormat_Op<[{
 def DirectiveAttrDictInvalidD : TestFormat_Op<[{
   type(attr-dict)
 }]>;
+
+// CHECK: error: strict properties in assembly format requires prop-dict
+// CHECK-SAME: unless all inherent attributes and properties are bound in the
+// CHECK-SAME: custom assembly format; missing attribute 'attr'
+def DirectiveAttrDictInvalidE : TestStrictPropertiesFormat_Op<[{
+  attr-dict
+}]> {
+  let arguments = (ins I64Attr:$attr);
+}
+
+// CHECK: error: strict properties in assembly format requires prop-dict
+// CHECK-SAME: unless all inherent attributes and properties are bound in the
+// CHECK-SAME: custom assembly format; missing property 'prop'
+def DirectiveAttrDictInvalidF : TestStrictPropertiesFormat_Op<[{
+  attr-dict
+}]> {
+  let arguments = (ins IntProp<"int64_t">:$prop);
+}
 
 //===----------------------------------------------------------------------===//
 // custom

--- a/mlir/test/mlir-tblgen/op-format.td
+++ b/mlir/test/mlir-tblgen/op-format.td
@@ -5,8 +5,16 @@ include "mlir/IR/OpBase.td"
 def TestDialect : Dialect {
   let name = "test";
 }
+def TestStrictPropertiesDialect : Dialect {
+  let name = "test_strict_properties";
+  let useStrictPropertiesInAssemblyFormat = 1;
+}
 class TestFormat_Op<string fmt, list<Trait> traits = []>
     : Op<TestDialect, "format_op", traits> {
+  let assemblyFormat = fmt;
+}
+class TestStrictPropertiesFormat_Op<string fmt, list<Trait> traits = []>
+    : Op<TestStrictPropertiesDialect, "format_op", traits> {
   let assemblyFormat = fmt;
 }
 
@@ -17,6 +25,50 @@ class TestFormat_Op<string fmt, list<Trait> traits = []>
 //===----------------------------------------------------------------------===//
 // custom
 //===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: AttrDictDefaultInherentAttr::parse
+// CHECK: verifyInherentAttrs
+def AttrDictDefaultInherentAttr : TestFormat_Op<[{
+  $attr attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
+
+// CHECK-LABEL: AttrDictStrictInferredSegmentAttr::parse
+// CHECK: result.getOrAddProperties<AttrDictStrictInferredSegmentAttr::Properties>().segment_sizes = parser.getBuilder().getDenseI32ArrayAttr(inputsOperandGroupSizes);
+// CHECK-LABEL: AttrDictStrictInferredSegmentAttr::print
+// CHECK: elidedAttrs.push_back("segment_sizes");
+def AttrDictStrictInferredSegmentAttr : TestStrictPropertiesFormat_Op<[{
+  custom<Foo>($inputs, type($inputs)) attr-dict
+}]>, Arguments<(ins VariadicOfVariadic<I64, "segment_sizes">:$inputs,
+                    DenseI32ArrayAttr:$segment_sizes)>;
+
+def PropDictStrictInferredSegmentAttr : TestStrictPropertiesFormat_Op<[{
+  custom<Foo>($inputs, type($inputs)) prop-dict attr-dict
+}]>, Arguments<(ins VariadicOfVariadic<I64, "segment_sizes">:$inputs,
+                    DenseI32ArrayAttr:$segment_sizes)>;
+
+// CHECK-LABEL: AttrDictStrictInherentAttr::parse
+// CHECK-NOT: verifyInherentAttrs
+// CHECK: if (result.attributes.get("attr"))
+// CHECK-NEXT: return parser.emitError(loc, "inherent attribute 'attr' cannot
+// CHECK-SAME: be parsed from attr-dict when strict properties in assembly
+// CHECK-SAME: format is enabled");
+// CHECK-NOT: verifyInherentAttrs
+// CHECK: return ::mlir::success();
+def AttrDictStrictInherentAttr : TestStrictPropertiesFormat_Op<[{
+  $attr attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
+
+def AttrDictStrictProperty : TestStrictPropertiesFormat_Op<[{
+  $prop attr-dict
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
+
+def AttrDictStrictPropDict : TestStrictPropertiesFormat_Op<[{
+  prop-dict attr-dict
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
+
+def AttrDictStrictPropDictInherentAttr : TestStrictPropertiesFormat_Op<[{
+  prop-dict attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
 
 // CHECK-LABEL: CustomStringLiteralA::parse
 // CHECK: parseFoo({{.*}}, parser.getBuilder().getI1Type())
@@ -109,6 +161,12 @@ def OptionalGroupC : TestFormat_Op<[{
 def OptionalGroupD : TestFormat_Op<[{
   (custom<Custom>($a, $b)^)? attr-dict
 }], [AttrSizedOperandSegments]>, Arguments<(ins Optional<I64>:$a, Optional<I64>:$b)>;
+
+// CHECK-LABEL: PropDictStrictInferredSegmentAttr::setPropertiesFromParsedAttr
+// CHECK-NOT: segment_sizes
+// CHECK: return ::mlir::success();
+// CHECK-LABEL: PropDictStrictInferredSegmentAttr::print
+// CHECK: elidedProps.push_back("segment_sizes");
 
 // CHECK-LABEL: RegionRef::parse
 // CHECK:   auto odsResult = parseCustom(parser, *bodyRegion);

--- a/mlir/test/mlir-tblgen/op-format.td
+++ b/mlir/test/mlir-tblgen/op-format.td
@@ -5,8 +5,16 @@ include "mlir/IR/OpBase.td"
 def TestDialect : Dialect {
   let name = "test";
 }
+def TestStrictPropertiesDialect : Dialect {
+  let name = "test_strict_properties";
+  let useStrictPropertiesInAssemblyFormat = 1;
+}
 class TestFormat_Op<string fmt, list<Trait> traits = []>
     : Op<TestDialect, "format_op", traits> {
+  let assemblyFormat = fmt;
+}
+class TestStrictPropertiesFormat_Op<string fmt, list<Trait> traits = []>
+    : Op<TestStrictPropertiesDialect, "format_op", traits> {
   let assemblyFormat = fmt;
 }
 
@@ -17,6 +25,50 @@ class TestFormat_Op<string fmt, list<Trait> traits = []>
 //===----------------------------------------------------------------------===//
 // custom
 //===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: AttrDictDefaultInherentAttr::parse
+// CHECK: verifyInherentAttrs
+def AttrDictDefaultInherentAttr : TestFormat_Op<[{
+  $attr attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
+
+// CHECK-LABEL: AttrDictStrictInferredSegmentAttr::parse
+// CHECK: result.getOrAddProperties<AttrDictStrictInferredSegmentAttr::Properties>().segment_sizes = parser.getBuilder().getDenseI32ArrayAttr(inputsOperandGroupSizes);
+// CHECK-LABEL: AttrDictStrictInferredSegmentAttr::print
+// CHECK: elidedAttrs.push_back("segment_sizes");
+def AttrDictStrictInferredSegmentAttr : TestStrictPropertiesFormat_Op<[{
+  custom<Foo>($inputs, type($inputs)) attr-dict
+}]>, Arguments<(ins VariadicOfVariadic<I64, "segment_sizes">:$inputs,
+                    DenseI32ArrayAttr:$segment_sizes)>;
+
+def PropDictStrictInferredSegmentAttr : TestStrictPropertiesFormat_Op<[{
+  custom<Foo>($inputs, type($inputs)) prop-dict attr-dict
+}]>, Arguments<(ins VariadicOfVariadic<I64, "segment_sizes">:$inputs,
+                    DenseI32ArrayAttr:$segment_sizes)>;
+
+// CHECK-LABEL: AttrDictStrictInherentAttr::parse
+// CHECK-NOT: verifyInherentAttrs
+// CHECK: if (result.attributes.get("attr"))
+// CHECK-NEXT: return parser.emitError(loc, "inherent attribute 'attr' cannot
+// CHECK-SAME: be parsed from attr-dict when strict properties in assembly
+// CHECK-SAME: format is enabled");
+// CHECK-NOT: verifyInherentAttrs
+// CHECK: return ::mlir::success();
+def AttrDictStrictInherentAttr : TestStrictPropertiesFormat_Op<[{
+  $attr attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
+
+def AttrDictStrictProperty : TestStrictPropertiesFormat_Op<[{
+  $prop attr-dict
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
+
+def AttrDictStrictPropDict : TestStrictPropertiesFormat_Op<[{
+  prop-dict attr-dict
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
+
+def AttrDictStrictPropDictInherentAttr : TestStrictPropertiesFormat_Op<[{
+  prop-dict attr-dict
+}]>, Arguments<(ins I64Attr:$attr)>;
 
 // CHECK-LABEL: CustomStringLiteralA::parse
 // CHECK: parseFoo({{.*}}, parser.getBuilder().getI1Type())
@@ -139,6 +191,12 @@ def PropDictSegmentSizesRequired : TestFormat_Op<[{
   `(` operands `)` `:` type(operands) prop-dict attr-dict
 }], [AttrSizedOperandSegments]>,
     Arguments<(ins Variadic<I64>:$a1, Variadic<I64>:$a2)>;
+
+// CHECK-LABEL: PropDictStrictInferredSegmentAttr::setPropertiesFromParsedAttr
+// CHECK-NOT: segment_sizes
+// CHECK: return ::mlir::success();
+// CHECK-LABEL: PropDictStrictInferredSegmentAttr::print
+// CHECK: elidedProps.push_back("segment_sizes");
 
 // CHECK-LABEL: RegionRef::parse
 // CHECK:   auto odsResult = parseCustom(parser, *bodyRegion);

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
@@ -345,7 +346,10 @@ struct OperationFormat {
   };
 
   OperationFormat(const Operator &op, bool hasProperties)
-      : useProperties(hasProperties), opCppClassName(op.getCppClassName()) {
+      : useProperties(hasProperties),
+        useStrictPropertiesInAssemblyFormat(
+            op.getDialect().useStrictPropertiesInAssemblyFormat()),
+        opCppClassName(op.getCppClassName()) {
     operandTypes.resize(op.getNumOperands(), TypeResolution());
     resultTypes.resize(op.getNumResults(), TypeResolution());
 
@@ -354,6 +358,11 @@ struct OperationFormat {
     });
 
     hasSingleBlockTrait = op.getTrait("::mlir::OpTrait::SingleBlock");
+
+    for (const NamedAttribute &attr : op.getAttributes()) {
+      if (!attr.attr.isDerivedAttr())
+        inherentAttrNames.push_back(attr.name);
+    }
   }
 
   /// Generate the operation parser from this format.
@@ -403,11 +412,17 @@ struct OperationFormat {
   /// Indicate whether we need to use properties for the current operator.
   bool useProperties;
 
+  /// Indicate whether the dialect uses strict properties in assembly formats.
+  bool useStrictPropertiesInAssemblyFormat;
+
   /// Indicate whether prop-dict is used in the format
-  bool hasPropDict;
+  bool hasPropDict = false;
 
   /// The Operation class name
   StringRef opCppClassName;
+
+  /// The names of inherent attributes for this operation.
+  SmallVector<StringRef> inherentAttrNames;
 
   /// A map of buildable types to indices.
   llvm::MapVector<StringRef, int, StringMap<int>> buildableTypes;
@@ -1339,6 +1354,8 @@ if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, [&]() {{
   for (const NamedProperty &namedProperty : op.getProperties()) {
     if (fmt.usedProperties.contains(&namedProperty))
       continue;
+    if (fmt.inferredAttributes.contains(namedProperty.name))
+      continue;
 
     auto scope = body.scope("{\n", "}\n", /*indent=*/true);
 
@@ -1357,6 +1374,8 @@ if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, [&]() {{
   // Generate the setter for any attribute not parsed elsewhere.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     if (fmt.usedAttributes.contains(&namedAttr))
+      continue;
+    if (fmt.inferredAttributes.contains(namedAttr.name))
       continue;
 
     const Attribute &attr = namedAttr.attr;
@@ -1633,13 +1652,20 @@ void OperationFormat::genElementParser(FormatElement *element, MethodBody &body,
                   << (attrDict->isWithKeyword() ? "WithKeyword" : "")
                   << "(result.attributes))\n"
                   << "  return ::mlir::failure();\n";
-    if (useProperties) {
+    if (useProperties && !useStrictPropertiesInAssemblyFormat) {
       body << "if (failed(verifyInherentAttrs(result.name, result.attributes, "
               "[&]() {\n"
            << "    return parser.emitError(loc) << \"'\" << "
               "result.name.getStringRef() << \"' op \";\n"
            << "  })))\n"
            << "  return ::mlir::failure();\n";
+    } else if (useProperties) {
+      for (StringRef name : inherentAttrNames) {
+        body << "if (result.attributes.get(\"" << name << "\"))\n"
+             << "  return parser.emitError(loc, \"inherent attribute '" << name
+             << "' cannot be parsed from attr-dict when strict properties in "
+                "assembly format is enabled\");\n";
+      }
     }
     body.unindent() << "}\n";
     body.unindent();
@@ -2036,6 +2062,8 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
 
   for (const NamedProperty *namedProperty : fmt.usedProperties)
     body << "  elidedProps.push_back(\"" << namedProperty->name << "\");\n";
+  for (const StringRef key : fmt.inferredAttributes.keys())
+    body << "  elidedProps.push_back(\"" << key << "\");\n";
   for (const NamedAttribute *namedAttr : fmt.usedAttributes)
     body << "  elidedProps.push_back(\"" << namedAttr->name << "\");\n";
 
@@ -2858,6 +2886,32 @@ LogicalResult OpFormatParser::verify(SMLoc loc,
       failed(verifyRegions(loc)) || failed(verifySuccessors(loc)) ||
       failed(verifyOIListElements(loc, elements)))
     return failure();
+
+  if (fmt.useProperties && fmt.useStrictPropertiesInAssemblyFormat &&
+      !hasPropDict) {
+    auto emitMissingError = [&](StringRef kind,
+                                StringRef name) -> LogicalResult {
+      return emitError(loc,
+                       llvm::Twine("strict properties in assembly format "
+                                   "requires prop-dict unless all inherent "
+                                   "attributes and properties are bound in "
+                                   "the custom assembly format; "
+                                   "missing ") +
+                           kind + " '" + name + "'");
+    };
+    for (const NamedAttribute &attr : op.getAttributes()) {
+      if (attr.attr.isDerivedAttr())
+        continue;
+      if (fmt.inferredAttributes.contains(attr.name))
+        continue;
+      if (!seenAttrs.count(&attr))
+        return emitMissingError("attribute", attr.name);
+    }
+    for (const NamedProperty &prop : op.getProperties()) {
+      if (!seenProperties.count(&prop))
+        return emitMissingError("property", prop.name);
+    }
+  }
 
   // Collect the set of used attributes in the format.
   fmt.usedAttributes = std::move(seenAttrs);

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
@@ -349,7 +350,10 @@ struct OperationFormat {
   };
 
   OperationFormat(const Operator &op, bool hasProperties)
-      : useProperties(hasProperties), opCppClassName(op.getCppClassName()) {
+      : useProperties(hasProperties),
+        useStrictPropertiesInAssemblyFormat(
+            op.getDialect().useStrictPropertiesInAssemblyFormat()),
+        opCppClassName(op.getCppClassName()) {
     operandTypes.resize(op.getNumOperands(), TypeResolution());
     resultTypes.resize(op.getNumResults(), TypeResolution());
 
@@ -358,6 +362,11 @@ struct OperationFormat {
     });
 
     hasSingleBlockTrait = op.getTrait("::mlir::OpTrait::SingleBlock");
+
+    for (const NamedAttribute &attr : op.getAttributes()) {
+      if (!attr.attr.isDerivedAttr())
+        inherentAttrNames.push_back(attr.name);
+    }
   }
 
   /// Generate the operation parser from this format.
@@ -407,11 +416,17 @@ struct OperationFormat {
   /// Indicate whether we need to use properties for the current operator.
   bool useProperties;
 
+  /// Indicate whether the dialect uses strict properties in assembly formats.
+  bool useStrictPropertiesInAssemblyFormat;
+
   /// Indicate whether prop-dict is used in the format
-  bool hasPropDict;
+  bool hasPropDict = false;
 
   /// The Operation class name
   StringRef opCppClassName;
+
+  /// The names of inherent attributes for this operation.
+  SmallVector<StringRef> inherentAttrNames;
 
   /// A map of buildable types to indices.
   llvm::MapVector<StringRef, int, StringMap<int>> buildableTypes;
@@ -1383,6 +1398,8 @@ if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, [&]() {{
   for (const NamedProperty &namedProperty : op.getProperties()) {
     if (fmt.usedProperties.contains(&namedProperty))
       continue;
+    if (fmt.inferredAttributes.contains(namedProperty.name))
+      continue;
 
     auto scope = body.scope("{\n", "}\n", /*indent=*/true);
 
@@ -1401,6 +1418,8 @@ if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, [&]() {{
   // Generate the setter for any attribute not parsed elsewhere.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     if (fmt.usedAttributes.contains(&namedAttr))
+      continue;
+    if (fmt.inferredAttributes.contains(namedAttr.name))
       continue;
 
     const Attribute &attr = namedAttr.attr;
@@ -1677,13 +1696,20 @@ void OperationFormat::genElementParser(FormatElement *element, MethodBody &body,
                   << (attrDict->isWithKeyword() ? "WithKeyword" : "")
                   << "(result.attributes))\n"
                   << "  return ::mlir::failure();\n";
-    if (useProperties) {
+    if (useProperties && !useStrictPropertiesInAssemblyFormat) {
       body << "if (failed(verifyInherentAttrs(result.name, result.attributes, "
               "[&]() {\n"
            << "    return parser.emitError(loc) << \"'\" << "
               "result.name.getStringRef() << \"' op \";\n"
            << "  })))\n"
            << "  return ::mlir::failure();\n";
+    } else if (useProperties) {
+      for (StringRef name : inherentAttrNames) {
+        body << "if (result.attributes.get(\"" << name << "\"))\n"
+             << "  return parser.emitError(loc, \"inherent attribute '" << name
+             << "' cannot be parsed from attr-dict when strict properties in "
+                "assembly format is enabled\");\n";
+      }
     }
     body.unindent() << "}\n";
     body.unindent();
@@ -2083,6 +2109,8 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
 
   for (const NamedProperty *namedProperty : fmt.usedProperties)
     body << "  elidedProps.push_back(\"" << namedProperty->name << "\");\n";
+  for (StringRef key : fmt.inferredAttributes.keys())
+    body << "  elidedProps.push_back(\"" << key << "\");\n";
   for (const NamedAttribute *namedAttr : fmt.usedAttributes)
     body << "  elidedProps.push_back(\"" << namedAttr->name << "\");\n";
 
@@ -2133,7 +2161,7 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
 
   genVariadicSegmentElision(fmt, op, body, "elidedAttrs");
 
-  for (const StringRef key : fmt.inferredAttributes.keys())
+  for (StringRef key : fmt.inferredAttributes.keys())
     body << "  elidedAttrs.push_back(\"" << key << "\");\n";
   for (const NamedAttribute *attr : fmt.usedAttributes)
     body << "  elidedAttrs.push_back(\"" << attr->name << "\");\n";
@@ -2905,6 +2933,32 @@ LogicalResult OpFormatParser::verify(SMLoc loc,
       failed(verifyRegions(loc)) || failed(verifySuccessors(loc)) ||
       failed(verifyOIListElements(loc, elements)))
     return failure();
+
+  if (fmt.useProperties && fmt.useStrictPropertiesInAssemblyFormat &&
+      !hasPropDict) {
+    auto emitMissingError = [&](StringRef kind,
+                                StringRef name) -> LogicalResult {
+      return emitError(loc,
+                       llvm::Twine("strict properties in assembly format "
+                                   "requires prop-dict unless all inherent "
+                                   "attributes and properties are bound in "
+                                   "the custom assembly format; "
+                                   "missing ") +
+                           kind + " '" + name + "'");
+    };
+    for (const NamedAttribute &attr : op.getAttributes()) {
+      if (attr.attr.isDerivedAttr())
+        continue;
+      if (fmt.inferredAttributes.contains(attr.name))
+        continue;
+      if (!seenAttrs.count(&attr))
+        return emitMissingError("attribute", attr.name);
+    }
+    for (const NamedProperty &prop : op.getProperties()) {
+      if (!seenProperties.count(&prop))
+        return emitMissingError("property", prop.name);
+    }
+  }
 
   // Collect the set of used attributes in the format.
   fmt.usedAttributes = std::move(seenAttrs);


### PR DESCRIPTION
Introduce a dialect-level ODS flag for strict property handling in declarative assembly formats. It is disabled by default for now, preserving existing parser behavior unless a dialect opts in.

Enable the mode immediately for dialects whose declarative assembly formats already satisfy these binding rules.

When enabled, a property-backed op format must bind every inherent attribute and property directly or include prop-dict.

Generated parsers for opted-in dialects also reject inherent attributes that arrive through attr-dict, preventing Operation::setAttrs from populating properties through that path.

Add mlir-tblgen coverage and document default and strict dialect behavior.

Assisted-by: Codex