### PR TITLE
[Driver] Handle mips*-*-none-elf triples

### DIFF
--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
+++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
@@ -55,6 +55,12 @@ static bool isX86BareMetal(const llvm::Triple &Triple) {
          Triple.getEnvironmentName() == "elf";
 }
 
+/// Is the triple mips{,el,64,64el}-*-none-elf?
+static bool isMIPSBareMetal(const llvm::Triple &Triple) {
+  return Triple.isMIPS() && Triple.getOS() == llvm::Triple::UnknownOS &&
+         Triple.getEnvironmentName() == "elf";
+}
+
 static bool findRISCVMultilibs(const Driver &D,
                                const llvm::Triple &TargetTriple,
                                const ArgList &Args, DetectedMultilibs &Result) {
@@ -281,7 +287,8 @@ void BareMetal::findMultilibs(const Driver &D, const llvm::Triple &Triple,
 bool BareMetal::handlesTarget(const llvm::Triple &Triple) {
   return arm::isARMEABIBareMetal(Triple) ||
          aarch64::isAArch64BareMetal(Triple) || isRISCVBareMetal(Triple) ||
-         isPPCBareMetal(Triple) || isX86BareMetal(Triple);
+         isPPCBareMetal(Triple) || isX86BareMetal(Triple) ||
+         isMIPSBareMetal(Triple);
 }
 
 Tool *BareMetal::buildLinker() const {

--- a/clang/test/Driver/mips-toolchain.c
+++ b/clang/test/Driver/mips-toolchain.c
@@ -1,0 +1,35 @@
+// UNSUPPORTED: system-windows
+
+// Verify that mips*-*-none-elf triples are handled by the BareMetal toolchain,
+// i.e. clang drives ld.lld directly with the correct ELF emulation instead of
+// delegating to a $target-gcc.
+
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld --target=mips-none-elf --sysroot= 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-BAREMETAL %s
+// MIPS-BAREMETAL: "-cc1" "-triple" "mips-unknown-none-elf"
+// MIPS-BAREMETAL: "{{.*}}/Inputs/lld/ld.lld"
+// MIPS-BAREMETAL-SAME: "-Bstatic" "-m" "elf32btsmip"
+
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld --target=mipsel-none-elf --sysroot= 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPSEL-BAREMETAL %s
+// MIPSEL-BAREMETAL: "-cc1" "-triple" "mipsel-unknown-none-elf"
+// MIPSEL-BAREMETAL: "{{.*}}/Inputs/lld/ld.lld"
+// MIPSEL-BAREMETAL-SAME: "-Bstatic" "-m" "elf32ltsmip"
+
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld --target=mips64-none-elf --sysroot= 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-BAREMETAL %s
+// MIPS64-BAREMETAL: "-cc1" "-triple" "mips64-unknown-none-elf"
+// MIPS64-BAREMETAL: "{{.*}}/Inputs/lld/ld.lld"
+// MIPS64-BAREMETAL-SAME: "-Bstatic" "-m" "elf64btsmip"
+
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld --target=mips64el-none-elf --sysroot= 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64EL-BAREMETAL %s
+// MIPS64EL-BAREMETAL: "-cc1" "-triple" "mips64el-unknown-none-elf"
+// MIPS64EL-BAREMETAL: "{{.*}}/Inputs/lld/ld.lld"
+// MIPS64EL-BAREMETAL-SAME: "-Bstatic" "-m" "elf64ltsmip"
+
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld --target=mips64-none-elf -mabi=n32 --sysroot= 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-N32-BAREMETAL %s
+// MIPS64-N32-BAREMETAL: "-cc1" "-triple" "mips64-unknown-none-elf"
+// MIPS64-N32-BAREMETAL: "{{.*}}/Inputs/lld/ld.lld"
+// MIPS64-N32-BAREMETAL-SAME: "-Bstatic" "-m" "elf32btsmipn32"


### PR DESCRIPTION
Add `mips{,el,64,64el}-unknown-elf` to the set of triples claimed by the BareMetal toolchain, mirroring the existing handling for `riscv{32,64}-unknown-elf`, `x86{,_64}-unknown-elf`, and `powerpc*-unknown-eabi`.
This is required for creating RockBox LLVM port (see https://gerrit.rockbox.org/r/c/rockbox/+/7466).