### PR TITLE
[MLIR][SPIRV] Enable strict property assembly format

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
@@ -52,6 +52,7 @@ def SPIRV_Dialect : Dialect {
   let hasOperationAttrVerify = 1;
   let hasRegionArgAttrVerify = 1;
   let hasRegionResultAttrVerify = 1;
+  let useStrictPropertiesInAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     void registerAttributes();

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -237,7 +237,10 @@ def SPIRV_FunctionCallOp : SPIRV_Op<"FunctionCall", [
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    $callee `(` $arguments `)` prop-dict attr-dict `:`
+    $callee `(` $arguments `)`
+      (`arg_attrs` `=` $arg_attrs^)?
+      (`res_attrs` `=` $res_attrs^)?
+      attr-dict `:`
       functional-type($arguments, results)
   }];
 }

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -237,7 +237,7 @@ def SPIRV_FunctionCallOp : SPIRV_Op<"FunctionCall", [
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    $callee `(` $arguments `)` attr-dict `:`
+    $callee `(` $arguments `)` prop-dict attr-dict `:`
       functional-type($arguments, results)
   }];
 }

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -237,7 +237,10 @@ def SPIRV_FunctionCallOp : SPIRV_Op<"FunctionCall", [
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    $callee `(` $arguments `)` attr-dict `:`
+    $callee `(` $arguments `)`
+      (`arg_attrs` `=` $arg_attrs^)?
+      (`res_attrs` `=` $res_attrs^)?
+      attr-dict `:`
       functional-type($arguments, results)
   }];
 }

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
@@ -151,7 +151,7 @@ def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, 
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    attr-dict `:` type($output)
+    prop-dict attr-dict `:` type($output)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
@@ -127,7 +127,7 @@ def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, 
     #### Example:
 
     ```mlir
-    %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+    %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
     ```
 
     GraphConstantID is a unique identifier which is use to map the contants
@@ -151,7 +151,7 @@ def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, 
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    attr-dict `:` type($output)
+    `id` `=` $graph_constant_id attr-dict `:` type($output)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
@@ -127,7 +127,7 @@ def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, 
     #### Example:
 
     ```mlir
-    %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+    %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
     ```
 
     GraphConstantID is a unique identifier which is use to map the contants
@@ -151,7 +151,7 @@ def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, 
   let autogenSerialization = 0;
 
   let assemblyFormat = [{
-    prop-dict attr-dict `:` type($output)
+    `id` `=` $graph_constant_id attr-dict `:` type($output)
   }];
 }
 

--- a/mlir/test/Conversion/TosaToSPIRVTosa/tosa-to-spirv.mlir
+++ b/mlir/test/Conversion/TosaToSPIRVTosa/tosa-to-spirv.mlir
@@ -965,7 +965,7 @@ func.func @const_int() -> tensor<2x3xi8> {
 
 // CHECK-LABEL: spirv.ARM.Graph @graph_constant
 func.func @graph_constant() -> tensor<17xi32> {
-  // CHECK: %[[CONST:.*]] = spirv.ARM.GraphConstant {graph_constant_id = 7 : i32} : !spirv.arm.tensor<17xi32>
+  // CHECK: %[[CONST:.*]] = spirv.ARM.GraphConstant id = 7 : !spirv.arm.tensor<17xi32>
   %res = "tosa.const"() <{values = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]> : tensor<17xi32>}> {grapharm.graph_constant_id = 7 : i32} : () -> tensor<17xi32>
   return %res : tensor<17xi32>
 }
