### PR TITLE
[MLIR][ControlFlow] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.td
@@ -23,6 +23,7 @@ def ControlFlow_Dialect : Dialect {
   let name = "cf";
   let cppNamespace = "::mlir::cf";
   let dependentDialects = ["arith::ArithDialect"];
+  let useStrictPropertiesInAssemblyFormat = 1;
   let description = [{
     This dialect contains low-level, i.e. non-region based, control flow
     constructs. These constructs generally represent control flow directly

--- a/mlir/test/Conversion/ControlFlowToLLVM/branch.mlir
+++ b/mlir/test/Conversion/ControlFlowToLLVM/branch.mlir
@@ -75,7 +75,7 @@ func.func @unreachable_block() {
 // CHECK-LABEL:   func.func @cf_cond_br_with_weights(
 func.func @cf_cond_br_with_weights(%cond: i1, %a: index, %b: index) -> index {
 // CHECK:           llvm.cond_br %{{.*}} weights([90, 10]), ^bb1(%{{.*}} : i64), ^bb2(%{{.*}} : i64)
-  cf.cond_br %cond, ^bb1(%a : index), ^bb2(%b : index) {branch_weights = array<i32: 90, 10>}
+  cf.cond_br %cond weights([90, 10]), ^bb1(%a : index), ^bb2(%b : index)
 ^bb1(%arg1: index):
   return %arg1 : index
 ^bb2(%arg2: index):


### PR DESCRIPTION
Enable the strict properties assembly format mode for the ControlFlow dialect. The dialect formats already cover their inherent attributes, except for a test that still used attr-dict spelling for branch weights.

Update that test to use the existing weights(...) syntax so the inherent attribute is parsed through the declarative format.

Assisted-by: Codex