### PR TITLE
[lldb] Include `<cstring>` for `memset`

### DIFF
--- a/lldb/test/API/lang/cpp/char1632_t/main.cpp
+++ b/lldb/test/API/lang/cpp/char1632_t/main.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <cstring>
 #include <string>
 
 #define UASZ 64


### PR DESCRIPTION
Fixes the failure on `lldb-aarch64-ubuntu` (https://lab.llvm.org/buildbot/#/builders/59/builds/34161) after #195514.