### PR TITLE
[AMDGPU] Add v2i32 V_BFI combines for andn2 and orn2

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -262,6 +262,7 @@ def xor_oneuse : HasOneUseBinOp<xor>;
 } // Properties = [SDNPCommutative, SDNPAssociative]
 
 def not_oneuse : HasOneUseUnaryOp<not>;
+def vnot_oneuse : HasOneUseUnaryOp<vnot>;
 
 def add_oneuse : HasOneUseBinOp<add>;
 def sub_oneuse : HasOneUseBinOp<sub>;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -261,7 +261,7 @@ def or_oneuse : HasOneUseBinOp<or>;
 def xor_oneuse : HasOneUseBinOp<xor>;
 } // Properties = [SDNPCommutative, SDNPAssociative]
 
-def not_oneuse : HasOneUseUnaryOp<not>;
+def not_oneuse  : HasOneUseUnaryOp<not>;
 def vnot_oneuse : HasOneUseUnaryOp<vnot>;
 
 def add_oneuse : HasOneUseBinOp<add>;

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -2707,9 +2707,8 @@ def BFIImm32 : PatFrag<
   }]
 >;
 
-
 // Definition from ISA doc:
-// (y & x) | (z & ~x)
+// 32-bit: (y & x) | (z & ~x)
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<or> (and i32:$y, i32:$x), (and i32:$z, (not i32:$x))),
   (V_BFI_B32_e64 (COPY_TO_REGCLASS VSrc_b32:$x, VGPR_32),
@@ -2717,90 +2716,26 @@ def : AMDGPUPatIgnoreCopies <
                 (COPY_TO_REGCLASS VSrc_b32:$z, VGPR_32))
 >;
 
-// (y & C) | (z & ~C)
+// 32-bit: (y & C) | (z & ~C)
 def : AMDGPUPatIgnoreCopies <
   (BFIImm32 i32:$x, i32:$y, i32:$z),
   (V_BFI_B32_e64 VSrc_b32:$x, VSrc_b32:$y, VSrc_b32:$z)
 >;
 
-// 64-bit version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<or> (and i64:$y, i64:$x), (and i64:$z, (not i64:$x))),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
->;
-
-// v2i32 version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<or> (and v2i32:$y, v2i32:$x), (and v2i32:$z, (vnot v2i32:$x))),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
->;
-
-// (z & ~x)
+// 32-bit: (z & ~x)
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<and> i32:$z, (not_oneuse i32:$x)),
   (V_BFI_B32_e64 VSrc_b32:$x, (i32 0), VSrc_b32:$z)
 >;
 
-// 64-bit version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<and> i64:$z, (not_oneuse i64:$x)),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)), (i32 0),
-                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)), (i32 0),
-                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
->;
-
-// v2i32 version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<and> v2i32:$z, (vnot_oneuse v2i32:$x)),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)), (i32 0),
-                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)), (i32 0),
-                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
->;
-
-// (y | ~x)
+// 32-bit: (y | ~x)
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<or> i32:$y, (not_oneuse i32:$x)),
   (V_BFI_B32_e64 VSrc_b32:$x, VSrc_b32:$y, (i32 -1))
 >;
 
-// 64-bit version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<or> i64:$y, (not_oneuse i64:$x)),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
-                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)), (i32 -1)), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
-                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)), (i32 -1)), sub1)
->;
-
-// v2i32 version
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<or> v2i32:$y, (vnot_oneuse v2i32:$x)),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
-                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)), (i32 -1)), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
-                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)), (i32 -1)), sub1)
->;
-
 // SHA-256 Ch function
-// z ^ (x & (y ^ z))
+// 32-bit: z ^ (x & (y ^ z))
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<xor> i32:$z, (and i32:$x, (xor i32:$y, i32:$z))),
   (V_BFI_B32_e64 (COPY_TO_REGCLASS VSrc_b32:$x, VGPR_32),
@@ -2808,18 +2743,57 @@ def : AMDGPUPatIgnoreCopies <
                 (COPY_TO_REGCLASS VSrc_b32:$z, VGPR_32))
 >;
 
