### PR TITLE
[Instrumentor] Use RequiredPassInfoMixin

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -678,7 +678,7 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
 } // namespace instrumentor
 
 /// The Instrumentor pass.
-class InstrumentorPass : public OptionalPassInfoMixin<InstrumentorPass> {
+class InstrumentorPass : public RequiredPassInfoMixin<InstrumentorPass> {
   using InstrumentationConfig = instrumentor::InstrumentationConfig;
   using InstrumentorIRBuilderTy = instrumentor::InstrumentorIRBuilderTy;
 

--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -678,7 +678,7 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
 } // namespace instrumentor
 
 /// The Instrumentor pass.
-class InstrumentorPass : public PassInfoMixin<InstrumentorPass> {
+class InstrumentorPass : public OptionalPassInfoMixin<InstrumentorPass> {
   using InstrumentationConfig = instrumentor::InstrumentationConfig;
   using InstrumentorIRBuilderTy = instrumentor::InstrumentorIRBuilderTy;
 


### PR DESCRIPTION
This preserves the existing behavior and makes the pass compliant with \#192120, which is important as inheriting from the normal PassInfoMixin will be going away soonish.