### PR TITLE
[C-API] Add LLVMIs for ConstantRangeAttribute and ConstantRangeListAttribute

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -802,6 +802,8 @@ LLVM_C_ABI const char *LLVMGetStringAttributeValue(LLVMAttributeRef A,
 LLVM_C_ABI LLVMBool LLVMIsEnumAttribute(LLVMAttributeRef A);
 LLVM_C_ABI LLVMBool LLVMIsStringAttribute(LLVMAttributeRef A);
 LLVM_C_ABI LLVMBool LLVMIsTypeAttribute(LLVMAttributeRef A);
+LLVM_C_ABI LLVMBool LLVMIsConstantRangeAttribute(LLVMAttributeRef A);
+LLVM_C_ABI LLVMBool LLVMIsConstantRangeListAttribute(LLVMAttributeRef A);
 
 /**
  * Obtain a Type from a context by its registered name.

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -259,6 +259,14 @@ LLVMBool LLVMIsTypeAttribute(LLVMAttributeRef A) {
   return unwrap(A).isTypeAttribute();
 }
 
+LLVMBool LLVMIsConstantRangeAttribute(LLVMAttributeRef A) {
+  return unwrap(A).isConstantRangeAttribute();
+}
+
+LLVMBool LLVMIsConstantRangeListAttribute(LLVMAttributeRef A) {
+  return unwrap(A).isConstantRangeListAttribute();
+}
+
 char *LLVMGetDiagInfoDescription(LLVMDiagnosticInfoRef DI) {
   std::string MsgStorage;
   raw_string_ostream Stream(MsgStorage);


### PR DESCRIPTION
#90505 added C-API for creating these attributes, but there is currently no way to check
if one is encountering such an attribute. Noticed downstream in LLVM.jl where we iterate over attributes
and encountered an unknown kind.
