### PR TITLE
[MLIR] Add IntLikeTypeInterface

### DIFF
--- a/clang/lib/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.cpp
+++ b/clang/lib/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.cpp
@@ -13,6 +13,7 @@
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
@@ -24,6 +25,13 @@ struct OpenMPPointerLikeModel
     return mlir::cast<cir::PointerType>(pointer).getPointee();
   }
 };
+
+struct CIRIntLikeModel
+    : public mlir::IntLikeType::ExternalModel<CIRIntLikeModel, cir::IntType> {
+  unsigned getWidth(mlir::Type type) const {
+    return mlir::cast<cir::IntType>(type).getWidth();
+  }
+};
 } // namespace
 
 namespace cir::omp {
@@ -33,6 +41,7 @@ void registerOpenMPExtensions(mlir::DialectRegistry &registry) {
     cir::FuncOp::attachInterface<
         mlir::omp::DeclareTargetDefaultModel<cir::FuncOp>>(*ctx);
     cir::PointerType::attachInterface<OpenMPPointerLikeModel>(*ctx);
+    cir::IntType::attachInterface<CIRIntLikeModel>(*ctx);
   });
 }
 

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOpBase.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOpBase.td
@@ -17,6 +17,7 @@ include "mlir/Dialect/OpenMP/OpenMPAttrDefs.td"
 include "mlir/Dialect/OpenMP/OpenMPDialect.td"
 include "mlir/Dialect/OpenMP/OpenMPOpsInterfaces.td"
 include "mlir/Dialect/OpenMP/OpenMPTypeInterfaces.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/OpBase.td"
 
 //===----------------------------------------------------------------------===//
@@ -28,8 +29,8 @@ class OpenMP_Type<string name, string typeMnemonic> :
   let mnemonic = typeMnemonic;
 }
 
-// Type which can be constraint accepting standard integers and indices.
-def IntLikeType : AnyTypeOf<[AnyInteger, Index]>;
+def IntLikeType : AnyTypeOf<[AnyInteger, Index,
+    TypeAlias<IntLikeTypeInterface, "integer-like type">]>;
 
 def OpenMP_PointerLikeType : TypeAlias<OpenMP_PointerLikeTypeInterface,
 	"OpenMP-compatible variable type">;

--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
@@ -159,6 +159,31 @@ def FloatTypeInterface : TypeInterface<"FloatType",
 }
 
 //===----------------------------------------------------------------------===//
+// IntLikeTypeInterface
+//===----------------------------------------------------------------------===//
+
+def IntLikeTypeInterface : TypeInterface<"IntLikeType"> {
+  let cppNamespace = "::mlir";
+  let description = [{
+    This type interface should be implemented by integer-like types. It provides
+    a common API for querying the bit width of the integer type. This is useful
+    for dialects that need to accept integer-like types from other dialects,
+    e.g. for loop bounds, steps, and other integer operands.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the bit width of this integer-like type.
+      }],
+      /*retTy=*/"unsigned",
+      /*methodName=*/"getWidth",
+      /*args=*/(ins)
+    >
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // MemRefElementTypeInterface
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -597,6 +597,7 @@ def Builtin_Index : Builtin_Type<"Index", "index",
 
 def Builtin_Integer : Builtin_Type<"Integer", "integer",
     [VectorElementTypeInterface, QuantStorageTypeInterface,
+     IntLikeTypeInterface,
      DeclareTypeInterfaceMethods<DenseElementTypeInterface, [
          "getDenseElementBitSize", "convertToAttribute",
          "convertFromAttribute"]>]> {

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -3284,7 +3284,7 @@ func.func @taskloop_private_count_mismatch(%lb : index, %ub : index, %step : ind
 
 // -----
 func.func @masked_arg_type_mismatch(%arg0: f32) {
-  // expected-error @below {{'omp.masked' op operand #0 must be integer or index, but got 'f32'}}
+  // expected-error @below {{'omp.masked' op operand #0 must be integer or index or integer-like type, but got 'f32'}}
   "omp.masked"(%arg0) ({
       omp.terminator
     }) : (f32) -> ()


### PR DESCRIPTION
This patch adds an integer like type interface to allow e.g. CIR ops to be inputs to OpenMP dialect operations.

Assisted-by: Cursor / claude-4.6-opus-high-thinking