@@ -1001,7 +1001,7 @@ func.func @const_shape_empty() -> !tosa.shape<0> {
 
 // CHECK-LABEL: spirv.ARM.Graph @graph_constant_shape
 func.func @graph_constant_shape() -> !tosa.shape<33> {
-  // CHECK: %[[SHAPE:.*]] = spirv.ARM.GraphConstant {graph_constant_id = 8 : i32} : !spirv.arm.tensor<33xi32>
+  // CHECK: %[[SHAPE:.*]] = spirv.ARM.GraphConstant id = 8 : !spirv.arm.tensor<33xi32>
   %res = "tosa.const_shape"() <{values = dense<[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]> : tensor<33xindex>}> {grapharm.graph_constant_id = 8 : i32} : () -> !tosa.shape<33>
   return %res : !tosa.shape<33>
 }

--- a/mlir/test/Dialect/SPIRV/IR/control-flow-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/control-flow-ops.mlir
@@ -165,7 +165,12 @@ spirv.module Logical GLSL450 {
     spirv.FunctionCall @f_2() : () -> ()
     // CHECK: {{%.*}} = spirv.FunctionCall @f_3({{%.*}}) : (i32) -> i32
     %1 = spirv.FunctionCall @f_3(%arg2) : (i32) -> i32
-    spirv.ReturnValue %1 : i32
+    // CHECK: {{%.*}} = spirv.FunctionCall @f_3({{%.*}}) arg_attrs = [{{.*}}] res_attrs = [{{.*}}] : (i32) -> i32
+    %2 = spirv.FunctionCall @f_3(%arg2)
+        arg_attrs = [{spirv.decoration = #spirv.decoration<RelaxedPrecision>}]
+        res_attrs = [{spirv.decoration = #spirv.decoration<RelaxedPrecision>}]
+        : (i32) -> i32
+    spirv.ReturnValue %2 : i32
   }
 
   spirv.func @f_0(%arg0 : vector<4xf32>, %arg1 : vector<4xf32>) -> (vector<4xf32>) "None" {

--- a/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
@@ -18,8 +18,8 @@ spirv.ARM.Graph @graphAndOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> !spirv.
 
 // CHECK: spirv.ARM.Graph {{@.*}}() -> !spirv.arm.tensor<2x3xi16> {
 spirv.ARM.Graph @graphConstant() -> !spirv.arm.tensor<2x3xi16> {
-  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant {graph_constant_id = 42 : i32} : !spirv.arm.tensor<2x3xi16>
-  %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
+  %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
   // CHECK: spirv.ARM.GraphOutputs [[CONST:%.*]] : !spirv.arm.tensor<2x3xi16>
   spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
 }
@@ -63,7 +63,7 @@ spirv.ARM.Graph @graphNoOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> () {
 //===----------------------------------------------------------------------===//
 
 // expected-error @+1 {{'spirv.ARM.GraphConstant' op failed to verify that op must appear in a spirv.ARM.Graph op's block}}
-%0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+%0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
 // -----
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
@@ -18,8 +18,8 @@ spirv.ARM.Graph @graphAndOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> !spirv.
 
 // CHECK: spirv.ARM.Graph {{@.*}}() -> !spirv.arm.tensor<2x3xi16> {
 spirv.ARM.Graph @graphConstant() -> !spirv.arm.tensor<2x3xi16> {
-  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
+  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
+  %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
   // CHECK: spirv.ARM.GraphOutputs [[CONST:%.*]] : !spirv.arm.tensor<2x3xi16>
   spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
 }
@@ -63,7 +63,7 @@ spirv.ARM.Graph @graphNoOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> () {
 //===----------------------------------------------------------------------===//
 
 // expected-error @+1 {{'spirv.ARM.GraphConstant' op failed to verify that op must appear in a spirv.ARM.Graph op's block}}
-%0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
+%0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
 // -----
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/graph-ops.mlir
@@ -18,8 +18,8 @@ spirv.ARM.Graph @graphAndOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> !spirv.
 
 // CHECK: spirv.ARM.Graph {{@.*}}() -> !spirv.arm.tensor<2x3xi16> {
 spirv.ARM.Graph @graphConstant() -> !spirv.arm.tensor<2x3xi16> {
-  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant {graph_constant_id = 42 : i32} : !spirv.arm.tensor<2x3xi16>
-  %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+  // CHECK: [[CONST:%.*]] = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
   // CHECK: spirv.ARM.GraphOutputs [[CONST:%.*]] : !spirv.arm.tensor<2x3xi16>
   spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
 }
@@ -63,7 +63,7 @@ spirv.ARM.Graph @graphNoOutputs(%arg0: !spirv.arm.tensor<14x19xi16>) -> () {
 //===----------------------------------------------------------------------===//
 
 // expected-error @+1 {{'spirv.ARM.GraphConstant' op failed to verify that op must appear in a spirv.ARM.Graph op's block}}
-%0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+%0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
 // -----
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
@@ -1604,42 +1604,42 @@ spirv.ARM.Graph @sub_output_shape_does_not_match_broadcast_shape(%arg0: !spirv.a
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_input_and_table_must_have_same_element_type(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that all of {input1, table} have same element type}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_output_shapes_must_match(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x6xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that all of {input1, output} have same shape}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x6xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x6xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_a_table_of_size_256(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<513xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<513xi8>
   // expected-error @+1 {{op failed to verify that table must have size 256 if input1 has element type 8-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<513xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_a_table_of_size_513(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that table must have size 513 if input1 has element type 16-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_an_output_with_element_type_i8(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that if input1 has type 8-bit signless integer then output must have a type in [8-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_an_output_with_element_type_i32(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<513xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<513xi16>
   // expected-error @+1 {{op failed to verify that if input1 has type 16-bit signless integer then output must have a type in [32-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<513xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
@@ -1604,42 +1604,42 @@ spirv.ARM.Graph @sub_output_shape_does_not_match_broadcast_shape(%arg0: !spirv.a
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_input_and_table_must_have_same_element_type(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that all of {input1, table} have same element type}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_output_shapes_must_match(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x6xi8>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that all of {input1, output} have same shape}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x6xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x6xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_a_table_of_size_256(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<513xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<513xi8>
   // expected-error @+1 {{op failed to verify that table must have size 256 if input1 has element type 8-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<513xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_a_table_of_size_513(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that table must have size 513 if input1 has element type 16-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_an_output_with_element_type_i8(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that if input1 has type 8-bit signless integer then output must have a type in [8-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_an_output_with_element_type_i32(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<513xi16>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<513xi16>
   // expected-error @+1 {{op failed to verify that if input1 has type 16-bit signless integer then output must have a type in [32-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<513xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops-verification.mlir
@@ -1604,42 +1604,42 @@ spirv.ARM.Graph @sub_output_shape_does_not_match_broadcast_shape(%arg0: !spirv.a
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_input_and_table_must_have_same_element_type(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that all of {input1, table} have same element type}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_output_shapes_must_match(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x6xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that all of {input1, output} have same shape}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x6xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x6xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_a_table_of_size_256(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<513xi8>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<513xi8>
   // expected-error @+1 {{op failed to verify that table must have size 256 if input1 has element type 8-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<513xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_a_table_of_size_513(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi16>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi16>
   // expected-error @+1 {{op failed to verify that table must have size 513 if input1 has element type 16-bit signless integer}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<256xi16> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i8_requires_an_output_with_element_type_i8(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi32>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
   // expected-error @+1 {{op failed to verify that if input1 has type 8-bit signless integer then output must have a type in [8-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi32>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi32>
 }
 
 spirv.ARM.Graph @table_input_with_element_type_i16_requires_an_output_with_element_type_i32(%arg0: !spirv.arm.tensor<3x2x15x7xi16>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<513xi16>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<513xi16>
   // expected-error @+1 {{op failed to verify that if input1 has type 16-bit signless integer then output must have a type in [32-bit signless integer]}}
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi16>, !spirv.arm.tensor<513xi16> -> !spirv.arm.tensor<3x2x15x7xi8>
   spirv.ARM.GraphOutputs %1 : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
@@ -523,7 +523,7 @@ spirv.ARM.Graph @sub_fp(%arg0: !spirv.arm.tensor<1x10x13x12xf16>, %arg1: !spirv.
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
@@ -523,7 +523,7 @@ spirv.ARM.Graph @sub_fp(%arg0: !spirv.arm.tensor<1x10x13x12xf16>, %arg1: !spirv.
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
   // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/tosa-ops.mlir
@@ -523,7 +523,7 @@ spirv.ARM.Graph @sub_fp(%arg0: !spirv.arm.tensor<1x10x13x12xf16>, %arg1: !spirv.
 //===----------------------------------------------------------------------===//
 
 spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-  %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
+  %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
   // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
   // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Target/SPIRV/graph-debug-info.mlir
+++ b/mlir/test/Target/SPIRV/graph-debug-info.mlir
@@ -69,14 +69,14 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.6, [VulkanMemoryModel, Shader
   spirv.GlobalVariable @test_res_0 bind(0, 1) : !spirv.ptr<!spirv.arm.tensor<2x9x3x32xi8>, UniformConstant>
   spirv.ARM.GraphEntryPoint @test, @test_arg_0, @test_res_0
   spirv.ARM.Graph @test(%arg0: !spirv.arm.tensor<2x9x3x32xi16> loc("tensor_0")) -> (!spirv.arm.tensor<2x9x3x32xi8>) attributes {entry_point = true} {
-    %weight = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<32x1x1x32xi8>
-    %bias = spirv.ARM.GraphConstant {graph_constant_id = 1 : i32} : !spirv.arm.tensor<32xi64>
+    %weight = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<32x1x1x32xi8>
+    %bias = spirv.ARM.GraphConstant id = 1 : !spirv.arm.tensor<32xi64>
     %0 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi16>
     %1 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi8>
     // CHECK: %[[CONV2D:.*]] = spirv.Tosa.Conv2D{{.*}}loc(#loc[[SAME_OP:.*]])
     %conv2d = spirv.Tosa.Conv2D pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1], acc_type = <INT48>, local_bound = false, %arg0, %weight, %bias, %0, %1  : !spirv.arm.tensor<2x9x3x32xi16>, !spirv.arm.tensor<32x1x1x32xi8>, !spirv.arm.tensor<32xi64>, !spirv.arm.tensor<1xi16>, !spirv.arm.tensor<1xi8> -> !spirv.arm.tensor<2x9x3x32xi64> loc("op_0")
-    %multiplier = spirv.ARM.GraphConstant {graph_constant_id = 2 : i32} : !spirv.arm.tensor<1xi16>
-    %shift = spirv.ARM.GraphConstant {graph_constant_id = 3 : i32} : !spirv.arm.tensor<1xi8>
+    %multiplier = spirv.ARM.GraphConstant id = 2 : !spirv.arm.tensor<1xi16>
+    %shift = spirv.ARM.GraphConstant id = 3 : !spirv.arm.tensor<1xi8>
     %5 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi64>
     %6 = spirv.Constant dense<-4> : !spirv.arm.tensor<1xi8>
     // CHECK: {{%.*}} = spirv.Tosa.Rescale{{.*}}loc(#loc[[SAME_OP]])
@@ -99,14 +99,14 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.6, [VulkanMemoryModel, Shader
   spirv.GlobalVariable @test_res_0 bind(0, 1) : !spirv.ptr<!spirv.arm.tensor<2x9x3x32xi8>, UniformConstant>
   spirv.ARM.GraphEntryPoint @test, @test_arg_0, @test_res_0
   spirv.ARM.Graph @test(%arg0: !spirv.arm.tensor<2x9x3x32xi16> loc("tensor_0")) -> (!spirv.arm.tensor<2x9x3x32xi8>) attributes {entry_point = true} {
-    %weight = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<32x1x1x32xi8>
-    %bias = spirv.ARM.GraphConstant {graph_constant_id = 1 : i32} : !spirv.arm.tensor<32xi64>
+    %weight = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<32x1x1x32xi8>
+    %bias = spirv.ARM.GraphConstant id = 1 : !spirv.arm.tensor<32xi64>
     %0 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi16>
     %1 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi8>
     // CHECK: %[[CONV2D:.*]] = spirv.Tosa.Conv2D{{.*}}loc(#loc[[MULTI_OP0:.*]])
     %conv2d = spirv.Tosa.Conv2D pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1], acc_type = <INT48>, local_bound = false, %arg0, %weight, %bias, %0, %1  : !spirv.arm.tensor<2x9x3x32xi16>, !spirv.arm.tensor<32x1x1x32xi8>, !spirv.arm.tensor<32xi64>, !spirv.arm.tensor<1xi16>, !spirv.arm.tensor<1xi8> -> !spirv.arm.tensor<2x9x3x32xi64> loc("op_0")
-    %multiplier = spirv.ARM.GraphConstant {graph_constant_id = 2 : i32} : !spirv.arm.tensor<1xi16>
-    %shift = spirv.ARM.GraphConstant {graph_constant_id = 3 : i32} : !spirv.arm.tensor<1xi8>
+    %multiplier = spirv.ARM.GraphConstant id = 2 : !spirv.arm.tensor<1xi16>
+    %shift = spirv.ARM.GraphConstant id = 3 : !spirv.arm.tensor<1xi8>
     %5 = spirv.Constant dense<0> : !spirv.arm.tensor<1xi64>
     %6 = spirv.Constant dense<-4> : !spirv.arm.tensor<1xi8>
     // CHECK: {{%.*}} = spirv.Tosa.Rescale{{.*}}loc(#loc[[MULTI_OP1:.*]])

--- a/mlir/test/Target/SPIRV/graph-ops.mlir
+++ b/mlir/test/Target/SPIRV/graph-ops.mlir
@@ -11,8 +11,8 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.ARM.GraphEntryPoint @main, @main_arg_0, @main_res_0
   // CHECK: spirv.ARM.Graph [[GN]]({{%.*}}: !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
   spirv.ARM.Graph @main(%arg0 : !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
-    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
-    %0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
+    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
+    %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
     // CHECK: spirv.ARM.GraphOutputs [[OUT:%.*]] : !spirv.arm.tensor<2x3xi16>
     spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
   }

--- a/mlir/test/Target/SPIRV/graph-ops.mlir
+++ b/mlir/test/Target/SPIRV/graph-ops.mlir
@@ -11,8 +11,8 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.ARM.GraphEntryPoint @main, @main_arg_0, @main_res_0
   // CHECK: spirv.ARM.Graph [[GN]]({{%.*}}: !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
   spirv.ARM.Graph @main(%arg0 : !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
-    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant {graph_constant_id = 42 : i32} : !spirv.arm.tensor<2x3xi16>
-    %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
+    %0 = spirv.ARM.GraphConstant <{graph_constant_id = 42 : i32}> : !spirv.arm.tensor<2x3xi16>
     // CHECK: spirv.ARM.GraphOutputs [[OUT:%.*]] : !spirv.arm.tensor<2x3xi16>
     spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
   }

--- a/mlir/test/Target/SPIRV/graph-ops.mlir
+++ b/mlir/test/Target/SPIRV/graph-ops.mlir
@@ -11,8 +11,8 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.ARM.GraphEntryPoint @main, @main_arg_0, @main_res_0
   // CHECK: spirv.ARM.Graph [[GN]]({{%.*}}: !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
   spirv.ARM.Graph @main(%arg0 : !spirv.arm.tensor<14x19xi16>) -> !spirv.arm.tensor<2x3xi16> attributes {entry_point = true} {
-    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant {graph_constant_id = 42 : i32} : !spirv.arm.tensor<2x3xi16>
-    %0 = spirv.ARM.GraphConstant { graph_constant_id = 42 : i32 } : !spirv.arm.tensor<2x3xi16>
+    // CHECK: [[CONST2:%.*]] = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
+    %0 = spirv.ARM.GraphConstant id = 42 : !spirv.arm.tensor<2x3xi16>
     // CHECK: spirv.ARM.GraphOutputs [[OUT:%.*]] : !spirv.arm.tensor<2x3xi16>
     spirv.ARM.GraphOutputs %0 : !spirv.arm.tensor<2x3xi16>
   }

--- a/mlir/test/Target/SPIRV/tosa-ops.mlir
+++ b/mlir/test/Target/SPIRV/tosa-ops.mlir
@@ -926,7 +926,7 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.GlobalVariable @table_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<3x2x15x7xi8>, UniformConstant>
   spirv.ARM.GraphEntryPoint @table_int, @table_int_arg_0, @table_int_res_0
   spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-    %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+    %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
     // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Target/SPIRV/tosa-ops.mlir
+++ b/mlir/test/Target/SPIRV/tosa-ops.mlir
@@ -926,7 +926,7 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.GlobalVariable @table_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<3x2x15x7xi8>, UniformConstant>
   spirv.ARM.GraphEntryPoint @table_int, @table_int_arg_0, @table_int_res_0
   spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-    %0 = spirv.ARM.GraphConstant <{graph_constant_id = 0 : i32}> : !spirv.arm.tensor<256xi8>
+    %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
     // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>

--- a/mlir/test/Target/SPIRV/tosa-ops.mlir
+++ b/mlir/test/Target/SPIRV/tosa-ops.mlir
@@ -926,7 +926,7 @@ spirv.module Logical Vulkan requires #spirv.vce<v1.3, [VulkanMemoryModel, Shader
   spirv.GlobalVariable @table_int_res_0 bind(1, 0) : !spirv.ptr<!spirv.arm.tensor<3x2x15x7xi8>, UniformConstant>
   spirv.ARM.GraphEntryPoint @table_int, @table_int_arg_0, @table_int_res_0
   spirv.ARM.Graph @table_int(%arg0: !spirv.arm.tensor<3x2x15x7xi8>) -> (!spirv.arm.tensor<3x2x15x7xi8>) {
-    %0 = spirv.ARM.GraphConstant {graph_constant_id = 0 : i32} : !spirv.arm.tensor<256xi8>
+    %0 = spirv.ARM.GraphConstant id = 0 : !spirv.arm.tensor<256xi8>
     // CHECK: {{%.*}} = spirv.Tosa.Table %arg0, {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     %1 = spirv.Tosa.Table %arg0, %0 : !spirv.arm.tensor<3x2x15x7xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2x15x7xi8>
     // CHECK: spirv.ARM.GraphOutputs {{%.*}} : !spirv.arm.tensor<3x2x15x7xi8>


### PR DESCRIPTION
Enable strict property assembly format mode for SPIR-V and add property dictionaries to declarative formats that still carry inherent attributes outside explicit operands or clauses.

Refresh ARM graph and TOSA tests so GraphConstant uses prop-dict spelling for its inherent constant identifier.

Assisted-by: Codex