### PR TITLE
[AArch64][llvm] Add missing form for `LD64B`/`ST64B` instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -12784,6 +12784,16 @@ class LoadStore64B<bits<3> opc, string asm_inst, dag iops, dag oops,
   let Inst{20-16} = 0b11111;
 }
 
+multiclass LoadStore64B<bits<3> opc, string asm_inst,
+                        bit may_load, bit may_store,
+                        dag iops, dag oops,
+                        list<dag> pat = []> {
+  let mayLoad = may_load, mayStore = may_store in
+  def "" : LoadStore64B<opc, asm_inst, iops, oops, pat>;
+  def : InstAlias<asm_inst # "\t$Rt, [$Rn, #0]",
+                  (!cast<Instruction>(NAME) GPR64x8:$Rt, GPR64sp:$Rn)>;
+}
+
 class Store64BV<bits<3> opc, string asm_inst, list<dag> pat = []>
     : LoadStore64B_base<opc, asm_inst, "\t$Rs, $Rt, [$Rn]",
                        (ins GPR64x8:$Rt, GPR64sp:$Rn), (outs GPR64:$Rs), pat> {

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -11363,12 +11363,10 @@ foreach i = 0-7 in {
 }
 
 let Predicates = [HasLS64] in {
-  let mayLoad = 1 in
-  def LD64B: LoadStore64B<0b101, "ld64b", (ins GPR64sp:$Rn),
-                                          (outs GPR64x8:$Rt)>;
-  let mayStore = 1 in
-  def ST64B: LoadStore64B<0b001, "st64b", (ins GPR64x8:$Rt, GPR64sp:$Rn),
-                                          (outs)>;
+  defm LD64B: LoadStore64B<0b101, "ld64b", 1, 0, (ins GPR64sp:$Rn),
+                                           (outs GPR64x8:$Rt)>;
+  defm ST64B: LoadStore64B<0b001, "st64b", 0, 1, (ins GPR64x8:$Rt, GPR64sp:$Rn),
+                                           (outs)>;
   def ST64BV:   Store64BV<0b011, "st64bv">;
   def ST64BV0:  Store64BV<0b010, "st64bv0">;
 

--- a/llvm/test/MC/AArch64/armv8.7a-ls64.s
+++ b/llvm/test/MC/AArch64/armv8.7a-ls64.s
@@ -5,23 +5,33 @@
 
   ld64b x0, [x13]
   st64b x14, [x13]
+  ld64b x2, [x13, #0]
+  st64b x16, [x13, #0]
   st64bv x1, x20, [x13]
   st64bv0 x1, x22, [x13]
 // CHECK: ld64b x0, [x13]        // encoding: [0xa0,0xd1,0x3f,0xf8]
 // CHECK: st64b x14, [x13]       // encoding: [0xae,0x91,0x3f,0xf8]
+// CHECK: ld64b x2, [x13]        // encoding: [0xa2,0xd1,0x3f,0xf8]
+// CHECK: st64b x16, [x13]       // encoding: [0xb0,0x91,0x3f,0xf8]
 // CHECK: st64bv x1, x20, [x13]  // encoding: [0xb4,0xb1,0x21,0xf8]
 // CHECK: st64bv0 x1, x22, [x13] // encoding: [0xb6,0xa1,0x21,0xf8]
-// CHECK-NO-LS64-ERR: [[@LINE-8]]:3: error: instruction requires: ls64
-// CHECK-NO-LS64-ERR: [[@LINE-8]]:3: error: instruction requires: ls64
-// CHECK-NO-LS64-ERR: [[@LINE-8]]:3: error: instruction requires: ls64
-// CHECK-NO-LS64-ERR: [[@LINE-8]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
+// CHECK-NO-LS64-ERR: [[@LINE-12]]:3: error: instruction requires: ls64
 
   ld64b x0, [sp]
+  ld64b x2, [sp, #0]
   st64b x14, [sp]
+  st64b x16, [sp, #0]
   st64bv x1, x20, [sp]
   st64bv0 x1, x22, [sp]
 // CHECK: ld64b x0, [sp]         // encoding: [0xe0,0xd3,0x3f,0xf8]
+// CHECK: ld64b x2, [sp]         // encoding: [0xe2,0xd3,0x3f,0xf8]
 // CHECK: st64b x14, [sp]        // encoding: [0xee,0x93,0x3f,0xf8]
+// CHECK: st64b x16, [sp]        // encoding: [0xf0,0x93,0x3f,0xf8]
 // CHECK: st64bv x1, x20, [sp]   // encoding: [0xf4,0xb3,0x21,0xf8]
 // CHECK: st64bv0 x1, x22, [sp]  // encoding: [0xf6,0xa3,0x21,0xf8]
 


### PR DESCRIPTION
`LD64B` and `ST64B` are defined as follows[1]:
```
  LD64B <Xt>, [<Xn|SP> {,#0}]
```

but they're missing the form that allows a zero immediate offset,
for example:
```
  ld64b x2, [x13, #0]
  st64b x16, [x13, #0]
```

Add support for zero immediate offsets for these instructions.

[1] https://developer.arm.com/documentation/ddi0602/2022-09/Base-Instructions/LD64B--Single-copy-Atomic-64-byte-Load-