-foreach vt = [i64, v2i32] in {
-def : AMDGPUPatIgnoreCopies <
-  (DivergentBinFrag<xor> vt:$z, (and vt:$x, (xor vt:$y, vt:$z))),
-  (REG_SEQUENCE VReg_64,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
-    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
-              (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
->;
+multiclass BFI64_Pattern <ValueType vt, PatFrag not_frag, PatFrag not_oneuse_frag> {
+  // (y & x) | (z & ~x)
+  def : AMDGPUPatIgnoreCopies <
+    (DivergentBinFrag<or> (and vt:$y, vt:$x), (and vt:$z, (not_frag vt:$x))),
+    (REG_SEQUENCE VReg_64,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
+                (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
+                (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
+                (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
+                (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
+  >;
+
+  // (z & ~x)
+  def : AMDGPUPatIgnoreCopies <
+    (DivergentBinFrag<and> vt:$z, (not_oneuse_frag vt:$x)),
+    (REG_SEQUENCE VReg_64,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)), (i32 0),
+                     (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)), (i32 0),
+                     (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
+  >;
+
+  // (y | ~x)
+  def : AMDGPUPatIgnoreCopies <
+    (DivergentBinFrag<or> vt:$y, (not_oneuse_frag vt:$x)),
+    (REG_SEQUENCE VReg_64,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
+                     (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)), (i32 -1)), sub0,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
+                     (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)), (i32 -1)), sub1)
+  >;
+
+  // SHA-256 Ch function
+  // z ^ (x & (y ^ z))
+  def : AMDGPUPatIgnoreCopies <
+    (DivergentBinFrag<xor> vt:$z, (and vt:$x, (xor vt:$y, vt:$z))),
+    (REG_SEQUENCE VReg_64,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
+                (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
+                (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
+      (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
+                (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
+                (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
+  >;
 }
+
+// 64-bit version
+defm : BFI64_Pattern<i64, not, not_oneuse>;
+// v2i32 version
+defm : BFI64_Pattern<v2i32, vnot, vnot_oneuse>;
 
 def : AMDGPUPat <
   (fcopysign f32:$src0, f32:$src1),

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -2743,7 +2743,11 @@ def : AMDGPUPatIgnoreCopies <
                 (COPY_TO_REGCLASS VSrc_b32:$z, VGPR_32))
 >;
 
-multiclass BFI64_Pattern <ValueType vt, PatFrag not_frag, PatFrag not_oneuse_frag> {
+// 64-bit versions (i64 and v2i32)
+foreach vt = [i64, v2i32] in {
+  defvar not_frag = !if(!eq(vt, i64), not, vnot);
+  defvar not_oneuse_frag = !if(!eq(vt, i64), not_oneuse, vnot_oneuse);
+
   // (y & x) | (z & ~x)
   def : AMDGPUPatIgnoreCopies <
     (DivergentBinFrag<or> (and vt:$y, vt:$x), (and vt:$z, (not_frag vt:$x))),
@@ -2789,11 +2793,6 @@ multiclass BFI64_Pattern <ValueType vt, PatFrag not_frag, PatFrag not_oneuse_fra
                 (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
   >;
 }
-
-// 64-bit version
-defm : BFI64_Pattern<i64, not, not_oneuse>;
-// v2i32 version
-defm : BFI64_Pattern<v2i32, vnot, vnot_oneuse>;
 
 def : AMDGPUPat <
   (fcopysign f32:$src0, f32:$src1),

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -2735,6 +2735,18 @@ def : AMDGPUPatIgnoreCopies <
               (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
 >;
 
+// v2i32 version
+def : AMDGPUPatIgnoreCopies <
+  (DivergentBinFrag<or> (and v2i32:$y, v2i32:$x), (and v2i32:$z, (vnot v2i32:$x))),
+  (REG_SEQUENCE VReg_64,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
+              (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)),
+              (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
+              (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)),
+              (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
+>;
+
 // (z & ~x)
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<and> i32:$z, (not_oneuse i32:$x)),
@@ -2751,6 +2763,16 @@ def : AMDGPUPatIgnoreCopies <
                    (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
 >;
 
+// v2i32 version
+def : AMDGPUPatIgnoreCopies <
+  (DivergentBinFrag<and> v2i32:$z, (vnot_oneuse v2i32:$x)),
+  (REG_SEQUENCE VReg_64,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)), (i32 0),
+                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub0))), sub0,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)), (i32 0),
+                   (i32 (EXTRACT_SUBREG VReg_64:$z, sub1))), sub1)
+>;
+
 // (y | ~x)
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<or> i32:$y, (not_oneuse i32:$x)),
@@ -2760,6 +2782,16 @@ def : AMDGPUPatIgnoreCopies <
 // 64-bit version
 def : AMDGPUPatIgnoreCopies <
   (DivergentBinFrag<or> i64:$y, (not_oneuse i64:$x)),
+  (REG_SEQUENCE VReg_64,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
+                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)), (i32 -1)), sub0,
+    (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub1)),
+                   (i32 (EXTRACT_SUBREG VReg_64:$y, sub1)), (i32 -1)), sub1)
+>;
+
+// v2i32 version
+def : AMDGPUPatIgnoreCopies <
+  (DivergentBinFrag<or> v2i32:$y, (vnot_oneuse v2i32:$x)),
   (REG_SEQUENCE VReg_64,
     (V_BFI_B32_e64 (i32 (EXTRACT_SUBREG VReg_64:$x, sub0)),
                    (i32 (EXTRACT_SUBREG VReg_64:$y, sub0)), (i32 -1)), sub0,

--- a/llvm/test/CodeGen/AMDGPU/andorn2.ll
+++ b/llvm/test/CodeGen/AMDGPU/andorn2.ll
@@ -522,5 +522,37 @@ entry:
   ret void
 }
 
