### PR TITLE
[sanitizer_common] Add GNU/Linux main wrapper support

### DIFF
--- a/compiler-rt/lib/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/CMakeLists.txt
@@ -135,6 +135,7 @@ set(SANITIZER_IMPL_HEADERS
   sanitizer_common_interceptors.inc
   sanitizer_common_interceptors_format.inc
   sanitizer_common_interceptors_ioctl.inc
+  sanitizer_common_interceptors_main.inc
   sanitizer_common_interceptors_memintrinsics.inc
   sanitizer_common_interface.inc
   sanitizer_common_interface_posix.inc

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -34,6 +34,9 @@ struct SignalContext;
 struct StackTrace;
 struct SymbolizedStack;
 
+// The full type of the function `main`.
+using MainFnTy = int (*)(int argc, char** argv, char** envp);
+
 // Constants.
 const uptr kWordSize = SANITIZER_WORDSIZE / 8;
 const uptr kWordSizeInBits = 8 * kWordSize;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_main.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_main.inc
@@ -6,14 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Opt-in Linux/glibc main wrapper via __libc_start_main interception.
+// Common main wrapper interceptor for tools that define a macro MAIN_WRAPPER
+// as a int expression as follows:
 //
-// A sanitizer enables this file by defining:
-//   #define MAIN_WRAPPER(main, argc, argv, envp) \
-//     ToolMainWrapper(main, argc, argv, envp)
-// before including it. `main` is the real user main (__sanitizer::MainFnTy);
-// argc, argv, and envp are the startup arguments forwarded to the wrapper.
-// The wrapper returns the process exit code and decides when to call main.
+// #define MAIN_WRAPPER(main, argc, argv, envp) ...
+//
+// Arguments:
+//   - main: the function pointer with MainFnTy, representing the real main.
+//   - argc/argv/envp: the real arguments of main.
+// Return:
+//   - the final result of MAIN_WRAPPER should be an int like what main returns.
 //
 //===----------------------------------------------------------------------===//
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_main.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_main.inc
@@ -1,0 +1,52 @@
+//===-- sanitizer_common_interceptors_main.inc -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Opt-in Linux/glibc main wrapper via __libc_start_main interception.
+//
+// A sanitizer enables this file by defining:
+//   #define MAIN_WRAPPER(main, argc, argv, envp) \
+//     ToolMainWrapper(main, argc, argv, envp)
+// before including it. `main` is the real user main (__sanitizer::MainFnTy);
+// argc, argv, and envp are the startup arguments forwarded to the wrapper.
+// The wrapper returns the process exit code and decides when to call main.
+//
+//===----------------------------------------------------------------------===//
+
+#include "interception/interception.h"
+#include "sanitizer_common.h"
+#include "sanitizer_platform.h"
+
+// __libc_start_main is a dynamic symbol in glibc.
+#if SANITIZER_LINUX && SANITIZER_GLIBC && defined(MAIN_WRAPPER)
+namespace __sanitizer {
+namespace {
+
+MainFnTy real_main;
+
+int WrappedMain(int argc, char **argv, char **envp) {
+  return MAIN_WRAPPER(real_main, argc, argv, envp);
+}
+
+}  // namespace
+}  // namespace __sanitizer
+
+INTERCEPTOR(int, __libc_start_main, __sanitizer::MainFnTy main, int argc,
+            char **argv, void (*init)(), void (*fini)(), void (*rtld_fini)(),
+            void *stack_end) {
+  // Lazily obtain the address of real __libc_start_main.
+  // Equivalent to the single-threaded version of functionl local static
+  // initialization.
+  // This is thread-safe as __libc_start_main is expected to be called AT FIRST
+  // from _start (the entry point of ELF), which is single-threaded.
+  if (!REAL(__libc_start_main))
+    CHECK(INTERCEPT_FUNCTION(__libc_start_main));
+  __sanitizer::real_main = main;
+  return REAL(__libc_start_main)(__sanitizer::WrappedMain, argc, argv, init,
+                                 fini, rtld_fini, stack_end);
+}
+#endif


### PR DESCRIPTION
## Summary

This patch adds a small `sanitizer_common` primitive for opt-in `main` wrapping on GNU/Linux glibc. Sanitizer runtimes can define:

```c++
#define MAIN_WRAPPER(main, argc, argv, envp) ...
#include "sanitizer_common/sanitizer_common_interceptors_main.inc"
```

and call `INIT_MAIN_WRAPPER` from their interceptor initialization path.

## Design space

| # | Approach | Prerequisite | Drawback |
|---|---|---|---|
| 1 | Instrumentation: add hooks at entry and exit points of `main` | The sanitizer already has an instrumentation pass, e.g. ASan | Depends on instrumentation; cannot express full wrapping |
| 2 | Instrumentation: synthesize a new `main` and wrap the old `main` | The sanitizer already has an instrumentation pass, e.g. ASan | Depends on instrumentation; may interfere downstream passes that treat `main` specially |
| 3 | Link-time interception: `--wrap=main` | User does not use `--wrap=main`; GNU/Linux linker | Platform-specific; conflicts with user-provided `--wrap=main` |
| **4** | **Runtime interception: intercept `__libc_start_main` and wrap `main`** | **GNU/Linux glibc** | **Platform-specific** |

**This patch chooses approach 4**. It gives sanitizer runtimes a driver primitive that can fully wrap `main` while

1. not relying on sanitizer IR instrumentation, and
2. preserving the behavior of the user-specific operations on `main`.

The implementation is intentionally limited to GNU/Linux glibc, where `__libc_start_main` is the process startup entry used to call `main`. Other libc/startup ABIs need separate providers.

## Simple PoC of __libc_start_main interception

```cpp
// RUN: clang++ -o poc poc.cc && ./poc
#include <dlfcn.h>
#include <stdio.h>

using MainFnTy = int (*)(int argc, char **argv, char **envp);

MainFnTy real_main;
int wrapped_main(int argc, char **argv, char **envp) {
  puts("[Before] Called from wrapped main.");
  int res = real_main(argc, argv, envp);
  puts("[After] Called from wrapped main.");
  return res;
}

extern "C" int __libc_start_main(MainFnTy main, int argc, char **argv,
                                 void (*init)(), void (*fini)(),
                                 void (*rtld_fini)(), void *stack_end) {
  static auto interceptee = []() {
    return (decltype(&__libc_start_main))dlsym(RTLD_NEXT, "__libc_start_main");
  }();

  real_main = main;
  return interceptee(wrapped_main, argc, argv, init, fini, rtld_fini,
                     stack_end);
}

int main() {
  puts("real main.");
  return 0;
}
```


## Notes

This PR only adds the `sanitizer_common` mechanism. Individual sanitizer runtimes can opt in by defining `MAIN_WRAPPER` in follow-up patches.

- As the prerequisite to land the discussion in https://github.com/llvm/llvm-project/pull/195238#issuecomment-4373072749
