### PR TITLE
[Dexter][NFC] Add split step-data collection methods for DAP

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -18,7 +18,7 @@ import sys
 import threading
 import time
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
@@ -936,6 +936,70 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
             stop_reason=reason,
             program_state=ProgramState(state_frames),
         )
+
+    def get_stack_frames(self, step_index: int) -> StepIR:
+        """Returns a StepIR with stackframes and source locations (but no watched values)."""
+        assert (
+            not self._debugger_state.is_running
+        ), "Cannot get step info while debugger is running!"
+        trace_req_id = self.send_message(
+            self.make_request("stackTrace", {"threadId": self._debugger_state.thread})
+        )
+        trace_response = self._await_response(trace_req_id)
+        if not trace_response["success"]:
+            raise DebuggerException("failed to get stack frames")
+        stackframes = trace_response["body"]["stackFrames"]
+
+        frames = []
+
+        for stackframe in stackframes:
+            # No source, skip the frame! Currently I've only observed this for frames below main, so we break here; if
+            # it happens elsewhere, then this will break more stuff and we'll come up with a better solution.
+            if (
+                stackframe.get("source") is None
+                or stackframe["source"].get("path") is None
+            ):
+                break
+
+            loc_dict = {
+                "path": self._external_to_debug_path(stackframe["source"]["path"]),
+                "lineno": stackframe["line"],
+                "column": stackframe["column"],
+            }
+            loc = LocIR(**loc_dict)
+            frame = FrameIR(
+                function=self._sanitize_function_name(stackframe["name"]),
+                is_inlined=stackframe["name"].startswith("[Inline Frame]"),
+                loc=loc,
+                instruction_addr=stackframe.get("instructionPointerReference", None)
+            )
+
+            # We skip frames that are below "main", since we do not expect those to be user code.
+            fname = frame.function or ""  # pylint: disable=no-member
+            if any(name in fname for name in self.frames_below_main):
+                break
+
+            frames.append(frame)
+
+        if len(frames) == 1 and frames[0].function is None:
+            frames = []
+
+        reason = self._translate_stop_reason(self._debugger_state.stopped_reason)
+
+        return StepIR(
+            step_index=step_index,
+            frames=frames,
+            stop_reason=reason,
+        )
+
+    def collect_watches(self, step: StepIR, watches: List[str]):
+        """Evaluates the provided watches and stores their evaluation results (ValueIR) in the provided step."""
+        frame_idx = 0
+        if not watches:
+            return
+        active_exprs = set(watches)
+        for expr in active_exprs:
+            step.watches[expr] = self.evaluate_expression(expr, frame_idx)
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -971,7 +971,7 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
                 function=self._sanitize_function_name(stackframe["name"]),
                 is_inlined=stackframe["name"].startswith("[Inline Frame]"),
                 loc=loc,
-                instruction_addr=stackframe.get("instructionPointerReference", None)
+                instruction_addr=stackframe.get("instructionPointerReference", None),
             )
 
             # We skip frames that are below "main", since we do not expect those to be user code.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerBase.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerBase.py
@@ -10,6 +10,7 @@ import abc
 import os
 import sys
 import traceback
+from typing import List
 import unittest
 
 from types import SimpleNamespace
@@ -215,6 +216,14 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _get_step_info(self, watches, step_index):
+        pass
+
+    @abc.abstractmethod
+    def get_stack_frames(self, step_index: int) -> StepIR:
+        pass
+
+    @abc.abstractmethod
+    def collect_watches(self, step: StepIR, watches: List[str]):
         pass
 
     @abc.abstractproperty

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
@@ -8,6 +8,7 @@
 import sys
 import os
 import platform
+from typing import List
 
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
@@ -166,6 +167,12 @@ class DbgEng(DebuggerBase):
             stop_reason=StopReason.STEP,
             program_state=ProgramState(state_frames),
         )
+
+    def get_stack_frames(self, step_index: int) -> StepIR:
+        raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
+
+    def collect_watches(self, step: StepIR, watches: List[str]):
+        raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -11,6 +11,7 @@ import os
 import shlex
 from subprocess import CalledProcessError, check_output, STDOUT
 import sys
+from typing import List
 
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.debugger.DAP import DAP
@@ -317,6 +318,12 @@ class LLDB(DebuggerBase):
             stop_reason=reason,
             program_state=ProgramState(state_frames),
         )
+
+    def get_stack_frames(self, step_index: int) -> StepIR:
+        raise NotImplementedError("--use-script debugging not supported in lldb yet.")
+
+    def collect_watches(self, step: StepIR, watches: List[str]):
+        raise NotImplementedError("--use-script debugging not supported in lldb yet.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -12,6 +12,7 @@ import sys
 from enum import IntEnum
 from pathlib import PurePath, Path
 from collections import defaultdict, namedtuple
+from typing import List
 
 from dex.command.CommandBase import StepExpectInfo
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
@@ -391,6 +392,12 @@ class VisualStudio(
             stop_reason=stop_reason,
             program_state=program_state,
         )
+
+    def get_stack_frames(self, step_index: int) -> StepIR:
+        raise NotImplementedError("--use-script debugging not supported in visual studio yet.")
+
+    def collect_watches(self, step: StepIR, watches: List[str]):
+        raise NotImplementedError("--use-script debugging not supported in visual studio yet.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -394,10 +394,14 @@ class VisualStudio(
         )
 
     def get_stack_frames(self, step_index: int) -> StepIR:
-        raise NotImplementedError("--use-script debugging not supported in visual studio yet.")
+        raise NotImplementedError(
+            "--use-script debugging not supported in visual studio yet."
+        )
 
     def collect_watches(self, step: StepIR, watches: List[str]):
-        raise NotImplementedError("--use-script debugging not supported in visual studio yet.")
+        raise NotImplementedError(
+            "--use-script debugging not supported in visual studio yet."
+        )
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/FrameIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/FrameIR.py
@@ -4,13 +4,16 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from typing import Optional
+
 from dex.dextIR.LocIR import LocIR
 
 
 class FrameIR:
     """Data class which represents a frame in the call stack"""
 
-    def __init__(self, function: str, is_inlined: bool, loc: LocIR):
+    def __init__(self, function: str, is_inlined: bool, loc: LocIR, instruction_addr: Optional[str] = None):
         self.function = function
         self.is_inlined = is_inlined
         self.loc = loc
+        self.instruction_addr = instruction_addr

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/FrameIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/FrameIR.py
@@ -12,7 +12,13 @@ from dex.dextIR.LocIR import LocIR
 class FrameIR:
     """Data class which represents a frame in the call stack"""
 
-    def __init__(self, function: str, is_inlined: bool, loc: LocIR, instruction_addr: Optional[str] = None):
+    def __init__(
+        self,
+        function: str,
+        is_inlined: bool,
+        loc: LocIR,
+        instruction_addr: Optional[str] = None,
+    ):
         self.function = function
         self.is_inlined = is_inlined
         self.loc = loc


### PR DESCRIPTION
This patch adds some extra state collection methods to DebuggerBase and implements them for DAP only. These methods are used to fetch a stacktrace without variable information, and to populate variable information into a StepIR containing only a stacktrace. These methods are currently unused, making this patch NFC, but this is a necessary precursor to the new script model, where we examine the stacktrace to determine what variable info we will collect.

As part of the stacktrace-collection function, we also fetch the instruction address for each stack frame, if it is made available by the debugger; to enable this, this patch adds a new value with default `None` to `FrameIR`.