### PR TITLE
[clang] make __builtin_object_size and __builtin_dynamic_object_size compatible with GCC's constexpr implementation

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15911,7 +15911,7 @@ static QualType getObjectType(APValue::LValueBase B) {
     if (const VarDecl *VD = dyn_cast<VarDecl>(D))
       return VD->getType();
   } else if (const Expr *E = B.dyn_cast<const Expr*>()) {
-    if (isa<CompoundLiteralExpr>(E))
+    if (isa<CompoundLiteralExpr>(E) || isa<StringLiteral>(E))
       return E->getType();
   } else if (B.is<TypeInfoLValue>()) {
     return B.getTypeInfoType();

--- a/clang/test/SemaCXX/builtin-object-size-cxx23.cpp
+++ b/clang/test/SemaCXX/builtin-object-size-cxx23.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 %s
+
+constexpr int stringLength(const char *p) {
+  return __builtin_dynamic_object_size(p, 0);
+}
+
+static_assert(stringLength("hello") == 6);
+
+constexpr int allocation(unsigned n) {
+  const char * ptr = new char[n];
+  int res = stringLength(ptr);
+  delete[] ptr;
+  return res;
+}
+
+static_assert(allocation(1) == 1);
+static_assert(allocation(14) == 14);
+
+
+


### PR DESCRIPTION
Recently GCC made these builtin constexpr, Tomasz Kaminski asked me about incompatibility of clang implementation. I found out it doesn't work on StringLiteral. This fixes that, I tried to look at the bytecode interpreter, but I'm not comfortable fixing it there.