+; GCN-LABEL: {{^}}vector_bfi_v2i32
+; GCN: v_bfi_b32
+; GCN: v_bfi_b32
+define <2 x i32> @vector_bfi_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i32> %z) {
+entry:
+  %ny = and <2 x i32> %y, %x
+  %nx = xor <2 x i32> %x, <i32 -1, i32 -1>
+  %nz = and <2 x i32> %z, %nx
+  %r = or <2 x i32> %ny, %nz
+  ret <2 x i32> %r
+}
+
+; GCN-LABEL: {{^}}vector_andn2_v2i32_one_use
+; GCN: v_bfi_b32
+; GCN: v_bfi_b32
+define <2 x i32> @vector_andn2_v2i32_one_use(<2 x i32> %v, <2 x i32> %s) {
+entry:
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r = and <2 x i32> %s, %not
+  ret <2 x i32> %r
+}
+
+; GCN-LABEL: {{^}}vector_orn2_v2i32_one_use
+; GCN: v_bfi_b32
+; GCN: v_bfi_b32
+define <2 x i32> @vector_orn2_v2i32_one_use(<2 x i32> %v, <2 x i32> %s) {
+entry:
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r = or <2 x i32> %s, %not
+  ret <2 x i32> %r
+}
+
 ; Function Attrs: nounwind readnone
 declare i32 @llvm.amdgcn.workitem.id.x() #0

--- a/llvm/test/CodeGen/AMDGPU/andorn2.ll
+++ b/llvm/test/CodeGen/AMDGPU/andorn2.ll
@@ -522,10 +522,45 @@ entry:
   ret void
 }
 
-; GCN-LABEL: {{^}}vector_bfi_v2i32
-; GCN: v_bfi_b32
-; GCN: v_bfi_b32
 define <2 x i32> @vector_bfi_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i32> %z) {
+; GFX6-LABEL: vector_bfi_v2i32:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v1, v1, v3, v5
+; GFX6-NEXT:    v_bfi_b32 v0, v0, v2, v4
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_bfi_v2i32:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v1, v1, v3, v5
+; GFX7-NEXT:    v_bfi_b32 v0, v0, v2, v4
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_bfi_v2i32:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v1, v1, v3, v5
+; GFX8-NEXT:    v_bfi_b32 v0, v0, v2, v4
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_bfi_v2i32:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, v1, v3, v5
+; GFX9-NEXT:    v_bfi_b32 v0, v0, v2, v4
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_bfi_v2i32:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, v2, v4
+; GFX12-NEXT:    v_bfi_b32 v1, v1, v3, v5
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %ny = and <2 x i32> %y, %x
   %nx = xor <2 x i32> %x, <i32 -1, i32 -1>
@@ -534,23 +569,461 @@ entry:
   ret <2 x i32> %r
 }
 
-; GCN-LABEL: {{^}}vector_andn2_v2i32_one_use
-; GCN: v_bfi_b32
-; GCN: v_bfi_b32
 define <2 x i32> @vector_andn2_v2i32_one_use(<2 x i32> %v, <2 x i32> %s) {
+; GFX6-LABEL: vector_andn2_v2i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v1, v1, 0, v3
+; GFX6-NEXT:    v_bfi_b32 v0, v0, 0, v2
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_andn2_v2i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v1, v1, 0, v3
+; GFX7-NEXT:    v_bfi_b32 v0, v0, 0, v2
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_andn2_v2i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v1, v1, 0, v3
+; GFX8-NEXT:    v_bfi_b32 v0, v0, 0, v2
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_andn2_v2i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, v1, 0, v3
+; GFX9-NEXT:    v_bfi_b32 v0, v0, 0, v2
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_andn2_v2i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, 0, v2
+; GFX12-NEXT:    v_bfi_b32 v1, v1, 0, v3
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %not = xor <2 x i32> %v, <i32 -1, i32 -1>
   %r = and <2 x i32> %s, %not
   ret <2 x i32> %r
 }
 
