### PR TITLE
[libc][math] Fix -Wshadow warnings in FMod.h

### DIFF
--- a/libc/src/__support/FPUtil/generic/FMod.h
+++ b/libc/src/__support/FPUtil/generic/FMod.h
@@ -171,7 +171,6 @@ private:
   using StorageType = typename FPB::StorageType;
 
   LIBC_INLINE static constexpr bool pre_check(T x, T y, T &out) {
-    using FPB = fputil::FPBits<T>;
     const T quiet_nan = FPB::quiet_nan().get_val();
     FPB sx(x), sy(y);
     if (LIBC_LIKELY(!sy.is_zero() && !sy.is_inf_or_nan() &&


### PR DESCRIPTION
The using statement inside the lambda is redundant with the same using 4 lines up.

No behavior change.