### PR TITLE
[ASan] MSVC test compatibility fixes

### DIFF
--- a/compiler-rt/test/asan/TestCases/asan_and_llvm_coverage_test.cpp
+++ b/compiler-rt/test/asan/TestCases/asan_and_llvm_coverage_test.cpp
@@ -1,8 +1,9 @@
 // RUN: %clangxx_asan -coverage -O0 \
-// RUN:   %if target={{.*-windows-msvc.*}} %{ \
-// RUN:     -D_MT -D_DLL \
-// RUN:     -Wl,-nodefaultlib:libcmt,-defaultlib:msvcrt,-defaultlib:oldnames \
-// RUN:   %} %s -o %t
+// RUN:   %if target={{.*-windows-msvc.*}} %{ -D_MT -D_DLL %} \
+// RUN:   %if !MSVC && target={{.*-windows-msvc.*}} %{ \
+// RUN:     -Wl,-nodefaultlib:libcmt,-defaultlib:msvcrt,-defaultlib:oldnames %} \
+// RUN:   %s -o %t \
+// RUN:   %if MSVC %{ /link /NODEFAULTLIB:libcmt /DEFAULTLIB:msvcrt /DEFAULTLIB:oldnames %}
 // RUN: %env_asan_opts=check_initialization_order=1 %run %t 2>&1 | FileCheck %s
 
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/debug_invalid_pointer_pair.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_invalid_pointer_pair.cpp
@@ -1,5 +1,6 @@
 // Checks that the ASan debugging API for getting report information
 // returns correct values for invalid pointer pairs.
+// UNSUPPORTED: MSVC
 // RUN: %clangxx_asan -O0 %s -o %t -mllvm -asan-detect-invalid-pointer-pair && %env_asan_opts=detect_invalid_pointer_pairs=1 not %run %t 2>&1 | FileCheck %s
 
 #include <sanitizer/asan_interface.h>

--- a/compiler-rt/test/asan/TestCases/debug_memcpy_overlap.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_memcpy_overlap.cpp
@@ -1,6 +1,6 @@
 // Checks that the ASan debugging API for getting report information reports
 // memory overlap error details.
-// RUN: %clangxx_asan -O0 %s -o %t && not %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -O0 %if MSVC %{ /Oi %} %s -o %t && not %run %t 2>&1 | FileCheck %s
 
 #include <sanitizer/asan_interface.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes a few tests with the MSVC toolchain due to incompatibilities:

1. `asan_and_llvm_coverage_test.cpp`: Adds MSVC-specific linker flags (/link /NODEFAULTLIB:libcmt ...) alongside the
existing clang-cl -Wl flags. It is probably better to convert these later to substitution changes in `lit.cfg.py`, but that will require upstreaming more test changes.
1. `debug_invalid_pointer_pair.cpp`: Marks the test `UNSUPPORTED: MSVC` because `-mllvm` and codegen isn't supported with MSVC.
1. `debug_memcpy_overlap.cpp` : Adds `/Oi` (enable intrinsics) when building with MSVC, so `memcpy` is emitted as a call 
that ASan can intercept.