-; GCN-LABEL: {{^}}vector_orn2_v2i32_one_use
-; GCN: v_bfi_b32
-; GCN: v_bfi_b32
+define <3 x i32> @vector_andn2_v3i32_one_use(<3 x i32> %v, <3 x i32> %s) {
+; GFX6-LABEL: vector_andn2_v3i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v0, v0, 0, v3
+; GFX6-NEXT:    v_bfi_b32 v1, v1, 0, v4
+; GFX6-NEXT:    v_bfi_b32 v2, v2, 0, v5
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_andn2_v3i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v0, v0, 0, v3
+; GFX7-NEXT:    v_bfi_b32 v1, v1, 0, v4
+; GFX7-NEXT:    v_bfi_b32 v2, v2, 0, v5
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_andn2_v3i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v0, v0, 0, v3
+; GFX8-NEXT:    v_bfi_b32 v1, v1, 0, v4
+; GFX8-NEXT:    v_bfi_b32 v2, v2, 0, v5
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_andn2_v3i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v0, v0, 0, v3
+; GFX9-NEXT:    v_bfi_b32 v1, v1, 0, v4
+; GFX9-NEXT:    v_bfi_b32 v2, v2, 0, v5
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_andn2_v3i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, 0, v3
+; GFX12-NEXT:    v_bfi_b32 v1, v1, 0, v4
+; GFX12-NEXT:    v_bfi_b32 v2, v2, 0, v5
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <3 x i32> %v, <i32 -1, i32 -1, i32 -1>
+  %r = and <3 x i32> %s, %not
+  ret <3 x i32> %r
+}
+
+define <4 x i32> @vector_andn2_v4i32_one_use(<4 x i32> %v, <4 x i32> %s) {
+; GFX6-LABEL: vector_andn2_v4i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v0, v0, 0, v4
+; GFX6-NEXT:    v_bfi_b32 v1, v1, 0, v5
+; GFX6-NEXT:    v_bfi_b32 v2, v2, 0, v6
+; GFX6-NEXT:    v_bfi_b32 v3, v3, 0, v7
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_andn2_v4i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v0, v0, 0, v4
+; GFX7-NEXT:    v_bfi_b32 v1, v1, 0, v5
+; GFX7-NEXT:    v_bfi_b32 v2, v2, 0, v6
+; GFX7-NEXT:    v_bfi_b32 v3, v3, 0, v7
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_andn2_v4i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v0, v0, 0, v4
+; GFX8-NEXT:    v_bfi_b32 v1, v1, 0, v5
+; GFX8-NEXT:    v_bfi_b32 v2, v2, 0, v6
+; GFX8-NEXT:    v_bfi_b32 v3, v3, 0, v7
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_andn2_v4i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v0, v0, 0, v4
+; GFX9-NEXT:    v_bfi_b32 v1, v1, 0, v5
+; GFX9-NEXT:    v_bfi_b32 v2, v2, 0, v6
+; GFX9-NEXT:    v_bfi_b32 v3, v3, 0, v7
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_andn2_v4i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, 0, v4
+; GFX12-NEXT:    v_bfi_b32 v1, v1, 0, v5
+; GFX12-NEXT:    v_bfi_b32 v2, v2, 0, v6
+; GFX12-NEXT:    v_bfi_b32 v3, v3, 0, v7
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <4 x i32> %v, <i32 -1, i32 -1, i32 -1, i32 -1>
+  %r = and <4 x i32> %s, %not
+  ret <4 x i32> %r
+}
+
+define <2 x i32> @vector_andn2_v2i32_multi_use(<2 x i32> %v, <2 x i32> %s1, <2 x i32> %s2) {
+; GFX6-LABEL: vector_andn2_v2i32_multi_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX6-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX6-NEXT:    v_and_b32_e32 v3, v3, v1
+; GFX6-NEXT:    v_and_b32_e32 v2, v2, v0
+; GFX6-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX6-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX6-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX6-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_andn2_v2i32_multi_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX7-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX7-NEXT:    v_and_b32_e32 v3, v3, v1
+; GFX7-NEXT:    v_and_b32_e32 v2, v2, v0
+; GFX7-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX7-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX7-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX7-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_andn2_v2i32_multi_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX8-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX8-NEXT:    v_and_b32_e32 v3, v3, v1
+; GFX8-NEXT:    v_and_b32_e32 v2, v2, v0
+; GFX8-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX8-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX8-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX8-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_andn2_v2i32_multi_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX9-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX9-NEXT:    v_and_b32_e32 v3, v3, v1
+; GFX9-NEXT:    v_and_b32_e32 v2, v2, v0
+; GFX9-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX9-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX9-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX9-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_andn2_v2i32_multi_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX12-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_and_b32_e32 v3, v3, v1
+; GFX12-NEXT:    v_and_b32_e32 v2, v2, v0
+; GFX12-NEXT:    v_or_b32_e32 v0, v4, v0
+; GFX12-NEXT:    v_or_b32_e32 v1, v5, v1
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX12-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r1 = and <2 x i32> %s1, %not
+  %r2 = or  <2 x i32> %s2, %not
+  %r = xor <2 x i32> %r1, %r2
+  ret <2 x i32> %r
+}
+
 define <2 x i32> @vector_orn2_v2i32_one_use(<2 x i32> %v, <2 x i32> %s) {
+; GFX6-LABEL: vector_orn2_v2i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v1, v1, v3, -1
+; GFX6-NEXT:    v_bfi_b32 v0, v0, v2, -1
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_orn2_v2i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v1, v1, v3, -1
+; GFX7-NEXT:    v_bfi_b32 v0, v0, v2, -1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_orn2_v2i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v1, v1, v3, -1
+; GFX8-NEXT:    v_bfi_b32 v0, v0, v2, -1
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_orn2_v2i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, v1, v3, -1
+; GFX9-NEXT:    v_bfi_b32 v0, v0, v2, -1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_orn2_v2i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, v2, -1
+; GFX12-NEXT:    v_bfi_b32 v1, v1, v3, -1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %not = xor <2 x i32> %v, <i32 -1, i32 -1>
   %r = or <2 x i32> %s, %not
+  ret <2 x i32> %r
+}
+
+define <3 x i32> @vector_orn2_v3i32_one_use(<3 x i32> %v, <3 x i32> %s) {
+; GFX6-LABEL: vector_orn2_v3i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v0, v0, v3, -1
+; GFX6-NEXT:    v_bfi_b32 v1, v1, v4, -1
+; GFX6-NEXT:    v_bfi_b32 v2, v2, v5, -1
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_orn2_v3i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v0, v0, v3, -1
+; GFX7-NEXT:    v_bfi_b32 v1, v1, v4, -1
+; GFX7-NEXT:    v_bfi_b32 v2, v2, v5, -1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_orn2_v3i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v0, v0, v3, -1
+; GFX8-NEXT:    v_bfi_b32 v1, v1, v4, -1
+; GFX8-NEXT:    v_bfi_b32 v2, v2, v5, -1
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_orn2_v3i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v0, v0, v3, -1
+; GFX9-NEXT:    v_bfi_b32 v1, v1, v4, -1
+; GFX9-NEXT:    v_bfi_b32 v2, v2, v5, -1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_orn2_v3i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, v3, -1
+; GFX12-NEXT:    v_bfi_b32 v1, v1, v4, -1
+; GFX12-NEXT:    v_bfi_b32 v2, v2, v5, -1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <3 x i32> %v, <i32 -1, i32 -1, i32 -1>
+  %r = or <3 x i32> %s, %not
+  ret <3 x i32> %r
+}
+
+define <4 x i32> @vector_orn2_v4i32_one_use(<4 x i32> %v, <4 x i32> %s) {
+; GFX6-LABEL: vector_orn2_v4i32_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_bfi_b32 v0, v0, v4, -1
+; GFX6-NEXT:    v_bfi_b32 v1, v1, v5, -1
+; GFX6-NEXT:    v_bfi_b32 v2, v2, v6, -1
+; GFX6-NEXT:    v_bfi_b32 v3, v3, v7, -1
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_orn2_v4i32_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfi_b32 v0, v0, v4, -1
+; GFX7-NEXT:    v_bfi_b32 v1, v1, v5, -1
+; GFX7-NEXT:    v_bfi_b32 v2, v2, v6, -1
+; GFX7-NEXT:    v_bfi_b32 v3, v3, v7, -1
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_orn2_v4i32_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_bfi_b32 v0, v0, v4, -1
+; GFX8-NEXT:    v_bfi_b32 v1, v1, v5, -1
+; GFX8-NEXT:    v_bfi_b32 v2, v2, v6, -1
+; GFX8-NEXT:    v_bfi_b32 v3, v3, v7, -1
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_orn2_v4i32_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v0, v0, v4, -1
+; GFX9-NEXT:    v_bfi_b32 v1, v1, v5, -1
+; GFX9-NEXT:    v_bfi_b32 v2, v2, v6, -1
+; GFX9-NEXT:    v_bfi_b32 v3, v3, v7, -1
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_orn2_v4i32_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_bfi_b32 v0, v0, v4, -1
+; GFX12-NEXT:    v_bfi_b32 v1, v1, v5, -1
+; GFX12-NEXT:    v_bfi_b32 v2, v2, v6, -1
+; GFX12-NEXT:    v_bfi_b32 v3, v3, v7, -1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <4 x i32> %v, <i32 -1, i32 -1, i32 -1, i32 -1>
+  %r = or <4 x i32> %s, %not
+  ret <4 x i32> %r
+}
+
+define <2 x i32> @vector_orn2_v2i32_multi_use(<2 x i32> %v, <2 x i32> %s1, <2 x i32> %s2) {
+; GFX6-LABEL: vector_orn2_v2i32_multi_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX6-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX6-NEXT:    v_or_b32_e32 v3, v3, v1
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX6-NEXT:    v_and_b32_e32 v1, v5, v1
+; GFX6-NEXT:    v_and_b32_e32 v0, v4, v0
+; GFX6-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX6-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX6-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-LABEL: vector_orn2_v2i32_multi_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX7-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v1
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX7-NEXT:    v_and_b32_e32 v1, v5, v1
+; GFX7-NEXT:    v_and_b32_e32 v0, v4, v0
+; GFX7-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX7-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-LABEL: vector_orn2_v2i32_multi_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX8-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX8-NEXT:    v_or_b32_e32 v3, v3, v1
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX8-NEXT:    v_and_b32_e32 v1, v5, v1
+; GFX8-NEXT:    v_and_b32_e32 v0, v4, v0
+; GFX8-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX8-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX8-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-LABEL: vector_orn2_v2i32_multi_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX9-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX9-NEXT:    v_or_b32_e32 v3, v3, v1
+; GFX9-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX9-NEXT:    v_and_b32_e32 v1, v5, v1
+; GFX9-NEXT:    v_and_b32_e32 v0, v4, v0
+; GFX9-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX9-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-LABEL: vector_orn2_v2i32_multi_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_xor_b32_e32 v1, -1, v1
+; GFX12-NEXT:    v_xor_b32_e32 v0, -1, v0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_or_b32_e32 v3, v3, v1
+; GFX12-NEXT:    v_or_b32_e32 v2, v2, v0
+; GFX12-NEXT:    v_and_b32_e32 v0, v4, v0
+; GFX12-NEXT:    v_and_b32_e32 v1, v5, v1
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_xor_b32_e32 v0, v2, v0
+; GFX12-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r1 = or  <2 x i32> %s1, %not
+  %r2 = and <2 x i32> %s2, %not
+  %r = xor <2 x i32> %r1, %r2
   ret <2 x i32> %r
 }
 

