### PR TITLE
[clang] Forward `-fvalidate-ast-input-files-content` when loading an AST dump

### DIFF
--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -780,11 +780,16 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
       DisableValidationForModuleKind::None;
   if (::getenv("LIBCLANG_DISABLE_PCH_VALIDATION"))
     disableValid = DisableValidationForModuleKind::All;
+  bool ValidateASTInputFilesContent = HSOpts.ValidateASTInputFilesContent;
+
   AST->Reader = llvm::makeIntrusiveRefCnt<ASTReader>(
       *AST->PP, *AST->ModCache, AST->Ctx.get(), PCHContainerRdr,
       *AST->CodeGenOpts, ArrayRef<std::shared_ptr<ModuleFileExtension>>(),
       /*isysroot=*/"",
-      /*DisableValidationKind=*/disableValid, AllowASTWithCompilerErrors);
+      /*DisableValidationKind=*/disableValid, AllowASTWithCompilerErrors,
+      /*AllowConfigurationMismatch=*/false,
+      /*ValidateSystemInputs=*/false,
+      /*ForceValidateUserInputs=*/true, ValidateASTInputFilesContent);
 
   // Attach the AST reader to the AST context as an external AST source, so that
   // declarations will be deserialized from the AST file as needed.

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -780,7 +780,6 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
       DisableValidationForModuleKind::None;
   if (::getenv("LIBCLANG_DISABLE_PCH_VALIDATION"))
     disableValid = DisableValidationForModuleKind::All;
-
   AST->Reader = llvm::makeIntrusiveRefCnt<ASTReader>(
       *AST->PP, *AST->ModCache, AST->Ctx.get(), PCHContainerRdr,
       *AST->CodeGenOpts, ArrayRef<std::shared_ptr<ModuleFileExtension>>(),

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -780,7 +780,6 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
       DisableValidationForModuleKind::None;
   if (::getenv("LIBCLANG_DISABLE_PCH_VALIDATION"))
     disableValid = DisableValidationForModuleKind::All;
-  bool ValidateASTInputFilesContent = HSOpts.ValidateASTInputFilesContent;
 
   AST->Reader = llvm::makeIntrusiveRefCnt<ASTReader>(
       *AST->PP, *AST->ModCache, AST->Ctx.get(), PCHContainerRdr,
@@ -789,7 +788,7 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
       /*DisableValidationKind=*/disableValid, AllowASTWithCompilerErrors,
       /*AllowConfigurationMismatch=*/false,
       /*ValidateSystemInputs=*/false,
-      /*ForceValidateUserInputs=*/true, ValidateASTInputFilesContent);
+      /*ForceValidateUserInputs=*/true, HSOpts.ValidateASTInputFilesContent);
 
   // Attach the AST reader to the AST context as an external AST source, so that
   // declarations will be deserialized from the AST file as needed.

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -1,0 +1,42 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// Step 1: Build PCH and defmap.
+// RUN: %clang_cc1 -x c -emit-pch -o %t/other.c.ast %t/other.c
+// RUN: %clang_extdef_map %t/other.c -- -c -x c > %t/externalDefMap.tmp.txt
+// RUN: sed 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
+
+// Step 2: Run CTU using the PCH - the division by zero is found via inlining.
+// RUN: %clang_cc1 -analyze \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
+// RUN:   -analyzer-config ctu-dir=%t \
+// RUN:   -verify %t/main.c
+
+// Step 3: Advance mtime of the source from which PCH was built.
+// RUN: %python -c "import os, sys, time; os.utime(sys.argv[1], (time.time() + 120, time.time() + 120))" %t/other.c
+
+// Step 4: Run CTU using the now-stale PCH - it breaks.
+// RUN: not %clang_cc1 -analyze \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
+// RUN:   -analyzer-config ctu-dir=%t \
+// RUN:   %t/main.c 2>&1 | FileCheck --check-prefix=BREAKS %s
+
+// BREAKS: file '{{.*}}other.c' has been modified since the precompiled file '{{.*}}other.c.ast' was built
+
+//--- main.c
+// Without CTU, always_zero() has an unknown return value so no bug is found.
+// With CTU, always_zero() is inlined and its return value (0) is known,
+// exposing the division by zero.
+
+int always_zero(void);
+
+void f(void) {
+  int x = always_zero();
+  (void)(1 / x); // expected-warning{{Division by zero}}
+}
+
+//--- other.c
+int always_zero(void) { return 0; }

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -3,12 +3,13 @@
 // RUN: split-file %s %t
 
 // Step 1: Build PCH and defmap.
