### PR TITLE
[libc] Add byteswap.h header with bswap_16/bswap_32/bswap_64

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -42,6 +42,7 @@ if (SPHINX_FOUND)
       aio
       arpa/inet
       assert
+      byteswap
       cpio
       ctype
       dirent

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -7,6 +7,7 @@ Implementation Status
    aio
    arpa/inet
    assert
+   byteswap
    complex
    cpio
    ctype

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -230,6 +230,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  byteswap
+  ../libc/include/byteswap.yaml
+  byteswap.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.byteswap_macros
+)
+
+add_header_macro(
   complex
   ../libc/include/complex.yaml
   complex.h

--- a/libc/include/byteswap.yaml
+++ b/libc/include/byteswap.yaml
@@ -1,0 +1,14 @@
+header: byteswap.h
+standards:
+  - linux
+macros:
+  - macro_name: bswap_16
+    macro_header: byteswap-macros.h
+  - macro_name: bswap_32
+    macro_header: byteswap-macros.h
+  - macro_name: bswap_64
+    macro_header: byteswap-macros.h
+types: []
+enums: []
+objects: []
+functions: []

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -49,6 +49,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  byteswap_macros
+  HDR
+    byteswap-macros.h
+)
+
+add_macro_header(
   error_number_macros
   HDR
     error-number-macros.h

--- a/libc/include/llvm-libc-macros/byteswap-macros.h
+++ b/libc/include/llvm-libc-macros/byteswap-macros.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from byteswap.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_BYTESWAP_MACROS_H
+#define LLVM_LIBC_MACROS_BYTESWAP_MACROS_H
+
+#define bswap_16(x) __builtin_bswap16((x))
+#define bswap_32(x) __builtin_bswap32((x))
+#define bswap_64(x) __builtin_bswap64((x))
+
+#endif // LLVM_LIBC_MACROS_BYTESWAP_MACROS_H

--- a/libc/utils/docgen/byteswap.yaml
+++ b/libc/utils/docgen/byteswap.yaml
@@ -1,0 +1,8 @@
+macros:
+  bswap_16:
+    c-definition: ''
+  bswap_32:
+    c-definition: ''
+  bswap_64:
+    c-definition: ''
+


### PR DESCRIPTION
Added the Linux byteswap.h header providing bswap_16, bswap_32, and bswap_64 as macros expanding to __builtin_bswap{16,32,64}. These are always inlined by the compiler to single instructions.

Follows the existing endian.h / endian-macros.h pattern.

Assisted-by: Automated tooling, human reviewed.