### PR TITLE
[lldb] Immediately connect in webinspector-wasm

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
@@ -30,6 +30,13 @@ static constexpr llvm::StringLiteral kServerBinary =
 static constexpr uint8_t kConnectAttempts = 5;
 static constexpr auto kConnectDelay = std::chrono::milliseconds(100);
 
+PlatformWebInspectorWasm::PlatformWebInspectorWasm() {
+  if (llvm::Error err = EnsureConnected()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Platform), std::move(err),
+                   "EnsureConnected failed: {0}");
+  }
+}
+
 llvm::StringRef PlatformWebInspectorWasm::GetPluginDescriptionStatic() {
   return "Platform for debugging Wasm via WebInspector";
 }

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.h
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.h
@@ -45,7 +45,7 @@ public:
 private:
   static lldb::PlatformSP CreateInstance(bool force, const ArchSpec *arch);
 
-  PlatformWebInspectorWasm() = default;
+  PlatformWebInspectorWasm();
 
   llvm::Error LaunchPlatformServer();
   llvm::Error EnsureConnected();


### PR DESCRIPTION
Call `EnsureConnected` in the `PlatformWebInspectorWasm` ctor so the platform reports being connected after selecting in. The lazy approach resulted in confusion due to the "Connected: no" in the `platform select` output:

```
(lldb) platform select webinspector-wasm
  Platform: webinspector-wasm
 Connected: no
```