### PR TITLE
[offload] add SKIP_KNOWN_FAILURE unittest macro

### DIFF
--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -9,6 +9,8 @@
 #include <OffloadAPI.h>
 #include <OffloadPrint.hpp>
 #include <gtest/gtest.h>
+#include <optional>
+#include <string>
 #include <thread>
 
 #include "Environment.hpp"
@@ -60,6 +62,53 @@
     ASSERT_TRUE(Res);                                                          \
   } while (0)
 #endif
+
+struct BackendMatcher {
+  ol_platform_backend_t Backend;
+  std::string Message;
+
+  BackendMatcher(ol_platform_backend_t B, std::string M = {})
+      : Backend(B), Message(std::move(M)) {}
+};
+
+struct LevelZero : BackendMatcher {
+  LevelZero(std::string M = {})
+      : BackendMatcher(OL_PLATFORM_BACKEND_LEVEL_ZERO, std::move(M)) {}
+};
+
+struct CUDA : BackendMatcher {
+  CUDA(std::string M = {})
+      : BackendMatcher(OL_PLATFORM_BACKEND_CUDA, std::move(M)) {}
+};
+
+struct AMDGPU : BackendMatcher {
+  AMDGPU(std::string M = {})
+      : BackendMatcher(OL_PLATFORM_BACKEND_AMDGPU, std::move(M)) {}
+};
+
+inline std::string knownFailureMessage(const BackendMatcher &M) {
+  std::string Msg;
+  llvm::raw_string_ostream OS(Msg);
+  OS << "Known failure on " << M.Backend;
+  if (!M.Message.empty())
+    OS << ": " << M.Message;
+  return Msg;
+}
+
+inline std::optional<std::string>
+findKnownFailure(ol_platform_backend_t CurBackend,
+                 std::initializer_list<BackendMatcher> Matchers) {
+  for (const auto &M : Matchers) {
+    if (M.Backend == CurBackend)
+      return knownFailureMessage(M);
+  }
+  return std::nullopt;
+}
+
+#define SKIP_KNOWN_FAILURE(...)                                                \
+  if (auto KFMsg =                                                             \
+          ::findKnownFailure(this->getPlatformBackend(), {__VA_ARGS__}))       \
+  GTEST_SKIP() << *KFMsg
 
 #define RETURN_ON_FATAL_FAILURE(...)                                           \
   __VA_ARGS__;                                                                 \

--- a/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
+++ b/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
@@ -16,6 +16,7 @@ namespace {
 struct olGetEventElapsedTimeTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
+    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
 
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
     ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),

--- a/offload/unittests/OffloadAPI/kernel/olCalculateOptimalOccupancy.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olCalculateOptimalOccupancy.cpp
@@ -10,7 +10,12 @@
 #include <OffloadAPI.h>
 #include <gtest/gtest.h>
 
-using olCalculateOptimalOccupancyTest = OffloadKernelTest;
+struct olCalculateOptimalOccupancyTest : OffloadKernelTest {
+  void SetUp() override {
+    RETURN_ON_FATAL_FAILURE(OffloadKernelTest::SetUp());
+    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+  }
+};
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olCalculateOptimalOccupancyTest);
 
 TEST_P(olCalculateOptimalOccupancyTest, Success) {

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -107,6 +107,8 @@ TEST_P(olLaunchKernelFooTest, Success) {
 }
 
 TEST_P(olLaunchKernelFooTest, SuccessThreaded) {
+  SKIP_KNOWN_FAILURE(LevelZero{"thread-safety issues"});
+
   threadify([&](size_t) {
     void *Mem;
     ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
@@ -170,6 +172,8 @@ TEST_P(olLaunchKernelFooTest, SuccessSynchronous) {
 }
 
 TEST_P(olLaunchKernelLocalMemTest, Success) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported DynSharedMemory"});
+
   LaunchArgs.NumGroups.x = 4;
   LaunchArgs.DynSharedMemory = 64 * sizeof(uint32_t);
 
@@ -195,6 +199,8 @@ TEST_P(olLaunchKernelLocalMemTest, Success) {
 }
 
 TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported DynSharedMemory"});
+
   LaunchArgs.NumGroups.x = 4;
   LaunchArgs.DynSharedMemory = 64 * sizeof(uint32_t);
 
@@ -218,6 +224,8 @@ TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
 }
 
 TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported DynSharedMemory"});
+
   LaunchArgs.NumGroups.x = 4;
   LaunchArgs.DynSharedMemory = 0;
 
@@ -272,6 +280,8 @@ TEST_P(olLaunchKernelGlobalTest, InvalidNotAKernel) {
 }
 
 TEST_P(olLaunchKernelGlobalCtorTest, Success) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+
   void *Mem;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
                             LaunchArgs.GroupSize.x * sizeof(uint32_t), &Mem));

--- a/offload/unittests/OffloadAPI/memory/olMemFill.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFill.cpp
@@ -11,6 +11,11 @@
 #include <gtest/gtest.h>
 
 struct olMemFillTest : OffloadQueueTest {
+  void SetUp() override {
+    RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
+    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+  }
+
   template <typename PatternTy, PatternTy PatternVal, size_t Size,
             bool Block = false>
   void test_body() {

--- a/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
@@ -19,6 +19,8 @@ TEST_P(olDestroyQueueTest, Success) {
 }
 
 TEST_P(olDestroyQueueTest, SuccessDelayedResolution) {
+  SKIP_KNOWN_FAILURE(LevelZero{"implicit synchronization issues"});
+
   ManuallyTriggeredTask Manual;
   ASSERT_SUCCESS(Manual.enqueue(Queue));
   ASSERT_SUCCESS(olDestroyQueue(Queue));

--- a/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
+++ b/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
@@ -11,10 +11,20 @@
 #include <gtest/gtest.h>
 #include <thread>
 
-struct olLaunchHostFunctionTest : OffloadQueueTest {};
+struct olLaunchHostFunctionTest : OffloadQueueTest {
+  void SetUp() override {
+    RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
+    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+  }
+};
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olLaunchHostFunctionTest);
 
-struct olLaunchHostFunctionKernelTest : OffloadKernelTest {};
+struct olLaunchHostFunctionKernelTest : OffloadKernelTest {
+  void SetUp() override {
+    RETURN_ON_FATAL_FAILURE(OffloadKernelTest::SetUp());
+    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+  }
+};
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olLaunchHostFunctionKernelTest);
 
 TEST_P(olLaunchHostFunctionTest, Success) {

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
@@ -52,6 +52,8 @@ TEST_P(olGetSymbolInfoKernelTest, InvalidSize) {
 }
 
 TEST_P(olGetSymbolInfoGlobalTest, SuccessSize) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+
   size_t RetrievedSize = 0;
   ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
                                  sizeof(RetrievedSize), &RetrievedSize));


### PR DESCRIPTION
... and disable failing level-zero tests, to be reenabled once the plugin is fully functional.

Here is the passrate for the level-zero plugin unit tests:
```
Total Discovered Tests: 645
  Skipped:  74 (11.47%)
  Passed : 571 (88.53%)
```

We are actively working on fixing the issues marked as known failures here.