### PR TITLE
[Object][Wasm] Fix off-by-one in data segment name index validation

### DIFF
--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -600,7 +600,7 @@ Error WasmObjectFile::parseNameSection(ReadContext &Ctx) {
           if (!SeenSegments.insert(Index).second)
             return make_error<GenericBinaryError>(
                 "segment named more than once", object_error::parse_failed);
-          if (Index > DataSegments.size())
+          if (static_cast<size_t>(Index) >= DataSegments.size())
             return make_error<GenericBinaryError>("invalid data segment name entry",
                                                   object_error::parse_failed);
           nameType = wasm::NameType::DATA_SEGMENT;

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -600,7 +600,7 @@ Error WasmObjectFile::parseNameSection(ReadContext &Ctx) {
           if (!SeenSegments.insert(Index).second)
             return make_error<GenericBinaryError>(
                 "segment named more than once", object_error::parse_failed);
-          if (static_cast<size_t>(Index) >= DataSegments.size())
+          if (Index >= DataSegments.size())
             return make_error<GenericBinaryError>("invalid data segment name entry",
                                                   object_error::parse_failed);
           nameType = wasm::NameType::DATA_SEGMENT;
@@ -833,7 +833,7 @@ Error WasmObjectFile::parseLinkingSectionSymtab(ReadContext &Ctx) {
         auto Offset = readVaruint64(Ctx);
         auto Size = readVaruint64(Ctx);
         if (!(Info.Flags & wasm::WASM_SYMBOL_ABSOLUTE)) {
-          if (static_cast<size_t>(Index) >= DataSegments.size())
+          if (Index >= DataSegments.size())
             return make_error<GenericBinaryError>(
                 "invalid data segment index: " + Twine(Index),
                 object_error::parse_failed);

--- a/llvm/test/tools/llvm-readobj/wasm/invalid-data-segment-name-index.test
+++ b/llvm/test/tools/llvm-readobj/wasm/invalid-data-segment-name-index.test
@@ -1,0 +1,25 @@
+# RUN: yaml2obj %s -o %t.wasm
+# RUN: not llvm-readobj --symbols %t.wasm 2>&1 | FileCheck %s
+
+# CHECK: error: '{{.*}}': invalid data segment name entry
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            MEMORY
+    Memories:
+      - Minimum:     0x1
+  - Type:            DATA
+    Segments:
+      - SectionOffset:   0
+        InitFlags:       0
+        Offset:
+          Opcode:        I32_CONST
+          Value:         0
+        Content:         ''
+  - Type:            CUSTOM
+    Name:            name
+    DataSegmentNames:
+      - Index:        1
+        Name:         invalid_data_segment_name


### PR DESCRIPTION
The check `Index > DataSegments.size()` in `parseNameSection()` allows
`Index == DataSegments.size()`, which is an out-of-bounds access.

In an assertions-disabled ASan build, a malformed wasm object with one
data segment and a data segment name entry using index 1 triggers a
heap-buffer-overflow READ in `WasmObjectFile::parseNameSection()`.

Fix by checking `Index >= DataSegments.size()` instead.

Also add a regression test that verifies the malformed input is rejected
with "invalid data segment name entry".