### PR TITLE
[mlir][Interfaces] Fix -Wunused-function

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/ReifyValueBounds.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ReifyValueBounds.cpp
@@ -18,7 +18,8 @@
 using namespace mlir;
 using namespace mlir::arith;
 
-static bool isIndexLikeType(Type type, ValueBoundsOptions options) {
+[[maybe_unused]] static bool isIndexLikeType(Type type,
+                                             ValueBoundsOptions options) {
   return type.isIndex() || (options.allowIntegerType && type.isInteger());
 }
 

--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -77,11 +77,12 @@ static std::optional<int64_t> getConstantIntValue(OpFoldResult ofr) {
   return std::nullopt;
 }
 
-static bool isIndexOrIntegerType(Type type) {
+[[maybe_unused]] static bool isIndexOrIntegerType(Type type) {
   return type.isIndex() || type.isInteger();
 }
 
-static bool isIndexLikeType(Type type, ValueBoundsOptions options) {
+[[maybe_unused]] static bool isIndexLikeType(Type type,
+                                             ValueBoundsOptions options) {
   return type.isIndex() || (options.allowIntegerType && type.isInteger());
 }
 


### PR DESCRIPTION
These functions are only used inside assert statements, so mark them
[[maybe_unused]] to prevent -Wunused-function when they are used in a
non-asserts build.