### PR TITLE
[analyzer] Clean up evalBind, fix bad logic

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3735,7 +3735,7 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
   getCheckerManager().runCheckersForBind(CheckedSet, Pred, location, Val,
                                          StoreE, AtDeclInit, *this, *PP);
 
-  NodeBuilder Bldr(CheckedSet, Dst, *currBldrCtx);
+  Dst.insert(CheckedSet);
 
   // If the location is not a 'Loc', it will already be handled by
   // the checkers.  There is nothing left to do.
@@ -3744,7 +3744,8 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
                                      /*tag*/nullptr);
     ProgramStateRef state = Pred->getState();
     state = processPointerEscapedOnBind(state, location, Val, LC);
-    Bldr.generateNode(L, state, Pred);
+    Dst.erase(Pred);
+    Dst.insert(Engine.makeNode(L, state, Pred));
     return;
   }
 
@@ -3766,7 +3767,8 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
     }
 
     const ProgramPoint L = PostStore(StoreE, LC, LocReg, nullptr);
-    Bldr.generateNode(L, state, PredI);
+    Dst.erase(PredI);
+    Dst.insert(Engine.makeNode(L, state, PredI));
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3735,11 +3735,11 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
   getCheckerManager().runCheckersForBind(CheckedSet, Pred, location, Val,
                                          StoreE, AtDeclInit, *this, *PP);
 
