### PR TITLE
[libc][math] Fix -Wshadow warnings in cos.h

### DIFF
--- a/libc/src/__support/math/cos.h
+++ b/libc/src/__support/math/cos.h
@@ -32,7 +32,6 @@ namespace math {
 
 LIBC_INLINE constexpr double cos(double x) {
   using namespace range_reduction_double_internal;
-  using DoubleDouble = fputil::DoubleDouble;
   using FPBits = typename fputil::FPBits<double>;
   FPBits xbits(x);
 
@@ -122,7 +121,6 @@ LIBC_INLINE constexpr double cos(double x) {
 #ifdef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
   return rr.hi + rr.lo;
 #else
-  using Float128 = typename fputil::DyadicFloat<128>;
   double rlp = rr.lo + err;
   double rlm = rr.lo - err;
 


### PR DESCRIPTION
cos() does `using namespace range_reduction_double_internal;` and range_reduction_double_internal after 51e9430a0c767 contains

    using LIBC_NAMESPACE::fputil::DoubleDouble;
    using Float128 = LIBC_NAMESPACE::fputil::DyadicFloat<128>;

So the local using statements for DoubleDouble and Float128 shadowed these. Just remove the local using statements.

No behavior change.