-// RUN: %clang_cc1 -x c -emit-pch -o %t/other.c.ast %t/other.c
+// RUN: %clang_cc1 -x c -emit-pch -fvalidate-ast-input-files-content -o %t/other.c.ast %t/other.c
 // RUN: %clang_extdef_map %t/other.c -- -c -x c > %t/externalDefMap.tmp.txt
 // RUN: sed 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
 
 // Step 2: Run CTU using the PCH - the division by zero is found via inlining.
 // RUN: %clang_cc1 -analyze \
+// RUN:   -fvalidate-ast-input-files-content \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
 // RUN:   -analyzer-config ctu-dir=%t \
@@ -17,14 +18,13 @@
 // Step 3: Advance mtime of the source from which PCH was built.
 // RUN: %python -c "import os, sys, time; os.utime(sys.argv[1], (time.time() + 120, time.time() + 120))" %t/other.c
 
-// Step 4: Run CTU using the now-stale PCH - it breaks.
-// RUN: not %clang_cc1 -analyze \
+// Step 4: Run CTU using the "stale" PCH
+// RUN: %clang_cc1 -analyze \
+// RUN:   -fvalidate-ast-input-files-content \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
 // RUN:   -analyzer-config ctu-dir=%t \
-// RUN:   %t/main.c 2>&1 | FileCheck --check-prefix=BREAKS %s
-
-// BREAKS: file '{{.*}}other.c' has been modified since the precompiled file '{{.*}}other.c.ast' was built
+// RUN:   -verify %t/main.c
 
 //--- main.c
 // Without CTU, always_zero() has an unknown return value so no bug is found.

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -5,7 +5,7 @@
 // Step 1: Build PCH and defmap.
 // RUN: %clang_cc1 -x c -emit-pch -fvalidate-ast-input-files-content -o %t/other.c.ast %t/other.c
 // RUN: %clang_extdef_map %t/other.c -- -c -x c > %t/externalDefMap.tmp.txt
-// RUN: sed 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
+// RUN: sed -e 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
 
 // Step 2: Run CTU using the PCH - the division by zero is found via inlining.
 // RUN: %clang_analyze_cc1 \

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -26,10 +26,22 @@
 // RUN:   -analyzer-config ctu-dir=%t \
 // RUN:   -verify %t/main.c
 
+// Step 4': Run without content validation: CTU import failure
+// RUN: not %clang_analyze_cc1 \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
+// RUN:   -analyzer-config ctu-dir=%t \
+// RUN:   -verify %t/main.c 2>&1 | FileCheck %s
+
 //--- main.c
 // Without CTU, always_zero() has an unknown return value so no bug is found.
 // With CTU, always_zero() is inlined and its return value (0) is known,
 // exposing the division by zero.
+
+// CHECK: fatal error: file '{{.*}}/other.c' has been modified since the precompiled file '{{.*}}/other.c.ast' was built
+// CHECK: note: mtime changed from expected
+// CHECK: note: earlier input file validation has covered only user files
+// CHECK: import of an external symbol for CTU failed: Failed to load external AST source.
 
 int always_zero(void);
 

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -8,7 +8,7 @@
 // RUN: sed 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
 
 // Step 2: Run CTU using the PCH - the division by zero is found via inlining.
-// RUN: %clang_cc1 -analyze \
+// RUN: %clang_analyze_cc1 \
 // RUN:   -fvalidate-ast-input-files-content \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
@@ -18,8 +18,9 @@
 // Step 3: Advance mtime of the source from which PCH was built.
 // RUN: %python -c "import os, sys, time; os.utime(sys.argv[1], (time.time() + 120, time.time() + 120))" %t/other.c
 
+// Step 4: Run CTU using the "stale" PCH
 // Step 4: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.
-// RUN: %clang_cc1 -analyze \
+// RUN: %clang_analyze_cc1 \
 // RUN:   -fvalidate-ast-input-files-content \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -15,8 +15,8 @@
 // RUN:   -analyzer-config ctu-dir=%t \
 // RUN:   -verify %t/main.c
 
-// Step 3: Advance mtime of the source from which PCH was built.
-// RUN: %python -c "import os, sys, time; os.utime(sys.argv[1], (time.time() + 120, time.time() + 120))" %t/other.c
+// Step 3: Set mtime of the source from which PCH was built to the year 3000 (way in the future).
+// RUN: touch -t 300001010000 %t/other.c
 
 // Step 4: Run CTU using the "stale" PCH
 // Step 4: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -18,7 +18,7 @@
 // Step 3: Advance mtime of the source from which PCH was built.
 // RUN: %python -c "import os, sys, time; os.utime(sys.argv[1], (time.time() + 120, time.time() + 120))" %t/other.c
 
