### PR TITLE
[lldb][test] Add missing include to char16/32_t test

### DIFF
--- a/lldb/test/API/lang/cpp/char1632_t/main.cpp
+++ b/lldb/test/API/lang/cpp/char1632_t/main.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <cstring>
 #include <string>
 
 #define UASZ 64


### PR DESCRIPTION
Fixes 605feeda1e50aa0064947e64d66d3351b9f9693e / #195514. Failed to build on AArch64 Linux without it.