--- a/llvm/test/CodeGen/AMDGPU/andorn2.ll
+++ b/llvm/test/CodeGen/AMDGPU/andorn2.ll
@@ -798,6 +798,214 @@ entry:
   ret <2 x i32> %r
 }
 
+define amdgpu_kernel void @vector_andn2_v2i32_s_v_one_use(ptr addrspace(1) %r0, <2 x i32> %s) {
+; GFX6-LABEL: vector_andn2_v2i32_s_v_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX6-NEXT:    s_mov_b32 s3, 0xf000
+; GFX6-NEXT:    s_mov_b32 s2, -1
+; GFX6-NEXT:    v_bfi_b32 v1, v1, 0, s5
+; GFX6-NEXT:    v_bfi_b32 v0, v0, 0, s4
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_andn2_v2i32_s_v_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX7-NEXT:    s_mov_b32 s3, 0xf000
+; GFX7-NEXT:    s_mov_b32 s2, -1
+; GFX7-NEXT:    v_bfi_b32 v1, v1, 0, s5
+; GFX7-NEXT:    v_bfi_b32 v0, v0, 0, s4
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_andn2_v2i32_s_v_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_bfi_b32 v1, v1, 0, s3
+; GFX8-NEXT:    v_bfi_b32 v0, v0, 0, s2
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_andn2_v2i32_s_v_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, v1, 0, s3
+; GFX9-NEXT:    v_bfi_b32 v0, v0, 0, s2
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_andn2_v2i32_s_v_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-NEXT:    v_bfe_u32 v1, v0, 10, 10
+; GFX12-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_bfi_b32 v1, v1, 0, s3
+; GFX12-NEXT:    v_bfi_b32 v0, v0, 0, s2
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %tidx = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidy = call i32 @llvm.amdgcn.workitem.id.y()
+  %v0 = insertelement <2 x i32> poison, i32 %tidx, i64 0
+  %v = insertelement <2 x i32> %v0, i32 %tidy, i64 1
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r = and <2 x i32> %s, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
+}
+
+define amdgpu_kernel void @vector_andn2_v2i32_v_s_one_use(ptr addrspace(1) %r0, <2 x i32> %s) {
+; GFX6-LABEL: vector_andn2_v2i32_v_s_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX6-NEXT:    s_mov_b32 s3, 0xf000
+; GFX6-NEXT:    s_mov_b32 s2, -1
+; GFX6-NEXT:    v_bfi_b32 v1, s5, 0, v1
+; GFX6-NEXT:    v_bfi_b32 v0, s4, 0, v0
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_andn2_v2i32_v_s_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX7-NEXT:    s_mov_b32 s3, 0xf000
+; GFX7-NEXT:    s_mov_b32 s2, -1
+; GFX7-NEXT:    v_bfi_b32 v1, s5, 0, v1
+; GFX7-NEXT:    v_bfi_b32 v0, s4, 0, v0
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_andn2_v2i32_v_s_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_bfi_b32 v1, s3, 0, v1
+; GFX8-NEXT:    v_bfi_b32 v0, s2, 0, v0
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_andn2_v2i32_v_s_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, s3, 0, v1
+; GFX9-NEXT:    v_bfi_b32 v0, s2, 0, v0
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_andn2_v2i32_v_s_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-NEXT:    v_bfe_u32 v1, v0, 10, 10
+; GFX12-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_bfi_b32 v1, s3, 0, v1
+; GFX12-NEXT:    v_bfi_b32 v0, s2, 0, v0
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %tidx = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidy = call i32 @llvm.amdgcn.workitem.id.y()
+  %v0 = insertelement <2 x i32> poison, i32 %tidx, i64 0
+  %v = insertelement <2 x i32> %v0, i32 %tidy, i64 1
+  %not = xor <2 x i32> %s, <i32 -1, i32 -1>
+  %r = and <2 x i32> %v, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
+}
+
+define amdgpu_kernel void @vector_andn2_v2i32_s_s_one_use(ptr addrspace(1) %r0, <2 x i32> %s1, <2 x i32> %s2) {
+; GFX6-LABEL: vector_andn2_v2i32_s_s_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0xb
+; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; GFX6-NEXT:    s_mov_b32 s7, 0xf000
+; GFX6-NEXT:    s_mov_b32 s6, -1
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX6-NEXT:    v_mov_b32_e32 v0, s0
+; GFX6-NEXT:    v_mov_b32_e32 v1, s1
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_andn2_v2i32_s_s_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0xb
+; GFX7-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; GFX7-NEXT:    s_mov_b32 s7, 0xf000
+; GFX7-NEXT:    s_mov_b32 s6, -1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX7-NEXT:    v_mov_b32_e32 v0, s0
+; GFX7-NEXT:    v_mov_b32_e32 v1, s1
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_andn2_v2i32_s_s_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x2c
+; GFX8-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX8-NEXT:    v_mov_b32_e32 v0, s6
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_mov_b32_e32 v1, s7
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_andn2_v2i32_s_s_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x2c
+; GFX9-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v0, s0
+; GFX9-NEXT:    v_mov_b32_e32 v1, s1
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[6:7]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_andn2_v2i32_s_s_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_clause 0x1
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x2c
+; GFX12-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_and_not1_b64 s[0:1], s[0:1], s[2:3]
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[4:5]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %not = xor <2 x i32> %s2, <i32 -1, i32 -1>
+  %r = and <2 x i32> %s1, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
+}
+
 define <2 x i32> @vector_orn2_v2i32_one_use(<2 x i32> %v, <2 x i32> %s) {
 ; GFX6-LABEL: vector_orn2_v2i32_one_use:
 ; GFX6:       ; %bb.0: ; %entry
@@ -1025,6 +1233,214 @@ entry:
   %r2 = and <2 x i32> %s2, %not
   %r = xor <2 x i32> %r1, %r2
   ret <2 x i32> %r
+}
+
+define amdgpu_kernel void @vector_orn2_v2i32_s_v_one_use(ptr addrspace(1) %r0, <2 x i32> %s) {
+; GFX6-LABEL: vector_orn2_v2i32_s_v_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX6-NEXT:    s_mov_b32 s3, 0xf000
+; GFX6-NEXT:    s_mov_b32 s2, -1
+; GFX6-NEXT:    v_bfi_b32 v1, v1, s5, -1
+; GFX6-NEXT:    v_bfi_b32 v0, v0, s4, -1
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_orn2_v2i32_s_v_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX7-NEXT:    s_mov_b32 s3, 0xf000
+; GFX7-NEXT:    s_mov_b32 s2, -1
+; GFX7-NEXT:    v_bfi_b32 v1, v1, s5, -1
+; GFX7-NEXT:    v_bfi_b32 v0, v0, s4, -1
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_orn2_v2i32_s_v_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_bfi_b32 v1, v1, s3, -1
+; GFX8-NEXT:    v_bfi_b32 v0, v0, s2, -1
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_orn2_v2i32_s_v_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, v1, s3, -1
+; GFX9-NEXT:    v_bfi_b32 v0, v0, s2, -1
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_orn2_v2i32_s_v_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-NEXT:    v_bfe_u32 v1, v0, 10, 10
+; GFX12-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_bfi_b32 v1, v1, s3, -1
+; GFX12-NEXT:    v_bfi_b32 v0, v0, s2, -1
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %tidx = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidy = call i32 @llvm.amdgcn.workitem.id.y()
+  %v0 = insertelement <2 x i32> poison, i32 %tidx, i64 0
+  %v = insertelement <2 x i32> %v0, i32 %tidy, i64 1
+  %not = xor <2 x i32> %v, <i32 -1, i32 -1>
+  %r = or <2 x i32> %s, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
+}
+
+define amdgpu_kernel void @vector_orn2_v2i32_v_s_one_use(ptr addrspace(1) %r0, <2 x i32> %s) {
+; GFX6-LABEL: vector_orn2_v2i32_v_s_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX6-NEXT:    s_mov_b32 s3, 0xf000
+; GFX6-NEXT:    s_mov_b32 s2, -1
+; GFX6-NEXT:    v_bfi_b32 v1, s5, v1, -1
+; GFX6-NEXT:    v_bfi_b32 v0, s4, v0, -1
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_orn2_v2i32_v_s_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GFX7-NEXT:    s_mov_b32 s3, 0xf000
+; GFX7-NEXT:    s_mov_b32 s2, -1
+; GFX7-NEXT:    v_bfi_b32 v1, s5, v1, -1
+; GFX7-NEXT:    v_bfi_b32 v0, s4, v0, -1
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_orn2_v2i32_v_s_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_bfi_b32 v1, s3, v1, -1
+; GFX8-NEXT:    v_bfi_b32 v0, s2, v0, -1
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_orn2_v2i32_v_s_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    v_bfi_b32 v1, s3, v1, -1
+; GFX9-NEXT:    v_bfi_b32 v0, s2, v0, -1
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_orn2_v2i32_v_s_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
+; GFX12-NEXT:    v_bfe_u32 v1, v0, 10, 10
+; GFX12-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX12-NEXT:    v_bfi_b32 v1, s3, v1, -1
+; GFX12-NEXT:    v_bfi_b32 v0, s2, v0, -1
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %tidx = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidy = call i32 @llvm.amdgcn.workitem.id.y()
+  %v0 = insertelement <2 x i32> poison, i32 %tidx, i64 0
+  %v = insertelement <2 x i32> %v0, i32 %tidy, i64 1
+  %not = xor <2 x i32> %s, <i32 -1, i32 -1>
+  %r = or <2 x i32> %v, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
+}
+
+define amdgpu_kernel void @vector_orn2_v2i32_s_s_one_use(ptr addrspace(1) %r0, <2 x i32> %s1, <2 x i32> %s2) {
+; GFX6-LABEL: vector_orn2_v2i32_s_s_one_use:
+; GFX6:       ; %bb.0: ; %entry
+; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0xb
+; GFX6-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; GFX6-NEXT:    s_mov_b32 s7, 0xf000
+; GFX6-NEXT:    s_mov_b32 s6, -1
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    s_orn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX6-NEXT:    v_mov_b32_e32 v0, s0
+; GFX6-NEXT:    v_mov_b32_e32 v1, s1
+; GFX6-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GFX6-NEXT:    s_endpgm
+;
+; GFX7-LABEL: vector_orn2_v2i32_s_s_one_use:
+; GFX7:       ; %bb.0: ; %entry
+; GFX7-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0xb
+; GFX7-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; GFX7-NEXT:    s_mov_b32 s7, 0xf000
+; GFX7-NEXT:    s_mov_b32 s6, -1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_orn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX7-NEXT:    v_mov_b32_e32 v0, s0
+; GFX7-NEXT:    v_mov_b32_e32 v1, s1
+; GFX7-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GFX7-NEXT:    s_endpgm
+;
+; GFX8-LABEL: vector_orn2_v2i32_s_s_one_use:
+; GFX8:       ; %bb.0: ; %entry
+; GFX8-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x2c
+; GFX8-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8-NEXT:    s_orn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX8-NEXT:    v_mov_b32_e32 v0, s6
+; GFX8-NEXT:    v_mov_b32_e32 v3, s1
+; GFX8-NEXT:    v_mov_b32_e32 v1, s7
+; GFX8-NEXT:    v_mov_b32_e32 v2, s0
+; GFX8-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GFX8-NEXT:    s_endpgm
+;
+; GFX9-LABEL: vector_orn2_v2i32_s_s_one_use:
+; GFX9:       ; %bb.0: ; %entry
+; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x2c
+; GFX9-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    s_orn2_b64 s[0:1], s[0:1], s[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v0, s0
+; GFX9-NEXT:    v_mov_b32_e32 v1, s1
+; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[6:7]
+; GFX9-NEXT:    s_endpgm
+;
+; GFX12-LABEL: vector_orn2_v2i32_s_s_one_use:
+; GFX12:       ; %bb.0: ; %entry
+; GFX12-NEXT:    s_clause 0x1
+; GFX12-NEXT:    s_load_b128 s[0:3], s[4:5], 0x2c
+; GFX12-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_or_not1_b64 s[0:1], s[0:1], s[2:3]
+; GFX12-NEXT:    v_mov_b32_e32 v2, 0
+; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-NEXT:    global_store_b64 v2, v[0:1], s[4:5]
+; GFX12-NEXT:    s_endpgm
+entry:
+  %not = xor <2 x i32> %s2, <i32 -1, i32 -1>
+  %r = or <2 x i32> %s1, %not
+  store <2 x i32> %r, ptr addrspace(1) %r0
+  ret void
 }
 
 ; Function Attrs: nounwind readnone


### PR DESCRIPTION
Add vector v2i32 pattern matches that lower to two lane wise V_BFI_B32 operations.

TODO: Support v2i16, v4i16 pattern.