### PR TITLE
[lldb] Revert recent changes to HostThreadPosix::Reset

### DIFF
--- a/lldb/include/lldb/Host/posix/HostThreadPosix.h
+++ b/lldb/include/lldb/Host/posix/HostThreadPosix.h
@@ -25,7 +25,7 @@ public:
   Status Join(lldb::thread_result_t *result) override;
   Status Cancel() override;
 
-  void Reset() override;
+  Status Detach();
 };
 
 } // namespace lldb_private

--- a/lldb/source/Host/common/MonitoringProcessLauncher.cpp
+++ b/lldb/source/Host/common/MonitoringProcessLauncher.cpp
@@ -56,17 +56,12 @@ MonitoringProcessLauncher::LaunchProcess(const ProcessLaunchInfo &launch_info,
     assert(launch_info.GetMonitorProcessCallback());
     llvm::Expected<HostThread> maybe_thread =
         process.StartMonitoring(launch_info.GetMonitorProcessCallback());
-    if (!maybe_thread) {
+    if (!maybe_thread)
       error = Status::FromErrorStringWithFormatv(
           "failed to launch host thread: {}",
           llvm::toString(maybe_thread.takeError()));
-    } else {
-      if (log)
-        log->PutCString("started monitoring child process.");
-
-      // Allow the thread to exit on its own once its work is done.
-      maybe_thread->Reset();
-    }
+    if (log)
+      log->PutCString("started monitoring child process.");
   } else {
     // Invalid process ID, something didn't go well
     if (error.Success())

--- a/lldb/source/Host/posix/HostThreadPosix.cpp
+++ b/lldb/source/Host/posix/HostThreadPosix.cpp
@@ -50,8 +50,12 @@ Status HostThreadPosix::Cancel() {
   return error;
 }
 
-void HostThreadPosix::Reset() {
-  if (IsJoinable())
-    ::pthread_detach(m_thread);
-  HostNativeThreadBase::Reset();
+Status HostThreadPosix::Detach() {
+  Status error;
+  if (IsJoinable()) {
+    int err = ::pthread_detach(m_thread);
+    error = Status(err, eErrorTypePOSIX);
+  }
+  Reset();
+  return error;
 }


### PR DESCRIPTION
These are suspected to have caused instability in CI testing https://github.com/llvm/llvm-project/issues/191372.

This reverts commits 4c225918a9e78463c9bf9cc0a26be5ae2ed1c827 and d7fac0f42a3a8a6d6cf827d1f8b38663f872fe0f (#179470 and #177572).

The second change could technically stay in, but it was using the first change to fix a bug in lldb-server. So I think it's better to revert both so we don't mistakenly think the bug is still fixed.