### PR TITLE
[NFC][MLIR][NVVM] Remove duplicate RUN line in nvvm-transcendentals.mlir

### DIFF
--- a/mlir/test/Dialect/LLVMIR/nvvm-transcendentals.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-transcendentals.mlir
@@ -13,7 +13,6 @@ func.func @nvvm_cos_ftz_f32(%arg0: f32) -> f32 {
   %0 = nvvm.cos %arg0 {ftz = true} : f32
   return %0 : f32
 }
-// RUN: mlir-opt %s -split-input-file | FileCheck %s
 
 // CHECK-LABEL: @nvvm_sin_f32
 func.func @nvvm_sin_f32(%arg0: f32) -> f32 {


### PR DESCRIPTION
The test `mlir/test/Dialect/LLVMIR/nvvm-transcendentals.mlir` contains
two identical RUN directives:

    // RUN: mlir-opt %s -split-input-file | FileCheck %s

The file has no `// -----` split markers, so the second RUN only
re-executes the same checks against the same input.
Removing the redundant directive. NFC.