-  Dst.insert(CheckedSet);
-
   // If the location is not a 'Loc', it will already be handled by
   // the checkers.  There is nothing left to do.
   if (!isa<Loc>(location)) {
+    Dst.insert(CheckedSet);
+
     const ProgramPoint L = PostStore(StoreE, LC, /*Loc*/nullptr,
                                      /*tag*/nullptr);
     ProgramStateRef state = Pred->getState();

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3738,12 +3738,12 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
   getCheckerManager().runCheckersForBind(CheckedSet, Pred, Location, Val,
                                          StoreE, AtDeclInit, *this, *PP);
 
-  for (const auto PredI : CheckedSet) {
+  for (ExplodedNode *PredI : CheckedSet) {
     ProgramStateRef State = PredI->getState();
 
     State = processPointerEscapedOnBind(State, Location, Val, LC);
 
-    if (std::optional<Loc> AsLoc = Location.getAs<Loc>()) {
+    if (auto AsLoc = Location.getAs<Loc>()) {
       // When binding the value, pass on the hint that this is a
       // initialization. For initializations, we do not need to inform clients
       // of region changes.
@@ -3751,10 +3751,8 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
     }
 
     const MemRegion *LocReg = nullptr;
-    if (std::optional<loc::MemRegionVal> LocRegVal =
-            Location.getAs<loc::MemRegionVal>()) {
+    if (auto LocRegVal = Location.getAs<loc::MemRegionVal>())
       LocReg = LocRegVal->getRegion();
-    }
 
     PostStore PS(StoreE, LC, LocReg, /*tag=*/nullptr);
     Dst.insert(Engine.makeNode(PS, State, PredI));

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3727,9 +3727,9 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
                           bool AtDeclInit, const ProgramPoint *PP) {
   assert(!isa<NonLoc>(location) && "evalBind location should not be NonLoc!");
   const LocationContext *LC = Pred->getLocationContext();
-  PostStmt PS(StoreE, LC);
+  PostStmt DefaultPP(StoreE, LC);
   if (!PP)
-    PP = &PS;
+    PP = &DefaultPP;
 
   // Do a previsit of the bind.
   ExplodedNodeSet CheckedSet;
@@ -3754,8 +3754,8 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
       LocReg = LocRegVal->getRegion();
     }
 
-    const ProgramPoint L = PostStore(StoreE, LC, LocReg, nullptr);
-    Dst.insert(Engine.makeNode(L, state, PredI));
+    PostStore PS(LC, LocReg, nullptr);
+    Dst.insert(Engine.makeNode(PS, state, PredI));
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3723,9 +3723,10 @@ ExprEngine::notifyCheckersOfPointerEscape(ProgramStateRef State,
 /// evalBind - Handle the semantics of binding a value to a specific location.
 ///  This method is used by evalStore and (soon) VisitDeclStmt, and others.
 void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
-                          ExplodedNode *Pred, SVal location, SVal Val,
+                          ExplodedNode *Pred, SVal Location, SVal Val,
                           bool AtDeclInit, const ProgramPoint *PP) {
-  assert(!isa<NonLoc>(location) && "evalBind location should not be NonLoc!");
+  assert(!isa<NonLoc>(Location) && "evalBind location should not be NonLoc!");
+
   const LocationContext *LC = Pred->getLocationContext();
   PostStmt DefaultPP(StoreE, LC);
   if (!PP)
@@ -3733,29 +3734,29 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
 
   // Do a previsit of the bind.
   ExplodedNodeSet CheckedSet;
-  getCheckerManager().runCheckersForBind(CheckedSet, Pred, location, Val,
+  getCheckerManager().runCheckersForBind(CheckedSet, Pred, Location, Val,
                                          StoreE, AtDeclInit, *this, *PP);
 
   for (const auto PredI : CheckedSet) {
-    ProgramStateRef state = PredI->getState();
+    ProgramStateRef State = PredI->getState();
 
-    state = processPointerEscapedOnBind(state, location, Val, LC);
+    State = processPointerEscapedOnBind(State, Location, Val, LC);
 
-    if (std::optional<Loc> AsLoc = location.getAs<Loc>()) {
+    if (std::optional<Loc> AsLoc = Location.getAs<Loc>()) {
       // When binding the value, pass on the hint that this is a
       // initialization. For initializations, we do not need to inform clients
       // of region changes.
-      state = state->bindLoc(*AsLoc, Val, LC, /*notifyChanges=*/!AtDeclInit);
+      State = State->bindLoc(*AsLoc, Val, LC, /*notifyChanges=*/!AtDeclInit);
     }
 
     const MemRegion *LocReg = nullptr;
     if (std::optional<loc::MemRegionVal> LocRegVal =
-            location.getAs<loc::MemRegionVal>()) {
+            Location.getAs<loc::MemRegionVal>()) {
       LocReg = LocRegVal->getRegion();
     }
 
-    PostStore PS(LC, LocReg, nullptr);
-    Dst.insert(Engine.makeNode(PS, state, PredI));
+    PostStore PS(StoreE, LC, LocReg, /*tag=*/nullptr);
+    Dst.insert(Engine.makeNode(PS, State, PredI));
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3725,6 +3725,7 @@ ExprEngine::notifyCheckersOfPointerEscape(ProgramStateRef State,
 void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
                           ExplodedNode *Pred, SVal location, SVal Val,
                           bool AtDeclInit, const ProgramPoint *PP) {
+  assert(!isa<NonLoc>(location) && "evalBind location should not be NonLoc!");
   const LocationContext *LC = Pred->getLocationContext();
   PostStmt PS(StoreE, LC);
   if (!PP)

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3721,10 +3721,11 @@ ExprEngine::notifyCheckersOfPointerEscape(ProgramStateRef State,
 }
 
 /// evalBind - Handle the semantics of binding a value to a specific location.
-///  This method is used by evalStore and (soon) VisitDeclStmt, and others.
+///  This method is used by evalStore, VisitDeclStmt, and others.
 void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
                           ExplodedNode *Pred, SVal Location, SVal Val,
                           bool AtDeclInit, const ProgramPoint *PP) {
+  // It may be a Loc, UnknownVal or perhaps UndefinedVal.
   assert(!isa<NonLoc>(Location) && "evalBind location should not be NonLoc!");
 
   const LocationContext *LC = Pred->getLocationContext();

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3767,7 +3767,6 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
     }
 
     const ProgramPoint L = PostStore(StoreE, LC, LocReg, nullptr);
-    Dst.erase(PredI);
     Dst.insert(Engine.makeNode(L, state, PredI));
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3736,30 +3736,17 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
   getCheckerManager().runCheckersForBind(CheckedSet, Pred, location, Val,
                                          StoreE, AtDeclInit, *this, *PP);
 
-  // If the location is not a 'Loc', it will already be handled by
-  // the checkers.  There is nothing left to do.
-  if (!isa<Loc>(location)) {
-    Dst.insert(CheckedSet);
-
-    const ProgramPoint L = PostStore(StoreE, LC, /*Loc*/nullptr,
-                                     /*tag*/nullptr);
-    ProgramStateRef state = Pred->getState();
-    state = processPointerEscapedOnBind(state, location, Val, LC);
-    Dst.erase(Pred);
-    Dst.insert(Engine.makeNode(L, state, Pred));
-    return;
-  }
-
   for (const auto PredI : CheckedSet) {
     ProgramStateRef state = PredI->getState();
 
     state = processPointerEscapedOnBind(state, location, Val, LC);
 
-    // When binding the value, pass on the hint that this is a initialization.
-    // For initializations, we do not need to inform clients of region
-    // changes.
-    state = state->bindLoc(location.castAs<Loc>(), Val, LC,
-                           /* notifyChanges = */ !AtDeclInit);
+    if (std::optional<Loc> AsLoc = location.getAs<Loc>()) {
+      // When binding the value, pass on the hint that this is a
+      // initialization. For initializations, we do not need to inform clients
+      // of region changes.
+      state = state->bindLoc(*AsLoc, Val, LC, /*notifyChanges=*/!AtDeclInit);
+    }
 
     const MemRegion *LocReg = nullptr;
     if (std::optional<loc::MemRegionVal> LocRegVal =

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3741,6 +3741,7 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
   for (ExplodedNode *PredI : CheckedSet) {
     ProgramStateRef State = PredI->getState();
 
+    // Check and record that 'Val' may escape:
     State = processPointerEscapedOnBind(State, Location, Val, LC);
 
     if (auto AsLoc = Location.getAs<Loc>()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3750,11 +3750,7 @@ void ExprEngine::evalBind(ExplodedNodeSet &Dst, const Stmt *StoreE,
       State = State->bindLoc(*AsLoc, Val, LC, /*notifyChanges=*/!AtDeclInit);
     }
 
-    const MemRegion *LocReg = nullptr;
-    if (auto LocRegVal = Location.getAs<loc::MemRegionVal>())
-      LocReg = LocRegVal->getRegion();
-
-    PostStore PS(StoreE, LC, LocReg, /*tag=*/nullptr);
+    PostStore PS(StoreE, LC, Location.getAsRegion(), /*tag=*/nullptr);
     Dst.insert(Engine.makeNode(PS, State, PredI));
   }
 }


### PR DESCRIPTION
This commit refactors `ExprEngine::evalBind` to eliminate the use of a `NodeBuilder` and fix incorrect logic that was apparently introduced because the `NodeBuilder` had obfuscated the underlying set operations.

In the special case when the engine is binding to an `Unknown` or `Undefined` memory location, with the old code on each execution path _either_ only the `check::Bind` checkers _or_ only the pointer escape checkers were invoked. This commit ensures that on each execution path _both_ the `check::Bind` checkers _and then_ the pointer escape checkers get a chance to activate.

I'm pretty sure that the bad logic did not cause incorrect behavior of the analyzer, because there are no `checkBind` checkers that generate non-sink transitions when the location is `Unknown` or `Undefined`.

I also added an assertion that the location argument of `evalBind` cannot be a `NonLoc`, because this is a common sense precondition, seems to be actually true and makes it easier to reason about the behavior of this function.