-// Step 4: Run CTU using the "stale" PCH
+// Step 4: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.
 // RUN: %clang_cc1 -analyze \
 // RUN:   -fvalidate-ast-input-files-content \
 // RUN:   -analyzer-checker=core \

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -18,7 +18,6 @@
 // Step 3: Set mtime of the source from which PCH was built to the year 3000 (way in the future).
 // RUN: touch -t 300001010000 %t/other.c
 
-// Step 4: Run CTU using the "stale" PCH
 // Step 4: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.
 // RUN: %clang_analyze_cc1 \
 // RUN:   -fvalidate-ast-input-files-content \

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -33,7 +33,7 @@
 // With CTU, always_zero() is inlined and its return value (0) is known,
 // exposing the division by zero.
 
-// CHECK: fatal error: file '{{.*}}/other.c' has been modified since the precompiled file '{{.*}}/other.c.ast' was built
+// CHECK: fatal error: file '{{.*}}other.c' has been modified since the precompiled file '{{.*}}other.c.ast' was built
 // CHECK: note: mtime changed from expected
 // CHECK: note: earlier input file validation has covered only user files
 // CHECK: import of an external symbol for CTU failed: Failed to load external AST source.

--- a/clang/test/Analysis/ctu/reusable-pch.c
+++ b/clang/test/Analysis/ctu/reusable-pch.c
@@ -1,37 +1,32 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
+//
+// DEFINE: %{ctu_analysis} =  %clang_analyze_cc1 \
+// DEFINE:                        -analyzer-checker=core \
+// DEFINE:                        -analyzer-config experimental-enable-naive-ctu-analysis=true \
+// DEFINE:                        -analyzer-config ctu-dir=%t \
+// DEFINE:                        -verify
 
 // Step 1: Build PCH and defmap.
 // RUN: %clang_cc1 -x c -emit-pch -fvalidate-ast-input-files-content -o %t/other.c.ast %t/other.c
 // RUN: %clang_extdef_map %t/other.c -- -c -x c > %t/externalDefMap.tmp.txt
 // RUN: sed -e 's| .*other\.c| other.c.ast|' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
 
-// Step 2: Run CTU using the PCH - the division by zero is found via inlining.
-// RUN: %clang_analyze_cc1 \
-// RUN:   -fvalidate-ast-input-files-content \
-// RUN:   -analyzer-checker=core \
-// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
-// RUN:   -analyzer-config ctu-dir=%t \
-// RUN:   -verify %t/main.c
+// Step 2a: Run CTU using the PCH - the division by zero is found via inlining.
+// RUN: %{ctu_analysis} %t/main.c
+
+// Step 2b: Run with content validation - no difference.
+// RUN: %{ctu_analysis} %t/main.c -fvalidate-ast-input-files-content
 
 // Step 3: Set mtime of the source from which PCH was built to the year 3000 (way in the future).
 // RUN: touch -t 300001010000 %t/other.c
 
-// Step 4: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.
-// RUN: %clang_analyze_cc1 \
-// RUN:   -fvalidate-ast-input-files-content \
-// RUN:   -analyzer-checker=core \
-// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
-// RUN:   -analyzer-config ctu-dir=%t \
-// RUN:   -verify %t/main.c
+// Step 4a: Run CTU using the "stale" PCH, and it should still load it and find the division by zero bug.
+// RUN: %{ctu_analysis} -fvalidate-ast-input-files-content %t/main.c
 
-// Step 4': Run without content validation: CTU import failure
-// RUN: not %clang_analyze_cc1 \
-// RUN:   -analyzer-checker=core \
-// RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
-// RUN:   -analyzer-config ctu-dir=%t \
-// RUN:   -verify %t/main.c 2>&1 | FileCheck %s
+// Step 4b: Run without content validation: CTU import failure
+// RUN: not %{ctu_analysis} %t/main.c 2>&1 | FileCheck %s
 
 //--- main.c
 // Without CTU, always_zero() has an unknown return value so no bug is found.


### PR DESCRIPTION
`-fvalidate-ast-input-files-content` is silently ignored when loading PCH files for additional translation units.

This triggers an import failure when modification time of some of input files changes (for example, the AST dump is being reused for a subsequent cross-translation-unit re-analysis with Clang Static Analyzer after a fresh code checkout).
This makes it difficult to use cached AST dumps.

This patch enables the user to control validation of AST input files, without imposing it on them.

--
CPP-8312, CPP-8025