### PR TITLE
[lld] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -3062,8 +3062,7 @@ DebugNamesSection<ELFT>::DebugNamesSection(Ctx &ctx)
                                       ELFT::Is64Bits ? 8 : 4);
     // .debug_str is needed to get symbol names from string offsets.
     DataExtractor strExtractor(dobj.getStrSection(),
-                               ELFT::Endianness == endianness::little,
-                               ELFT::Is64Bits ? 8 : 4);
+                               ELFT::Endianness == endianness::little);
     inputChunk.section = dobj.getNamesSection();
 
     inputChunk.llvmDebugNames.emplace(namesExtractor, strExtractor);


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.