### PR TITLE
DAGCombiner: (srl/sra (add nuw/nsw X, c), d) --> (add nuw/nsw (srl/sra X, d), c >> d)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -11428,6 +11428,24 @@ SDValue DAGCombiner::visitSRA(SDNode *N) {
     }
   }
 
+  // fold (sra (add nsw X, C), D) -> (add nsw (sra X, D), C s>> D)
+  // when C has D trailing zeros (so C s>> D is exact).
+  if (N1C && N0.hasOneUse() && N0.getOpcode() == ISD::ADD &&
+      N0->getFlags().hasNoSignedWrap()) {
+    if (ConstantSDNode *AddC = isConstOrConstSplat(N0.getOperand(1))) {
+      const APInt &ShAmt = N1C->getAPIntValue();
+      const APInt &AddVal = AddC->getAPIntValue();
+      if (ShAmt.ult(AddVal.countr_zero())) {
+        SDNodeFlags ShiftFlags = N->getFlags();
+        SDValue NewSra =
+            DAG.getNode(ISD::SRA, DL, VT, N0.getOperand(0), N1, ShiftFlags);
+        SDValue NewC = DAG.getConstant(AddVal.ashr(ShAmt), DL, VT);
+        SDNodeFlags AddFlags = N0->getFlags();
+        return DAG.getNode(ISD::ADD, DL, VT, NewSra, NewC, AddFlags);
+      }
+    }
+  }
+
   // Simplify, based on bits shifted out of the LHS.
   if (SimplifyDemandedBits(SDValue(N, 0)))
     return SDValue(N, 0);
@@ -11692,6 +11710,24 @@ SDValue DAGCombiner::visitSRL(SDNode *N) {
                                  LastElt);
         return DAG.getZExtOrTrunc(DAG.getZExtOrTrunc(LastElt, DL, IntEltVT), DL,
                                   VT);
+      }
+    }
+  }
+
+  // fold (srl (add nuw X, C), D) -> (add nuw (srl X, D), C u>> D)
+  // when C has D trailing zeros (so C >> D is exact).
+  if (N1C && N0.hasOneUse() && N0.getOpcode() == ISD::ADD &&
+      N0->getFlags().hasNoUnsignedWrap()) {
+    if (ConstantSDNode *AddC = isConstOrConstSplat(N0.getOperand(1))) {
+      const APInt &ShAmt = N1C->getAPIntValue();
+      const APInt &AddVal = AddC->getAPIntValue();
+      if (ShAmt.ult(AddVal.countr_zero())) {
+        SDNodeFlags ShiftFlags = N->getFlags();
+        SDValue NewSrl =
+            DAG.getNode(ISD::SRL, DL, VT, N0.getOperand(0), N1, ShiftFlags);
+        SDValue NewC = DAG.getConstant(AddVal.lshr(ShAmt), DL, VT);
+        SDNodeFlags AddFlags = N0->getFlags();
+        return DAG.getNode(ISD::ADD, DL, VT, NewSrl, NewC, AddFlags);
       }
     }
   }

--- a/llvm/test/CodeGen/AMDGPU/ctpop16.ll
+++ b/llvm/test/CodeGen/AMDGPU/ctpop16.ll
@@ -840,7 +840,7 @@ define amdgpu_kernel void @v_ctpop_v16i16(ptr addrspace(1) noalias %out, ptr add
 ; EG-NEXT:    ALU 3, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
 ; EG-NEXT:    ALU 114, @16, KC0[], KC1[]
-; EG-NEXT:    ALU 34, @131, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 33, @131, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 1
 ; EG-NEXT:    CF_END
@@ -993,13 +993,12 @@ define amdgpu_kernel void @v_ctpop_v16i16(ptr addrspace(1) noalias %out, ptr add
 ; EG-NEXT:     AND_INT T1.W, T21.W, literal.x,
 ; EG-NEXT:     LSHR * T21.X, KC0[2].Y, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     AND_INT T0.Z, PV.X, literal.x,
 ; EG-NEXT:     BCNT_INT T1.W, PV.W,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    -65536(nan), 16(2.242078e-44)
-; EG-NEXT:     LSHR T22.X, PS, literal.x,
-; EG-NEXT:     OR_INT * T20.W, PV.Z, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     AND_INT * T2.W, PV.X, literal.x,
+; EG-NEXT:    -65536(nan), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T22.X, T21.X, literal.x,
+; EG-NEXT:     OR_INT * T20.W, PS, PV.W,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T17.X, PV.W,
 ; EG-NEXT:     MOV * T0.X, T4.X,
 ; EG-NEXT:     MOV * T0.Z, T8.X,

--- a/llvm/test/CodeGen/AMDGPU/fp_to_sint.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp_to_sint.ll
@@ -897,169 +897,167 @@ define amdgpu_kernel void @fp_to_sint_v4i64(ptr addrspace(1) %out, <4 x float> %
 ;
 ; EG-LABEL: fp_to_sint_v4i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 99, @6, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 54, @106, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T0.X, 1
+; EG-NEXT:    ALU 102, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 49, @109, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T1.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T1.W, KC0[3].Z, literal.x, PV.W,
-; EG-NEXT:     AND_INT * T2.W, KC0[3].Z, literal.y,
+; EG-NEXT:     BFE_UINT T1.W, KC0[4].X, literal.x, PV.W,
+; EG-NEXT:     AND_INT * T2.W, KC0[4].X, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 8388607(1.175494e-38)
 ; EG-NEXT:     OR_INT T2.W, PS, literal.x,
 ; EG-NEXT:     ADD_INT * T3.W, PV.W, literal.y,
 ; EG-NEXT:    8388608(1.175494e-38), -150(nan)
 ; EG-NEXT:     ADD_INT T0.X, T1.W, literal.x,
-; EG-NEXT:     BFE_UINT T0.Y, KC0[4].X, literal.y, T0.W,
-; EG-NEXT:     AND_INT T0.Z, PS, literal.z,
-; EG-NEXT:     NOT_INT T4.W, PS,
-; EG-NEXT:     LSHR * T5.W, PV.W, 1,
-; EG-NEXT:    -127(nan), 23(3.222986e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T0.Y, PS, literal.y,
+; EG-NEXT:     SUB_INT T0.Z, literal.z, T1.W,
+; EG-NEXT:     NOT_INT T1.W, PS,
+; EG-NEXT:     LSHR * T4.W, PV.W, 1,
+; EG-NEXT:    -127(nan), 31(4.344025e-44)
+; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
 ; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, PS, PV.W,
-; EG-NEXT:     AND_INT T1.Y, T3.W, literal.x,
-; EG-NEXT:     LSHL T0.Z, T2.W, PV.Z, BS:VEC_120/SCL_212
-; EG-NEXT:     AND_INT T3.W, KC0[4].X, literal.y,
-; EG-NEXT:     ADD_INT * T4.W, PV.Y, literal.z,
-; EG-NEXT:    32(4.484155e-44), 8388607(1.175494e-38)
-; EG-NEXT:    -150(nan), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T2.Y, PS, literal.x,
-; EG-NEXT:     OR_INT T1.Z, PV.W, literal.y,
-; EG-NEXT:     CNDE_INT T3.W, PV.Y, PV.X, PV.Z,
-; EG-NEXT:     SETGT_INT * T5.W, T0.X, literal.z,
-; EG-NEXT:    31(4.344025e-44), 8388608(1.175494e-38)
+; EG-NEXT:     AND_INT T1.Y, PV.Z, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T0.Z, 0.0, T2.W, PV.Z,
+; EG-NEXT:     LSHL T1.W, T2.W, PV.Y,
+; EG-NEXT:     AND_INT * T2.W, T3.W, literal.x,
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T0.Z, PV.Y, PV.Z, 0.0,
+; EG-NEXT:     CNDE_INT T1.W, PS, PV.X, PV.W,
+; EG-NEXT:     SETGT_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T3.Y, PS, 0.0, PV.W,
-; EG-NEXT:     SUB_INT T2.Z, literal.x, T1.W,
-; EG-NEXT:     LSHL T1.W, PV.Z, PV.Y,
-; EG-NEXT:     AND_INT * T3.W, T4.W, literal.y,
-; EG-NEXT:    150(2.101948e-43), 32(4.484155e-44)
-; EG-NEXT:     CNDE_INT T1.X, PS, PV.W, 0.0,
-; EG-NEXT:     AND_INT T2.Y, PV.Z, literal.x,
-; EG-NEXT:     SUB_INT T3.Z, literal.y, T0.Y,
-; EG-NEXT:     NOT_INT T4.W, T4.W,
-; EG-NEXT:     LSHR * T6.W, T1.Z, 1,
-; EG-NEXT:    32(4.484155e-44), 150(2.101948e-43)
-; EG-NEXT:     BIT_ALIGN_INT T2.X, 0.0, T2.W, T2.Z,
-; EG-NEXT:     ADD_INT T0.Y, T0.Y, literal.x,
-; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, PS, PV.W,
-; EG-NEXT:     BIT_ALIGN_INT T2.W, 0.0, T1.Z, PV.Z,
-; EG-NEXT:     AND_INT * T4.W, PV.Z, literal.y,
-; EG-NEXT:    -127(nan), 32(4.484155e-44)
-; EG-NEXT:     CNDE_INT T3.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T4.Y, T3.W, PV.Z, T1.W,
-; EG-NEXT:     SETGT_INT T1.Z, PV.Y, literal.x,
-; EG-NEXT:     CNDE_INT T1.W, T1.Y, T0.Z, 0.0,
-; EG-NEXT:     CNDE_INT * T2.W, T2.Y, PV.X, 0.0,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T2.X, T5.W, PS, PV.W,
-; EG-NEXT:     ASHR T1.Y, KC0[3].Z, literal.x,
-; EG-NEXT:     CNDE_INT T0.Z, PV.Z, 0.0, PV.Y,
-; EG-NEXT:     CNDE_INT T1.W, PV.Z, PV.X, T1.X,
+; EG-NEXT:     CNDE_INT T1.Z, PS, 0.0, PV.W,
+; EG-NEXT:     CNDE_INT T1.W, PS, PV.Z, PV.Y,
 ; EG-NEXT:     ASHR * T2.W, KC0[4].X, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T2.Y, PV.W, PS,
-; EG-NEXT:     XOR_INT T0.Z, PV.Z, PS,
-; EG-NEXT:     XOR_INT T1.W, PV.X, PV.Y,
-; EG-NEXT:     XOR_INT * T3.W, T3.Y, PV.Y,
-; EG-NEXT:     SUB_INT T3.Y, PS, T1.Y,
-; EG-NEXT:     SUBB_UINT T1.Z, PV.W, T1.Y,
-; EG-NEXT:     SUB_INT T3.W, PV.Z, T2.W,
-; EG-NEXT:     SUBB_UINT * T4.W, PV.Y, T2.W,
-; EG-NEXT:     SUB_INT T4.Y, PV.W, PS,
-; EG-NEXT:     SUB_INT T0.Z, PV.Y, PV.Z,
-; EG-NEXT:     BFE_UINT T3.W, KC0[3].Y, literal.x, T0.W,
-; EG-NEXT:     AND_INT * T4.W, KC0[3].Y, literal.y,
-; EG-NEXT:    23(3.222986e-44), 8388607(1.175494e-38)
-; EG-NEXT:     SETGT_INT T0.X, 0.0, T0.X,
-; EG-NEXT:     ADD_INT T3.Y, PV.W, literal.x,
-; EG-NEXT:     OR_INT T1.Z, PS, literal.y,
-; EG-NEXT:     BFE_UINT T0.W, KC0[3].W, literal.z, T0.W,
-; EG-NEXT:     ADD_INT * T4.W, PV.W, literal.w,
-; EG-NEXT:    -127(nan), 8388608(1.175494e-38)
-; EG-NEXT:    23(3.222986e-44), -150(nan)
-; EG-NEXT:     AND_INT T1.X, KC0[3].W, literal.x,
-; EG-NEXT:     ADD_INT T5.Y, PV.W, literal.y,
-; EG-NEXT:     SUB_INT T2.Z, literal.z, T3.W,
-; EG-NEXT:     NOT_INT T3.W, PS,
-; EG-NEXT:     LSHR * T5.W, PV.Z, 1,
+; EG-NEXT:     XOR_INT T0.Z, PV.W, PS,
+; EG-NEXT:     BFE_UINT T1.W, KC0[3].Z, literal.x, T0.W,
+; EG-NEXT:     XOR_INT * T3.W, PV.Z, PS,
+; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T0.Y, KC0[3].Z, literal.x,
+; EG-NEXT:     ADD_INT T1.Z, PV.W, literal.y,
+; EG-NEXT:     SUB_INT T3.W, PS, T2.W,
+; EG-NEXT:     SUBB_UINT * T4.W, PV.Z, T2.W,
 ; EG-NEXT:    8388607(1.175494e-38), -150(nan)
-; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T2.X, 0.0, PS, PV.W,
-; EG-NEXT:     AND_INT T6.Y, PV.Z, literal.x,
-; EG-NEXT:     AND_INT T3.Z, PV.Y, literal.y,
-; EG-NEXT:     OR_INT T3.W, PV.X, literal.z,
-; EG-NEXT:     AND_INT * T5.W, T4.W, literal.y,
-; EG-NEXT:    32(4.484155e-44), 31(4.344025e-44)
+; EG-NEXT:     SUB_INT T1.Y, PV.W, PS,
+; EG-NEXT:     AND_INT T2.Z, PV.Z, literal.x,
+; EG-NEXT:     BFE_UINT T3.W, KC0[3].Y, literal.y, T0.W,
+; EG-NEXT:     OR_INT * T4.W, PV.Y, literal.z,
+; EG-NEXT:    31(4.344025e-44), 23(3.222986e-44)
 ; EG-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, T1.Z, T2.Z,
-; EG-NEXT:     LSHL T7.Y, T1.Z, PS,
-; EG-NEXT:     AND_INT T1.Z, T4.W, literal.x,
-; EG-NEXT:     LSHL T4.W, PV.W, PV.Z,
-; EG-NEXT:     AND_INT * T5.W, T5.Y, literal.x,
+; EG-NEXT:     SETGT_INT T0.X, 0.0, T0.X,
+; EG-NEXT:     AND_INT T0.Y, KC0[3].Y, literal.x,
+; EG-NEXT:     ADD_INT T3.Z, PV.W, literal.y,
+; EG-NEXT:     LSHL T5.W, PS, PV.Z,
+; EG-NEXT:     AND_INT * T6.W, T1.Z, literal.z,
+; EG-NEXT:    8388607(1.175494e-38), -150(nan)
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T3.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T8.Y, PV.Z, PV.Y, 0.0,
-; EG-NEXT:     CNDE_INT * T2.Z, T6.Y, PV.X, 0.0,
-; EG-NEXT:    ALU clause starting at 106:
-; EG-NEXT:     CNDE_INT T6.W, T1.Z, T2.X, T7.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGT_INT * T7.W, T3.Y, literal.x,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T1.X, PS, 0.0, PV.W,
-; EG-NEXT:     CNDE_INT T6.Y, PS, T2.Z, T8.Y,
-; EG-NEXT:     SUB_INT T1.Z, literal.x, T0.W,
-; EG-NEXT:     NOT_INT T6.W, T5.Y,
-; EG-NEXT:     LSHR * T7.W, T3.W, 1,
+; EG-NEXT:     BFE_UINT T1.X, KC0[3].W, literal.x, T0.W,
+; EG-NEXT:     CNDE_INT T2.Y, PS, PV.W, 0.0,
+; EG-NEXT:     AND_INT T2.Z, PV.Z, literal.y,
+; EG-NEXT:     OR_INT T0.W, PV.Y, literal.z,
+; EG-NEXT:     SUB_INT * T7.W, literal.w, T1.W,
+; EG-NEXT:    23(3.222986e-44), 31(4.344025e-44)
+; EG-NEXT:    8388608(1.175494e-38), 150(2.101948e-43)
+; EG-NEXT:     NOT_INT T2.X, T1.Z,
+; EG-NEXT:     LSHR T0.Y, T4.W, 1,
+; EG-NEXT:     AND_INT T1.Z, PS, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T4.W, 0.0, T4.W, PS,
+; EG-NEXT:     ADD_INT * T1.W, T1.W, literal.y,
+; EG-NEXT:    32(4.484155e-44), -127(nan)
+; EG-NEXT:     SETGT_INT T3.X, PS, literal.x,
+; EG-NEXT:     CNDE_INT T3.Y, PV.Z, PV.W, 0.0,
+; EG-NEXT:     BIT_ALIGN_INT T1.Z, 0.0, PV.Y, PV.X,
+; EG-NEXT:     LSHL T4.W, T0.W, T2.Z,
+; EG-NEXT:     AND_INT * T7.W, T3.Z, literal.y,
+; EG-NEXT:    23(3.222986e-44), 32(4.484155e-44)
+; EG-NEXT:     AND_INT T2.X, KC0[3].W, literal.x,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T1.Z, T6.W, PV.Z, T5.W,
+; EG-NEXT:     CNDE_INT T5.W, PV.X, PV.Y, T2.Y,
+; EG-NEXT:     ASHR * T6.W, KC0[3].Z, literal.y,
+; EG-NEXT:    8388607(1.175494e-38), 31(4.344025e-44)
+; EG-NEXT:     XOR_INT T4.X, PV.W, PS,
+; EG-NEXT:     SUB_INT T2.Y, literal.x, T3.W,
+; EG-NEXT:     NOT_INT T2.Z, T3.Z,
+; EG-NEXT:     LSHR T5.W, T0.W, 1,
+; EG-NEXT:     CNDE_INT * T8.W, T3.X, 0.0, PV.Z, BS:VEC_021/SCL_122
 ; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
-; EG-NEXT:     ASHR T2.X, KC0[3].Y, literal.x,
-; EG-NEXT:     ADD_INT T5.Y, T0.W, literal.y,
-; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, PS, PV.W,
-; EG-NEXT:     BIT_ALIGN_INT T0.W, 0.0, T3.W, PV.Z,
-; EG-NEXT:     AND_INT * T3.W, PV.Z, literal.z,
-; EG-NEXT:    31(4.344025e-44), -127(nan)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T7.Y, T5.W, PV.Z, T4.W,
+; EG-NEXT:     XOR_INT T3.X, PS, T6.W,
+; EG-NEXT:     ADD_INT T3.Y, T3.W, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T1.Z, 0.0, PV.W, PV.Z,
+; EG-NEXT:     BIT_ALIGN_INT T0.W, 0.0, T0.W, PV.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     AND_INT * T3.W, PV.Y, literal.y,
+; EG-NEXT:    -127(nan), 32(4.484155e-44)
+; EG-NEXT:     CNDE_INT T5.X, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T2.Y, T7.W, PV.Z, T4.W,
 ; EG-NEXT:     SETGT_INT T1.Z, PV.Y, literal.x,
-; EG-NEXT:     XOR_INT T0.W, T6.Y, PV.X,
-; EG-NEXT:     XOR_INT * T3.W, T1.X, PV.X,
+; EG-NEXT:     SUB_INT T0.W, PV.X, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T4.X, T6.W,
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T1.X, PS, T2.X,
-; EG-NEXT:     SUBB_UINT T6.Y, PV.W, T2.X,
-; EG-NEXT:     CNDE_INT T2.Z, PV.Z, 0.0, PV.Y,
-; EG-NEXT:     CNDE_INT T3.W, PV.Z, PV.X, T3.X,
-; EG-NEXT:     ASHR * T4.W, KC0[3].W, literal.x,
+; EG-NEXT:     SUB_INT T3.X, PV.W, PS,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, 0.0, PV.Y,
+; EG-NEXT:     CNDE_INT T1.Z, PV.Z, PV.X, T0.Y,
+; EG-NEXT:     OR_INT T0.W, T2.X, literal.x,
+; EG-NEXT:     ADD_INT * T3.W, T1.X, literal.y,
+; EG-NEXT:    8388608(1.175494e-38), -150(nan)
+; EG-NEXT:     ADD_INT * T2.X, T1.X, literal.x,
+; EG-NEXT:    -127(nan), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 109:
+; EG-NEXT:     AND_INT T0.Y, T3.W, literal.x,
+; EG-NEXT:     SUB_INT T2.Z, literal.y, T1.X,
+; EG-NEXT:     NOT_INT T4.W, T3.W,
+; EG-NEXT:     LSHR * T5.W, T0.W, 1,
+; EG-NEXT:    31(4.344025e-44), 150(2.101948e-43)
+; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, PS, PV.W,
+; EG-NEXT:     AND_INT T4.Y, PV.Z, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, T0.W, PV.Z,
+; EG-NEXT:     LSHL T0.W, T0.W, PV.Y,
+; EG-NEXT:     AND_INT * T3.W, T3.W, literal.x,
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T5.X, KC0[3].Y, literal.x,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T2.Z, PV.Y, PV.Z, 0.0,
+; EG-NEXT:     CNDE_INT T0.W, PS, PV.X, PV.W,
+; EG-NEXT:     SETGT_INT * T3.W, T2.X, literal.y,
+; EG-NEXT:    31(4.344025e-44), 23(3.222986e-44)
+; EG-NEXT:     CNDE_INT T1.X, PS, 0.0, PV.W,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.Z, PV.Y,
+; EG-NEXT:     ASHR T2.Z, KC0[3].W, literal.x,
+; EG-NEXT:     XOR_INT T0.W, T1.Z, PV.X,
+; EG-NEXT:     XOR_INT * T3.W, T2.Y, PV.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T3.X, PV.W, PS,
-; EG-NEXT:     XOR_INT T7.Y, PV.Z, PS,
-; EG-NEXT:     SUB_INT T1.Z, PV.X, PV.Y,
+; EG-NEXT:     SETGT_INT T6.X, 0.0, T1.W,
+; EG-NEXT:     SUB_INT T2.Y, PS, T5.X,
+; EG-NEXT:     SUBB_UINT T1.Z, PV.W, T5.X,
+; EG-NEXT:     XOR_INT T1.W, PV.Y, PV.Z,
+; EG-NEXT:     XOR_INT * T3.W, PV.X, PV.Z,
+; EG-NEXT:     SUB_INT T1.X, PS, T2.Z,
+; EG-NEXT:     SUBB_UINT T0.Y, PV.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.Z, PV.Y, PV.Z,
 ; EG-NEXT:     SETGT_INT T3.W, 0.0, T3.Y,
-; EG-NEXT:     CNDE_INT * T6.W, T0.X, T0.Z, 0.0,
-; EG-NEXT:     SETGT_INT T1.X, 0.0, T0.Y,
+; EG-NEXT:     CNDE_INT * T4.W, PV.X, T3.X, 0.0,
+; EG-NEXT:     SUB_INT T3.X, T4.X, T6.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PV.Z, 0.0,
+; EG-NEXT:     SUB_INT T1.Z, PV.X, PV.Y,
+; EG-NEXT:     SETGT_INT T5.W, 0.0, T2.X,
+; EG-NEXT:     CNDE_INT * T6.W, T0.X, T1.Y, 0.0,
 ; EG-NEXT:     CNDE_INT T6.Y, PV.W, PV.Z, 0.0,
-; EG-NEXT:     SUB_INT T0.Z, T1.W, T1.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T1.W, PV.Y, T4.W,
-; EG-NEXT:     SUBB_UINT * T5.W, PV.X, T4.W,
-; EG-NEXT:     SUB_INT T4.X, PV.W, PS,
-; EG-NEXT:     SETGT_INT T0.Y, 0.0, T5.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T6.Z, T0.X, PV.Z, 0.0,
-; EG-NEXT:     SUB_INT T0.W, T0.W, T2.X,
-; EG-NEXT:     CNDE_INT * T1.W, PV.X, T4.Y, 0.0,
-; EG-NEXT:     CNDE_INT T6.X, T3.W, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Y, PV.X, 0.0,
-; EG-NEXT:     SUB_INT T0.W, T2.Y, T2.W,
+; EG-NEXT:     CNDE_INT T4.Z, T6.X, PV.X, 0.0,
+; EG-NEXT:     SUB_INT T2.W, T0.Z, T2.W,
+; EG-NEXT:     SUB_INT * T0.W, T0.W, T5.X,
+; EG-NEXT:     CNDE_INT T4.X, T3.W, PS, 0.0,
+; EG-NEXT:     CNDE_INT T6.Z, T0.X, PV.W, 0.0,
+; EG-NEXT:     SUB_INT * T0.W, T1.W, T2.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     CNDE_INT T6.X, T5.W, PV.W, 0.0,
 ; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T1.Z, T1.X, PV.W, 0.0,
-; EG-NEXT:     SUB_INT * T0.W, T3.X, T4.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT T1.X, T0.Y, PV.W, 0.0,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T2.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T1.X, PS, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %conv = fptosi <4 x float> %x to <4 x i64>
   store <4 x i64> %conv, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/fp_to_uint.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp_to_uint.ll
@@ -677,169 +677,167 @@ define amdgpu_kernel void @fp_to_uint_v4f32_to_v4i64(ptr addrspace(1) %out, <4 x
 ;
 ; EG-LABEL: fp_to_uint_v4f32_to_v4i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 99, @6, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 54, @106, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T0.X, 1
+; EG-NEXT:    ALU 102, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 49, @109, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T1.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T1.W, KC0[3].Z, literal.x, PV.W,
-; EG-NEXT:     AND_INT * T2.W, KC0[3].Z, literal.y,
+; EG-NEXT:     BFE_UINT T1.W, KC0[4].X, literal.x, PV.W,
+; EG-NEXT:     AND_INT * T2.W, KC0[4].X, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 8388607(1.175494e-38)
 ; EG-NEXT:     OR_INT T2.W, PS, literal.x,
 ; EG-NEXT:     ADD_INT * T3.W, PV.W, literal.y,
 ; EG-NEXT:    8388608(1.175494e-38), -150(nan)
 ; EG-NEXT:     ADD_INT T0.X, T1.W, literal.x,
-; EG-NEXT:     BFE_UINT T0.Y, KC0[4].X, literal.y, T0.W,
-; EG-NEXT:     AND_INT T0.Z, PS, literal.z,
-; EG-NEXT:     NOT_INT T4.W, PS,
-; EG-NEXT:     LSHR * T5.W, PV.W, 1,
-; EG-NEXT:    -127(nan), 23(3.222986e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T0.Y, PS, literal.y,
+; EG-NEXT:     SUB_INT T0.Z, literal.z, T1.W,
+; EG-NEXT:     NOT_INT T1.W, PS,
+; EG-NEXT:     LSHR * T4.W, PV.W, 1,
+; EG-NEXT:    -127(nan), 31(4.344025e-44)
+; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
 ; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, PS, PV.W,
-; EG-NEXT:     AND_INT T1.Y, T3.W, literal.x,
-; EG-NEXT:     LSHL T0.Z, T2.W, PV.Z, BS:VEC_120/SCL_212
-; EG-NEXT:     AND_INT T3.W, KC0[4].X, literal.y,
-; EG-NEXT:     ADD_INT * T4.W, PV.Y, literal.z,
-; EG-NEXT:    32(4.484155e-44), 8388607(1.175494e-38)
-; EG-NEXT:    -150(nan), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T2.Y, PS, literal.x,
-; EG-NEXT:     OR_INT T1.Z, PV.W, literal.y,
-; EG-NEXT:     CNDE_INT T3.W, PV.Y, PV.X, PV.Z,
-; EG-NEXT:     SETGT_INT * T5.W, T0.X, literal.z,
-; EG-NEXT:    31(4.344025e-44), 8388608(1.175494e-38)
+; EG-NEXT:     AND_INT T1.Y, PV.Z, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T0.Z, 0.0, T2.W, PV.Z,
+; EG-NEXT:     LSHL T1.W, T2.W, PV.Y,
+; EG-NEXT:     AND_INT * T2.W, T3.W, literal.x,
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T0.Z, PV.Y, PV.Z, 0.0,
+; EG-NEXT:     CNDE_INT T1.W, PS, PV.X, PV.W,
+; EG-NEXT:     SETGT_INT * T2.W, T0.X, literal.x,
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T3.Y, PS, 0.0, PV.W,
-; EG-NEXT:     SUB_INT T2.Z, literal.x, T1.W,
-; EG-NEXT:     LSHL T1.W, PV.Z, PV.Y,
-; EG-NEXT:     AND_INT * T3.W, T4.W, literal.y,
-; EG-NEXT:    150(2.101948e-43), 32(4.484155e-44)
-; EG-NEXT:     CNDE_INT T1.X, PS, PV.W, 0.0,
-; EG-NEXT:     AND_INT T2.Y, PV.Z, literal.x,
-; EG-NEXT:     SUB_INT T3.Z, literal.y, T0.Y,
-; EG-NEXT:     NOT_INT T4.W, T4.W,
-; EG-NEXT:     LSHR * T6.W, T1.Z, 1,
-; EG-NEXT:    32(4.484155e-44), 150(2.101948e-43)
-; EG-NEXT:     BIT_ALIGN_INT T2.X, 0.0, T2.W, T2.Z,
-; EG-NEXT:     ADD_INT T0.Y, T0.Y, literal.x,
-; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, PS, PV.W,
-; EG-NEXT:     BIT_ALIGN_INT T2.W, 0.0, T1.Z, PV.Z,
-; EG-NEXT:     AND_INT * T4.W, PV.Z, literal.y,
-; EG-NEXT:    -127(nan), 32(4.484155e-44)
-; EG-NEXT:     CNDE_INT T3.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T4.Y, T3.W, PV.Z, T1.W,
-; EG-NEXT:     SETGT_INT T1.Z, PV.Y, literal.x,
-; EG-NEXT:     CNDE_INT T1.W, T1.Y, T0.Z, 0.0,
-; EG-NEXT:     CNDE_INT * T2.W, T2.Y, PV.X, 0.0,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T2.X, T5.W, PS, PV.W,
-; EG-NEXT:     ASHR T1.Y, KC0[3].Z, literal.x,
-; EG-NEXT:     CNDE_INT T0.Z, PV.Z, 0.0, PV.Y,
-; EG-NEXT:     CNDE_INT T1.W, PV.Z, PV.X, T1.X,
+; EG-NEXT:     CNDE_INT T1.Z, PS, 0.0, PV.W,
+; EG-NEXT:     CNDE_INT T1.W, PS, PV.Z, PV.Y,
 ; EG-NEXT:     ASHR * T2.W, KC0[4].X, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T2.Y, PV.W, PS,
-; EG-NEXT:     XOR_INT T0.Z, PV.Z, PS,
-; EG-NEXT:     XOR_INT T1.W, PV.X, PV.Y,
-; EG-NEXT:     XOR_INT * T3.W, T3.Y, PV.Y,
-; EG-NEXT:     SUB_INT T3.Y, PS, T1.Y,
-; EG-NEXT:     SUBB_UINT T1.Z, PV.W, T1.Y,
-; EG-NEXT:     SUB_INT T3.W, PV.Z, T2.W,
-; EG-NEXT:     SUBB_UINT * T4.W, PV.Y, T2.W,
-; EG-NEXT:     SUB_INT T4.Y, PV.W, PS,
-; EG-NEXT:     SUB_INT T0.Z, PV.Y, PV.Z,
-; EG-NEXT:     BFE_UINT T3.W, KC0[3].Y, literal.x, T0.W,
-; EG-NEXT:     AND_INT * T4.W, KC0[3].Y, literal.y,
-; EG-NEXT:    23(3.222986e-44), 8388607(1.175494e-38)
-; EG-NEXT:     SETGT_INT T0.X, 0.0, T0.X,
-; EG-NEXT:     ADD_INT T3.Y, PV.W, literal.x,
-; EG-NEXT:     OR_INT T1.Z, PS, literal.y,
-; EG-NEXT:     BFE_UINT T0.W, KC0[3].W, literal.z, T0.W,
-; EG-NEXT:     ADD_INT * T4.W, PV.W, literal.w,
-; EG-NEXT:    -127(nan), 8388608(1.175494e-38)
-; EG-NEXT:    23(3.222986e-44), -150(nan)
-; EG-NEXT:     AND_INT T1.X, KC0[3].W, literal.x,
-; EG-NEXT:     ADD_INT T5.Y, PV.W, literal.y,
-; EG-NEXT:     SUB_INT T2.Z, literal.z, T3.W,
-; EG-NEXT:     NOT_INT T3.W, PS,
-; EG-NEXT:     LSHR * T5.W, PV.Z, 1,
+; EG-NEXT:     XOR_INT T0.Z, PV.W, PS,
+; EG-NEXT:     BFE_UINT T1.W, KC0[3].Z, literal.x, T0.W,
+; EG-NEXT:     XOR_INT * T3.W, PV.Z, PS,
+; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T0.Y, KC0[3].Z, literal.x,
+; EG-NEXT:     ADD_INT T1.Z, PV.W, literal.y,
+; EG-NEXT:     SUB_INT T3.W, PS, T2.W,
+; EG-NEXT:     SUBB_UINT * T4.W, PV.Z, T2.W,
 ; EG-NEXT:    8388607(1.175494e-38), -150(nan)
-; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T2.X, 0.0, PS, PV.W,
-; EG-NEXT:     AND_INT T6.Y, PV.Z, literal.x,
-; EG-NEXT:     AND_INT T3.Z, PV.Y, literal.y,
-; EG-NEXT:     OR_INT T3.W, PV.X, literal.z,
-; EG-NEXT:     AND_INT * T5.W, T4.W, literal.y,
-; EG-NEXT:    32(4.484155e-44), 31(4.344025e-44)
+; EG-NEXT:     SUB_INT T1.Y, PV.W, PS,
+; EG-NEXT:     AND_INT T2.Z, PV.Z, literal.x,
+; EG-NEXT:     BFE_UINT T3.W, KC0[3].Y, literal.y, T0.W,
+; EG-NEXT:     OR_INT * T4.W, PV.Y, literal.z,
+; EG-NEXT:    31(4.344025e-44), 23(3.222986e-44)
 ; EG-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, T1.Z, T2.Z,
-; EG-NEXT:     LSHL T7.Y, T1.Z, PS,
-; EG-NEXT:     AND_INT T1.Z, T4.W, literal.x,
-; EG-NEXT:     LSHL T4.W, PV.W, PV.Z,
-; EG-NEXT:     AND_INT * T5.W, T5.Y, literal.x,
+; EG-NEXT:     SETGT_INT T0.X, 0.0, T0.X,
+; EG-NEXT:     AND_INT T0.Y, KC0[3].Y, literal.x,
+; EG-NEXT:     ADD_INT T3.Z, PV.W, literal.y,
+; EG-NEXT:     LSHL T5.W, PS, PV.Z,
+; EG-NEXT:     AND_INT * T6.W, T1.Z, literal.z,
+; EG-NEXT:    8388607(1.175494e-38), -150(nan)
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T3.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T8.Y, PV.Z, PV.Y, 0.0,
-; EG-NEXT:     CNDE_INT * T2.Z, T6.Y, PV.X, 0.0,
-; EG-NEXT:    ALU clause starting at 106:
-; EG-NEXT:     CNDE_INT T6.W, T1.Z, T2.X, T7.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGT_INT * T7.W, T3.Y, literal.x,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T1.X, PS, 0.0, PV.W,
-; EG-NEXT:     CNDE_INT T6.Y, PS, T2.Z, T8.Y,
-; EG-NEXT:     SUB_INT T1.Z, literal.x, T0.W,
-; EG-NEXT:     NOT_INT T6.W, T5.Y,
-; EG-NEXT:     LSHR * T7.W, T3.W, 1,
+; EG-NEXT:     BFE_UINT T1.X, KC0[3].W, literal.x, T0.W,
+; EG-NEXT:     CNDE_INT T2.Y, PS, PV.W, 0.0,
+; EG-NEXT:     AND_INT T2.Z, PV.Z, literal.y,
+; EG-NEXT:     OR_INT T0.W, PV.Y, literal.z,
+; EG-NEXT:     SUB_INT * T7.W, literal.w, T1.W,
+; EG-NEXT:    23(3.222986e-44), 31(4.344025e-44)
+; EG-NEXT:    8388608(1.175494e-38), 150(2.101948e-43)
+; EG-NEXT:     NOT_INT T2.X, T1.Z,
+; EG-NEXT:     LSHR T0.Y, T4.W, 1,
+; EG-NEXT:     AND_INT T1.Z, PS, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T4.W, 0.0, T4.W, PS,
+; EG-NEXT:     ADD_INT * T1.W, T1.W, literal.y,
+; EG-NEXT:    32(4.484155e-44), -127(nan)
+; EG-NEXT:     SETGT_INT T3.X, PS, literal.x,
+; EG-NEXT:     CNDE_INT T3.Y, PV.Z, PV.W, 0.0,
+; EG-NEXT:     BIT_ALIGN_INT T1.Z, 0.0, PV.Y, PV.X,
+; EG-NEXT:     LSHL T4.W, T0.W, T2.Z,
+; EG-NEXT:     AND_INT * T7.W, T3.Z, literal.y,
+; EG-NEXT:    23(3.222986e-44), 32(4.484155e-44)
+; EG-NEXT:     AND_INT T2.X, KC0[3].W, literal.x,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T1.Z, T6.W, PV.Z, T5.W,
+; EG-NEXT:     CNDE_INT T5.W, PV.X, PV.Y, T2.Y,
+; EG-NEXT:     ASHR * T6.W, KC0[3].Z, literal.y,
+; EG-NEXT:    8388607(1.175494e-38), 31(4.344025e-44)
+; EG-NEXT:     XOR_INT T4.X, PV.W, PS,
+; EG-NEXT:     SUB_INT T2.Y, literal.x, T3.W,
+; EG-NEXT:     NOT_INT T2.Z, T3.Z,
+; EG-NEXT:     LSHR T5.W, T0.W, 1,
+; EG-NEXT:     CNDE_INT * T8.W, T3.X, 0.0, PV.Z, BS:VEC_021/SCL_122
 ; EG-NEXT:    150(2.101948e-43), 0(0.000000e+00)
-; EG-NEXT:     ASHR T2.X, KC0[3].Y, literal.x,
-; EG-NEXT:     ADD_INT T5.Y, T0.W, literal.y,
-; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, PS, PV.W,
-; EG-NEXT:     BIT_ALIGN_INT T0.W, 0.0, T3.W, PV.Z,
-; EG-NEXT:     AND_INT * T3.W, PV.Z, literal.z,
-; EG-NEXT:    31(4.344025e-44), -127(nan)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, PS, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T7.Y, T5.W, PV.Z, T4.W,
+; EG-NEXT:     XOR_INT T3.X, PS, T6.W,
+; EG-NEXT:     ADD_INT T3.Y, T3.W, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T1.Z, 0.0, PV.W, PV.Z,
+; EG-NEXT:     BIT_ALIGN_INT T0.W, 0.0, T0.W, PV.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     AND_INT * T3.W, PV.Y, literal.y,
+; EG-NEXT:    -127(nan), 32(4.484155e-44)
+; EG-NEXT:     CNDE_INT T5.X, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T2.Y, T7.W, PV.Z, T4.W,
 ; EG-NEXT:     SETGT_INT T1.Z, PV.Y, literal.x,
-; EG-NEXT:     XOR_INT T0.W, T6.Y, PV.X,
-; EG-NEXT:     XOR_INT * T3.W, T1.X, PV.X,
+; EG-NEXT:     SUB_INT T0.W, PV.X, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T4.X, T6.W,
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T1.X, PS, T2.X,
-; EG-NEXT:     SUBB_UINT T6.Y, PV.W, T2.X,
-; EG-NEXT:     CNDE_INT T2.Z, PV.Z, 0.0, PV.Y,
-; EG-NEXT:     CNDE_INT T3.W, PV.Z, PV.X, T3.X,
-; EG-NEXT:     ASHR * T4.W, KC0[3].W, literal.x,
+; EG-NEXT:     SUB_INT T3.X, PV.W, PS,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, 0.0, PV.Y,
+; EG-NEXT:     CNDE_INT T1.Z, PV.Z, PV.X, T0.Y,
+; EG-NEXT:     OR_INT T0.W, T2.X, literal.x,
+; EG-NEXT:     ADD_INT * T3.W, T1.X, literal.y,
+; EG-NEXT:    8388608(1.175494e-38), -150(nan)
+; EG-NEXT:     ADD_INT * T2.X, T1.X, literal.x,
+; EG-NEXT:    -127(nan), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 109:
+; EG-NEXT:     AND_INT T0.Y, T3.W, literal.x,
+; EG-NEXT:     SUB_INT T2.Z, literal.y, T1.X,
+; EG-NEXT:     NOT_INT T4.W, T3.W,
+; EG-NEXT:     LSHR * T5.W, T0.W, 1,
+; EG-NEXT:    31(4.344025e-44), 150(2.101948e-43)
+; EG-NEXT:     BIT_ALIGN_INT T1.X, 0.0, PS, PV.W,
+; EG-NEXT:     AND_INT T4.Y, PV.Z, literal.x,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, 0.0, T0.W, PV.Z,
+; EG-NEXT:     LSHL T0.W, T0.W, PV.Y,
+; EG-NEXT:     AND_INT * T3.W, T3.W, literal.x,
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T5.X, KC0[3].Y, literal.x,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.W, 0.0,
+; EG-NEXT:     CNDE_INT T2.Z, PV.Y, PV.Z, 0.0,
+; EG-NEXT:     CNDE_INT T0.W, PS, PV.X, PV.W,
+; EG-NEXT:     SETGT_INT * T3.W, T2.X, literal.y,
+; EG-NEXT:    31(4.344025e-44), 23(3.222986e-44)
+; EG-NEXT:     CNDE_INT T1.X, PS, 0.0, PV.W,
+; EG-NEXT:     CNDE_INT T0.Y, PS, PV.Z, PV.Y,
+; EG-NEXT:     ASHR T2.Z, KC0[3].W, literal.x,
+; EG-NEXT:     XOR_INT T0.W, T1.Z, PV.X,
+; EG-NEXT:     XOR_INT * T3.W, T2.Y, PV.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T3.X, PV.W, PS,
-; EG-NEXT:     XOR_INT T7.Y, PV.Z, PS,
-; EG-NEXT:     SUB_INT T1.Z, PV.X, PV.Y,
+; EG-NEXT:     SETGT_INT T6.X, 0.0, T1.W,
+; EG-NEXT:     SUB_INT T2.Y, PS, T5.X,
+; EG-NEXT:     SUBB_UINT T1.Z, PV.W, T5.X,
+; EG-NEXT:     XOR_INT T1.W, PV.Y, PV.Z,
+; EG-NEXT:     XOR_INT * T3.W, PV.X, PV.Z,
+; EG-NEXT:     SUB_INT T1.X, PS, T2.Z,
+; EG-NEXT:     SUBB_UINT T0.Y, PV.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.Z, PV.Y, PV.Z,
 ; EG-NEXT:     SETGT_INT T3.W, 0.0, T3.Y,
-; EG-NEXT:     CNDE_INT * T6.W, T0.X, T0.Z, 0.0,
-; EG-NEXT:     SETGT_INT T1.X, 0.0, T0.Y,
+; EG-NEXT:     CNDE_INT * T4.W, PV.X, T3.X, 0.0,
+; EG-NEXT:     SUB_INT T3.X, T4.X, T6.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PV.Z, 0.0,
+; EG-NEXT:     SUB_INT T1.Z, PV.X, PV.Y,
+; EG-NEXT:     SETGT_INT T5.W, 0.0, T2.X,
+; EG-NEXT:     CNDE_INT * T6.W, T0.X, T1.Y, 0.0,
 ; EG-NEXT:     CNDE_INT T6.Y, PV.W, PV.Z, 0.0,
-; EG-NEXT:     SUB_INT T0.Z, T1.W, T1.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T1.W, PV.Y, T4.W,
-; EG-NEXT:     SUBB_UINT * T5.W, PV.X, T4.W,
-; EG-NEXT:     SUB_INT T4.X, PV.W, PS,
-; EG-NEXT:     SETGT_INT T0.Y, 0.0, T5.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T6.Z, T0.X, PV.Z, 0.0,
-; EG-NEXT:     SUB_INT T0.W, T0.W, T2.X,
-; EG-NEXT:     CNDE_INT * T1.W, PV.X, T4.Y, 0.0,
-; EG-NEXT:     CNDE_INT T6.X, T3.W, PV.W, 0.0,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Y, PV.X, 0.0,
-; EG-NEXT:     SUB_INT T0.W, T2.Y, T2.W,
+; EG-NEXT:     CNDE_INT T4.Z, T6.X, PV.X, 0.0,
+; EG-NEXT:     SUB_INT T2.W, T0.Z, T2.W,
+; EG-NEXT:     SUB_INT * T0.W, T0.W, T5.X,
+; EG-NEXT:     CNDE_INT T4.X, T3.W, PS, 0.0,
+; EG-NEXT:     CNDE_INT T6.Z, T0.X, PV.W, 0.0,
+; EG-NEXT:     SUB_INT * T0.W, T1.W, T2.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     CNDE_INT T6.X, T5.W, PV.W, 0.0,
 ; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T1.Z, T1.X, PV.W, 0.0,
-; EG-NEXT:     SUB_INT * T0.W, T3.X, T4.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT T1.X, T0.Y, PV.W, 0.0,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T2.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T1.X, PS, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %conv = fptoui <4 x float> %x to <4 x i64>
   store <4 x i64> %conv, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/kernel-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/kernel-args.ll
@@ -1142,7 +1142,7 @@ define amdgpu_kernel void @v3i32_arg(ptr addrspace(1) nocapture %out, <3 x i32> 
 ;
 ; EG-LABEL: v3i32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 6, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
 ; EG-NEXT:    CF_END
@@ -1151,28 +1151,24 @@ define amdgpu_kernel void @v3i32_arg(ptr addrspace(1) nocapture %out, <3 x i32> 
 ; EG-NEXT:     MOV T0.X, KC0[3].Y,
 ; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T2.X, PS, literal.x,
 ; EG-NEXT:     MOV * T3.X, KC0[3].W,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v3i32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T0.X
+; CM-NEXT:    ALU 6, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T1.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T0.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T1.X, KC0[3].W,
-; CM-NEXT:     MOV * T2.Y, KC0[3].Z,
-; CM-NEXT:     MOV * T2.X, KC0[3].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT * T1.X, PV.X, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV T2.X, KC0[3].W,
+; CM-NEXT:     MOV * T3.Y, KC0[3].Z,
+; CM-NEXT:     MOV * T3.X, KC0[3].Y,
 entry:
   store <3 x i32> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -1221,7 +1217,7 @@ define amdgpu_kernel void @v3f32_arg(ptr addrspace(1) nocapture %out, <3 x float
 ;
 ; EG-LABEL: v3f32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 6, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
 ; EG-NEXT:    CF_END
@@ -1230,28 +1226,24 @@ define amdgpu_kernel void @v3f32_arg(ptr addrspace(1) nocapture %out, <3 x float
 ; EG-NEXT:     MOV T0.X, KC0[3].Y,
 ; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T2.X, PS, literal.x,
 ; EG-NEXT:     MOV * T3.X, KC0[3].W,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v3f32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T0.X
+; CM-NEXT:    ALU 6, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T1.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T0.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T1.X, KC0[3].W,
-; CM-NEXT:     MOV * T2.Y, KC0[3].Z,
-; CM-NEXT:     MOV * T2.X, KC0[3].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT * T1.X, PV.X, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV T2.X, KC0[3].W,
+; CM-NEXT:     MOV * T3.Y, KC0[3].Z,
+; CM-NEXT:     MOV * T3.X, KC0[3].Y,
 entry:
   store <3 x float> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -1957,7 +1949,7 @@ define amdgpu_kernel void @v5i32_arg(ptr addrspace(1) nocapture %out, <5 x i32> 
 ;
 ; EG-LABEL: v5i32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 10, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
@@ -1968,30 +1960,26 @@ define amdgpu_kernel void @v5i32_arg(ptr addrspace(1) nocapture %out, <5 x i32> 
 ; EG-NEXT:     MOV T0.X, KC0[4].Y,
 ; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T2.X, PS, literal.x,
 ; EG-NEXT:     MOV * T3.X, KC0[5].Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v5i32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 10, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T1.X
+; CM-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T0.W, KC0[5].X,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T1.X, PV.Z, literal.x,
-; CM-NEXT:     MOV * T0.Z, KC0[4].W,
+; CM-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.W, KC0[5].X,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.X, KC0[5].Y,
-; CM-NEXT:     MOV * T0.Y, KC0[4].Z,
-; CM-NEXT:     MOV * T0.X, KC0[4].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T2.X, PV.X, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[4].W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV T3.X, KC0[5].Y,
+; CM-NEXT:     MOV * T1.Y, KC0[4].Z,
+; CM-NEXT:     MOV * T1.X, KC0[4].Y,
 entry:
   store <5 x i32> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -2056,7 +2044,7 @@ define amdgpu_kernel void @v5f32_arg(ptr addrspace(1) nocapture %out, <5 x float
 ;
 ; EG-LABEL: v5f32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 10, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
@@ -2067,30 +2055,26 @@ define amdgpu_kernel void @v5f32_arg(ptr addrspace(1) nocapture %out, <5 x float
 ; EG-NEXT:     MOV T0.X, KC0[4].Y,
 ; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T2.X, PS, literal.x,
 ; EG-NEXT:     MOV * T3.X, KC0[5].Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v5f32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 10, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T1.X
+; CM-NEXT:    ALU 8, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T0.W, KC0[5].X,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T1.X, PV.Z, literal.x,
-; CM-NEXT:     MOV * T0.Z, KC0[4].W,
+; CM-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.W, KC0[5].X,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.X, KC0[5].Y,
-; CM-NEXT:     MOV * T0.Y, KC0[4].Z,
-; CM-NEXT:     MOV * T0.X, KC0[4].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T2.X, PV.X, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[4].W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV T3.X, KC0[5].Y,
+; CM-NEXT:     MOV * T1.Y, KC0[4].Z,
+; CM-NEXT:     MOV * T1.X, KC0[4].Y,
 entry:
   store <5 x float> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -2178,7 +2162,7 @@ define amdgpu_kernel void @v5i64_arg(ptr addrspace(1) nocapture %out, <5 x i64> 
 ;
 ; EG-LABEL: v5i64_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 18, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 14, @6, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XY, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
@@ -2186,53 +2170,46 @@ define amdgpu_kernel void @v5i64_arg(ptr addrspace(1) nocapture %out, <5 x i64> 
 ; EG-NEXT:    PAD
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, KC0[7].X,
-; EG-NEXT:     MOV * T0.Z, KC0[6].W,
-; EG-NEXT:     MOV T0.Y, KC0[6].Z,
+; EG-NEXT:     MOV T0.Z, KC0[6].W,
 ; EG-NEXT:     MOV * T1.W, KC0[8].X,
-; EG-NEXT:     MOV T0.X, KC0[6].Y,
+; EG-NEXT:     MOV T0.Y, KC0[6].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[7].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[6].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[7].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T1.X, KC0[7].Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     MOV T5.Y, KC0[8].Z,
-; EG-NEXT:     MOV * T5.X, KC0[8].Y,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, PS, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     MOV * T5.Y, KC0[8].Z,
+; EG-NEXT:     MOV * T5.X, KC0[8].Y,
 ;
 ; CM-LABEL: v5i64_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 18, @6, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T5.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T4.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
+; CM-NEXT:    ALU 15, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     MOV * T0.W, KC0[8].X,
-; CM-NEXT:     MOV T1.Y, KC0[8].Z,
-; CM-NEXT:     MOV * T0.Z, KC0[7].W,
-; CM-NEXT:     MOV T1.X, KC0[8].Y,
-; CM-NEXT:     MOV * T0.Y, KC0[7].Z,
-; CM-NEXT:     MOV T0.X, KC0[7].Y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T2.W, KC0[7].X,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T3.X, PV.Z, literal.x,
-; CM-NEXT:     MOV T2.Z, KC0[6].W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T4.X, PV.W, literal.x,
-; CM-NEXT:     MOV * T2.Y, KC0[6].Z,
+; CM-NEXT:     MOV * T0.Y, KC0[8].Z,
+; CM-NEXT:     MOV T0.X, KC0[8].Y,
+; CM-NEXT:     MOV * T1.W, KC0[8].X,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[7].W,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV * T2.X, KC0[6].Y,
-; CM-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     MOV T1.Y, KC0[7].Z,
+; CM-NEXT:     MOV * T4.W, KC0[7].X,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T1.X, KC0[7].Y,
+; CM-NEXT:     MOV * T4.Z, KC0[6].W,
+; CM-NEXT:     ADD_INT T5.X, T2.X, literal.x,
+; CM-NEXT:     MOV * T4.Y, KC0[6].Z,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV * T4.X, KC0[6].Y,
 entry:
   store <5 x i64> %in, ptr addrspace(1) %out, align 8
   ret void
@@ -2320,7 +2297,7 @@ define amdgpu_kernel void @v5f64_arg(ptr addrspace(1) nocapture %out, <5 x doubl
 ;
 ; EG-LABEL: v5f64_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 18, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 14, @6, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XY, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
@@ -2328,53 +2305,46 @@ define amdgpu_kernel void @v5f64_arg(ptr addrspace(1) nocapture %out, <5 x doubl
 ; EG-NEXT:    PAD
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, KC0[7].X,
-; EG-NEXT:     MOV * T0.Z, KC0[6].W,
-; EG-NEXT:     MOV T0.Y, KC0[6].Z,
+; EG-NEXT:     MOV T0.Z, KC0[6].W,
 ; EG-NEXT:     MOV * T1.W, KC0[8].X,
-; EG-NEXT:     MOV T0.X, KC0[6].Y,
+; EG-NEXT:     MOV T0.Y, KC0[6].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[7].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[6].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[7].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T1.X, KC0[7].Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     MOV T5.Y, KC0[8].Z,
-; EG-NEXT:     MOV * T5.X, KC0[8].Y,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, PS, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     MOV * T5.Y, KC0[8].Z,
+; EG-NEXT:     MOV * T5.X, KC0[8].Y,
 ;
 ; CM-LABEL: v5f64_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 18, @6, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T5.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T4.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
+; CM-NEXT:    ALU 15, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     MOV * T0.W, KC0[8].X,
-; CM-NEXT:     MOV T1.Y, KC0[8].Z,
-; CM-NEXT:     MOV * T0.Z, KC0[7].W,
-; CM-NEXT:     MOV T1.X, KC0[8].Y,
-; CM-NEXT:     MOV * T0.Y, KC0[7].Z,
-; CM-NEXT:     MOV T0.X, KC0[7].Y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T2.W, KC0[7].X,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T3.X, PV.Z, literal.x,
-; CM-NEXT:     MOV T2.Z, KC0[6].W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T4.X, PV.W, literal.x,
-; CM-NEXT:     MOV * T2.Y, KC0[6].Z,
+; CM-NEXT:     MOV * T0.Y, KC0[8].Z,
+; CM-NEXT:     MOV T0.X, KC0[8].Y,
+; CM-NEXT:     MOV * T1.W, KC0[8].X,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[7].W,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV * T2.X, KC0[6].Y,
-; CM-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     MOV T1.Y, KC0[7].Z,
+; CM-NEXT:     MOV * T4.W, KC0[7].X,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T1.X, KC0[7].Y,
+; CM-NEXT:     MOV * T4.Z, KC0[6].W,
+; CM-NEXT:     ADD_INT T5.X, T2.X, literal.x,
+; CM-NEXT:     MOV * T4.Y, KC0[6].Z,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV * T4.X, KC0[6].Y,
 entry:
   store <5 x double> %in, ptr addrspace(1) %out, align 8
   ret void
@@ -2945,31 +2915,29 @@ define amdgpu_kernel void @v8i32_arg(ptr addrspace(1) nocapture %out, <8 x i32> 
 ;
 ; EG-LABEL: v8i32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 4:
 ; EG-NEXT:     MOV * T0.W, KC0[5].X,
-; EG-NEXT:     MOV * T0.Z, KC0[4].W,
-; EG-NEXT:     MOV T0.Y, KC0[4].Z,
+; EG-NEXT:     MOV T0.Z, KC0[4].W,
 ; EG-NEXT:     MOV * T1.W, KC0[6].X,
-; EG-NEXT:     MOV T0.X, KC0[4].Y,
+; EG-NEXT:     MOV T0.Y, KC0[4].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[5].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[4].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[5].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T1.X, KC0[5].Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v8i32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
+; CM-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
 ; CM-NEXT:     MOV * T0.W, KC0[6].X,
@@ -2977,15 +2945,13 @@ define amdgpu_kernel void @v8i32_arg(ptr addrspace(1) nocapture %out, <8 x i32> 
 ; CM-NEXT:     MOV * T0.Y, KC0[5].Z,
 ; CM-NEXT:     MOV T0.X, KC0[5].Y,
 ; CM-NEXT:     MOV * T1.W, KC0[5].X,
-; CM-NEXT:     MOV T1.Z, KC0[4].W,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T2.X, PV.W, literal.x,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[4].W,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
 ; CM-NEXT:     MOV * T1.Y, KC0[4].Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T1.X, KC0[4].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 entry:
   store <8 x i32> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -3056,31 +3022,29 @@ define amdgpu_kernel void @v8f32_arg(ptr addrspace(1) nocapture %out, <8 x float
 ;
 ; EG-LABEL: v8f32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 4:
 ; EG-NEXT:     MOV * T0.W, KC0[5].X,
-; EG-NEXT:     MOV * T0.Z, KC0[4].W,
-; EG-NEXT:     MOV T0.Y, KC0[4].Z,
+; EG-NEXT:     MOV T0.Z, KC0[4].W,
 ; EG-NEXT:     MOV * T1.W, KC0[6].X,
-; EG-NEXT:     MOV T0.X, KC0[4].Y,
+; EG-NEXT:     MOV T0.Y, KC0[4].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[5].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[4].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[5].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T1.X, KC0[5].Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: v8f32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
+; CM-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
 ; CM-NEXT:     MOV * T0.W, KC0[6].X,
@@ -3088,15 +3052,13 @@ define amdgpu_kernel void @v8f32_arg(ptr addrspace(1) nocapture %out, <8 x float
 ; CM-NEXT:     MOV * T0.Y, KC0[5].Z,
 ; CM-NEXT:     MOV T0.X, KC0[5].Y,
 ; CM-NEXT:     MOV * T1.W, KC0[5].X,
-; CM-NEXT:     MOV T1.Z, KC0[4].W,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T2.X, PV.W, literal.x,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[4].W,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
 ; CM-NEXT:     MOV * T1.Y, KC0[4].Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T1.X, KC0[4].Y,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 entry:
   store <8 x float> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -3650,7 +3612,7 @@ define amdgpu_kernel void @v16i16_arg(ptr addrspace(1) %out, <16 x i16> %in) {
 ; EG-NEXT:    TEX 0 @64
 ; EG-NEXT:    ALU 5, @154, KC0[], KC1[]
 ; EG-NEXT:    TEX 0 @66
-; EG-NEXT:    ALU 13, @160, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 12, @160, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T13.X, 1
 ; EG-NEXT:    CF_END
@@ -3795,13 +3757,12 @@ define amdgpu_kernel void @v16i16_arg(ptr addrspace(1) %out, <16 x i16> %in) {
 ; EG-NEXT:     MOV T6.X, PV.Z,
 ; EG-NEXT:     MOV * T0.Y, T8.X,
 ; EG-NEXT:    ALU clause starting at 160:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
 ; EG-NEXT:     AND_INT T0.W, T0.Y, literal.y,
 ; EG-NEXT:     AND_INT * T1.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), -65536(nan)
+; EG-NEXT:    4(5.605194e-45), -65536(nan)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
 ; EG-NEXT:     OR_INT * T11.X, PV.W, PS,
 ; EG-NEXT:     MOV T8.X, PV.X,
@@ -3844,9 +3805,9 @@ define amdgpu_kernel void @v16i16_arg(ptr addrspace(1) %out, <16 x i16> %in) {
 ; CM-NEXT:    TEX 0 @64
 ; CM-NEXT:    ALU 5, @154, KC0[], KC1[]
 ; CM-NEXT:    TEX 0 @66
-; CM-NEXT:    ALU 14, @160, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T13.X
+; CM-NEXT:    ALU 12, @160, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T14.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 36:
 ; CM-NEXT:     VTX_READ_16 T12.X, T11.X, 98, #3
@@ -3989,14 +3950,12 @@ define amdgpu_kernel void @v16i16_arg(ptr addrspace(1) %out, <16 x i16> %in) {
 ; CM-NEXT:     MOV T6.X, PV.Z,
 ; CM-NEXT:     MOV * T0.Y, T8.X,
 ; CM-NEXT:    ALU clause starting at 160:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T13.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR T14.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T14.X, PV.X, literal.x,
 ; CM-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
 ; CM-NEXT:     AND_INT * T0.W, T11.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), -65536(nan)
+; CM-NEXT:    4(5.605194e-45), -65536(nan)
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
 ; CM-NEXT:     OR_INT * T11.X, PV.Z, PV.W,
 ; CM-NEXT:     MOV T8.X, PV.X,
@@ -4116,50 +4075,44 @@ define amdgpu_kernel void @v16i32_arg(ptr addrspace(1) nocapture %out, <16 x i32
 ;
 ; EG-LABEL: v16i32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 29, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 23, @6, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, KC0[7].X,
-; EG-NEXT:     MOV * T0.Z, KC0[6].W,
-; EG-NEXT:     MOV T0.Y, KC0[6].Z,
+; EG-NEXT:     MOV T0.Z, KC0[6].W,
 ; EG-NEXT:     MOV * T1.W, KC0[8].X,
-; EG-NEXT:     MOV T0.X, KC0[6].Y,
+; EG-NEXT:     MOV T0.Y, KC0[6].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[7].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[6].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[7].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     MOV * T3.W, KC0[9].X,
 ; EG-NEXT:     MOV T1.X, KC0[7].Y,
-; EG-NEXT:     MOV * T3.Z, KC0[8].W,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     MOV T3.Y, KC0[8].Z,
+; EG-NEXT:     MOV * T2.W, KC0[9].X,
+; EG-NEXT:     LSHR T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T2.Z, KC0[8].W,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; EG-NEXT:     MOV T2.Y, KC0[8].Z,
 ; EG-NEXT:     MOV * T5.W, KC0[10].X,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     MOV T3.X, KC0[8].Y,
-; EG-NEXT:     MOV * T5.Z, KC0[9].W,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     MOV T5.Y, KC0[9].Z,
-; EG-NEXT:     MOV * T5.X, KC0[9].Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:     MOV T2.X, KC0[8].Y,
+; EG-NEXT:     MOV T5.Z, KC0[9].W,
+; EG-NEXT:     ADD_INT * T6.X, T3.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV * T5.Y, KC0[9].Z,
+; EG-NEXT:     MOV T5.X, KC0[9].Y,
+; EG-NEXT:     ADD_INT * T7.X, T3.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: v16i32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 28, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 23, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T2.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T6.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T5.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 6:
@@ -4167,31 +4120,26 @@ define amdgpu_kernel void @v16i32_arg(ptr addrspace(1) nocapture %out, <16 x i32
 ; CM-NEXT:     MOV * T0.Z, KC0[9].W,
 ; CM-NEXT:     MOV * T0.Y, KC0[9].Z,
 ; CM-NEXT:     MOV T0.X, KC0[9].Y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T2.W, KC0[9].X,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.Z, KC0[8].W,
-; CM-NEXT:     MOV * T1.W, KC0[8].X,
-; CM-NEXT:     LSHR T3.X, T1.Z, literal.x,
-; CM-NEXT:     MOV T2.Y, KC0[8].Z,
-; CM-NEXT:     MOV * T1.Z, KC0[7].W,
+; CM-NEXT:     MOV * T1.W, KC0[9].X,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[8].W,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.X, KC0[8].Y,
-; CM-NEXT:     MOV * T1.Y, KC0[7].Z,
-; CM-NEXT:     MOV T1.X, KC0[7].Y,
-; CM-NEXT:     ADD_INT T3.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T4.W, KC0[7].X,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T5.X, PV.Z, literal.x,
-; CM-NEXT:     MOV T4.Z, KC0[6].W,
-; CM-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T6.X, PV.W, literal.x,
-; CM-NEXT:     MOV * T4.Y, KC0[6].Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV * T4.X, KC0[6].Y,
-; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     MOV T1.Y, KC0[8].Z,
+; CM-NEXT:     MOV * T4.W, KC0[8].X,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T1.X, KC0[8].Y,
+; CM-NEXT:     MOV * T4.Z, KC0[7].W,
+; CM-NEXT:     ADD_INT T5.X, T2.X, literal.x,
+; CM-NEXT:     MOV T4.Y, KC0[7].Z,
+; CM-NEXT:     MOV * T6.W, KC0[7].X,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T4.X, KC0[7].Y,
+; CM-NEXT:     MOV * T6.Z, KC0[6].W,
+; CM-NEXT:     ADD_INT T7.X, T2.X, literal.x,
+; CM-NEXT:     MOV * T6.Y, KC0[6].Z,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV * T6.X, KC0[6].Y,
 entry:
   store <16 x i32> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -4304,50 +4252,44 @@ define amdgpu_kernel void @v16f32_arg(ptr addrspace(1) nocapture %out, <16 x flo
 ;
 ; EG-LABEL: v16f32_arg:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 29, @6, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 23, @6, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 6:
 ; EG-NEXT:     MOV * T0.W, KC0[7].X,
-; EG-NEXT:     MOV * T0.Z, KC0[6].W,
-; EG-NEXT:     MOV T0.Y, KC0[6].Z,
+; EG-NEXT:     MOV T0.Z, KC0[6].W,
 ; EG-NEXT:     MOV * T1.W, KC0[8].X,
-; EG-NEXT:     MOV T0.X, KC0[6].Y,
+; EG-NEXT:     MOV T0.Y, KC0[6].Z,
 ; EG-NEXT:     MOV * T1.Z, KC0[7].W,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV T0.X, KC0[6].Y,
 ; EG-NEXT:     MOV * T1.Y, KC0[7].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     MOV * T3.W, KC0[9].X,
 ; EG-NEXT:     MOV T1.X, KC0[7].Y,
-; EG-NEXT:     MOV * T3.Z, KC0[8].W,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     MOV T3.Y, KC0[8].Z,
+; EG-NEXT:     MOV * T2.W, KC0[9].X,
+; EG-NEXT:     LSHR T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T2.Z, KC0[8].W,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; EG-NEXT:     MOV T2.Y, KC0[8].Z,
 ; EG-NEXT:     MOV * T5.W, KC0[10].X,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     MOV T3.X, KC0[8].Y,
-; EG-NEXT:     MOV * T5.Z, KC0[9].W,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     MOV T5.Y, KC0[9].Z,
-; EG-NEXT:     MOV * T5.X, KC0[9].Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:     MOV T2.X, KC0[8].Y,
+; EG-NEXT:     MOV T5.Z, KC0[9].W,
+; EG-NEXT:     ADD_INT * T6.X, T3.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV * T5.Y, KC0[9].Z,
+; EG-NEXT:     MOV T5.X, KC0[9].Y,
+; EG-NEXT:     ADD_INT * T7.X, T3.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: v16f32_arg:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 28, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 23, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T2.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T6.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T5.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 6:
@@ -4355,31 +4297,26 @@ define amdgpu_kernel void @v16f32_arg(ptr addrspace(1) nocapture %out, <16 x flo
 ; CM-NEXT:     MOV * T0.Z, KC0[9].W,
 ; CM-NEXT:     MOV * T0.Y, KC0[9].Z,
 ; CM-NEXT:     MOV T0.X, KC0[9].Y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T2.W, KC0[9].X,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.Z, KC0[8].W,
-; CM-NEXT:     MOV * T1.W, KC0[8].X,
-; CM-NEXT:     LSHR T3.X, T1.Z, literal.x,
-; CM-NEXT:     MOV T2.Y, KC0[8].Z,
-; CM-NEXT:     MOV * T1.Z, KC0[7].W,
+; CM-NEXT:     MOV * T1.W, KC0[9].X,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     MOV * T1.Z, KC0[8].W,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV T2.X, KC0[8].Y,
-; CM-NEXT:     MOV * T1.Y, KC0[7].Z,
-; CM-NEXT:     MOV T1.X, KC0[7].Y,
-; CM-NEXT:     ADD_INT T3.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T4.W, KC0[7].X,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T5.X, PV.Z, literal.x,
-; CM-NEXT:     MOV T4.Z, KC0[6].W,
-; CM-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T6.X, PV.W, literal.x,
-; CM-NEXT:     MOV * T4.Y, KC0[6].Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     MOV * T4.X, KC0[6].Y,
-; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     MOV T1.Y, KC0[8].Z,
+; CM-NEXT:     MOV * T4.W, KC0[8].X,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T1.X, KC0[8].Y,
+; CM-NEXT:     MOV * T4.Z, KC0[7].W,
+; CM-NEXT:     ADD_INT T5.X, T2.X, literal.x,
+; CM-NEXT:     MOV T4.Y, KC0[7].Z,
+; CM-NEXT:     MOV * T6.W, KC0[7].X,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     MOV T4.X, KC0[7].Y,
+; CM-NEXT:     MOV * T6.Z, KC0[6].W,
+; CM-NEXT:     ADD_INT T7.X, T2.X, literal.x,
+; CM-NEXT:     MOV * T6.Y, KC0[6].Z,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:     MOV * T6.X, KC0[6].Y,
 entry:
   store <16 x float> %in, ptr addrspace(1) %out, align 4
   ret void
@@ -6092,14 +6029,14 @@ define amdgpu_kernel void @byref_natural_align_constant_v16i32_arg(ptr addrspace
 ; EG-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @16
 ; EG-NEXT:    ALU 3, @25, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 0
-; EG-NEXT:    ALU 3, @29, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; EG-NEXT:    ALU 1, @29, KC0[], KC1[]
 ; EG-NEXT:    TEX 0 @18
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T1.X, 0
-; EG-NEXT:    ALU 3, @33, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 0
+; EG-NEXT:    ALU 1, @31, KC0[], KC1[]
 ; EG-NEXT:    TEX 0 @20
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T1.X, 0
-; EG-NEXT:    ALU 2, @37, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 0
+; EG-NEXT:    ALU 0, @33, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T2.X, 1
@@ -6108,46 +6045,40 @@ define amdgpu_kernel void @byref_natural_align_constant_v16i32_arg(ptr addrspace
 ; EG-NEXT:    Fetch clause starting at 16:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 48, #1
 ; EG-NEXT:    Fetch clause starting at 18:
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 32, #1
 ; EG-NEXT:    Fetch clause starting at 20:
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 16, #1
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 24:
 ; EG-NEXT:     MOV * T0.X, KC0[6].Y,
 ; EG-NEXT:    ALU clause starting at 25:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T2.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 29:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T1.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 33:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T1.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 37:
-; EG-NEXT:     MOV T1.X, KC0[10].Y,
 ; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 29:
+; EG-NEXT:     ADD_INT * T1.X, T2.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 31:
+; EG-NEXT:     ADD_INT * T1.X, T2.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 33:
+; EG-NEXT:     MOV * T1.X, KC0[10].Y,
 ;
 ; CM-LABEL: byref_natural_align_constant_v16i32_arg:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @16
 ; CM-NEXT:    ALU 3, @25, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
-; CM-NEXT:    ALU 3, @29, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
+; CM-NEXT:    ALU 1, @29, KC0[], KC1[]
 ; CM-NEXT:    TEX 0 @18
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T1.X
-; CM-NEXT:    ALU 3, @33, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T1.X
+; CM-NEXT:    ALU 1, @31, KC0[], KC1[]
 ; CM-NEXT:    TEX 0 @20
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T1.X
-; CM-NEXT:    ALU 2, @37, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T1.X
+; CM-NEXT:    ALU 0, @33, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @22
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T2.X
@@ -6156,32 +6087,26 @@ define amdgpu_kernel void @byref_natural_align_constant_v16i32_arg(ptr addrspace
 ; CM-NEXT:    Fetch clause starting at 16:
 ; CM-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 48, #1
 ; CM-NEXT:    Fetch clause starting at 18:
-; CM-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 32, #1
 ; CM-NEXT:    Fetch clause starting at 20:
-; CM-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 16, #1
+; CM-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 16, #1
 ; CM-NEXT:    Fetch clause starting at 22:
 ; CM-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 24:
 ; CM-NEXT:     MOV * T0.X, KC0[6].Y,
 ; CM-NEXT:    ALU clause starting at 25:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T2.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 29:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T1.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 33:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T1.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 37:
-; CM-NEXT:     MOV * T1.X, KC0[10].Y,
 ; CM-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:    ALU clause starting at 29:
+; CM-NEXT:     ADD_INT * T1.X, T2.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:    ALU clause starting at 31:
+; CM-NEXT:     ADD_INT * T1.X, T2.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; CM-NEXT:    ALU clause starting at 33:
+; CM-NEXT:     MOV * T1.X, KC0[10].Y,
   %in = load <16 x i32>, ptr addrspace(4) %in.byref
   store volatile <16 x i32> %in, ptr addrspace(1) %out, align 4
   store volatile i32 %after.offset, ptr addrspace(1) %out, align 4

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp.ll
@@ -1212,375 +1212,371 @@ define amdgpu_kernel void @s_exp_v3f32(ptr addrspace(1) %out, <3 x float> %in) {
 ;
 ; R600-LABEL: s_exp_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 99, @6, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    ALU 69, @106, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; R600-NEXT:    ALU 98, @6, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    ALU 69, @105, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    PAD
 ; R600-NEXT:    ALU clause starting at 6:
 ; R600-NEXT:     AND_INT * T0.W, KC0[3].Y, literal.x,
 ; R600-NEXT:    -4096(nan), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T1.W, PV.W, literal.x,
-; R600-NEXT:     ADD * T2.W, KC0[3].Y, -PV.W,
+; R600-NEXT:     ADD * T1.W, KC0[3].Y, -PV.W,
+; R600-NEXT:     MUL_IEEE T2.W, PV.W, literal.x,
+; R600-NEXT:     MUL_IEEE * T3.W, T0.W, literal.y,
+; R600-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
+; R600-NEXT:     RNDNE T4.W, PS,
+; R600-NEXT:     MULADD_IEEE * T1.W, T1.W, literal.x, PV.W, BS:VEC_021/SCL_122
 ; R600-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
-; R600-NEXT:     RNDNE * T3.W, PV.W,
-; R600-NEXT:     TRUNC T4.W, PV.W,
-; R600-NEXT:     MUL_IEEE * T5.W, T2.W, literal.x,
+; R600-NEXT:     MULADD_IEEE T0.W, T0.W, literal.x, PS,
+; R600-NEXT:     ADD * T1.W, T3.W, -PV.W,
 ; R600-NEXT:    967029397(3.122284e-04), 0(0.000000e+00)
-; R600-NEXT:     MULADD_IEEE T2.W, T2.W, literal.x, PS,
-; R600-NEXT:     FLT_TO_INT * T4.W, PV.W,
-; R600-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
-; R600-NEXT:     MAX_INT T0.Z, PS, literal.x,
-; R600-NEXT:     MULADD_IEEE T0.W, T0.W, literal.y, PV.W,
-; R600-NEXT:     ADD * T1.W, T1.W, -T3.W,
-; R600-NEXT:    -330(nan), 967029397(3.122284e-04)
-; R600-NEXT:     ADD T0.Y, PS, PV.W,
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.x,
-; R600-NEXT:     ADD_INT T0.W, T4.W, literal.y,
-; R600-NEXT:     SETGT_UINT * T1.W, T4.W, literal.z,
-; R600-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; R600-NEXT:    -229(nan), 0(0.000000e+00)
-; R600-NEXT:     CNDE_INT T0.Z, PS, PV.Z, PV.W,
-; R600-NEXT:     SETGT_INT T0.W, T4.W, literal.x,
-; R600-NEXT:     EXP_IEEE * T0.X, PV.Y,
-; R600-NEXT:    -127(nan), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.W, PS, PV.W,
+; R600-NEXT:     TRUNC * T1.W, T4.W,
+; R600-NEXT:     FLT_TO_INT T1.W, PS,
+; R600-NEXT:     EXP_IEEE * T0.X, PV.W,
+; R600-NEXT:     MAX_INT T0.W, PV.W, literal.x,
+; R600-NEXT:     MUL_IEEE * T2.W, PS, literal.y,
+; R600-NEXT:    -330(nan), 209715200(1.972152e-31)
 ; R600-NEXT:     MUL_IEEE T1.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T0.Y, PV.W, PV.Z, T4.W,
-; R600-NEXT:     MIN_INT T0.Z, T4.W, literal.y,
-; R600-NEXT:     AND_INT T2.W, KC0[3].W, literal.z,
-; R600-NEXT:     MUL_IEEE * T3.W, PS, literal.w,
-; R600-NEXT:    2130706432(1.701412e+38), 381(5.338947e-43)
-; R600-NEXT:    -4096(nan), 209715200(1.972152e-31)
-; R600-NEXT:     MUL_IEEE T2.X, PS, literal.x,
-; R600-NEXT:     ADD T1.Y, KC0[3].W, -PV.W,
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.y,
-; R600-NEXT:     ADD_INT T5.W, T4.W, literal.z,
-; R600-NEXT:     SETGT_UINT * T6.W, T4.W, literal.w,
-; R600-NEXT:    209715200(1.972152e-31), -254(nan)
-; R600-NEXT:    -127(nan), 254(3.559298e-43)
-; R600-NEXT:     CNDE_INT T3.X, PS, PV.W, PV.Z,
-; R600-NEXT:     SETGT_INT T2.Y, T4.W, literal.x,
-; R600-NEXT:     MUL_IEEE T0.Z, PV.Y, literal.y,
-; R600-NEXT:     MUL_IEEE * T4.W, T2.W, literal.z, BS:VEC_120/SCL_212
-; R600-NEXT:    127(1.779649e-43), 967029397(3.122284e-04)
-; R600-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
-; R600-NEXT:     CNDE_INT * T1.W, T1.W, T2.X, T3.W,
-; R600-NEXT:     CNDE_INT T0.X, T0.W, PV.W, T0.X, BS:VEC_021/SCL_122
-; R600-NEXT:     RNDNE T3.Y, T4.W, BS:VEC_120/SCL_212
-; R600-NEXT:     MULADD_IEEE T0.Z, T1.Y, literal.x, T0.Z,
-; R600-NEXT:     CNDE_INT T0.W, T2.Y, T0.Y, T3.X, BS:VEC_120/SCL_212
-; R600-NEXT:     MUL_IEEE * T1.W, T1.X, literal.y,
-; R600-NEXT:    1069064192(1.442383e+00), 2130706432(1.701412e+38)
-; R600-NEXT:     CNDE_INT T1.X, T6.W, T1.X, PS,
-; R600-NEXT:     LSHL T0.Y, PV.W, literal.x,
-; R600-NEXT:     AND_INT T1.Z, KC0[3].Z, literal.y,
-; R600-NEXT:     MULADD_IEEE T0.W, T2.W, literal.z, PV.Z, BS:VEC_120/SCL_212
-; R600-NEXT:     ADD * T1.W, T4.W, -PV.Y,
-; R600-NEXT:    23(3.222986e-44), -4096(nan)
-; R600-NEXT:    967029397(3.122284e-04), 0(0.000000e+00)
-; R600-NEXT:     ADD T1.Y, PS, PV.W,
-; R600-NEXT:     MUL_IEEE T0.Z, PV.Z, literal.x,
-; R600-NEXT:     ADD_INT T0.W, PV.Y, literal.y,
-; R600-NEXT:     CNDE_INT * T1.W, T2.Y, T0.X, PV.X,
-; R600-NEXT:    1069064192(1.442383e+00), 1065353216(1.000000e+00)
-; R600-NEXT:     MUL_IEEE T0.X, PS, PV.W,
-; R600-NEXT:     ADD T0.Y, KC0[3].Z, -T1.Z,
-; R600-NEXT:     RNDNE T2.Z, PV.Z,
-; R600-NEXT:     TRUNC T0.W, T3.Y,
-; R600-NEXT:     EXP_IEEE * T1.X, PV.Y,
-; R600-NEXT:     SETGT T2.X, literal.x, KC0[3].Y,
-; R600-NEXT:     FLT_TO_INT T1.Y, PV.W,
-; R600-NEXT:     TRUNC T3.Z, PV.Z,
-; R600-NEXT:     MUL_IEEE T0.W, PV.Y, literal.y,
-; R600-NEXT:     MUL_IEEE * T1.W, PS, literal.z,
-; R600-NEXT:    -1026650416(-1.032789e+02), 967029397(3.122284e-04)
-; R600-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T3.X, PS, literal.x,
-; R600-NEXT:     MUL_IEEE T2.Y, T1.X, literal.y,
-; R600-NEXT:     MULADD_IEEE T4.Z, T0.Y, literal.z, PV.W,
-; R600-NEXT:     FLT_TO_INT T0.W, PV.Z,
-; R600-NEXT:     MIN_INT * T2.W, PV.Y, literal.w,
-; R600-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
-; R600-NEXT:    1069064192(1.442383e+00), 381(5.338947e-43)
-; R600-NEXT:     ADD_INT T4.X, PS, literal.x,
-; R600-NEXT:     MAX_INT T0.Y, PV.W, literal.y,
-; R600-NEXT:     MULADD_IEEE T1.Z, T1.Z, literal.z, PV.Z,
-; R600-NEXT:     ADD T2.W, T0.Z, -T2.Z, BS:VEC_120/SCL_212
-; R600-NEXT:     MIN_INT * T3.W, PV.W, literal.w,
-; R600-NEXT:    -254(nan), -330(nan)
-; R600-NEXT:    967029397(3.122284e-04), 381(5.338947e-43)
-; R600-NEXT:     ADD_INT T5.X, PS, literal.x,
-; R600-NEXT:     ADD T3.Y, PV.W, PV.Z,
-; R600-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; R600-NEXT:     ADD_INT T2.W, T0.W, literal.z,
-; R600-NEXT:     SETGT_UINT * T3.W, T0.W, literal.w,
-; R600-NEXT:    -254(nan), 204(2.858649e-43)
+; R600-NEXT:     ADD_INT T0.Y, PV.W, literal.y,
+; R600-NEXT:     ADD_INT T0.Z, T1.W, literal.z,
+; R600-NEXT:     SETGT_UINT * T0.W, T1.W, literal.w,
+; R600-NEXT:    209715200(1.972152e-31), 204(2.858649e-43)
 ; R600-NEXT:    102(1.429324e-43), -229(nan)
-; R600-NEXT:     ADD_INT * T6.X, T0.W, literal.x,
+; R600-NEXT:     AND_INT * T3.W, KC0[3].W, literal.x,
+; R600-NEXT:    -4096(nan), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T2.X, T0.X, literal.x,
+; R600-NEXT:     AND_INT T1.Y, KC0[3].Z, literal.y,
+; R600-NEXT:     ADD T1.Z, KC0[3].W, -PV.W,
+; R600-NEXT:     CNDE_INT T4.W, T0.W, T0.Y, T0.Z,
+; R600-NEXT:     SETGT_INT * T5.W, T1.W, literal.z,
+; R600-NEXT:    2130706432(1.701412e+38), -4096(nan)
 ; R600-NEXT:    -127(nan), 0(0.000000e+00)
-; R600-NEXT:    ALU clause starting at 106:
-; R600-NEXT:     SETGT_UINT T0.Y, T0.W, literal.x,
-; R600-NEXT:     CNDE_INT T0.Z, T3.W, T0.Z, T2.W, BS:VEC_102/SCL_221
-; R600-NEXT:     SETGT_INT T2.W, T0.W, literal.y,
-; R600-NEXT:     EXP_IEEE * T1.Z, T3.Y,
-; R600-NEXT:    254(3.559298e-43), -127(nan)
-; R600-NEXT:     ADD_INT T7.X, T1.Y, literal.x,
-; R600-NEXT:     MUL_IEEE T3.Y, PS, literal.y,
-; R600-NEXT:     CNDE_INT T0.Z, PV.W, PV.Z, T0.W,
-; R600-NEXT:     CNDE_INT T4.W, PV.Y, T6.X, T5.X,
-; R600-NEXT:     SETGT_INT * T0.W, T0.W, literal.z,
-; R600-NEXT:    -127(nan), 209715200(1.972152e-31)
-; R600-NEXT:    127(1.779649e-43), 0(0.000000e+00)
-; R600-NEXT:     SETGT_UINT T5.X, T1.Y, literal.x,
-; R600-NEXT:     CNDE_INT T4.Y, PS, PV.Z, PV.W,
-; R600-NEXT:     MAX_INT T0.Z, T1.Y, literal.y,
-; R600-NEXT:     MUL_IEEE T4.W, PV.Y, literal.z,
-; R600-NEXT:     MUL_IEEE * T5.W, T1.Z, literal.w,
-; R600-NEXT:    254(3.559298e-43), -330(nan)
-; R600-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
-; R600-NEXT:     MUL_IEEE T6.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T3.Y, T3.W, PV.W, T3.Y, BS:VEC_021/SCL_122
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.y,
-; R600-NEXT:     ADD_INT T3.W, T1.Y, literal.z,
-; R600-NEXT:     SETGT_UINT * T4.W, T1.Y, literal.w,
-; R600-NEXT:    2130706432(1.701412e+38), 204(2.858649e-43)
-; R600-NEXT:    102(1.429324e-43), -229(nan)
-; R600-NEXT:     CNDE_INT T8.X, PS, PV.Z, PV.W,
-; R600-NEXT:     SETGT_INT T5.Y, T1.Y, literal.x,
-; R600-NEXT:     CNDE_INT T0.Z, T2.W, PV.Y, T1.Z,
-; R600-NEXT:     CNDE_INT T2.W, T0.Y, T5.W, PV.X, BS:VEC_120/SCL_212
-; R600-NEXT:     LSHL * T3.W, T4.Y, literal.y,
-; R600-NEXT:    -127(nan), 23(3.222986e-44)
-; R600-NEXT:     ADD_INT T6.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T0.Y, T0.W, PV.Z, PV.W,
-; R600-NEXT:     CNDE_INT T0.Z, PV.Y, PV.X, T1.Y,
-; R600-NEXT:     CNDE_INT T0.W, T5.X, T7.X, T4.X,
-; R600-NEXT:     SETGT_INT * T2.W, T1.Y, literal.y,
-; R600-NEXT:    1065353216(1.000000e+00), 127(1.779649e-43)
-; R600-NEXT:     CNDE_INT T4.X, PS, PV.Z, PV.W,
-; R600-NEXT:     MUL_IEEE T0.Y, PV.Y, PV.X,
-; R600-NEXT:     SETGT T0.Z, literal.x, KC0[3].Z,
+; R600-NEXT:     CNDE_INT T3.X, PS, PV.W, T1.W,
+; R600-NEXT:     MUL_IEEE T0.Y, PV.Z, literal.x,
+; R600-NEXT:     MUL_IEEE T0.Z, T3.W, literal.y,
+; R600-NEXT:     MIN_INT T4.W, T1.W, literal.z, BS:VEC_120/SCL_212
+; R600-NEXT:     ADD * T6.W, KC0[3].Z, -PV.Y,
+; R600-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
+; R600-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T4.X, PS, literal.x,
+; R600-NEXT:     MUL_IEEE T2.Y, T1.Y, literal.y,
+; R600-NEXT:     ADD_INT T2.Z, PV.W, literal.z,
+; R600-NEXT:     ADD_INT * T4.W, T1.W, literal.w,
+; R600-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
+; R600-NEXT:    -254(nan), -127(nan)
+; R600-NEXT:     SETGT_UINT * T7.W, T1.W, literal.x,
+; R600-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT T5.X, PV.W, T4.W, T2.Z,
+; R600-NEXT:     RNDNE T3.Y, T2.Y,
+; R600-NEXT:     MULADD_IEEE T2.Z, T6.W, literal.x, T4.X,
+; R600-NEXT:     RNDNE T4.W, T0.Z,
+; R600-NEXT:     MULADD_IEEE * T6.W, T1.Z, literal.x, T0.Y, BS:VEC_021/SCL_122
+; R600-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
+; R600-NEXT:     SETGT_INT T4.X, T1.W, literal.x,
+; R600-NEXT:     MULADD_IEEE T0.Y, T3.W, literal.y, PS, BS:VEC_120/SCL_212
+; R600-NEXT:     ADD T0.Z, T0.Z, -PV.W,
+; R600-NEXT:     MULADD_IEEE T1.W, T1.Y, literal.y, PV.Z,
+; R600-NEXT:     ADD * T3.W, T2.Y, -PV.Y,
+; R600-NEXT:    127(1.779649e-43), 967029397(3.122284e-04)
+; R600-NEXT:     ADD T6.X, PS, PV.W,
+; R600-NEXT:     ADD T0.Y, PV.Z, PV.Y,
+; R600-NEXT:     CNDE_INT T0.Z, PV.X, T3.X, T5.X,
+; R600-NEXT:     MUL_IEEE * T1.W, T2.X, literal.x,
+; R600-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT * T0.W, T0.W, T1.X, T2.W,
+; R600-NEXT:     CNDE_INT T0.X, T5.W, PV.W, T0.X,
+; R600-NEXT:     CNDE_INT T1.Y, T7.W, T2.X, T1.W, BS:VEC_102/SCL_221
+; R600-NEXT:     LSHL * T0.Z, T0.Z, literal.x,
+; R600-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; R600-NEXT:     TRUNC T0.W, T4.W,
+; R600-NEXT:     EXP_IEEE * T0.Y, T0.Y,
+; R600-NEXT:     FLT_TO_INT T1.X, PV.W,
+; R600-NEXT:     TRUNC T2.Y, T3.Y, BS:VEC_120/SCL_212
+; R600-NEXT:     MUL_IEEE T1.Z, PS, literal.x,
+; R600-NEXT:     ADD_INT T0.W, T0.Z, literal.y,
+; R600-NEXT:     CNDE_INT * T1.W, T4.X, T0.X, T1.Y,
+; R600-NEXT:    209715200(1.972152e-31), 1065353216(1.000000e+00)
+; R600-NEXT:     MUL_IEEE T0.X, PS, PV.W,
+; R600-NEXT:     MUL_IEEE T1.Y, PV.Z, literal.x,
+; R600-NEXT:     FLT_TO_INT T0.Z, PV.Y,
+; R600-NEXT:     MAX_INT T0.W, PV.X, literal.y,
+; R600-NEXT:     EXP_IEEE * T1.W, T6.X,
+; R600-NEXT:    209715200(1.972152e-31), -330(nan)
+; R600-NEXT:     MUL_IEEE T2.X, T0.Y, literal.x,
+; R600-NEXT:     MUL_IEEE T2.Y, PS, literal.y,
+; R600-NEXT:     ADD_INT T2.Z, PV.W, literal.z,
+; R600-NEXT:     ADD_INT * T0.W, T1.X, literal.w,
+; R600-NEXT:    2130706432(1.701412e+38), 209715200(1.972152e-31)
+; R600-NEXT:    204(2.858649e-43), 102(1.429324e-43)
+; R600-NEXT:     MAX_INT * T2.W, T0.Z, literal.x,
+; R600-NEXT:    -330(nan), 0(0.000000e+00)
+; R600-NEXT:     SETGT_UINT T3.X, T1.X, literal.x,
+; R600-NEXT:     ADD_INT T3.Y, PV.W, literal.y,
+; R600-NEXT:     ADD_INT T3.Z, T0.Z, literal.z,
+; R600-NEXT:     SETGT_UINT * T2.W, T0.Z, literal.x,
+; R600-NEXT:    -229(nan), 204(2.858649e-43)
+; R600-NEXT:    102(1.429324e-43), 0(0.000000e+00)
+; R600-NEXT:    ALU clause starting at 105:
+; R600-NEXT:     MIN_INT * T3.W, T0.Z, literal.x,
+; R600-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT T4.X, PV.W, literal.x,
+; R600-NEXT:     ADD_INT T4.Y, T0.Z, literal.y,
+; R600-NEXT:     SETGT_UINT T4.Z, T0.Z, literal.z,
+; R600-NEXT:     CNDE_INT T3.W, T2.W, T3.Y, T3.Z, BS:VEC_021/SCL_122
+; R600-NEXT:     SETGT_INT * T4.W, T0.Z, literal.y,
+; R600-NEXT:    -254(nan), -127(nan)
+; R600-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT T5.X, PS, PV.W, T0.Z,
+; R600-NEXT:     CNDE_INT T3.Y, PV.Z, PV.Y, PV.X,
+; R600-NEXT:     SETGT_INT T0.Z, T0.Z, literal.x,
+; R600-NEXT:     CNDE_INT T0.W, T3.X, T2.Z, T0.W,
+; R600-NEXT:     SETGT_INT * T3.W, T1.X, literal.y,
+; R600-NEXT:    127(1.779649e-43), -127(nan)
+; R600-NEXT:     CNDE_INT T4.X, PS, PV.W, T1.X,
+; R600-NEXT:     CNDE_INT T3.Y, PV.Z, PV.X, PV.Y,
+; R600-NEXT:     MIN_INT T2.Z, T1.X, literal.x,
 ; R600-NEXT:     MUL_IEEE T0.W, T2.Y, literal.y,
-; R600-NEXT:     CNDE_INT * T1.W, T4.W, T3.X, T1.W,
-; R600-NEXT:    -1026650416(-1.032789e+02), 2130706432(1.701412e+38)
-; R600-NEXT:     CNDE_INT T1.X, T5.Y, PS, T1.X,
-; R600-NEXT:     CNDE_INT T1.Y, T5.X, T2.Y, PV.W,
-; R600-NEXT:     CNDE T0.Z, PV.Z, PV.Y, 0.0,
-; R600-NEXT:     SETGT T0.W, KC0[3].Z, literal.x,
-; R600-NEXT:     LSHL * T1.W, PV.X, literal.y,
-; R600-NEXT:    1118925336(8.872284e+01), 23(3.222986e-44)
-; R600-NEXT:     ADD_INT T3.X, PS, literal.x,
-; R600-NEXT:     CNDE T0.Y, PV.W, PV.Z, literal.y,
-; R600-NEXT:     CNDE_INT T0.Z, T2.W, PV.X, PV.Y,
-; R600-NEXT:     CNDE T0.W, T2.X, T0.X, 0.0,
+; R600-NEXT:     MUL_IEEE * T5.W, T1.W, literal.z,
+; R600-NEXT:    381(5.338947e-43), 209715200(1.972152e-31)
+; R600-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T5.X, PS, literal.x,
+; R600-NEXT:     CNDE_INT T2.Y, T2.W, PV.W, T2.Y,
+; R600-NEXT:     ADD_INT T2.Z, PV.Z, literal.y,
+; R600-NEXT:     ADD_INT T0.W, T1.X, literal.z,
+; R600-NEXT:     SETGT_UINT * T2.W, T1.X, literal.w,
+; R600-NEXT:    2130706432(1.701412e+38), -254(nan)
+; R600-NEXT:    -127(nan), 254(3.559298e-43)
+; R600-NEXT:     CNDE_INT T6.X, PS, PV.W, PV.Z,
+; R600-NEXT:     SETGT_INT T4.Y, T1.X, literal.x,
+; R600-NEXT:     CNDE_INT T2.Z, T4.W, PV.Y, T1.W,
+; R600-NEXT:     CNDE_INT T0.W, T4.Z, T5.W, PV.X,
+; R600-NEXT:     LSHL * T1.W, T3.Y, literal.y,
+; R600-NEXT:    127(1.779649e-43), 23(3.222986e-44)
+; R600-NEXT:     ADD_INT T1.X, PS, literal.x,
+; R600-NEXT:     CNDE_INT T2.Y, T0.Z, PV.Z, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     CNDE_INT T0.Z, PV.Y, T4.X, PV.X,
+; R600-NEXT:     MUL_IEEE T0.W, T2.X, literal.y,
+; R600-NEXT:     CNDE_INT * T1.W, T3.X, T1.Y, T1.Z,
+; R600-NEXT:    1065353216(1.000000e+00), 2130706432(1.701412e+38)
+; R600-NEXT:     CNDE_INT T3.X, T3.W, PS, T0.Y,
+; R600-NEXT:     CNDE_INT T0.Y, T2.W, T2.X, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     LSHL T0.Z, PV.Z, literal.x,
+; R600-NEXT:     MUL_IEEE T0.W, PV.Y, PV.X,
+; R600-NEXT:     SETGT * T1.W, literal.y, KC0[3].Z,
+; R600-NEXT:    23(3.222986e-44), -1026650416(-1.032789e+02)
+; R600-NEXT:     SETGT T1.X, literal.x, KC0[3].Y,
+; R600-NEXT:     CNDE T1.Y, PS, PV.W, 0.0,
+; R600-NEXT:     SETGT T1.Z, KC0[3].Z, literal.y,
+; R600-NEXT:     ADD_INT T0.W, PV.Z, literal.z,
+; R600-NEXT:     CNDE_INT * T1.W, T4.Y, PV.X, PV.Y,
+; R600-NEXT:    -1026650416(-1.032789e+02), 1118925336(8.872284e+01)
+; R600-NEXT:    1065353216(1.000000e+00), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T2.X, PS, PV.W,
+; R600-NEXT:     CNDE T0.Y, PV.Z, PV.Y, literal.x,
+; R600-NEXT:     SETGT T0.Z, literal.y, KC0[3].W,
+; R600-NEXT:     CNDE T0.W, PV.X, T0.X, 0.0,
 ; R600-NEXT:     SETGT * T1.W, KC0[3].Y, literal.z,
-; R600-NEXT:    1065353216(1.000000e+00), 2139095040(INF)
+; R600-NEXT:    2139095040(INF), -1026650416(-1.032789e+02)
 ; R600-NEXT:    1118925336(8.872284e+01), 0(0.000000e+00)
 ; R600-NEXT:     CNDE T0.X, PS, PV.W, literal.x,
-; R600-NEXT:     MUL_IEEE T0.W, PV.Z, PV.X,
-; R600-NEXT:     SETGT * T1.W, literal.y, KC0[3].W,
-; R600-NEXT:    2139095040(INF), -1026650416(-1.032789e+02)
-; R600-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; R600-NEXT:     CNDE T0.W, PS, PV.W, 0.0,
+; R600-NEXT:     CNDE T0.W, PV.Z, PV.X, 0.0,
 ; R600-NEXT:     SETGT * T1.W, KC0[3].W, literal.y,
-; R600-NEXT:    2(2.802597e-45), 1118925336(8.872284e+01)
-; R600-NEXT:     CNDE T2.X, PS, PV.W, literal.x,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; R600-NEXT:    2139095040(INF), 8(1.121039e-44)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:    2139095040(INF), 1118925336(8.872284e+01)
+; R600-NEXT:     CNDE T1.X, PS, PV.W, literal.x,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.y,
+; R600-NEXT:    2139095040(INF), 2(2.802597e-45)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_exp_v3f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 101, @6, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 77, @108, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T1.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T3.X
+; CM-NEXT:    ALU 98, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 77, @105, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     AND_INT * T0.W, KC0[3].Y, literal.x,
+; CM-NEXT:     AND_INT * T0.W, KC0[3].W, literal.x,
 ; CM-NEXT:    -4096(nan), 0(0.000000e+00)
-; CM-NEXT:     ADD * T1.W, KC0[3].Y, -PV.W,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.W, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, T0.W, literal.y,
-; CM-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
-; CM-NEXT:     RNDNE T1.Z, PV.W,
-; CM-NEXT:     MULADD_IEEE * T1.W, T1.W, literal.x, PV.Z,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.W, literal.x,
 ; CM-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
-; CM-NEXT:     MULADD_IEEE T0.Z, T0.W, literal.x, PV.W,
-; CM-NEXT:     ADD * T0.W, T2.W, -PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:    967029397(3.122284e-04), 0(0.000000e+00)
-; CM-NEXT:     TRUNC T1.Z, T1.Z,
-; CM-NEXT:     ADD * T0.W, PV.W, PV.Z,
-; CM-NEXT:     EXP_IEEE T0.X, T0.W,
-; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     FLT_TO_INT T0.Z, T1.Z,
-; CM-NEXT:     MUL_IEEE * T0.W, PV.X, literal.x,
-; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
+; CM-NEXT:     RNDNE T0.Z, PV.W,
+; CM-NEXT:     ADD * T2.W, KC0[3].W, -T0.W,
 ; CM-NEXT:     MUL_IEEE T0.Y, PV.W, literal.x,
-; CM-NEXT:     MAX_INT T1.Z, PV.Z, literal.y,
-; CM-NEXT:     MIN_INT * T1.W, PV.Z, literal.z,
-; CM-NEXT:    209715200(1.972152e-31), -330(nan)
+; CM-NEXT:     AND_INT T1.Z, KC0[3].Y, literal.y,
+; CM-NEXT:     TRUNC * T3.W, PV.Z,
+; CM-NEXT:    967029397(3.122284e-04), -4096(nan)
+; CM-NEXT:     FLT_TO_INT T1.Y, PV.W,
+; CM-NEXT:     ADD T2.Z, KC0[3].Y, -PV.Z,
+; CM-NEXT:     MULADD_IEEE * T2.W, T2.W, literal.x, PV.Y,
+; CM-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T0.X, T0.W, literal.x, PV.W,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.Z, literal.x,
+; CM-NEXT:     MAX_INT T3.Z, PV.Y, literal.y,
+; CM-NEXT:     MIN_INT * T0.W, PV.Y, literal.z,
+; CM-NEXT:    967029397(3.122284e-04), -330(nan)
 ; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
 ; CM-NEXT:     ADD_INT T1.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T1.Y, PV.Z, literal.y,
-; CM-NEXT:     ADD_INT T1.Z, T0.Z, literal.z,
-; CM-NEXT:     SETGT_UINT * T1.W, T0.Z, literal.w,
+; CM-NEXT:     ADD_INT T2.Y, PV.Z, literal.y,
+; CM-NEXT:     ADD_INT T3.Z, T1.Y, literal.z,
+; CM-NEXT:     SETGT_UINT * T0.W, T1.Y, literal.w,
 ; CM-NEXT:    -254(nan), 204(2.858649e-43)
 ; CM-NEXT:    102(1.429324e-43), -229(nan)
-; CM-NEXT:     ADD_INT T2.X, T0.Z, literal.x,
-; CM-NEXT:     SETGT_UINT T2.Y, T0.Z, literal.y,
+; CM-NEXT:     ADD_INT T2.X, T1.Y, literal.x,
+; CM-NEXT:     SETGT_UINT T3.Y, T1.Y, literal.y,
+; CM-NEXT:     CNDE_INT T3.Z, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     SETGT_INT * T2.W, T1.Y, literal.x,
+; CM-NEXT:    -127(nan), 254(3.559298e-43)
+; CM-NEXT:     MUL_IEEE T3.X, T1.Z, literal.x,
+; CM-NEXT:     CNDE_INT T2.Y, PV.W, PV.Z, T1.Y,
+; CM-NEXT:     CNDE_INT T3.Z, PV.Y, PV.X, T1.X,
+; CM-NEXT:     SETGT_INT * T3.W, T1.Y, literal.y,
+; CM-NEXT:    1069064192(1.442383e+00), 127(1.779649e-43)
+; CM-NEXT:     ADD T1.X, T1.W, -T0.Z,
+; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     RNDNE T0.Z, PV.X,
+; CM-NEXT:     MULADD_IEEE * T1.W, T2.Z, literal.x, T0.Y,
+; CM-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T2.X, T1.Z, literal.x, PV.W,
+; CM-NEXT:     ADD T0.Y, T3.X, -PV.Z,
+; CM-NEXT:     LSHL T1.Z, PV.Y, literal.y,
+; CM-NEXT:     ADD * T1.W, PV.X, T0.X,
+; CM-NEXT:    967029397(3.122284e-04), 23(3.222986e-44)
+; CM-NEXT:     EXP_IEEE T0.X, T1.W,
+; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     ADD_INT T1.Y, T1.Z, literal.x,
+; CM-NEXT:     MUL_IEEE T1.Z, PV.X, literal.y,
+; CM-NEXT:     ADD * T1.W, T0.Y, T2.X,
+; CM-NEXT:    1065353216(1.000000e+00), 209715200(1.972152e-31)
+; CM-NEXT:     EXP_IEEE T0.X (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE T0.Y, T1.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     TRUNC T1.X, T0.Z,
+; CM-NEXT:     MUL_IEEE T2.Y, T1.Z, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     MUL_IEEE T0.Z, T0.X, literal.y,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.Y, literal.x,
+; CM-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
+; CM-NEXT:     MUL_IEEE T2.X, PV.W, literal.x,
+; CM-NEXT:     MUL_IEEE T4.Y, PV.Z, literal.y,
+; CM-NEXT:     CNDE_INT T1.Z, T0.W, PV.Y, T1.Z,
+; CM-NEXT:     FLT_TO_INT * T0.W, PV.X,
+; CM-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
+; CM-NEXT:     SETGT_UINT T1.X, PV.W, literal.x,
+; CM-NEXT:     AND_INT T2.Y, KC0[3].Z, literal.y,
+; CM-NEXT:     CNDE_INT T1.Z, T2.W, PV.Z, T0.X,
+; CM-NEXT:     CNDE_INT * T2.W, T3.Y, T0.Z, PV.Y,
+; CM-NEXT:    -229(nan), -4096(nan)
+; CM-NEXT:     CNDE_INT T0.X, T3.W, PV.Z, PV.W,
+; CM-NEXT:     ADD T3.Y, KC0[3].Z, -PV.Y,
+; CM-NEXT:     CNDE_INT T0.Z, PV.X, T2.X, T1.W,
+; CM-NEXT:     SETGT_INT * T1.W, T0.W, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    -127(nan), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T2.X, PV.W, PV.Z, T0.Y,
+; CM-NEXT:     MUL_IEEE T0.Y, T0.Y, literal.x,
+; CM-NEXT:     MUL_IEEE T0.Z, T2.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     MUL_IEEE * T2.W, PV.Y, literal.z,
+; CM-NEXT:    2130706432(1.701412e+38), 1069064192(1.442383e+00)
+; CM-NEXT:    967029397(3.122284e-04), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T3.X, T3.Y, literal.x, PV.W,
+; CM-NEXT:     RNDNE T3.Y, PV.Z,
+; CM-NEXT:     MUL_IEEE T1.Z, PV.Y, literal.y,
+; CM-NEXT:     SETGT_UINT * T2.W, T0.W, literal.z,
+; CM-NEXT:    1069064192(1.442383e+00), 2130706432(1.701412e+38)
+; CM-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T4.X, PV.W, T0.Y, PV.Z,
+; CM-NEXT:     TRUNC T0.Y, PV.Y,
+; CM-NEXT:     MULADD_IEEE T1.Z, T2.Y, literal.x, PV.X,
+; CM-NEXT:     MAX_INT * T3.W, T0.W, literal.y,
+; CM-NEXT:    967029397(3.122284e-04), -330(nan)
+; CM-NEXT:     ADD T3.X, T0.Z, -T3.Y,
+; CM-NEXT:     ADD_INT T2.Y, PV.W, literal.x,
+; CM-NEXT:     ADD_INT * T0.Z, T0.W, literal.y,
+; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
+; CM-NEXT:    ALU clause starting at 105:
+; CM-NEXT:     MIN_INT * T3.W, T0.W, literal.x,
+; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T5.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T3.Y, T0.W, literal.y,
+; CM-NEXT:     CNDE_INT T0.Z, T1.X, T2.Y, T0.Z,
+; CM-NEXT:     ADD * T3.W, T3.X, T1.Z, BS:VEC_102/SCL_221
+; CM-NEXT:    -254(nan), -127(nan)
+; CM-NEXT:     EXP_IEEE T1.X, T3.W,
+; CM-NEXT:     EXP_IEEE T1.Y (MASKED), T3.W,
+; CM-NEXT:     EXP_IEEE T1.Z (MASKED), T3.W,
+; CM-NEXT:     EXP_IEEE * T1.W (MASKED), T3.W,
+; CM-NEXT:     CNDE_INT T3.X, T1.W, T0.Z, T0.W,
+; CM-NEXT:     CNDE_INT T2.Y, T2.W, T3.Y, T5.X, BS:VEC_120/SCL_212
+; CM-NEXT:     FLT_TO_INT T0.Z, T0.Y,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.X, literal.x,
+; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
+; CM-NEXT:     SETGT_INT T5.X, T0.W, literal.x,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.W, literal.y,
+; CM-NEXT:     MAX_INT T1.Z, PV.Z, literal.z,
+; CM-NEXT:     MIN_INT * T0.W, PV.Z, literal.w,
+; CM-NEXT:    127(1.779649e-43), 209715200(1.972152e-31)
+; CM-NEXT:    -330(nan), 381(5.338947e-43)
+; CM-NEXT:     ADD_INT T6.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T3.Y, PV.Z, literal.y,
+; CM-NEXT:     ADD_INT T1.Z, T0.Z, literal.z,
+; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.w,
+; CM-NEXT:    -254(nan), 204(2.858649e-43)
+; CM-NEXT:    102(1.429324e-43), -229(nan)
+; CM-NEXT:     ADD_INT T7.X, T0.Z, literal.x,
+; CM-NEXT:     SETGT_UINT T4.Y, T0.Z, literal.y,
 ; CM-NEXT:     CNDE_INT T1.Z, PV.W, PV.Y, PV.Z,
 ; CM-NEXT:     SETGT_INT * T2.W, T0.Z, literal.x,
 ; CM-NEXT:    -127(nan), 254(3.559298e-43)
-; CM-NEXT:     MUL_IEEE T3.X, T0.X, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Z, T0.Z,
-; CM-NEXT:     CNDE_INT T1.Z, PV.Y, PV.X, T1.X,
+; CM-NEXT:     MUL_IEEE T8.X, T1.X, literal.x,
+; CM-NEXT:     CNDE_INT T3.Y, PV.W, PV.Z, T0.Z,
+; CM-NEXT:     CNDE_INT T1.Z, PV.Y, PV.X, T6.X,
 ; CM-NEXT:     SETGT_INT * T3.W, T0.Z, literal.y,
 ; CM-NEXT:    2130706432(1.701412e+38), 127(1.779649e-43)
-; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Y, PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.X, literal.x,
-; CM-NEXT:     CNDE_INT * T0.W, T1.W, T0.Y, T0.W,
+; CM-NEXT:     CNDE_INT T6.X, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     MUL_IEEE T3.Y, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T0.Z, T0.W, T0.Y, T1.W,
+; CM-NEXT:     CNDE_INT * T0.W, T5.X, T3.X, T2.Y,
 ; CM-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T0.X, T2.W, PV.W, T0.X,
-; CM-NEXT:     CNDE_INT T0.Y, T2.Y, T3.X, PV.Z,
-; CM-NEXT:     LSHL T0.Z, PV.Y, literal.x,
-; CM-NEXT:     AND_INT * T0.W, KC0[3].Z, literal.y,
-; CM-NEXT:    23(3.222986e-44), -4096(nan)
-; CM-NEXT:     ADD T1.Y, KC0[3].Z, -PV.W,
-; CM-NEXT:     ADD_INT T0.Z, PV.Z, literal.x,
-; CM-NEXT:     CNDE_INT * T1.W, T3.W, PV.X, PV.Y,
+; CM-NEXT:     LSHL T3.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, T2.W, PV.Z, T1.X,
+; CM-NEXT:     CNDE_INT T0.Z, T4.Y, T8.X, PV.Y,
+; CM-NEXT:     LSHL * T0.W, PV.X, literal.x,
+; CM-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T1.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, T3.W, PV.Y, PV.Z,
+; CM-NEXT:     ADD_INT T0.Z, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT * T0.W, T5.X, T2.X, T4.X,
 ; CM-NEXT:    1065353216(1.000000e+00), 0(0.000000e+00)
-; CM-NEXT:     MUL_IEEE T0.X, PV.W, PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Y, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE T0.Z, T0.W, literal.y,
-; CM-NEXT:     AND_INT * T1.W, KC0[3].W, literal.z,
-; CM-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
-; CM-NEXT:    -4096(nan), 0(0.000000e+00)
-; CM-NEXT:     SETGT T1.X, literal.x, KC0[3].Y,
-; CM-NEXT:     ADD T2.Y, KC0[3].W, -PV.W,
-; CM-NEXT:     RNDNE T1.Z, PV.Z,
-; CM-NEXT:     MULADD_IEEE * T2.W, T1.Y, literal.y, PV.Y,
-; CM-NEXT:    -1026650416(-1.032789e+02), 1069064192(1.442383e+00)
-; CM-NEXT:     MULADD_IEEE T2.X, T0.W, literal.x, PV.W,
-; CM-NEXT:     ADD T0.Y, T0.Z, -PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE * T0.W, T1.W, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    967029397(3.122284e-04), 1069064192(1.442383e+00)
-; CM-NEXT:     TRUNC T3.X, T1.Z,
-; CM-NEXT:     RNDNE T1.Y, PV.W,
-; CM-NEXT:     MULADD_IEEE T0.Z, T2.Y, literal.x, PV.Z,
-; CM-NEXT:     ADD * T2.W, PV.Y, PV.X,
-; CM-NEXT:    1069064192(1.442383e+00), 0(0.000000e+00)
-; CM-NEXT:     EXP_IEEE T0.X (MASKED), T2.W,
-; CM-NEXT:     EXP_IEEE T0.Y, T2.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     MULADD_IEEE T2.X, T1.W, literal.x, T0.Z,
-; CM-NEXT:     ADD T2.Y, T0.W, -T1.Y, BS:VEC_120/SCL_212
-; CM-NEXT:     FLT_TO_INT T0.Z, T3.X,
-; CM-NEXT:     MUL_IEEE * T0.W, PV.Y, literal.y,
-; CM-NEXT:    967029397(3.122284e-04), 209715200(1.972152e-31)
-; CM-NEXT:     MUL_IEEE T3.X, PV.W, literal.x,
-; CM-NEXT:     SETGT_UINT T3.Y, PV.Z, literal.y,
-; CM-NEXT:     TRUNC T1.Z, T1.Y,
-; CM-NEXT:     ADD * T1.W, PV.Y, PV.X,
-; CM-NEXT:    209715200(1.972152e-31), -229(nan)
-; CM-NEXT:     EXP_IEEE T1.X (MASKED), T1.W,
-; CM-NEXT:     EXP_IEEE T1.Y, T1.W,
-; CM-NEXT:     EXP_IEEE T1.Z (MASKED), T1.W,
-; CM-NEXT:     EXP_IEEE * T1.W (MASKED), T1.W,
-; CM-NEXT:     FLT_TO_INT T2.X, T1.Z,
-; CM-NEXT:     MUL_IEEE T2.Y, PV.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Z, T3.Y, T3.X, T0.W,
-; CM-NEXT:     SETGT_INT * T0.W, T0.Z, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    209715200(1.972152e-31), -127(nan)
-; CM-NEXT:     CNDE_INT T3.X, PV.W, PV.Z, T0.Y,
-; CM-NEXT:     MUL_IEEE * T4.Y, PV.Y, literal.x,
-; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 108:
-; CM-NEXT:     SETGT_UINT T1.Z, T2.X, literal.x,
-; CM-NEXT:     MAX_INT * T1.W, T0.Z, literal.y,
-; CM-NEXT:    -229(nan), -330(nan)
-; CM-NEXT:     ADD_INT T4.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T5.Y, T0.Z, literal.y,
-; CM-NEXT:     CNDE_INT T2.Z, PV.Z, T4.Y, T2.Y,
-; CM-NEXT:     SETGT_INT * T1.W, T2.X, literal.z,
-; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; CM-NEXT:    -127(nan), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T5.X, PV.W, PV.Z, T1.Y,
-; CM-NEXT:     MUL_IEEE T0.Y, T0.Y, literal.x,
-; CM-NEXT:     MAX_INT T2.Z, T2.X, literal.y,
-; CM-NEXT:     CNDE_INT * T2.W, T3.Y, PV.X, PV.Y, BS:VEC_120/SCL_212
-; CM-NEXT:    2130706432(1.701412e+38), -330(nan)
-; CM-NEXT:     CNDE_INT T4.X, T0.W, PV.W, T0.Z,
-; CM-NEXT:     ADD_INT T2.Y, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT T2.Z, T2.X, literal.y,
-; CM-NEXT:     MIN_INT * T0.W, T2.X, literal.z,
-; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
-; CM-NEXT:     ADD_INT T6.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T3.Y, T2.X, literal.y,
-; CM-NEXT:     SETGT_UINT T3.Z, T2.X, literal.z,
-; CM-NEXT:     CNDE_INT * T0.W, T1.Z, PV.Y, PV.Z,
-; CM-NEXT:    -254(nan), -127(nan)
-; CM-NEXT:    254(3.559298e-43), 0(0.000000e+00)
-; CM-NEXT:     MUL_IEEE T7.X, T1.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, T1.W, PV.W, T2.X,
-; CM-NEXT:     CNDE_INT T1.Z, PV.Z, PV.Y, PV.X,
-; CM-NEXT:     MIN_INT * T0.W, T0.Z, literal.y,
-; CM-NEXT:    2130706432(1.701412e+38), 381(5.338947e-43)
-; CM-NEXT:     SETGT_INT T2.X, T2.X, literal.x,
-; CM-NEXT:     ADD_INT T2.Y, PV.W, literal.y,
-; CM-NEXT:     ADD_INT T2.Z, T0.Z, literal.z,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.w,
-; CM-NEXT:    127(1.779649e-43), -254(nan)
-; CM-NEXT:    -127(nan), 254(3.559298e-43)
-; CM-NEXT:     CNDE_INT T6.X, PV.W, PV.Z, PV.Y,
-; CM-NEXT:     SETGT_INT T2.Y, T0.Z, literal.x,
-; CM-NEXT:     CNDE_INT T0.Z, PV.X, T1.Y, T1.Z,
-; CM-NEXT:     MUL_IEEE * T1.W, T7.X, literal.y,
-; CM-NEXT:    127(1.779649e-43), 2130706432(1.701412e+38)
-; CM-NEXT:     CNDE_INT T7.X, T3.Z, T7.X, PV.W,
-; CM-NEXT:     LSHL T1.Y, PV.Z, literal.x,
-; CM-NEXT:     CNDE_INT T0.Z, PV.Y, T4.X, PV.X, BS:VEC_021/SCL_122
-; CM-NEXT:     MUL_IEEE * T1.W, T0.Y, literal.y,
-; CM-NEXT:    23(3.222986e-44), 2130706432(1.701412e+38)
-; CM-NEXT:     CNDE_INT T4.X, T0.W, T0.Y, PV.W,
-; CM-NEXT:     LSHL T0.Y, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE_INT * T0.W, T2.X, T5.X, PV.X,
-; CM-NEXT:    23(3.222986e-44), 1065353216(1.000000e+00)
 ; CM-NEXT:     MUL_IEEE T2.X, PV.W, PV.Z,
-; CM-NEXT:     SETGT T1.Y, literal.x, KC0[3].W,
-; CM-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE_INT * T0.W, T2.Y, T3.X, PV.X,
-; CM-NEXT:    -1026650416(-1.032789e+02), 1065353216(1.000000e+00)
-; CM-NEXT:     MUL_IEEE T3.X, PV.W, PV.Z,
-; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
-; CM-NEXT:     CNDE T0.Z, PV.Y, PV.X, 0.0,
-; CM-NEXT:     SETGT * T0.W, KC0[3].W, literal.y,
-; CM-NEXT:    -1026650416(-1.032789e+02), 1118925336(8.872284e+01)
-; CM-NEXT:     CNDE T2.X, PV.W, PV.Z, literal.x,
-; CM-NEXT:     CNDE T0.Y, PV.Y, PV.X, 0.0,
-; CM-NEXT:     SETGT T0.Z, KC0[3].Z, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2139095040(INF), 1118925336(8.872284e+01)
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T3.X, PV.W, literal.x,
-; CM-NEXT:     CNDE T0.Y, PV.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE T0.Z, T1.X, T0.X, 0.0,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.Y, PV.X,
+; CM-NEXT:     MUL_IEEE T0.Z, T0.X, T1.Y,
+; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
+; CM-NEXT:    -1026650416(-1.032789e+02), 0(0.000000e+00)
+; CM-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; CM-NEXT:     SETGT T1.Y, literal.y, KC0[3].Z,
+; CM-NEXT:     CNDE T0.Z, PV.W, PV.Z, 0.0,
+; CM-NEXT:     SETGT * T0.W, KC0[3].W, literal.z,
+; CM-NEXT:    2(2.802597e-45), -1026650416(-1.032789e+02)
+; CM-NEXT:    1118925336(8.872284e+01), 0(0.000000e+00)
+; CM-NEXT:     CNDE T1.X, PV.W, PV.Z, literal.x,
+; CM-NEXT:     SETGT T2.Y, literal.y, KC0[3].Y,
+; CM-NEXT:     CNDE T0.Z, PV.Y, T0.Y, 0.0,
+; CM-NEXT:     SETGT * T0.W, KC0[3].Z, literal.z,
+; CM-NEXT:    2139095040(INF), -1026650416(-1.032789e+02)
+; CM-NEXT:    1118925336(8.872284e+01), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; CM-NEXT:     CNDE T4.Y, PV.W, PV.Z, literal.y,
+; CM-NEXT:     CNDE T0.Z, PV.Y, T2.X, 0.0,
 ; CM-NEXT:     SETGT * T0.W, KC0[3].Y, literal.z,
 ; CM-NEXT:    2(2.802597e-45), 2139095040(INF)
 ; CM-NEXT:    1118925336(8.872284e+01), 0(0.000000e+00)
-; CM-NEXT:     CNDE * T0.X, PV.W, PV.Z, literal.x,
+; CM-NEXT:     CNDE * T4.X, PV.W, PV.Z, literal.x,
 ; CM-NEXT:    2139095040(INF), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %result = call <3 x float> @llvm.exp.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp10.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp10.ll
@@ -1214,375 +1214,371 @@ define amdgpu_kernel void @s_exp10_v3f32(ptr addrspace(1) %out, <3 x float> %in)
 ;
 ; R600-LABEL: s_exp10_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 99, @6, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    ALU 69, @106, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; R600-NEXT:    ALU 98, @6, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    ALU 69, @105, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    PAD
 ; R600-NEXT:    ALU clause starting at 6:
 ; R600-NEXT:     AND_INT * T0.W, KC0[3].Y, literal.x,
 ; R600-NEXT:    -4096(nan), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T1.W, PV.W, literal.x,
-; R600-NEXT:     ADD * T2.W, KC0[3].Y, -PV.W,
+; R600-NEXT:     ADD * T1.W, KC0[3].Y, -PV.W,
+; R600-NEXT:     MUL_IEEE T2.W, PV.W, literal.x,
+; R600-NEXT:     MUL_IEEE * T3.W, T0.W, literal.y,
+; R600-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
+; R600-NEXT:     RNDNE T4.W, PS,
+; R600-NEXT:     MULADD_IEEE * T1.W, T1.W, literal.x, PV.W, BS:VEC_021/SCL_122
 ; R600-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
-; R600-NEXT:     RNDNE * T3.W, PV.W,
-; R600-NEXT:     TRUNC T4.W, PV.W,
-; R600-NEXT:     MUL_IEEE * T5.W, T2.W, literal.x,
+; R600-NEXT:     MULADD_IEEE T0.W, T0.W, literal.x, PS,
+; R600-NEXT:     ADD * T1.W, T3.W, -PV.W,
 ; R600-NEXT:    975668412(6.390323e-04), 0(0.000000e+00)
-; R600-NEXT:     MULADD_IEEE T2.W, T2.W, literal.x, PS,
-; R600-NEXT:     FLT_TO_INT * T4.W, PV.W,
-; R600-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
-; R600-NEXT:     MAX_INT T0.Z, PS, literal.x,
-; R600-NEXT:     MULADD_IEEE T0.W, T0.W, literal.y, PV.W,
-; R600-NEXT:     ADD * T1.W, T1.W, -T3.W,
-; R600-NEXT:    -330(nan), 975668412(6.390323e-04)
-; R600-NEXT:     ADD T0.Y, PS, PV.W,
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.x,
-; R600-NEXT:     ADD_INT T0.W, T4.W, literal.y,
-; R600-NEXT:     SETGT_UINT * T1.W, T4.W, literal.z,
-; R600-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; R600-NEXT:    -229(nan), 0(0.000000e+00)
-; R600-NEXT:     CNDE_INT T0.Z, PS, PV.Z, PV.W,
-; R600-NEXT:     SETGT_INT T0.W, T4.W, literal.x,
-; R600-NEXT:     EXP_IEEE * T0.X, PV.Y,
-; R600-NEXT:    -127(nan), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.W, PS, PV.W,
+; R600-NEXT:     TRUNC * T1.W, T4.W,
+; R600-NEXT:     FLT_TO_INT T1.W, PS,
+; R600-NEXT:     EXP_IEEE * T0.X, PV.W,
+; R600-NEXT:     MAX_INT T0.W, PV.W, literal.x,
+; R600-NEXT:     MUL_IEEE * T2.W, PS, literal.y,
+; R600-NEXT:    -330(nan), 209715200(1.972152e-31)
 ; R600-NEXT:     MUL_IEEE T1.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T0.Y, PV.W, PV.Z, T4.W,
-; R600-NEXT:     MIN_INT T0.Z, T4.W, literal.y,
-; R600-NEXT:     AND_INT T2.W, KC0[3].W, literal.z,
-; R600-NEXT:     MUL_IEEE * T3.W, PS, literal.w,
-; R600-NEXT:    2130706432(1.701412e+38), 381(5.338947e-43)
-; R600-NEXT:    -4096(nan), 209715200(1.972152e-31)
-; R600-NEXT:     MUL_IEEE T2.X, PS, literal.x,
-; R600-NEXT:     ADD T1.Y, KC0[3].W, -PV.W,
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.y,
-; R600-NEXT:     ADD_INT T5.W, T4.W, literal.z,
-; R600-NEXT:     SETGT_UINT * T6.W, T4.W, literal.w,
-; R600-NEXT:    209715200(1.972152e-31), -254(nan)
-; R600-NEXT:    -127(nan), 254(3.559298e-43)
-; R600-NEXT:     CNDE_INT T3.X, PS, PV.W, PV.Z,
-; R600-NEXT:     SETGT_INT T2.Y, T4.W, literal.x,
-; R600-NEXT:     MUL_IEEE T0.Z, PV.Y, literal.y,
-; R600-NEXT:     MUL_IEEE * T4.W, T2.W, literal.z, BS:VEC_120/SCL_212
-; R600-NEXT:    127(1.779649e-43), 975668412(6.390323e-04)
-; R600-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
-; R600-NEXT:     CNDE_INT * T1.W, T1.W, T2.X, T3.W,
-; R600-NEXT:     CNDE_INT T0.X, T0.W, PV.W, T0.X, BS:VEC_021/SCL_122
-; R600-NEXT:     RNDNE T3.Y, T4.W, BS:VEC_120/SCL_212
-; R600-NEXT:     MULADD_IEEE T0.Z, T1.Y, literal.x, T0.Z,
-; R600-NEXT:     CNDE_INT T0.W, T2.Y, T0.Y, T3.X, BS:VEC_120/SCL_212
-; R600-NEXT:     MUL_IEEE * T1.W, T1.X, literal.y,
-; R600-NEXT:    1079283712(3.321289e+00), 2130706432(1.701412e+38)
-; R600-NEXT:     CNDE_INT T1.X, T6.W, T1.X, PS,
-; R600-NEXT:     LSHL T0.Y, PV.W, literal.x,
-; R600-NEXT:     AND_INT T1.Z, KC0[3].Z, literal.y,
-; R600-NEXT:     MULADD_IEEE T0.W, T2.W, literal.z, PV.Z, BS:VEC_120/SCL_212
-; R600-NEXT:     ADD * T1.W, T4.W, -PV.Y,
-; R600-NEXT:    23(3.222986e-44), -4096(nan)
-; R600-NEXT:    975668412(6.390323e-04), 0(0.000000e+00)
-; R600-NEXT:     ADD T1.Y, PS, PV.W,
-; R600-NEXT:     MUL_IEEE T0.Z, PV.Z, literal.x,
-; R600-NEXT:     ADD_INT T0.W, PV.Y, literal.y,
-; R600-NEXT:     CNDE_INT * T1.W, T2.Y, T0.X, PV.X,
-; R600-NEXT:    1079283712(3.321289e+00), 1065353216(1.000000e+00)
-; R600-NEXT:     MUL_IEEE T0.X, PS, PV.W,
-; R600-NEXT:     ADD T0.Y, KC0[3].Z, -T1.Z,
-; R600-NEXT:     RNDNE T2.Z, PV.Z,
-; R600-NEXT:     TRUNC T0.W, T3.Y,
-; R600-NEXT:     EXP_IEEE * T1.X, PV.Y,
-; R600-NEXT:     SETGT T2.X, literal.x, KC0[3].Y,
-; R600-NEXT:     FLT_TO_INT T1.Y, PV.W,
-; R600-NEXT:     TRUNC T3.Z, PV.Z,
-; R600-NEXT:     MUL_IEEE T0.W, PV.Y, literal.y,
-; R600-NEXT:     MUL_IEEE * T1.W, PS, literal.z,
-; R600-NEXT:    -1036817932(-4.485347e+01), 975668412(6.390323e-04)
-; R600-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T3.X, PS, literal.x,
-; R600-NEXT:     MUL_IEEE T2.Y, T1.X, literal.y,
-; R600-NEXT:     MULADD_IEEE T4.Z, T0.Y, literal.z, PV.W,
-; R600-NEXT:     FLT_TO_INT T0.W, PV.Z,
-; R600-NEXT:     MIN_INT * T2.W, PV.Y, literal.w,
-; R600-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
-; R600-NEXT:    1079283712(3.321289e+00), 381(5.338947e-43)
-; R600-NEXT:     ADD_INT T4.X, PS, literal.x,
-; R600-NEXT:     MAX_INT T0.Y, PV.W, literal.y,
-; R600-NEXT:     MULADD_IEEE T1.Z, T1.Z, literal.z, PV.Z,
-; R600-NEXT:     ADD T2.W, T0.Z, -T2.Z, BS:VEC_120/SCL_212
-; R600-NEXT:     MIN_INT * T3.W, PV.W, literal.w,
-; R600-NEXT:    -254(nan), -330(nan)
-; R600-NEXT:    975668412(6.390323e-04), 381(5.338947e-43)
-; R600-NEXT:     ADD_INT T5.X, PS, literal.x,
-; R600-NEXT:     ADD T3.Y, PV.W, PV.Z,
-; R600-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; R600-NEXT:     ADD_INT T2.W, T0.W, literal.z,
-; R600-NEXT:     SETGT_UINT * T3.W, T0.W, literal.w,
-; R600-NEXT:    -254(nan), 204(2.858649e-43)
+; R600-NEXT:     ADD_INT T0.Y, PV.W, literal.y,
+; R600-NEXT:     ADD_INT T0.Z, T1.W, literal.z,
+; R600-NEXT:     SETGT_UINT * T0.W, T1.W, literal.w,
+; R600-NEXT:    209715200(1.972152e-31), 204(2.858649e-43)
 ; R600-NEXT:    102(1.429324e-43), -229(nan)
-; R600-NEXT:     ADD_INT * T6.X, T0.W, literal.x,
+; R600-NEXT:     AND_INT * T3.W, KC0[3].W, literal.x,
+; R600-NEXT:    -4096(nan), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T2.X, T0.X, literal.x,
+; R600-NEXT:     AND_INT T1.Y, KC0[3].Z, literal.y,
+; R600-NEXT:     ADD T1.Z, KC0[3].W, -PV.W,
+; R600-NEXT:     CNDE_INT T4.W, T0.W, T0.Y, T0.Z,
+; R600-NEXT:     SETGT_INT * T5.W, T1.W, literal.z,
+; R600-NEXT:    2130706432(1.701412e+38), -4096(nan)
 ; R600-NEXT:    -127(nan), 0(0.000000e+00)
-; R600-NEXT:    ALU clause starting at 106:
-; R600-NEXT:     SETGT_UINT T0.Y, T0.W, literal.x,
-; R600-NEXT:     CNDE_INT T0.Z, T3.W, T0.Z, T2.W, BS:VEC_102/SCL_221
-; R600-NEXT:     SETGT_INT T2.W, T0.W, literal.y,
-; R600-NEXT:     EXP_IEEE * T1.Z, T3.Y,
-; R600-NEXT:    254(3.559298e-43), -127(nan)
-; R600-NEXT:     ADD_INT T7.X, T1.Y, literal.x,
-; R600-NEXT:     MUL_IEEE T3.Y, PS, literal.y,
-; R600-NEXT:     CNDE_INT T0.Z, PV.W, PV.Z, T0.W,
-; R600-NEXT:     CNDE_INT T4.W, PV.Y, T6.X, T5.X,
-; R600-NEXT:     SETGT_INT * T0.W, T0.W, literal.z,
-; R600-NEXT:    -127(nan), 209715200(1.972152e-31)
-; R600-NEXT:    127(1.779649e-43), 0(0.000000e+00)
-; R600-NEXT:     SETGT_UINT T5.X, T1.Y, literal.x,
-; R600-NEXT:     CNDE_INT T4.Y, PS, PV.Z, PV.W,
-; R600-NEXT:     MAX_INT T0.Z, T1.Y, literal.y,
-; R600-NEXT:     MUL_IEEE T4.W, PV.Y, literal.z,
-; R600-NEXT:     MUL_IEEE * T5.W, T1.Z, literal.w,
-; R600-NEXT:    254(3.559298e-43), -330(nan)
-; R600-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
-; R600-NEXT:     MUL_IEEE T6.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T3.Y, T3.W, PV.W, T3.Y, BS:VEC_021/SCL_122
-; R600-NEXT:     ADD_INT T0.Z, PV.Z, literal.y,
-; R600-NEXT:     ADD_INT T3.W, T1.Y, literal.z,
-; R600-NEXT:     SETGT_UINT * T4.W, T1.Y, literal.w,
-; R600-NEXT:    2130706432(1.701412e+38), 204(2.858649e-43)
-; R600-NEXT:    102(1.429324e-43), -229(nan)
-; R600-NEXT:     CNDE_INT T8.X, PS, PV.Z, PV.W,
-; R600-NEXT:     SETGT_INT T5.Y, T1.Y, literal.x,
-; R600-NEXT:     CNDE_INT T0.Z, T2.W, PV.Y, T1.Z,
-; R600-NEXT:     CNDE_INT T2.W, T0.Y, T5.W, PV.X, BS:VEC_120/SCL_212
-; R600-NEXT:     LSHL * T3.W, T4.Y, literal.y,
-; R600-NEXT:    -127(nan), 23(3.222986e-44)
-; R600-NEXT:     ADD_INT T6.X, PS, literal.x,
-; R600-NEXT:     CNDE_INT T0.Y, T0.W, PV.Z, PV.W,
-; R600-NEXT:     CNDE_INT T0.Z, PV.Y, PV.X, T1.Y,
-; R600-NEXT:     CNDE_INT T0.W, T5.X, T7.X, T4.X,
-; R600-NEXT:     SETGT_INT * T2.W, T1.Y, literal.y,
-; R600-NEXT:    1065353216(1.000000e+00), 127(1.779649e-43)
-; R600-NEXT:     CNDE_INT T4.X, PS, PV.Z, PV.W,
-; R600-NEXT:     MUL_IEEE T0.Y, PV.Y, PV.X,
-; R600-NEXT:     SETGT T0.Z, literal.x, KC0[3].Z,
+; R600-NEXT:     CNDE_INT T3.X, PS, PV.W, T1.W,
+; R600-NEXT:     MUL_IEEE T0.Y, PV.Z, literal.x,
+; R600-NEXT:     MUL_IEEE T0.Z, T3.W, literal.y,
+; R600-NEXT:     MIN_INT T4.W, T1.W, literal.z, BS:VEC_120/SCL_212
+; R600-NEXT:     ADD * T6.W, KC0[3].Z, -PV.Y,
+; R600-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
+; R600-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T4.X, PS, literal.x,
+; R600-NEXT:     MUL_IEEE T2.Y, T1.Y, literal.y,
+; R600-NEXT:     ADD_INT T2.Z, PV.W, literal.z,
+; R600-NEXT:     ADD_INT * T4.W, T1.W, literal.w,
+; R600-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
+; R600-NEXT:    -254(nan), -127(nan)
+; R600-NEXT:     SETGT_UINT * T7.W, T1.W, literal.x,
+; R600-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT T5.X, PV.W, T4.W, T2.Z,
+; R600-NEXT:     RNDNE T3.Y, T2.Y,
+; R600-NEXT:     MULADD_IEEE T2.Z, T6.W, literal.x, T4.X,
+; R600-NEXT:     RNDNE T4.W, T0.Z,
+; R600-NEXT:     MULADD_IEEE * T6.W, T1.Z, literal.x, T0.Y, BS:VEC_021/SCL_122
+; R600-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
+; R600-NEXT:     SETGT_INT T4.X, T1.W, literal.x,
+; R600-NEXT:     MULADD_IEEE T0.Y, T3.W, literal.y, PS, BS:VEC_120/SCL_212
+; R600-NEXT:     ADD T0.Z, T0.Z, -PV.W,
+; R600-NEXT:     MULADD_IEEE T1.W, T1.Y, literal.y, PV.Z,
+; R600-NEXT:     ADD * T3.W, T2.Y, -PV.Y,
+; R600-NEXT:    127(1.779649e-43), 975668412(6.390323e-04)
+; R600-NEXT:     ADD T6.X, PS, PV.W,
+; R600-NEXT:     ADD T0.Y, PV.Z, PV.Y,
+; R600-NEXT:     CNDE_INT T0.Z, PV.X, T3.X, T5.X,
+; R600-NEXT:     MUL_IEEE * T1.W, T2.X, literal.x,
+; R600-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT * T0.W, T0.W, T1.X, T2.W,
+; R600-NEXT:     CNDE_INT T0.X, T5.W, PV.W, T0.X,
+; R600-NEXT:     CNDE_INT T1.Y, T7.W, T2.X, T1.W, BS:VEC_102/SCL_221
+; R600-NEXT:     LSHL * T0.Z, T0.Z, literal.x,
+; R600-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; R600-NEXT:     TRUNC T0.W, T4.W,
+; R600-NEXT:     EXP_IEEE * T0.Y, T0.Y,
+; R600-NEXT:     FLT_TO_INT T1.X, PV.W,
+; R600-NEXT:     TRUNC T2.Y, T3.Y, BS:VEC_120/SCL_212
+; R600-NEXT:     MUL_IEEE T1.Z, PS, literal.x,
+; R600-NEXT:     ADD_INT T0.W, T0.Z, literal.y,
+; R600-NEXT:     CNDE_INT * T1.W, T4.X, T0.X, T1.Y,
+; R600-NEXT:    209715200(1.972152e-31), 1065353216(1.000000e+00)
+; R600-NEXT:     MUL_IEEE T0.X, PS, PV.W,
+; R600-NEXT:     MUL_IEEE T1.Y, PV.Z, literal.x,
+; R600-NEXT:     FLT_TO_INT T0.Z, PV.Y,
+; R600-NEXT:     MAX_INT T0.W, PV.X, literal.y,
+; R600-NEXT:     EXP_IEEE * T1.W, T6.X,
+; R600-NEXT:    209715200(1.972152e-31), -330(nan)
+; R600-NEXT:     MUL_IEEE T2.X, T0.Y, literal.x,
+; R600-NEXT:     MUL_IEEE T2.Y, PS, literal.y,
+; R600-NEXT:     ADD_INT T2.Z, PV.W, literal.z,
+; R600-NEXT:     ADD_INT * T0.W, T1.X, literal.w,
+; R600-NEXT:    2130706432(1.701412e+38), 209715200(1.972152e-31)
+; R600-NEXT:    204(2.858649e-43), 102(1.429324e-43)
+; R600-NEXT:     MAX_INT * T2.W, T0.Z, literal.x,
+; R600-NEXT:    -330(nan), 0(0.000000e+00)
+; R600-NEXT:     SETGT_UINT T3.X, T1.X, literal.x,
+; R600-NEXT:     ADD_INT T3.Y, PV.W, literal.y,
+; R600-NEXT:     ADD_INT T3.Z, T0.Z, literal.z,
+; R600-NEXT:     SETGT_UINT * T2.W, T0.Z, literal.x,
+; R600-NEXT:    -229(nan), 204(2.858649e-43)
+; R600-NEXT:    102(1.429324e-43), 0(0.000000e+00)
+; R600-NEXT:    ALU clause starting at 105:
+; R600-NEXT:     MIN_INT * T3.W, T0.Z, literal.x,
+; R600-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT T4.X, PV.W, literal.x,
+; R600-NEXT:     ADD_INT T4.Y, T0.Z, literal.y,
+; R600-NEXT:     SETGT_UINT T4.Z, T0.Z, literal.z,
+; R600-NEXT:     CNDE_INT T3.W, T2.W, T3.Y, T3.Z, BS:VEC_021/SCL_122
+; R600-NEXT:     SETGT_INT * T4.W, T0.Z, literal.y,
+; R600-NEXT:    -254(nan), -127(nan)
+; R600-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; R600-NEXT:     CNDE_INT T5.X, PS, PV.W, T0.Z,
+; R600-NEXT:     CNDE_INT T3.Y, PV.Z, PV.Y, PV.X,
+; R600-NEXT:     SETGT_INT T0.Z, T0.Z, literal.x,
+; R600-NEXT:     CNDE_INT T0.W, T3.X, T2.Z, T0.W,
+; R600-NEXT:     SETGT_INT * T3.W, T1.X, literal.y,
+; R600-NEXT:    127(1.779649e-43), -127(nan)
+; R600-NEXT:     CNDE_INT T4.X, PS, PV.W, T1.X,
+; R600-NEXT:     CNDE_INT T3.Y, PV.Z, PV.X, PV.Y,
+; R600-NEXT:     MIN_INT T2.Z, T1.X, literal.x,
 ; R600-NEXT:     MUL_IEEE T0.W, T2.Y, literal.y,
-; R600-NEXT:     CNDE_INT * T1.W, T4.W, T3.X, T1.W,
-; R600-NEXT:    -1036817932(-4.485347e+01), 2130706432(1.701412e+38)
-; R600-NEXT:     CNDE_INT T1.X, T5.Y, PS, T1.X,
-; R600-NEXT:     CNDE_INT T1.Y, T5.X, T2.Y, PV.W,
-; R600-NEXT:     CNDE T0.Z, PV.Z, PV.Y, 0.0,
-; R600-NEXT:     SETGT T0.W, KC0[3].Z, literal.x,
-; R600-NEXT:     LSHL * T1.W, PV.X, literal.y,
-; R600-NEXT:    1109008539(3.853184e+01), 23(3.222986e-44)
-; R600-NEXT:     ADD_INT T3.X, PS, literal.x,
-; R600-NEXT:     CNDE T0.Y, PV.W, PV.Z, literal.y,
-; R600-NEXT:     CNDE_INT T0.Z, T2.W, PV.X, PV.Y,
-; R600-NEXT:     CNDE T0.W, T2.X, T0.X, 0.0,
+; R600-NEXT:     MUL_IEEE * T5.W, T1.W, literal.z,
+; R600-NEXT:    381(5.338947e-43), 209715200(1.972152e-31)
+; R600-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T5.X, PS, literal.x,
+; R600-NEXT:     CNDE_INT T2.Y, T2.W, PV.W, T2.Y,
+; R600-NEXT:     ADD_INT T2.Z, PV.Z, literal.y,
+; R600-NEXT:     ADD_INT T0.W, T1.X, literal.z,
+; R600-NEXT:     SETGT_UINT * T2.W, T1.X, literal.w,
+; R600-NEXT:    2130706432(1.701412e+38), -254(nan)
+; R600-NEXT:    -127(nan), 254(3.559298e-43)
+; R600-NEXT:     CNDE_INT T6.X, PS, PV.W, PV.Z,
+; R600-NEXT:     SETGT_INT T4.Y, T1.X, literal.x,
+; R600-NEXT:     CNDE_INT T2.Z, T4.W, PV.Y, T1.W,
+; R600-NEXT:     CNDE_INT T0.W, T4.Z, T5.W, PV.X,
+; R600-NEXT:     LSHL * T1.W, T3.Y, literal.y,
+; R600-NEXT:    127(1.779649e-43), 23(3.222986e-44)
+; R600-NEXT:     ADD_INT T1.X, PS, literal.x,
+; R600-NEXT:     CNDE_INT T2.Y, T0.Z, PV.Z, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     CNDE_INT T0.Z, PV.Y, T4.X, PV.X,
+; R600-NEXT:     MUL_IEEE T0.W, T2.X, literal.y,
+; R600-NEXT:     CNDE_INT * T1.W, T3.X, T1.Y, T1.Z,
+; R600-NEXT:    1065353216(1.000000e+00), 2130706432(1.701412e+38)
+; R600-NEXT:     CNDE_INT T3.X, T3.W, PS, T0.Y,
+; R600-NEXT:     CNDE_INT T0.Y, T2.W, T2.X, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     LSHL T0.Z, PV.Z, literal.x,
+; R600-NEXT:     MUL_IEEE T0.W, PV.Y, PV.X,
+; R600-NEXT:     SETGT * T1.W, literal.y, KC0[3].Z,
+; R600-NEXT:    23(3.222986e-44), -1036817932(-4.485347e+01)
+; R600-NEXT:     SETGT T1.X, literal.x, KC0[3].Y,
+; R600-NEXT:     CNDE T1.Y, PS, PV.W, 0.0,
+; R600-NEXT:     SETGT T1.Z, KC0[3].Z, literal.y,
+; R600-NEXT:     ADD_INT T0.W, PV.Z, literal.z,
+; R600-NEXT:     CNDE_INT * T1.W, T4.Y, PV.X, PV.Y,
+; R600-NEXT:    -1036817932(-4.485347e+01), 1109008539(3.853184e+01)
+; R600-NEXT:    1065353216(1.000000e+00), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T2.X, PS, PV.W,
+; R600-NEXT:     CNDE T0.Y, PV.Z, PV.Y, literal.x,
+; R600-NEXT:     SETGT T0.Z, literal.y, KC0[3].W,
+; R600-NEXT:     CNDE T0.W, PV.X, T0.X, 0.0,
 ; R600-NEXT:     SETGT * T1.W, KC0[3].Y, literal.z,
-; R600-NEXT:    1065353216(1.000000e+00), 2139095040(INF)
+; R600-NEXT:    2139095040(INF), -1036817932(-4.485347e+01)
 ; R600-NEXT:    1109008539(3.853184e+01), 0(0.000000e+00)
 ; R600-NEXT:     CNDE T0.X, PS, PV.W, literal.x,
-; R600-NEXT:     MUL_IEEE T0.W, PV.Z, PV.X,
-; R600-NEXT:     SETGT * T1.W, literal.y, KC0[3].W,
-; R600-NEXT:    2139095040(INF), -1036817932(-4.485347e+01)
-; R600-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; R600-NEXT:     CNDE T0.W, PS, PV.W, 0.0,
+; R600-NEXT:     CNDE T0.W, PV.Z, PV.X, 0.0,
 ; R600-NEXT:     SETGT * T1.W, KC0[3].W, literal.y,
-; R600-NEXT:    2(2.802597e-45), 1109008539(3.853184e+01)
-; R600-NEXT:     CNDE T2.X, PS, PV.W, literal.x,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; R600-NEXT:    2139095040(INF), 8(1.121039e-44)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:    2139095040(INF), 1109008539(3.853184e+01)
+; R600-NEXT:     CNDE T1.X, PS, PV.W, literal.x,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.y,
+; R600-NEXT:    2139095040(INF), 2(2.802597e-45)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_exp10_v3f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 101, @6, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 77, @108, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T1.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T3.X
+; CM-NEXT:    ALU 98, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 77, @105, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     AND_INT * T0.W, KC0[3].Y, literal.x,
+; CM-NEXT:     AND_INT * T0.W, KC0[3].W, literal.x,
 ; CM-NEXT:    -4096(nan), 0(0.000000e+00)
-; CM-NEXT:     ADD * T1.W, KC0[3].Y, -PV.W,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.W, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, T0.W, literal.y,
-; CM-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
-; CM-NEXT:     RNDNE T1.Z, PV.W,
-; CM-NEXT:     MULADD_IEEE * T1.W, T1.W, literal.x, PV.Z,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.W, literal.x,
 ; CM-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
-; CM-NEXT:     MULADD_IEEE T0.Z, T0.W, literal.x, PV.W,
-; CM-NEXT:     ADD * T0.W, T2.W, -PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:    975668412(6.390323e-04), 0(0.000000e+00)
-; CM-NEXT:     TRUNC T1.Z, T1.Z,
-; CM-NEXT:     ADD * T0.W, PV.W, PV.Z,
-; CM-NEXT:     EXP_IEEE T0.X, T0.W,
-; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     FLT_TO_INT T0.Z, T1.Z,
-; CM-NEXT:     MUL_IEEE * T0.W, PV.X, literal.x,
-; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
+; CM-NEXT:     RNDNE T0.Z, PV.W,
+; CM-NEXT:     ADD * T2.W, KC0[3].W, -T0.W,
 ; CM-NEXT:     MUL_IEEE T0.Y, PV.W, literal.x,
-; CM-NEXT:     MAX_INT T1.Z, PV.Z, literal.y,
-; CM-NEXT:     MIN_INT * T1.W, PV.Z, literal.z,
-; CM-NEXT:    209715200(1.972152e-31), -330(nan)
+; CM-NEXT:     AND_INT T1.Z, KC0[3].Y, literal.y,
+; CM-NEXT:     TRUNC * T3.W, PV.Z,
+; CM-NEXT:    975668412(6.390323e-04), -4096(nan)
+; CM-NEXT:     FLT_TO_INT T1.Y, PV.W,
+; CM-NEXT:     ADD T2.Z, KC0[3].Y, -PV.Z,
+; CM-NEXT:     MULADD_IEEE * T2.W, T2.W, literal.x, PV.Y,
+; CM-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T0.X, T0.W, literal.x, PV.W,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.Z, literal.x,
+; CM-NEXT:     MAX_INT T3.Z, PV.Y, literal.y,
+; CM-NEXT:     MIN_INT * T0.W, PV.Y, literal.z,
+; CM-NEXT:    975668412(6.390323e-04), -330(nan)
 ; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
 ; CM-NEXT:     ADD_INT T1.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T1.Y, PV.Z, literal.y,
-; CM-NEXT:     ADD_INT T1.Z, T0.Z, literal.z,
-; CM-NEXT:     SETGT_UINT * T1.W, T0.Z, literal.w,
+; CM-NEXT:     ADD_INT T2.Y, PV.Z, literal.y,
+; CM-NEXT:     ADD_INT T3.Z, T1.Y, literal.z,
+; CM-NEXT:     SETGT_UINT * T0.W, T1.Y, literal.w,
 ; CM-NEXT:    -254(nan), 204(2.858649e-43)
 ; CM-NEXT:    102(1.429324e-43), -229(nan)
-; CM-NEXT:     ADD_INT T2.X, T0.Z, literal.x,
-; CM-NEXT:     SETGT_UINT T2.Y, T0.Z, literal.y,
+; CM-NEXT:     ADD_INT T2.X, T1.Y, literal.x,
+; CM-NEXT:     SETGT_UINT T3.Y, T1.Y, literal.y,
+; CM-NEXT:     CNDE_INT T3.Z, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     SETGT_INT * T2.W, T1.Y, literal.x,
+; CM-NEXT:    -127(nan), 254(3.559298e-43)
+; CM-NEXT:     MUL_IEEE T3.X, T1.Z, literal.x,
+; CM-NEXT:     CNDE_INT T2.Y, PV.W, PV.Z, T1.Y,
+; CM-NEXT:     CNDE_INT T3.Z, PV.Y, PV.X, T1.X,
+; CM-NEXT:     SETGT_INT * T3.W, T1.Y, literal.y,
+; CM-NEXT:    1079283712(3.321289e+00), 127(1.779649e-43)
+; CM-NEXT:     ADD T1.X, T1.W, -T0.Z,
+; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     RNDNE T0.Z, PV.X,
+; CM-NEXT:     MULADD_IEEE * T1.W, T2.Z, literal.x, T0.Y,
+; CM-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T2.X, T1.Z, literal.x, PV.W,
+; CM-NEXT:     ADD T0.Y, T3.X, -PV.Z,
+; CM-NEXT:     LSHL T1.Z, PV.Y, literal.y,
+; CM-NEXT:     ADD * T1.W, PV.X, T0.X,
+; CM-NEXT:    975668412(6.390323e-04), 23(3.222986e-44)
+; CM-NEXT:     EXP_IEEE T0.X, T1.W,
+; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     ADD_INT T1.Y, T1.Z, literal.x,
+; CM-NEXT:     MUL_IEEE T1.Z, PV.X, literal.y,
+; CM-NEXT:     ADD * T1.W, T0.Y, T2.X,
+; CM-NEXT:    1065353216(1.000000e+00), 209715200(1.972152e-31)
+; CM-NEXT:     EXP_IEEE T0.X (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE T0.Y, T1.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     TRUNC T1.X, T0.Z,
+; CM-NEXT:     MUL_IEEE T2.Y, T1.Z, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     MUL_IEEE T0.Z, T0.X, literal.y,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.Y, literal.x,
+; CM-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
+; CM-NEXT:     MUL_IEEE T2.X, PV.W, literal.x,
+; CM-NEXT:     MUL_IEEE T4.Y, PV.Z, literal.y,
+; CM-NEXT:     CNDE_INT T1.Z, T0.W, PV.Y, T1.Z,
+; CM-NEXT:     FLT_TO_INT * T0.W, PV.X,
+; CM-NEXT:    209715200(1.972152e-31), 2130706432(1.701412e+38)
+; CM-NEXT:     SETGT_UINT T1.X, PV.W, literal.x,
+; CM-NEXT:     AND_INT T2.Y, KC0[3].Z, literal.y,
+; CM-NEXT:     CNDE_INT T1.Z, T2.W, PV.Z, T0.X,
+; CM-NEXT:     CNDE_INT * T2.W, T3.Y, T0.Z, PV.Y,
+; CM-NEXT:    -229(nan), -4096(nan)
+; CM-NEXT:     CNDE_INT T0.X, T3.W, PV.Z, PV.W,
+; CM-NEXT:     ADD T3.Y, KC0[3].Z, -PV.Y,
+; CM-NEXT:     CNDE_INT T0.Z, PV.X, T2.X, T1.W,
+; CM-NEXT:     SETGT_INT * T1.W, T0.W, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    -127(nan), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T2.X, PV.W, PV.Z, T0.Y,
+; CM-NEXT:     MUL_IEEE T0.Y, T0.Y, literal.x,
+; CM-NEXT:     MUL_IEEE T0.Z, T2.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     MUL_IEEE * T2.W, PV.Y, literal.z,
+; CM-NEXT:    2130706432(1.701412e+38), 1079283712(3.321289e+00)
+; CM-NEXT:    975668412(6.390323e-04), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T3.X, T3.Y, literal.x, PV.W,
+; CM-NEXT:     RNDNE T3.Y, PV.Z,
+; CM-NEXT:     MUL_IEEE T1.Z, PV.Y, literal.y,
+; CM-NEXT:     SETGT_UINT * T2.W, T0.W, literal.z,
+; CM-NEXT:    1079283712(3.321289e+00), 2130706432(1.701412e+38)
+; CM-NEXT:    254(3.559298e-43), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T4.X, PV.W, T0.Y, PV.Z,
+; CM-NEXT:     TRUNC T0.Y, PV.Y,
+; CM-NEXT:     MULADD_IEEE T1.Z, T2.Y, literal.x, PV.X,
+; CM-NEXT:     MAX_INT * T3.W, T0.W, literal.y,
+; CM-NEXT:    975668412(6.390323e-04), -330(nan)
+; CM-NEXT:     ADD T3.X, T0.Z, -T3.Y,
+; CM-NEXT:     ADD_INT T2.Y, PV.W, literal.x,
+; CM-NEXT:     ADD_INT * T0.Z, T0.W, literal.y,
+; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
+; CM-NEXT:    ALU clause starting at 105:
+; CM-NEXT:     MIN_INT * T3.W, T0.W, literal.x,
+; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T5.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T3.Y, T0.W, literal.y,
+; CM-NEXT:     CNDE_INT T0.Z, T1.X, T2.Y, T0.Z,
+; CM-NEXT:     ADD * T3.W, T3.X, T1.Z, BS:VEC_102/SCL_221
+; CM-NEXT:    -254(nan), -127(nan)
+; CM-NEXT:     EXP_IEEE T1.X, T3.W,
+; CM-NEXT:     EXP_IEEE T1.Y (MASKED), T3.W,
+; CM-NEXT:     EXP_IEEE T1.Z (MASKED), T3.W,
+; CM-NEXT:     EXP_IEEE * T1.W (MASKED), T3.W,
+; CM-NEXT:     CNDE_INT T3.X, T1.W, T0.Z, T0.W,
+; CM-NEXT:     CNDE_INT T2.Y, T2.W, T3.Y, T5.X, BS:VEC_120/SCL_212
+; CM-NEXT:     FLT_TO_INT T0.Z, T0.Y,
+; CM-NEXT:     MUL_IEEE * T1.W, PV.X, literal.x,
+; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
+; CM-NEXT:     SETGT_INT T5.X, T0.W, literal.x,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.W, literal.y,
+; CM-NEXT:     MAX_INT T1.Z, PV.Z, literal.z,
+; CM-NEXT:     MIN_INT * T0.W, PV.Z, literal.w,
+; CM-NEXT:    127(1.779649e-43), 209715200(1.972152e-31)
+; CM-NEXT:    -330(nan), 381(5.338947e-43)
+; CM-NEXT:     ADD_INT T6.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T3.Y, PV.Z, literal.y,
+; CM-NEXT:     ADD_INT T1.Z, T0.Z, literal.z,
+; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.w,
+; CM-NEXT:    -254(nan), 204(2.858649e-43)
+; CM-NEXT:    102(1.429324e-43), -229(nan)
+; CM-NEXT:     ADD_INT T7.X, T0.Z, literal.x,
+; CM-NEXT:     SETGT_UINT T4.Y, T0.Z, literal.y,
 ; CM-NEXT:     CNDE_INT T1.Z, PV.W, PV.Y, PV.Z,
 ; CM-NEXT:     SETGT_INT * T2.W, T0.Z, literal.x,
 ; CM-NEXT:    -127(nan), 254(3.559298e-43)
-; CM-NEXT:     MUL_IEEE T3.X, T0.X, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Z, T0.Z,
-; CM-NEXT:     CNDE_INT T1.Z, PV.Y, PV.X, T1.X,
+; CM-NEXT:     MUL_IEEE T8.X, T1.X, literal.x,
+; CM-NEXT:     CNDE_INT T3.Y, PV.W, PV.Z, T0.Z,
+; CM-NEXT:     CNDE_INT T1.Z, PV.Y, PV.X, T6.X,
 ; CM-NEXT:     SETGT_INT * T3.W, T0.Z, literal.y,
 ; CM-NEXT:    2130706432(1.701412e+38), 127(1.779649e-43)
-; CM-NEXT:     CNDE_INT T1.Y, PV.W, PV.Y, PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.X, literal.x,
-; CM-NEXT:     CNDE_INT * T0.W, T1.W, T0.Y, T0.W,
+; CM-NEXT:     CNDE_INT T6.X, PV.W, PV.Y, PV.Z,
+; CM-NEXT:     MUL_IEEE T3.Y, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T0.Z, T0.W, T0.Y, T1.W,
+; CM-NEXT:     CNDE_INT * T0.W, T5.X, T3.X, T2.Y,
 ; CM-NEXT:    2130706432(1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T0.X, T2.W, PV.W, T0.X,
-; CM-NEXT:     CNDE_INT T0.Y, T2.Y, T3.X, PV.Z,
-; CM-NEXT:     LSHL T0.Z, PV.Y, literal.x,
-; CM-NEXT:     AND_INT * T0.W, KC0[3].Z, literal.y,
-; CM-NEXT:    23(3.222986e-44), -4096(nan)
-; CM-NEXT:     ADD T1.Y, KC0[3].Z, -PV.W,
-; CM-NEXT:     ADD_INT T0.Z, PV.Z, literal.x,
-; CM-NEXT:     CNDE_INT * T1.W, T3.W, PV.X, PV.Y,
+; CM-NEXT:     LSHL T3.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, T2.W, PV.Z, T1.X,
+; CM-NEXT:     CNDE_INT T0.Z, T4.Y, T8.X, PV.Y,
+; CM-NEXT:     LSHL * T0.W, PV.X, literal.x,
+; CM-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T1.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, T3.W, PV.Y, PV.Z,
+; CM-NEXT:     ADD_INT T0.Z, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT * T0.W, T5.X, T2.X, T4.X,
 ; CM-NEXT:    1065353216(1.000000e+00), 0(0.000000e+00)
-; CM-NEXT:     MUL_IEEE T0.X, PV.W, PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Y, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE T0.Z, T0.W, literal.y,
-; CM-NEXT:     AND_INT * T1.W, KC0[3].W, literal.z,
-; CM-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
-; CM-NEXT:    -4096(nan), 0(0.000000e+00)
-; CM-NEXT:     SETGT T1.X, literal.x, KC0[3].Y,
-; CM-NEXT:     ADD T2.Y, KC0[3].W, -PV.W,
-; CM-NEXT:     RNDNE T1.Z, PV.Z,
-; CM-NEXT:     MULADD_IEEE * T2.W, T1.Y, literal.y, PV.Y,
-; CM-NEXT:    -1036817932(-4.485347e+01), 1079283712(3.321289e+00)
-; CM-NEXT:     MULADD_IEEE T2.X, T0.W, literal.x, PV.W,
-; CM-NEXT:     ADD T0.Y, T0.Z, -PV.Z,
-; CM-NEXT:     MUL_IEEE T0.Z, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE * T0.W, T1.W, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    975668412(6.390323e-04), 1079283712(3.321289e+00)
-; CM-NEXT:     TRUNC T3.X, T1.Z,
-; CM-NEXT:     RNDNE T1.Y, PV.W,
-; CM-NEXT:     MULADD_IEEE T0.Z, T2.Y, literal.x, PV.Z,
-; CM-NEXT:     ADD * T2.W, PV.Y, PV.X,
-; CM-NEXT:    1079283712(3.321289e+00), 0(0.000000e+00)
-; CM-NEXT:     EXP_IEEE T0.X (MASKED), T2.W,
-; CM-NEXT:     EXP_IEEE T0.Y, T2.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     MULADD_IEEE T2.X, T1.W, literal.x, T0.Z,
-; CM-NEXT:     ADD T2.Y, T0.W, -T1.Y, BS:VEC_120/SCL_212
-; CM-NEXT:     FLT_TO_INT T0.Z, T3.X,
-; CM-NEXT:     MUL_IEEE * T0.W, PV.Y, literal.y,
-; CM-NEXT:    975668412(6.390323e-04), 209715200(1.972152e-31)
-; CM-NEXT:     MUL_IEEE T3.X, PV.W, literal.x,
-; CM-NEXT:     SETGT_UINT T3.Y, PV.Z, literal.y,
-; CM-NEXT:     TRUNC T1.Z, T1.Y,
-; CM-NEXT:     ADD * T1.W, PV.Y, PV.X,
-; CM-NEXT:    209715200(1.972152e-31), -229(nan)
-; CM-NEXT:     EXP_IEEE T1.X (MASKED), T1.W,
-; CM-NEXT:     EXP_IEEE T1.Y, T1.W,
-; CM-NEXT:     EXP_IEEE T1.Z (MASKED), T1.W,
-; CM-NEXT:     EXP_IEEE * T1.W (MASKED), T1.W,
-; CM-NEXT:     FLT_TO_INT T2.X, T1.Z,
-; CM-NEXT:     MUL_IEEE T2.Y, PV.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Z, T3.Y, T3.X, T0.W,
-; CM-NEXT:     SETGT_INT * T0.W, T0.Z, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    209715200(1.972152e-31), -127(nan)
-; CM-NEXT:     CNDE_INT T3.X, PV.W, PV.Z, T0.Y,
-; CM-NEXT:     MUL_IEEE * T4.Y, PV.Y, literal.x,
-; CM-NEXT:    209715200(1.972152e-31), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 108:
-; CM-NEXT:     SETGT_UINT T1.Z, T2.X, literal.x,
-; CM-NEXT:     MAX_INT * T1.W, T0.Z, literal.y,
-; CM-NEXT:    -229(nan), -330(nan)
-; CM-NEXT:     ADD_INT T4.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T5.Y, T0.Z, literal.y,
-; CM-NEXT:     CNDE_INT T2.Z, PV.Z, T4.Y, T2.Y,
-; CM-NEXT:     SETGT_INT * T1.W, T2.X, literal.z,
-; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; CM-NEXT:    -127(nan), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T5.X, PV.W, PV.Z, T1.Y,
-; CM-NEXT:     MUL_IEEE T0.Y, T0.Y, literal.x,
-; CM-NEXT:     MAX_INT T2.Z, T2.X, literal.y,
-; CM-NEXT:     CNDE_INT * T2.W, T3.Y, PV.X, PV.Y, BS:VEC_120/SCL_212
-; CM-NEXT:    2130706432(1.701412e+38), -330(nan)
-; CM-NEXT:     CNDE_INT T4.X, T0.W, PV.W, T0.Z,
-; CM-NEXT:     ADD_INT T2.Y, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT T2.Z, T2.X, literal.y,
-; CM-NEXT:     MIN_INT * T0.W, T2.X, literal.z,
-; CM-NEXT:    204(2.858649e-43), 102(1.429324e-43)
-; CM-NEXT:    381(5.338947e-43), 0(0.000000e+00)
-; CM-NEXT:     ADD_INT T6.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T3.Y, T2.X, literal.y,
-; CM-NEXT:     SETGT_UINT T3.Z, T2.X, literal.z,
-; CM-NEXT:     CNDE_INT * T0.W, T1.Z, PV.Y, PV.Z,
-; CM-NEXT:    -254(nan), -127(nan)
-; CM-NEXT:    254(3.559298e-43), 0(0.000000e+00)
-; CM-NEXT:     MUL_IEEE T7.X, T1.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, T1.W, PV.W, T2.X,
-; CM-NEXT:     CNDE_INT T1.Z, PV.Z, PV.Y, PV.X,
-; CM-NEXT:     MIN_INT * T0.W, T0.Z, literal.y,
-; CM-NEXT:    2130706432(1.701412e+38), 381(5.338947e-43)
-; CM-NEXT:     SETGT_INT T2.X, T2.X, literal.x,
-; CM-NEXT:     ADD_INT T2.Y, PV.W, literal.y,
-; CM-NEXT:     ADD_INT T2.Z, T0.Z, literal.z,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.w,
-; CM-NEXT:    127(1.779649e-43), -254(nan)
-; CM-NEXT:    -127(nan), 254(3.559298e-43)
-; CM-NEXT:     CNDE_INT T6.X, PV.W, PV.Z, PV.Y,
-; CM-NEXT:     SETGT_INT T2.Y, T0.Z, literal.x,
-; CM-NEXT:     CNDE_INT T0.Z, PV.X, T1.Y, T1.Z,
-; CM-NEXT:     MUL_IEEE * T1.W, T7.X, literal.y,
-; CM-NEXT:    127(1.779649e-43), 2130706432(1.701412e+38)
-; CM-NEXT:     CNDE_INT T7.X, T3.Z, T7.X, PV.W,
-; CM-NEXT:     LSHL T1.Y, PV.Z, literal.x,
-; CM-NEXT:     CNDE_INT T0.Z, PV.Y, T4.X, PV.X, BS:VEC_021/SCL_122
-; CM-NEXT:     MUL_IEEE * T1.W, T0.Y, literal.y,
-; CM-NEXT:    23(3.222986e-44), 2130706432(1.701412e+38)
-; CM-NEXT:     CNDE_INT T4.X, T0.W, T0.Y, PV.W,
-; CM-NEXT:     LSHL T0.Y, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE_INT * T0.W, T2.X, T5.X, PV.X,
-; CM-NEXT:    23(3.222986e-44), 1065353216(1.000000e+00)
 ; CM-NEXT:     MUL_IEEE T2.X, PV.W, PV.Z,
-; CM-NEXT:     SETGT T1.Y, literal.x, KC0[3].W,
-; CM-NEXT:     ADD_INT T0.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE_INT * T0.W, T2.Y, T3.X, PV.X,
-; CM-NEXT:    -1036817932(-4.485347e+01), 1065353216(1.000000e+00)
-; CM-NEXT:     MUL_IEEE T3.X, PV.W, PV.Z,
-; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
-; CM-NEXT:     CNDE T0.Z, PV.Y, PV.X, 0.0,
-; CM-NEXT:     SETGT * T0.W, KC0[3].W, literal.y,
-; CM-NEXT:    -1036817932(-4.485347e+01), 1109008539(3.853184e+01)
-; CM-NEXT:     CNDE T2.X, PV.W, PV.Z, literal.x,
-; CM-NEXT:     CNDE T0.Y, PV.Y, PV.X, 0.0,
-; CM-NEXT:     SETGT T0.Z, KC0[3].Z, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2139095040(INF), 1109008539(3.853184e+01)
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T3.X, PV.W, literal.x,
-; CM-NEXT:     CNDE T0.Y, PV.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE T0.Z, T1.X, T0.X, 0.0,
+; CM-NEXT:     MUL_IEEE T0.Y, PV.Y, PV.X,
+; CM-NEXT:     MUL_IEEE T0.Z, T0.X, T1.Y,
+; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
+; CM-NEXT:    -1036817932(-4.485347e+01), 0(0.000000e+00)
+; CM-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; CM-NEXT:     SETGT T1.Y, literal.y, KC0[3].Z,
+; CM-NEXT:     CNDE T0.Z, PV.W, PV.Z, 0.0,
+; CM-NEXT:     SETGT * T0.W, KC0[3].W, literal.z,
+; CM-NEXT:    2(2.802597e-45), -1036817932(-4.485347e+01)
+; CM-NEXT:    1109008539(3.853184e+01), 0(0.000000e+00)
+; CM-NEXT:     CNDE T1.X, PV.W, PV.Z, literal.x,
+; CM-NEXT:     SETGT T2.Y, literal.y, KC0[3].Y,
+; CM-NEXT:     CNDE T0.Z, PV.Y, T0.Y, 0.0,
+; CM-NEXT:     SETGT * T0.W, KC0[3].Z, literal.z,
+; CM-NEXT:    2139095040(INF), -1036817932(-4.485347e+01)
+; CM-NEXT:    1109008539(3.853184e+01), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; CM-NEXT:     CNDE T4.Y, PV.W, PV.Z, literal.y,
+; CM-NEXT:     CNDE T0.Z, PV.Y, T2.X, 0.0,
 ; CM-NEXT:     SETGT * T0.W, KC0[3].Y, literal.z,
 ; CM-NEXT:    2(2.802597e-45), 2139095040(INF)
 ; CM-NEXT:    1109008539(3.853184e+01), 0(0.000000e+00)
-; CM-NEXT:     CNDE * T0.X, PV.W, PV.Z, literal.x,
+; CM-NEXT:     CNDE * T4.X, PV.W, PV.Z, literal.x,
 ; CM-NEXT:    2139095040(INF), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %result = call <3 x float> @llvm.exp10.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.exp2.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.exp2.ll
@@ -576,9 +576,9 @@ define amdgpu_kernel void @s_exp2_v3f32(ptr addrspace(1) %out, <3 x float> %in) 
 ;
 ; R600-LABEL: s_exp2_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 29, @4, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T0.X, 1
+; R600-NEXT:    ALU 27, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     SETGT T0.W, literal.x, KC0[3].Z,
@@ -586,75 +586,73 @@ define amdgpu_kernel void @s_exp2_v3f32(ptr addrspace(1) %out, <3 x float> %in) 
 ; R600-NEXT:    -1023672320(-1.260000e+02), 0(0.000000e+00)
 ; R600-NEXT:     CNDE * T2.W, PV.W, 0.0, literal.x,
 ; R600-NEXT:    1115684864(6.400000e+01), 0(0.000000e+00)
-; R600-NEXT:     ADD T2.W, KC0[3].Z, PV.W,
-; R600-NEXT:     CNDE * T3.W, T1.W, 0.0, literal.x,
-; R600-NEXT:    1115684864(6.400000e+01), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.Z, KC0[3].Z, PV.W,
+; R600-NEXT:     SETGT T2.W, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE * T3.W, T1.W, 0.0, literal.y,
+; R600-NEXT:    -1023672320(-1.260000e+02), 1115684864(6.400000e+01)
 ; R600-NEXT:     ADD T0.Y, KC0[3].Y, PS,
-; R600-NEXT:     SETGT T0.Z, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE T1.Z, PV.W, 0.0, literal.x,
 ; R600-NEXT:     CNDE T0.W, T0.W, 1.0, literal.y,
-; R600-NEXT:     EXP_IEEE * T0.X, PV.W,
-; R600-NEXT:    -1023672320(-1.260000e+02), 528482304(5.421011e-20)
-; R600-NEXT:     MUL_IEEE T1.Y, PS, PV.W,
-; R600-NEXT:     CNDE T1.Z, PV.Z, 0.0, literal.x,
-; R600-NEXT:     CNDE T0.W, T1.W, 1.0, literal.y,
-; R600-NEXT:     EXP_IEEE * T0.X, PV.Y,
+; R600-NEXT:     EXP_IEEE * T0.X, PV.Z,
 ; R600-NEXT:    1115684864(6.400000e+01), 528482304(5.421011e-20)
-; R600-NEXT:     MUL_IEEE T1.X, PS, PV.W,
-; R600-NEXT:     ADD T0.W, KC0[3].W, PV.Z,
-; R600-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
-; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; R600-NEXT:     CNDE T1.W, T0.Z, 1.0, literal.x,
-; R600-NEXT:     EXP_IEEE * T0.Y, PV.W,
+; R600-NEXT:     MUL_IEEE T1.Y, PS, PV.W,
+; R600-NEXT:     ADD T0.Z, KC0[3].W, PV.Z,
+; R600-NEXT:     CNDE T0.W, T1.W, 1.0, literal.x,
+; R600-NEXT:     EXP_IEEE * T0.X, PV.Y,
 ; R600-NEXT:    528482304(5.421011e-20), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T2.X, PS, PV.W,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:     MUL_IEEE T1.X, PS, PV.W,
+; R600-NEXT:     CNDE T0.W, T2.W, 1.0, literal.x,
+; R600-NEXT:     EXP_IEEE * T0.X, PV.Z,
+; R600-NEXT:    528482304(5.421011e-20), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T0.X, PS, PV.W,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_exp2_v3f32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 35, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T1.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
 ; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
 ; CM-NEXT:    -1023672320(-1.260000e+02), 0(0.000000e+00)
-; CM-NEXT:     CNDE T0.Y, PV.W, 0.0, literal.x,
-; CM-NEXT:     SETGT T0.Z, literal.y, KC0[3].Z,
-; CM-NEXT:     SETGT * T1.W, literal.y, KC0[3].Y,
-; CM-NEXT:    1115684864(6.400000e+01), -1023672320(-1.260000e+02)
-; CM-NEXT:     CNDE T0.X, PV.W, 0.0, literal.x,
-; CM-NEXT:     CNDE T1.Y, PV.Z, 0.0, literal.x,
-; CM-NEXT:     CNDE T1.Z, T0.W, 1.0, literal.y,
-; CM-NEXT:     ADD * T0.W, KC0[3].W, PV.Y,
-; CM-NEXT:    1115684864(6.400000e+01), 528482304(5.421011e-20)
-; CM-NEXT:     EXP_IEEE T0.X (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE T0.Y, T0.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     MUL_IEEE T1.X, PV.Y, T1.Z,
-; CM-NEXT:     CNDE T0.Y, T0.Z, 1.0, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     ADD * T0.W, KC0[3].Z, T1.Y,
-; CM-NEXT:    528482304(5.421011e-20), 8(1.121039e-44)
-; CM-NEXT:     EXP_IEEE T0.X (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     EXP_IEEE * T0.W, T0.W,
-; CM-NEXT:     LSHR T2.X, T0.Z, literal.x,
-; CM-NEXT:     MUL_IEEE T0.Y, PV.W, T0.Y,
-; CM-NEXT:     CNDE T0.Z, T1.W, 1.0, literal.y,
-; CM-NEXT:     ADD * T0.W, KC0[3].Y, T0.X,
-; CM-NEXT:    2(2.802597e-45), 528482304(5.421011e-20)
+; CM-NEXT:     CNDE * T1.W, PV.W, 0.0, literal.x,
+; CM-NEXT:    1115684864(6.400000e+01), 0(0.000000e+00)
+; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
+; CM-NEXT:     CNDE T0.Z, T0.W, 1.0, literal.y,
+; CM-NEXT:     ADD * T0.W, KC0[3].W, PV.W,
+; CM-NEXT:    -1023672320(-1.260000e+02), 528482304(5.421011e-20)
 ; CM-NEXT:     EXP_IEEE T0.X, T0.W,
 ; CM-NEXT:     EXP_IEEE T0.Y (MASKED), T0.W,
 ; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
 ; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     MUL_IEEE * T0.X, PV.X, T0.Z,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     MUL_IEEE T0.X, PV.X, T0.Z,
+; CM-NEXT:     CNDE T0.Z, T0.Y, 0.0, literal.x,
+; CM-NEXT:     SETGT * T0.W, literal.y, KC0[3].Y,
+; CM-NEXT:    1115684864(6.400000e+01), -1023672320(-1.260000e+02)
+; CM-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; CM-NEXT:     CNDE T1.Y, PV.W, 0.0, literal.y,
+; CM-NEXT:     CNDE T1.Z, T0.Y, 1.0, literal.z,
+; CM-NEXT:     ADD * T1.W, KC0[3].Z, PV.Z,
+; CM-NEXT:    2(2.802597e-45), 1115684864(6.400000e+01)
+; CM-NEXT:    528482304(5.421011e-20), 0(0.000000e+00)
+; CM-NEXT:     EXP_IEEE T0.X (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE T0.Y, T1.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     ADD_INT T2.X, T1.X, literal.x,
+; CM-NEXT:     MUL_IEEE T3.Y, PV.Y, T1.Z,
+; CM-NEXT:     CNDE T0.Z, T0.W, 1.0, literal.y,
+; CM-NEXT:     ADD * T0.W, KC0[3].Y, T1.Y,
+; CM-NEXT:    2(2.802597e-45), 528482304(5.421011e-20)
+; CM-NEXT:     EXP_IEEE T0.X (MASKED), T0.W,
+; CM-NEXT:     EXP_IEEE T0.Y, T0.W,
+; CM-NEXT:     EXP_IEEE T0.Z (MASKED), T0.W,
+; CM-NEXT:     EXP_IEEE * T0.W (MASKED), T0.W,
+; CM-NEXT:     MUL_IEEE * T3.X, PV.Y, T0.Z,
   %result = call <3 x float> @llvm.exp2.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.log.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.log.ll
@@ -1544,9 +1544,9 @@ define amdgpu_kernel void @s_log_v3f32(ptr addrspace(1) %out, <3 x float> %in) {
 ;
 ; R600-LABEL: s_log_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 62, @4, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T0.X, 1
+; R600-NEXT:    ALU 61, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     SETGT T0.W, literal.x, KC0[3].Z,
@@ -1554,141 +1554,138 @@ define amdgpu_kernel void @s_log_v3f32(ptr addrspace(1) %out, <3 x float> %in) {
 ; R600-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
 ; R600-NEXT:     CNDE * T2.W, PV.W, 1.0, literal.x,
 ; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T2.W, KC0[3].Z, PV.W,
-; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.x,
+; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].Z, PV.W,
+; R600-NEXT:     SETGT T2.W, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.y,
+; R600-NEXT:    8388608(1.175494e-38), 1333788672(4.294967e+09)
+; R600-NEXT:     MUL_IEEE T1.Z, KC0[3].Y, PS,
+; R600-NEXT:     CNDE T3.W, PV.W, 1.0, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.X, PV.Z,
 ; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].Y, PS,
-; R600-NEXT:     SETGT T3.W, literal.x, KC0[3].W,
-; R600-NEXT:     LOG_IEEE * T0.X, PV.W,
-; R600-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; R600-NEXT:     AND_INT T1.Z, PS, literal.x,
-; R600-NEXT:     CNDE T2.W, PV.W, 1.0, literal.y,
-; R600-NEXT:     LOG_IEEE * T0.Y, PV.Z,
-; R600-NEXT:    -4096(nan), 1333788672(4.294967e+09)
 ; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].W, PV.W,
-; R600-NEXT:     ADD T2.W, T0.X, -PV.Z,
-; R600-NEXT:     AND_INT * T4.W, PS, literal.x,
+; R600-NEXT:     AND_INT T3.W, PS, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.Y, PV.Z,
 ; R600-NEXT:    -4096(nan), 0(0.000000e+00)
-; R600-NEXT:     ADD T2.Z, T0.Y, -PS,
-; R600-NEXT:     MUL_IEEE T5.W, PV.W, literal.x,
+; R600-NEXT:     ADD T1.Z, T0.X, -PV.W,
+; R600-NEXT:     AND_INT T4.W, PS, literal.x,
 ; R600-NEXT:     LOG_IEEE * T0.Z, PV.Z,
-; R600-NEXT:    939916788(3.194618e-05), 0(0.000000e+00)
-; R600-NEXT:     MULADD_IEEE T3.Z, T1.Z, literal.x, PV.W,
-; R600-NEXT:     AND_INT T5.W, PS, literal.y,
-; R600-NEXT:     MUL_IEEE * T6.W, PV.Z, literal.x,
+; R600-NEXT:    -4096(nan), 0(0.000000e+00)
+; R600-NEXT:     ADD T2.Z, T0.Y, -PV.W,
+; R600-NEXT:     MUL_IEEE T5.W, PV.Z, literal.x,
+; R600-NEXT:     AND_INT * T6.W, PS, literal.y,
 ; R600-NEXT:    939916788(3.194618e-05), -4096(nan)
-; R600-NEXT:     MULADD_IEEE T4.Z, T4.W, literal.x, PS,
-; R600-NEXT:     ADD T6.W, T0.Z, -PV.W,
-; R600-NEXT:     MULADD_IEEE * T2.W, T2.W, literal.y, PV.Z, BS:VEC_021/SCL_122
-; R600-NEXT:    939916788(3.194618e-05), 1060204544(6.931152e-01)
-; R600-NEXT:     MULADD_IEEE T1.Y, T1.Z, literal.x, PS,
-; R600-NEXT:     SETGT T1.Z, literal.y, |T0.X|,
-; R600-NEXT:     MUL_IEEE T2.W, PV.W, literal.z,
-; R600-NEXT:     MULADD_IEEE * T7.W, T2.Z, literal.x, PV.Z, BS:VEC_021/SCL_122
-; R600-NEXT:    1060204544(6.931152e-01), 2139095040(INF)
+; R600-NEXT:     ADD T3.Z, T0.Z, -PS,
+; R600-NEXT:     MULADD_IEEE T5.W, T3.W, literal.x, PV.W,
+; R600-NEXT:     MUL_IEEE * T7.W, PV.Z, literal.x,
 ; R600-NEXT:    939916788(3.194618e-05), 0(0.000000e+00)
+; R600-NEXT:     MULADD_IEEE T4.Z, T4.W, literal.x, PS,
+; R600-NEXT:     MULADD_IEEE T5.W, T1.Z, literal.y, PV.W,
+; R600-NEXT:     MUL_IEEE * T7.W, PV.Z, literal.x,
+; R600-NEXT:    939916788(3.194618e-05), 1060204544(6.931152e-01)
+; R600-NEXT:     MULADD_IEEE T1.Y, T6.W, literal.x, PS,
+; R600-NEXT:     MULADD_IEEE T1.Z, T3.W, literal.y, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     SETGT T3.W, literal.z, |T0.X|,
+; R600-NEXT:     MULADD_IEEE * T5.W, T2.Z, literal.y, PV.Z, BS:VEC_021/SCL_122
+; R600-NEXT:    939916788(3.194618e-05), 1060204544(6.931152e-01)
+; R600-NEXT:    2139095040(INF), 0(0.000000e+00)
 ; R600-NEXT:     MULADD_IEEE T1.X, T4.W, literal.x, PS,
 ; R600-NEXT:     SETGT T2.Y, literal.y, |T0.Y|,
-; R600-NEXT:     MULADD_IEEE T2.Z, T5.W, literal.z, PV.W, BS:VEC_120/SCL_212
-; R600-NEXT:     CNDE T2.W, PV.Z, T0.X, PV.Y,
-; R600-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.w,
+; R600-NEXT:     CNDE T1.Z, PV.W, T0.X, PV.Z,
+; R600-NEXT:     CNDE T0.W, T0.W, 0.0, literal.z, BS:VEC_120/SCL_212
+; R600-NEXT:     MULADD_IEEE * T3.W, T3.Z, literal.x, PV.Y, BS:VEC_021/SCL_122
 ; R600-NEXT:    1060204544(6.931152e-01), 2139095040(INF)
-; R600-NEXT:    939916788(3.194618e-05), 1102148120(2.218071e+01)
-; R600-NEXT:     ADD T1.Y, PV.W, -PS,
-; R600-NEXT:     MULADD_IEEE T1.Z, T6.W, literal.x, PV.Z,
+; R600-NEXT:    1102148120(2.218071e+01), 0(0.000000e+00)
+; R600-NEXT:     MULADD_IEEE T0.X, T6.W, literal.x, PS,
+; R600-NEXT:     ADD T1.Y, PV.Z, -PV.W,
+; R600-NEXT:     SETGT T1.Z, literal.y, |T0.Z|,
 ; R600-NEXT:     CNDE T0.W, PV.Y, T0.Y, PV.X,
-; R600-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.y,
-; R600-NEXT:    1060204544(6.931152e-01), 1102148120(2.218071e+01)
-; R600-NEXT:     ADD T1.X, PV.W, -PS,
-; R600-NEXT:     MULADD_IEEE T0.W, T5.W, literal.x, PV.Z,
-; R600-NEXT:     SETGT * T1.W, literal.y, |T0.Z|,
+; R600-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.z,
 ; R600-NEXT:    1060204544(6.931152e-01), 2139095040(INF)
-; R600-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; R600-NEXT:     CNDE T0.W, PS, T0.Z, PV.W,
-; R600-NEXT:     CNDE * T1.W, T3.W, 0.0, literal.y,
-; R600-NEXT:    2(2.802597e-45), 1102148120(2.218071e+01)
-; R600-NEXT:     ADD T2.X, PV.W, -PS,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:    1102148120(2.218071e+01), 0(0.000000e+00)
+; R600-NEXT:     ADD T1.X, PV.W, -PS,
+; R600-NEXT:     CNDE T0.W, PV.Z, T0.Z, PV.X,
+; R600-NEXT:     CNDE * T1.W, T2.W, 0.0, literal.x,
+; R600-NEXT:    1102148120(2.218071e+01), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.X, PV.W, -PS,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_log_v3f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 68, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4.X, T1.X
+; CM-NEXT:    ALU 66, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].Y,
+; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
 ; CM-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; CM-NEXT:     CNDE T0.Z, PV.W, 1.0, literal.x,
-; CM-NEXT:     SETGT * T1.W, literal.y, KC0[3].W,
-; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
-; CM-NEXT:     CNDE T0.Y, PV.W, 1.0, literal.x,
-; CM-NEXT:     SETGT T1.Z, literal.y, KC0[3].Z,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Y, PV.Z,
-; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
-; CM-NEXT:     LOG_IEEE T0.X, T2.W,
-; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     CNDE T1.Y, T1.Z, 1.0, literal.x,
-; CM-NEXT:     AND_INT T0.Z, PV.X, literal.y,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].W, T0.Y,
+; CM-NEXT:     CNDE * T1.W, PV.W, 1.0, literal.x,
+; CM-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
+; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
+; CM-NEXT:     SETGT T0.Z, literal.x, KC0[3].Y,
+; CM-NEXT:     MUL_IEEE * T1.W, KC0[3].W, PV.W,
+; CM-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
+; CM-NEXT:     LOG_IEEE T0.X, T1.W,
+; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     CNDE T1.Y, T0.Z, 1.0, literal.x,
+; CM-NEXT:     CNDE T1.Z, T0.Y, 1.0, literal.x,
+; CM-NEXT:     AND_INT * T1.W, PV.X, literal.y,
 ; CM-NEXT:    1333788672(4.294967e+09), -4096(nan)
-; CM-NEXT:     LOG_IEEE T0.X (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE T0.Y, T2.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     ADD T2.Y, T0.X, -T0.Z,
-; CM-NEXT:     AND_INT T2.Z, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Z, T1.Y,
-; CM-NEXT:    -4096(nan), 0(0.000000e+00)
+; CM-NEXT:     ADD T2.Y, T0.X, -PV.W,
+; CM-NEXT:     MUL_IEEE T1.Z, KC0[3].Z, PV.Z,
+; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Y, PV.Y,
 ; CM-NEXT:     LOG_IEEE T1.X, T2.W,
 ; CM-NEXT:     LOG_IEEE T1.Y (MASKED), T2.W,
 ; CM-NEXT:     LOG_IEEE T1.Z (MASKED), T2.W,
 ; CM-NEXT:     LOG_IEEE * T1.W (MASKED), T2.W,
-; CM-NEXT:     ADD T1.Y, T0.Y, -T2.Z,
-; CM-NEXT:     AND_INT T3.Z, PV.X, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, T2.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LOG_IEEE T1.X (MASKED), T1.Z,
+; CM-NEXT:     LOG_IEEE T1.Y, T1.Z,
+; CM-NEXT:     LOG_IEEE T1.Z (MASKED), T1.Z,
+; CM-NEXT:     LOG_IEEE * T1.W (MASKED), T1.Z,
+; CM-NEXT:     AND_INT T3.Y, PV.Y, literal.x,
+; CM-NEXT:     AND_INT T1.Z, T1.X, literal.x,
+; CM-NEXT:     MUL_IEEE * T2.W, T2.Y, literal.y,
 ; CM-NEXT:    -4096(nan), 939916788(3.194618e-05)
-; CM-NEXT:     MULADD_IEEE T3.Y, T0.Z, literal.x, PV.W,
-; CM-NEXT:     ADD T4.Z, T1.X, -PV.Z,
-; CM-NEXT:     MUL_IEEE * T2.W, PV.Y, literal.x,
+; CM-NEXT:     MULADD_IEEE T4.Y, T1.W, literal.x, PV.W,
+; CM-NEXT:     ADD T2.Z, T1.X, -PV.Z,
+; CM-NEXT:     ADD * T2.W, T1.Y, -PV.Y,
 ; CM-NEXT:    939916788(3.194618e-05), 0(0.000000e+00)
-; CM-NEXT:     MULADD_IEEE T4.Y, T2.Z, literal.x, PV.W,
-; CM-NEXT:     MUL_IEEE T5.Z, PV.Z, literal.x,
-; CM-NEXT:     MULADD_IEEE * T2.W, T2.Y, literal.y, PV.Y,
+; CM-NEXT:     MUL_IEEE T5.Y, PV.W, literal.x,
+; CM-NEXT:     MUL_IEEE T3.Z, PV.Z, literal.x,
+; CM-NEXT:     MULADD_IEEE * T3.W, T2.Y, literal.y, PV.Y,
 ; CM-NEXT:    939916788(3.194618e-05), 1060204544(6.931152e-01)
-; CM-NEXT:     MULADD_IEEE T2.Y, T0.Z, literal.x, PV.W,
-; CM-NEXT:     MULADD_IEEE T0.Z, T3.Z, literal.y, PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:     MULADD_IEEE * T2.W, T1.Y, literal.x, PV.Y,
-; CM-NEXT:    1060204544(6.931152e-01), 939916788(3.194618e-05)
-; CM-NEXT:     SETGT T2.X, literal.x, |T0.X|,
-; CM-NEXT:     MULADD_IEEE T1.Y, T2.Z, literal.y, PV.W,
-; CM-NEXT:     SETGT T2.Z, literal.x, |T0.Y|,
-; CM-NEXT:     MULADD_IEEE * T2.W, T4.Z, literal.y, PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:    2139095040(INF), 1060204544(6.931152e-01)
-; CM-NEXT:     MULADD_IEEE T3.X, T3.Z, literal.x, PV.W,
-; CM-NEXT:     SETGT T3.Y, literal.y, |T1.X|,
-; CM-NEXT:     CNDE T0.Z, PV.Z, T0.Y, PV.Y,
-; CM-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.z,
+; CM-NEXT:     MULADD_IEEE T2.X, T1.W, literal.x, PV.W,
+; CM-NEXT:     SETGT T2.Y, literal.y, |T0.X|,
+; CM-NEXT:     MULADD_IEEE T3.Z, T1.Z, literal.z, PV.Z,
+; CM-NEXT:     MULADD_IEEE * T1.W, T3.Y, literal.z, PV.Y,
 ; CM-NEXT:    1060204544(6.931152e-01), 2139095040(INF)
+; CM-NEXT:    939916788(3.194618e-05), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T3.X, T2.W, literal.x, PV.W,
+; CM-NEXT:     MULADD_IEEE T4.Y, T2.Z, literal.x, PV.Z,
+; CM-NEXT:     CNDE T2.Z, PV.Y, T0.X, PV.X,
+; CM-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    1060204544(6.931152e-01), 1102148120(2.218071e+01)
+; CM-NEXT:     ADD T0.X, PV.Z, -PV.W,
+; CM-NEXT:     MULADD_IEEE T2.Y, T1.Z, literal.x, PV.Y,
+; CM-NEXT:     MULADD_IEEE T1.Z, T3.Y, literal.x, PV.X,
+; CM-NEXT:     SETGT * T0.W, literal.y, |T1.Y|,
+; CM-NEXT:    1060204544(6.931152e-01), 2139095040(INF)
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     SETGT T3.Y, literal.y, |T1.X|,
+; CM-NEXT:     CNDE T1.Z, PV.W, T1.Y, PV.Z,
+; CM-NEXT:     CNDE * T0.W, T0.Y, 0.0, literal.z,
+; CM-NEXT:    2(2.802597e-45), 2139095040(INF)
 ; CM-NEXT:    1102148120(2.218071e+01), 0(0.000000e+00)
-; CM-NEXT:     ADD T4.X, PV.Z, -PV.W,
-; CM-NEXT:     CNDE T0.Y, PV.Y, T1.X, PV.X,
-; CM-NEXT:     CNDE T0.Z, T1.Z, 0.0, literal.x,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    1102148120(2.218071e+01), 8(1.121039e-44)
-; CM-NEXT:     LSHR T1.X, PV.W, literal.x,
-; CM-NEXT:     ADD T0.Y, PV.Y, -PV.Z,
-; CM-NEXT:     CNDE T0.Z, T2.X, T0.X, T2.Y,
-; CM-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.y,
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     ADD T1.Y, PV.Z, -PV.W,
+; CM-NEXT:     CNDE T1.Z, PV.Y, T1.X, T2.Y,
+; CM-NEXT:     CNDE * T0.W, T0.Z, 0.0, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 1102148120(2.218071e+01)
-; CM-NEXT:     ADD * T0.X, PV.Z, -PV.W,
-; CM-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD * T1.X, PV.Z, -PV.W,
   %result = call <3 x float> @llvm.log.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.log10.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.log10.ll
@@ -1544,9 +1544,9 @@ define amdgpu_kernel void @s_log10_v3f32(ptr addrspace(1) %out, <3 x float> %in)
 ;
 ; R600-LABEL: s_log10_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 62, @4, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T0.X, 1
+; R600-NEXT:    ALU 61, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     SETGT T0.W, literal.x, KC0[3].Z,
@@ -1554,141 +1554,138 @@ define amdgpu_kernel void @s_log10_v3f32(ptr addrspace(1) %out, <3 x float> %in)
 ; R600-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
 ; R600-NEXT:     CNDE * T2.W, PV.W, 1.0, literal.x,
 ; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T2.W, KC0[3].Z, PV.W,
-; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.x,
+; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].Z, PV.W,
+; R600-NEXT:     SETGT T2.W, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.y,
+; R600-NEXT:    8388608(1.175494e-38), 1333788672(4.294967e+09)
+; R600-NEXT:     MUL_IEEE T1.Z, KC0[3].Y, PS,
+; R600-NEXT:     CNDE T3.W, PV.W, 1.0, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.X, PV.Z,
 ; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].Y, PS,
-; R600-NEXT:     SETGT T3.W, literal.x, KC0[3].W,
-; R600-NEXT:     LOG_IEEE * T0.X, PV.W,
-; R600-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; R600-NEXT:     AND_INT T1.Z, PS, literal.x,
-; R600-NEXT:     CNDE T2.W, PV.W, 1.0, literal.y,
-; R600-NEXT:     LOG_IEEE * T0.Y, PV.Z,
-; R600-NEXT:    -4096(nan), 1333788672(4.294967e+09)
 ; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].W, PV.W,
-; R600-NEXT:     ADD T2.W, T0.X, -PV.Z,
-; R600-NEXT:     AND_INT * T4.W, PS, literal.x,
+; R600-NEXT:     AND_INT T3.W, PS, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.Y, PV.Z,
 ; R600-NEXT:    -4096(nan), 0(0.000000e+00)
-; R600-NEXT:     ADD T2.Z, T0.Y, -PS,
-; R600-NEXT:     MUL_IEEE T5.W, PV.W, literal.x,
+; R600-NEXT:     ADD T1.Z, T0.X, -PV.W,
+; R600-NEXT:     AND_INT T4.W, PS, literal.x,
 ; R600-NEXT:     LOG_IEEE * T0.Z, PV.Z,
-; R600-NEXT:    916096251(4.605039e-06), 0(0.000000e+00)
-; R600-NEXT:     MULADD_IEEE T3.Z, T1.Z, literal.x, PV.W,
-; R600-NEXT:     AND_INT T5.W, PS, literal.y,
-; R600-NEXT:     MUL_IEEE * T6.W, PV.Z, literal.x,
+; R600-NEXT:    -4096(nan), 0(0.000000e+00)
+; R600-NEXT:     ADD T2.Z, T0.Y, -PV.W,
+; R600-NEXT:     MUL_IEEE T5.W, PV.Z, literal.x,
+; R600-NEXT:     AND_INT * T6.W, PS, literal.y,
 ; R600-NEXT:    916096251(4.605039e-06), -4096(nan)
-; R600-NEXT:     MULADD_IEEE T4.Z, T4.W, literal.x, PS,
-; R600-NEXT:     ADD T6.W, T0.Z, -PV.W,
-; R600-NEXT:     MULADD_IEEE * T2.W, T2.W, literal.y, PV.Z, BS:VEC_021/SCL_122
-; R600-NEXT:    916096251(4.605039e-06), 1050288128(3.010254e-01)
-; R600-NEXT:     MULADD_IEEE T1.Y, T1.Z, literal.x, PS,
-; R600-NEXT:     SETGT T1.Z, literal.y, |T0.X|,
-; R600-NEXT:     MUL_IEEE T2.W, PV.W, literal.z,
-; R600-NEXT:     MULADD_IEEE * T7.W, T2.Z, literal.x, PV.Z, BS:VEC_021/SCL_122
-; R600-NEXT:    1050288128(3.010254e-01), 2139095040(INF)
+; R600-NEXT:     ADD T3.Z, T0.Z, -PS,
+; R600-NEXT:     MULADD_IEEE T5.W, T3.W, literal.x, PV.W,
+; R600-NEXT:     MUL_IEEE * T7.W, PV.Z, literal.x,
 ; R600-NEXT:    916096251(4.605039e-06), 0(0.000000e+00)
+; R600-NEXT:     MULADD_IEEE T4.Z, T4.W, literal.x, PS,
+; R600-NEXT:     MULADD_IEEE T5.W, T1.Z, literal.y, PV.W,
+; R600-NEXT:     MUL_IEEE * T7.W, PV.Z, literal.x,
+; R600-NEXT:    916096251(4.605039e-06), 1050288128(3.010254e-01)
+; R600-NEXT:     MULADD_IEEE T1.Y, T6.W, literal.x, PS,
+; R600-NEXT:     MULADD_IEEE T1.Z, T3.W, literal.y, PV.W, BS:VEC_120/SCL_212
+; R600-NEXT:     SETGT T3.W, literal.z, |T0.X|,
+; R600-NEXT:     MULADD_IEEE * T5.W, T2.Z, literal.y, PV.Z, BS:VEC_021/SCL_122
+; R600-NEXT:    916096251(4.605039e-06), 1050288128(3.010254e-01)
+; R600-NEXT:    2139095040(INF), 0(0.000000e+00)
 ; R600-NEXT:     MULADD_IEEE T1.X, T4.W, literal.x, PS,
 ; R600-NEXT:     SETGT T2.Y, literal.y, |T0.Y|,
-; R600-NEXT:     MULADD_IEEE T2.Z, T5.W, literal.z, PV.W, BS:VEC_120/SCL_212
-; R600-NEXT:     CNDE T2.W, PV.Z, T0.X, PV.Y,
-; R600-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.w,
+; R600-NEXT:     CNDE T1.Z, PV.W, T0.X, PV.Z,
+; R600-NEXT:     CNDE T0.W, T0.W, 0.0, literal.z, BS:VEC_120/SCL_212
+; R600-NEXT:     MULADD_IEEE * T3.W, T3.Z, literal.x, PV.Y, BS:VEC_021/SCL_122
 ; R600-NEXT:    1050288128(3.010254e-01), 2139095040(INF)
-; R600-NEXT:    916096251(4.605039e-06), 1092231323(9.632960e+00)
-; R600-NEXT:     ADD T1.Y, PV.W, -PS,
-; R600-NEXT:     MULADD_IEEE T1.Z, T6.W, literal.x, PV.Z,
+; R600-NEXT:    1092231323(9.632960e+00), 0(0.000000e+00)
+; R600-NEXT:     MULADD_IEEE T0.X, T6.W, literal.x, PS,
+; R600-NEXT:     ADD T1.Y, PV.Z, -PV.W,
+; R600-NEXT:     SETGT T1.Z, literal.y, |T0.Z|,
 ; R600-NEXT:     CNDE T0.W, PV.Y, T0.Y, PV.X,
-; R600-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.y,
-; R600-NEXT:    1050288128(3.010254e-01), 1092231323(9.632960e+00)
-; R600-NEXT:     ADD T1.X, PV.W, -PS,
-; R600-NEXT:     MULADD_IEEE T0.W, T5.W, literal.x, PV.Z,
-; R600-NEXT:     SETGT * T1.W, literal.y, |T0.Z|,
+; R600-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.z,
 ; R600-NEXT:    1050288128(3.010254e-01), 2139095040(INF)
-; R600-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; R600-NEXT:     CNDE T0.W, PS, T0.Z, PV.W,
-; R600-NEXT:     CNDE * T1.W, T3.W, 0.0, literal.y,
-; R600-NEXT:    2(2.802597e-45), 1092231323(9.632960e+00)
-; R600-NEXT:     ADD T2.X, PV.W, -PS,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:    1092231323(9.632960e+00), 0(0.000000e+00)
+; R600-NEXT:     ADD T1.X, PV.W, -PS,
+; R600-NEXT:     CNDE T0.W, PV.Z, T0.Z, PV.X,
+; R600-NEXT:     CNDE * T1.W, T2.W, 0.0, literal.x,
+; R600-NEXT:    1092231323(9.632960e+00), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.X, PV.W, -PS,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_log10_v3f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 68, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4.X, T1.X
+; CM-NEXT:    ALU 66, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].Y,
+; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
 ; CM-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; CM-NEXT:     CNDE T0.Z, PV.W, 1.0, literal.x,
-; CM-NEXT:     SETGT * T1.W, literal.y, KC0[3].W,
-; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
-; CM-NEXT:     CNDE T0.Y, PV.W, 1.0, literal.x,
-; CM-NEXT:     SETGT T1.Z, literal.y, KC0[3].Z,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Y, PV.Z,
-; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
-; CM-NEXT:     LOG_IEEE T0.X, T2.W,
-; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     CNDE T1.Y, T1.Z, 1.0, literal.x,
-; CM-NEXT:     AND_INT T0.Z, PV.X, literal.y,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].W, T0.Y,
+; CM-NEXT:     CNDE * T1.W, PV.W, 1.0, literal.x,
+; CM-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
+; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
+; CM-NEXT:     SETGT T0.Z, literal.x, KC0[3].Y,
+; CM-NEXT:     MUL_IEEE * T1.W, KC0[3].W, PV.W,
+; CM-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
+; CM-NEXT:     LOG_IEEE T0.X, T1.W,
+; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     CNDE T1.Y, T0.Z, 1.0, literal.x,
+; CM-NEXT:     CNDE T1.Z, T0.Y, 1.0, literal.x,
+; CM-NEXT:     AND_INT * T1.W, PV.X, literal.y,
 ; CM-NEXT:    1333788672(4.294967e+09), -4096(nan)
-; CM-NEXT:     LOG_IEEE T0.X (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE T0.Y, T2.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T2.W,
-; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T2.W,
-; CM-NEXT:     ADD T2.Y, T0.X, -T0.Z,
-; CM-NEXT:     AND_INT T2.Z, PV.Y, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Z, T1.Y,
-; CM-NEXT:    -4096(nan), 0(0.000000e+00)
+; CM-NEXT:     ADD T2.Y, T0.X, -PV.W,
+; CM-NEXT:     MUL_IEEE T1.Z, KC0[3].Z, PV.Z,
+; CM-NEXT:     MUL_IEEE * T2.W, KC0[3].Y, PV.Y,
 ; CM-NEXT:     LOG_IEEE T1.X, T2.W,
 ; CM-NEXT:     LOG_IEEE T1.Y (MASKED), T2.W,
 ; CM-NEXT:     LOG_IEEE T1.Z (MASKED), T2.W,
 ; CM-NEXT:     LOG_IEEE * T1.W (MASKED), T2.W,
-; CM-NEXT:     ADD T1.Y, T0.Y, -T2.Z,
-; CM-NEXT:     AND_INT T3.Z, PV.X, literal.x,
-; CM-NEXT:     MUL_IEEE * T2.W, T2.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LOG_IEEE T1.X (MASKED), T1.Z,
+; CM-NEXT:     LOG_IEEE T1.Y, T1.Z,
+; CM-NEXT:     LOG_IEEE T1.Z (MASKED), T1.Z,
+; CM-NEXT:     LOG_IEEE * T1.W (MASKED), T1.Z,
+; CM-NEXT:     AND_INT T3.Y, PV.Y, literal.x,
+; CM-NEXT:     AND_INT T1.Z, T1.X, literal.x,
+; CM-NEXT:     MUL_IEEE * T2.W, T2.Y, literal.y,
 ; CM-NEXT:    -4096(nan), 916096251(4.605039e-06)
-; CM-NEXT:     MULADD_IEEE T3.Y, T0.Z, literal.x, PV.W,
-; CM-NEXT:     ADD T4.Z, T1.X, -PV.Z,
-; CM-NEXT:     MUL_IEEE * T2.W, PV.Y, literal.x,
+; CM-NEXT:     MULADD_IEEE T4.Y, T1.W, literal.x, PV.W,
+; CM-NEXT:     ADD T2.Z, T1.X, -PV.Z,
+; CM-NEXT:     ADD * T2.W, T1.Y, -PV.Y,
 ; CM-NEXT:    916096251(4.605039e-06), 0(0.000000e+00)
-; CM-NEXT:     MULADD_IEEE T4.Y, T2.Z, literal.x, PV.W,
-; CM-NEXT:     MUL_IEEE T5.Z, PV.Z, literal.x,
-; CM-NEXT:     MULADD_IEEE * T2.W, T2.Y, literal.y, PV.Y,
+; CM-NEXT:     MUL_IEEE T5.Y, PV.W, literal.x,
+; CM-NEXT:     MUL_IEEE T3.Z, PV.Z, literal.x,
+; CM-NEXT:     MULADD_IEEE * T3.W, T2.Y, literal.y, PV.Y,
 ; CM-NEXT:    916096251(4.605039e-06), 1050288128(3.010254e-01)
-; CM-NEXT:     MULADD_IEEE T2.Y, T0.Z, literal.x, PV.W,
-; CM-NEXT:     MULADD_IEEE T0.Z, T3.Z, literal.y, PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:     MULADD_IEEE * T2.W, T1.Y, literal.x, PV.Y,
-; CM-NEXT:    1050288128(3.010254e-01), 916096251(4.605039e-06)
-; CM-NEXT:     SETGT T2.X, literal.x, |T0.X|,
-; CM-NEXT:     MULADD_IEEE T1.Y, T2.Z, literal.y, PV.W,
-; CM-NEXT:     SETGT T2.Z, literal.x, |T0.Y|,
-; CM-NEXT:     MULADD_IEEE * T2.W, T4.Z, literal.y, PV.Z, BS:VEC_120/SCL_212
-; CM-NEXT:    2139095040(INF), 1050288128(3.010254e-01)
-; CM-NEXT:     MULADD_IEEE T3.X, T3.Z, literal.x, PV.W,
-; CM-NEXT:     SETGT T3.Y, literal.y, |T1.X|,
-; CM-NEXT:     CNDE T0.Z, PV.Z, T0.Y, PV.Y,
-; CM-NEXT:     CNDE * T1.W, T1.W, 0.0, literal.z,
+; CM-NEXT:     MULADD_IEEE T2.X, T1.W, literal.x, PV.W,
+; CM-NEXT:     SETGT T2.Y, literal.y, |T0.X|,
+; CM-NEXT:     MULADD_IEEE T3.Z, T1.Z, literal.z, PV.Z,
+; CM-NEXT:     MULADD_IEEE * T1.W, T3.Y, literal.z, PV.Y,
 ; CM-NEXT:    1050288128(3.010254e-01), 2139095040(INF)
+; CM-NEXT:    916096251(4.605039e-06), 0(0.000000e+00)
+; CM-NEXT:     MULADD_IEEE T3.X, T2.W, literal.x, PV.W,
+; CM-NEXT:     MULADD_IEEE T4.Y, T2.Z, literal.x, PV.Z,
+; CM-NEXT:     CNDE T2.Z, PV.Y, T0.X, PV.X,
+; CM-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    1050288128(3.010254e-01), 1092231323(9.632960e+00)
+; CM-NEXT:     ADD T0.X, PV.Z, -PV.W,
+; CM-NEXT:     MULADD_IEEE T2.Y, T1.Z, literal.x, PV.Y,
+; CM-NEXT:     MULADD_IEEE T1.Z, T3.Y, literal.x, PV.X,
+; CM-NEXT:     SETGT * T0.W, literal.y, |T1.Y|,
+; CM-NEXT:    1050288128(3.010254e-01), 2139095040(INF)
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     SETGT T3.Y, literal.y, |T1.X|,
+; CM-NEXT:     CNDE T1.Z, PV.W, T1.Y, PV.Z,
+; CM-NEXT:     CNDE * T0.W, T0.Y, 0.0, literal.z,
+; CM-NEXT:    2(2.802597e-45), 2139095040(INF)
 ; CM-NEXT:    1092231323(9.632960e+00), 0(0.000000e+00)
-; CM-NEXT:     ADD T4.X, PV.Z, -PV.W,
-; CM-NEXT:     CNDE T0.Y, PV.Y, T1.X, PV.X,
-; CM-NEXT:     CNDE T0.Z, T1.Z, 0.0, literal.x,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    1092231323(9.632960e+00), 8(1.121039e-44)
-; CM-NEXT:     LSHR T1.X, PV.W, literal.x,
-; CM-NEXT:     ADD T0.Y, PV.Y, -PV.Z,
-; CM-NEXT:     CNDE T0.Z, T2.X, T0.X, T2.Y,
-; CM-NEXT:     CNDE * T0.W, T0.W, 0.0, literal.y,
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     ADD T1.Y, PV.Z, -PV.W,
+; CM-NEXT:     CNDE T1.Z, PV.Y, T1.X, T2.Y,
+; CM-NEXT:     CNDE * T0.W, T0.Z, 0.0, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 1092231323(9.632960e+00)
-; CM-NEXT:     ADD * T0.X, PV.Z, -PV.W,
-; CM-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD * T1.X, PV.Z, -PV.W,
   %result = call <3 x float> @llvm.log10.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.log2.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.log2.ll
@@ -766,9 +766,9 @@ define amdgpu_kernel void @s_log2_v3f32(ptr addrspace(1) %out, <3 x float> %in) 
 ;
 ; R600-LABEL: s_log2_v3f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 29, @4, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T0.X, 1
+; R600-NEXT:    ALU 27, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     SETGT T0.W, literal.x, KC0[3].Z,
@@ -776,75 +776,73 @@ define amdgpu_kernel void @s_log2_v3f32(ptr addrspace(1) %out, <3 x float> %in) 
 ; R600-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
 ; R600-NEXT:     CNDE * T2.W, PV.W, 1.0, literal.x,
 ; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
-; R600-NEXT:     MUL_IEEE T2.W, KC0[3].Z, PV.W,
-; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.x,
-; R600-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
+; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].Z, PV.W,
+; R600-NEXT:     SETGT T2.W, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE * T3.W, T1.W, 1.0, literal.y,
+; R600-NEXT:    8388608(1.175494e-38), 1333788672(4.294967e+09)
 ; R600-NEXT:     MUL_IEEE T0.Y, KC0[3].Y, PS,
-; R600-NEXT:     SETGT T0.Z, literal.x, KC0[3].W,
+; R600-NEXT:     CNDE T1.Z, PV.W, 1.0, literal.x,
 ; R600-NEXT:     CNDE T0.W, T0.W, 0.0, literal.y,
-; R600-NEXT:     LOG_IEEE * T0.X, PV.W,
-; R600-NEXT:    8388608(1.175494e-38), 1107296256(3.200000e+01)
-; R600-NEXT:     ADD T1.Y, PS, -PV.W,
-; R600-NEXT:     CNDE T1.Z, PV.Z, 1.0, literal.x,
-; R600-NEXT:     CNDE T0.W, T1.W, 0.0, literal.y,
-; R600-NEXT:     LOG_IEEE * T0.X, PV.Y,
+; R600-NEXT:     LOG_IEEE * T0.X, PV.Z,
 ; R600-NEXT:    1333788672(4.294967e+09), 1107296256(3.200000e+01)
-; R600-NEXT:     ADD T1.X, PS, -PV.W,
-; R600-NEXT:     MUL_IEEE T0.W, KC0[3].W, PV.Z,
-; R600-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
-; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; R600-NEXT:     CNDE T1.W, T0.Z, 0.0, literal.x,
-; R600-NEXT:     LOG_IEEE * T0.Y, PV.W,
+; R600-NEXT:     ADD T1.Y, PS, -PV.W,
+; R600-NEXT:     MUL_IEEE T0.Z, KC0[3].W, PV.Z,
+; R600-NEXT:     CNDE T0.W, T1.W, 0.0, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.X, PV.Y,
 ; R600-NEXT:    1107296256(3.200000e+01), 0(0.000000e+00)
-; R600-NEXT:     ADD T2.X, PS, -PV.W,
-; R600-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; R600-NEXT:     ADD T1.X, PS, -PV.W,
+; R600-NEXT:     CNDE T0.W, T2.W, 0.0, literal.x,
+; R600-NEXT:     LOG_IEEE * T0.X, PV.Z,
+; R600-NEXT:    1107296256(3.200000e+01), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.X, PS, -PV.W,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: s_log2_v3f32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 35, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T1.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
 ; CM-NEXT:     SETGT * T0.W, literal.x, KC0[3].W,
 ; CM-NEXT:    8388608(1.175494e-38), 0(0.000000e+00)
-; CM-NEXT:     CNDE T0.Y, PV.W, 1.0, literal.x,
-; CM-NEXT:     SETGT T0.Z, literal.y, KC0[3].Z,
-; CM-NEXT:     SETGT * T1.W, literal.y, KC0[3].Y,
-; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
-; CM-NEXT:     CNDE T0.X, PV.W, 1.0, literal.x,
-; CM-NEXT:     CNDE T1.Y, PV.Z, 1.0, literal.x,
-; CM-NEXT:     CNDE T1.Z, T0.W, 0.0, literal.y,
-; CM-NEXT:     MUL_IEEE * T0.W, KC0[3].W, PV.Y,
-; CM-NEXT:    1333788672(4.294967e+09), 1107296256(3.200000e+01)
-; CM-NEXT:     LOG_IEEE T0.X (MASKED), T0.W,
-; CM-NEXT:     LOG_IEEE T0.Y, T0.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     ADD T1.X, PV.Y, -T1.Z,
-; CM-NEXT:     CNDE T0.Y, T0.Z, 0.0, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     MUL_IEEE * T0.W, KC0[3].Z, T1.Y,
-; CM-NEXT:    1107296256(3.200000e+01), 8(1.121039e-44)
-; CM-NEXT:     LOG_IEEE T0.X (MASKED), T0.W,
-; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T0.W,
-; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T0.W,
-; CM-NEXT:     LOG_IEEE * T0.W, T0.W,
-; CM-NEXT:     LSHR T2.X, T0.Z, literal.x,
-; CM-NEXT:     ADD T0.Y, PV.W, -T0.Y,
-; CM-NEXT:     CNDE T0.Z, T1.W, 0.0, literal.y,
-; CM-NEXT:     MUL_IEEE * T0.W, KC0[3].Y, T0.X,
-; CM-NEXT:    2(2.802597e-45), 1107296256(3.200000e+01)
+; CM-NEXT:     CNDE * T1.W, PV.W, 1.0, literal.x,
+; CM-NEXT:    1333788672(4.294967e+09), 0(0.000000e+00)
+; CM-NEXT:     SETGT T0.Y, literal.x, KC0[3].Z,
+; CM-NEXT:     CNDE T0.Z, T0.W, 0.0, literal.y,
+; CM-NEXT:     MUL_IEEE * T0.W, KC0[3].W, PV.W,
+; CM-NEXT:    8388608(1.175494e-38), 1107296256(3.200000e+01)
 ; CM-NEXT:     LOG_IEEE T0.X, T0.W,
 ; CM-NEXT:     LOG_IEEE T0.Y (MASKED), T0.W,
 ; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T0.W,
 ; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T0.W,
-; CM-NEXT:     ADD * T0.X, PV.X, -T0.Z,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD T0.X, PV.X, -T0.Z,
+; CM-NEXT:     CNDE T0.Z, T0.Y, 1.0, literal.x,
+; CM-NEXT:     SETGT * T0.W, literal.y, KC0[3].Y,
+; CM-NEXT:    1333788672(4.294967e+09), 8388608(1.175494e-38)
+; CM-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; CM-NEXT:     CNDE T1.Y, PV.W, 1.0, literal.y,
+; CM-NEXT:     CNDE T1.Z, T0.Y, 0.0, literal.z,
+; CM-NEXT:     MUL_IEEE * T1.W, KC0[3].Z, PV.Z,
+; CM-NEXT:    2(2.802597e-45), 1333788672(4.294967e+09)
+; CM-NEXT:    1107296256(3.200000e+01), 0(0.000000e+00)
+; CM-NEXT:     LOG_IEEE T0.X (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE T0.Y, T1.W,
+; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T1.W,
+; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T1.W,
+; CM-NEXT:     ADD_INT T2.X, T1.X, literal.x,
+; CM-NEXT:     ADD T3.Y, PV.Y, -T1.Z,
+; CM-NEXT:     CNDE T0.Z, T0.W, 0.0, literal.y,
+; CM-NEXT:     MUL_IEEE * T0.W, KC0[3].Y, T1.Y,
+; CM-NEXT:    2(2.802597e-45), 1107296256(3.200000e+01)
+; CM-NEXT:     LOG_IEEE T0.X (MASKED), T0.W,
+; CM-NEXT:     LOG_IEEE T0.Y, T0.W,
+; CM-NEXT:     LOG_IEEE T0.Z (MASKED), T0.W,
+; CM-NEXT:     LOG_IEEE * T0.W (MASKED), T0.W,
+; CM-NEXT:     ADD * T3.X, PV.Y, -T0.Z,
   %result = call <3 x float> @llvm.log2.v3f32(<3 x float> %in)
   store <3 x float> %result, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/llvm.round.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.round.ll
@@ -708,61 +708,58 @@ define amdgpu_kernel void @round_v8f32(ptr addrspace(1) %out, <8 x float> %in) #
 ;
 ; R600-LABEL: round_v8f32:
 ; R600:       ; %bb.0:
-; R600-NEXT:    ALU 50, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    ALU 49, @4, KC0[CB0:0-32], KC1[]
 ; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 1
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T1.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     TRUNC * T0.W, KC0[6].X,
-; R600-NEXT:     ADD T0.Z, KC0[6].X, -PV.W,
-; R600-NEXT:     TRUNC * T1.W, KC0[5].X,
-; R600-NEXT:     TRUNC * T2.W, KC0[4].W,
-; R600-NEXT:     ADD T1.Z, KC0[4].W, -PV.W,
-; R600-NEXT:     ADD T3.W, KC0[5].X, -T1.W,
-; R600-NEXT:     SETGE * T4.W, |T0.Z|, 0.5,
-; R600-NEXT:     BFI_INT T0.Y, literal.x, PS, KC0[6].X,
-; R600-NEXT:     SETGE T0.Z, |PV.W|, 0.5,
-; R600-NEXT:     SETGE T3.W, |PV.Z|, 0.5,
-; R600-NEXT:     TRUNC * T4.W, KC0[5].Y,
+; R600-NEXT:     ADD T1.W, KC0[6].X, -PV.W,
+; R600-NEXT:     TRUNC * T2.W, KC0[5].X,
+; R600-NEXT:     ADD T3.W, KC0[5].X, -PS,
+; R600-NEXT:     SETGE * T1.W, |PV.W|, 0.5,
+; R600-NEXT:     BFI_INT T0.Z, literal.x, PS, KC0[6].X,
+; R600-NEXT:     SETGE T1.W, |PV.W|, 0.5,
+; R600-NEXT:     TRUNC * T3.W, KC0[5].Y,
 ; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
-; R600-NEXT:     ADD T1.Y, KC0[5].Y, -PS,
-; R600-NEXT:     BFI_INT T1.Z, literal.x, PV.W, KC0[4].W,
-; R600-NEXT:     BFI_INT T3.W, literal.x, PV.Z, KC0[5].X,
-; R600-NEXT:     TRUNC * T5.W, KC0[4].Z,
+; R600-NEXT:     ADD T0.Y, KC0[5].Y, -PS,
+; R600-NEXT:     BFI_INT T1.Z, literal.x, PV.W, KC0[5].X,
+; R600-NEXT:     TRUNC * T1.W, KC0[4].Y,
 ; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
-; R600-NEXT:     TRUNC T0.Z, KC0[4].Y,
-; R600-NEXT:     TRUNC * T6.W, KC0[5].W,
-; R600-NEXT:     ADD * T7.W, KC0[4].Z, -T5.W,
-; R600-NEXT:     TRUNC T0.X, KC0[5].Z,
-; R600-NEXT:     SETGE T2.Y, |PV.W|, 0.5,
-; R600-NEXT:     ADD T2.Z, KC0[5].W, -T6.W, BS:VEC_102/SCL_221
-; R600-NEXT:     ADD T7.W, KC0[4].Y, -T0.Z,
-; R600-NEXT:     ADD * T3.W, T1.W, T3.W,
-; R600-NEXT:     SETGE T1.X, |PV.W|, 0.5,
-; R600-NEXT:     SETGE T4.Y, |PV.Z|, 0.5,
-; R600-NEXT:     ADD T3.Z, T2.W, T1.Z,
-; R600-NEXT:     BFI_INT T1.W, literal.x, PV.Y, KC0[4].Z,
-; R600-NEXT:     ADD * T2.W, KC0[5].Z, -PV.X,
+; R600-NEXT:     TRUNC * T4.W, KC0[4].W,
+; R600-NEXT:     ADD T1.Y, KC0[4].W, -PV.W,
+; R600-NEXT:     TRUNC T2.Z, KC0[4].Z,
+; R600-NEXT:     TRUNC * T5.W, KC0[5].W,
+; R600-NEXT:     ADD * T6.W, KC0[4].Y, -T1.W,
+; R600-NEXT:     SETGE T0.X, |PV.W|, 0.5,
+; R600-NEXT:     ADD T2.Y, KC0[5].W, -T5.W,
+; R600-NEXT:     ADD T3.Z, KC0[4].Z, -T2.Z,
+; R600-NEXT:     SETGE T6.W, |T1.Y|, 0.5,
+; R600-NEXT:     TRUNC * T7.W, KC0[5].Z,
+; R600-NEXT:     ADD T1.X, KC0[5].Z, -PS,
+; R600-NEXT:     BFI_INT T1.Y, literal.x, PV.W, KC0[4].W,
+; R600-NEXT:     SETGE T3.Z, |PV.Z|, 0.5,
+; R600-NEXT:     SETGE T6.W, |PV.Y|, 0.5,
+; R600-NEXT:     ADD * T8.W, T2.W, T1.Z,
 ; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
-; R600-NEXT:     SETGE T2.X, |PS|, 0.5,
-; R600-NEXT:     ADD T3.Y, T5.W, PV.W,
-; R600-NEXT:     BFI_INT T1.Z, literal.x, PV.Y, KC0[5].W,
-; R600-NEXT:     BFI_INT T1.W, literal.x, PV.X, KC0[4].Y,
-; R600-NEXT:     ADD * T0.W, T0.W, T0.Y,
+; R600-NEXT:     BFI_INT T2.X, literal.x, PV.W, KC0[5].W,
+; R600-NEXT:     BFI_INT T2.Y, literal.x, PV.Z, KC0[4].Z,
+; R600-NEXT:     ADD T8.Z, T4.W, PV.Y,
+; R600-NEXT:     SETGE T2.W, |PV.X|, 0.5,
+; R600-NEXT:     ADD * T0.W, T0.W, T0.Z,
 ; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
-; R600-NEXT:     ADD T3.X, T0.Z, PV.W,
-; R600-NEXT:     ADD T0.Z, T6.W, PV.Z,
-; R600-NEXT:     BFI_INT T1.W, literal.x, PV.X, KC0[5].Z,
-; R600-NEXT:     SETGE * T2.W, |T1.Y|, 0.5,
+; R600-NEXT:     BFI_INT T1.X, literal.x, PV.W, KC0[5].Z,
+; R600-NEXT:     ADD T8.Y, T2.Z, PV.Y,
+; R600-NEXT:     ADD T0.Z, T5.W, PV.X,
+; R600-NEXT:     BFI_INT T2.W, literal.x, T0.X, KC0[4].Y,
+; R600-NEXT:     SETGE * T4.W, |T0.Y|, 0.5,
 ; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
-; R600-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; R600-NEXT:     ADD T0.Y, T0.X, PV.W,
-; R600-NEXT:     BFI_INT * T1.W, literal.y, PS, KC0[5].Y,
-; R600-NEXT:    2(2.802597e-45), 2147483647(nan)
-; R600-NEXT:     ADD T0.X, T4.W, PV.W,
-; R600-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; R600-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T2.X, PV.W, literal.x,
+; R600-NEXT:     ADD T8.X, T1.W, PV.W,
+; R600-NEXT:     ADD T0.Y, T7.W, PV.X, BS:VEC_120/SCL_212
+; R600-NEXT:     BFI_INT * T1.W, literal.x, PS, KC0[5].Y,
+; R600-NEXT:    2147483647(nan), 0(0.000000e+00)
+; R600-NEXT:     ADD T0.X, T3.W, PV.W,
+; R600-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %result = call <8 x float> @llvm.round.v8f32(<8 x float> %in) #1
   store <8 x float> %result, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
@@ -1217,7 +1217,7 @@ define amdgpu_kernel void @constant_zextload_v3i1_to_v3i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 8, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 7, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -1228,12 +1228,11 @@ define amdgpu_kernel void @constant_zextload_v3i1_to_v3i32(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     BFE_UINT * T1.Y, T0.X, 1, 1,
 ; EG-NEXT:     AND_INT T1.X, T0.X, 1,
+; EG-NEXT:     LSHR * T0.X, T0.X, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, T0.X, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v3i1_to_v3i32:
@@ -1334,25 +1333,24 @@ define amdgpu_kernel void @constant_sextload_v3i1_to_v3i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 10, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T0.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XY, T1.X, 1
+; EG-NEXT:    ALU 9, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XY, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_8 T0.X, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     LSHR * T0.W, T0.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT * T2.X, PV.W, 0.0, 1,
-; EG-NEXT:     BFE_INT T3.X, T0.X, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T0.X, 1,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T3.Y, PV.W, 0.0, 1,
+; EG-NEXT:     BFE_INT * T1.X, PV.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T2.X, T0.X, 0.0, 1,
+; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T0.W, T0.X, 1,
+; EG-NEXT:     ADD_INT T0.X, T3.X, literal.x,
+; EG-NEXT:     BFE_INT * T2.Y, PV.W, 0.0, 1,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v3i1_to_v3i32:
@@ -1676,7 +1674,7 @@ define amdgpu_kernel void @constant_zextload_v8i1_to_v8i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -1687,22 +1685,20 @@ define amdgpu_kernel void @constant_zextload_v8i1_to_v8i32(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     BFE_UINT * T6.W, T5.X, literal.x, 1,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT * T6.Z, T5.X, literal.x, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T6.Z, T5.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T5.W, T5.X, literal.y, 1,
+; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
 ; EG-NEXT:     BFE_UINT T6.Y, T5.X, 1, 1,
-; EG-NEXT:     BFE_UINT * T5.W, T5.X, literal.x, 1,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T5.Z, T5.X, literal.x, 1,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T6.X, T5.X, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T5.X, literal.x, 1,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 2(2.802597e-45)
 ; EG-NEXT:     BFE_UINT * T5.Y, T5.X, literal.x, 1,
 ; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T5.X, T5.X, literal.x, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T8.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    4(5.605194e-45), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT * T8.X, PS, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i1_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -1860,25 +1856,25 @@ define amdgpu_kernel void @constant_sextload_v8i1_to_v8i32(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_INT T6.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
 ; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T5.X, 0.0, 1,
 ; EG-NEXT:     BFE_INT T6.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T7.X, T5.X, 0.0, 1,
+; EG-NEXT:     BFE_INT T6.Y, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T5.X, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T5.X, literal.y,
-; EG-NEXT:    3(4.203895e-45), 5(7.006492e-45)
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     BFE_INT T6.Y, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T5.X, literal.x,
-; EG-NEXT:     BFE_INT T7.W, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T5.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 4(5.605194e-45)
+; EG-NEXT:    3(4.203895e-45), 4(5.605194e-45)
 ; EG-NEXT:     BFE_INT T6.X, PS, 0.0, 1,
-; EG-NEXT:     BFE_INT T7.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T5.X, 1,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T5.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T7.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T7.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, 1,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T5.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, 1,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v8i1_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -2038,11 +2034,11 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 36, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 31, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T14.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T13.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T10.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T11.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_16 T7.X, T7.X, 0, #1
@@ -2051,41 +2047,36 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i32(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 11:
 ; EG-NEXT:     BFE_UINT * T8.W, T7.X, literal.x, 1,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT * T8.Z, T7.X, literal.x, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T8.Z, T7.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T9.W, T7.X, literal.y, 1,
+; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
 ; EG-NEXT:     BFE_UINT T8.Y, T7.X, 1, 1,
-; EG-NEXT:     BFE_UINT * T9.W, T7.X, literal.x, 1,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T9.Z, T7.X, literal.x, 1,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T8.X, T7.X, 1,
-; EG-NEXT:     BFE_UINT T9.Z, T7.X, literal.x, 1,
-; EG-NEXT:     LSHR * T10.X, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 2(2.802597e-45)
-; EG-NEXT:     BFE_UINT T9.Y, T7.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT * T11.W, T7.X, literal.y, 1,
-; EG-NEXT:    5(7.006492e-45), 11(1.541428e-44)
+; EG-NEXT:     BFE_UINT * T9.Y, T7.X, literal.x, 1,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T9.X, T7.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT T11.Z, T7.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    4(5.605194e-45), 10(1.401298e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T11.Y, T7.X, literal.y, 1,
-; EG-NEXT:     LSHR * T7.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
-; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T11.X, T7.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT T7.Z, T7.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    8(1.121039e-44), 14(1.961818e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT * T7.Y, T7.X, literal.y, 1,
-; EG-NEXT:    2(2.802597e-45), 13(1.821688e-44)
-; EG-NEXT:     BFE_UINT T7.X, T7.X, literal.x, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    12(1.681558e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T14.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT T10.W, T7.X, literal.y, 1,
+; EG-NEXT:     LSHR * T11.X, KC0[2].Y, literal.z,
+; EG-NEXT:    4(5.605194e-45), 11(1.541428e-44)
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T10.Z, T7.X, literal.x, 1,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, T11.X, literal.x,
+; EG-NEXT:     BFE_UINT T10.Y, T7.X, literal.y, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T7.W, T7.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:    4(5.605194e-45), 9(1.261169e-44)
+; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T10.X, T7.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT T7.Z, T7.X, literal.y, 1,
+; EG-NEXT:     ADD_INT * T13.X, T11.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 14(1.961818e-44)
+; EG-NEXT:     BFE_UINT * T7.Y, T7.X, literal.x, 1,
+; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T7.X, T7.X, literal.x, 1,
+; EG-NEXT:     ADD_INT * T14.X, T11.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i1_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2260,11 +2251,11 @@ define amdgpu_kernel void @constant_sextload_v16i1_to_v16i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 51, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 47, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T14.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T11.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T9.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T10.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_16 T7.X, T7.X, 0, #1
@@ -2277,52 +2268,48 @@ define amdgpu_kernel void @constant_sextload_v16i1_to_v16i32(ptr addrspace(1) %o
 ; EG-NEXT:     LSHR * T0.W, T7.X, literal.x,
 ; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T8.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T7.X, literal.x,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T8.Y, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
-; EG-NEXT:    11(1.541428e-44), 5(7.006492e-45)
-; EG-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
-; EG-NEXT:     BFE_INT T8.Y, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T7.X, literal.y,
-; EG-NEXT:     BFE_INT T10.W, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 10(1.401298e-44)
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    11(1.541428e-44), 4(5.605194e-45)
 ; EG-NEXT:     BFE_INT T8.X, PS, 0.0, 1,
-; EG-NEXT:     BFE_INT T10.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    9(1.261169e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T11.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T10.Y, PV.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T9.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T7.X, literal.x,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T10.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T9.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T7.X, literal.y,
+; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
+; EG-NEXT:     ADD_INT T11.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T9.Y, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T7.X, literal.y,
 ; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 15(2.101948e-44)
+; EG-NEXT:    4(5.605194e-45), 15(2.101948e-44)
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T10.X, PS, 0.0, 1,
+; EG-NEXT:     BFE_INT T9.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T12.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T7.X, literal.x,
 ; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T13.X, T7.X, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T7.X, literal.x,
 ; EG-NEXT:     BFE_INT T12.Z, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T7.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
 ; EG-NEXT:    3(4.203895e-45), 13(1.821688e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T14.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T12.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T7.X, literal.x,
-; EG-NEXT:     BFE_INT T13.W, PV.Y, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T7.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T14.X, T10.X, literal.x,
+; EG-NEXT:     BFE_INT T12.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T7.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T13.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T7.X, literal.z,
+; EG-NEXT:    8(1.121039e-44), 2(2.802597e-45)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T12.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T13.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T7.X, 1,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T7.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T7.X, T10.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT * T13.Y, PV.W, 0.0, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v16i1_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2611,15 +2598,15 @@ define amdgpu_kernel void @constant_zextload_v32i1_to_v32i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 76, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 59, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T24.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T20.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T18.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T18.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T16.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T15.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_32 T11.X, T11.X, 0, #1
@@ -2628,81 +2615,64 @@ define amdgpu_kernel void @constant_zextload_v32i1_to_v32i32(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 15:
 ; EG-NEXT:     BFE_UINT * T12.W, T11.X, literal.x, 1,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT * T12.Z, T11.X, literal.x, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T12.Z, T11.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T13.W, T11.X, literal.y, 1,
+; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
 ; EG-NEXT:     BFE_UINT T12.Y, T11.X, 1, 1,
-; EG-NEXT:     BFE_UINT * T13.W, T11.X, literal.x, 1,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T13.Z, T11.X, literal.x, 1,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T12.X, T11.X, 1,
-; EG-NEXT:     BFE_UINT T13.Z, T11.X, literal.x, 1,
-; EG-NEXT:     LSHR * T14.X, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 2(2.802597e-45)
-; EG-NEXT:     BFE_UINT T13.Y, T11.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT * T15.W, T11.X, literal.y, 1,
-; EG-NEXT:    5(7.006492e-45), 11(1.541428e-44)
+; EG-NEXT:     BFE_UINT * T13.Y, T11.X, literal.x, 1,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T13.X, T11.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT T15.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    4(5.605194e-45), 10(1.401298e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T15.Y, T11.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T17.W, T11.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
+; EG-NEXT:     BFE_UINT T14.W, T11.X, literal.y, 1,
+; EG-NEXT:     LSHR * T15.X, KC0[2].Y, literal.z,
+; EG-NEXT:    4(5.605194e-45), 11(1.541428e-44)
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T14.Z, T11.X, literal.x, 1,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T16.X, T15.X, literal.x,
+; EG-NEXT:     BFE_UINT T14.Y, T11.X, literal.y, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_UINT * T17.W, T11.X, literal.z, 1, BS:VEC_120/SCL_212
+; EG-NEXT:    4(5.605194e-45), 9(1.261169e-44)
 ; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T15.X, T11.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT T14.X, T11.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T17.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T18.X, T15.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 14(1.961818e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T17.Y, T11.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T19.W, T11.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 13(1.821688e-44)
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T17.Y, T11.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T19.W, T11.X, literal.y, 1,
+; EG-NEXT:    13(1.821688e-44), 19(2.662467e-44)
 ; EG-NEXT:     BFE_UINT T17.X, T11.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T19.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T20.X, T15.X, literal.x,
 ; EG-NEXT:    12(1.681558e-44), 18(2.522337e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T19.Y, T11.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T21.W, T11.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 17(2.382207e-44)
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T19.Y, T11.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T21.W, T11.X, literal.y, 1,
+; EG-NEXT:    17(2.382207e-44), 23(3.222986e-44)
 ; EG-NEXT:     BFE_UINT T19.X, T11.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T21.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T22.X, T15.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 22(3.082857e-44)
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T21.Y, T11.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T23.W, T11.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 21(2.942727e-44)
-; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T21.Y, T11.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T23.W, T11.X, literal.y, 1,
+; EG-NEXT:    21(2.942727e-44), 27(3.783506e-44)
 ; EG-NEXT:     BFE_UINT T21.X, T11.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T23.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T24.X, T15.X, literal.x,
 ; EG-NEXT:    20(2.802597e-44), 26(3.643376e-44)
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T23.Y, T11.X, literal.y, 1,
-; EG-NEXT:     LSHR * T11.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 25(3.503246e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T23.Y, T11.X, literal.x, 1,
+; EG-NEXT:     LSHR * T11.W, T11.X, literal.y,
+; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_UINT T23.X, T11.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T11.Z, T11.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T25.X, T15.X, literal.x,
 ; EG-NEXT:    24(3.363116e-44), 30(4.203895e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT * T11.Y, T11.X, literal.y, 1,
-; EG-NEXT:    2(2.802597e-45), 29(4.063766e-44)
+; EG-NEXT:     BFE_UINT * T11.Y, T11.X, literal.x, 1,
+; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T11.X, T11.X, literal.x, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    28(3.923636e-44), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T26.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T26.X, T15.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i1_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -3048,132 +3018,118 @@ define amdgpu_kernel void @constant_sextload_v32i1_to_v32i32(ptr addrspace(1) %o
 ;
 ; EG-LABEL: constant_sextload_v32i1_to_v32i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 0 @14
-; EG-NEXT:    ALU 99, @17, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 5, @117, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @12
+; EG-NEXT:    ALU 94, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T23.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T19.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T17.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T17.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T15.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T13.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T14.X, 1
 ; EG-NEXT:    CF_END
-; EG-NEXT:    PAD
-; EG-NEXT:    Fetch clause starting at 14:
+; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_32 T11.X, T11.X, 0, #1
-; EG-NEXT:    ALU clause starting at 16:
+; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 17:
+; EG-NEXT:    ALU clause starting at 15:
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.x,
 ; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T12.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.x,
 ; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T12.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T11.X, literal.x,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T12.Y, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T11.X, literal.y,
-; EG-NEXT:    11(1.541428e-44), 5(7.006492e-45)
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     BFE_INT T12.Y, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; EG-NEXT:     BFE_INT T14.W, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 10(1.401298e-44)
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    11(1.541428e-44), 4(5.605194e-45)
 ; EG-NEXT:     BFE_INT T12.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.x,
-; EG-NEXT:     BFE_INT T14.Z, PV.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T13.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T11.X, literal.x,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T14.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T13.Z, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    15(2.101948e-44), 9(1.261169e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T15.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T14.Y, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.z,
+; EG-NEXT:    2(2.802597e-45), 15(2.101948e-44)
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T15.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T13.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; EG-NEXT:     BFE_INT T16.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T16.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 14(1.961818e-44)
+; EG-NEXT:    4(5.605194e-45), 14(1.961818e-44)
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T14.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.x,
+; EG-NEXT:     BFE_INT T13.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T16.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T11.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 13(1.821688e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T17.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T16.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; EG-NEXT:     BFE_INT T18.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T17.X, T14.X, literal.x,
+; EG-NEXT:     BFE_INT T16.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T18.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 18(2.522337e-44)
+; EG-NEXT:    8(1.121039e-44), 18(2.522337e-44)
 ; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T16.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.x,
 ; EG-NEXT:     BFE_INT T18.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T11.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 17(2.382207e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T19.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T18.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; EG-NEXT:     BFE_INT T20.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T19.X, T14.X, literal.x,
+; EG-NEXT:     BFE_INT T18.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T20.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 22(3.082857e-44)
+; EG-NEXT:    12(1.681558e-44), 22(3.082857e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T18.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.x,
 ; EG-NEXT:     BFE_INT T20.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T11.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.y,
 ; EG-NEXT:    27(3.783506e-44), 21(2.942727e-44)
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T21.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T20.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; EG-NEXT:     BFE_INT T22.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T21.X, T14.X, literal.x,
+; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T22.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 26(3.643376e-44)
+; EG-NEXT:    16(2.242078e-44), 26(3.643376e-44)
 ; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T22.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    25(3.503246e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T23.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, T14.X, literal.y,
+; EG-NEXT:    25(3.503246e-44), 20(2.802597e-44)
 ; EG-NEXT:     BFE_INT T22.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T11.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; EG-NEXT:     LSHR * T0.W, T11.X, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T22.X, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
 ; EG-NEXT:     ASHR * T24.W, T11.X, literal.y,
 ; EG-NEXT:    30(4.203895e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T25.X, T11.X, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.x,
 ; EG-NEXT:     BFE_INT T24.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T11.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.y,
 ; EG-NEXT:    3(4.203895e-45), 29(4.063766e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T24.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.x,
-; EG-NEXT:     BFE_INT T25.W, PV.Y, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T11.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T26.X, T14.X, literal.x,
+; EG-NEXT:     BFE_INT T24.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T25.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T11.X, literal.z,
+; EG-NEXT:    24(3.363116e-44), 2(2.802597e-45)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T24.X, PS, 0.0, 1,
-; EG-NEXT:     BFE_INT * T25.Z, PV.Z, 0.0, 1,
-; EG-NEXT:    ALU clause starting at 117:
+; EG-NEXT:     BFE_INT T25.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T11.X, 1,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T11.X, T14.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT * T25.Y, PV.W, 0.0, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v32i1_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -3706,8 +3662,8 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
-; EG-NEXT:    ALU 96, @25, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 57, @122, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 89, @25, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 32, @115, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T49.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T47.X, 0
@@ -3721,9 +3677,9 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T32.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T26.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T23.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
@@ -3733,160 +3689,128 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 25:
 ; EG-NEXT:     BFE_UINT * T19.W, T21.X, literal.x, 1,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT * T19.Z, T21.X, literal.x, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T19.Z, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T20.W, T21.X, literal.y, 1,
+; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
 ; EG-NEXT:     BFE_UINT T19.Y, T21.X, 1, 1,
-; EG-NEXT:     BFE_UINT * T20.W, T21.X, literal.x, 1,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T20.Z, T21.X, literal.x, 1,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T19.X, T21.X, 1,
-; EG-NEXT:     BFE_UINT T20.Z, T21.X, literal.x, 1,
-; EG-NEXT:     LSHR * T22.X, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 2(2.802597e-45)
-; EG-NEXT:     BFE_UINT T20.Y, T21.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT * T23.W, T21.X, literal.y, 1,
-; EG-NEXT:    5(7.006492e-45), 11(1.541428e-44)
+; EG-NEXT:     BFE_UINT * T20.Y, T21.X, literal.x, 1,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T20.X, T21.X, literal.x, 1,
-; EG-NEXT:     BFE_UINT T23.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    4(5.605194e-45), 10(1.401298e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T23.Y, T21.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T25.W, T21.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
+; EG-NEXT:     BFE_UINT T22.W, T21.X, literal.y, 1,
+; EG-NEXT:     LSHR * T23.X, KC0[2].Y, literal.z,
+; EG-NEXT:    4(5.605194e-45), 11(1.541428e-44)
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T22.Z, T21.X, literal.x, 1,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T24.X, T23.X, literal.x,
+; EG-NEXT:     BFE_UINT T22.Y, T21.X, literal.y, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_UINT * T25.W, T21.X, literal.z, 1, BS:VEC_120/SCL_212
+; EG-NEXT:    4(5.605194e-45), 9(1.261169e-44)
 ; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T23.X, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT T22.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T25.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T26.X, T23.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 14(1.961818e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T25.Y, T21.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T27.W, T21.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 13(1.821688e-44)
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T25.Y, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T27.W, T21.X, literal.y, 1,
+; EG-NEXT:    13(1.821688e-44), 19(2.662467e-44)
 ; EG-NEXT:     BFE_UINT T25.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T27.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T28.X, T23.X, literal.x,
 ; EG-NEXT:    12(1.681558e-44), 18(2.522337e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T27.Y, T21.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T29.W, T21.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 17(2.382207e-44)
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T27.Y, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T29.W, T21.X, literal.y, 1,
+; EG-NEXT:    17(2.382207e-44), 23(3.222986e-44)
 ; EG-NEXT:     BFE_UINT T27.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T29.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T30.X, T23.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 22(3.082857e-44)
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T29.Y, T21.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T31.W, T21.X, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 21(2.942727e-44)
-; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T29.Y, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T31.W, T21.X, literal.y, 1,
+; EG-NEXT:    21(2.942727e-44), 27(3.783506e-44)
 ; EG-NEXT:     BFE_UINT T29.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T31.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T32.X, T23.X, literal.x,
 ; EG-NEXT:    20(2.802597e-44), 26(3.643376e-44)
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T31.Y, T21.X, literal.y, 1,
-; EG-NEXT:     LSHR * T33.W, T21.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 25(3.503246e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T31.Y, T21.X, literal.x, 1,
+; EG-NEXT:     LSHR * T33.W, T21.X, literal.y,
+; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_UINT T31.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T33.Z, T21.X, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T34.X, T23.X, literal.x,
 ; EG-NEXT:    24(3.363116e-44), 30(4.203895e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T33.Y, T21.X, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T35.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 29(4.063766e-44)
-; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T33.Y, T21.X, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T35.W, T21.Y, literal.y, 1,
+; EG-NEXT:    29(4.063766e-44), 3(4.203895e-45)
 ; EG-NEXT:     BFE_UINT T33.X, T21.X, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T35.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T21.X, T23.X, literal.x,
 ; EG-NEXT:    28(3.923636e-44), 2(2.802597e-45)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
 ; EG-NEXT:     BFE_UINT T35.Y, T21.Y, 1, 1,
-; EG-NEXT:     BFE_UINT T36.W, T21.Y, literal.y, 1,
-; EG-NEXT:     AND_INT * T35.X, T21.Y, 1,
-; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
+; EG-NEXT:     BFE_UINT * T36.W, T21.Y, literal.x, 1,
+; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T35.X, T21.Y, 1,
 ; EG-NEXT:     BFE_UINT T36.Z, T21.Y, literal.x, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T36.Y, T21.Y, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T38.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 5(7.006492e-45)
-; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T37.X, T23.X, literal.y,
+; EG-NEXT:    6(8.407791e-45), 32(4.484155e-44)
+; EG-NEXT:     BFE_UINT T36.Y, T21.Y, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T38.W, T21.Y, literal.y, 1,
+; EG-NEXT:    5(7.006492e-45), 11(1.541428e-44)
 ; EG-NEXT:     BFE_UINT T36.X, T21.Y, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T38.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T39.X, T23.X, literal.z,
 ; EG-NEXT:    4(5.605194e-45), 10(1.401298e-44)
-; EG-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 122:
-; EG-NEXT:     LSHR T39.X, T0.W, literal.x,
-; EG-NEXT:     BFE_UINT T38.Y, T21.Y, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T40.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
-; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
+; EG-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T38.Y, T21.Y, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T40.W, T21.Y, literal.y, 1,
+; EG-NEXT:    9(1.261169e-44), 15(2.101948e-44)
 ; EG-NEXT:     BFE_UINT T38.X, T21.Y, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T40.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T41.X, T23.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 14(1.961818e-44)
-; EG-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T40.Y, T21.Y, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T42.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 13(1.821688e-44)
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T40.X, T21.Y, literal.x, 1,
-; EG-NEXT:     BFE_UINT T42.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    12(1.681558e-44), 18(2.522337e-44)
-; EG-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T43.X, PV.W, literal.x,
+; EG-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T40.Y, T21.Y, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T42.W, T21.Y, literal.y, 1,
+; EG-NEXT:    13(1.821688e-44), 19(2.662467e-44)
+; EG-NEXT:     BFE_UINT * T40.X, T21.Y, literal.x, 1,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 115:
+; EG-NEXT:     BFE_UINT * T42.Z, T21.Y, literal.x, 1,
+; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T43.X, T23.X, literal.x,
 ; EG-NEXT:     BFE_UINT T42.Y, T21.Y, literal.y, 1,
 ; EG-NEXT:     BFE_UINT * T44.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 17(2.382207e-44)
+; EG-NEXT:    44(6.165713e-44), 17(2.382207e-44)
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T42.X, T21.Y, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T44.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T45.X, T23.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 22(3.082857e-44)
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T45.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T44.Y, T21.Y, literal.y, 1,
-; EG-NEXT:     BFE_UINT * T46.W, T21.Y, literal.z, 1,
-; EG-NEXT:    2(2.802597e-45), 21(2.942727e-44)
-; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T44.Y, T21.Y, literal.x, 1,
+; EG-NEXT:     BFE_UINT * T46.W, T21.Y, literal.y, 1,
+; EG-NEXT:    21(2.942727e-44), 27(3.783506e-44)
 ; EG-NEXT:     BFE_UINT T44.X, T21.Y, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T46.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T47.X, T23.X, literal.z,
 ; EG-NEXT:    20(2.802597e-44), 26(3.643376e-44)
-; EG-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T46.Y, T21.Y, literal.y, 1,
-; EG-NEXT:     LSHR * T48.W, T21.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 25(3.503246e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T46.Y, T21.Y, literal.x, 1,
+; EG-NEXT:     LSHR * T48.W, T21.Y, literal.y,
+; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_UINT T46.X, T21.Y, literal.x, 1,
 ; EG-NEXT:     BFE_UINT T48.Z, T21.Y, literal.y, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T49.X, T23.X, literal.z,
 ; EG-NEXT:    24(3.363116e-44), 30(4.203895e-44)
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT * T48.Y, T21.Y, literal.y, 1,
-; EG-NEXT:    2(2.802597e-45), 29(4.063766e-44)
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T48.Y, T21.Y, literal.x, 1,
+; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T48.X, T21.Y, literal.x, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    28(3.923636e-44), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T50.X, T23.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 60(8.407791e-44)
 ;
 ; GFX12-LABEL: constant_zextload_v64i1_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -4544,26 +4468,26 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
-; EG-NEXT:    ALU 99, @25, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 98, @125, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 13, @224, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 101, @25, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 85, @127, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T19.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T46.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T44.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T40.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T38.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T36.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T36.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T33.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T31.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T21.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
+; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_64 T19.XY, T19.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 24:
@@ -4575,215 +4499,189 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; EG-NEXT:     LSHR * T0.W, T19.X, literal.x,
 ; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T19.X, literal.x,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T20.Y, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T19.X, literal.y,
-; EG-NEXT:    11(1.541428e-44), 5(7.006492e-45)
-; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     BFE_INT T22.W, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 10(1.401298e-44)
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    11(1.541428e-44), 4(5.605194e-45)
 ; EG-NEXT:     BFE_INT T20.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.X, literal.x,
-; EG-NEXT:     BFE_INT T22.Z, PV.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T21.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T19.X, literal.x,
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T21.Z, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    15(2.101948e-44), 9(1.261169e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T22.Y, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.z,
+; EG-NEXT:    2(2.802597e-45), 15(2.101948e-44)
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T23.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T21.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     BFE_INT T24.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T24.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 14(1.961818e-44)
+; EG-NEXT:    4(5.605194e-45), 14(1.961818e-44)
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T22.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.X, literal.x,
+; EG-NEXT:     BFE_INT T21.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T24.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 13(1.821688e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T25.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T24.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     BFE_INT T26.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T25.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T24.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T19.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T26.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 18(2.522337e-44)
+; EG-NEXT:    8(1.121039e-44), 18(2.522337e-44)
 ; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T24.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.X, literal.x,
 ; EG-NEXT:     BFE_INT T26.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 17(2.382207e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T27.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T26.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     BFE_INT T28.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T27.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T26.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T19.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T28.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 22(3.082857e-44)
+; EG-NEXT:    12(1.681558e-44), 22(3.082857e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T26.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.X, literal.x,
 ; EG-NEXT:     BFE_INT T28.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.X, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.y,
 ; EG-NEXT:    27(3.783506e-44), 21(2.942727e-44)
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T29.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T28.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     BFE_INT T30.W, PV.Y, 0.0, 1,
+; EG-NEXT:     ADD_INT T29.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T28.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T19.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T30.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 26(3.643376e-44)
+; EG-NEXT:    16(2.242078e-44), 26(3.643376e-44)
 ; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T28.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T30.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    25(3.503246e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T31.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T22.X, literal.y,
+; EG-NEXT:    25(3.503246e-44), 20(2.802597e-44)
 ; EG-NEXT:     BFE_INT T30.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.X, literal.y,
-; EG-NEXT:     LSHR T0.W, T19.X, literal.z,
-; EG-NEXT:     ASHR * T32.W, T19.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 30(4.203895e-44)
-; EG-NEXT:    24(3.363116e-44), 31(4.344025e-44)
+; EG-NEXT:     LSHR T0.Z, T19.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T19.X, literal.y,
+; EG-NEXT:     ASHR * T32.W, T19.X, literal.z,
+; EG-NEXT:    30(4.203895e-44), 24(3.363116e-44)
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T30.X, PV.W, 0.0, 1,
 ; EG-NEXT:     BFE_INT T32.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    29(4.063766e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T33.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T22.X, literal.y,
+; EG-NEXT:    29(4.063766e-44), 24(3.363116e-44)
 ; EG-NEXT:     BFE_INT T32.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.Y, literal.y,
-; EG-NEXT:     LSHR * T1.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
-; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.y,
+; EG-NEXT:    7(9.809089e-45), 28(3.923636e-44)
 ; EG-NEXT:     BFE_INT T32.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.Y, literal.x,
 ; EG-NEXT:     BFE_INT T34.W, PV.W, 0.0, 1,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    6(8.407791e-45), 112(1.569454e-43)
-; EG-NEXT:    ALU clause starting at 125:
-; EG-NEXT:     LSHR T35.X, T0.W, literal.x,
-; EG-NEXT:     LSHR T0.Y, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T34.Z, T0.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 11(1.541428e-44)
-; EG-NEXT:    5(7.006492e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T36.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T34.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T37.W, PV.Y, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 10(1.401298e-44)
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T34.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
-; EG-NEXT:     BFE_INT T37.Z, PV.Z, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T19.Y, literal.x,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T35.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T34.Z, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    15(2.101948e-44), 9(1.261169e-44)
-; EG-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T38.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T37.Y, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.z,
+; EG-NEXT:    28(3.923636e-44), 11(1.541428e-44)
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T36.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T34.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T39.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T37.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 14(1.961818e-44)
+; EG-NEXT:    32(4.484155e-44), 10(1.401298e-44)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 127:
+; EG-NEXT:     BFE_INT T34.X, T0.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T37.Z, T0.Z, 0.0, 1,
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.y,
+; EG-NEXT:    15(2.101948e-44), 9(1.261169e-44)
+; EG-NEXT:     ADD_INT T38.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T37.Y, PS, 0.0, 1,
+; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
+; EG-NEXT:     BFE_INT T39.W, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
+; EG-NEXT:    36(5.044674e-44), 14(1.961818e-44)
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T37.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
 ; EG-NEXT:     BFE_INT T39.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 13(1.821688e-44)
-; EG-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T40.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T39.Y, PV.W, 0.0, 1,
+; EG-NEXT:     ADD_INT T40.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T39.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T41.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T41.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 18(2.522337e-44)
+; EG-NEXT:    40(5.605194e-44), 18(2.522337e-44)
 ; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T39.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
 ; EG-NEXT:     BFE_INT T41.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 17(2.382207e-44)
-; EG-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T42.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T41.Y, PV.W, 0.0, 1,
+; EG-NEXT:     ADD_INT T42.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T41.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T43.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T43.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 22(3.082857e-44)
+; EG-NEXT:    44(6.165713e-44), 22(3.082857e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T41.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
 ; EG-NEXT:     BFE_INT T43.Z, PV.Z, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T19.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.y,
 ; EG-NEXT:    27(3.783506e-44), 21(2.942727e-44)
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T44.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T43.Y, PV.W, 0.0, 1,
+; EG-NEXT:     ADD_INT T44.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T43.Y, PS, 0.0, 1,
 ; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; EG-NEXT:     BFE_INT T45.W, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T45.W, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T0.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 26(3.643376e-44)
+; EG-NEXT:    48(6.726233e-44), 26(3.643376e-44)
 ; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T43.X, PS, 0.0, 1,
 ; EG-NEXT:     BFE_INT T45.Z, PV.Z, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    25(3.503246e-44), 208(2.914701e-43)
-; EG-NEXT:     LSHR T46.X, PS, literal.x,
+; EG-NEXT:     ADD_INT * T46.X, T22.X, literal.y,
+; EG-NEXT:    25(3.503246e-44), 52(7.286752e-44)
 ; EG-NEXT:     BFE_INT T45.Y, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T19.Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; EG-NEXT:     LSHR * T0.W, T19.Y, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T45.X, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.Z, T19.Y, literal.x,
-; EG-NEXT:     LSHR T0.W, T19.X, 1,
-; EG-NEXT:     LSHR * T1.W, T19.Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 3(4.203895e-45)
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T19.X, 1,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T47.X, T19.X, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T19.X, literal.x,
-; EG-NEXT:     LSHR T1.Z, T19.X, literal.y,
-; EG-NEXT:     LSHR T2.W, T19.Y, literal.z,
-; EG-NEXT:     ASHR * T48.W, T19.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 3(4.203895e-45)
-; EG-NEXT:    30(4.203895e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_INT T19.X, T19.Y, 0.0, 1,
-; EG-NEXT:     LSHR T1.Y, T19.Y, literal.x,
+; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
+; EG-NEXT:     LSHR T0.Z, T19.X, literal.x,
+; EG-NEXT:     LSHR T2.W, T19.Y, literal.y,
+; EG-NEXT:     ASHR * T48.W, T19.Y, literal.z,
+; EG-NEXT:    3(4.203895e-45), 30(4.203895e-44)
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T49.X, T19.Y, 0.0, 1,
+; EG-NEXT:     LSHR T1.Y, T19.X, literal.x,
 ; EG-NEXT:     BFE_INT T48.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     BFE_INT T47.W, PV.Z, 0.0, 1,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    29(4.063766e-44), 224(3.138909e-43)
-; EG-NEXT:     LSHR * T49.X, PS, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 224:
-; EG-NEXT:     BFE_INT T48.Y, T1.Y, 0.0, 1,
-; EG-NEXT:     BFE_INT T47.Z, T0.Y, 0.0, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T19.W, T1.W, 0.0, 1,
-; EG-NEXT:     LSHR * T1.W, T19.Y, literal.x,
-; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T2.W, T19.Y, literal.y,
+; EG-NEXT:    2(2.802597e-45), 29(4.063766e-44)
+; EG-NEXT:     ADD_INT T19.X, T22.X, literal.x,
+; EG-NEXT:     BFE_INT T48.Y, PS, 0.0, 1,
+; EG-NEXT:     BFE_INT T47.Z, PV.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T49.W, T0.Y, 0.0, 1,
+; EG-NEXT:     LSHR * T2.W, T19.Y, literal.y,
+; EG-NEXT:    56(7.847271e-44), 28(3.923636e-44)
 ; EG-NEXT:     BFE_INT T48.X, PS, 0.0, 1,
-; EG-NEXT:     BFE_INT T47.Y, T0.W, 0.0, 1,
-; EG-NEXT:     BFE_INT T19.Z, T0.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T47.Y, T1.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T49.Z, T0.W, 0.0, 1, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR T0.W, T19.Y, 1,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T50.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T19.Y, PV.W, 0.0, 1,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T50.X, T22.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T49.Y, PV.W, 0.0, 1,
 ;
 ; GFX12-LABEL: constant_sextload_v64i1_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -5658,7 +5556,7 @@ define amdgpu_kernel void @constant_zextload_v3i1_to_v3i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 10, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -5674,11 +5572,10 @@ define amdgpu_kernel void @constant_zextload_v3i1_to_v3i64(ptr addrspace(1) %out
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T0.Y, 0.0,
 ; EG-NEXT:     MOV * T1.W, 0.0,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v3i1_to_v3i64:
 ; GFX12:       ; %bb.0:
@@ -5811,7 +5708,7 @@ define amdgpu_kernel void @constant_sextload_v3i1_to_v3i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 12, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -5822,19 +5719,17 @@ define amdgpu_kernel void @constant_sextload_v3i1_to_v3i64(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     BFE_INT T1.X, T0.X, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T0.X, 1,
+; EG-NEXT:     LSHR * T1.W, T0.X, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T0.X, PS, 0.0, 1,
+; EG-NEXT:     BFE_INT T1.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T1.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T0.X, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T0.X, PV.W, 0.0, 1,
-; EG-NEXT:     MOV T1.Y, T1.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     MOV T0.Y, PV.X,
+; EG-NEXT:     MOV * T1.Y, T1.X,
+; EG-NEXT:     ADD_INT T3.X, T2.X, literal.x,
+; EG-NEXT:     MOV T0.Y, T0.X, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T1.W, T1.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v3i1_to_v3i64:
 ; GFX12:       ; %bb.0:
@@ -5945,7 +5840,7 @@ define amdgpu_kernel void @constant_zextload_v4i1_to_v4i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 13, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -5964,11 +5859,10 @@ define amdgpu_kernel void @constant_zextload_v4i1_to_v4i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV T0.Y, 0.0,
 ; EG-NEXT:     MOV T1.W, 0.0,
 ; EG-NEXT:     MOV * T0.W, 0.0,
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v4i1_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6119,7 +6013,7 @@ define amdgpu_kernel void @constant_sextload_v4i1_to_v4i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
@@ -6139,13 +6033,12 @@ define amdgpu_kernel void @constant_sextload_v4i1_to_v4i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV T2.Y, PV.X,
 ; EG-NEXT:     BFE_INT * T1.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     MOV T1.Y, T1.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T1.Y, T1.X,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
 ; EG-NEXT:     MOV T1.W, T1.Z,
 ; EG-NEXT:     MOV * T2.W, T2.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v4i1_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6289,7 +6182,7 @@ define amdgpu_kernel void @constant_zextload_v8i1_to_v8i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 30, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 26, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T10.X, 0
@@ -6320,17 +6213,13 @@ define amdgpu_kernel void @constant_zextload_v8i1_to_v8i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV * T7.W, 0.0,
 ; EG-NEXT:     MOV T8.W, 0.0,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T12.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T9.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T10.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T11.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T12.X, T9.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i1_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -6503,55 +6392,53 @@ define amdgpu_kernel void @constant_sextload_v8i1_to_v8i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 37, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 35, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T11.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T10.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T6.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T10.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T9.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_8 T5.X, T5.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T5.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR * T0.W, T5.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 7(9.809089e-45)
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.X, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T7.X, T5.X, 0.0, 1,
 ; EG-NEXT:     BFE_INT T8.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T5.X, literal.x,
-; EG-NEXT:     LSHR * T1.W, T5.X, literal.y,
-; EG-NEXT:    3(4.203895e-45), 6(8.407791e-45)
-; EG-NEXT:     BFE_INT T8.X, PS, 0.0, 1,
-; EG-NEXT:     BFE_INT T9.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T8.X, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T5.X, 1,
-; EG-NEXT:     LSHR * T1.W, T5.X, literal.x,
+; EG-NEXT:     LSHR * T9.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T9.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T8.Y, PV.X,
 ; EG-NEXT:     BFE_INT T7.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T5.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    5(7.006492e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PS, literal.x,
-; EG-NEXT:     MOV T9.Y, PV.X,
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x,
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T10.X, T9.X, literal.x,
+; EG-NEXT:     MOV T6.Y, T6.X, BS:VEC_120/SCL_212
 ; EG-NEXT:     BFE_INT T5.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T0.W, T5.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 4(5.605194e-45)
+; EG-NEXT:     LSHR * T0.W, T5.X, literal.x, BS:VEC_201
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T5.X, PV.W, 0.0, 1,
 ; EG-NEXT:     MOV T7.Y, T7.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T11.X, T9.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T5.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
 ; EG-NEXT:     MOV T7.W, T7.Z,
-; EG-NEXT:     MOV * T9.W, T9.Z,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T12.X, PV.Z, literal.x,
+; EG-NEXT:     MOV * T6.W, T6.Z,
+; EG-NEXT:     ADD_INT T12.X, T9.X, literal.x,
 ; EG-NEXT:     MOV T5.W, T5.Z,
 ; EG-NEXT:     MOV * T8.W, T8.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v8i1_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -6788,7 +6675,7 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 62, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 52, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T20.X, 0
@@ -6843,29 +6730,19 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV * T13.W, 0.0,
 ; EG-NEXT:     MOV T14.W, 0.0,
 ; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T22.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T15.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T18.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T15.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T20.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T15.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T22.X, T15.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i1_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -7218,7 +7095,7 @@ define amdgpu_kernel void @constant_sextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 78, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 68, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T18.X, 0
@@ -7233,33 +7110,26 @@ define amdgpu_kernel void @constant_sextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T0.W, T7.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 15(2.101948e-44)
+; EG-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T10.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T11.X, T8.X, literal.x,
+; EG-NEXT:     ADD_INT * T12.X, T8.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T0.W, T7.X, literal.x,
+; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T13.X, T7.X, 0.0, 1,
 ; EG-NEXT:     BFE_INT T14.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
 ; EG-NEXT:    11(1.541428e-44), 14(1.961818e-44)
 ; EG-NEXT:     BFE_INT T14.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T0.Y, T7.X, literal.x,
 ; EG-NEXT:     BFE_INT T15.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T7.X, literal.y,
-; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
-; EG-NEXT:    12(1.681558e-44), 7(9.809089e-45)
-; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
+; EG-NEXT:    7(9.809089e-45), 10(1.401298e-44)
 ; EG-NEXT:     BFE_INT T15.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T14.Y, PV.X,
 ; EG-NEXT:     BFE_INT T16.Z, PV.W, 0.0, 1,
@@ -7276,42 +7146,39 @@ define amdgpu_kernel void @constant_sextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV T16.Y, PV.X,
 ; EG-NEXT:     BFE_INT T13.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     LSHR T0.W, T7.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    5(7.006492e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T18.X, PS, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 5(7.006492e-45)
+; EG-NEXT:     ADD_INT T18.X, T8.X, literal.x,
 ; EG-NEXT:     MOV T17.Y, PV.X,
-; EG-NEXT:     BFE_INT T19.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T7.X, literal.y,
-; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
+; EG-NEXT:     BFE_INT T19.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR T1.W, T7.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T7.X, literal.z,
+; EG-NEXT:    20(2.802597e-44), 9(1.261169e-44)
 ; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T19.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T13.Y, T13.X,
 ; EG-NEXT:     BFE_INT T7.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T0.W, T7.X, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, T7.X, literal.y,
+; EG-NEXT:     LSHR T1.W, T7.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T7.X, literal.y,
 ; EG-NEXT:    13(1.821688e-44), 8(1.121039e-44)
 ; EG-NEXT:     BFE_INT T7.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T19.Y, PV.X,
 ; EG-NEXT:     BFE_INT T20.Z, PV.W, 0.0, 1,
 ; EG-NEXT:     MOV T13.W, T13.Z,
 ; EG-NEXT:     MOV * T17.W, T17.Z,
-; EG-NEXT:     BFE_INT T20.X, T0.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T20.X, T0.W, 0.0, 1,
 ; EG-NEXT:     MOV T7.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
 ; EG-NEXT:     MOV T19.W, T19.Z,
 ; EG-NEXT:     MOV * T16.W, T16.Z,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T21.X, PV.Z, literal.x,
+; EG-NEXT:     ADD_INT T21.X, T8.X, literal.x,
 ; EG-NEXT:     MOV T20.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
 ; EG-NEXT:     MOV T7.W, T7.Z,
 ; EG-NEXT:     MOV * T15.W, T15.Z,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T22.X, PV.Z, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T22.X, T8.X, literal.x,
 ; EG-NEXT:     MOV T20.W, T20.Z,
 ; EG-NEXT:     MOV * T14.W, T14.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v16i1_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -7725,7 +7592,7 @@ define amdgpu_kernel void @constant_zextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
 ; EG-NEXT:    ALU 96, @25, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 30, @122, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 7, @122, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T40.X, 0
@@ -7829,55 +7696,32 @@ define amdgpu_kernel void @constant_zextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV * T25.W, 0.0,
 ; EG-NEXT:     MOV T26.W, 0.0,
 ; EG-NEXT:     MOV * T11.W, 0.0,
-; EG-NEXT:     LSHR T27.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR * T32.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T27.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T28.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T30.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T27.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T32.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T27.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T34.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T35.X, T27.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T36.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T37.X, T27.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
 ; EG-NEXT:    ALU clause starting at 122:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T42.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T38.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T27.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T40.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T41.X, T27.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT * T42.X, T27.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i1_to_v32i64:
 ; GFX12:       ; %bb.0:
@@ -8470,8 +8314,8 @@ define amdgpu_kernel void @constant_sextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @24, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
-; EG-NEXT:    ALU 92, @25, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 65, @118, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 97, @25, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 39, @123, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T34.X, 0
@@ -8495,166 +8339,145 @@ define amdgpu_kernel void @constant_sextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 24:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 25:
-; EG-NEXT:     LSHR T12.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Y, T11.X, literal.y,
-; EG-NEXT:     LSHR T0.Z, T11.X, literal.z,
-; EG-NEXT:     LSHR * T0.W, T11.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 28(3.923636e-44)
-; EG-NEXT:    29(4.063766e-44), 24(3.363116e-44)
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T11.X, literal.y,
-; EG-NEXT:     LSHR T1.Z, T11.X, literal.z,
-; EG-NEXT:     LSHR * T1.W, T11.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 25(3.503246e-44)
-; EG-NEXT:    20(2.802597e-44), 21(2.942727e-44)
-; EG-NEXT:     LSHR * T2.W, T11.X, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T12.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T13.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T14.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T15.X, T12.X, literal.x,
+; EG-NEXT:     ADD_INT * T16.X, T12.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T17.X, T12.X, literal.x,
+; EG-NEXT:     ADD_INT * T18.X, T12.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T19.X, T12.X, literal.x,
+; EG-NEXT:     ADD_INT * T20.X, T12.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T21.X, T12.X, literal.x,
+; EG-NEXT:     ADD_INT * T22.X, T12.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T23.X, T12.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T11.X, literal.z,
+; EG-NEXT:    44(6.165713e-44), 28(3.923636e-44)
+; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T24.X, T12.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T0.Z, T11.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T11.X, literal.w, BS:VEC_120/SCL_212
+; EG-NEXT:    48(6.726233e-44), 24(3.363116e-44)
+; EG-NEXT:    25(3.503246e-44), 20(2.802597e-44)
+; EG-NEXT:     LSHR * T3.W, T11.X, literal.x,
+; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T25.X, T11.X, 0.0, 1,
-; EG-NEXT:     LSHR T2.Y, T11.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T11.X, literal.x,
 ; EG-NEXT:     ASHR T26.Z, T11.X, literal.y,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.z,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.w,
-; EG-NEXT:    17(2.382207e-44), 31(4.344025e-44)
+; EG-NEXT:     LSHR T4.W, T11.X, literal.z,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.w,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:    27(3.783506e-44), 30(4.203895e-44)
 ; EG-NEXT:     BFE_INT T26.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T3.Y, T11.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T11.X, literal.x,
 ; EG-NEXT:     BFE_INT T27.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.y,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.z,
-; EG-NEXT:    12(1.681558e-44), 23(3.222986e-44)
+; EG-NEXT:     LSHR T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.z,
+; EG-NEXT:    17(2.382207e-44), 23(3.222986e-44)
 ; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T27.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T26.Y, PV.X,
 ; EG-NEXT:     BFE_INT T28.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 22(3.082857e-44)
 ; EG-NEXT:     BFE_INT T28.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T27.Y, PV.X,
 ; EG-NEXT:     BFE_INT T29.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
 ; EG-NEXT:    15(2.101948e-44), 18(2.522337e-44)
 ; EG-NEXT:     BFE_INT T29.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T28.Y, PV.X,
 ; EG-NEXT:     BFE_INT T30.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
 ; EG-NEXT:    11(1.541428e-44), 14(1.961818e-44)
 ; EG-NEXT:     BFE_INT T30.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T29.Y, PV.X,
 ; EG-NEXT:     BFE_INT T31.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
 ; EG-NEXT:    7(9.809089e-45), 10(1.401298e-44)
 ; EG-NEXT:     BFE_INT T31.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T30.Y, PV.X,
 ; EG-NEXT:     BFE_INT T32.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
 ; EG-NEXT:    3(4.203895e-45), 6(8.407791e-45)
-; EG-NEXT:    ALU clause starting at 118:
-; EG-NEXT:     BFE_INT T32.X, T4.W, 0.0, 1,
-; EG-NEXT:     MOV T31.Y, T31.X,
-; EG-NEXT:     BFE_INT T33.Z, T3.W, 0.0, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T3.W, T11.X, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.x,
+; EG-NEXT:     BFE_INT T32.X, PS, 0.0, 1,
+; EG-NEXT:     MOV T31.Y, PV.X,
+; EG-NEXT:     BFE_INT T33.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR T4.W, T11.X, 1,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T33.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T32.Y, PV.X,
 ; EG-NEXT:     BFE_INT T25.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    5(7.006492e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T34.X, PS, literal.x,
+; EG-NEXT:     LSHR T4.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 5(7.006492e-45)
+; EG-NEXT:     ADD_INT T34.X, T12.X, literal.x,
 ; EG-NEXT:     MOV T33.Y, PV.X,
-; EG-NEXT:     BFE_INT T35.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.y,
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
+; EG-NEXT:     BFE_INT T35.Z, PS, 0.0, 1,
+; EG-NEXT:     LSHR T5.W, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T6.W, T11.X, literal.z,
+; EG-NEXT:    52(7.286752e-44), 9(1.261169e-44)
 ; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T35.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T25.Y, T25.X,
 ; EG-NEXT:     BFE_INT T11.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T4.W, T11.X, literal.y,
-; EG-NEXT:    13(1.821688e-44), 8(1.121039e-44)
-; EG-NEXT:     BFE_INT T11.X, PS, 0.0, 1,
-; EG-NEXT:     MOV T35.Y, PV.X,
-; EG-NEXT:     BFE_INT T36.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR * T5.W, T11.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 123:
+; EG-NEXT:     LSHR * T6.W, T11.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T11.X, PV.W, 0.0, 1,
+; EG-NEXT:     MOV T35.Y, T35.X,
+; EG-NEXT:     BFE_INT T36.Z, T5.W, 0.0, 1,
 ; EG-NEXT:     MOV T25.W, T25.Z,
 ; EG-NEXT:     MOV * T33.W, T33.Z,
-; EG-NEXT:     BFE_INT T36.X, T3.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T36.X, T4.W, 0.0, 1,
 ; EG-NEXT:     MOV T11.Y, PV.X,
-; EG-NEXT:     BFE_INT T37.Z, T2.Y, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T37.Z, T2.Y, 0.0, 1,
 ; EG-NEXT:     MOV T35.W, T35.Z,
 ; EG-NEXT:     MOV * T32.W, T32.Z,
-; EG-NEXT:     BFE_INT T37.X, T2.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T37.X, T1.Y, 0.0, 1,
 ; EG-NEXT:     MOV T36.Y, PV.X,
-; EG-NEXT:     BFE_INT T38.Z, T1.W, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T38.Z, T3.W, 0.0, 1,
 ; EG-NEXT:     MOV T11.W, T11.Z,
 ; EG-NEXT:     MOV * T31.W, T31.Z,
-; EG-NEXT:     BFE_INT T38.X, T1.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T38.X, T2.W, 0.0, 1,
 ; EG-NEXT:     MOV T37.Y, PV.X,
-; EG-NEXT:     BFE_INT T39.Z, T1.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T39.Z, T0.Z, 0.0, 1,
 ; EG-NEXT:     MOV T36.W, T36.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T30.W, T30.Z,
-; EG-NEXT:     BFE_INT T39.X, T0.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T39.X, T0.Y, 0.0, 1,
 ; EG-NEXT:     MOV T38.Y, PV.X,
-; EG-NEXT:     BFE_INT T40.Z, T0.Z, 0.0, 1,
-; EG-NEXT:     MOV T37.W, T37.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T40.Z, T1.W, 0.0, 1,
+; EG-NEXT:     MOV T37.W, T37.Z,
 ; EG-NEXT:     MOV * T29.W, T29.Z,
-; EG-NEXT:     BFE_INT T40.X, T0.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T40.X, T0.W, 0.0, 1,
 ; EG-NEXT:     MOV T39.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
 ; EG-NEXT:     MOV T38.W, T38.Z,
 ; EG-NEXT:     MOV * T28.W, T28.Z,
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T41.X, PV.Z, literal.x,
+; EG-NEXT:     ADD_INT T41.X, T12.X, literal.x,
 ; EG-NEXT:     MOV T40.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
 ; EG-NEXT:     MOV T39.W, T39.Z,
 ; EG-NEXT:     MOV * T27.W, T27.Z,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR T42.X, PV.Z, literal.x,
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T42.X, T12.X, literal.x,
 ; EG-NEXT:     MOV T40.W, T40.Z,
 ; EG-NEXT:     MOV * T26.W, T26.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v32i1_to_v32i64:
 ; GFX12:       ; %bb.0:
@@ -9444,7 +9267,7 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; EG-NEXT:    TEX 0 @38
 ; EG-NEXT:    ALU 95, @41, KC0[], KC1[]
 ; EG-NEXT:    ALU 99, @137, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 60, @237, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 13, @237, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T82.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T81.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T80.X, 0
@@ -9645,103 +9468,56 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV * T49.W, 0.0,
 ; EG-NEXT:     MOV T50.W, 0.0,
 ; EG-NEXT:     MOV * T20.W, 0.0,
-; EG-NEXT:     LSHR T51.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T52.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T53.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T54.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T55.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T56.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T57.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T58.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T59.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T60.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T61.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR * T62.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T51.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T52.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T53.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T54.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T55.X, T51.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T56.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T57.X, T51.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T58.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T59.X, T51.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T60.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T61.X, T51.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T62.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T63.X, T51.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T64.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T65.X, T51.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT T66.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T67.X, T51.X, literal.y,
+; EG-NEXT:    60(8.407791e-44), 64(8.968310e-44)
+; EG-NEXT:     ADD_INT T68.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T69.X, T51.X, literal.y,
+; EG-NEXT:    68(9.528830e-44), 72(1.008935e-43)
+; EG-NEXT:     ADD_INT T70.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T71.X, T51.X, literal.y,
+; EG-NEXT:    76(1.064987e-43), 80(1.121039e-43)
+; EG-NEXT:     ADD_INT T72.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T73.X, T51.X, literal.y,
+; EG-NEXT:    84(1.177091e-43), 88(1.233143e-43)
 ; EG-NEXT:    ALU clause starting at 237:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T63.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T64.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T65.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR T66.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 256(3.587324e-43)
-; EG-NEXT:     LSHR T67.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 272(3.811532e-43)
-; EG-NEXT:     LSHR T68.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 288(4.035740e-43)
-; EG-NEXT:     LSHR T69.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 304(4.259947e-43)
-; EG-NEXT:     LSHR T70.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 320(4.484155e-43)
-; EG-NEXT:     LSHR T71.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 336(4.708363e-43)
-; EG-NEXT:     LSHR T72.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 352(4.932571e-43)
-; EG-NEXT:     LSHR T73.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 368(5.156778e-43)
-; EG-NEXT:     LSHR T74.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 384(5.380986e-43)
-; EG-NEXT:     LSHR T75.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 400(5.605194e-43)
-; EG-NEXT:     LSHR T76.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 416(5.829402e-43)
-; EG-NEXT:     LSHR T77.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 432(6.053609e-43)
-; EG-NEXT:     LSHR T78.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 448(6.277817e-43)
-; EG-NEXT:     LSHR T79.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 464(6.502025e-43)
-; EG-NEXT:     LSHR T80.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 480(6.726233e-43)
-; EG-NEXT:     LSHR T81.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 496(6.950440e-43)
-; EG-NEXT:     LSHR * T82.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T74.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T75.X, T51.X, literal.y,
+; EG-NEXT:    92(1.289195e-43), 96(1.345247e-43)
+; EG-NEXT:     ADD_INT T76.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T77.X, T51.X, literal.y,
+; EG-NEXT:    100(1.401298e-43), 104(1.457350e-43)
+; EG-NEXT:     ADD_INT T78.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T79.X, T51.X, literal.y,
+; EG-NEXT:    108(1.513402e-43), 112(1.569454e-43)
+; EG-NEXT:     ADD_INT T80.X, T51.X, literal.x,
+; EG-NEXT:     ADD_INT * T81.X, T51.X, literal.y,
+; EG-NEXT:    116(1.625506e-43), 120(1.681558e-43)
+; EG-NEXT:     ADD_INT * T82.X, T51.X, literal.x,
+; EG-NEXT:    124(1.737610e-43), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v64i1_to_v64i64:
 ; GFX12:       ; %bb.0:
@@ -10930,11 +10706,11 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ;
 ; EG-LABEL: constant_sextload_v64i1_to_v64i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 22, @40, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @40, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @38
-; EG-NEXT:    ALU 89, @63, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 99, @153, KC0[], KC1[]
-; EG-NEXT:    ALU 107, @253, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 90, @41, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 100, @132, KC0[], KC1[]
+; EG-NEXT:    ALU 78, @233, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T50.XYZW, T82.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T80.XYZW, T81.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T51.XYZW, T73.X, 0
@@ -10946,355 +10722,306 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T54.XYZW, T43.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T76.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T55.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T75.XYZW, T39.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T56.XYZW, T38.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T74.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T66.XYZW, T35.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T34.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T72.XYZW, T33.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T32.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T71.XYZW, T31.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T30.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T70.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T61.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T69.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T62.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T68.XYZW, T25.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T64.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T67.XYZW, T21.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T65.XYZW, T20.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T19.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T75.XYZW, T40.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T56.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T74.XYZW, T38.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T37.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T66.XYZW, T36.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T72.XYZW, T34.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T33.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T71.XYZW, T32.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T31.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T70.XYZW, T30.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T61.XYZW, T29.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T69.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T62.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T68.XYZW, T26.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T64.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T67.XYZW, T22.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T65.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T20.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 38:
-; EG-NEXT:     VTX_READ_64 T40.XY, T26.X, 0, #1
+; EG-NEXT:     VTX_READ_64 T19.XY, T19.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 40:
-; EG-NEXT:     LSHR T19.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T26.X, KC0[2].Z,
+; EG-NEXT:     MOV * T19.X, KC0[2].Z,
+; EG-NEXT:    ALU clause starting at 41:
+; EG-NEXT:     LSHR * T20.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 63:
-; EG-NEXT:     LSHR T26.X, T0.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 256(3.587324e-43)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 272(3.811532e-43)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 288(4.035740e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 304(4.259947e-43)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 320(4.484155e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 336(4.708363e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 352(4.932571e-43)
-; EG-NEXT:     LSHR T42.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Z, T40.Y, literal.y,
-; EG-NEXT:     LSHR T0.W, T40.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 28(3.923636e-44)
-; EG-NEXT:    29(4.063766e-44), 368(5.156778e-43)
-; EG-NEXT:     LSHR T43.X, PS, literal.x,
-; EG-NEXT:     LSHR T0.Y, T40.Y, literal.y,
-; EG-NEXT:     LSHR T1.Z, T40.Y, literal.z,
-; EG-NEXT:     LSHR * T1.W, T40.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    25(3.503246e-44), 20(2.802597e-44)
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    384(5.380986e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T40.Y, literal.y,
-; EG-NEXT:     LSHR T2.Z, T40.Y, literal.z,
-; EG-NEXT:     LSHR * T2.W, T40.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 21(2.942727e-44)
-; EG-NEXT:    16(2.242078e-44), 17(2.382207e-44)
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.x,
-; EG-NEXT:    400(5.605194e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T45.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T2.Y, T40.Y, literal.y,
-; EG-NEXT:     LSHR T3.Z, T40.Y, literal.z,
-; EG-NEXT:     LSHR * T3.W, T40.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 12(1.681558e-44)
-; EG-NEXT:    13(1.821688e-44), 8(1.121039e-44)
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.x,
-; EG-NEXT:    416(5.829402e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T3.Y, T40.Y, literal.y,
-; EG-NEXT:     LSHR T4.Z, T40.Y, literal.z,
-; EG-NEXT:     LSHR * T4.W, T40.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 9(1.261169e-44)
-; EG-NEXT:    4(5.605194e-45), 5(7.006492e-45)
-; EG-NEXT:     ADD_INT * T5.W, KC0[2].Y, literal.x,
-; EG-NEXT:    432(6.053609e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T4.Y, KC0[2].Y, literal.y,
-; EG-NEXT:     LSHR T5.Z, T40.Y, 1,
-; EG-NEXT:     LSHR T5.W, T40.X, literal.z,
-; EG-NEXT:     ADD_INT * T6.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 464(6.502025e-43)
-; EG-NEXT:    28(3.923636e-44), 448(6.277817e-43)
-; EG-NEXT:    ALU clause starting at 153:
-; EG-NEXT:     LSHR T48.X, T6.W, literal.x,
-; EG-NEXT:     LSHR T5.Y, T40.X, literal.y,
-; EG-NEXT:     LSHR T6.Z, T40.X, literal.z,
-; EG-NEXT:     LSHR * T6.W, T40.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 29(4.063766e-44)
+; EG-NEXT:     ADD_INT T21.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T22.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T23.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T24.X, T20.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T25.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T26.X, T20.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T27.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T28.X, T20.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T29.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T30.X, T20.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T31.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T32.X, T20.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T33.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T34.X, T20.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT T35.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T36.X, T20.X, literal.y,
+; EG-NEXT:    60(8.407791e-44), 64(8.968310e-44)
+; EG-NEXT:     ADD_INT T37.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T38.X, T20.X, literal.y,
+; EG-NEXT:    68(9.528830e-44), 72(1.008935e-43)
+; EG-NEXT:     ADD_INT T39.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T40.X, T20.X, literal.y,
+; EG-NEXT:    76(1.064987e-43), 80(1.121039e-43)
+; EG-NEXT:     ADD_INT T41.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T42.X, T20.X, literal.y,
+; EG-NEXT:    84(1.177091e-43), 88(1.233143e-43)
+; EG-NEXT:     ADD_INT T43.X, T20.X, literal.x,
+; EG-NEXT:     ADD_INT * T44.X, T20.X, literal.y,
+; EG-NEXT:    92(1.289195e-43), 96(1.345247e-43)
+; EG-NEXT:     LSHR T0.Y, T19.Y, literal.x,
+; EG-NEXT:     LSHR T0.Z, T19.Y, literal.y,
+; EG-NEXT:     LSHR T0.W, T19.Y, literal.z,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.w,
+; EG-NEXT:    28(3.923636e-44), 29(4.063766e-44)
 ; EG-NEXT:    24(3.363116e-44), 25(3.503246e-44)
-; EG-NEXT:     LSHR * T7.W, T40.X, literal.x,
+; EG-NEXT:     ADD_INT T45.X, T20.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T19.Y, literal.y,
+; EG-NEXT:     LSHR T1.Z, T19.Y, literal.z,
+; EG-NEXT:     LSHR * T2.W, T19.Y, literal.w,
+; EG-NEXT:    100(1.401298e-43), 20(2.802597e-44)
+; EG-NEXT:    21(2.942727e-44), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T3.W, T19.Y, literal.x,
+; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T46.X, T20.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T19.Y, literal.y,
+; EG-NEXT:     LSHR T2.Z, T19.Y, literal.z,
+; EG-NEXT:     LSHR * T4.W, T19.Y, literal.w,
+; EG-NEXT:    104(1.457350e-43), 12(1.681558e-44)
+; EG-NEXT:    13(1.821688e-44), 8(1.121039e-44)
+; EG-NEXT:     LSHR * T5.W, T19.Y, literal.x,
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T47.X, T20.X, literal.x,
+; EG-NEXT:     LSHR T3.Y, T19.Y, literal.y,
+; EG-NEXT:     LSHR T3.Z, T19.Y, literal.z,
+; EG-NEXT:     LSHR T6.W, T19.Y, 1,
+; EG-NEXT:     LSHR * T7.W, T19.X, literal.w,
+; EG-NEXT:    108(1.513402e-43), 4(5.605194e-45)
+; EG-NEXT:    5(7.006492e-45), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T48.X, T20.X, literal.x,
+; EG-NEXT:     LSHR T4.Y, T19.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T4.Z, T19.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T8.W, T19.X, literal.w, BS:VEC_120/SCL_212
+; EG-NEXT:    112(1.569454e-43), 29(4.063766e-44)
+; EG-NEXT:    24(3.363116e-44), 25(3.503246e-44)
+; EG-NEXT:     LSHR * T9.W, T19.X, literal.x,
 ; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T49.X, T40.X, 0.0, 1,
-; EG-NEXT:     LSHR T6.Y, T40.X, literal.x,
-; EG-NEXT:     ASHR T50.Z, T40.Y, literal.y,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.z,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.w,
+; EG-NEXT:     BFE_INT T49.X, T19.X, 0.0, 1,
+; EG-NEXT:     LSHR T5.Y, T19.X, literal.x,
+; EG-NEXT:     ASHR T50.Z, T19.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.z,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.w,
 ; EG-NEXT:    21(2.942727e-44), 31(4.344025e-44)
 ; EG-NEXT:    27(3.783506e-44), 30(4.203895e-44)
 ; EG-NEXT:     BFE_INT T50.X, PS, 0.0, 1,
-; EG-NEXT:     LSHR T7.Y, T40.X, literal.x,
+; EG-NEXT:     LSHR T6.Y, T19.X, literal.x,
 ; EG-NEXT:     BFE_INT T51.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.y,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.z,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.y,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 23(3.222986e-44)
 ; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T51.X, PS, 0.0, 1,
-; EG-NEXT:     MOV T50.Y, PV.X,
-; EG-NEXT:     BFE_INT T52.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     MOV * T50.Y, PV.X,
+; EG-NEXT:    ALU clause starting at 132:
+; EG-NEXT:     BFE_INT T52.Z, T10.W, 0.0, 1,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 22(3.082857e-44)
 ; EG-NEXT:     BFE_INT T52.X, PS, 0.0, 1,
-; EG-NEXT:     MOV T51.Y, PV.X,
+; EG-NEXT:     MOV T51.Y, T51.X,
 ; EG-NEXT:     BFE_INT T53.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    15(2.101948e-44), 18(2.522337e-44)
 ; EG-NEXT:     BFE_INT T53.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T52.Y, PV.X,
 ; EG-NEXT:     BFE_INT T54.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    11(1.541428e-44), 14(1.961818e-44)
 ; EG-NEXT:     BFE_INT T54.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T53.Y, PV.X,
 ; EG-NEXT:     BFE_INT T55.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    7(9.809089e-45), 10(1.401298e-44)
 ; EG-NEXT:     BFE_INT T55.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T54.Y, PV.X,
 ; EG-NEXT:     BFE_INT T56.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.Y, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.Y, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    3(4.203895e-45), 6(8.407791e-45)
 ; EG-NEXT:     BFE_INT T56.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T55.Y, PV.X,
 ; EG-NEXT:     BFE_INT T57.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T8.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T9.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR T10.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T11.W, T19.Y, literal.y,
 ; EG-NEXT:    17(2.382207e-44), 2(2.802597e-45)
 ; EG-NEXT:     BFE_INT T57.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T56.Y, PV.X,
-; EG-NEXT:     ASHR T58.Z, T40.X, literal.x,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.y,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.z,
+; EG-NEXT:     ASHR T58.Z, T19.X, literal.x,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.y,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.z,
 ; EG-NEXT:    31(4.344025e-44), 27(3.783506e-44)
 ; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T58.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T57.Y, PV.X,
 ; EG-NEXT:     BFE_INT T59.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    23(3.222986e-44), 26(3.643376e-44)
 ; EG-NEXT:     BFE_INT T59.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T58.Y, PV.X,
 ; EG-NEXT:     BFE_INT T60.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    19(2.662467e-44), 22(3.082857e-44)
 ; EG-NEXT:     BFE_INT T60.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T59.Y, PV.X,
 ; EG-NEXT:     BFE_INT T61.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    15(2.101948e-44), 18(2.522337e-44)
 ; EG-NEXT:     BFE_INT T61.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T60.Y, PV.X,
 ; EG-NEXT:     BFE_INT T62.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    11(1.541428e-44), 14(1.961818e-44)
 ; EG-NEXT:     BFE_INT T62.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T61.Y, PV.X,
 ; EG-NEXT:     BFE_INT T63.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    7(9.809089e-45), 10(1.401298e-44)
 ; EG-NEXT:     BFE_INT T63.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T62.Y, PV.X,
 ; EG-NEXT:     BFE_INT T64.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR * T9.W, T40.X, literal.x,
-; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 253:
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.x,
-; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T64.X, PV.W, 0.0, 1,
-; EG-NEXT:     MOV T63.Y, T63.X,
-; EG-NEXT:     BFE_INT T65.Z, T9.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.x,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
+; EG-NEXT:    3(4.203895e-45), 6(8.407791e-45)
+; EG-NEXT:     BFE_INT T64.X, PS, 0.0, 1,
+; EG-NEXT:     MOV T63.Y, PV.X,
+; EG-NEXT:     BFE_INT T65.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR T11.W, T19.X, 1,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T65.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T64.Y, PV.X,
 ; EG-NEXT:     BFE_INT T49.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T9.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T11.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T12.W, T19.X, literal.y,
 ; EG-NEXT:    12(1.681558e-44), 5(7.006492e-45)
-; EG-NEXT:     BFE_INT T66.X, T40.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T66.X, T19.Y, 0.0, 1,
 ; EG-NEXT:     MOV T65.Y, PV.X,
 ; EG-NEXT:     BFE_INT T67.Z, PS, 0.0, 1,
-; EG-NEXT:     LSHR T10.W, T40.X, literal.x,
-; EG-NEXT:     LSHR * T11.W, T40.X, literal.y,
+; EG-NEXT:     LSHR T12.W, T19.X, literal.x,
+; EG-NEXT:     LSHR * T13.W, T19.X, literal.y,
 ; EG-NEXT:    9(1.261169e-44), 4(5.605194e-45)
 ; EG-NEXT:     BFE_INT T67.X, PS, 0.0, 1,
 ; EG-NEXT:     MOV T49.Y, T49.X,
-; EG-NEXT:     BFE_INT T40.Z, PV.W, 0.0, 1,
-; EG-NEXT:     LSHR T10.W, T40.X, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T11.W, T40.X, literal.y,
+; EG-NEXT:     BFE_INT T19.Z, PV.W, 0.0, 1,
+; EG-NEXT:     LSHR T12.W, T19.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T13.W, T19.X, literal.y,
 ; EG-NEXT:    13(1.821688e-44), 8(1.121039e-44)
-; EG-NEXT:     BFE_INT T40.X, PS, 0.0, 1,
-; EG-NEXT:     MOV T67.Y, PV.X,
-; EG-NEXT:     BFE_INT T68.Z, PV.W, 0.0, 1,
+; EG-NEXT:    ALU clause starting at 233:
+; EG-NEXT:     BFE_INT T19.X, T13.W, 0.0, 1,
+; EG-NEXT:     MOV T67.Y, T67.X,
+; EG-NEXT:     BFE_INT T68.Z, T12.W, 0.0, 1, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV T49.W, T49.Z,
 ; EG-NEXT:     MOV * T65.W, T65.Z,
-; EG-NEXT:     BFE_INT T68.X, T9.W, 0.0, 1,
-; EG-NEXT:     MOV T40.Y, PV.X,
-; EG-NEXT:     BFE_INT T69.Z, T8.W, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T68.X, T11.W, 0.0, 1,
+; EG-NEXT:     MOV T19.Y, PV.X,
+; EG-NEXT:     BFE_INT T69.Z, T10.W, 0.0, 1, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV T67.W, T67.Z,
 ; EG-NEXT:     MOV * T64.W, T64.Z,
-; EG-NEXT:     BFE_INT T69.X, T7.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T69.X, T6.Y, 0.0, 1,
 ; EG-NEXT:     MOV T68.Y, PV.X,
-; EG-NEXT:     BFE_INT T70.Z, T6.Y, 0.0, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     MOV T40.W, T40.Z,
+; EG-NEXT:     BFE_INT T70.Z, T5.Y, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     MOV T19.W, T19.Z,
 ; EG-NEXT:     MOV * T63.W, T63.Z,
-; EG-NEXT:     BFE_INT T70.X, T7.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T70.X, T9.W, 0.0, 1,
 ; EG-NEXT:     MOV T69.Y, PV.X,
-; EG-NEXT:     BFE_INT T71.Z, T6.W, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T71.Z, T8.W, 0.0, 1, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV T68.W, T68.Z,
 ; EG-NEXT:     MOV * T62.W, T62.Z,
-; EG-NEXT:     BFE_INT T71.X, T6.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T71.X, T4.Z, 0.0, 1,
 ; EG-NEXT:     MOV T70.Y, PV.X,
-; EG-NEXT:     BFE_INT T72.Z, T5.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T72.Z, T4.Y, 0.0, 1,
 ; EG-NEXT:     MOV T69.W, T69.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T61.W, T61.Z,
-; EG-NEXT:     BFE_INT T72.X, T5.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T72.X, T7.W, 0.0, 1,
 ; EG-NEXT:     MOV T71.Y, PV.X,
-; EG-NEXT:     BFE_INT T66.Z, T5.Z, 0.0, 1,
-; EG-NEXT:     MOV T70.W, T70.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T66.Z, T6.W, 0.0, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     MOV T70.W, T70.Z,
 ; EG-NEXT:     MOV * T60.W, T60.Z,
-; EG-NEXT:     LSHR T73.X, T4.Y, literal.x,
+; EG-NEXT:     ADD_INT T73.X, T20.X, literal.x,
 ; EG-NEXT:     MOV T72.Y, PV.X,
-; EG-NEXT:     BFE_INT T74.Z, T4.W, 0.0, 1,
-; EG-NEXT:     MOV T71.W, T71.Z,
+; EG-NEXT:     BFE_INT T74.Z, T3.Z, 0.0, 1,
+; EG-NEXT:     MOV T71.W, T71.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T59.W, T59.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T74.X, T4.Z, 0.0, 1,
+; EG-NEXT:    116(1.625506e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T74.X, T3.Y, 0.0, 1,
 ; EG-NEXT:     MOV T66.Y, T66.X,
-; EG-NEXT:     BFE_INT T75.Z, T3.Y, 0.0, 1,
-; EG-NEXT:     MOV T72.W, T72.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T75.Z, T5.W, 0.0, 1,
+; EG-NEXT:     MOV T72.W, T72.Z,
 ; EG-NEXT:     MOV * T58.W, T58.Z,
-; EG-NEXT:     BFE_INT T75.X, T3.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T75.X, T4.W, 0.0, 1,
 ; EG-NEXT:     MOV T74.Y, PV.X,
-; EG-NEXT:     BFE_INT T76.Z, T3.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T76.Z, T2.Z, 0.0, 1,
 ; EG-NEXT:     MOV T66.W, T66.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T57.W, T57.Z,
 ; EG-NEXT:     BFE_INT T76.X, T2.Y, 0.0, 1,
 ; EG-NEXT:     MOV T75.Y, PV.X,
-; EG-NEXT:     BFE_INT T77.Z, T2.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T77.Z, T3.W, 0.0, 1,
 ; EG-NEXT:     MOV T74.W, T74.Z,
 ; EG-NEXT:     MOV * T56.W, T56.Z,
-; EG-NEXT:     BFE_INT T77.X, T2.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T77.X, T2.W, 0.0, 1,
 ; EG-NEXT:     MOV T76.Y, PV.X,
-; EG-NEXT:     BFE_INT T78.Z, T1.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T78.Z, T1.Z, 0.0, 1,
 ; EG-NEXT:     MOV T75.W, T75.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T55.W, T55.Z,
-; EG-NEXT:     BFE_INT T78.X, T1.W, 0.0, 1,
+; EG-NEXT:     BFE_INT T78.X, T1.Y, 0.0, 1,
 ; EG-NEXT:     MOV T77.Y, PV.X,
-; EG-NEXT:     BFE_INT T79.Z, T1.Z, 0.0, 1,
-; EG-NEXT:     MOV T76.W, T76.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T79.Z, T1.W, 0.0, 1,
+; EG-NEXT:     MOV T76.W, T76.Z,
 ; EG-NEXT:     MOV * T54.W, T54.Z,
-; EG-NEXT:     BFE_INT T79.X, T0.Y, 0.0, 1,
+; EG-NEXT:     BFE_INT T79.X, T0.W, 0.0, 1,
 ; EG-NEXT:     MOV T78.Y, PV.X,
-; EG-NEXT:     BFE_INT T80.Z, T0.W, 0.0, 1,
-; EG-NEXT:     MOV T77.W, T77.Z,
+; EG-NEXT:     BFE_INT T80.Z, T0.Z, 0.0, 1,
+; EG-NEXT:     MOV T77.W, T77.Z, BS:VEC_120/SCL_212
 ; EG-NEXT:     MOV * T53.W, T53.Z,
-; EG-NEXT:     BFE_INT T80.X, T0.Z, 0.0, 1,
+; EG-NEXT:     BFE_INT T80.X, T0.Y, 0.0, 1,
 ; EG-NEXT:     MOV T79.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
-; EG-NEXT:     MOV T78.W, T78.Z, BS:VEC_120/SCL_212
+; EG-NEXT:     MOV T78.W, T78.Z,
 ; EG-NEXT:     MOV * T52.W, T52.Z,
-; EG-NEXT:    480(6.726233e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T81.X, PV.Z, literal.x,
+; EG-NEXT:     ADD_INT T81.X, T20.X, literal.x,
 ; EG-NEXT:     MOV T80.Y, PV.X,
-; EG-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
 ; EG-NEXT:     MOV T79.W, T79.Z,
 ; EG-NEXT:     MOV * T51.W, T51.Z,
-; EG-NEXT:    2(2.802597e-45), 496(6.950440e-43)
-; EG-NEXT:     LSHR T82.X, PV.Z, literal.x,
+; EG-NEXT:    120(1.681558e-43), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T82.X, T20.X, literal.x,
 ; EG-NEXT:     MOV T80.W, T80.Z,
 ; EG-NEXT:     MOV * T50.W, T50.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    124(1.737610e-43), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v64i1_to_v64i64:
 ; GFX12:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
@@ -518,7 +518,7 @@ define amdgpu_kernel void @constant_load_v16i16(ptr addrspace(1) %out, ptr addrs
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -528,11 +528,10 @@ define amdgpu_kernel void @constant_load_v16i16(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_load_v16i16:
 ; GFX12:       ; %bb.0: ; %entry
@@ -1381,9 +1380,9 @@ define amdgpu_kernel void @constant_zextload_v3i16_to_v3i32(ptr addrspace(1) %ou
 ;
 ; EG-LABEL: constant_zextload_v3i16_to_v3i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 4, @12, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 2, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @6
-; EG-NEXT:    ALU 2, @17, KC0[], KC1[]
+; EG-NEXT:    ALU 2, @15, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XY, T0.X, 1
 ; EG-NEXT:    CF_END
@@ -1395,11 +1394,9 @@ define amdgpu_kernel void @constant_zextload_v3i16_to_v3i32(ptr addrspace(1) %ou
 ; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     MOV * T1.X, KC0[2].Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 17:
-; EG-NEXT:     LSHR T4.X, T0.W, literal.x,
-; EG-NEXT:     MOV * T3.Y, T1.X,
+; EG-NEXT:    ALU clause starting at 15:
+; EG-NEXT:     ADD_INT T4.X, T0.X, literal.x,
+; EG-NEXT:     MOV * T3.Y, T1.X, BS:VEC_120/SCL_212
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v3i16_to_v3i32:
@@ -1483,9 +1480,9 @@ define amdgpu_kernel void @constant_sextload_v3i16_to_v3i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @6
-; EG-NEXT:    ALU 9, @13, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; EG-NEXT:    ALU 8, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_16 T1.X, T0.X, 2, #1
@@ -1496,13 +1493,12 @@ define amdgpu_kernel void @constant_sextload_v3i16_to_v3i32(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 13:
 ; EG-NEXT:     BFE_INT * T0.Y, T1.X, 0.0, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T0.X, T0.X, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
+; EG-NEXT:     BFE_INT * T0.X, T0.X, 0.0, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T1.X, T2.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
-; EG-NEXT:     BFE_INT T2.X, T2.X, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v3i16_to_v3i32:
@@ -1847,7 +1843,7 @@ define amdgpu_kernel void @constant_zextload_v8i16_to_v8i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T10.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -1858,22 +1854,20 @@ define amdgpu_kernel void @constant_zextload_v8i16_to_v8i32(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     LSHR * T8.W, T7.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T8.Z, T7.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T8.Y, T7.X, literal.x,
-; EG-NEXT:     LSHR * T9.W, T7.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
-; EG-NEXT:     AND_INT T9.Z, T7.W, literal.x,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR * T9.Y, T7.Z, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T9.X, T7.Z, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T8.Z, T7.Y, literal.x,
+; EG-NEXT:     LSHR * T9.W, T7.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T10.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T8.Y, T7.X, literal.x,
+; EG-NEXT:     AND_INT * T9.Z, T7.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
+; EG-NEXT:     LSHR T9.Y, T7.Z, literal.y,
+; EG-NEXT:     AND_INT * T9.X, T7.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T10.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i16_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -2008,7 +2002,7 @@ define amdgpu_kernel void @constant_sextload_v8i16_to_v8i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 19, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T10.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -2030,13 +2024,12 @@ define amdgpu_kernel void @constant_sextload_v8i16_to_v8i32(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     BFE_INT T8.Y, PS, 0.0, literal.y,
-; EG-NEXT:     LSHR T1.Z, T7.Z, literal.y,
 ; EG-NEXT:     BFE_INT T9.W, PV.Z, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Z, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T9.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T10.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT * T9.Y, PS, 0.0, literal.y,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v8i16_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -2240,11 +2233,11 @@ define amdgpu_kernel void @constant_zextload_v16i16_to_v16i32(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 35, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 31, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T18.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T11.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T16.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T12.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T15.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -2254,40 +2247,36 @@ define amdgpu_kernel void @constant_zextload_v16i16_to_v16i32(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 13:
 ; EG-NEXT:     LSHR * T13.W, T12.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T13.Z, T12.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T13.Y, T12.X, literal.x,
-; EG-NEXT:     LSHR * T14.W, T12.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T13.X, T12.X, literal.x,
-; EG-NEXT:     AND_INT T14.Z, T12.W, literal.x,
-; EG-NEXT:     LSHR * T12.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR T14.Y, T12.Z, literal.x,
-; EG-NEXT:     LSHR * T15.W, T11.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T14.X, T12.Z, literal.x,
-; EG-NEXT:     AND_INT T15.Z, T11.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T13.Z, T12.Y, literal.x,
+; EG-NEXT:     LSHR * T14.W, T12.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T15.Y, T11.X, literal.y,
+; EG-NEXT:     LSHR T13.Y, T12.X, literal.x,
+; EG-NEXT:     AND_INT * T14.Z, T12.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T13.X, T12.X, literal.x,
+; EG-NEXT:     LSHR T14.Y, T12.Z, literal.y,
+; EG-NEXT:     AND_INT * T14.X, T12.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T12.W, T11.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
+; EG-NEXT:     AND_INT * T12.Z, T11.Y, literal.y,
+; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T12.Y, T11.X, literal.y,
 ; EG-NEXT:     LSHR T17.W, T11.W, literal.y,
-; EG-NEXT:     AND_INT * T15.X, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     AND_INT * T12.X, T11.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T17.Z, T11.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
+; EG-NEXT:     AND_INT * T17.Z, T11.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T11.X, T15.X, literal.x,
 ; EG-NEXT:     LSHR T17.Y, T11.Z, literal.y,
 ; EG-NEXT:     AND_INT * T17.X, T11.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T18.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T18.X, T15.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i16_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2505,7 +2494,7 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i32(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 39, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 35, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T14.X, 0
@@ -2517,20 +2506,18 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i32(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 12:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 13:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_INT * T15.Z, T11.Y, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T15.X, T11.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Y, T12.W, literal.x,
-; EG-NEXT:     BFE_INT T16.Z, T11.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T16.Z, T11.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.W, T12.Y, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T11.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T16.X, T11.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Y, T11.W, literal.x,
+; EG-NEXT:     LSHR T0.Y, T11.W, literal.x,
 ; EG-NEXT:     BFE_INT T17.Z, T12.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T15.W, PS, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T11.X, literal.x,
@@ -2543,20 +2530,18 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i32(ptr addrspace(1) %
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T18.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T16.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Z, T12.X, literal.x,
-; EG-NEXT:     BFE_INT T17.W, T0.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T17.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T12.Z, literal.y,
-; EG-NEXT:     BFE_INT T18.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T18.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR T0.Z, T12.W, literal.x,
+; EG-NEXT:     BFE_INT T17.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T12.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T11.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T17.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T18.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T12.Z, literal.y,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T12.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT * T18.Y, PS, 0.0, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v16i16_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2920,15 +2905,15 @@ define amdgpu_kernel void @constant_zextload_v32i16_to_v32i32(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 71, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 62, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T32.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T19.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T19.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T20.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T25.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
@@ -2940,76 +2925,67 @@ define amdgpu_kernel void @constant_zextload_v32i16_to_v32i32(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 21:
 ; EG-NEXT:     LSHR * T23.W, T20.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T23.Z, T20.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.Y, T20.X, literal.x,
-; EG-NEXT:     LSHR * T24.W, T20.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T23.X, T20.X, literal.x,
-; EG-NEXT:     AND_INT T24.Z, T20.W, literal.x,
-; EG-NEXT:     LSHR * T20.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR T24.Y, T20.Z, literal.x,
-; EG-NEXT:     LSHR * T25.W, T19.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T24.X, T20.Z, literal.x,
-; EG-NEXT:     AND_INT T25.Z, T19.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T23.Z, T20.Y, literal.x,
+; EG-NEXT:     LSHR * T24.W, T20.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T25.Y, T19.X, literal.y,
+; EG-NEXT:     LSHR T23.Y, T20.X, literal.x,
+; EG-NEXT:     AND_INT * T24.Z, T20.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T23.X, T20.X, literal.x,
+; EG-NEXT:     LSHR T24.Y, T20.Z, literal.y,
+; EG-NEXT:     AND_INT * T24.X, T20.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T20.W, T19.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T25.X, KC0[2].Y, literal.x,
+; EG-NEXT:     AND_INT * T20.Z, T19.Y, literal.y,
+; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; EG-NEXT:     ADD_INT T26.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T20.Y, T19.X, literal.y,
 ; EG-NEXT:     LSHR T27.W, T19.W, literal.y,
-; EG-NEXT:     AND_INT * T25.X, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     AND_INT * T20.X, T19.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T27.Z, T19.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
+; EG-NEXT:     AND_INT * T27.Z, T19.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T19.X, T25.X, literal.x,
 ; EG-NEXT:     LSHR T27.Y, T19.Z, literal.y,
 ; EG-NEXT:     LSHR T28.W, T22.Y, literal.y,
 ; EG-NEXT:     AND_INT * T27.X, T19.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T28.Z, T22.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T28.Y, T22.X, literal.y,
+; EG-NEXT:     AND_INT * T28.Z, T22.Y, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T29.X, T25.X, literal.x,
+; EG-NEXT:     LSHR T28.Y, T22.X, literal.y, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR T30.W, T22.W, literal.y,
 ; EG-NEXT:     AND_INT * T28.X, T22.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T30.Z, T22.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 64(8.968310e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T30.Y, T22.Z, literal.y,
-; EG-NEXT:     LSHR T31.W, T21.Y, literal.y,
-; EG-NEXT:     AND_INT * T30.X, T22.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     AND_INT * T30.Z, T22.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T31.Z, T21.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 80(1.121039e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T31.Y, T21.X, literal.y,
+; EG-NEXT:     ADD_INT T22.X, T25.X, literal.x,
+; EG-NEXT:     LSHR T30.Y, T22.Z, literal.x,
+; EG-NEXT:     LSHR T31.W, T21.Y, literal.x,
+; EG-NEXT:     AND_INT * T30.X, T22.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT * T31.Z, T21.Y, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T32.X, T25.X, literal.x,
+; EG-NEXT:     LSHR T31.Y, T21.X, literal.y, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR T33.W, T21.W, literal.y,
 ; EG-NEXT:     AND_INT * T31.X, T21.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T33.Z, T21.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 96(1.345247e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
+; EG-NEXT:     AND_INT * T33.Z, T21.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T21.X, T25.X, literal.x,
 ; EG-NEXT:     LSHR T33.Y, T21.Z, literal.y,
 ; EG-NEXT:     AND_INT * T33.X, T21.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T34.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T34.X, T25.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i16_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -3402,108 +3378,96 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i32(ptr addrspace(1) %
 ;
 ; EG-LABEL: constant_sextload_v32i16_to_v32i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 8, @20, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 73, @29, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T22.X, 0
+; EG-NEXT:    ALU 69, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T19.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T27.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T21.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T20.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T19.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T23.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
-; EG-NEXT:     VTX_READ_128 T23.XYZW, T22.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T24.XYZW, T22.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T25.XYZW, T22.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T22.XYZW, T22.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T21.XYZW, T19.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T19.XYZW, T19.X, 48, #1
 ; EG-NEXT:    ALU clause starting at 20:
-; EG-NEXT:     LSHR T19.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T22.X, KC0[2].Z,
+; EG-NEXT:     MOV * T19.X, KC0[2].Z,
+; EG-NEXT:    ALU clause starting at 21:
+; EG-NEXT:     LSHR * T23.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 29:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.W, T22.W, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T28.X, PS, literal.x,
-; EG-NEXT:     LSHR T0.Y, T22.Y, literal.y,
-; EG-NEXT:     BFE_INT T29.Z, T25.Y, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T1.W, T24.W, literal.y,
-; EG-NEXT:     LSHR * T2.W, T24.Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T29.X, T25.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Y, T23.W, literal.x,
-; EG-NEXT:     BFE_INT T30.Z, T25.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T3.W, T23.Y, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.Y, literal.x,
+; EG-NEXT:     ADD_INT T24.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T26.X, T23.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T23.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T28.X, T23.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T19.Y, literal.y,
+; EG-NEXT:     BFE_INT T29.Z, T22.Y, 0.0, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T0.W, T21.W, literal.y,
+; EG-NEXT:     LSHR * T1.W, T21.Y, literal.y,
+; EG-NEXT:    20(2.802597e-44), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT T29.X, T22.X, 0.0, literal.x,
+; EG-NEXT:     LSHR T1.Y, T20.W, literal.x,
+; EG-NEXT:     BFE_INT T30.Z, T22.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T2.W, T20.Y, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T30.X, T25.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.Y, T25.W, literal.x,
-; EG-NEXT:     BFE_INT T31.Z, T23.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.X, T22.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR T2.Y, T22.W, literal.x,
+; EG-NEXT:     BFE_INT T31.Z, T20.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T29.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.X, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T31.X, T23.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T31.X, T20.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T29.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T32.Z, T23.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T32.Z, T20.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T30.W, PV.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.Z, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T32.X, T23.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T32.X, T20.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T30.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.Z, T24.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.W, T3.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T23.X, literal.x,
+; EG-NEXT:     BFE_INT T22.Z, T21.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T31.W, T2.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.W, T20.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T25.X, T24.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.X, T21.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T31.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T33.Z, T24.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T33.Z, T21.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T32.W, T1.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T23.Z, literal.x,
+; EG-NEXT:     LSHR * T2.W, T20.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T33.X, T24.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T33.X, T21.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T32.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.Z, T22.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.W, T2.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T2.W, T24.X, literal.x,
+; EG-NEXT:     BFE_INT T20.Z, T19.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.W, T1.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T1.W, T21.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T23.X, T22.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T34.Z, T22.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T33.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, T24.Z, literal.x,
+; EG-NEXT:     BFE_INT T20.X, T19.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T34.Z, T19.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T33.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T21.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T34.X, T22.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T34.X, T19.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T33.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Z, T22.X, literal.x,
-; EG-NEXT:     BFE_INT T23.W, T0.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T22.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T23.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T22.Z, literal.y,
-; EG-NEXT:     BFE_INT T34.W, T0.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T34.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR T0.Z, T19.W, literal.x,
+; EG-NEXT:     BFE_INT T20.W, T0.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T19.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T19.X, T23.X, literal.x,
+; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T34.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T19.Z, literal.y,
+; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T21.X, T23.X, literal.x,
+; EG-NEXT:     BFE_INT * T34.Y, PS, 0.0, literal.y,
+; EG-NEXT:    28(3.923636e-44), 16(2.242078e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v32i16_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -4185,185 +4149,158 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; EG-LABEL: constant_zextload_v64i16_to_v64i32:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 3 @22
-; EG-NEXT:    ALU 55, @39, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 3 @30
-; EG-NEXT:    ALU 87, @95, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 2 @22
+; EG-NEXT:    ALU 34, @39, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 4 @28
+; EG-NEXT:    ALU 81, @74, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T65.XYZW, T66.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T45.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T62.XYZW, T64.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T50.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T46.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T61.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T51.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T47.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T56.XYZW, T58.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T54.XYZW, T52.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T54.XYZW, T48.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T53.XYZW, T55.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T39.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T48.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T46.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T43.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T38.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T51.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T50.XYZW, T52.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T44.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T40.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T42.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T41.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T38.XYZW, T37.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T39.XYZW, T37.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T40.XYZW, T37.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T41.XYZW, T37.X, 16, #1
-; EG-NEXT:    Fetch clause starting at 30:
-; EG-NEXT:     VTX_READ_128 T49.XYZW, T37.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T50.XYZW, T37.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T51.XYZW, T37.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T52.XYZW, T37.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T37.XYZW, T38.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T39.XYZW, T38.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T40.XYZW, T38.X, 16, #1
+; EG-NEXT:    Fetch clause starting at 28:
+; EG-NEXT:     VTX_READ_128 T45.XYZW, T38.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T46.XYZW, T38.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T47.XYZW, T38.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T48.XYZW, T38.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T49.XYZW, T38.X, 48, #1
 ; EG-NEXT:    ALU clause starting at 38:
-; EG-NEXT:     MOV * T37.X, KC0[2].Z,
+; EG-NEXT:     MOV * T38.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 39:
-; EG-NEXT:     LSHR * T35.W, T38.Y, literal.x,
+; EG-NEXT:     LSHR * T35.W, T37.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T35.Z, T38.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.Y, T38.X, literal.x,
-; EG-NEXT:     LSHR * T36.W, T38.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T35.X, T38.X, literal.x,
-; EG-NEXT:     AND_INT T36.Z, T38.W, literal.x,
-; EG-NEXT:     LSHR * T38.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR T36.Y, T38.Z, literal.x,
-; EG-NEXT:     LSHR * T42.W, T41.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T36.X, T38.Z, literal.x,
-; EG-NEXT:     AND_INT T42.Z, T41.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T35.Z, T37.Y, literal.x,
+; EG-NEXT:     LSHR * T36.W, T37.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T43.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T42.Y, T41.X, literal.y,
-; EG-NEXT:     LSHR T44.W, T41.W, literal.y,
-; EG-NEXT:     AND_INT * T42.X, T41.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T44.Z, T41.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T44.Y, T41.Z, literal.y,
-; EG-NEXT:     LSHR T45.W, T40.Y, literal.y,
-; EG-NEXT:     AND_INT * T44.X, T41.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T45.Z, T40.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T45.Y, T40.X, literal.y,
-; EG-NEXT:     LSHR T47.W, T40.W, literal.y,
-; EG-NEXT:     AND_INT * T45.X, T40.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T47.Z, T40.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 64(8.968310e-44)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T47.Y, T40.Z, literal.y,
-; EG-NEXT:     AND_INT * T47.X, T40.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR * T37.W, T39.Y, literal.y,
-; EG-NEXT:    80(1.121039e-43), 16(2.242078e-44)
-; EG-NEXT:     LSHR T48.X, PV.W, literal.x,
-; EG-NEXT:     AND_INT * T37.Z, T39.Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    ALU clause starting at 95:
-; EG-NEXT:     LSHR T37.Y, T39.X, literal.x,
-; EG-NEXT:     LSHR * T53.W, T39.W, literal.x,
+; EG-NEXT:     LSHR T35.Y, T37.X, literal.x,
+; EG-NEXT:     AND_INT * T36.Z, T37.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T35.X, T37.X, literal.x,
+; EG-NEXT:     LSHR T36.Y, T37.Z, literal.y,
+; EG-NEXT:     AND_INT * T36.X, T37.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T37.W, T40.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T37.X, T39.X, literal.x,
-; EG-NEXT:     AND_INT T53.Z, T39.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 96(1.345247e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T53.Y, T39.Z, literal.y,
-; EG-NEXT:     LSHR T54.W, T52.Y, literal.y,
-; EG-NEXT:     AND_INT * T53.X, T39.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR T41.X, KC0[2].Y, literal.x,
+; EG-NEXT:     AND_INT * T37.Z, T40.Y, literal.y,
+; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; EG-NEXT:     ADD_INT T42.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T37.Y, T40.X, literal.y,
+; EG-NEXT:     LSHR T43.W, T40.W, literal.y,
+; EG-NEXT:     AND_INT * T37.X, T40.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T54.Z, T52.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 112(1.569454e-43)
-; EG-NEXT:     LSHR T55.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T54.Y, T52.X, literal.y,
-; EG-NEXT:     LSHR T56.W, T52.W, literal.y,
-; EG-NEXT:     AND_INT * T54.X, T52.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     AND_INT * T43.Z, T40.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T56.Z, T52.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 128(1.793662e-43)
-; EG-NEXT:     LSHR T52.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T56.Y, T52.Z, literal.y,
-; EG-NEXT:     LSHR T57.W, T51.Y, literal.y,
-; EG-NEXT:     AND_INT * T56.X, T52.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T40.X, T41.X, literal.x,
+; EG-NEXT:     LSHR T43.Y, T40.Z, literal.y,
+; EG-NEXT:     AND_INT * T43.X, T40.Z, literal.z,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T57.Z, T51.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 144(2.017870e-43)
-; EG-NEXT:     LSHR T58.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T57.Y, T51.X, literal.y,
-; EG-NEXT:     LSHR T59.W, T51.W, literal.y,
-; EG-NEXT:     AND_INT * T57.X, T51.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T59.Z, T51.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 160(2.242078e-43)
-; EG-NEXT:     LSHR T51.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T59.Y, T51.Z, literal.y,
-; EG-NEXT:     LSHR T60.W, T50.Y, literal.y,
-; EG-NEXT:     AND_INT * T59.X, T51.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T60.Z, T50.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 176(2.466285e-43)
-; EG-NEXT:     LSHR T61.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T60.Y, T50.X, literal.y,
-; EG-NEXT:     LSHR T62.W, T50.W, literal.y,
-; EG-NEXT:     AND_INT * T60.X, T50.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T62.Z, T50.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 192(2.690493e-43)
-; EG-NEXT:     LSHR T50.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T62.Y, T50.Z, literal.y,
-; EG-NEXT:     LSHR T63.W, T49.Y, literal.y,
-; EG-NEXT:     AND_INT * T62.X, T50.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T63.Z, T49.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 208(2.914701e-43)
-; EG-NEXT:     LSHR T64.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T63.Y, T49.X, literal.y,
-; EG-NEXT:     LSHR T65.W, T49.W, literal.y,
-; EG-NEXT:     AND_INT * T63.X, T49.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T65.Z, T49.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 224(3.138909e-43)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T65.Y, T49.Z, literal.y,
-; EG-NEXT:     AND_INT * T65.X, T49.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T66.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T38.W, T39.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T44.X, T41.X, literal.x,
+; EG-NEXT:     AND_INT * T38.Z, T39.Y, literal.y,
+; EG-NEXT:    12(1.681558e-44), 65535(9.183409e-41)
+; EG-NEXT:    ALU clause starting at 74:
+; EG-NEXT:     LSHR T38.Y, T39.X, literal.x,
+; EG-NEXT:     LSHR * T50.W, T39.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T38.X, T39.X, literal.x,
+; EG-NEXT:     AND_INT T50.Z, T39.W, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR T50.Y, T39.Z, literal.x,
+; EG-NEXT:     LSHR * T51.W, T49.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T50.X, T39.Z, literal.x,
+; EG-NEXT:     AND_INT T51.Z, T49.Y, literal.x,
+; EG-NEXT:     ADD_INT * T52.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 20(2.802597e-44)
+; EG-NEXT:     LSHR T51.Y, T49.X, literal.x,
+; EG-NEXT:     LSHR * T53.W, T49.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T51.X, T49.X, literal.x,
+; EG-NEXT:     AND_INT T53.Z, T49.W, literal.x,
+; EG-NEXT:     ADD_INT * T49.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 24(3.363116e-44)
+; EG-NEXT:     LSHR T53.Y, T49.Z, literal.x,
+; EG-NEXT:     LSHR * T54.W, T48.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T53.X, T49.Z, literal.x,
+; EG-NEXT:     AND_INT T54.Z, T48.Y, literal.x,
+; EG-NEXT:     ADD_INT * T55.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 28(3.923636e-44)
+; EG-NEXT:     LSHR T54.Y, T48.X, literal.x,
+; EG-NEXT:     LSHR * T56.W, T48.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T54.X, T48.X, literal.x,
+; EG-NEXT:     AND_INT T56.Z, T48.W, literal.x,
+; EG-NEXT:     ADD_INT * T48.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
+; EG-NEXT:     LSHR T56.Y, T48.Z, literal.x,
+; EG-NEXT:     LSHR * T57.W, T47.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T56.X, T48.Z, literal.x,
+; EG-NEXT:     AND_INT T57.Z, T47.Y, literal.x,
+; EG-NEXT:     ADD_INT * T58.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 36(5.044674e-44)
+; EG-NEXT:     LSHR T57.Y, T47.X, literal.x,
+; EG-NEXT:     LSHR * T59.W, T47.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T57.X, T47.X, literal.x,
+; EG-NEXT:     AND_INT T59.Z, T47.W, literal.x,
+; EG-NEXT:     ADD_INT * T47.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 40(5.605194e-44)
+; EG-NEXT:     LSHR T59.Y, T47.Z, literal.x,
+; EG-NEXT:     LSHR * T60.W, T46.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T59.X, T47.Z, literal.x,
+; EG-NEXT:     AND_INT T60.Z, T46.Y, literal.x,
+; EG-NEXT:     ADD_INT * T61.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 44(6.165713e-44)
+; EG-NEXT:     LSHR T60.Y, T46.X, literal.x,
+; EG-NEXT:     LSHR * T62.W, T46.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T60.X, T46.X, literal.x,
+; EG-NEXT:     AND_INT T62.Z, T46.W, literal.x,
+; EG-NEXT:     ADD_INT * T46.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
+; EG-NEXT:     LSHR T62.Y, T46.Z, literal.x,
+; EG-NEXT:     LSHR * T63.W, T45.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T62.X, T46.Z, literal.x,
+; EG-NEXT:     AND_INT T63.Z, T45.Y, literal.x,
+; EG-NEXT:     ADD_INT * T64.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 52(7.286752e-44)
+; EG-NEXT:     LSHR T63.Y, T45.X, literal.x,
+; EG-NEXT:     LSHR * T65.W, T45.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T63.X, T45.X, literal.x,
+; EG-NEXT:     AND_INT T65.Z, T45.W, literal.x,
+; EG-NEXT:     ADD_INT * T45.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 56(7.847271e-44)
+; EG-NEXT:     LSHR * T65.Y, T45.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T65.X, T45.Z, literal.x,
+; EG-NEXT:     ADD_INT * T66.X, T41.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 60(8.407791e-44)
 ;
 ; GFX12-LABEL: constant_zextload_v64i16_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -5103,206 +5040,181 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ;
 ; EG-LABEL: constant_sextload_v64i16_to_v64i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 17, @38, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @22
-; EG-NEXT:    ALU 75, @56, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 71, @132, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T66.XYZW, T48.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T41.X, 0
+; EG-NEXT:    ALU 73, @39, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 65, @113, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T66.XYZW, T36.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T65.XYZW, T56.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T55.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T55.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T64.XYZW, T54.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T53.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T53.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T52.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T51.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T51.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T62.XYZW, T50.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T49.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T61.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T39.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T38.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T35.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T61.XYZW, T48.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T47.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T46.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T45.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T44.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T43.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T42.XYZW, T41.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T43.XYZW, T41.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T44.XYZW, T41.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T45.XYZW, T41.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T46.XYZW, T41.X, 64, #1
-; EG-NEXT:     VTX_READ_128 T47.XYZW, T41.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T48.XYZW, T41.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T41.XYZW, T41.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T41.XYZW, T35.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T40.XYZW, T35.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T42.XYZW, T35.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T39.XYZW, T35.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T38.XYZW, T35.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T36.XYZW, T35.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T35.XYZW, T35.X, 112, #1
 ; EG-NEXT:    ALU clause starting at 38:
-; EG-NEXT:     LSHR T35.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T41.X, KC0[2].Z,
+; EG-NEXT:     MOV * T35.X, KC0[2].Z,
+; EG-NEXT:    ALU clause starting at 39:
+; EG-NEXT:     LSHR * T43.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 56:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T50.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T51.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T52.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T53.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Y, T41.W, literal.y,
-; EG-NEXT:     LSHR T0.Z, T41.Y, literal.y,
-; EG-NEXT:     LSHR T0.W, T48.W, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T54.X, PS, literal.x,
-; EG-NEXT:     LSHR T1.Y, T48.Y, literal.y,
-; EG-NEXT:     LSHR T1.Z, T47.W, literal.y,
-; EG-NEXT:     LSHR T1.W, T47.Y, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T55.X, PS, literal.x,
-; EG-NEXT:     LSHR T2.Y, T46.W, literal.y,
-; EG-NEXT:     LSHR T2.Z, T46.Y, literal.y,
-; EG-NEXT:     LSHR T2.W, T45.W, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T56.X, PS, literal.x,
-; EG-NEXT:     LSHR T3.Y, T45.Y, literal.y,
-; EG-NEXT:     BFE_INT T57.Z, T44.Y, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T3.W, T43.W, literal.y,
-; EG-NEXT:     LSHR * T4.W, T43.Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T57.X, T44.X, 0.0, literal.x,
+; EG-NEXT:     ADD_INT T44.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T45.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T46.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T47.X, T43.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T48.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T49.X, T43.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T50.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T51.X, T43.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T52.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T53.X, T43.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T54.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T35.Y, literal.y,
+; EG-NEXT:     LSHR T0.Z, T36.W, literal.y,
+; EG-NEXT:     LSHR T0.W, T36.Y, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T37.W, literal.y,
+; EG-NEXT:    44(6.165713e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T55.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T37.Y, literal.y,
+; EG-NEXT:     LSHR T1.Z, T38.W, literal.y,
+; EG-NEXT:     LSHR T2.W, T38.Y, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T39.W, literal.y,
+; EG-NEXT:    48(6.726233e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T56.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T39.Y, literal.y,
+; EG-NEXT:     BFE_INT T57.Z, T42.Y, 0.0, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T4.W, T40.W, literal.y,
+; EG-NEXT:     LSHR * T5.W, T40.Y, literal.y,
+; EG-NEXT:    52(7.286752e-44), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT T57.X, T42.X, 0.0, literal.x,
+; EG-NEXT:     LSHR T3.Y, T41.W, literal.x,
+; EG-NEXT:     BFE_INT T58.Z, T42.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T6.W, T41.Y, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T58.X, T42.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR T4.Y, T42.W, literal.x,
-; EG-NEXT:     BFE_INT T58.Z, T44.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T5.W, T42.Y, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T58.X, T44.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T5.Y, T44.W, literal.x,
-; EG-NEXT:     BFE_INT T59.Z, T42.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.Z, T41.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T57.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.X, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T59.X, T42.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.X, T41.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T57.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T60.Z, T42.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T60.Z, T41.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T58.W, PV.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.Z, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T60.X, T42.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T60.X, T41.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T58.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.Z, T43.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T59.W, T5.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T5.W, T42.X, literal.x,
+; EG-NEXT:     BFE_INT T42.Z, T40.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.W, T6.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T6.W, T41.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T44.X, T43.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.X, T40.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T59.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T61.Z, T43.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T60.W, T4.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T5.W, T42.Z, literal.x,
+; EG-NEXT:     BFE_INT T61.Z, T40.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T60.W, T3.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T6.W, T41.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T61.X, T43.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T61.X, T40.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T60.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.Z, T45.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT * T44.W, T4.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.Z, T39.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.W, T5.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T5.W, T40.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 132:
-; EG-NEXT:     LSHR * T4.W, T43.X, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T39.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT * T42.Y, PS, 0.0, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T42.X, T45.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.Y, PV.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T62.Z, T45.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T61.W, T3.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T43.Z, literal.x,
+; EG-NEXT:    ALU clause starting at 113:
+; EG-NEXT:     BFE_INT T62.Z, T39.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T61.W, T4.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T4.W, T40.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T62.X, T45.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T62.X, T39.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T61.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Z, T46.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.W, T3.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T45.X, literal.x,
+; EG-NEXT:     BFE_INT T40.Z, T38.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.W, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T4.W, T39.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T43.X, T46.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T63.Z, T46.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T62.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T2.W, T45.Z, literal.x,
+; EG-NEXT:     BFE_INT T40.X, T38.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.Z, T38.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T62.W, T3.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T39.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T63.X, T46.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.X, T38.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T62.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Z, T47.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.W, T2.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T2.W, T46.X, literal.x,
+; EG-NEXT:     BFE_INT T39.Z, T37.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.W, T2.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.W, T38.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T45.X, T47.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T64.Z, T47.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T63.W, T2.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T2.W, T46.Z, literal.x,
+; EG-NEXT:     BFE_INT T39.X, T37.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.Z, T37.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.W, T1.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.W, T38.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T64.X, T47.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.X, T37.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T63.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.Z, T48.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.W, T1.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.W, T47.X, literal.x,
+; EG-NEXT:     BFE_INT T38.Z, T36.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.W, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T37.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T46.X, T48.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T65.Z, T48.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T64.W, T1.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.W, T47.Z, literal.x,
+; EG-NEXT:     BFE_INT T38.X, T36.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T65.Z, T36.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T37.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T65.X, T48.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T65.X, T36.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T64.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T47.Z, T41.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.W, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, T48.X, literal.x,
+; EG-NEXT:     BFE_INT T37.Z, T35.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T38.W, T0.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T36.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T47.X, T41.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T66.Z, T41.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T65.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T0.W, T48.Z, literal.x,
+; EG-NEXT:     BFE_INT T37.X, T35.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T38.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T66.Z, T35.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T65.W, T0.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T36.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T66.X, T41.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T66.X, T35.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T65.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Z, T41.X, literal.x,
-; EG-NEXT:     BFE_INT T47.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 224(3.138909e-43)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T47.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T41.Z, literal.y,
-; EG-NEXT:     BFE_INT T66.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T48.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T66.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR T0.Z, T35.W, literal.x,
+; EG-NEXT:     BFE_INT T37.W, T0.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T35.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T35.X, T43.X, literal.x,
+; EG-NEXT:     BFE_INT T37.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T66.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T35.Z, literal.y,
+; EG-NEXT:    56(7.847271e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T36.X, T43.X, literal.x,
+; EG-NEXT:     BFE_INT * T66.Y, PS, 0.0, literal.y,
+; EG-NEXT:    60(8.407791e-44), 16(2.242078e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v64i16_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -6114,7 +6026,7 @@ define amdgpu_kernel void @constant_zextload_v4i16_to_v4i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 13, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -6133,11 +6045,10 @@ define amdgpu_kernel void @constant_zextload_v4i16_to_v4i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV T5.Y, 0.0,
 ; EG-NEXT:     MOV T6.W, 0.0,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T8.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T8.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v4i16_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6265,32 +6176,31 @@ define amdgpu_kernel void @constant_sextload_v4i16_to_v4i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T6.X, 1
+; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T8.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T5.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     ASHR * T5.W, T5.X, literal.x,
+; EG-NEXT:     ASHR * T6.W, T5.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ASHR T5.Z, T5.X, literal.y,
-; EG-NEXT:     ASHR * T7.W, T5.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T5.X, T5.X, 0.0, literal.x,
-; EG-NEXT:     ASHR * T7.Z, T5.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T5.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; EG-NEXT:     ASHR T6.Z, T5.Y, literal.x,
+; EG-NEXT:     ASHR * T5.W, T5.X, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T7.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
+; EG-NEXT:     ASHR * T5.Z, T5.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T5.X, T5.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
+; EG-NEXT:     ASHR * T5.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T8.X, T7.X, literal.x,
+; EG-NEXT:     ASHR * T6.Y, T6.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v4i16_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6451,7 +6361,7 @@ define amdgpu_kernel void @constant_zextload_v8i16_to_v8i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 30, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 26, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T12.X, 0
@@ -6482,17 +6392,13 @@ define amdgpu_kernel void @constant_zextload_v8i16_to_v8i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV * T9.W, 0.0,
 ; EG-NEXT:     MOV T10.W, 0.0,
 ; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     LSHR T11.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T14.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T11.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T13.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T14.X, T11.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i16_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -6698,7 +6604,7 @@ define amdgpu_kernel void @constant_sextload_v8i16_to_v8i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 29, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T9.X, 0
@@ -6709,19 +6615,16 @@ define amdgpu_kernel void @constant_sextload_v8i16_to_v8i64(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T10.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T10.Z, T7.X, literal.y,
-; EG-NEXT:     ASHR * T12.W, T7.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T10.W, T7.X, literal.y,
+; EG-NEXT:     ADD_INT * T11.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T10.Z, T7.X, literal.x,
+; EG-NEXT:     ASHR * T12.W, T7.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T10.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T12.Z, T7.Y, literal.x,
 ; EG-NEXT:     ASHR * T13.W, T7.Z, literal.y,
@@ -6737,12 +6640,11 @@ define amdgpu_kernel void @constant_sextload_v8i16_to_v8i64(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T14.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T13.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T7.X, T8.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T14.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T14.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v8i16_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -7012,7 +6914,7 @@ define amdgpu_kernel void @constant_zextload_v16i16_to_v16i64(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 62, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 52, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T24.X, 0
@@ -7068,29 +6970,19 @@ define amdgpu_kernel void @constant_zextload_v16i16_to_v16i64(ptr addrspace(1) %
 ; EG-NEXT:     MOV * T17.W, 0.0,
 ; EG-NEXT:     MOV T18.W, 0.0,
 ; EG-NEXT:     MOV * T11.W, 0.0,
-; EG-NEXT:     LSHR T19.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T26.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T19.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T20.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T22.X, T19.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, T19.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T24.X, T19.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T19.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T26.X, T19.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i16_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -7459,7 +7351,7 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i64(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 65, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 55, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T20.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T18.X, 0
@@ -7475,31 +7367,22 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i64(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 16:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 17:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T19.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T19.Z, T11.X, literal.y,
-; EG-NEXT:     ASHR * T21.W, T11.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T13.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; EG-NEXT:     ASHR T19.W, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT * T20.X, T13.X, literal.z,
+; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T19.Z, T11.X, literal.x,
+; EG-NEXT:     ASHR * T21.W, T11.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T19.X, T11.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T21.Z, T11.Y, literal.x,
 ; EG-NEXT:     ASHR * T22.W, T11.Z, literal.y,
@@ -7535,12 +7418,11 @@ define amdgpu_kernel void @constant_sextload_v16i16_to_v16i64(ptr addrspace(1) %
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T26.X, T12.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T25.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T12.X, T13.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T26.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T26.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v16i16_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -8032,33 +7914,33 @@ define amdgpu_kernel void @constant_zextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG-LABEL: constant_zextload_v32i16_to_v32i64:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 2 @22
-; EG-NEXT:    ALU 33, @31, KC0[], KC1[]
-; EG-NEXT:    TEX 0 @28
-; EG-NEXT:    ALU 92, @65, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @22
+; EG-NEXT:    ALU 9, @31, KC0[], KC1[]
+; EG-NEXT:    TEX 2 @24
+; EG-NEXT:    ALU 94, @41, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T50.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T49.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T48.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T48.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T47.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T46.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T45.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T44.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T43.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T42.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T43.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T39.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T37.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T35.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T35.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T21.XYZW, T20.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T22.XYZW, T20.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T23.XYZW, T20.X, 32, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T29.XYZW, T20.X, 0, #1
+; EG-NEXT:    Fetch clause starting at 24:
+; EG-NEXT:     VTX_READ_128 T23.XYZW, T20.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T24.XYZW, T20.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T25.XYZW, T20.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 30:
 ; EG-NEXT:     MOV * T20.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
@@ -8066,130 +7948,108 @@ define amdgpu_kernel void @constant_zextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T19.X, T21.W, literal.x,
 ; EG-NEXT:     MOV T19.Y, 0.0,
-; EG-NEXT:     LSHR T24.Z, T21.Z, literal.y,
-; EG-NEXT:     AND_INT * T24.X, T21.Z, literal.x,
+; EG-NEXT:     LSHR T22.Z, T21.Z, literal.y,
+; EG-NEXT:     AND_INT * T22.X, T21.Z, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T24.Y, 0.0,
-; EG-NEXT:     LSHR * T25.Z, T21.Y, literal.x,
+; EG-NEXT:     MOV T22.Y, 0.0,
+; EG-NEXT:     LSHR * T20.Z, T21.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T25.X, T21.Y, literal.x,
-; EG-NEXT:     MOV T25.Y, 0.0,
+; EG-NEXT:    ALU clause starting at 41:
+; EG-NEXT:     AND_INT T20.X, T21.Y, literal.x,
+; EG-NEXT:     MOV T20.Y, 0.0,
 ; EG-NEXT:     LSHR T21.Z, T21.X, literal.y,
 ; EG-NEXT:     AND_INT * T21.X, T21.X, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T21.Y, 0.0,
-; EG-NEXT:     LSHR * T26.Z, T23.W, literal.x,
+; EG-NEXT:     LSHR * T26.Z, T25.W, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T26.X, T23.W, literal.x,
+; EG-NEXT:     AND_INT T26.X, T25.W, literal.x,
 ; EG-NEXT:     MOV T26.Y, 0.0,
-; EG-NEXT:     LSHR T27.Z, T23.Z, literal.y,
-; EG-NEXT:     AND_INT * T27.X, T23.Z, literal.x,
+; EG-NEXT:     LSHR T27.Z, T25.Z, literal.y,
+; EG-NEXT:     AND_INT * T27.X, T25.Z, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T27.Y, 0.0,
-; EG-NEXT:     LSHR * T28.Z, T23.Y, literal.x,
+; EG-NEXT:     LSHR * T28.Z, T25.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T28.X, T23.Y, literal.x,
+; EG-NEXT:     AND_INT T28.X, T25.Y, literal.x,
 ; EG-NEXT:     MOV T28.Y, 0.0,
+; EG-NEXT:     LSHR T25.Z, T25.X, literal.y,
+; EG-NEXT:     AND_INT * T25.X, T25.X, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T25.Y, 0.0,
+; EG-NEXT:     LSHR * T29.Z, T24.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T29.X, T24.W, literal.x,
+; EG-NEXT:     MOV T29.Y, 0.0,
+; EG-NEXT:     LSHR T30.Z, T24.Z, literal.y,
+; EG-NEXT:     AND_INT * T30.X, T24.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T30.Y, 0.0,
+; EG-NEXT:     LSHR * T31.Z, T24.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T31.X, T24.Y, literal.x,
+; EG-NEXT:     MOV T31.Y, 0.0,
+; EG-NEXT:     LSHR T24.Z, T24.X, literal.y,
+; EG-NEXT:     AND_INT * T24.X, T24.X, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T24.Y, 0.0,
+; EG-NEXT:     LSHR * T32.Z, T23.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T32.X, T23.W, literal.x,
+; EG-NEXT:     MOV T32.Y, 0.0,
+; EG-NEXT:     LSHR T33.Z, T23.Z, literal.y,
+; EG-NEXT:     AND_INT * T33.X, T23.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T33.Y, 0.0,
+; EG-NEXT:     LSHR * T34.Z, T23.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T34.X, T23.Y, literal.x,
+; EG-NEXT:     MOV T34.Y, 0.0,
 ; EG-NEXT:     LSHR T23.Z, T23.X, literal.y,
 ; EG-NEXT:     AND_INT * T23.X, T23.X, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T23.Y, 0.0,
-; EG-NEXT:     LSHR * T20.Z, T22.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 65:
-; EG-NEXT:     AND_INT T20.X, T22.W, literal.x,
-; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     LSHR T30.Z, T22.Z, literal.y,
-; EG-NEXT:     AND_INT * T30.X, T22.Z, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T30.Y, 0.0,
-; EG-NEXT:     LSHR * T31.Z, T22.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T31.X, T22.Y, literal.x,
-; EG-NEXT:     MOV T31.Y, 0.0,
-; EG-NEXT:     LSHR T22.Z, T22.X, literal.y,
-; EG-NEXT:     AND_INT * T22.X, T22.X, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     LSHR * T32.Z, T29.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T32.X, T29.W, literal.x,
-; EG-NEXT:     MOV T32.Y, 0.0,
-; EG-NEXT:     LSHR T33.Z, T29.Z, literal.y,
-; EG-NEXT:     AND_INT * T33.X, T29.Z, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T33.Y, 0.0,
-; EG-NEXT:     LSHR * T34.Z, T29.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T34.X, T29.Y, literal.x,
-; EG-NEXT:     MOV T34.Y, 0.0,
-; EG-NEXT:     LSHR T29.Z, T29.X, literal.y,
-; EG-NEXT:     AND_INT * T29.X, T29.X, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T29.Y, 0.0,
 ; EG-NEXT:     MOV T19.W, 0.0,
-; EG-NEXT:     MOV * T24.W, 0.0,
-; EG-NEXT:     MOV T25.W, 0.0,
+; EG-NEXT:     MOV * T22.W, 0.0,
+; EG-NEXT:     MOV T20.W, 0.0,
 ; EG-NEXT:     MOV * T21.W, 0.0,
 ; EG-NEXT:     MOV T26.W, 0.0,
 ; EG-NEXT:     MOV * T27.W, 0.0,
 ; EG-NEXT:     MOV T28.W, 0.0,
-; EG-NEXT:     MOV * T23.W, 0.0,
-; EG-NEXT:     MOV T20.W, 0.0,
+; EG-NEXT:     MOV * T25.W, 0.0,
+; EG-NEXT:     MOV T29.W, 0.0,
 ; EG-NEXT:     MOV * T30.W, 0.0,
 ; EG-NEXT:     MOV T31.W, 0.0,
-; EG-NEXT:     MOV * T22.W, 0.0,
+; EG-NEXT:     MOV * T24.W, 0.0,
 ; EG-NEXT:     MOV T32.W, 0.0,
 ; EG-NEXT:     MOV * T33.W, 0.0,
 ; EG-NEXT:     MOV T34.W, 0.0,
-; EG-NEXT:     MOV * T29.W, 0.0,
-; EG-NEXT:     LSHR T35.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T42.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T43.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T45.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T48.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T50.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T23.W, 0.0,
+; EG-NEXT:     LSHR * T35.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T36.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T37.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T38.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T35.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T40.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T41.X, T35.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T42.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T43.X, T35.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T44.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T45.X, T35.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T46.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T47.X, T35.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T48.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T49.X, T35.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT * T50.X, T35.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i16_to_v32i64:
 ; GFX12:       ; %bb.0:
@@ -8886,9 +8746,9 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
-; EG-NEXT:    ALU 55, @31, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 33, @31, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @24
-; EG-NEXT:    ALU 74, @87, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 74, @65, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T50.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T36.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T34.X, 0
@@ -8903,8 +8763,8 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T24.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T21.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T22.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T21.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
@@ -8915,68 +8775,47 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 30:
 ; EG-NEXT:     MOV * T19.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
-; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T35.W, T20.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T35.Z, T20.X, literal.y,
-; EG-NEXT:     ASHR * T37.W, T20.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T35.X, T20.X, 0.0, literal.x,
-; EG-NEXT:     ASHR * T37.Z, T20.Y, literal.x,
+; EG-NEXT:     LSHR * T21.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T24.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T21.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T26.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T21.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T28.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, T21.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T30.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T21.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T32.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T21.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; EG-NEXT:     ASHR T35.W, T20.Y, literal.y,
+; EG-NEXT:     ADD_INT * T36.X, T21.X, literal.z,
+; EG-NEXT:    52(7.286752e-44), 31(4.344025e-44)
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T35.Z, T20.Y, literal.x,
+; EG-NEXT:     ASHR * T37.W, T20.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT T35.X, T20.Y, 0.0, literal.x,
+; EG-NEXT:     ASHR * T37.Z, T20.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T37.X, T20.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR T35.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T37.X, T20.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR * T19.W, T20.Z, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    ALU clause starting at 87:
-; EG-NEXT:     ASHR T19.Z, T20.Z, literal.x,
-; EG-NEXT:     ASHR * T41.W, T20.W, literal.y,
-; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:    ALU clause starting at 65:
+; EG-NEXT:     ASHR T37.Y, T37.X, literal.x,
+; EG-NEXT:     ASHR T19.Z, T20.Z, literal.y,
+; EG-NEXT:     ASHR * T41.W, T20.W, literal.x,
+; EG-NEXT:    31(4.344025e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T19.X, T20.Z, 0.0, literal.x,
-; EG-NEXT:     ASHR T37.Y, T37.X, literal.y,
+; EG-NEXT:     ASHR T35.Y, T35.X, literal.y,
 ; EG-NEXT:     ASHR T41.Z, T20.W, literal.x,
 ; EG-NEXT:     ASHR * T42.W, T40.X, literal.y, BS:VEC_120/SCL_212
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
@@ -9041,12 +8880,11 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T50.X, T38.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T49.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T38.X, T21.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T50.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T50.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v32i16_to_v32i64:
 ; GFX12:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i32.ll
@@ -252,21 +252,19 @@ define amdgpu_kernel void @constant_load_v3i32(ptr addrspace(1) %out, ptr addrsp
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 6, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; EG-NEXT:    ALU 4, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; EG-NEXT:     MOV * T2.X, T0.Z,
+; EG-NEXT:     MOV T1.X, T0.Z,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_load_v3i32:
@@ -496,7 +494,7 @@ define amdgpu_kernel void @constant_load_v8i32(ptr addrspace(1) %out, ptr addrsp
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -506,11 +504,10 @@ define amdgpu_kernel void @constant_load_v8i32(ptr addrspace(1) %out, ptr addrsp
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_load_v8i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -664,7 +661,7 @@ define amdgpu_kernel void @constant_load_v9i32(ptr addrspace(1) %out, ptr addrsp
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 7, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 4, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.X, T5.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 1
@@ -677,14 +674,11 @@ define amdgpu_kernel void @constant_load_v9i32(ptr addrspace(1) %out, ptr addrsp
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     LSHR T3.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR * T5.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T5.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
 ;
 ; GFX9-HSA-LABEL: constant_load_v9i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -848,30 +842,26 @@ define amdgpu_kernel void @constant_load_v10i32(ptr addrspace(1) %out, ptr addrs
 ;
 ; EG-LABEL: constant_load_v10i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 2, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 8, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 1
+; EG-NEXT:    ALU 2, @17, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
-; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T1.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T1.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T1.XYZW, T1.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 14:
-; EG-NEXT:     MOV * T0.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T4.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T1.X, KC0[2].Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T5.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 17:
+; EG-NEXT:     ADD_INT T4.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T5.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 4(5.605194e-45)
 ;
 ; GFX9-HSA-LABEL: constant_load_v10i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -1045,11 +1035,11 @@ define amdgpu_kernel void @constant_load_v11i32(ptr addrspace(1) %out, ptr addrs
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 13, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 7, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T6.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.X, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.X, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 16, #1
@@ -1058,20 +1048,14 @@ define amdgpu_kernel void @constant_load_v11i32(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T4.X, T0.Z,
+; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    40(5.605194e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; EG-NEXT:     MOV * T5.X, T0.Z,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T6.X, T3.X, literal.x,
+; EG-NEXT:     ADD_INT * T7.X, T3.X, literal.y,
+; EG-NEXT:    10(1.401298e-44), 4(5.605194e-45)
 ;
 ; GFX9-HSA-LABEL: constant_load_v11i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -1245,9 +1229,9 @@ define amdgpu_kernel void @constant_load_v12i32(ptr addrspace(1) %out, ptr addrs
 ;
 ; EG-LABEL: constant_load_v12i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 7, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 4, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 1, @22, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @19, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T5.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
@@ -1258,17 +1242,14 @@ define amdgpu_kernel void @constant_load_v12i32(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:     VTX_READ_128 T4.XYZW, T2.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T2.XYZW, T2.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 14:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
 ; EG-NEXT:     MOV * T2.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 22:
-; EG-NEXT:     LSHR * T5.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 19:
+; EG-NEXT:     ADD_INT * T5.X, T0.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_load_v12i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -1466,9 +1447,9 @@ define amdgpu_kernel void @constant_load_v16i32(ptr addrspace(1) %out, ptr addrs
 ;
 ; EG-LABEL: constant_load_v16i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 10, @16, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 5, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @8
-; EG-NEXT:    ALU 1, @27, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @22, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T1.X, 0
@@ -1480,20 +1461,15 @@ define amdgpu_kernel void @constant_load_v16i32(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:     VTX_READ_128 T6.XYZW, T3.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T3.XYZW, T3.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 16:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
 ; EG-NEXT:     MOV * T3.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 27:
-; EG-NEXT:     LSHR * T7.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 22:
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_load_v16i32:
 ; GFX9-HSA:       ; %bb.0: ; %entry
@@ -2297,7 +2273,7 @@ define amdgpu_kernel void @constant_zextload_v4i32_to_v4i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 12, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
@@ -2314,11 +2290,10 @@ define amdgpu_kernel void @constant_zextload_v4i32_to_v4i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV T1.W, 0.0,
 ; EG-NEXT:     MOV * T2.Z, T0.Y,
 ; EG-NEXT:     MOV * T2.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_zextload_v4i32_to_v4i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -2461,31 +2436,30 @@ define amdgpu_kernel void @constant_sextload_v4i32_to_v4i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 1
+; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     ASHR * T1.W, T0.Y, literal.x,
+; EG-NEXT:     ASHR * T1.W, T0.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ASHR T1.Y, T0.X, literal.y,
-; EG-NEXT:     ASHR T3.W, T0.W, literal.y,
-; EG-NEXT:     MOV * T1.X, T0.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     ASHR * T3.Y, T0.Z, literal.x,
+; EG-NEXT:     ASHR T1.Y, T0.Z, literal.x,
+; EG-NEXT:     ASHR * T2.W, T0.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T3.X, T0.Z,
-; EG-NEXT:     MOV T1.Z, T0.Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T3.Z, T0.W,
+; EG-NEXT:     MOV T1.X, T0.Z,
+; EG-NEXT:     ASHR T2.Y, T0.X, literal.x,
+; EG-NEXT:     MOV * T2.X, T0.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T2.Z, T0.Y,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; EG-NEXT:     MOV * T1.Z, T0.W,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_sextload_v4i32_to_v4i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -2665,7 +2639,7 @@ define amdgpu_kernel void @constant_zextload_v8i32_to_v8i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 26, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 22, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 0
@@ -2693,17 +2667,13 @@ define amdgpu_kernel void @constant_zextload_v8i32_to_v8i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV T4.W, 0.0,
 ; EG-NEXT:     MOV * T5.Z, T0.Y,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_zextload_v8i32_to_v8i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -2928,7 +2898,7 @@ define amdgpu_kernel void @constant_sextload_v8i32_to_v8i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 31, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 27, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T0.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T5.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T3.X, 0
@@ -2940,38 +2910,34 @@ define amdgpu_kernel void @constant_sextload_v8i32_to_v8i64(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 12:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 13:
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T4.W, T0.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T4.W, T0.Y, literal.y,
+; EG-NEXT:     ADD_INT * T5.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T4.Y, T0.X, literal.x,
+; EG-NEXT:     ASHR * T6.W, T0.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T4.Y, T0.X, literal.y,
-; EG-NEXT:     ASHR T6.W, T0.W, literal.y,
-; EG-NEXT:     MOV * T4.X, T0.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     MOV T4.X, T0.X,
 ; EG-NEXT:     ASHR T6.Y, T0.Z, literal.x,
-; EG-NEXT:     ASHR * T7.W, T1.Y, literal.x,
+; EG-NEXT:     ASHR T7.W, T1.Y, literal.x,
+; EG-NEXT:     MOV * T6.X, T0.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T6.X, T0.Z,
 ; EG-NEXT:     ASHR T7.Y, T1.X, literal.x,
 ; EG-NEXT:     MOV T4.Z, T0.Y,
-; EG-NEXT:     ASHR T8.W, T1.W, literal.x,
-; EG-NEXT:     MOV * T7.X, T1.X,
+; EG-NEXT:     ASHR * T8.W, T1.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T7.X, T1.X,
 ; EG-NEXT:     ASHR T8.Y, T1.Z, literal.x,
-; EG-NEXT:     MOV * T6.Z, T0.W,
+; EG-NEXT:     MOV T6.Z, T0.W,
+; EG-NEXT:     MOV * T8.X, T1.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T8.X, T1.Z,
-; EG-NEXT:     MOV T7.Z, T1.Y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T7.Z, T1.Y,
+; EG-NEXT:     ADD_INT T0.X, T2.X, literal.x,
 ; EG-NEXT:     MOV * T8.Z, T1.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_sextload_v8i32_to_v8i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -3349,7 +3315,7 @@ define amdgpu_kernel void @constant_sextload_v16i32_to_v16i64(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 63, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 53, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T1.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T9.X, 0
@@ -3367,70 +3333,60 @@ define amdgpu_kernel void @constant_sextload_v16i32_to_v16i64(ptr addrspace(1) %
 ; EG-NEXT:    ALU clause starting at 20:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 21:
-; EG-NEXT:     LSHR T4.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T10.W, T0.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
+; EG-NEXT:     LSHR * T4.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T5.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T7.X, T4.X, literal.x,
+; EG-NEXT:     ADD_INT * T8.X, T4.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T9.X, T4.X, literal.x,
+; EG-NEXT:     ASHR T10.W, T0.Y, literal.y,
+; EG-NEXT:     ADD_INT * T11.X, T4.X, literal.z,
+; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T10.Y, T0.X, literal.x,
+; EG-NEXT:     ASHR * T12.W, T0.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T10.Y, T0.X, literal.y,
-; EG-NEXT:     ASHR T12.W, T0.W, literal.y,
-; EG-NEXT:     MOV * T10.X, T0.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     MOV T10.X, T0.X,
 ; EG-NEXT:     ASHR T12.Y, T0.Z, literal.x,
-; EG-NEXT:     ASHR * T13.W, T3.Y, literal.x,
+; EG-NEXT:     ASHR T13.W, T3.Y, literal.x,
+; EG-NEXT:     MOV * T12.X, T0.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T12.X, T0.Z,
 ; EG-NEXT:     ASHR T13.Y, T3.X, literal.x,
 ; EG-NEXT:     MOV T10.Z, T0.Y,
-; EG-NEXT:     ASHR T14.W, T3.W, literal.x,
-; EG-NEXT:     MOV * T13.X, T3.X,
+; EG-NEXT:     ASHR * T14.W, T3.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T13.X, T3.X,
 ; EG-NEXT:     ASHR T14.Y, T3.Z, literal.x,
 ; EG-NEXT:     MOV T12.Z, T0.W,
-; EG-NEXT:     ASHR * T0.W, T2.Y, literal.x,
+; EG-NEXT:     ASHR T0.W, T2.Y, literal.x,
+; EG-NEXT:     MOV * T14.X, T3.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T14.X, T3.Z,
 ; EG-NEXT:     ASHR T0.Y, T2.X, literal.x,
 ; EG-NEXT:     MOV T13.Z, T3.Y,
-; EG-NEXT:     ASHR T15.W, T2.W, literal.x,
-; EG-NEXT:     MOV * T0.X, T2.X,
+; EG-NEXT:     ASHR * T15.W, T2.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T0.X, T2.X,
 ; EG-NEXT:     ASHR T15.Y, T2.Z, literal.x,
 ; EG-NEXT:     MOV T14.Z, T3.W,
-; EG-NEXT:     ASHR * T3.W, T1.Y, literal.x,
+; EG-NEXT:     ASHR T3.W, T1.Y, literal.x,
+; EG-NEXT:     MOV * T15.X, T2.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T15.X, T2.Z,
 ; EG-NEXT:     ASHR T3.Y, T1.X, literal.x,
 ; EG-NEXT:     MOV T0.Z, T2.Y,
-; EG-NEXT:     ASHR T16.W, T1.W, literal.x,
-; EG-NEXT:     MOV * T3.X, T1.X,
+; EG-NEXT:     ASHR * T16.W, T1.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T3.X, T1.X,
 ; EG-NEXT:     ASHR T16.Y, T1.Z, literal.x,
-; EG-NEXT:     MOV * T15.Z, T2.W,
+; EG-NEXT:     MOV T15.Z, T2.W,
+; EG-NEXT:     MOV * T16.X, T1.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T16.X, T1.Z,
-; EG-NEXT:     MOV T3.Z, T1.Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T3.Z, T1.Y,
+; EG-NEXT:     ADD_INT T1.X, T4.X, literal.x,
 ; EG-NEXT:     MOV * T16.Z, T1.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_sextload_v16i32_to_v16i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -3799,7 +3755,7 @@ define amdgpu_kernel void @constant_zextload_v16i32_to_v16i64(ptr addrspace(1) %
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 54, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 44, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T15.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T13.X, 0
@@ -3849,29 +3805,19 @@ define amdgpu_kernel void @constant_zextload_v16i32_to_v16i64(ptr addrspace(1) %
 ; EG-NEXT:     MOV T10.W, 0.0,
 ; EG-NEXT:     MOV * T11.Z, T2.Y,
 ; EG-NEXT:     MOV * T11.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T15.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T12.X, T0.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T13.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T14.X, T0.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_zextload_v16i32_to_v16i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -4509,167 +4455,144 @@ define amdgpu_kernel void @constant_sextload_v32i32_to_v32i64(ptr addrspace(1) %
 ;
 ; EG-LABEL: constant_sextload_v32i32_to_v32i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 32, @36, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 10, @36, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @20
-; EG-NEXT:    ALU 96, @69, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T23.X, 0
+; EG-NEXT:    ALU 95, @47, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T23.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T21.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T20.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T20.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T19.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T10.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T9.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T18.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T17.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T16.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T15.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T4.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T1.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 20:
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T13.XYZW, T11.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T14.XYZW, T11.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T15.XYZW, T11.X, 64, #1
-; EG-NEXT:     VTX_READ_128 T16.XYZW, T11.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T17.XYZW, T11.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T18.XYZW, T11.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T7.XYZW, T6.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T8.XYZW, T6.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T9.XYZW, T6.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T10.XYZW, T6.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T11.XYZW, T6.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T12.XYZW, T6.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T13.XYZW, T6.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T6.XYZW, T6.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 36:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T11.X, KC0[2].Z,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 69:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T22.W, T11.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     MOV * T6.X, KC0[2].Z,
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 47:
+; EG-NEXT:     ADD_INT T14.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.y,
+; EG-NEXT:    24(3.363116e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T16.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T0.X, literal.y,
+; EG-NEXT:    32(4.484155e-44), 36(5.044674e-44)
+; EG-NEXT:     ADD_INT T18.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T0.X, literal.y,
+; EG-NEXT:    40(5.605194e-44), 44(6.165713e-44)
+; EG-NEXT:     ADD_INT T20.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T0.X, literal.y,
+; EG-NEXT:    48(6.726233e-44), 52(7.286752e-44)
+; EG-NEXT:     ASHR * T22.W, T6.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T22.Y, T11.X, literal.y,
-; EG-NEXT:     ASHR T24.W, T11.W, literal.y,
-; EG-NEXT:     MOV * T22.X, T11.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     ASHR T24.Y, T11.Z, literal.x,
-; EG-NEXT:     ASHR * T25.W, T18.Y, literal.x,
+; EG-NEXT:     ADD_INT T23.X, T0.X, literal.x,
+; EG-NEXT:     ASHR T22.Y, T6.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ASHR T24.W, T6.W, literal.y,
+; EG-NEXT:     MOV * T22.X, T6.X,
+; EG-NEXT:    56(7.847271e-44), 31(4.344025e-44)
+; EG-NEXT:     ASHR T24.Y, T6.Z, literal.x,
+; EG-NEXT:     ASHR * T25.W, T13.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T24.X, T11.Z,
-; EG-NEXT:     ASHR T25.Y, T18.X, literal.x,
-; EG-NEXT:     MOV T22.Z, T11.Y,
-; EG-NEXT:     ASHR T26.W, T18.W, literal.x,
-; EG-NEXT:     MOV * T25.X, T18.X,
+; EG-NEXT:     MOV T24.X, T6.Z,
+; EG-NEXT:     ASHR T25.Y, T13.X, literal.x,
+; EG-NEXT:     MOV T22.Z, T6.Y,
+; EG-NEXT:     ASHR T26.W, T13.W, literal.x,
+; EG-NEXT:     MOV * T25.X, T13.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T26.Y, T18.Z, literal.x,
-; EG-NEXT:     MOV T24.Z, T11.W,
-; EG-NEXT:     ASHR * T11.W, T17.Y, literal.x,
+; EG-NEXT:     ASHR T26.Y, T13.Z, literal.x,
+; EG-NEXT:     MOV T24.Z, T6.W,
+; EG-NEXT:     ASHR * T6.W, T12.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T26.X, T18.Z,
-; EG-NEXT:     ASHR T11.Y, T17.X, literal.x,
-; EG-NEXT:     MOV T25.Z, T18.Y,
-; EG-NEXT:     ASHR T27.W, T17.W, literal.x,
-; EG-NEXT:     MOV * T11.X, T17.X,
+; EG-NEXT:     MOV T26.X, T13.Z,
+; EG-NEXT:     ASHR T6.Y, T12.X, literal.x,
+; EG-NEXT:     MOV T25.Z, T13.Y,
+; EG-NEXT:     ASHR T27.W, T12.W, literal.x,
+; EG-NEXT:     MOV * T6.X, T12.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T27.Y, T17.Z, literal.x,
-; EG-NEXT:     MOV T26.Z, T18.W,
-; EG-NEXT:     ASHR * T18.W, T16.Y, literal.x,
+; EG-NEXT:     ASHR T27.Y, T12.Z, literal.x,
+; EG-NEXT:     MOV T26.Z, T13.W,
+; EG-NEXT:     ASHR * T13.W, T11.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T27.X, T17.Z,
-; EG-NEXT:     ASHR T18.Y, T16.X, literal.x,
-; EG-NEXT:     MOV T11.Z, T17.Y,
-; EG-NEXT:     ASHR T28.W, T16.W, literal.x,
-; EG-NEXT:     MOV * T18.X, T16.X,
+; EG-NEXT:     MOV T27.X, T12.Z,
+; EG-NEXT:     ASHR T13.Y, T11.X, literal.x,
+; EG-NEXT:     MOV T6.Z, T12.Y,
+; EG-NEXT:     ASHR T28.W, T11.W, literal.x,
+; EG-NEXT:     MOV * T13.X, T11.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T28.Y, T16.Z, literal.x,
-; EG-NEXT:     MOV T27.Z, T17.W,
-; EG-NEXT:     ASHR * T17.W, T15.Y, literal.x,
+; EG-NEXT:     ASHR T28.Y, T11.Z, literal.x,
+; EG-NEXT:     MOV T27.Z, T12.W,
+; EG-NEXT:     ASHR * T12.W, T10.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T28.X, T16.Z,
-; EG-NEXT:     ASHR T17.Y, T15.X, literal.x,
-; EG-NEXT:     MOV T18.Z, T16.Y,
-; EG-NEXT:     ASHR T29.W, T15.W, literal.x,
-; EG-NEXT:     MOV * T17.X, T15.X,
+; EG-NEXT:     MOV T28.X, T11.Z,
+; EG-NEXT:     ASHR T12.Y, T10.X, literal.x,
+; EG-NEXT:     MOV T13.Z, T11.Y,
+; EG-NEXT:     ASHR T29.W, T10.W, literal.x,
+; EG-NEXT:     MOV * T12.X, T10.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T29.Y, T15.Z, literal.x,
-; EG-NEXT:     MOV T28.Z, T16.W,
-; EG-NEXT:     ASHR * T16.W, T14.Y, literal.x,
+; EG-NEXT:     ASHR T29.Y, T10.Z, literal.x,
+; EG-NEXT:     MOV T28.Z, T11.W,
+; EG-NEXT:     ASHR * T11.W, T9.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T29.X, T15.Z,
-; EG-NEXT:     ASHR T16.Y, T14.X, literal.x,
-; EG-NEXT:     MOV T17.Z, T15.Y,
-; EG-NEXT:     ASHR T30.W, T14.W, literal.x,
-; EG-NEXT:     MOV * T16.X, T14.X,
+; EG-NEXT:     MOV T29.X, T10.Z,
+; EG-NEXT:     ASHR T11.Y, T9.X, literal.x,
+; EG-NEXT:     MOV T12.Z, T10.Y,
+; EG-NEXT:     ASHR T30.W, T9.W, literal.x,
+; EG-NEXT:     MOV * T11.X, T9.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T30.Y, T14.Z, literal.x,
-; EG-NEXT:     MOV T29.Z, T15.W,
-; EG-NEXT:     ASHR * T15.W, T13.Y, literal.x,
+; EG-NEXT:     ASHR T30.Y, T9.Z, literal.x,
+; EG-NEXT:     MOV T29.Z, T10.W,
+; EG-NEXT:     ASHR * T10.W, T8.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T30.X, T14.Z,
-; EG-NEXT:     ASHR T15.Y, T13.X, literal.x,
-; EG-NEXT:     MOV T16.Z, T14.Y,
-; EG-NEXT:     ASHR T31.W, T13.W, literal.x,
-; EG-NEXT:     MOV * T15.X, T13.X,
+; EG-NEXT:     MOV T30.X, T9.Z,
+; EG-NEXT:     ASHR T10.Y, T8.X, literal.x,
+; EG-NEXT:     MOV T11.Z, T9.Y,
+; EG-NEXT:     ASHR T31.W, T8.W, literal.x,
+; EG-NEXT:     MOV * T10.X, T8.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T31.Y, T13.Z, literal.x,
-; EG-NEXT:     MOV T30.Z, T14.W,
-; EG-NEXT:     ASHR * T14.W, T12.Y, literal.x,
+; EG-NEXT:     ASHR T31.Y, T8.Z, literal.x,
+; EG-NEXT:     MOV T30.Z, T9.W,
+; EG-NEXT:     ASHR * T9.W, T7.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T31.X, T13.Z,
-; EG-NEXT:     ASHR T14.Y, T12.X, literal.x,
-; EG-NEXT:     MOV T15.Z, T13.Y,
-; EG-NEXT:     ASHR T32.W, T12.W, literal.x,
-; EG-NEXT:     MOV * T14.X, T12.X,
+; EG-NEXT:     MOV T31.X, T8.Z,
+; EG-NEXT:     ASHR T9.Y, T7.X, literal.x,
+; EG-NEXT:     MOV T10.Z, T8.Y,
+; EG-NEXT:     ASHR T32.W, T7.W, literal.x,
+; EG-NEXT:     MOV * T9.X, T7.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T32.Y, T12.Z, literal.x,
-; EG-NEXT:     MOV * T31.Z, T13.W,
+; EG-NEXT:     ASHR T32.Y, T7.Z, literal.x,
+; EG-NEXT:     MOV * T31.Z, T8.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T32.X, T12.Z,
-; EG-NEXT:     MOV T14.Z, T12.Y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T32.Z, T12.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     MOV T32.X, T7.Z,
+; EG-NEXT:     MOV T9.Z, T7.Y,
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV * T32.Z, T7.W,
 ;
 ; GFX9-HSA-LABEL: constant_sextload_v32i32_to_v32i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -5357,153 +5280,127 @@ define amdgpu_kernel void @constant_zextload_v32i32_to_v32i64(ptr addrspace(1) %
 ;
 ; EG-LABEL: constant_zextload_v32i32_to_v32i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 2 @22
-; EG-NEXT:    ALU 10, @39, KC0[], KC1[]
-; EG-NEXT:    TEX 4 @28
-; EG-NEXT:    ALU 99, @50, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T31.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T30.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T26.X, 0
+; EG-NEXT:    ALU 0, @36, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 7 @20
+; EG-NEXT:    ALU 88, @37, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T31.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T30.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T29.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T13.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T11.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T10.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T1.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
-; EG-NEXT:    Fetch clause starting at 22:
+; EG-NEXT:    Fetch clause starting at 20:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 96, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T10.XYZW, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T0.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T0.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T13.XYZW, T0.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 64, #1
-; EG-NEXT:    ALU clause starting at 38:
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T4.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T5.XYZW, T0.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T6.XYZW, T0.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T7.XYZW, T0.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 96, #1
+; EG-NEXT:    ALU clause starting at 36:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 39:
-; EG-NEXT:     MOV T4.X, T1.Z,
-; EG-NEXT:     MOV T4.Y, 0.0,
-; EG-NEXT:     MOV * T5.X, T1.X,
-; EG-NEXT:     MOV * T5.Y, 0.0,
-; EG-NEXT:     MOV T6.X, T3.Z,
-; EG-NEXT:     MOV T6.Y, 0.0,
-; EG-NEXT:     MOV * T7.X, T3.X,
-; EG-NEXT:     MOV * T7.Y, 0.0,
-; EG-NEXT:     MOV T8.X, T2.Z,
+; EG-NEXT:    ALU clause starting at 37:
+; EG-NEXT:     MOV T8.X, T1.Z,
 ; EG-NEXT:     MOV T8.Y, 0.0,
-; EG-NEXT:     MOV * T9.X, T2.X,
-; EG-NEXT:    ALU clause starting at 50:
+; EG-NEXT:     MOV * T9.X, T1.X,
 ; EG-NEXT:     MOV * T9.Y, 0.0,
-; EG-NEXT:     MOV T14.X, T0.Z,
+; EG-NEXT:     MOV T10.X, T0.Z,
+; EG-NEXT:     MOV T10.Y, 0.0,
+; EG-NEXT:     MOV * T11.X, T0.X,
+; EG-NEXT:     MOV * T11.Y, 0.0,
+; EG-NEXT:     MOV T12.X, T7.Z,
+; EG-NEXT:     MOV T12.Y, 0.0,
+; EG-NEXT:     MOV * T13.X, T7.X,
+; EG-NEXT:     MOV * T13.Y, 0.0,
+; EG-NEXT:     MOV T14.X, T6.Z,
 ; EG-NEXT:     MOV T14.Y, 0.0,
-; EG-NEXT:     MOV * T15.X, T0.X,
+; EG-NEXT:     MOV * T15.X, T6.X,
 ; EG-NEXT:     MOV * T15.Y, 0.0,
-; EG-NEXT:     MOV T16.X, T13.Z,
+; EG-NEXT:     MOV T16.X, T5.Z,
 ; EG-NEXT:     MOV T16.Y, 0.0,
-; EG-NEXT:     MOV * T17.X, T13.X,
+; EG-NEXT:     MOV * T17.X, T5.X,
 ; EG-NEXT:     MOV * T17.Y, 0.0,
-; EG-NEXT:     MOV T18.X, T12.Z,
+; EG-NEXT:     MOV T18.X, T4.Z,
 ; EG-NEXT:     MOV T18.Y, 0.0,
-; EG-NEXT:     MOV * T19.X, T12.X,
+; EG-NEXT:     MOV * T19.X, T4.X,
 ; EG-NEXT:     MOV * T19.Y, 0.0,
-; EG-NEXT:     MOV T20.X, T11.Z,
+; EG-NEXT:     MOV T20.X, T3.Z,
 ; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     MOV * T21.X, T11.X,
+; EG-NEXT:     MOV * T21.X, T3.X,
 ; EG-NEXT:     MOV * T21.Y, 0.0,
-; EG-NEXT:     MOV T22.X, T10.Z,
+; EG-NEXT:     MOV T22.X, T2.Z,
 ; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     MOV * T23.X, T10.X,
+; EG-NEXT:     MOV * T23.X, T2.X,
 ; EG-NEXT:     MOV T23.Y, 0.0,
-; EG-NEXT:     MOV T4.Z, T1.W,
-; EG-NEXT:     MOV T4.W, 0.0,
-; EG-NEXT:     MOV * T5.Z, T1.Y,
-; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     MOV T6.Z, T3.W,
-; EG-NEXT:     MOV T6.W, 0.0,
-; EG-NEXT:     MOV * T7.Z, T3.Y,
-; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     MOV T8.Z, T2.W,
+; EG-NEXT:     MOV T8.Z, T1.W,
 ; EG-NEXT:     MOV T8.W, 0.0,
-; EG-NEXT:     MOV * T9.Z, T2.Y,
+; EG-NEXT:     MOV * T9.Z, T1.Y,
 ; EG-NEXT:     MOV * T9.W, 0.0,
-; EG-NEXT:     MOV T14.Z, T0.W,
+; EG-NEXT:     MOV T10.Z, T0.W,
+; EG-NEXT:     MOV T10.W, 0.0,
+; EG-NEXT:     MOV * T11.Z, T0.Y,
+; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     MOV T12.Z, T7.W,
+; EG-NEXT:     MOV T12.W, 0.0,
+; EG-NEXT:     MOV * T13.Z, T7.Y,
+; EG-NEXT:     MOV * T13.W, 0.0,
+; EG-NEXT:     MOV T14.Z, T6.W,
 ; EG-NEXT:     MOV T14.W, 0.0,
-; EG-NEXT:     MOV * T15.Z, T0.Y,
+; EG-NEXT:     MOV * T15.Z, T6.Y,
 ; EG-NEXT:     MOV * T15.W, 0.0,
-; EG-NEXT:     MOV T16.Z, T13.W,
+; EG-NEXT:     MOV T16.Z, T5.W,
 ; EG-NEXT:     MOV T16.W, 0.0,
-; EG-NEXT:     MOV * T17.Z, T13.Y,
+; EG-NEXT:     MOV * T17.Z, T5.Y,
 ; EG-NEXT:     MOV * T17.W, 0.0,
-; EG-NEXT:     MOV T18.Z, T12.W,
+; EG-NEXT:     MOV T18.Z, T4.W,
 ; EG-NEXT:     MOV T18.W, 0.0,
-; EG-NEXT:     MOV * T19.Z, T12.Y,
+; EG-NEXT:     MOV * T19.Z, T4.Y,
 ; EG-NEXT:     MOV * T19.W, 0.0,
-; EG-NEXT:     MOV T20.Z, T11.W,
+; EG-NEXT:     MOV T20.Z, T3.W,
 ; EG-NEXT:     MOV T20.W, 0.0,
-; EG-NEXT:     MOV * T21.Z, T11.Y,
+; EG-NEXT:     MOV * T21.Z, T3.Y,
 ; EG-NEXT:     MOV * T21.W, 0.0,
-; EG-NEXT:     MOV T22.Z, T10.W,
+; EG-NEXT:     MOV T22.Z, T2.W,
 ; EG-NEXT:     MOV T22.W, 0.0,
-; EG-NEXT:     MOV * T23.Z, T10.Y,
+; EG-NEXT:     MOV * T23.Z, T2.Y,
 ; EG-NEXT:     MOV * T23.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T31.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, T0.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T7.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T24.X, T0.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T25.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T26.X, T0.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T27.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T28.X, T0.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T29.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T30.X, T0.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT * T31.X, T0.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_zextload_v32i32_to_v32i64:
 ; GFX9-HSA:       ; %bb.0:
@@ -5934,9 +5831,9 @@ define amdgpu_kernel void @constant_load_v32i32(ptr addrspace(1) %out, ptr addrs
 ;
 ; EG-LABEL: constant_load_v32i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 22, @28, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @28, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @12
-; EG-NEXT:    ALU 1, @51, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @40, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T15.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T5.X, 0
@@ -5956,32 +5853,21 @@ define amdgpu_kernel void @constant_load_v32i32(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:     VTX_READ_128 T14.XYZW, T7.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 28:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, T0.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 51:
-; EG-NEXT:     LSHR * T15.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 40:
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX9-HSA-LABEL: constant_load_v32i32:
 ; GFX9-HSA:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i64.ll
@@ -235,21 +235,20 @@ define amdgpu_kernel void @constant_load_v3i64(ptr addrspace(1) %out, ptr addrsp
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
-; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_load_v3i64:
 ; GFX12:       ; %bb.0: ; %entry
@@ -350,7 +349,7 @@ define amdgpu_kernel void @constant_load_v4i64(ptr addrspace(1) %out, ptr addrsp
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -360,11 +359,10 @@ define amdgpu_kernel void @constant_load_v4i64(ptr addrspace(1) %out, ptr addrsp
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_load_v4i64:
 ; GFX12:       ; %bb.0: ; %entry
@@ -510,9 +508,9 @@ define amdgpu_kernel void @constant_load_v8i64(ptr addrspace(1) %out, ptr addrsp
 ;
 ; EG-LABEL: constant_load_v8i64:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 10, @16, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 5, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @8
-; EG-NEXT:    ALU 1, @27, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @22, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T1.X, 0
@@ -524,20 +522,15 @@ define amdgpu_kernel void @constant_load_v8i64(ptr addrspace(1) %out, ptr addrsp
 ; EG-NEXT:     VTX_READ_128 T6.XYZW, T3.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T3.XYZW, T3.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 16:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
 ; EG-NEXT:     MOV * T3.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 27:
-; EG-NEXT:     LSHR * T7.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 22:
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_load_v8i64:
 ; GFX12:       ; %bb.0: ; %entry
@@ -797,9 +790,9 @@ define amdgpu_kernel void @constant_load_v16i64(ptr addrspace(1) %out, ptr addrs
 ;
 ; EG-LABEL: constant_load_v16i64:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 22, @28, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @28, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @12
-; EG-NEXT:    ALU 1, @51, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @40, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T15.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T5.X, 0
@@ -819,32 +812,21 @@ define amdgpu_kernel void @constant_load_v16i64(ptr addrspace(1) %out, ptr addrs
 ; EG-NEXT:     VTX_READ_128 T14.XYZW, T7.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 28:
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, T0.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 51:
-; EG-NEXT:     LSHR * T15.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 40:
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_load_v16i64:
 ; GFX12:       ; %bb.0: ; %entry

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
@@ -1139,7 +1139,7 @@ define amdgpu_kernel void @constant_zextload_v3i8_to_v3i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 10, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.X, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XY, T6.X, 1
 ; EG-NEXT:    CF_END
@@ -1152,13 +1152,12 @@ define amdgpu_kernel void @constant_zextload_v3i8_to_v3i32(ptr addrspace(1) %out
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT * T5.Y, T4.X, literal.x, PV.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T5.X, T4.X, literal.x,
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.y,
-; EG-NEXT:    255(3.573311e-43), 2(2.802597e-45)
+; EG-NEXT:     AND_INT * T5.X, T4.X, literal.x,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T4.X, T4.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT * T7.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v3i8_to_v3i32:
@@ -1244,25 +1243,25 @@ define amdgpu_kernel void @constant_sextload_v3i8_to_v3i32(ptr addrspace(1) %out
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
 ; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.X, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XY, T5.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.X, T4.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XY, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T4.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     LSHR T5.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR * T0.W, T4.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT * T6.X, PV.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T5.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T4.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.W, T4.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T6.X, T4.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    8(1.121039e-44), 2(2.802597e-45)
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T4.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
+; EG-NEXT:     ADD_INT T4.X, T7.X, literal.x,
+; EG-NEXT:     BFE_INT * T6.Y, PV.W, 0.0, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v3i8_to_v3i32:
@@ -1604,7 +1603,7 @@ define amdgpu_kernel void @constant_zextload_v8i8_to_v8i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 20, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T5.X, 1
 ; EG-NEXT:    CF_END
@@ -1618,22 +1617,19 @@ define amdgpu_kernel void @constant_zextload_v8i8_to_v8i32(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_UINT * T6.Z, T5.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T6.Y, T5.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T7.Z, T5.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T6.W, T5.X, literal.z,
+; EG-NEXT:     BFE_UINT * T7.Z, T5.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T7.Y, T5.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T6.W, T5.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T6.X, T5.X, literal.x,
-; EG-NEXT:     BFE_UINT T7.Y, T5.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T7.W, T5.Y, literal.y,
+; EG-NEXT:     AND_INT * T7.X, T5.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T7.W, T5.Y, literal.x,
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T7.X, T5.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    255(3.573311e-43), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T8.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T8.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i8_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -1766,7 +1762,7 @@ define amdgpu_kernel void @constant_sextload_v8i8_to_v8i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 23, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T5.X, 1
 ; EG-NEXT:    CF_END
@@ -1792,13 +1788,11 @@ define amdgpu_kernel void @constant_sextload_v8i8_to_v8i32(ptr addrspace(1) %out
 ; EG-NEXT:     LSHR T5.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     BFE_INT T6.Y, PS, 0.0, literal.y,
 ; EG-NEXT:     BFE_INT T7.Z, PV.Y, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.W, T5.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR * T0.W, T5.Y, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T8.X, PS, literal.x,
+; EG-NEXT:     ADD_INT T8.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v8i8_to_v8i32:
 ; GFX12:       ; %bb.0:
@@ -2003,7 +1997,7 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 39, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T11.X, 0
@@ -2019,41 +2013,35 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i32(ptr addrspace(1) %o
 ; EG-NEXT:     BFE_UINT * T8.Z, T7.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T8.Y, T7.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T9.Z, T7.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T8.W, T7.X, literal.z,
+; EG-NEXT:     BFE_UINT * T9.Z, T7.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T9.Y, T7.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T8.W, T7.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
-; EG-NEXT:     BFE_UINT T9.Y, T7.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T10.Z, T7.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T9.W, T7.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T9.X, T7.Y, literal.x,
-; EG-NEXT:     BFE_UINT T10.Y, T7.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T9.W, T7.Y, literal.y,
+; EG-NEXT:     AND_INT * T9.X, T7.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T10.Z, T7.Z, literal.x, T0.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT * T10.Y, T7.Z, literal.y, T0.W,
+; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T11.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_UINT T12.Z, T7.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T10.W, T7.Z, literal.z,
 ; EG-NEXT:     AND_INT * T10.X, T7.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T12.Y, T7.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T12.Y, T7.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T13.X, T7.X, literal.x,
 ; EG-NEXT:     LSHR T12.W, T7.W, literal.y,
 ; EG-NEXT:     AND_INT * T12.X, T7.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T14.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T14.X, T7.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i8_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2272,65 +2260,59 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 47, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 0
+; EG-NEXT:    ALU 41, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T13.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T8.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T12.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR T0.W, T7.W, literal.y,
-; EG-NEXT:     LSHR * T1.W, T7.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT * T8.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T9.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T7.W, literal.y,
-; EG-NEXT:     LSHR T0.Z, T7.Z, literal.z,
-; EG-NEXT:     LSHR T2.W, T7.Y, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.y,
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.Z, T7.W, literal.z,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.y,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T10.X, T7.Y, 0.0, literal.x,
 ; EG-NEXT:     LSHR T1.Y, T7.Z, literal.y,
 ; EG-NEXT:     LSHR T1.Z, T7.Y, literal.y,
 ; EG-NEXT:     BFE_INT T9.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.z,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T11.X, T7.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR T2.Y, T7.Y, literal.y,
 ; EG-NEXT:     BFE_INT T9.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T10.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T12.X, T7.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T9.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T10.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.W, T1.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T7.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T10.Y, T2.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T11.Z, T0.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T12.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T9.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T10.Z, PV.Y, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.W, T1.Y, 0.0, literal.y,
+; EG-NEXT:     LSHR * T1.W, T7.Y, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T13.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T11.Y, T1.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T12.Z, T0.W, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T0.W, T7.W, literal.y, BS:VEC_201
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T14.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T12.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T12.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T10.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.Z, T0.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T8.W, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Z, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T13.X, T7.X, literal.x,
+; EG-NEXT:     BFE_INT T11.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T8.Z, T0.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.W, T7.W, literal.x,
+; EG-NEXT:     ADD_INT * T14.X, T7.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 12(1.681558e-44)
+; EG-NEXT:     BFE_INT * T8.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v16i8_to_v16i32:
 ; GFX12:       ; %bb.0:
@@ -2693,7 +2675,7 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 75, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 64, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T23.X, 0
@@ -2714,77 +2696,66 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i32(ptr addrspace(1) %o
 ; EG-NEXT:     BFE_UINT * T13.Z, T11.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T13.Y, T11.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T14.Z, T11.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T13.W, T11.X, literal.z,
+; EG-NEXT:     BFE_UINT * T14.Z, T11.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T14.Y, T11.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T13.W, T11.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T13.X, T11.X, literal.x,
-; EG-NEXT:     BFE_UINT T14.Y, T11.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T11.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T15.Z, T11.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T14.W, T11.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T14.X, T11.Y, literal.x,
-; EG-NEXT:     BFE_UINT T15.Y, T11.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T14.W, T11.Y, literal.y,
+; EG-NEXT:     AND_INT * T14.X, T11.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T15.Z, T11.Z, literal.x, T0.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T11.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT * T15.Y, T11.Z, literal.y, T0.W,
+; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_UINT T17.Z, T11.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T15.W, T11.Z, literal.z,
 ; EG-NEXT:     AND_INT * T15.X, T11.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T17.Y, T11.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T19.Z, T12.X, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T17.W, T11.W, literal.z,
+; EG-NEXT:     BFE_UINT * T17.Y, T11.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T18.X, T11.X, literal.x,
+; EG-NEXT:     BFE_UINT T19.Z, T12.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T17.W, T11.W, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     AND_INT * T17.X, T11.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T19.Y, T12.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T19.Y, T12.X, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T20.X, T11.X, literal.x,
 ; EG-NEXT:     BFE_UINT T21.Z, T12.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T19.W, T12.X, literal.z,
+; EG-NEXT:     LSHR T19.W, T12.X, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     AND_INT * T19.X, T12.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T21.Y, T12.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 64(8.968310e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T22.Z, T12.Z, literal.y, T0.W,
-; EG-NEXT:     LSHR T21.W, T12.Y, literal.z,
-; EG-NEXT:     AND_INT * T21.X, T12.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T22.Y, T12.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T21.Y, T12.Y, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, T11.X, literal.x,
+; EG-NEXT:     BFE_UINT T22.Z, T12.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR T21.W, T12.Y, literal.y,
+; EG-NEXT:     AND_INT * T21.X, T12.Y, literal.z,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T22.Y, T12.Z, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T23.X, T11.X, literal.x,
 ; EG-NEXT:     BFE_UINT T24.Z, T12.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T22.W, T12.Z, literal.z,
 ; EG-NEXT:     AND_INT * T22.X, T12.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T24.Y, T12.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T24.W, T12.W, literal.y,
-; EG-NEXT:     AND_INT * T24.X, T12.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T26.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T24.Y, T12.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T25.X, T11.X, literal.x,
+; EG-NEXT:     LSHR T24.W, T12.W, literal.x,
+; EG-NEXT:     AND_INT * T24.X, T12.W, literal.y,
+; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
+; EG-NEXT:     ADD_INT * T26.X, T11.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i8_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -3178,9 +3149,9 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @18, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @14
-; EG-NEXT:    ALU 18, @19, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 9, @19, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @16
-; EG-NEXT:    ALU 75, @38, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 73, @29, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T12.X, 0
@@ -3197,102 +3168,91 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i32(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 18:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 19:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Z, T12.W, literal.y,
-; EG-NEXT:     LSHR T0.W, T12.Z, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PS, literal.x,
-; EG-NEXT:     LSHR T0.Y, T12.W, literal.y,
-; EG-NEXT:     LSHR T1.Z, T12.Z, literal.z,
-; EG-NEXT:     LSHR T1.W, T12.Y, literal.w,
-; EG-NEXT:     LSHR * T2.W, T12.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:    ALU clause starting at 38:
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.x,
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T12.Y, literal.y,
-; EG-NEXT:     LSHR T2.Z, T12.Y, literal.z,
-; EG-NEXT:     LSHR T3.W, T12.X, literal.y,
-; EG-NEXT:     LSHR * T4.W, T12.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T12.W, literal.y,
+; EG-NEXT:     LSHR * T1.W, T12.W, literal.z,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 29:
+; EG-NEXT:     LSHR T2.W, T12.Z, literal.x,
+; EG-NEXT:     LSHR * T3.W, T12.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T17.X, T13.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T12.Y, literal.x,
+; EG-NEXT:     LSHR T0.Z, T12.Y, literal.y,
+; EG-NEXT:     LSHR T4.W, T12.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T5.W, T12.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     BFE_INT T18.X, T11.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.Y, T11.W, literal.y,
-; EG-NEXT:     LSHR T3.Z, T11.W, literal.z,
-; EG-NEXT:     LSHR T5.W, T11.Z, literal.y,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.z,
+; EG-NEXT:     LSHR T1.Y, T11.W, literal.y,
+; EG-NEXT:     LSHR T1.Z, T11.W, literal.z,
+; EG-NEXT:     LSHR T6.W, T11.Z, literal.y,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T19.X, T11.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR T3.Y, T11.Z, literal.y,
-; EG-NEXT:     LSHR T4.Z, T11.Y, literal.y,
+; EG-NEXT:     LSHR T2.Y, T11.Z, literal.y,
+; EG-NEXT:     LSHR T2.Z, T11.Y, literal.y,
 ; EG-NEXT:     BFE_INT T18.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.z,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.X, T11.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T4.Y, T11.Y, literal.y,
+; EG-NEXT:     LSHR T3.Y, T11.Y, literal.y,
 ; EG-NEXT:     BFE_INT T18.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T21.X, T11.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T18.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.W, T3.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.Y, literal.x,
+; EG-NEXT:     BFE_INT T20.W, T2.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.W, T11.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T22.X, T12.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.Z, T5.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.W, T3.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T5.W, T11.Z, literal.x,
+; EG-NEXT:     BFE_INT T20.Z, T6.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T21.W, T1.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T6.W, T11.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T11.X, T12.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Z, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T22.W, T4.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.W, literal.x,
+; EG-NEXT:     BFE_INT T21.Z, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T22.W, T5.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T23.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T21.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T22.Z, T3.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.W, T2.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T12.X, literal.x,
+; EG-NEXT:     BFE_INT T22.Z, T4.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T11.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T4.W, T12.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T24.X, T12.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T22.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.Z, T1.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T12.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T11.Y, T1.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T23.Z, T1.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T24.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T25.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T23.Y, T0.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T24.Z, T0.Z, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.Z, T0.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T23.W, T3.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T12.Y, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T11.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T23.Z, T2.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T24.W, T1.W, 0.0, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T12.Z, literal.y,
+; EG-NEXT:    20(2.802597e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T25.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T23.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T24.Z, T0.W, 0.0, literal.y,
 ; EG-NEXT:     LSHR T0.W, T12.W, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T24.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T26.X, T13.X, literal.z,
+; EG-NEXT:    24(3.363116e-44), 8(1.121039e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T24.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v32i8_to_v32i32:
 ; GFX12:       ; %bb.0:
@@ -3975,185 +3935,166 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 59, @31, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 36, @31, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @26
-; EG-NEXT:    ALU 88, @91, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 92, @68, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T49.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T47.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T32.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T44.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T33.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T35.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T31.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T33.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T27.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T25.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T23.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T24.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T22.XYZW, T21.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T23.XYZW, T21.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T23.XYZW, T22.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T24.XYZW, T22.X, 0, #1
 ; EG-NEXT:    Fetch clause starting at 26:
-; EG-NEXT:     VTX_READ_128 T32.XYZW, T21.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T33.XYZW, T21.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T29.XYZW, T22.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T30.XYZW, T22.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 30:
-; EG-NEXT:     MOV * T21.X, KC0[2].Z,
+; EG-NEXT:     MOV * T22.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
 ; EG-NEXT:     MOV * T0.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT * T19.Z, T23.X, literal.x, PV.W,
+; EG-NEXT:     BFE_UINT * T19.Z, T24.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T19.Y, T23.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T20.Z, T23.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T19.W, T23.X, literal.z,
+; EG-NEXT:     BFE_UINT T19.Y, T24.X, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T20.Z, T24.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T19.X, T23.X, literal.x,
-; EG-NEXT:     BFE_UINT T20.Y, T23.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T23.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T24.Z, T23.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T20.W, T23.Y, literal.y,
+; EG-NEXT:     BFE_UINT T20.Y, T24.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T19.W, T24.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T19.X, T24.X, literal.x,
+; EG-NEXT:     LSHR T20.W, T24.Y, literal.y,
+; EG-NEXT:     AND_INT * T20.X, T24.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T21.Z, T24.Z, literal.x, T0.W,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T24.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT * T21.Y, T24.Z, literal.y, T0.W,
+; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T25.X, PV.X, literal.x,
+; EG-NEXT:     BFE_UINT T26.Z, T24.W, literal.y, T0.W,
+; EG-NEXT:     LSHR T21.W, T24.Z, literal.z,
+; EG-NEXT:     AND_INT * T21.X, T24.Z, literal.w,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
+; EG-NEXT:     BFE_UINT * T26.Y, T24.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T27.X, T24.X, literal.x,
+; EG-NEXT:     LSHR T26.W, T24.W, literal.y,
+; EG-NEXT:     AND_INT * T26.X, T24.W, literal.z,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T22.Z, T23.X, literal.x, T0.W,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T28.X, T24.X, literal.x,
+; EG-NEXT:     BFE_UINT * T22.Y, T23.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; EG-NEXT:    12(1.681558e-44), 8(1.121039e-44)
+; EG-NEXT:    ALU clause starting at 68:
+; EG-NEXT:     BFE_UINT T31.Z, T23.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T22.W, T23.X, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T20.X, T23.Y, literal.x,
-; EG-NEXT:     BFE_UINT T24.Y, T23.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     AND_INT T22.X, T23.X, literal.x,
+; EG-NEXT:     BFE_UINT T31.Y, T23.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T23.X, T24.X, literal.z,
 ; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T26.Z, T23.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T24.W, T23.Z, literal.z,
-; EG-NEXT:     AND_INT * T24.X, T23.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T26.Y, T23.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T28.Z, T22.X, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T26.W, T23.W, literal.z,
-; EG-NEXT:     AND_INT * T26.X, T23.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T28.Y, T22.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T30.Z, T22.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T28.W, T22.X, literal.z,
-; EG-NEXT:     AND_INT * T28.X, T22.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T30.Y, T22.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 64(8.968310e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T30.W, T22.Y, literal.y,
-; EG-NEXT:     AND_INT * T30.X, T22.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T21.Z, T22.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT * T21.Y, T22.Z, literal.y, T0.W,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    ALU clause starting at 91:
-; EG-NEXT:     BFE_UINT T34.Z, T22.W, literal.x, T0.W,
-; EG-NEXT:     LSHR * T21.W, T22.Z, literal.y,
+; EG-NEXT:     BFE_UINT T32.Z, T23.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T31.W, T23.Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T21.X, T22.Z, literal.x,
-; EG-NEXT:     BFE_UINT T34.Y, T22.W, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     AND_INT T31.X, T23.Y, literal.x,
+; EG-NEXT:     BFE_UINT T32.Y, T23.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T33.X, T24.X, literal.z,
 ; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T36.Z, T33.X, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T34.W, T22.W, literal.z,
-; EG-NEXT:     AND_INT * T34.X, T22.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T36.Y, T33.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 112(1.569454e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T38.Z, T33.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T36.W, T33.X, literal.z,
-; EG-NEXT:     AND_INT * T36.X, T33.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T38.Y, T33.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 128(1.793662e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T39.Z, T33.Z, literal.y, T0.W,
-; EG-NEXT:     LSHR T38.W, T33.Y, literal.z,
-; EG-NEXT:     AND_INT * T38.X, T33.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T39.Y, T33.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 144(2.017870e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T41.Z, T33.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T39.W, T33.Z, literal.z,
-; EG-NEXT:     AND_INT * T39.X, T33.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T41.Y, T33.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 160(2.242078e-43)
-; EG-NEXT:     LSHR T42.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T43.Z, T32.X, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T41.W, T33.W, literal.z,
-; EG-NEXT:     AND_INT * T41.X, T33.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T43.Y, T32.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 176(2.466285e-43)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T45.Z, T32.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T43.W, T32.X, literal.z,
-; EG-NEXT:     AND_INT * T43.X, T32.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T45.Y, T32.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 192(2.690493e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T46.Z, T32.Z, literal.y, T0.W,
-; EG-NEXT:     LSHR T45.W, T32.Y, literal.z,
-; EG-NEXT:     AND_INT * T45.X, T32.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T46.Y, T32.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 208(2.914701e-43)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T48.Z, T32.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T46.W, T32.Z, literal.z,
-; EG-NEXT:     AND_INT * T46.X, T32.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T48.Y, T32.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 224(3.138909e-43)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T48.W, T32.W, literal.y,
-; EG-NEXT:     AND_INT * T48.X, T32.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T34.Z, T23.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T32.W, T23.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T32.X, T23.Z, literal.x,
+; EG-NEXT:     BFE_UINT T34.Y, T23.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T35.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T36.Z, T30.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T34.W, T23.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T34.X, T23.W, literal.x,
+; EG-NEXT:     BFE_UINT T36.Y, T30.X, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T37.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T38.Z, T30.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T36.W, T30.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T36.X, T30.X, literal.x,
+; EG-NEXT:     BFE_UINT T38.Y, T30.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T30.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T39.Z, T30.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T38.W, T30.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T38.X, T30.Y, literal.x,
+; EG-NEXT:     BFE_UINT T39.Y, T30.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T40.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T41.Z, T30.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T39.W, T30.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T39.X, T30.Z, literal.x,
+; EG-NEXT:     BFE_UINT T41.Y, T30.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T42.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T43.Z, T29.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T41.W, T30.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T41.X, T30.W, literal.x,
+; EG-NEXT:     BFE_UINT T43.Y, T29.X, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T44.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T45.Z, T29.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T43.W, T29.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T43.X, T29.X, literal.x,
+; EG-NEXT:     BFE_UINT T45.Y, T29.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T29.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T46.Z, T29.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T45.W, T29.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T45.X, T29.Y, literal.x,
+; EG-NEXT:     BFE_UINT T46.Y, T29.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T47.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T48.Z, T29.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T46.W, T29.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T46.X, T29.Z, literal.x,
+; EG-NEXT:     BFE_UINT T48.Y, T29.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T49.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T48.W, T29.W, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T48.X, T29.W, literal.x,
+; EG-NEXT:     ADD_INT * T50.X, T24.X, literal.y,
+; EG-NEXT:    255(3.573311e-43), 60(8.407791e-44)
 ;
 ; GFX12-LABEL: constant_zextload_v64i8_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -4889,231 +4830,207 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; EG-LABEL: constant_sextload_v64i8_to_v64i32:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @32, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @24
-; EG-NEXT:    ALU 40, @33, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @28
-; EG-NEXT:    ALU 76, @74, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 72, @151, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @24
+; EG-NEXT:    ALU 17, @33, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 2 @26
+; EG-NEXT:    ALU 76, @51, KC0[], KC1[]
+; EG-NEXT:    ALU 71, @128, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T49.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T19.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T33.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T32.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T30.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T25.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T22.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T32.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T31.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T26.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T22.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T21.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 24:
-; EG-NEXT:     VTX_READ_128 T20.XYZW, T21.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T19.XYZW, T21.X, 48, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T31.XYZW, T21.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T21.XYZW, T21.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T19.XYZW, T20.X, 48, #1
+; EG-NEXT:    Fetch clause starting at 26:
+; EG-NEXT:     VTX_READ_128 T29.XYZW, T20.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T30.XYZW, T20.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T20.XYZW, T20.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 32:
-; EG-NEXT:     MOV * T21.X, KC0[2].Z,
+; EG-NEXT:     MOV * T20.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 33:
-; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T21.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T24.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T21.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T26.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T21.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T28.X, T21.X, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T19.W, literal.y,
-; EG-NEXT:     LSHR T0.Z, T19.Z, literal.z,
-; EG-NEXT:     LSHR * T0.W, T19.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T19.Z, literal.y,
+; EG-NEXT:     LSHR T0.Z, T19.W, literal.z,
+; EG-NEXT:     LSHR T0.W, T19.Z, literal.y,
+; EG-NEXT:     LSHR * T1.W, T19.Z, literal.z,
+; EG-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 51:
+; EG-NEXT:     ADD_INT T31.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T19.Y, literal.y,
 ; EG-NEXT:     LSHR T1.Z, T19.Y, literal.z,
-; EG-NEXT:     LSHR * T1.W, T19.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    128(1.793662e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T2.Y, T19.Y, literal.y,
-; EG-NEXT:     LSHR T2.Z, T19.Y, literal.z,
-; EG-NEXT:     LSHR T2.W, T19.X, literal.y,
+; EG-NEXT:     LSHR T2.W, T19.X, literal.y, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR * T3.W, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    32(4.484155e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 74:
-; EG-NEXT:     LSHR T3.Y, T20.W, literal.x,
-; EG-NEXT:     LSHR T3.Z, T20.W, literal.y,
-; EG-NEXT:     LSHR T4.W, T20.Z, literal.x,
-; EG-NEXT:     ADD_INT * T5.W, KC0[2].Y, literal.z,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T32.X, PS, literal.x,
-; EG-NEXT:     LSHR T4.Y, T20.Z, literal.y,
-; EG-NEXT:     LSHR T4.Z, T20.Y, literal.z,
-; EG-NEXT:     LSHR T5.W, T20.Y, literal.y,
-; EG-NEXT:     ADD_INT * T6.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 160(2.242078e-43)
-; EG-NEXT:     LSHR T33.X, PS, literal.x,
-; EG-NEXT:     LSHR T5.Y, T20.X, literal.y,
-; EG-NEXT:     LSHR T5.Z, T20.X, literal.z,
-; EG-NEXT:     LSHR T6.W, T21.W, literal.y,
-; EG-NEXT:     ADD_INT * T7.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 176(2.466285e-43)
-; EG-NEXT:     LSHR T34.X, PS, literal.x,
-; EG-NEXT:     LSHR T6.Y, T21.W, literal.y,
-; EG-NEXT:     LSHR T6.Z, T21.Z, literal.z,
-; EG-NEXT:     LSHR T7.W, T21.Z, literal.y,
-; EG-NEXT:     ADD_INT * T8.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 192(2.690493e-43)
-; EG-NEXT:     LSHR T35.X, PS, literal.x,
-; EG-NEXT:     LSHR T7.Y, T21.Y, literal.y,
-; EG-NEXT:     LSHR T7.Z, T21.Y, literal.z,
-; EG-NEXT:     LSHR T8.W, T21.X, literal.y,
-; EG-NEXT:     LSHR * T9.W, T21.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T32.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T20.W, literal.y,
+; EG-NEXT:     LSHR T2.Z, T20.W, literal.z,
+; EG-NEXT:     LSHR T4.W, T20.Z, literal.y,
+; EG-NEXT:     LSHR * T5.W, T20.Z, literal.z,
+; EG-NEXT:    36(5.044674e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T36.X, T31.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T8.Y, T31.W, literal.y,
-; EG-NEXT:     LSHR T8.Z, T31.W, literal.z,
-; EG-NEXT:     LSHR T10.W, T31.Z, literal.y,
-; EG-NEXT:     LSHR * T11.W, T31.X, literal.z,
+; EG-NEXT:     ADD_INT T33.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T3.Y, T20.Y, literal.y,
+; EG-NEXT:     LSHR T3.Z, T20.Y, literal.z,
+; EG-NEXT:     LSHR T6.W, T20.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T7.W, T20.X, literal.z,
+; EG-NEXT:    40(5.605194e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T4.Y, T30.W, literal.y,
+; EG-NEXT:     LSHR T4.Z, T30.W, literal.z,
+; EG-NEXT:     LSHR T8.W, T30.Z, literal.y,
+; EG-NEXT:     LSHR * T9.W, T30.Z, literal.z,
+; EG-NEXT:    44(6.165713e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T35.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T5.Y, T30.Y, literal.y,
+; EG-NEXT:     LSHR T5.Z, T30.Y, literal.z,
+; EG-NEXT:     LSHR T10.W, T30.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T11.W, T30.X, literal.z,
+; EG-NEXT:    48(6.726233e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T36.X, T29.X, 0.0, literal.x,
+; EG-NEXT:     LSHR T6.Y, T29.W, literal.y,
+; EG-NEXT:     LSHR T6.Z, T29.W, literal.z,
+; EG-NEXT:     LSHR T12.W, T29.Z, literal.y,
+; EG-NEXT:     LSHR * T13.W, T29.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T37.X, T31.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR T9.Y, T31.Z, literal.y,
-; EG-NEXT:     LSHR T9.Z, T31.Y, literal.y,
+; EG-NEXT:     BFE_INT T37.X, T29.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR T7.Y, T29.Z, literal.y,
+; EG-NEXT:     LSHR T7.Z, T29.Y, literal.y,
 ; EG-NEXT:     BFE_INT T36.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.X, literal.z,
+; EG-NEXT:     LSHR * T13.W, T29.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T38.X, T31.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T10.Y, T31.Y, literal.y,
+; EG-NEXT:     BFE_INT T38.X, T29.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR T8.Y, T29.Y, literal.y,
 ; EG-NEXT:     BFE_INT T36.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.X, literal.x,
+; EG-NEXT:     LSHR * T13.W, T29.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T39.X, T31.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.X, T29.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T36.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T38.W, T9.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.Y, literal.x,
+; EG-NEXT:     BFE_INT T38.W, T7.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T13.W, T29.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T40.X, T21.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.X, T30.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T38.Z, T10.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T39.W, T8.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T10.W, T31.Z, literal.x,
+; EG-NEXT:     BFE_INT T38.Z, T12.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.W, T6.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T12.W, T29.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T31.X, T21.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.X, T30.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T38.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T39.Z, T8.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T40.W, T9.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T9.W, T31.W, literal.x,
+; EG-NEXT:     BFE_INT T39.Z, T6.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T40.W, T11.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T11.W, T29.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T41.X, T21.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T30.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T39.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T40.Z, T8.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT * T31.W, T7.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT * T40.Z, T10.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 151:
-; EG-NEXT:     LSHR * T8.W, T21.X, literal.x,
+; EG-NEXT:    ALU clause starting at 128:
+; EG-NEXT:     BFE_INT T29.W, T5.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T10.W, T30.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T42.X, T21.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T40.Y, PV.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.Z, T7.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T41.W, T7.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T7.W, T21.Y, literal.x,
+; EG-NEXT:     BFE_INT T42.X, T30.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.Z, T5.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.W, T9.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T9.W, T30.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T43.X, T20.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T41.Z, T6.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.W, T6.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T7.W, T21.Z, literal.x,
+; EG-NEXT:     BFE_INT T29.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.Z, T8.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.W, T4.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T8.W, T30.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T21.X, T20.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.X, T20.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T41.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.Z, T6.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.W, T5.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T21.W, literal.x,
+; EG-NEXT:     BFE_INT T42.Z, T4.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T43.W, T7.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.W, T30.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T44.X, T20.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T42.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Z, T5.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.W, T5.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T5.W, T20.X, literal.x,
+; EG-NEXT:     BFE_INT T43.Z, T6.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.W, T3.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T6.W, T20.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T45.X, T20.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T43.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Z, T4.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.W, T4.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.Z, T3.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T44.W, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR * T5.W, T20.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T46.X, T19.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T44.Z, T4.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.W, T3.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T45.W, T2.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T4.W, T20.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.X, T19.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T44.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Z, T3.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T45.Z, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:     BFE_INT T46.W, T3.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T3.W, T20.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T47.X, T19.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T45.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T46.Z, T2.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.W, T2.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T20.W, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR * T2.W, T19.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T48.X, T19.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T46.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.Z, T2.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T20.Z, T1.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T47.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 208(2.914701e-43)
-; EG-NEXT:     LSHR T19.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T20.Y, T1.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T47.Z, T1.Y, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T48.W, T0.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T49.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T47.Y, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T1.W, T19.Y, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T19.X, T21.X, literal.x,
+; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T47.Z, T0.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T48.W, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T19.Z, literal.y,
+; EG-NEXT:    52(7.286752e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T49.X, T21.X, literal.x,
+; EG-NEXT:     BFE_INT T47.Y, PS, 0.0, literal.y,
 ; EG-NEXT:     BFE_INT T48.Z, T0.Y, 0.0, literal.y,
 ; EG-NEXT:     LSHR T0.W, T19.W, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T50.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T48.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T50.X, T21.X, literal.z,
+; EG-NEXT:    56(7.847271e-44), 8(1.121039e-44)
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T48.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v64i8_to_v64i32:
 ; GFX12:       ; %bb.0:
@@ -5965,7 +5882,7 @@ define amdgpu_kernel void @constant_zextload_v4i8_to_v4i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T6.X, 1
 ; EG-NEXT:    CF_END
@@ -5987,11 +5904,10 @@ define amdgpu_kernel void @constant_zextload_v4i8_to_v4i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV T5.W, 0.0,
 ; EG-NEXT:     MOV * T4.W, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T7.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v4i8_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6117,33 +6033,33 @@ define amdgpu_kernel void @constant_sextload_v4i8_to_v4i64(ptr addrspace(1) %out
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
 ; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T6.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T4.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     BFE_INT T5.X, T4.X, 0.0, literal.x,
-; EG-NEXT:     ASHR T4.W, T4.X, literal.y,
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.z,
+; EG-NEXT:     ASHR * T5.W, T4.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.X, T4.X, 0.0, literal.x,
+; EG-NEXT:     ASHR T5.Z, T4.X, literal.y,
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.z,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T5.X, PV.W, 0.0, literal.x,
+; EG-NEXT:     ASHR T6.Y, PV.X, literal.y,
+; EG-NEXT:     LSHR T0.W, T4.X, literal.x,
+; EG-NEXT:     LSHR * T4.X, KC0[2].Y, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.x,
-; EG-NEXT:     ASHR T4.Z, T4.X, literal.y,
-; EG-NEXT:     LSHR T0.W, T4.X, literal.z,
-; EG-NEXT:     LSHR * T1.W, T4.X, literal.w,
-; EG-NEXT:    31(4.344025e-44), 24(3.363116e-44)
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T4.X, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T5.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T4.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR * T5.W, PV.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT * T6.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T7.X, T4.X, literal.x,
+; EG-NEXT:     ASHR T5.Y, T5.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ASHR * T6.W, PV.Z, literal.y,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v4i8_to_v4i64:
 ; GFX12:       ; %bb.0:
@@ -6304,7 +6220,7 @@ define amdgpu_kernel void @constant_zextload_v8i8_to_v8i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 34, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 30, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T10.X, 0
@@ -6339,17 +6255,13 @@ define amdgpu_kernel void @constant_zextload_v8i8_to_v8i64(ptr addrspace(1) %out
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
 ; EG-NEXT:     MOV T8.W, 0.0,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T12.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T9.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T10.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T11.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T12.X, T9.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v8i8_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -6564,33 +6476,29 @@ define amdgpu_kernel void @constant_sextload_v8i8_to_v8i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 39, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 34, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T9.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T9.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T6.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T5.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T5.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T7.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    8(1.121039e-44), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT T8.X, PS, literal.x,
+; EG-NEXT:     ASHR T6.Y, PV.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T5.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T9.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T7.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ASHR * T10.W, T5.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T9.X, PS, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:     ASHR * T10.W, T5.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T11.X, T5.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T10.Z, T5.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T5.X, literal.z,
@@ -6607,14 +6515,13 @@ define amdgpu_kernel void @constant_sextload_v8i8_to_v8i64(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_INT T5.X, PS, 0.0, literal.x,
 ; EG-NEXT:     ASHR T10.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T11.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T12.X, T7.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR T11.W, PV.Z, literal.y,
-; EG-NEXT:     ASHR * T7.W, T7.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T5.Y, PV.X, literal.x,
+; EG-NEXT:     ASHR T11.W, PV.Z, literal.x,
+; EG-NEXT:     ASHR * T6.W, T6.Z, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_sextload_v8i8_to_v8i64:
 ; GFX12:       ; %bb.0:
@@ -6888,7 +6795,7 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 68, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 58, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T20.X, 0
@@ -6949,29 +6856,19 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV * T13.W, 0.0,
 ; EG-NEXT:     MOV T14.W, 0.0,
 ; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T22.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T15.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T18.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T15.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T20.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T15.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T22.X, T15.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v16i8_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -7355,7 +7252,7 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 78, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 67, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T16.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T15.X, 0
@@ -7370,39 +7267,30 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR * T12.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T10.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T11.X, T8.X, literal.x,
+; EG-NEXT:     ADD_INT * T12.X, T8.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT * T13.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T14.X, T7.Y, 0.0, literal.x,
 ; EG-NEXT:     ASHR T13.Y, PV.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T7.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T15.X, T8.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T15.X, PS, literal.x,
-; EG-NEXT:     ASHR T14.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T13.Z, PV.W, 0.0, literal.z,
-; EG-NEXT:     LSHR T0.W, T7.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T16.X, PS, literal.x,
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T14.Y, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T13.Z, PV.W, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Y, literal.y,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T8.X, literal.x,
 ; EG-NEXT:     BFE_INT T14.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ASHR * T17.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ASHR * T17.W, T7.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:    24(3.363116e-44), 8(1.121039e-44)
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T18.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T17.Z, T7.X, literal.y,
@@ -7420,22 +7308,20 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:     BFE_INT T19.X, PS, 0.0, literal.x,
 ; EG-NEXT:     ASHR T17.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T18.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.z,
 ; EG-NEXT:     ASHR * T20.W, T7.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T7.X, T7.Z, 0.0, literal.x,
 ; EG-NEXT:     ASHR T19.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T20.Z, T7.Z, literal.z,
-; EG-NEXT:     LSHR T1.W, T7.Z, literal.w,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.w,
 ; EG-NEXT:     ASHR * T21.W, T7.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T20.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T7.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T21.Z, T7.W, literal.z,
-; EG-NEXT:     LSHR T1.W, T7.Z, literal.x,
-; EG-NEXT:     LSHR * T2.W, T7.W, literal.w,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.W, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T21.X, PS, 0.0, literal.x,
@@ -7444,11 +7330,11 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i64(ptr addrspace(1) %o
 ; EG-NEXT:     ASHR T18.W, T18.Z, literal.y,
 ; EG-NEXT:     ASHR * T14.W, T14.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T22.X, T0.W, literal.x,
+; EG-NEXT:     ADD_INT T22.X, T8.X, literal.x,
 ; EG-NEXT:     ASHR T21.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T7.W, PV.Z, literal.y,
 ; EG-NEXT:     ASHR * T13.W, T13.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    28(3.923636e-44), 31(4.344025e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v16i8_to_v16i64:
 ; GFX12:       ; %bb.0:
@@ -7944,9 +7830,10 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-LABEL: constant_zextload_v32i8_to_v32i64:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 103, @27, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 33, @131, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @22
+; EG-NEXT:    ALU 12, @27, KC0[], KC1[]
+; EG-NEXT:    TEX 0 @24
+; EG-NEXT:    ALU 102, @40, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T40.X, 0
@@ -7954,7 +7841,7 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T37.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T33.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T32.X, 0
@@ -7962,88 +7849,90 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T27.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T27.X, 1
 ; EG-NEXT:    CF_END
-; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 16, #1
+; EG-NEXT:    Fetch clause starting at 24:
+; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 26:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 27:
 ; EG-NEXT:     MOV * T0.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T13.X, T11.W, literal.x, PV.W,
-; EG-NEXT:     LSHR * T13.Z, T11.W, literal.y,
+; EG-NEXT:     BFE_UINT T13.X, T12.W, literal.x, PV.W,
+; EG-NEXT:     LSHR * T13.Z, T12.W, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T13.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T14.Z, T11.W, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T14.Z, T12.W, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T14.X, T11.W, literal.x,
+; EG-NEXT:     AND_INT T14.X, T12.W, literal.x,
 ; EG-NEXT:     MOV * T14.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T15.X, T11.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T15.Z, T11.Z, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T15.X, T12.Z, literal.x, T0.W,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 40:
+; EG-NEXT:     LSHR * T15.Z, T12.Z, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T15.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T16.Z, T11.Z, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T16.Z, T12.Z, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T16.X, T11.Z, literal.x,
+; EG-NEXT:     AND_INT T16.X, T12.Z, literal.x,
 ; EG-NEXT:     MOV * T16.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T17.X, T11.Y, literal.x, T0.W,
-; EG-NEXT:     LSHR * T17.Z, T11.Y, literal.y,
+; EG-NEXT:     BFE_UINT T17.X, T12.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T17.Z, T12.Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T17.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T18.Z, T11.Y, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T18.Z, T12.Y, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T18.X, T11.Y, literal.x,
+; EG-NEXT:     AND_INT T18.X, T12.Y, literal.x,
 ; EG-NEXT:     MOV * T18.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T19.X, T11.X, literal.x, T0.W,
-; EG-NEXT:     LSHR * T19.Z, T11.X, literal.y,
+; EG-NEXT:     BFE_UINT T19.X, T12.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T19.Z, T12.X, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T19.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T11.Z, T11.X, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T11.X, T11.X, literal.x,
-; EG-NEXT:     MOV * T11.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T20.X, T12.W, literal.x, T0.W,
-; EG-NEXT:     LSHR * T20.Z, T12.W, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T21.Z, T12.W, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T21.X, T12.W, literal.x,
-; EG-NEXT:     MOV * T21.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T22.X, T12.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T22.Z, T12.Z, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T23.Z, T12.Z, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T23.X, T12.Z, literal.x,
-; EG-NEXT:     MOV * T23.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T24.X, T12.Y, literal.x, T0.W,
-; EG-NEXT:     LSHR * T24.Z, T12.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T24.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T25.Z, T12.Y, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T25.X, T12.Y, literal.x,
-; EG-NEXT:     MOV * T25.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T26.X, T12.X, literal.x, T0.W,
-; EG-NEXT:     LSHR * T26.Z, T12.X, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T26.Y, 0.0,
 ; EG-NEXT:     BFE_UINT * T12.Z, T12.X, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T12.X, T12.X, literal.x,
-; EG-NEXT:     MOV T12.Y, 0.0,
+; EG-NEXT:     MOV * T12.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T20.X, T11.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T20.Z, T11.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T20.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T21.Z, T11.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T21.X, T11.W, literal.x,
+; EG-NEXT:     MOV * T21.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T22.X, T11.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T22.Z, T11.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T22.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T23.Z, T11.Z, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T23.X, T11.Z, literal.x,
+; EG-NEXT:     MOV * T23.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T24.X, T11.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T24.Z, T11.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T24.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T25.Z, T11.Y, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T25.X, T11.Y, literal.x,
+; EG-NEXT:     MOV * T25.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T26.X, T11.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T26.Z, T11.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T26.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T11.Z, T11.X, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T11.X, T11.X, literal.x,
+; EG-NEXT:     MOV T11.Y, 0.0,
 ; EG-NEXT:     MOV T13.W, 0.0,
 ; EG-NEXT:     MOV * T14.W, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
@@ -8052,7 +7941,7 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV T17.W, 0.0,
 ; EG-NEXT:     MOV * T18.W, 0.0,
 ; EG-NEXT:     MOV T19.W, 0.0,
-; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     MOV * T12.W, 0.0,
 ; EG-NEXT:     MOV T20.W, 0.0,
 ; EG-NEXT:     MOV * T21.W, 0.0,
 ; EG-NEXT:     MOV T22.W, 0.0,
@@ -8060,56 +7949,32 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:     MOV T24.W, 0.0,
 ; EG-NEXT:     MOV * T25.W, 0.0,
 ; EG-NEXT:     MOV T26.W, 0.0,
-; EG-NEXT:     MOV * T12.W, 0.0,
-; EG-NEXT:     LSHR T27.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR * T31.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     LSHR * T27.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 131:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T42.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T28.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T30.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T27.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T32.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T27.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T34.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T35.X, T27.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T36.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T37.X, T27.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T38.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T27.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T40.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T41.X, T27.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT * T42.X, T27.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; GFX12-LABEL: constant_zextload_v32i8_to_v32i64:
 ; GFX12:       ; %bb.0:
@@ -8837,8 +8702,8 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 84, @27, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 71, @112, KC0[], KC1[]
+; EG-NEXT:    ALU 83, @27, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 50, @111, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T31.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T30.X, 0
@@ -8863,44 +8728,26 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:    ALU clause starting at 26:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 27:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR * T25.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T13.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T13.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T20.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T13.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T22.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, T13.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T24.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T13.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
 ; EG-NEXT:     BFE_INT * T26.X, T11.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T27.X, T11.Y, 0.0, literal.x,
@@ -8916,78 +8763,74 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:     ASHR T28.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T27.Z, PV.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T30.X, T13.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T30.X, PS, literal.x,
-; EG-NEXT:     ASHR T29.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T28.Z, PV.W, 0.0, literal.z,
-; EG-NEXT:     LSHR T0.W, T12.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 224(3.138909e-43)
-; EG-NEXT:     LSHR T31.X, PS, literal.x,
+; EG-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T29.Y, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T28.Z, PV.W, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T12.W, literal.y,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T31.X, T13.X, literal.x,
 ; EG-NEXT:     BFE_INT T29.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:     ASHR * T32.W, T12.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    240(3.363116e-43), 31(4.344025e-44)
+; EG-NEXT:     ASHR * T32.W, T12.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:    56(7.847271e-44), 8(1.121039e-44)
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T33.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T11.Z, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR T32.Z, T12.X, literal.y,
-; EG-NEXT:     LSHR T1.W, T12.X, literal.z,
+; EG-NEXT:     LSHR T0.W, T12.X, literal.z,
 ; EG-NEXT:     ASHR * T34.W, T12.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T32.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T33.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T34.Z, T12.Y, literal.z,
-; EG-NEXT:     LSHR T1.W, T12.Z, literal.x,
-; EG-NEXT:     LSHR * T2.W, T12.Y, literal.w,
+; EG-NEXT:     LSHR T0.W, T12.Z, literal.x,
+; EG-NEXT:     LSHR * T1.W, T12.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT * T34.X, PS, 0.0, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 112:
-; EG-NEXT:     ASHR T32.Y, T32.X, literal.x,
-; EG-NEXT:     BFE_INT T33.Z, T1.W, 0.0, literal.y,
-; EG-NEXT:     LSHR T1.W, T11.W, literal.z, BS:VEC_120/SCL_212
-; EG-NEXT:     ASHR * T35.W, T12.Z, literal.x,
-; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     BFE_INT T34.X, PS, 0.0, literal.x,
+; EG-NEXT:     ASHR T32.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T33.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.W, T11.W, literal.z,
+; EG-NEXT:     ASHR * T35.W, T12.Z, literal.y,
+; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T36.X, T12.X, 0.0, literal.x,
-; EG-NEXT:     ASHR T34.Y, T34.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ASHR T34.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T35.Z, T12.Z, literal.z,
-; EG-NEXT:     LSHR T2.W, T12.Z, literal.w,
+; EG-NEXT:     LSHR T1.W, T12.Z, literal.w,
 ; EG-NEXT:     ASHR * T37.W, T12.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T35.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T36.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T37.Z, T12.W, literal.z,
-; EG-NEXT:     LSHR T2.W, T12.X, literal.x,
-; EG-NEXT:     LSHR * T3.W, T12.W, literal.w,
+; EG-NEXT:     LSHR T1.W, T12.X, literal.x,
+; EG-NEXT:     LSHR * T2.W, T12.W, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T37.X, PS, 0.0, literal.x,
-; EG-NEXT:     ASHR T35.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T36.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.W, T11.Z, literal.z,
-; EG-NEXT:     ASHR * T12.W, T11.X, literal.y,
-; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT * T37.X, PS, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 111:
+; EG-NEXT:     ASHR T35.Y, T35.X, literal.x,
+; EG-NEXT:     BFE_INT T36.Z, T1.W, 0.0, literal.y,
+; EG-NEXT:     LSHR T1.W, T11.Z, literal.z,
+; EG-NEXT:     ASHR * T12.W, T11.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T38.X, T12.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR T37.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR T12.Z, T11.X, literal.z,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.w,
+; EG-NEXT:     ASHR T37.Y, T37.X, literal.y,
+; EG-NEXT:     ASHR T12.Z, T11.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T2.W, T11.X, literal.w, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR * T39.W, T11.Y, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T12.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T38.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T39.Z, T11.Y, literal.z,
-; EG-NEXT:     LSHR T3.W, T12.Y, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T4.W, T11.Y, literal.w,
+; EG-NEXT:     LSHR T2.W, T12.Y, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T11.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T39.X, PS, 0.0, literal.x,
@@ -9003,24 +8846,24 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; EG-NEXT:     ASHR * T41.W, T11.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T40.X, T2.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.X, T1.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T11.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T41.Z, T11.W, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR T33.W, T33.Z, literal.y,
 ; EG-NEXT:     ASHR * T29.W, T29.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T41.X, T1.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T0.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T40.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T11.Z, T0.Y, 0.0, literal.x,
 ; EG-NEXT:     ASHR T28.W, T28.Z, literal.y,
 ; EG-NEXT:     ASHR * T27.W, T27.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T42.X, T0.W, literal.x,
+; EG-NEXT:     ADD_INT T42.X, T13.X, literal.x,
 ; EG-NEXT:     ASHR T41.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T11.W, PV.Z, literal.y,
 ; EG-NEXT:     ASHR * T26.W, T26.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    60(8.407791e-44), 31(4.344025e-44)
 ;
 ; GFX12-LABEL: constant_sextload_v32i8_to_v32i64:
 ; GFX12:       ; %bb.0:
@@ -10712,9 +10555,9 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i16(ptr addrspace(1) %o
 ; EG-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
 ; EG-NEXT:    ALU 103, @12, KC0[], KC1[]
-; EG-NEXT:    ALU 20, @116, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T21.X, 1
+; EG-NEXT:    ALU 19, @116, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -10833,17 +10676,16 @@ define amdgpu_kernel void @constant_zextload_v16i8_to_v16i16(ptr addrspace(1) %o
 ; EG-NEXT:     OR_INT * T0.W, PV.W, T0.W,
 ; EG-NEXT:     MOV * T5.X, PV.W,
 ; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     LSHR T0.W, T19.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T21.X, PS, literal.x,
+; EG-NEXT:     LSHR * T0.W, T19.W, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     AND_INT T1.W, PV.Y, literal.y,
 ; EG-NEXT:     AND_INT * T0.W, PV.W, literal.z,
 ; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
 ; EG-NEXT:    16711680(2.341805e-38), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
 ; EG-NEXT:     OR_INT * T19.W, PV.W, PS,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T5.X, PV.W,
 ; EG-NEXT:     MOV * T20.X, T16.X,
 ; EG-NEXT:     MOV * T20.Z, T12.X,
@@ -11102,9 +10944,9 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i16(ptr addrspace(1) %o
 ; EG-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
 ; EG-NEXT:    ALU 104, @12, KC0[], KC1[]
-; EG-NEXT:    ALU 46, @117, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T21.X, 1
+; EG-NEXT:    ALU 45, @117, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -11250,17 +11092,16 @@ define amdgpu_kernel void @constant_sextload_v16i8_to_v16i16(ptr addrspace(1) %o
 ; EG-NEXT:     OR_INT * T0.W, T1.W, PV.W,
 ; EG-NEXT:     MOV * T5.X, PV.W,
 ; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ASHR T0.W, T19.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T21.X, PS, literal.x,
+; EG-NEXT:     ASHR * T0.W, T19.W, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     AND_INT T1.W, PV.Y, literal.y,
 ; EG-NEXT:     LSHL * T0.W, PV.W, literal.z,
 ; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
 ; EG-NEXT:     OR_INT * T19.W, PV.W, PS,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T5.X, PV.W,
 ; EG-NEXT:     MOV * T20.X, T16.X,
 ; EG-NEXT:     MOV * T20.Z, T12.X,
@@ -11639,11 +11480,11 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i16(ptr addrspace(1) %o
 ; EG-NEXT:    TEX 1 @10
 ; EG-NEXT:    ALU 103, @16, KC0[], KC1[]
 ; EG-NEXT:    ALU 104, @120, KC0[], KC1[]
-; EG-NEXT:    ALU 41, @225, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 37, @225, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T39.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T40.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 10:
 ; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -11878,24 +11719,20 @@ define amdgpu_kernel void @constant_zextload_v32i8_to_v32i16(ptr addrspace(1) %o
 ; EG-NEXT:    -65536(nan), 0(0.000000e+00)
 ; EG-NEXT:     OR_INT * T0.W, PV.W, T0.W,
 ; EG-NEXT:     MOV * T21.X, PV.W,
-; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T40.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T0.Y, PV.X,
+; EG-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.W, T35.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
-; EG-NEXT:     AND_INT T0.W, PV.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    16711680(2.341805e-38), 32(4.484155e-44)
-; EG-NEXT:     LSHR T42.X, PS, literal.x,
-; EG-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T35.W, literal.y,
+; EG-NEXT:     ADD_INT * T41.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T1.W, T0.Y, literal.x,
+; EG-NEXT:     AND_INT * T0.W, PV.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16711680(2.341805e-38)
+; EG-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; EG-NEXT:     OR_INT * T35.W, PV.W, PS,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T21.X, PV.W,
 ; EG-NEXT:     MOV * T36.X, T16.X,
 ; EG-NEXT:     MOV * T36.Z, T12.X,
@@ -12367,11 +12204,11 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i16(ptr addrspace(1) %o
 ; EG-NEXT:    TEX 1 @10
 ; EG-NEXT:    ALU 104, @16, KC0[], KC1[]
 ; EG-NEXT:    ALU 104, @121, KC0[], KC1[]
-; EG-NEXT:    ALU 95, @226, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 91, @226, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T39.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T40.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 10:
 ; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -12661,24 +12498,20 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i16(ptr addrspace(1) %o
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
 ; EG-NEXT:     OR_INT * T0.W, T1.W, PV.W,
 ; EG-NEXT:     MOV * T21.X, PV.W,
-; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T40.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T0.Y, PV.X,
+; EG-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ASHR T0.W, T35.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    24(3.363116e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
-; EG-NEXT:     LSHL T0.W, PV.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    16(2.242078e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T42.X, PS, literal.x,
-; EG-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T0.W, T35.W, literal.y,
+; EG-NEXT:     ADD_INT * T41.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 24(3.363116e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T1.W, T0.Y, literal.x,
+; EG-NEXT:     LSHL * T0.W, PV.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; EG-NEXT:     OR_INT * T35.W, PV.W, PS,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T21.X, PV.W,
 ; EG-NEXT:     MOV * T36.X, T16.X,
 ; EG-NEXT:     MOV * T36.Z, T12.X,

--- a/llvm/test/CodeGen/AMDGPU/load-global-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-global-i16.ll
@@ -586,9 +586,9 @@ define amdgpu_kernel void @global_load_v16i16(ptr addrspace(1) %out, ptr addrspa
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
@@ -596,17 +596,16 @@ define amdgpu_kernel void @global_load_v16i16(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_load_v16i16:
 ; CM:       ; %bb.0: ; %entry
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @6
-; CM-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
 ; CM-NEXT:    CF_END
@@ -616,11 +615,10 @@ define amdgpu_kernel void @global_load_v16i16(ptr addrspace(1) %out, ptr addrspa
 ; CM-NEXT:    ALU clause starting at 10:
 ; CM-NEXT:     MOV * T0.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 11:
-; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 entry:
   %ld = load <16 x i16>, ptr addrspace(1) %in
   store <16 x i16> %ld, ptr addrspace(1) %out
@@ -770,7 +768,7 @@ define amdgpu_kernel void @global_load_v16i16_align2(ptr addrspace(1) %in, ptr a
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
@@ -780,19 +778,18 @@ define amdgpu_kernel void @global_load_v16i16_align2(ptr addrspace(1) %in, ptr a
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Y,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T2.X, KC0[2].Z, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Z, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_load_v16i16_align2:
 ; CM:       ; %bb.0: ; %entry
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @6
-; CM-NEXT:    ALU 5, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 16, #1
@@ -800,12 +797,10 @@ define amdgpu_kernel void @global_load_v16i16_align2(ptr addrspace(1) %in, ptr a
 ; CM-NEXT:    ALU clause starting at 10:
 ; CM-NEXT:     MOV * T0.X, KC0[2].Y,
 ; CM-NEXT:    ALU clause starting at 11:
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Z, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T2.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T2.X, KC0[2].Z, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T3.X, KC0[2].Z, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 entry:
   %ld =  load <16 x i16>, ptr addrspace(1) %in, align 2
   store <16 x i16> %ld, ptr addrspace(1) %out, align 32
@@ -1437,9 +1432,9 @@ define amdgpu_kernel void @global_zextload_v3i16_to_v3i32(ptr addrspace(1) %out,
 ;
 ; EG-LABEL: global_zextload_v3i16_to_v3i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 4, @12, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 2, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @6
-; EG-NEXT:    ALU 2, @17, KC0[], KC1[]
+; EG-NEXT:    ALU 2, @15, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XY, T0.X, 1
 ; EG-NEXT:    CF_END
@@ -1451,34 +1446,30 @@ define amdgpu_kernel void @global_zextload_v3i16_to_v3i32(ptr addrspace(1) %out,
 ; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     MOV * T1.X, KC0[2].Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 17:
-; EG-NEXT:     LSHR T4.X, T0.W, literal.x,
-; EG-NEXT:     MOV * T3.Y, T1.X,
+; EG-NEXT:    ALU clause starting at 15:
+; EG-NEXT:     ADD_INT T4.X, T0.X, literal.x,
+; EG-NEXT:     MOV * T3.Y, T1.X, BS:VEC_120/SCL_212
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v3i16_to_v3i32:
 ; CM:       ; %bb.0: ; %entry
-; CM-NEXT:    ALU 4, @12, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 2, @12, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 2 @6
-; CM-NEXT:    ALU 2, @17, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T4.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T0.X
+; CM-NEXT:    ALU 2, @15, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T0.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T4.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_16 T2.X, T1.X, 4, #1
 ; CM-NEXT:     VTX_READ_16 T3.X, T1.X, 0, #1
 ; CM-NEXT:     VTX_READ_16 T1.X, T1.X, 2, #1
 ; CM-NEXT:    ALU clause starting at 12:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T0.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T1.X, KC0[2].Z,
-; CM-NEXT:    ALU clause starting at 17:
-; CM-NEXT:     LSHR T4.X, KC0[2].Y, literal.x,
-; CM-NEXT:     MOV * T3.Y, T1.X,
+; CM-NEXT:    ALU clause starting at 15:
+; CM-NEXT:     ADD_INT T4.X, T0.X, literal.x,
+; CM-NEXT:     MOV * T3.Y, T1.X, BS:VEC_120/SCL_212
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 entry:
   %ld = load <3 x i16>, ptr addrspace(1) %in
@@ -1552,9 +1543,9 @@ define amdgpu_kernel void @global_sextload_v3i16_to_v3i32(ptr addrspace(1) %out,
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @6
-; EG-NEXT:    ALU 9, @13, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; EG-NEXT:    ALU 8, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_16 T1.X, T0.X, 2, #1
@@ -1565,22 +1556,21 @@ define amdgpu_kernel void @global_sextload_v3i16_to_v3i32(ptr addrspace(1) %out,
 ; EG-NEXT:    ALU clause starting at 13:
 ; EG-NEXT:     BFE_INT * T0.Y, T1.X, 0.0, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T0.X, T0.X, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.y,
+; EG-NEXT:     BFE_INT * T0.X, T0.X, 0.0, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T1.X, T2.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
-; EG-NEXT:     BFE_INT T2.X, T2.X, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v3i16_to_v3i32:
 ; CM:       ; %bb.0: ; %entry
 ; CM-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 2 @6
-; CM-NEXT:    ALU 9, @13, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T3.X
+; CM-NEXT:    ALU 8, @13, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T4.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_16 T1.X, T0.X, 4, #1
@@ -1589,16 +1579,15 @@ define amdgpu_kernel void @global_sextload_v3i16_to_v3i32(ptr addrspace(1) %out,
 ; CM-NEXT:    ALU clause starting at 12:
 ; CM-NEXT:     MOV * T0.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 13:
-; CM-NEXT:     BFE_INT T1.X, T1.X, 0.0, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; CM-NEXT:     LSHR T3.X, PV.W, literal.x,
+; CM-NEXT:     BFE_INT * T1.X, T1.X, 0.0, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T4.X, PV.X, literal.x,
 ; CM-NEXT:     BFE_INT * T0.Y, T0.X, 0.0, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
 ; CM-NEXT:     BFE_INT * T0.X, T2.X, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 entry:
   %ld = load <3 x i16>, ptr addrspace(1) %in
   %ext = sext <3 x i16> %ld to <3 x i32>
@@ -1929,7 +1918,7 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T10.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -1940,30 +1929,28 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; EG-NEXT:    ALU clause starting at 9:
 ; EG-NEXT:     LSHR * T8.W, T7.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T8.Z, T7.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T8.Y, T7.X, literal.x,
-; EG-NEXT:     LSHR * T9.W, T7.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
-; EG-NEXT:     AND_INT T9.Z, T7.W, literal.x,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR * T9.Y, T7.Z, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T9.X, T7.Z, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T8.Z, T7.Y, literal.x,
+; EG-NEXT:     LSHR * T9.W, T7.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T10.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T8.Y, T7.X, literal.x,
+; EG-NEXT:     AND_INT * T9.Z, T7.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
+; EG-NEXT:     LSHR T9.Y, T7.Z, literal.y,
+; EG-NEXT:     AND_INT * T9.X, T7.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T10.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v8i16_to_v8i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T10.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T9.X
+; CM-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T9.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T10.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
@@ -1974,20 +1961,19 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT * T8.Z, T7.W, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T8.Y, T7.Z, literal.x,
-; CM-NEXT:     LSHR * T7.W, T7.Y, literal.x,
+; CM-NEXT:     LSHR * T8.Y, T7.Z, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T8.X, T7.Z, literal.x,
-; CM-NEXT:     AND_INT T7.Z, T7.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; CM-NEXT:     LSHR * T7.W, T7.Y, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
+; CM-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
+; CM-NEXT:     AND_INT * T7.Z, T7.Y, literal.y,
+; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; CM-NEXT:     ADD_INT T10.X, PV.X, literal.x,
 ; CM-NEXT:     LSHR * T7.Y, T7.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; CM-NEXT:     AND_INT * T7.X, T7.X, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T10.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %load = load <8 x i16>, ptr addrspace(1) %in
   %ext = zext <8 x i16> %load to <8 x i32>
   store <8 x i32> %ext, ptr addrspace(1) %out
@@ -2081,7 +2067,7 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 19, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T10.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -2103,21 +2089,20 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     BFE_INT T8.Y, PS, 0.0, literal.y,
-; EG-NEXT:     LSHR T1.Z, T7.Z, literal.y,
 ; EG-NEXT:     BFE_INT T9.W, PV.Z, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Z, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T9.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T10.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT * T9.Y, PS, 0.0, literal.y,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ;
 ; CM-LABEL: global_sextload_v8i16_to_v8i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 19, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T10.X
+; CM-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T10.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T7.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
@@ -2127,23 +2112,22 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i32(ptr addrspace(1) %out,
 ; CM-NEXT:     BFE_INT * T8.Z, T7.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T8.X, T7.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T0.Y, T7.Y, literal.x,
 ; CM-NEXT:     BFE_INT T9.Z, T7.Y, 0.0, literal.x,
 ; CM-NEXT:     LSHR * T0.W, T7.W, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T9.X, T7.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T1.Y, T7.Z, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHR T0.Y, T7.Y, literal.x,
+; CM-NEXT:     LSHR T0.Z, T7.Z, literal.x,
 ; CM-NEXT:     BFE_INT * T8.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T10.X, PV.Z, literal.x,
-; CM-NEXT:     BFE_INT T8.Y, PV.Y, 0.0, literal.y,
+; CM-NEXT:     LSHR T10.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_INT T8.Y, PV.Z, 0.0, literal.y,
 ; CM-NEXT:     LSHR T0.Z, T7.X, literal.y,
-; CM-NEXT:     BFE_INT * T9.W, T0.Y, 0.0, literal.y,
+; CM-NEXT:     BFE_INT * T9.W, PV.Y, 0.0, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T7.X, PV.X, literal.x,
 ; CM-NEXT:     BFE_INT * T9.Y, PV.Z, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
   %load = load <8 x i16>, ptr addrspace(1) %in
   %ext = sext <8 x i16> %load to <8 x i32>
   store <8 x i32> %ext, ptr addrspace(1) %out
@@ -2284,11 +2268,11 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 35, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 31, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T18.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T11.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T16.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T12.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T15.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -2298,50 +2282,46 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 13:
 ; EG-NEXT:     LSHR * T13.W, T12.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T13.Z, T12.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T13.Y, T12.X, literal.x,
-; EG-NEXT:     LSHR * T14.W, T12.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T13.X, T12.X, literal.x,
-; EG-NEXT:     AND_INT T14.Z, T12.W, literal.x,
-; EG-NEXT:     LSHR * T12.X, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 2(2.802597e-45)
-; EG-NEXT:     LSHR T14.Y, T12.Z, literal.x,
-; EG-NEXT:     LSHR * T15.W, T11.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T14.X, T12.Z, literal.x,
-; EG-NEXT:     AND_INT T15.Z, T11.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     AND_INT T13.Z, T12.Y, literal.x,
+; EG-NEXT:     LSHR * T14.W, T12.W, literal.y,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T15.Y, T11.X, literal.y,
+; EG-NEXT:     LSHR T13.Y, T12.X, literal.x,
+; EG-NEXT:     AND_INT * T14.Z, T12.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 65535(9.183409e-41)
+; EG-NEXT:     AND_INT T13.X, T12.X, literal.x,
+; EG-NEXT:     LSHR T14.Y, T12.Z, literal.y,
+; EG-NEXT:     AND_INT * T14.X, T12.Z, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T12.W, T11.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
+; EG-NEXT:     AND_INT * T12.Z, T11.Y, literal.y,
+; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T12.Y, T11.X, literal.y,
 ; EG-NEXT:     LSHR T17.W, T11.W, literal.y,
-; EG-NEXT:     AND_INT * T15.X, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     AND_INT * T12.X, T11.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T17.Z, T11.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
+; EG-NEXT:     AND_INT * T17.Z, T11.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T11.X, T15.X, literal.x,
 ; EG-NEXT:     LSHR T17.Y, T11.Z, literal.y,
 ; EG-NEXT:     AND_INT * T17.X, T11.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T18.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T18.X, T15.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v16i16_to_v16i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @8
-; CM-NEXT:    ALU 33, @13, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T14.X
+; CM-NEXT:    ALU 30, @13, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T14.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T17.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T15.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 16, #1
@@ -2353,36 +2333,33 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT * T13.Z, T12.W, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.Y, T12.Z, literal.x,
-; CM-NEXT:     LSHR * T12.W, T12.Y, literal.x,
+; CM-NEXT:     LSHR * T13.Y, T12.Z, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T13.X, T12.Z, literal.x,
-; CM-NEXT:     AND_INT T12.Z, T12.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; CM-NEXT:     LSHR T14.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T12.Y, T12.X, literal.y,
-; CM-NEXT:     LSHR * T15.W, T11.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T12.X, T12.X, literal.x,
-; CM-NEXT:     AND_INT T15.Z, T11.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; CM-NEXT:     LSHR T16.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T15.Y, T11.Z, literal.y,
-; CM-NEXT:     LSHR * T11.W, T11.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T15.X, T11.Z, literal.x,
-; CM-NEXT:     AND_INT T11.Z, T11.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; CM-NEXT:     LSHR * T12.W, T12.Y, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     LSHR * T11.Y, T11.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     LSHR T14.X, KC0[2].Y, literal.x,
+; CM-NEXT:     AND_INT * T12.Z, T12.Y, literal.y,
+; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; CM-NEXT:     ADD_INT T15.X, PV.X, literal.x,
+; CM-NEXT:     LSHR T12.Y, T12.X, literal.y,
+; CM-NEXT:     LSHR * T16.W, T11.W, literal.y,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T12.X, T12.X, literal.x,
+; CM-NEXT:     AND_INT * T16.Z, T11.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T17.X, T14.X, literal.x,
+; CM-NEXT:     LSHR T16.Y, T11.Z, literal.y,
+; CM-NEXT:     LSHR * T11.W, T11.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T16.X, T11.Z, literal.x,
+; CM-NEXT:     AND_INT * T11.Z, T11.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T18.X, T14.X, literal.x,
+; CM-NEXT:     LSHR * T11.Y, T11.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; CM-NEXT:     AND_INT * T11.X, T11.X, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T18.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %load = load <16 x i16>, ptr addrspace(1) %in
   %ext = zext <16 x i16> %load to <16 x i32>
   store <16 x i32> %ext, ptr addrspace(1) %out
@@ -2523,7 +2500,7 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 39, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 35, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T14.X, 0
@@ -2535,20 +2512,18 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 12:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 13:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_INT * T15.Z, T11.Y, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T15.X, T11.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Y, T12.W, literal.x,
-; EG-NEXT:     BFE_INT T16.Z, T11.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T16.Z, T11.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.W, T12.Y, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T11.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T16.X, T11.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Y, T11.W, literal.x,
+; EG-NEXT:     LSHR T0.Y, T11.W, literal.x,
 ; EG-NEXT:     BFE_INT T17.Z, T12.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T15.W, PS, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T1.W, T11.X, literal.x,
@@ -2561,30 +2536,28 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T18.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T16.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Z, T12.X, literal.x,
-; EG-NEXT:     BFE_INT T17.W, T0.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T17.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T12.Z, literal.y,
-; EG-NEXT:     BFE_INT T18.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T18.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR T0.Z, T12.W, literal.x,
+; EG-NEXT:     BFE_INT T17.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T12.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T11.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T17.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T18.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T12.Z, literal.y,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T12.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT * T18.Y, PS, 0.0, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ;
 ; CM-LABEL: global_sextload_v16i16_to_v16i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @8
-; CM-NEXT:    ALU 40, @13, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T11.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T13.X
+; CM-NEXT:    ALU 35, @13, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T11.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T14.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 16, #1
@@ -2592,47 +2565,42 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i32(ptr addrspace(1) %ou
 ; CM-NEXT:    ALU clause starting at 12:
 ; CM-NEXT:     MOV * T11.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 13:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Y, T11.Y, literal.y,
-; CM-NEXT:     LSHR T0.Z, T11.Z, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; CM-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHR * T0.W, T11.Y, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T14.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T1.Y, T11.W, literal.y,
+; CM-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; CM-NEXT:     LSHR T0.Y, T11.W, literal.y,
 ; CM-NEXT:     BFE_INT T15.Z, T12.W, 0.0, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:     LSHR * T0.W, T12.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     LSHR * T1.W, T12.X, literal.y,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; CM-NEXT:     BFE_INT T15.X, T12.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T2.Y, T12.Y, literal.x,
+; CM-NEXT:     LSHR T1.Y, T12.Y, literal.x,
 ; CM-NEXT:     BFE_INT T16.Z, T12.Y, 0.0, literal.x,
-; CM-NEXT:     LSHR * T1.W, T12.W, literal.x,
+; CM-NEXT:     LSHR * T2.W, T12.W, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T16.X, T12.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T3.Y, T12.Z, literal.x,
+; CM-NEXT:     LSHR T2.Y, T12.Z, literal.x,
 ; CM-NEXT:     BFE_INT T12.Z, T11.W, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT * T15.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T12.X, T11.Z, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T15.Y, PV.Y, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T17.Z, T11.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T16.W, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T16.W, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T17.X, T11.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T16.Y, T0.W, 0.0, literal.x,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT * T12.W, T1.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T16.Y, T1.W, 0.0, literal.x,
+; CM-NEXT:     LSHR T0.Z, T11.Z, literal.x,
+; CM-NEXT:     BFE_INT * T12.W, T0.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T18.X, PV.Z, literal.x,
-; CM-NEXT:     BFE_INT T12.Y, T0.Z, 0.0, literal.y,
-; CM-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; CM-NEXT:     BFE_INT * T17.W, T0.Y, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T11.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; CM-NEXT:     BFE_INT T12.Y, PV.Z, 0.0, literal.y,
+; CM-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T17.W, T0.W, 0.0, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T11.X, T13.X, literal.x,
 ; CM-NEXT:     BFE_INT * T17.Y, PV.Z, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
   %load = load <16 x i16>, ptr addrspace(1) %in
   %ext = sext <16 x i16> %load to <16 x i32>
   store <16 x i32> %ext, ptr addrspace(1) %out
@@ -2867,15 +2835,15 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i32(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 72, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 59, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T33.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T32.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T24.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T26.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
@@ -2889,89 +2857,76 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i32(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT * T23.Z, T20.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.Y, T20.Z, literal.x,
-; EG-NEXT:     LSHR * T20.W, T20.Y, literal.x,
+; EG-NEXT:     LSHR * T23.Y, T20.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T23.X, T20.Z, literal.x,
-; EG-NEXT:     AND_INT T20.Z, T20.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     LSHR T20.W, T20.Y, literal.y,
+; EG-NEXT:     LSHR * T24.X, KC0[2].Y, literal.z,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T20.Y, T20.X, literal.y,
-; EG-NEXT:     LSHR T25.W, T19.W, literal.y,
-; EG-NEXT:     AND_INT * T20.X, T20.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T25.Z, T19.W, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR T25.Y, T19.Z, literal.y,
-; EG-NEXT:     LSHR T19.W, T19.Y, literal.y,
-; EG-NEXT:     AND_INT * T25.X, T19.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T19.Z, T19.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T19.Y, T19.X, literal.y,
-; EG-NEXT:     LSHR T28.W, T22.W, literal.y,
-; EG-NEXT:     AND_INT * T19.X, T19.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T28.Z, T22.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T28.Y, T22.Z, literal.y,
-; EG-NEXT:     LSHR T22.W, T22.Y, literal.y,
-; EG-NEXT:     AND_INT * T28.X, T22.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T22.Z, T22.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 80(1.121039e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T22.Y, T22.X, literal.y,
-; EG-NEXT:     LSHR T31.W, T21.W, literal.y,
-; EG-NEXT:     AND_INT * T22.X, T22.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T31.Z, T21.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 64(8.968310e-44)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T31.Y, T21.Z, literal.y,
-; EG-NEXT:     LSHR T21.W, T21.Y, literal.y,
-; EG-NEXT:     AND_INT * T31.X, T21.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T21.Z, T21.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 112(1.569454e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T21.Y, T21.X, literal.y,
-; EG-NEXT:     AND_INT * T21.X, T21.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T34.X, PV.W, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T20.Z, T20.Y, literal.x,
+; EG-NEXT:     LSHR * T25.W, T19.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T26.X, T24.X, literal.x,
+; EG-NEXT:     LSHR T20.Y, T20.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     AND_INT T25.Z, T19.W, literal.z,
+; EG-NEXT:     AND_INT * T20.X, T20.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
+; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     LSHR T25.Y, T19.Z, literal.x,
+; EG-NEXT:     LSHR * T19.W, T19.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T25.X, T19.Z, literal.x,
+; EG-NEXT:     AND_INT T19.Z, T19.Y, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 12(1.681558e-44)
+; EG-NEXT:     LSHR T19.Y, T19.X, literal.x,
+; EG-NEXT:     LSHR * T28.W, T22.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T19.X, T19.X, literal.x,
+; EG-NEXT:     AND_INT T28.Z, T22.W, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 8(1.121039e-44)
+; EG-NEXT:     LSHR T28.Y, T22.Z, literal.x,
+; EG-NEXT:     LSHR * T22.W, T22.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T28.X, T22.Z, literal.x,
+; EG-NEXT:     AND_INT T22.Z, T22.Y, literal.x,
+; EG-NEXT:     ADD_INT * T30.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 20(2.802597e-44)
+; EG-NEXT:     LSHR T22.Y, T22.X, literal.x,
+; EG-NEXT:     LSHR * T31.W, T21.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T22.X, T22.X, literal.x,
+; EG-NEXT:     AND_INT T31.Z, T21.W, literal.x,
+; EG-NEXT:     ADD_INT * T32.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR T31.Y, T21.Z, literal.x,
+; EG-NEXT:     LSHR * T21.W, T21.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T31.X, T21.Z, literal.x,
+; EG-NEXT:     AND_INT T21.Z, T21.Y, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 28(3.923636e-44)
+; EG-NEXT:     LSHR * T21.Y, T21.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T21.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T34.X, T24.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 24(3.363116e-44)
 ;
 ; CM-LABEL: global_zextload_v32i16_to_v32i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 3 @12
-; CM-NEXT:    ALU 65, @21, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T34.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T32.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T29.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T19.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T20.X
+; CM-NEXT:    ALU 59, @21, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T20.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T34.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T22.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T25.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 48, #1
@@ -2985,68 +2940,62 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i32(ptr addrspace(1) %ou
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT * T23.Z, T20.Y, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T23.Y, T20.X, literal.x,
-; CM-NEXT:     LSHR * T24.W, T20.W, literal.x,
+; CM-NEXT:     LSHR * T23.Y, T20.X, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T23.X, T20.X, literal.x,
-; CM-NEXT:     AND_INT T24.Z, T20.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 96(1.345247e-43)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T24.Y, T20.Z, literal.y,
-; CM-NEXT:     LSHR * T25.W, T19.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T24.X, T20.Z, literal.x,
-; CM-NEXT:     AND_INT T25.Z, T19.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 112(1.569454e-43)
-; CM-NEXT:     LSHR T26.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T25.Y, T19.X, literal.y,
-; CM-NEXT:     LSHR * T27.W, T19.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T25.X, T19.X, literal.x,
-; CM-NEXT:     AND_INT T27.Z, T19.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 64(8.968310e-44)
-; CM-NEXT:     LSHR T19.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T27.Y, T19.Z, literal.y,
-; CM-NEXT:     LSHR * T28.W, T22.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T27.X, T19.Z, literal.x,
-; CM-NEXT:     AND_INT T28.Z, T22.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 80(1.121039e-43)
-; CM-NEXT:     LSHR T29.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T28.Y, T22.X, literal.y,
-; CM-NEXT:     LSHR * T30.W, T22.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T28.X, T22.X, literal.x,
-; CM-NEXT:     AND_INT T30.Z, T22.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T30.Y, T22.Z, literal.y,
-; CM-NEXT:     LSHR * T31.W, T21.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T30.X, T22.Z, literal.x,
-; CM-NEXT:     AND_INT T31.Z, T21.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; CM-NEXT:     LSHR T32.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T31.Y, T21.X, literal.y,
-; CM-NEXT:     LSHR * T33.W, T21.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T31.X, T21.X, literal.x,
-; CM-NEXT:     AND_INT * T33.Z, T21.W, literal.x,
-; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; CM-NEXT:     LSHR * T33.Y, T21.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T33.X, T21.Z, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; CM-NEXT:     LSHR * T24.W, T20.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T34.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     LSHR T20.X, KC0[2].Y, literal.x,
+; CM-NEXT:     AND_INT * T24.Z, T20.W, literal.y,
+; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; CM-NEXT:     ADD_INT T25.X, PV.X, literal.x,
+; CM-NEXT:     LSHR T24.Y, T20.Z, literal.y,
+; CM-NEXT:     LSHR * T26.W, T19.Y, literal.y,
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T24.X, T20.Z, literal.x,
+; CM-NEXT:     AND_INT * T26.Z, T19.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T27.X, T20.X, literal.x,
+; CM-NEXT:     LSHR T26.Y, T19.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T28.W, T19.W, literal.y,
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T26.X, T19.X, literal.x,
+; CM-NEXT:     AND_INT * T28.Z, T19.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T19.X, T20.X, literal.x,
+; CM-NEXT:     LSHR T28.Y, T19.Z, literal.x,
+; CM-NEXT:     LSHR * T29.W, T22.Y, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T28.X, T19.Z, literal.x,
+; CM-NEXT:     AND_INT * T29.Z, T22.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T30.X, T20.X, literal.x,
+; CM-NEXT:     LSHR T29.Y, T22.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T31.W, T22.W, literal.y,
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T29.X, T22.X, literal.x,
+; CM-NEXT:     AND_INT * T31.Z, T22.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T22.X, T20.X, literal.x,
+; CM-NEXT:     LSHR T31.Y, T22.Z, literal.y,
+; CM-NEXT:     LSHR * T32.W, T21.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T31.X, T22.Z, literal.x,
+; CM-NEXT:     AND_INT T32.Z, T21.Y, literal.x,
+; CM-NEXT:     LSHR * T33.W, T21.W, literal.y,
+; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T34.X, T20.X, literal.x,
+; CM-NEXT:     LSHR T32.Y, T21.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     AND_INT * T33.Z, T21.W, literal.z,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T32.X, T21.X, literal.x,
+; CM-NEXT:     LSHR * T33.Y, T21.Z, literal.y,
+; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; CM-NEXT:     AND_INT * T33.X, T21.Z, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T21.X, T20.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <32 x i16>, ptr addrspace(1) %in
   %ext = zext <32 x i16> %load to <32 x i32>
   store <32 x i32> %ext, ptr addrspace(1) %out
@@ -3279,221 +3228,191 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i32(ptr addrspace(1) %ou
 ;
 ; EG-LABEL: global_sextload_v32i16_to_v32i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 9, @20, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 73, @30, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T22.X, 0
+; EG-NEXT:    ALU 69, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T19.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T34.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T28.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T21.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T20.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T19.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T26.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T24.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
-; EG-NEXT:     VTX_READ_128 T23.XYZW, T22.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T24.XYZW, T22.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T25.XYZW, T22.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T22.XYZW, T22.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T21.XYZW, T19.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T19.XYZW, T19.X, 48, #1
 ; EG-NEXT:    ALU clause starting at 20:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T20.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T19.X, KC0[2].Z,
+; EG-NEXT:    ALU clause starting at 21:
+; EG-NEXT:     LSHR * T23.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T22.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 30:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.W, T22.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T28.X, PS, literal.x,
-; EG-NEXT:     LSHR T0.Y, T22.W, literal.y,
-; EG-NEXT:     BFE_INT T29.Z, T25.W, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T1.W, T24.Y, literal.y,
-; EG-NEXT:     LSHR * T2.W, T24.W, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T29.X, T25.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Y, T23.Y, literal.x,
-; EG-NEXT:     BFE_INT T30.Z, T25.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T3.W, T23.W, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.W, literal.x,
+; EG-NEXT:     ADD_INT T24.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T26.X, T23.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T23.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T28.X, T23.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T19.W, literal.x,
+; EG-NEXT:     BFE_INT T29.Z, T22.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T0.W, T21.Y, literal.x,
+; EG-NEXT:     LSHR * T1.W, T21.W, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T30.X, T25.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.Y, T25.Y, literal.x,
-; EG-NEXT:     BFE_INT T31.Z, T23.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.X, T22.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR T1.Y, T20.Y, literal.x,
+; EG-NEXT:     BFE_INT T30.Z, T22.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T2.W, T20.W, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T30.X, T22.X, 0.0, literal.x,
+; EG-NEXT:     LSHR T2.Y, T22.Y, literal.x,
+; EG-NEXT:     BFE_INT T31.Z, T20.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T29.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.Z, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T31.X, T23.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T31.X, T20.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T29.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.Z, T23.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.Z, T20.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T30.W, PV.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T25.X, literal.x,
+; EG-NEXT:     LSHR * T3.W, T22.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T25.X, T23.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.X, T20.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T30.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T32.Z, T24.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.W, T3.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T23.Z, literal.x,
+; EG-NEXT:     BFE_INT T32.Z, T21.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T31.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T20.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T32.X, T24.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T32.X, T21.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T31.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.Z, T24.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.W, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T23.X, literal.x,
+; EG-NEXT:     BFE_INT T20.Z, T21.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.W, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T20.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T23.X, T24.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T25.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T33.Z, T22.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T32.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T2.W, T24.Z, literal.x,
+; EG-NEXT:     BFE_INT T20.X, T21.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T22.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T33.Z, T19.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T32.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T21.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T33.X, T22.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T33.X, T19.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T32.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T24.Z, T22.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.W, T1.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.W, T24.X, literal.x,
+; EG-NEXT:     BFE_INT T21.Z, T19.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T20.W, T0.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T21.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T24.X, T22.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.Z, T22.Z, literal.x,
-; EG-NEXT:     BFE_INT T33.W, T0.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 112(1.569454e-43)
-; EG-NEXT:     LSHR T34.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T33.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T22.X, literal.y,
-; EG-NEXT:     BFE_INT T24.W, T0.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T24.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT T21.X, T19.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.Z, T19.Y, literal.x,
+; EG-NEXT:     BFE_INT T33.W, T0.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T19.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T34.X, T23.X, literal.x,
+; EG-NEXT:     BFE_INT T33.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T21.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T19.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T19.X, T23.X, literal.x,
+; EG-NEXT:     BFE_INT * T21.Y, PS, 0.0, literal.y,
+; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ;
 ; CM-LABEL: global_sextload_v32i16_to_v32i32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 0, @22, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 0 @14
-; CM-NEXT:    ALU 7, @23, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 2 @16
-; CM-NEXT:    ALU 76, @31, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    TEX 3 @12
+; CM-NEXT:    ALU 71, @21, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T34.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T28.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T27.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T25.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T24.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T28.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T24.X
 ; CM-NEXT:    CF_END
-; CM-NEXT:    Fetch clause starting at 14:
-; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
-; CM-NEXT:    Fetch clause starting at 16:
-; CM-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 48, #1
-; CM-NEXT:     VTX_READ_128 T23.XYZW, T19.X, 32, #1
-; CM-NEXT:     VTX_READ_128 T19.XYZW, T19.X, 16, #1
-; CM-NEXT:    ALU clause starting at 22:
+; CM-NEXT:    Fetch clause starting at 12:
+; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T21.XYZW, T19.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 16, #1
+; CM-NEXT:     VTX_READ_128 T19.XYZW, T19.X, 0, #1
+; CM-NEXT:    ALU clause starting at 20:
 ; CM-NEXT:     MOV * T19.X, KC0[2].Z,
-; CM-NEXT:    ALU clause starting at 23:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T21.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Y, T20.Z, literal.y,
-; CM-NEXT:     LSHR T0.Z, T20.W, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 31:
-; CM-NEXT:     LSHR T24.X, T0.W, literal.x,
-; CM-NEXT:     LSHR T1.Y, T20.Y, literal.y,
-; CM-NEXT:     LSHR T1.Z, T19.Z, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T25.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T2.Y, T19.W, literal.y,
-; CM-NEXT:     LSHR T2.Z, T19.X, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T26.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T3.Y, T19.Y, literal.y,
-; CM-NEXT:     LSHR T3.Z, T23.Z, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T27.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T4.Y, T23.W, literal.y,
-; CM-NEXT:     LSHR T4.Z, T23.X, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T28.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T5.Y, T23.Y, literal.y,
-; CM-NEXT:     BFE_INT T29.Z, T22.Y, 0.0, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    ALU clause starting at 21:
+; CM-NEXT:     LSHR * T23.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T24.X, PV.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T25.X, T23.X, literal.x,
+; CM-NEXT:     LSHR T0.Y, T19.W, literal.y,
+; CM-NEXT:     LSHR T0.Z, T19.Y, literal.y,
 ; CM-NEXT:     LSHR * T0.W, T22.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     BFE_INT T29.X, T22.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T6.Y, T22.W, literal.x,
-; CM-NEXT:     BFE_INT T30.Z, T22.W, 0.0, literal.x,
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T26.X, T23.X, literal.x,
+; CM-NEXT:     LSHR T1.Y, T22.W, literal.x,
+; CM-NEXT:     LSHR T1.Z, T22.X, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:     LSHR * T1.W, T22.Y, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T30.X, T22.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T7.Y, T22.X, literal.x,
-; CM-NEXT:     BFE_INT T22.Z, T23.Y, 0.0, literal.x,
+; CM-NEXT:     ADD_INT T27.X, T23.X, literal.x,
+; CM-NEXT:     LSHR T2.Y, T21.Z, literal.y,
+; CM-NEXT:     LSHR T2.Z, T21.W, literal.y,
+; CM-NEXT:     LSHR * T2.W, T21.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T28.X, T23.X, literal.x,
+; CM-NEXT:     LSHR T3.Y, T21.Y, literal.y,
+; CM-NEXT:     BFE_INT T29.Z, T20.Y, 0.0, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T3.W, T20.Z, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     BFE_INT T29.X, T20.X, 0.0, literal.x,
+; CM-NEXT:     LSHR T4.Y, T20.W, literal.x,
+; CM-NEXT:     BFE_INT T30.Z, T20.W, 0.0, literal.x,
+; CM-NEXT:     LSHR * T4.W, T20.Y, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T30.X, T20.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR T5.Y, T20.X, literal.x,
+; CM-NEXT:     BFE_INT T20.Z, T21.Y, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT * T29.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T22.X, T23.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.X, T21.X, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T29.Y, PV.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T31.Z, T23.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T30.W, T6.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T31.Z, T21.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T30.W, T4.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T31.X, T23.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T30.Y, T0.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T23.Z, T19.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T22.W, T5.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T31.X, T21.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T30.Y, T3.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.Z, T22.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T20.W, T3.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T23.X, T19.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T22.Y, T4.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T32.Z, T19.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T31.W, T4.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.X, T22.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.Y, T2.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T32.Z, T22.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T31.W, T2.Z, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T32.X, T19.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T31.Y, T3.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T19.Z, T20.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T23.W, T3.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T32.X, T22.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T31.Y, T2.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T22.Z, T19.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T21.W, T1.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T19.X, T20.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T23.Y, T2.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T33.Z, T20.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T32.W, T2.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T22.X, T19.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.Y, T1.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T33.Z, T19.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T32.W, T1.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T33.X, T20.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T32.Y, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     LSHR T1.Z, T20.X, literal.x,
-; CM-NEXT:     BFE_INT * T19.W, T1.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T33.X, T19.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T32.Y, T0.W, 0.0, literal.x,
+; CM-NEXT:     LSHR T1.Z, T19.X, literal.x,
+; CM-NEXT:     BFE_INT * T22.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T20.X, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT T19.Y, PV.Z, 0.0, literal.y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     BFE_INT * T33.W, T0.Z, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T34.X, PV.Z, literal.x,
-; CM-NEXT:     BFE_INT * T33.Y, T0.Y, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T19.X, T23.X, literal.x,
+; CM-NEXT:     BFE_INT T22.Y, PV.Z, 0.0, literal.y,
+; CM-NEXT:     LSHR T0.Z, T19.Z, literal.y,
+; CM-NEXT:     BFE_INT * T33.W, T0.Y, 0.0, literal.y,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T34.X, T23.X, literal.x,
+; CM-NEXT:     BFE_INT * T33.Y, PV.Z, 0.0, literal.y,
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
   %load = load <32 x i16>, ptr addrspace(1) %in
   %ext = sext <32 x i16> %load to <32 x i32>
   store <32 x i32> %ext, ptr addrspace(1) %out
@@ -3967,37 +3886,37 @@ define amdgpu_kernel void @global_zextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; EG-LABEL: global_zextload_v64i16_to_v64i32:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 3 @22
-; EG-NEXT:    ALU 56, @39, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 3 @30
-; EG-NEXT:    ALU 87, @96, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T66.X, 0
+; EG-NEXT:    TEX 2 @22
+; EG-NEXT:    ALU 35, @39, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 4 @28
+; EG-NEXT:    ALU 81, @75, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T66.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T65.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T50.XYZW, T64.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T64.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T62.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T51.XYZW, T61.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T61.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T59.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T52.XYZW, T58.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T58.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T54.XYZW, T56.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T55.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T53.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T48.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T47.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T46.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T44.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T43.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T41.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T55.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T51.XYZW, T53.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T52.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T50.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T44.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T43.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T40.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T42.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T36.XYZW, T37.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T38.XYZW, T37.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T39.XYZW, T37.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T40.XYZW, T37.X, 16, #1
-; EG-NEXT:    Fetch clause starting at 30:
-; EG-NEXT:     VTX_READ_128 T49.XYZW, T37.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T50.XYZW, T37.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T51.XYZW, T37.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T52.XYZW, T37.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T38.XYZW, T37.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T39.XYZW, T37.X, 16, #1
+; EG-NEXT:    Fetch clause starting at 28:
+; EG-NEXT:     VTX_READ_128 T45.XYZW, T37.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T46.XYZW, T37.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T47.XYZW, T37.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T48.XYZW, T37.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T49.XYZW, T37.X, 48, #1
 ; EG-NEXT:    ALU clause starting at 38:
 ; EG-NEXT:     MOV * T37.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 39:
@@ -4005,317 +3924,276 @@ define amdgpu_kernel void @global_zextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT * T35.Z, T36.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.Y, T36.Z, literal.x,
-; EG-NEXT:     LSHR * T36.W, T36.Y, literal.x,
+; EG-NEXT:     LSHR * T35.Y, T36.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T35.X, T36.Z, literal.x,
-; EG-NEXT:     AND_INT T36.Z, T36.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; EG-NEXT:     LSHR T36.W, T36.Y, literal.y,
+; EG-NEXT:     LSHR * T40.X, KC0[2].Y, literal.z,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T36.Y, T36.X, literal.y,
-; EG-NEXT:     LSHR T42.W, T40.W, literal.y,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T36.Z, T36.Y, literal.x,
+; EG-NEXT:     LSHR * T41.W, T39.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T42.X, T40.X, literal.x,
+; EG-NEXT:     LSHR T36.Y, T36.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     AND_INT T41.Z, T39.W, literal.z,
 ; EG-NEXT:     AND_INT * T36.X, T36.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT * T42.Z, T40.W, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     LSHR T43.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR T42.Y, T40.Z, literal.y,
-; EG-NEXT:     LSHR T40.W, T40.Y, literal.y,
-; EG-NEXT:     AND_INT * T42.X, T40.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T40.Z, T40.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T40.Y, T40.X, literal.y,
-; EG-NEXT:     LSHR T45.W, T39.W, literal.y,
-; EG-NEXT:     AND_INT * T40.X, T40.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T45.Z, T39.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T45.Y, T39.Z, literal.y,
-; EG-NEXT:     LSHR T39.W, T39.Y, literal.y,
-; EG-NEXT:     AND_INT * T45.X, T39.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     LSHR T41.Y, T39.Z, literal.x,
+; EG-NEXT:     LSHR * T39.W, T39.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T41.X, T39.Z, literal.x,
 ; EG-NEXT:     AND_INT T39.Z, T39.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 80(1.121039e-43)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T39.Y, T39.X, literal.y,
-; EG-NEXT:     AND_INT * T39.X, T39.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT * T43.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 12(1.681558e-44)
+; EG-NEXT:     LSHR * T39.Y, T39.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T39.X, T39.X, literal.x,
+; EG-NEXT:     LSHR T37.W, T38.W, literal.y,
+; EG-NEXT:     ADD_INT * T44.X, T40.X, literal.z,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT * T37.Z, T38.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR * T37.W, T38.W, literal.y,
-; EG-NEXT:    64(8.968310e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T48.X, PV.W, literal.x,
-; EG-NEXT:     AND_INT * T37.Z, T38.W, literal.y,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    ALU clause starting at 96:
+; EG-NEXT:    ALU clause starting at 75:
 ; EG-NEXT:     LSHR T37.Y, T38.Z, literal.x,
 ; EG-NEXT:     LSHR * T38.W, T38.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T37.X, T38.Z, literal.x,
 ; EG-NEXT:     AND_INT T38.Z, T38.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 112(1.569454e-43)
-; EG-NEXT:     LSHR T53.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T38.Y, T38.X, literal.y,
-; EG-NEXT:     LSHR T54.W, T52.W, literal.y,
-; EG-NEXT:     AND_INT * T38.X, T38.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T54.Z, T52.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 96(1.345247e-43)
-; EG-NEXT:     LSHR T55.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T54.Y, T52.Z, literal.y,
-; EG-NEXT:     LSHR T52.W, T52.Y, literal.y,
-; EG-NEXT:     AND_INT * T54.X, T52.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T52.Z, T52.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 144(2.017870e-43)
-; EG-NEXT:     LSHR T56.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T52.Y, T52.X, literal.y,
-; EG-NEXT:     LSHR T57.W, T51.W, literal.y,
-; EG-NEXT:     AND_INT * T52.X, T52.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T57.Z, T51.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 128(1.793662e-43)
-; EG-NEXT:     LSHR T58.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T57.Y, T51.Z, literal.y,
-; EG-NEXT:     LSHR T51.W, T51.Y, literal.y,
-; EG-NEXT:     AND_INT * T57.X, T51.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T51.Z, T51.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 176(2.466285e-43)
-; EG-NEXT:     LSHR T59.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T51.Y, T51.X, literal.y,
-; EG-NEXT:     LSHR T60.W, T50.W, literal.y,
-; EG-NEXT:     AND_INT * T51.X, T51.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T60.Z, T50.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 160(2.242078e-43)
-; EG-NEXT:     LSHR T61.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T60.Y, T50.Z, literal.y,
-; EG-NEXT:     LSHR T50.W, T50.Y, literal.y,
-; EG-NEXT:     AND_INT * T60.X, T50.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T50.Z, T50.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 208(2.914701e-43)
-; EG-NEXT:     LSHR T62.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T50.Y, T50.X, literal.y,
-; EG-NEXT:     LSHR T63.W, T49.W, literal.y,
-; EG-NEXT:     AND_INT * T50.X, T50.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T63.Z, T49.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 192(2.690493e-43)
-; EG-NEXT:     LSHR T64.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T63.Y, T49.Z, literal.y,
-; EG-NEXT:     LSHR T49.W, T49.Y, literal.y,
-; EG-NEXT:     AND_INT * T63.X, T49.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T50.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 20(2.802597e-44)
+; EG-NEXT:     LSHR T38.Y, T38.X, literal.x,
+; EG-NEXT:     LSHR * T51.W, T49.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T38.X, T38.X, literal.x,
+; EG-NEXT:     AND_INT T51.Z, T49.W, literal.x,
+; EG-NEXT:     ADD_INT * T52.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     LSHR T51.Y, T49.Z, literal.x,
+; EG-NEXT:     LSHR * T49.W, T49.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T51.X, T49.Z, literal.x,
 ; EG-NEXT:     AND_INT T49.Z, T49.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    65535(9.183409e-41), 240(3.363116e-43)
-; EG-NEXT:     LSHR T65.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T49.Y, T49.X, literal.y,
-; EG-NEXT:     AND_INT * T49.X, T49.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T66.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T53.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 28(3.923636e-44)
+; EG-NEXT:     LSHR T49.Y, T49.X, literal.x,
+; EG-NEXT:     LSHR * T54.W, T48.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T49.X, T49.X, literal.x,
+; EG-NEXT:     AND_INT T54.Z, T48.W, literal.x,
+; EG-NEXT:     ADD_INT * T55.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 24(3.363116e-44)
+; EG-NEXT:     LSHR T54.Y, T48.Z, literal.x,
+; EG-NEXT:     LSHR * T48.W, T48.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T54.X, T48.Z, literal.x,
+; EG-NEXT:     AND_INT T48.Z, T48.Y, literal.x,
+; EG-NEXT:     ADD_INT * T56.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 36(5.044674e-44)
+; EG-NEXT:     LSHR T48.Y, T48.X, literal.x,
+; EG-NEXT:     LSHR * T57.W, T47.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T48.X, T48.X, literal.x,
+; EG-NEXT:     AND_INT T57.Z, T47.W, literal.x,
+; EG-NEXT:     ADD_INT * T58.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
+; EG-NEXT:     LSHR T57.Y, T47.Z, literal.x,
+; EG-NEXT:     LSHR * T47.W, T47.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T57.X, T47.Z, literal.x,
+; EG-NEXT:     AND_INT T47.Z, T47.Y, literal.x,
+; EG-NEXT:     ADD_INT * T59.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 44(6.165713e-44)
+; EG-NEXT:     LSHR T47.Y, T47.X, literal.x,
+; EG-NEXT:     LSHR * T60.W, T46.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T47.X, T47.X, literal.x,
+; EG-NEXT:     AND_INT T60.Z, T46.W, literal.x,
+; EG-NEXT:     ADD_INT * T61.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 40(5.605194e-44)
+; EG-NEXT:     LSHR T60.Y, T46.Z, literal.x,
+; EG-NEXT:     LSHR * T46.W, T46.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T60.X, T46.Z, literal.x,
+; EG-NEXT:     AND_INT T46.Z, T46.Y, literal.x,
+; EG-NEXT:     ADD_INT * T62.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 52(7.286752e-44)
+; EG-NEXT:     LSHR T46.Y, T46.X, literal.x,
+; EG-NEXT:     LSHR * T63.W, T45.W, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T46.X, T46.X, literal.x,
+; EG-NEXT:     AND_INT T63.Z, T45.W, literal.x,
+; EG-NEXT:     ADD_INT * T64.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
+; EG-NEXT:     LSHR T63.Y, T45.Z, literal.x,
+; EG-NEXT:     LSHR * T45.W, T45.Y, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T63.X, T45.Z, literal.x,
+; EG-NEXT:     AND_INT T45.Z, T45.Y, literal.x,
+; EG-NEXT:     ADD_INT * T65.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 60(8.407791e-44)
+; EG-NEXT:     LSHR * T45.Y, T45.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T45.X, T45.X, literal.x,
+; EG-NEXT:     ADD_INT * T66.X, T40.X, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 56(7.847271e-44)
 ;
 ; CM-LABEL: global_zextload_v64i16_to_v64i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 3 @22
-; CM-NEXT:    ALU 50, @39, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 3 @30
-; CM-NEXT:    ALU 78, @90, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T65, T66.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T63, T48.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T62, T64.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T60, T49.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T59, T61.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T57, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T56, T58.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T54, T51.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T53, T55.X
+; CM-NEXT:    TEX 2 @22
+; CM-NEXT:    ALU 32, @39, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    TEX 4 @28
+; CM-NEXT:    ALU 82, @72, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T65, T45.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T64, T36.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T63, T66.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T61, T46.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T60, T62.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T58, T47.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T57, T59.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T55, T48.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T54, T56.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T52, T49.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T51, T53.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T37.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T52.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T38.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T46.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T39.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T43.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T36.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T50.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T38.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T43.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T41.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 22:
 ; CM-NEXT:     VTX_READ_128 T36.XYZW, T35.X, 112, #1
-; CM-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 64, #1
-; CM-NEXT:     VTX_READ_128 T38.XYZW, T35.X, 80, #1
-; CM-NEXT:     VTX_READ_128 T39.XYZW, T35.X, 96, #1
-; CM-NEXT:    Fetch clause starting at 30:
-; CM-NEXT:     VTX_READ_128 T48.XYZW, T35.X, 0, #1
-; CM-NEXT:     VTX_READ_128 T49.XYZW, T35.X, 16, #1
-; CM-NEXT:     VTX_READ_128 T50.XYZW, T35.X, 32, #1
-; CM-NEXT:     VTX_READ_128 T51.XYZW, T35.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 80, #1
+; CM-NEXT:     VTX_READ_128 T38.XYZW, T35.X, 96, #1
+; CM-NEXT:    Fetch clause starting at 28:
+; CM-NEXT:     VTX_READ_128 T45.XYZW, T35.X, 0, #1
+; CM-NEXT:     VTX_READ_128 T46.XYZW, T35.X, 16, #1
+; CM-NEXT:     VTX_READ_128 T47.XYZW, T35.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T48.XYZW, T35.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T49.XYZW, T35.X, 64, #1
 ; CM-NEXT:    ALU clause starting at 38:
 ; CM-NEXT:     MOV * T35.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 39:
-; CM-NEXT:     LSHR * T40.W, T36.Y, literal.x,
+; CM-NEXT:     LSHR * T39.W, T36.Y, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT * T40.Z, T36.Y, literal.x,
+; CM-NEXT:     AND_INT * T39.Z, T36.Y, literal.x,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T40.Y, T36.X, literal.x,
-; CM-NEXT:     LSHR * T41.W, T36.W, literal.x,
+; CM-NEXT:     LSHR * T39.Y, T36.X, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T40.X, T36.X, literal.x,
-; CM-NEXT:     AND_INT T41.Z, T36.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 224(3.138909e-43)
-; CM-NEXT:     LSHR T36.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T41.Y, T36.Z, literal.y,
-; CM-NEXT:     LSHR * T42.W, T39.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T41.X, T36.Z, literal.x,
-; CM-NEXT:     AND_INT T42.Z, T39.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 240(3.363116e-43)
-; CM-NEXT:     LSHR T43.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T42.Y, T39.X, literal.y,
-; CM-NEXT:     LSHR * T44.W, T39.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T42.X, T39.X, literal.x,
-; CM-NEXT:     AND_INT T44.Z, T39.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 192(2.690493e-43)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T44.Y, T39.Z, literal.y,
-; CM-NEXT:     LSHR * T45.W, T38.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T44.X, T39.Z, literal.x,
-; CM-NEXT:     AND_INT T45.Z, T38.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 208(2.914701e-43)
-; CM-NEXT:     LSHR T46.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T45.Y, T38.X, literal.y,
-; CM-NEXT:     LSHR * T47.W, T38.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T45.X, T38.X, literal.x,
-; CM-NEXT:     AND_INT T47.Z, T38.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 160(2.242078e-43)
-; CM-NEXT:     LSHR T38.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T47.Y, T38.Z, literal.y,
-; CM-NEXT:     LSHR * T35.W, T37.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T47.X, T38.Z, literal.x,
-; CM-NEXT:     AND_INT T35.Z, T37.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 176(2.466285e-43)
-; CM-NEXT:    ALU clause starting at 90:
-; CM-NEXT:     LSHR T52.X, T0.W, literal.x,
-; CM-NEXT:     LSHR T35.Y, T37.X, literal.y,
-; CM-NEXT:     LSHR * T53.W, T37.W, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T35.X, T37.X, literal.x,
-; CM-NEXT:     AND_INT T53.Z, T37.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 128(1.793662e-43)
-; CM-NEXT:     LSHR T37.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T53.Y, T37.Z, literal.y,
-; CM-NEXT:     LSHR * T54.W, T51.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T53.X, T37.Z, literal.x,
-; CM-NEXT:     AND_INT T54.Z, T51.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 144(2.017870e-43)
-; CM-NEXT:     LSHR T55.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T54.Y, T51.X, literal.y,
-; CM-NEXT:     LSHR * T56.W, T51.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T54.X, T51.X, literal.x,
-; CM-NEXT:     AND_INT T56.Z, T51.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 96(1.345247e-43)
-; CM-NEXT:     LSHR T51.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T56.Y, T51.Z, literal.y,
-; CM-NEXT:     LSHR * T57.W, T50.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T56.X, T51.Z, literal.x,
-; CM-NEXT:     AND_INT T57.Z, T50.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 112(1.569454e-43)
-; CM-NEXT:     LSHR T58.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T57.Y, T50.X, literal.y,
-; CM-NEXT:     LSHR * T59.W, T50.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T57.X, T50.X, literal.x,
-; CM-NEXT:     AND_INT T59.Z, T50.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 64(8.968310e-44)
-; CM-NEXT:     LSHR T50.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T59.Y, T50.Z, literal.y,
-; CM-NEXT:     LSHR * T60.W, T49.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T59.X, T50.Z, literal.x,
-; CM-NEXT:     AND_INT T60.Z, T49.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 80(1.121039e-43)
-; CM-NEXT:     LSHR T61.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T60.Y, T49.X, literal.y,
-; CM-NEXT:     LSHR * T62.W, T49.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T60.X, T49.X, literal.x,
-; CM-NEXT:     AND_INT T62.Z, T49.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 32(4.484155e-44)
-; CM-NEXT:     LSHR T49.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T62.Y, T49.Z, literal.y,
-; CM-NEXT:     LSHR * T63.W, T48.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T62.X, T49.Z, literal.x,
-; CM-NEXT:     AND_INT T63.Z, T48.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    65535(9.183409e-41), 48(6.726233e-44)
-; CM-NEXT:     LSHR T64.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T63.Y, T48.X, literal.y,
-; CM-NEXT:     LSHR * T65.W, T48.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T63.X, T48.X, literal.x,
-; CM-NEXT:     AND_INT * T65.Z, T48.W, literal.x,
-; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     LSHR T48.X, KC0[2].Y, literal.x,
-; CM-NEXT:     LSHR * T65.Y, T48.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T65.X, T48.Z, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
+; CM-NEXT:     AND_INT T39.X, T36.X, literal.x,
+; CM-NEXT:     LSHR * T40.W, T36.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T66.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     LSHR T36.X, KC0[2].Y, literal.x,
+; CM-NEXT:     AND_INT * T40.Z, T36.W, literal.y,
+; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
+; CM-NEXT:     ADD_INT T41.X, PV.X, literal.x,
+; CM-NEXT:     LSHR T40.Y, T36.Z, literal.y,
+; CM-NEXT:     LSHR * T42.W, T38.Y, literal.y,
+; CM-NEXT:    56(7.847271e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T40.X, T36.Z, literal.x,
+; CM-NEXT:     AND_INT * T42.Z, T38.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T43.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T42.Y, T38.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T44.W, T38.W, literal.y,
+; CM-NEXT:    60(8.407791e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T42.X, T38.X, literal.x,
+; CM-NEXT:     AND_INT * T44.Z, T38.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T38.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T44.Y, T38.Z, literal.y,
+; CM-NEXT:     LSHR * T35.W, T37.Y, literal.y,
+; CM-NEXT:    48(6.726233e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T44.X, T38.Z, literal.x,
+; CM-NEXT:     AND_INT * T35.Z, T37.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:    ALU clause starting at 72:
+; CM-NEXT:     ADD_INT T50.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T35.Y, T37.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T51.W, T37.W, literal.y,
+; CM-NEXT:    52(7.286752e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T35.X, T37.X, literal.x,
+; CM-NEXT:     AND_INT * T51.Z, T37.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T37.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T51.Y, T37.Z, literal.y,
+; CM-NEXT:     LSHR * T52.W, T49.Y, literal.y,
+; CM-NEXT:    40(5.605194e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T51.X, T37.Z, literal.x,
+; CM-NEXT:     AND_INT * T52.Z, T49.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T53.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T52.Y, T49.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T54.W, T49.W, literal.y,
+; CM-NEXT:    44(6.165713e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T52.X, T49.X, literal.x,
+; CM-NEXT:     AND_INT * T54.Z, T49.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T49.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T54.Y, T49.Z, literal.y,
+; CM-NEXT:     LSHR * T55.W, T48.Y, literal.y,
+; CM-NEXT:    32(4.484155e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T54.X, T49.Z, literal.x,
+; CM-NEXT:     AND_INT * T55.Z, T48.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T56.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T55.Y, T48.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T57.W, T48.W, literal.y,
+; CM-NEXT:    36(5.044674e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T55.X, T48.X, literal.x,
+; CM-NEXT:     AND_INT * T57.Z, T48.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T48.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T57.Y, T48.Z, literal.y,
+; CM-NEXT:     LSHR * T58.W, T47.Y, literal.y,
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T57.X, T48.Z, literal.x,
+; CM-NEXT:     AND_INT * T58.Z, T47.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T59.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T58.Y, T47.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T60.W, T47.W, literal.y,
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T58.X, T47.X, literal.x,
+; CM-NEXT:     AND_INT * T60.Z, T47.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T47.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T60.Y, T47.Z, literal.x,
+; CM-NEXT:     LSHR * T61.W, T46.Y, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T60.X, T47.Z, literal.x,
+; CM-NEXT:     AND_INT * T61.Z, T46.Y, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T62.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T61.Y, T46.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T63.W, T46.W, literal.y,
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T61.X, T46.X, literal.x,
+; CM-NEXT:     AND_INT * T63.Z, T46.W, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T46.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T63.Y, T46.Z, literal.y,
+; CM-NEXT:     LSHR * T64.W, T45.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T63.X, T46.Z, literal.x,
+; CM-NEXT:     AND_INT T64.Z, T45.Y, literal.x,
+; CM-NEXT:     LSHR * T65.W, T45.W, literal.y,
+; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T66.X, T36.X, literal.x,
+; CM-NEXT:     LSHR T64.Y, T45.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     AND_INT * T65.Z, T45.W, literal.z,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T64.X, T45.X, literal.x,
+; CM-NEXT:     LSHR * T65.Y, T45.Z, literal.y,
+; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; CM-NEXT:     AND_INT * T65.X, T45.Z, literal.x,
+; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T45.X, T36.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <64 x i16>, ptr addrspace(1) %in
   %ext = zext <64 x i16> %load to <64 x i32>
   store <64 x i32> %ext, ptr addrspace(1) %out
@@ -4773,421 +4651,363 @@ define amdgpu_kernel void @global_sextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ;
 ; EG-LABEL: global_sextload_v64i16_to_v64i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 18, @38, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @22
-; EG-NEXT:    ALU 75, @57, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 71, @133, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T41.X, 0
+; EG-NEXT:    ALU 73, @39, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 65, @113, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T65.XYZW, T66.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T56.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T56.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T64.XYZW, T55.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T54.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T54.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T63.XYZW, T53.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T52.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T52.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T62.XYZW, T51.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T50.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T61.XYZW, T49.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T39.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T38.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T35.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T48.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T60.XYZW, T47.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T46.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T59.XYZW, T45.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T58.XYZW, T43.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T57.XYZW, T44.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T42.XYZW, T41.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T43.XYZW, T41.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T44.XYZW, T41.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T45.XYZW, T41.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T46.XYZW, T41.X, 64, #1
-; EG-NEXT:     VTX_READ_128 T47.XYZW, T41.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T48.XYZW, T41.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T41.XYZW, T41.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T41.XYZW, T35.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T40.XYZW, T35.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T42.XYZW, T35.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T39.XYZW, T35.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T38.XYZW, T35.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T36.XYZW, T35.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T35.XYZW, T35.X, 112, #1
 ; EG-NEXT:    ALU clause starting at 38:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T35.X, KC0[2].Z,
+; EG-NEXT:    ALU clause starting at 39:
+; EG-NEXT:     LSHR * T43.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T44.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T45.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T46.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T47.X, T43.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T48.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T49.X, T43.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T50.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T51.X, T43.X, literal.y,
+; EG-NEXT:    24(3.363116e-44), 36(5.044674e-44)
+; EG-NEXT:     ADD_INT T52.X, T43.X, literal.x,
+; EG-NEXT:     ADD_INT * T53.X, T43.X, literal.y,
+; EG-NEXT:    32(4.484155e-44), 44(6.165713e-44)
+; EG-NEXT:     ADD_INT T54.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T35.W, literal.y,
+; EG-NEXT:     LSHR T0.Z, T36.Y, literal.y,
+; EG-NEXT:     LSHR T0.W, T36.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T37.Y, literal.y,
+; EG-NEXT:    40(5.605194e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T55.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T37.W, literal.y,
+; EG-NEXT:     LSHR T1.Z, T38.Y, literal.y,
+; EG-NEXT:     LSHR T2.W, T38.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T39.Y, literal.y,
+; EG-NEXT:    52(7.286752e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T56.X, T43.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T39.W, literal.y,
+; EG-NEXT:     BFE_INT T57.Z, T42.W, 0.0, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T4.W, T40.Y, literal.y,
+; EG-NEXT:     LSHR * T5.W, T40.W, literal.y,
+; EG-NEXT:    48(6.726233e-44), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT T57.X, T42.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR T3.Y, T41.Y, literal.x,
+; EG-NEXT:     BFE_INT T58.Z, T42.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T6.W, T41.W, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.W, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T36.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T41.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 57:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T50.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T51.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T52.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T53.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Y, T41.Y, literal.y,
-; EG-NEXT:     LSHR T0.Z, T41.W, literal.y,
-; EG-NEXT:     LSHR T0.W, T48.Y, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T54.X, PS, literal.x,
-; EG-NEXT:     LSHR T1.Y, T48.W, literal.y,
-; EG-NEXT:     LSHR T1.Z, T47.Y, literal.y,
-; EG-NEXT:     LSHR T1.W, T47.W, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T55.X, PS, literal.x,
-; EG-NEXT:     LSHR T2.Y, T46.Y, literal.y,
-; EG-NEXT:     LSHR T2.Z, T46.W, literal.y,
-; EG-NEXT:     LSHR T2.W, T45.Y, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T56.X, PS, literal.x,
-; EG-NEXT:     LSHR T3.Y, T45.W, literal.y,
-; EG-NEXT:     BFE_INT T57.Z, T44.W, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T3.W, T43.Y, literal.y,
-; EG-NEXT:     LSHR * T4.W, T43.W, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T57.X, T44.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T58.X, T42.X, 0.0, literal.x,
 ; EG-NEXT:     LSHR T4.Y, T42.Y, literal.x,
-; EG-NEXT:     BFE_INT T58.Z, T44.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T5.W, T42.W, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.W, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T58.X, T44.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T5.Y, T44.Y, literal.x,
-; EG-NEXT:     BFE_INT T59.Z, T42.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.Z, T41.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T57.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.Z, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T59.X, T42.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.X, T41.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T57.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.Z, T42.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.Z, T41.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T58.W, PV.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T44.X, literal.x,
+; EG-NEXT:     LSHR * T7.W, T42.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T44.X, T42.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.X, T41.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T58.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T60.Z, T43.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T59.W, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T5.W, T42.Z, literal.x,
+; EG-NEXT:     BFE_INT T60.Z, T40.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T59.W, T6.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T6.W, T41.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T60.X, T43.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T60.X, T40.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T59.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.Z, T43.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.W, T4.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T5.W, T42.X, literal.x,
+; EG-NEXT:     BFE_INT T41.Z, T40.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.W, T3.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T6.W, T41.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T42.X, T43.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T44.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T61.Z, T45.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT * T60.W, T4.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 133:
-; EG-NEXT:     LSHR * T4.W, T43.Z, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T61.X, T45.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T60.Y, PV.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Z, T45.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.W, T3.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T43.X, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T43.X, T45.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T40.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T42.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T62.Z, T46.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T61.W, T3.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T45.Z, literal.x,
+; EG-NEXT:     BFE_INT T61.Z, T39.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T60.W, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T5.W, T40.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T62.X, T46.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T61.X, T39.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT * T60.Y, PS, 0.0, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 113:
+; EG-NEXT:     BFE_INT T40.Z, T39.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.W, T4.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T4.W, T40.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T40.X, T39.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T62.Z, T38.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T61.W, T2.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T4.W, T39.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T62.X, T38.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T61.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Z, T46.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.W, T2.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T2.W, T45.X, literal.x,
+; EG-NEXT:     BFE_INT T39.Z, T38.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.W, T3.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T3.W, T39.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T45.X, T46.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T63.Z, T47.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T62.W, T2.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T2.W, T46.Z, literal.x,
+; EG-NEXT:     BFE_INT T39.X, T38.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.Z, T37.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T62.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T38.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T63.X, T47.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.X, T37.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T62.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.Z, T47.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.W, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T2.W, T46.X, literal.x,
+; EG-NEXT:     BFE_INT T38.Z, T37.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.W, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T2.W, T38.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T46.X, T47.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T64.Z, T48.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T63.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, T47.Z, literal.x,
+; EG-NEXT:     BFE_INT T38.X, T37.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.Z, T36.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T63.W, T1.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T2.W, T37.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T64.X, T48.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.X, T36.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T63.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T47.Z, T48.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.W, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, T47.X, literal.x,
+; EG-NEXT:     BFE_INT T37.Z, T36.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T38.W, T1.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T1.W, T37.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T47.X, T48.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T65.Z, T41.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T64.W, T1.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T1.W, T48.Z, literal.x,
+; EG-NEXT:     BFE_INT T37.X, T36.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T38.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T65.Z, T35.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T64.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T36.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T65.X, T41.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T65.X, T35.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T64.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T48.Z, T41.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T47.W, T0.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T0.W, T48.X, literal.x,
+; EG-NEXT:     BFE_INT T36.Z, T35.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T37.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T36.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T48.X, T41.X, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T47.Y, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR T1.Z, T41.Z, literal.x,
-; EG-NEXT:     BFE_INT T65.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 240(3.363116e-43)
-; EG-NEXT:     LSHR T66.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T65.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.Z, T41.X, literal.y,
-; EG-NEXT:     BFE_INT T48.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T48.Y, PV.Z, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT T36.X, T35.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T37.Y, PS, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.Z, T35.Y, literal.x,
+; EG-NEXT:     BFE_INT T65.W, T0.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T0.W, T35.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T66.X, T43.X, literal.x,
+; EG-NEXT:     BFE_INT T65.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T36.W, PV.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T35.X, literal.y,
+; EG-NEXT:    60(8.407791e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T35.X, T43.X, literal.x,
+; EG-NEXT:     BFE_INT * T36.Y, PS, 0.0, literal.y,
+; EG-NEXT:    56(7.847271e-44), 16(2.242078e-44)
 ;
 ; CM-LABEL: global_sextload_v64i16_to_v64i32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 0, @40, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 1 @24
-; CM-NEXT:    ALU 15, @41, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 5 @28
-; CM-NEXT:    ALU 82, @57, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 72, @140, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    TEX 7 @22
+; CM-NEXT:    ALU 75, @39, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 67, @115, KC0[], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T65, T66.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T35.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T64, T56.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T55.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T63, T54.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T53.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T62, T52.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T51.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T61, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T49.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T60, T48.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T47.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T59, T46.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T40.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T58, T39.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T57, T38.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T43.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T64, T35.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T56.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T63, T55.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T54.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T62, T53.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T52.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T61, T51.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T50.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T60, T49.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T48.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T59, T47.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T46.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T58, T45.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T57, T44.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
-; CM-NEXT:    Fetch clause starting at 24:
-; CM-NEXT:     VTX_READ_128 T36.XYZW, T37.X, 16, #1
-; CM-NEXT:     VTX_READ_128 T35.XYZW, T37.X, 0, #1
-; CM-NEXT:    Fetch clause starting at 28:
-; CM-NEXT:     VTX_READ_128 T41.XYZW, T37.X, 112, #1
-; CM-NEXT:     VTX_READ_128 T42.XYZW, T37.X, 96, #1
-; CM-NEXT:     VTX_READ_128 T43.XYZW, T37.X, 80, #1
-; CM-NEXT:     VTX_READ_128 T44.XYZW, T37.X, 64, #1
-; CM-NEXT:     VTX_READ_128 T45.XYZW, T37.X, 48, #1
-; CM-NEXT:     VTX_READ_128 T37.XYZW, T37.X, 32, #1
-; CM-NEXT:    ALU clause starting at 40:
-; CM-NEXT:     MOV * T37.X, KC0[2].Z,
-; CM-NEXT:    ALU clause starting at 41:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T38.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Y, T35.Z, literal.y,
-; CM-NEXT:     LSHR T0.Z, T35.W, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T40.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T1.Y, T35.Y, literal.y,
-; CM-NEXT:     LSHR T1.Z, T36.Z, literal.y,
-; CM-NEXT:     LSHR * T0.W, T36.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    ALU clause starting at 57:
-; CM-NEXT:     LSHR T2.Z, T36.X, literal.x,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    16(2.242078e-44), 208(2.914701e-43)
-; CM-NEXT:     LSHR T46.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T2.Y, T36.Y, literal.y,
-; CM-NEXT:     LSHR T3.Z, T37.Z, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T47.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T3.Y, T37.W, literal.y,
-; CM-NEXT:     LSHR T4.Z, T37.X, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T48.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T4.Y, T37.Y, literal.y,
-; CM-NEXT:     LSHR T5.Z, T45.Z, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    128(1.793662e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T49.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T5.Y, T45.W, literal.y,
-; CM-NEXT:     LSHR T6.Z, T45.X, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T50.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T6.Y, T45.Y, literal.y,
-; CM-NEXT:     LSHR T7.Z, T44.Z, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T51.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T7.Y, T44.W, literal.y,
-; CM-NEXT:     LSHR T8.Z, T44.X, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T52.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T8.Y, T44.Y, literal.y,
-; CM-NEXT:     LSHR T9.Z, T43.Z, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T53.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T9.Y, T43.W, literal.y,
-; CM-NEXT:     LSHR T10.Z, T43.X, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T54.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T10.Y, T43.Y, literal.y,
-; CM-NEXT:     LSHR T11.Z, T42.Z, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T55.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T11.Y, T42.W, literal.y,
-; CM-NEXT:     LSHR T12.Z, T42.X, literal.y,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    Fetch clause starting at 22:
+; CM-NEXT:     VTX_READ_128 T42.XYZW, T35.X, 112, #1
+; CM-NEXT:     VTX_READ_128 T41.XYZW, T35.X, 96, #1
+; CM-NEXT:     VTX_READ_128 T40.XYZW, T35.X, 80, #1
+; CM-NEXT:     VTX_READ_128 T39.XYZW, T35.X, 64, #1
+; CM-NEXT:     VTX_READ_128 T38.XYZW, T35.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T36.XYZW, T35.X, 16, #1
+; CM-NEXT:     VTX_READ_128 T35.XYZW, T35.X, 0, #1
+; CM-NEXT:    ALU clause starting at 38:
+; CM-NEXT:     MOV * T35.X, KC0[2].Z,
+; CM-NEXT:    ALU clause starting at 39:
+; CM-NEXT:     LSHR * T43.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T44.X, PV.X, literal.x,
+; CM-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T45.X, T43.X, literal.x,
+; CM-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T46.X, T43.X, literal.x,
 ; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T56.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T12.Y, T42.Y, literal.y,
-; CM-NEXT:     BFE_INT T57.Z, T41.Y, 0.0, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:     LSHR * T1.W, T41.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     BFE_INT T57.X, T41.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T13.Y, T41.W, literal.x,
-; CM-NEXT:     BFE_INT T58.Z, T41.W, 0.0, literal.x,
-; CM-NEXT:     LSHR * T2.W, T41.Y, literal.x,
+; CM-NEXT:     ADD_INT T47.X, T43.X, literal.x,
+; CM-NEXT:     LSHR * T0.W, T35.W, literal.y,
+; CM-NEXT:    52(7.286752e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T48.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T0.Y, T35.Y, literal.y,
+; CM-NEXT:     LSHR T0.Z, T36.Z, literal.y,
+; CM-NEXT:     LSHR * T1.W, T36.W, literal.y,
+; CM-NEXT:    40(5.605194e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T49.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T1.Y, T36.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T1.Z, T36.Y, literal.y,
+; CM-NEXT:     LSHR * T2.W, T37.Z, literal.y,
+; CM-NEXT:    44(6.165713e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T50.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T2.Y, T37.W, literal.y,
+; CM-NEXT:     LSHR T2.Z, T37.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T3.W, T37.Y, literal.y,
+; CM-NEXT:    32(4.484155e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T51.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T3.Y, T38.Z, literal.y,
+; CM-NEXT:     LSHR T3.Z, T38.W, literal.y,
+; CM-NEXT:     LSHR * T4.W, T38.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    36(5.044674e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T52.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T4.Y, T38.Y, literal.y,
+; CM-NEXT:     LSHR T4.Z, T39.Z, literal.y,
+; CM-NEXT:     LSHR * T5.W, T39.W, literal.y,
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T53.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T5.Y, T39.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T5.Z, T39.Y, literal.y,
+; CM-NEXT:     LSHR * T6.W, T40.Z, literal.y,
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T54.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T6.Y, T40.W, literal.x,
+; CM-NEXT:     LSHR T6.Z, T40.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T7.W, T40.Y, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T58.X, T41.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T14.Y, T41.X, literal.x,
-; CM-NEXT:     BFE_INT T41.Z, T42.Y, 0.0, literal.x,
+; CM-NEXT:     ADD_INT T55.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T7.Y, T41.Z, literal.y,
+; CM-NEXT:     LSHR T7.Z, T41.W, literal.y,
+; CM-NEXT:     LSHR * T8.W, T41.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T56.X, T43.X, literal.x,
+; CM-NEXT:     LSHR T8.Y, T41.Y, literal.y,
+; CM-NEXT:     BFE_INT T57.Z, T42.Y, 0.0, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T9.W, T42.Z, literal.y,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     BFE_INT T57.X, T42.X, 0.0, literal.x,
+; CM-NEXT:     LSHR T9.Y, T42.W, literal.x,
+; CM-NEXT:     BFE_INT T58.Z, T42.W, 0.0, literal.x,
+; CM-NEXT:     LSHR * T10.W, T42.Y, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T58.X, T42.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR T10.Y, T42.X, literal.x,
+; CM-NEXT:     BFE_INT T42.Z, T41.Y, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT * T57.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T41.X, T42.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T42.X, T41.X, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T57.Y, PV.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T59.Z, T42.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T58.W, T13.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T59.Z, T41.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T58.W, T9.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 140:
-; CM-NEXT:     BFE_INT T59.X, T42.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T58.Y, T1.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T42.Z, T43.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T41.W, T12.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T59.X, T41.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T58.Y, T9.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T41.Z, T40.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T42.W, T8.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T42.X, T43.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T41.Y, T12.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T60.Z, T43.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T59.W, T11.Y, 0.0, literal.x,
+; CM-NEXT:    ALU clause starting at 115:
+; CM-NEXT:     BFE_INT T41.X, T40.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T42.Y, T8.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T60.Z, T40.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T59.W, T7.Z, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T60.X, T43.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T59.Y, T11.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T43.Z, T44.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T42.W, T10.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T60.X, T40.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T59.Y, T7.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.Z, T39.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T41.W, T7.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T43.X, T44.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T42.Y, T10.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T61.Z, T44.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T60.W, T9.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.X, T39.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T41.Y, T6.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T61.Z, T39.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T60.W, T6.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T61.X, T44.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T60.Y, T9.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T44.Z, T45.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T43.W, T8.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T61.X, T39.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T60.Y, T6.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.Z, T38.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T40.W, T5.Z, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T44.X, T45.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T43.Y, T8.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T62.Z, T45.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T61.W, T7.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.X, T38.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.Y, T5.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T62.Z, T38.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T61.W, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T62.X, T45.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T61.Y, T7.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T45.Z, T37.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T44.W, T6.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T62.X, T38.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T61.Y, T4.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T38.Z, T37.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T39.W, T4.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T45.X, T37.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T44.Y, T6.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T63.Z, T37.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T62.W, T5.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T38.X, T37.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.Y, T4.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T63.Z, T37.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T62.W, T3.Z, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T63.X, T37.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T62.Y, T5.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T37.Z, T36.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T45.W, T4.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T62.Y, T3.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.Z, T36.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T38.W, T3.W, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T37.X, T36.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T45.Y, T4.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T38.Y, T2.Z, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T64.Z, T36.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T63.W, T3.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T63.W, T2.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T64.X, T36.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T63.Y, T3.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T63.Y, T2.W, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T36.Z, T35.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T37.W, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T37.W, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T36.X, T35.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T37.Y, T2.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.Y, T1.Y, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T65.Z, T35.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T64.W, T0.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T64.W, T1.W, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T65.X, T35.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T64.Y, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     LSHR T1.Z, T35.X, literal.x,
-; CM-NEXT:     BFE_INT * T36.W, T1.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T64.Y, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T0.Z, T35.X, literal.x,
+; CM-NEXT:     BFE_INT * T36.W, T0.Y, 0.0, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T35.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T35.X, T43.X, literal.x,
 ; CM-NEXT:     BFE_INT T36.Y, PV.Z, 0.0, literal.y,
-; CM-NEXT:     ADD_INT T1.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     BFE_INT * T65.W, T0.Z, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR T66.X, PV.Z, literal.x,
-; CM-NEXT:     BFE_INT * T65.Y, T0.Y, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     LSHR T0.Z, T35.Z, literal.y,
+; CM-NEXT:     BFE_INT * T65.W, T0.W, 0.0, literal.y,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T66.X, T43.X, literal.x,
+; CM-NEXT:     BFE_INT * T65.Y, PV.Z, 0.0, literal.y,
+; CM-NEXT:    4(5.605194e-45), 16(2.242078e-44)
   %load = load <64 x i16>, ptr addrspace(1) %in
   %ext = sext <64 x i16> %load to <64 x i32>
   store <64 x i32> %ext, ptr addrspace(1) %out
@@ -5899,7 +5719,7 @@ define amdgpu_kernel void @global_zextload_v4i16_to_v4i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 13, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
@@ -5918,19 +5738,18 @@ define amdgpu_kernel void @global_zextload_v4i16_to_v4i64(ptr addrspace(1) %out,
 ; EG-NEXT:     MOV T5.Y, 0.0,
 ; EG-NEXT:     MOV T6.W, 0.0,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T8.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T8.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v4i16_to_v4i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T8.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T7.X
+; CM-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T8.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
@@ -5948,12 +5767,10 @@ define amdgpu_kernel void @global_zextload_v4i16_to_v4i64(ptr addrspace(1) %out,
 ; CM-NEXT:     MOV * T6.W, 0.0,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T5.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T8.X, PV.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <4 x i16>, ptr addrspace(1) %in
   %ext = zext <4 x i16> %load to <4 x i64>
   store <4 x i64> %ext, ptr addrspace(1) %out
@@ -6050,63 +5867,61 @@ define amdgpu_kernel void @global_sextload_v4i16_to_v4i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T6.X, 1
+; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T8.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T5.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     ASHR * T5.W, T5.X, literal.x,
+; EG-NEXT:     ASHR * T6.W, T5.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ASHR T5.Z, T5.X, literal.y,
-; EG-NEXT:     ASHR * T7.W, T5.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T5.X, T5.X, 0.0, literal.x,
-; EG-NEXT:     ASHR * T7.Z, T5.Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T5.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; EG-NEXT:     ASHR T6.Z, T5.Y, literal.x,
+; EG-NEXT:     ASHR * T5.W, T5.X, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T7.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
+; EG-NEXT:     ASHR * T5.Z, T5.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T5.X, T5.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
+; EG-NEXT:     ASHR * T5.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T8.X, T7.X, literal.x,
+; EG-NEXT:     ASHR * T6.Y, T6.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
 ;
 ; CM-LABEL: global_sextload_v4i16_to_v4i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T8.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T7.X
+; CM-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T8.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 8:
 ; CM-NEXT:     MOV * T5.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 9:
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.x,
+; CM-NEXT:     ASHR * T5.W, T5.X, literal.x,
+; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; CM-NEXT:     ASHR T5.Z, T5.X, literal.x,
 ; CM-NEXT:     ASHR * T6.W, T5.Y, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T7.X, PV.Z, literal.x,
-; CM-NEXT:     ASHR T6.Z, T5.Y, literal.y,
-; CM-NEXT:     ASHR * T5.W, T5.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
-; CM-NEXT:     ASHR * T5.Z, T5.X, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T5.X, T5.X, 0.0, literal.x,
+; CM-NEXT:     ASHR * T6.Z, T5.Y, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT * T6.X, T5.Y, 0.0, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
 ; CM-NEXT:     ASHR * T6.Y, PV.X, literal.y,
-; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; CM-NEXT:     ASHR * T5.Y, PV.X, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:     ADD_INT T8.X, PV.X, literal.x,
+; CM-NEXT:     ASHR * T5.Y, T5.X, literal.y,
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <4 x i16>, ptr addrspace(1) %in
   %ext = sext <4 x i16> %load to <4 x i64>
   store <4 x i64> %ext, ptr addrspace(1) %out
@@ -6237,7 +6052,7 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 30, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 26, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T12.X, 0
@@ -6268,27 +6083,23 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; EG-NEXT:     MOV * T9.W, 0.0,
 ; EG-NEXT:     MOV T10.W, 0.0,
 ; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     LSHR T11.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T14.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T11.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T13.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T14.X, T11.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v8i16_to_v8i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 32, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T13.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T11.X
+; CM-NEXT:    ALU 28, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T11.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T14.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T12.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
@@ -6316,18 +6127,14 @@ define amdgpu_kernel void @global_zextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; CM-NEXT:     MOV * T9.W, 0.0,
 ; CM-NEXT:     MOV * T10.W, 0.0,
 ; CM-NEXT:     MOV * T7.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T11.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T12.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T13.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T11.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T14.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T12.X, PV.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T13.X, T11.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T14.X, T11.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <8 x i16>, ptr addrspace(1) %in
   %ext = zext <8 x i16> %load to <8 x i64>
   store <8 x i64> %ext, ptr addrspace(1) %out
@@ -6500,7 +6307,7 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 29, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T9.X, 0
@@ -6511,19 +6318,16 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T10.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T10.Z, T7.X, literal.y,
-; EG-NEXT:     ASHR * T12.W, T7.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T10.W, T7.X, literal.y,
+; EG-NEXT:     ADD_INT * T11.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T10.Z, T7.X, literal.x,
+; EG-NEXT:     ASHR * T12.W, T7.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T10.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T12.Z, T7.Y, literal.x,
 ; EG-NEXT:     ASHR * T13.W, T7.Z, literal.y,
@@ -6539,42 +6343,36 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T14.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T13.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T7.X, T8.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T14.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T14.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v8i16_to_v8i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T11.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T9.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T8.X
+; CM-NEXT:    ALU 28, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T8.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T14.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T11.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T9.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 10:
 ; CM-NEXT:     MOV * T7.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 11:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T8.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     ASHR * T10.W, T7.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T11.X, PV.Z, literal.x,
+; CM-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; CM-NEXT:     ASHR * T10.W, T7.W, literal.y,
+; CM-NEXT:    12(1.681558e-44), 31(4.344025e-44)
+; CM-NEXT:     ADD_INT T11.X, T8.X, literal.x,
 ; CM-NEXT:     ASHR T10.Z, T7.W, literal.y,
 ; CM-NEXT:     ASHR * T12.W, T7.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T10.X, T7.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T12.Z, T7.Z, literal.x,
@@ -6592,9 +6390,9 @@ define amdgpu_kernel void @global_sextload_v8i16_to_v8i64(ptr addrspace(1) %out,
 ; CM-NEXT:     BFE_INT T7.X, T7.X, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T13.Y, PV.X, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T14.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T14.X, T8.X, literal.x,
 ; CM-NEXT:     ASHR * T7.Y, PV.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <8 x i16>, ptr addrspace(1) %in
   %ext = sext <8 x i16> %load to <8 x i64>
   store <8 x i64> %ext, ptr addrspace(1) %out
@@ -6811,7 +6609,7 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 62, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 52, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T24.X, 0
@@ -6867,43 +6665,33 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV * T17.W, 0.0,
 ; EG-NEXT:     MOV T18.W, 0.0,
 ; EG-NEXT:     MOV * T11.W, 0.0,
-; EG-NEXT:     LSHR T19.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T26.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T19.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T20.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T22.X, T19.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, T19.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T24.X, T19.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T19.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T26.X, T19.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v16i16_to_v16i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @12
-; CM-NEXT:    ALU 64, @17, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T25.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T24.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T23.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T19.X
+; CM-NEXT:    ALU 56, @17, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T24.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T22.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T20.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -6952,30 +6740,22 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; CM-NEXT:     MOV * T17.W, 0.0,
 ; CM-NEXT:     MOV * T18.W, 0.0,
 ; CM-NEXT:     MOV * T11.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T19.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T21.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T23.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T24.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T25.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T19.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T26.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T20.X, PV.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T21.X, T19.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T22.X, T19.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T23.X, T19.X, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T24.X, T19.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T25.X, T19.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T26.X, T19.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <16 x i16>, ptr addrspace(1) %in
   %ext = zext <16 x i16> %load to <16 x i64>
   store <16 x i64> %ext, ptr addrspace(1) %out
@@ -7276,7 +7056,7 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 65, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 55, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T20.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T18.X, 0
@@ -7292,31 +7072,22 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 16:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 17:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T19.W, T11.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T19.Z, T11.X, literal.y,
-; EG-NEXT:     ASHR * T21.W, T11.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T13.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; EG-NEXT:     ASHR T19.W, T11.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT * T20.X, T13.X, literal.z,
+; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T19.Z, T11.X, literal.x,
+; EG-NEXT:     ASHR * T21.W, T11.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T19.X, T11.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T21.Z, T11.Y, literal.x,
 ; EG-NEXT:     ASHR * T22.W, T11.Z, literal.y,
@@ -7352,26 +7123,25 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T26.X, T12.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T25.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T12.X, T13.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T26.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T26.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v16i16_to_v16i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @12
-; CM-NEXT:    ALU 65, @17, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T15.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T13.X
+; CM-NEXT:    ALU 56, @17, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T20.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T17.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T16.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T14.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -7379,32 +7149,23 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; CM-NEXT:    ALU clause starting at 16:
 ; CM-NEXT:     MOV * T11.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 17:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T14.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T16.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T18.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     ASHR * T19.W, T11.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T20.X, PV.Z, literal.x,
+; CM-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T14.X, PV.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T15.X, T13.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T16.X, T13.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T17.X, T13.X, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; CM-NEXT:     ASHR * T19.W, T11.W, literal.y,
+; CM-NEXT:    12(1.681558e-44), 31(4.344025e-44)
+; CM-NEXT:     ADD_INT T20.X, T13.X, literal.x,
 ; CM-NEXT:     ASHR T19.Z, T11.W, literal.y,
 ; CM-NEXT:     ASHR * T21.W, T11.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T19.X, T11.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T21.Z, T11.Z, literal.x,
@@ -7442,9 +7203,9 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; CM-NEXT:     BFE_INT T12.X, T12.X, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T25.Y, PV.X, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T26.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T26.X, T13.X, literal.x,
 ; CM-NEXT:     ASHR * T12.Y, PV.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <16 x i16>, ptr addrspace(1) %in
   %ext = sext <16 x i16> %load to <16 x i64>
   store <16 x i64> %ext, ptr addrspace(1) %out
@@ -7850,33 +7611,33 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG-LABEL: global_zextload_v32i16_to_v32i64:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 2 @22
-; EG-NEXT:    ALU 33, @31, KC0[], KC1[]
-; EG-NEXT:    TEX 0 @28
-; EG-NEXT:    ALU 93, @65, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @22
+; EG-NEXT:    ALU 9, @31, KC0[], KC1[]
+; EG-NEXT:    TEX 2 @24
+; EG-NEXT:    ALU 94, @41, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T50.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T49.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T48.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T49.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T48.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T47.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T46.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T45.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T44.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T43.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T42.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T43.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T39.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T35.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T36.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T21.XYZW, T20.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T22.XYZW, T20.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T23.XYZW, T20.X, 32, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T29.XYZW, T20.X, 0, #1
+; EG-NEXT:    Fetch clause starting at 24:
+; EG-NEXT:     VTX_READ_128 T23.XYZW, T20.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T24.XYZW, T20.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T25.XYZW, T20.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 30:
 ; EG-NEXT:     MOV * T20.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
@@ -7884,295 +7645,256 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T19.X, T21.Z, literal.x,
 ; EG-NEXT:     MOV T19.Y, 0.0,
-; EG-NEXT:     LSHR T24.Z, T21.W, literal.y,
-; EG-NEXT:     AND_INT * T24.X, T21.W, literal.x,
+; EG-NEXT:     LSHR T22.Z, T21.W, literal.y,
+; EG-NEXT:     AND_INT * T22.X, T21.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T24.Y, 0.0,
-; EG-NEXT:     LSHR * T25.Z, T21.X, literal.x,
+; EG-NEXT:     MOV T22.Y, 0.0,
+; EG-NEXT:     LSHR * T20.Z, T21.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T25.X, T21.X, literal.x,
-; EG-NEXT:     MOV T25.Y, 0.0,
+; EG-NEXT:    ALU clause starting at 41:
+; EG-NEXT:     AND_INT T20.X, T21.X, literal.x,
+; EG-NEXT:     MOV T20.Y, 0.0,
 ; EG-NEXT:     LSHR T21.Z, T21.Y, literal.y,
 ; EG-NEXT:     AND_INT * T21.X, T21.Y, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T21.Y, 0.0,
-; EG-NEXT:     LSHR * T26.Z, T23.Z, literal.x,
+; EG-NEXT:     LSHR * T26.Z, T25.Z, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T26.X, T23.Z, literal.x,
+; EG-NEXT:     AND_INT T26.X, T25.Z, literal.x,
 ; EG-NEXT:     MOV T26.Y, 0.0,
-; EG-NEXT:     LSHR T27.Z, T23.W, literal.y,
-; EG-NEXT:     AND_INT * T27.X, T23.W, literal.x,
+; EG-NEXT:     LSHR T27.Z, T25.W, literal.y,
+; EG-NEXT:     AND_INT * T27.X, T25.W, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T27.Y, 0.0,
-; EG-NEXT:     LSHR * T28.Z, T23.X, literal.x,
+; EG-NEXT:     LSHR * T28.Z, T25.X, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T28.X, T23.X, literal.x,
+; EG-NEXT:     AND_INT T28.X, T25.X, literal.x,
 ; EG-NEXT:     MOV T28.Y, 0.0,
+; EG-NEXT:     LSHR T25.Z, T25.Y, literal.y,
+; EG-NEXT:     AND_INT * T25.X, T25.Y, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T25.Y, 0.0,
+; EG-NEXT:     LSHR * T29.Z, T24.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T29.X, T24.Z, literal.x,
+; EG-NEXT:     MOV T29.Y, 0.0,
+; EG-NEXT:     LSHR T30.Z, T24.W, literal.y,
+; EG-NEXT:     AND_INT * T30.X, T24.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T30.Y, 0.0,
+; EG-NEXT:     LSHR * T31.Z, T24.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T31.X, T24.X, literal.x,
+; EG-NEXT:     MOV T31.Y, 0.0,
+; EG-NEXT:     LSHR T24.Z, T24.Y, literal.y,
+; EG-NEXT:     AND_INT * T24.X, T24.Y, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T24.Y, 0.0,
+; EG-NEXT:     LSHR * T32.Z, T23.Z, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T32.X, T23.Z, literal.x,
+; EG-NEXT:     MOV T32.Y, 0.0,
+; EG-NEXT:     LSHR T33.Z, T23.W, literal.y,
+; EG-NEXT:     AND_INT * T33.X, T23.W, literal.x,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     MOV T33.Y, 0.0,
+; EG-NEXT:     LSHR * T34.Z, T23.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T34.X, T23.X, literal.x,
+; EG-NEXT:     MOV T34.Y, 0.0,
 ; EG-NEXT:     LSHR T23.Z, T23.Y, literal.y,
 ; EG-NEXT:     AND_INT * T23.X, T23.Y, literal.x,
 ; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; EG-NEXT:     MOV T23.Y, 0.0,
-; EG-NEXT:     LSHR * T20.Z, T22.Z, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 65:
-; EG-NEXT:     AND_INT T20.X, T22.Z, literal.x,
-; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     LSHR T30.Z, T22.W, literal.y,
-; EG-NEXT:     AND_INT * T30.X, T22.W, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T30.Y, 0.0,
-; EG-NEXT:     LSHR * T31.Z, T22.X, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T31.X, T22.X, literal.x,
-; EG-NEXT:     MOV T31.Y, 0.0,
-; EG-NEXT:     LSHR T22.Z, T22.Y, literal.y,
-; EG-NEXT:     AND_INT * T22.X, T22.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     LSHR * T32.Z, T29.Z, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T32.X, T29.Z, literal.x,
-; EG-NEXT:     MOV T32.Y, 0.0,
-; EG-NEXT:     LSHR T33.Z, T29.W, literal.y,
-; EG-NEXT:     AND_INT * T33.X, T29.W, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T33.Y, 0.0,
-; EG-NEXT:     LSHR * T34.Z, T29.X, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T34.X, T29.X, literal.x,
-; EG-NEXT:     MOV T34.Y, 0.0,
-; EG-NEXT:     LSHR T29.Z, T29.Y, literal.y,
-; EG-NEXT:     AND_INT * T29.X, T29.Y, literal.x,
-; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; EG-NEXT:     MOV T29.Y, 0.0,
 ; EG-NEXT:     MOV T19.W, 0.0,
-; EG-NEXT:     MOV * T24.W, 0.0,
-; EG-NEXT:     MOV T25.W, 0.0,
+; EG-NEXT:     MOV * T22.W, 0.0,
+; EG-NEXT:     MOV T20.W, 0.0,
 ; EG-NEXT:     MOV * T21.W, 0.0,
 ; EG-NEXT:     MOV T26.W, 0.0,
 ; EG-NEXT:     MOV * T27.W, 0.0,
 ; EG-NEXT:     MOV T28.W, 0.0,
-; EG-NEXT:     MOV * T23.W, 0.0,
-; EG-NEXT:     MOV T20.W, 0.0,
+; EG-NEXT:     MOV * T25.W, 0.0,
+; EG-NEXT:     MOV T29.W, 0.0,
 ; EG-NEXT:     MOV * T30.W, 0.0,
 ; EG-NEXT:     MOV T31.W, 0.0,
-; EG-NEXT:     MOV * T22.W, 0.0,
+; EG-NEXT:     MOV * T24.W, 0.0,
 ; EG-NEXT:     MOV T32.W, 0.0,
 ; EG-NEXT:     MOV * T33.W, 0.0,
 ; EG-NEXT:     MOV T34.W, 0.0,
-; EG-NEXT:     MOV * T29.W, 0.0,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T36.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T23.W, 0.0,
+; EG-NEXT:     LSHR * T35.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T42.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T43.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T45.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T47.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T48.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T36.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T37.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T38.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T35.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T40.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T41.X, T35.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T42.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T43.X, T35.X, literal.y,
+; EG-NEXT:    24(3.363116e-44), 36(5.044674e-44)
+; EG-NEXT:     ADD_INT T44.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T45.X, T35.X, literal.y,
+; EG-NEXT:    32(4.484155e-44), 44(6.165713e-44)
+; EG-NEXT:     ADD_INT T46.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T47.X, T35.X, literal.y,
+; EG-NEXT:    40(5.605194e-44), 52(7.286752e-44)
+; EG-NEXT:     ADD_INT T48.X, T35.X, literal.x,
+; EG-NEXT:     ADD_INT * T49.X, T35.X, literal.y,
+; EG-NEXT:    48(6.726233e-44), 60(8.407791e-44)
+; EG-NEXT:     ADD_INT * T50.X, T35.X, literal.x,
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v32i16_to_v32i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 2 @22
-; CM-NEXT:    ALU 33, @31, KC0[], KC1[]
-; CM-NEXT:    TEX 0 @28
-; CM-NEXT:    ALU 94, @65, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T49.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T48.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T47.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T46.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T45.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T44.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T43.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T42.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T41.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T40.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T39.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T38.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T37.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T34, T36.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T22.X
+; CM-NEXT:    TEX 0 @22
+; CM-NEXT:    ALU 9, @31, KC0[], KC1[]
+; CM-NEXT:    TEX 2 @24
+; CM-NEXT:    ALU 102, @41, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T50.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T49.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T48.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T47.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T46.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T45.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T44.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T43.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T42.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T31, T41.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T40.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T38.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T34, T37.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T36.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 22:
 ; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
-; CM-NEXT:     VTX_READ_128 T21.XYZW, T19.X, 32, #1
-; CM-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 16, #1
-; CM-NEXT:    Fetch clause starting at 28:
-; CM-NEXT:     VTX_READ_128 T22.XYZW, T19.X, 48, #1
+; CM-NEXT:    Fetch clause starting at 24:
+; CM-NEXT:     VTX_READ_128 T23.XYZW, T19.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T24.XYZW, T19.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T25.XYZW, T19.X, 16, #1
 ; CM-NEXT:    ALU clause starting at 30:
 ; CM-NEXT:     MOV * T19.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 31:
-; CM-NEXT:     LSHR * T23.Z, T20.Y, literal.x,
+; CM-NEXT:     LSHR * T21.Z, T20.Y, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T23.X, T20.Y, literal.x,
-; CM-NEXT:     MOV T23.Y, 0.0,
-; CM-NEXT:     LSHR * T24.Z, T20.X, literal.y,
+; CM-NEXT:     AND_INT T21.X, T20.Y, literal.x,
+; CM-NEXT:     MOV T21.Y, 0.0,
+; CM-NEXT:     LSHR * T22.Z, T20.X, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T24.X, T20.X, literal.x,
-; CM-NEXT:     MOV T24.Y, 0.0,
-; CM-NEXT:     LSHR * T25.Z, T20.W, literal.y,
+; CM-NEXT:     AND_INT T22.X, T20.X, literal.x,
+; CM-NEXT:     MOV T22.Y, 0.0,
+; CM-NEXT:     LSHR * T19.Z, T20.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T25.X, T20.W, literal.x,
-; CM-NEXT:     MOV T25.Y, 0.0,
+; CM-NEXT:    ALU clause starting at 41:
+; CM-NEXT:     AND_INT T19.X, T20.W, literal.x,
+; CM-NEXT:     MOV T19.Y, 0.0,
 ; CM-NEXT:     LSHR * T26.Z, T20.Z, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
 ; CM-NEXT:     AND_INT T26.X, T20.Z, literal.x,
 ; CM-NEXT:     MOV T26.Y, 0.0,
-; CM-NEXT:     LSHR * T20.Z, T22.Y, literal.y,
+; CM-NEXT:     LSHR * T20.Z, T25.Y, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T20.X, T22.Y, literal.x,
+; CM-NEXT:     AND_INT T20.X, T25.Y, literal.x,
 ; CM-NEXT:     MOV T20.Y, 0.0,
-; CM-NEXT:     LSHR * T27.Z, T22.X, literal.y,
+; CM-NEXT:     LSHR * T27.Z, T25.X, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T27.X, T22.X, literal.x,
+; CM-NEXT:     AND_INT T27.X, T25.X, literal.x,
 ; CM-NEXT:     MOV T27.Y, 0.0,
-; CM-NEXT:     LSHR * T28.Z, T22.W, literal.y,
+; CM-NEXT:     LSHR * T28.Z, T25.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T28.X, T22.W, literal.x,
+; CM-NEXT:     AND_INT T28.X, T25.W, literal.x,
 ; CM-NEXT:     MOV T28.Y, 0.0,
-; CM-NEXT:     LSHR * T29.Z, T22.Z, literal.y,
+; CM-NEXT:     LSHR * T29.Z, T25.Z, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T29.X, T22.Z, literal.x,
+; CM-NEXT:     AND_INT T29.X, T25.Z, literal.x,
 ; CM-NEXT:     MOV T29.Y, 0.0,
-; CM-NEXT:     LSHR * T19.Z, T21.Y, literal.y,
+; CM-NEXT:     LSHR * T25.Z, T24.Y, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:    ALU clause starting at 65:
-; CM-NEXT:     AND_INT T19.X, T21.Y, literal.x,
-; CM-NEXT:     MOV T19.Y, 0.0,
-; CM-NEXT:     LSHR * T30.Z, T21.X, literal.y,
+; CM-NEXT:     AND_INT T25.X, T24.Y, literal.x,
+; CM-NEXT:     MOV T25.Y, 0.0,
+; CM-NEXT:     LSHR * T30.Z, T24.X, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T30.X, T21.X, literal.x,
+; CM-NEXT:     AND_INT T30.X, T24.X, literal.x,
 ; CM-NEXT:     MOV T30.Y, 0.0,
-; CM-NEXT:     LSHR * T31.Z, T21.W, literal.y,
+; CM-NEXT:     LSHR * T31.Z, T24.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T31.X, T21.W, literal.x,
+; CM-NEXT:     AND_INT T31.X, T24.W, literal.x,
 ; CM-NEXT:     MOV T31.Y, 0.0,
-; CM-NEXT:     LSHR * T32.Z, T21.Z, literal.y,
+; CM-NEXT:     LSHR * T32.Z, T24.Z, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T32.X, T21.Z, literal.x,
+; CM-NEXT:     AND_INT T32.X, T24.Z, literal.x,
 ; CM-NEXT:     MOV T32.Y, 0.0,
-; CM-NEXT:     LSHR * T21.Z, T22.Y, literal.y,
+; CM-NEXT:     LSHR * T24.Z, T23.Y, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T21.X, T22.Y, literal.x,
-; CM-NEXT:     MOV T21.Y, 0.0,
-; CM-NEXT:     LSHR * T33.Z, T22.X, literal.y,
+; CM-NEXT:     AND_INT T24.X, T23.Y, literal.x,
+; CM-NEXT:     MOV T24.Y, 0.0,
+; CM-NEXT:     LSHR * T33.Z, T23.X, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T33.X, T22.X, literal.x,
+; CM-NEXT:     AND_INT T33.X, T23.X, literal.x,
 ; CM-NEXT:     MOV T33.Y, 0.0,
-; CM-NEXT:     LSHR * T34.Z, T22.W, literal.y,
+; CM-NEXT:     LSHR * T34.Z, T23.W, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T34.X, T22.W, literal.x,
+; CM-NEXT:     AND_INT T34.X, T23.W, literal.x,
 ; CM-NEXT:     MOV T34.Y, 0.0,
-; CM-NEXT:     LSHR * T35.Z, T22.Z, literal.y,
+; CM-NEXT:     LSHR * T35.Z, T23.Z, literal.y,
 ; CM-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
-; CM-NEXT:     AND_INT T35.X, T22.Z, literal.x,
+; CM-NEXT:     AND_INT T35.X, T23.Z, literal.x,
 ; CM-NEXT:     MOV T35.Y, 0.0,
-; CM-NEXT:     MOV * T23.W, 0.0,
+; CM-NEXT:     MOV * T21.W, 0.0,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-; CM-NEXT:     MOV * T24.W, 0.0,
-; CM-NEXT:     MOV * T25.W, 0.0,
+; CM-NEXT:     MOV * T22.W, 0.0,
+; CM-NEXT:     MOV * T19.W, 0.0,
 ; CM-NEXT:     MOV * T26.W, 0.0,
 ; CM-NEXT:     MOV * T20.W, 0.0,
 ; CM-NEXT:     MOV * T27.W, 0.0,
 ; CM-NEXT:     MOV * T28.W, 0.0,
 ; CM-NEXT:     MOV * T29.W, 0.0,
-; CM-NEXT:     MOV * T19.W, 0.0,
+; CM-NEXT:     MOV * T25.W, 0.0,
 ; CM-NEXT:     MOV * T30.W, 0.0,
 ; CM-NEXT:     MOV * T31.W, 0.0,
 ; CM-NEXT:     MOV * T32.W, 0.0,
-; CM-NEXT:     MOV * T21.W, 0.0,
+; CM-NEXT:     MOV * T24.W, 0.0,
 ; CM-NEXT:     MOV * T33.W, 0.0,
 ; CM-NEXT:     MOV * T34.W, 0.0,
 ; CM-NEXT:     MOV * T35.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; CM-NEXT:     LSHR T36.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; CM-NEXT:     LSHR T37.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; CM-NEXT:     LSHR T38.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; CM-NEXT:     LSHR T40.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; CM-NEXT:     LSHR T41.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; CM-NEXT:     LSHR T42.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T43.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; CM-NEXT:     LSHR T44.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T45.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T46.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T47.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR * T48.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T23.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR T49.X, KC0[2].Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T36.X, PV.X, literal.x,
+; CM-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T37.X, T23.X, literal.x,
+; CM-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T38.X, T23.X, literal.x,
+; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T39.X, T23.X, literal.x,
+; CM-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T40.X, T23.X, literal.x,
+; CM-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T41.X, T23.X, literal.x,
+; CM-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T42.X, T23.X, literal.x,
+; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T43.X, T23.X, literal.x,
+; CM-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T44.X, T23.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T45.X, T23.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T46.X, T23.X, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T47.X, T23.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T48.X, T23.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T49.X, T23.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T50.X, T23.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <32 x i16>, ptr addrspace(1) %in
   %ext = zext <32 x i16> %load to <32 x i64>
   store <32 x i64> %ext, ptr addrspace(1) %out
@@ -8727,9 +8449,9 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @22
-; EG-NEXT:    ALU 56, @31, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 33, @31, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @24
-; EG-NEXT:    ALU 74, @88, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 74, @65, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T50.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T49.XYZW, T36.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T34.X, 0
@@ -8744,8 +8466,8 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T24.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T21.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 0, #1
@@ -8756,69 +8478,47 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 30:
 ; EG-NEXT:     MOV * T19.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T35.W, T20.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T35.Z, T20.Y, literal.y,
-; EG-NEXT:     ASHR * T37.W, T20.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T35.X, T20.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR * T37.Z, T20.X, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T24.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T21.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T26.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T21.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T28.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, T21.X, literal.y,
+; EG-NEXT:    24(3.363116e-44), 36(5.044674e-44)
+; EG-NEXT:     ADD_INT T30.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T21.X, literal.y,
+; EG-NEXT:    32(4.484155e-44), 44(6.165713e-44)
+; EG-NEXT:     ADD_INT T32.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T21.X, literal.y,
+; EG-NEXT:    40(5.605194e-44), 52(7.286752e-44)
+; EG-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; EG-NEXT:     ASHR T35.W, T20.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT * T36.X, T21.X, literal.z,
+; EG-NEXT:    48(6.726233e-44), 31(4.344025e-44)
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T35.Z, T20.X, literal.x,
+; EG-NEXT:     ASHR * T37.W, T20.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT T35.X, T20.X, 0.0, literal.x,
+; EG-NEXT:     ASHR * T37.Z, T20.Y, literal.x,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T37.X, T20.X, 0.0, literal.x,
-; EG-NEXT:     ASHR T35.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T37.X, T20.Y, 0.0, literal.x,
 ; EG-NEXT:     ASHR * T19.W, T20.W, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    ALU clause starting at 88:
-; EG-NEXT:     ASHR T19.Z, T20.W, literal.x,
-; EG-NEXT:     ASHR * T41.W, T20.Z, literal.y,
-; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:    ALU clause starting at 65:
+; EG-NEXT:     ASHR T37.Y, T37.X, literal.x,
+; EG-NEXT:     ASHR T19.Z, T20.W, literal.y,
+; EG-NEXT:     ASHR * T41.W, T20.Z, literal.x,
+; EG-NEXT:    31(4.344025e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T19.X, T20.W, 0.0, literal.x,
-; EG-NEXT:     ASHR T37.Y, T37.X, literal.y,
+; EG-NEXT:     ASHR T35.Y, T35.X, literal.y,
 ; EG-NEXT:     ASHR T41.Z, T20.Z, literal.x,
 ; EG-NEXT:     ASHR * T20.W, T40.Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
@@ -8883,36 +8583,35 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T50.X, T38.Z, 0.0, literal.x,
 ; EG-NEXT:     ASHR T49.Y, PV.X, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T38.X, T21.X, literal.z,
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ASHR * T50.Y, PV.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR * T50.Y, PV.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v32i16_to_v32i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @22
-; CM-NEXT:    ALU 55, @31, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 39, @31, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 2 @24
-; CM-NEXT:    ALU 73, @87, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 73, @71, KC0[], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T49, T36.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T48, T34.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T33.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T32.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T46, T31.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T30.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T29.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T28.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T27.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T25.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T24.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T49, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T48, T36.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T34.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T33.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T46, T32.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T31.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T29.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T28.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T24.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T23.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T21.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 22:
 ; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 48, #1
@@ -8923,68 +8622,53 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; CM-NEXT:    ALU clause starting at 30:
 ; CM-NEXT:     MOV * T19.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 31:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T21.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; CM-NEXT:     LSHR T23.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; CM-NEXT:     LSHR T24.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; CM-NEXT:     LSHR T25.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; CM-NEXT:     LSHR T26.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; CM-NEXT:     LSHR T27.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; CM-NEXT:     LSHR T28.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T29.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; CM-NEXT:     LSHR T30.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T31.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T32.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T33.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T34.X, PV.W, literal.x,
-; CM-NEXT:     ASHR * T35.W, T20.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; CM-NEXT:     LSHR T36.X, KC0[2].Y, literal.x,
-; CM-NEXT:     ASHR T35.Z, T20.Z, literal.y,
-; CM-NEXT:     ASHR * T37.W, T20.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T35.X, T20.Z, 0.0, literal.x,
-; CM-NEXT:     ASHR * T37.Z, T20.W, literal.x,
+; CM-NEXT:     LSHR * T21.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T22.X, PV.X, literal.x,
+; CM-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T23.X, T21.X, literal.x,
+; CM-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T24.X, T21.X, literal.x,
+; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T25.X, T21.X, literal.x,
+; CM-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T26.X, T21.X, literal.x,
+; CM-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T27.X, T21.X, literal.x,
+; CM-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T28.X, T21.X, literal.x,
+; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T29.X, T21.X, literal.x,
+; CM-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T30.X, T21.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T31.X, T21.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T32.X, T21.X, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T37.X, T20.W, 0.0, literal.x,
-; CM-NEXT:     ASHR T35.Y, PV.X, literal.y,
+; CM-NEXT:     ADD_INT * T33.X, T21.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; CM-NEXT:     ASHR * T35.W, T20.W, literal.y,
+; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; CM-NEXT:     ADD_INT T36.X, T21.X, literal.x,
+; CM-NEXT:     ASHR T35.Z, T20.W, literal.y,
+; CM-NEXT:     ASHR * T37.W, T20.Z, literal.z,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T35.X, T20.W, 0.0, literal.x,
+; CM-NEXT:     ASHR * T37.Z, T20.Z, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T37.X, T20.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T19.W, T20.X, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:    ALU clause starting at 87:
-; CM-NEXT:     ASHR T19.Z, T20.X, literal.x,
-; CM-NEXT:     ASHR * T20.W, T20.Y, literal.y,
-; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; CM-NEXT:    ALU clause starting at 71:
+; CM-NEXT:     ASHR T37.Y, T37.X, literal.x,
+; CM-NEXT:     ASHR T19.Z, T20.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     ASHR * T20.W, T20.Y, literal.x,
+; CM-NEXT:    31(4.344025e-44), 16(2.242078e-44)
 ; CM-NEXT:     BFE_INT T19.X, T20.X, 0.0, literal.x,
-; CM-NEXT:     ASHR T37.Y, T37.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     ASHR T35.Y, T35.X, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:     ASHR T20.Z, T20.Y, literal.x,
 ; CM-NEXT:     ASHR * T41.W, T40.Z, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
@@ -9048,12 +8732,11 @@ define amdgpu_kernel void @global_sextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; CM-NEXT:     ASHR * T38.Z, T38.Y, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; CM-NEXT:     BFE_INT T38.X, T38.Y, 0.0, literal.x,
-; CM-NEXT:     ASHR T49.Y, PV.X, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; CM-NEXT:     ASHR * T49.Y, PV.X, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T50.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T50.X, T21.X, literal.x,
 ; CM-NEXT:     ASHR * T38.Y, PV.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <32 x i16>, ptr addrspace(1) %in
   %ext = sext <32 x i16> %load to <32 x i64>
   store <32 x i64> %ext, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/load-global-i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-global-i32.ll
@@ -226,21 +226,19 @@ define amdgpu_kernel void @global_load_v3i32(ptr addrspace(1) %out, ptr addrspac
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 6, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; EG-NEXT:    ALU 4, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; EG-NEXT:     MOV * T2.X, T0.Z,
+; EG-NEXT:     MOV T1.X, T0.Z,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v3i32:
@@ -412,9 +410,9 @@ define amdgpu_kernel void @global_load_v8i32(ptr addrspace(1) %out, ptr addrspac
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 4, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
+; EG-NEXT:    ALU 3, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
@@ -422,11 +420,10 @@ define amdgpu_kernel void @global_load_v8i32(ptr addrspace(1) %out, ptr addrspac
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v8i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -533,12 +530,12 @@ define amdgpu_kernel void @global_load_v9i32(ptr addrspace(1) %out, ptr addrspac
 ;
 ; EG-LABEL: global_load_v9i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 8, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 5, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 1, @23, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T0.X, 1
+; EG-NEXT:    ALU 1, @20, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -546,18 +543,15 @@ define amdgpu_kernel void @global_load_v9i32(ptr addrspace(1) %out, ptr addrspac
 ; EG-NEXT:     VTX_READ_128 T2.XYZW, T2.X, 16, #1
 ; EG-NEXT:     VTX_READ_32 T3.X, T3.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 14:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
 ; EG-NEXT:     MOV * T2.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV * T3.X, PS,
-; EG-NEXT:    ALU clause starting at 23:
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 20:
+; EG-NEXT:     ADD_INT * T5.X, T0.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v9i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -667,29 +661,26 @@ define amdgpu_kernel void @global_load_v10i32(ptr addrspace(1) %out, ptr addrspa
 ;
 ; EG-LABEL: global_load_v10i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 2, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 7, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 1
+; EG-NEXT:    ALU 2, @17, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XY, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
-; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T1.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T1.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T1.XYZW, T1.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 14:
-; EG-NEXT:     MOV * T0.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T1.X, KC0[2].Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 17:
+; EG-NEXT:     ADD_INT T4.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T5.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 4(5.605194e-45)
 ;
 ; GCN-HSA-LABEL: global_load_v10i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -802,11 +793,11 @@ define amdgpu_kernel void @global_load_v11i32(ptr addrspace(1) %out, ptr addrspa
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 12, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T6.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.X, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T3.X, 1
+; EG-NEXT:    ALU 7, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.X, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
@@ -815,19 +806,14 @@ define amdgpu_kernel void @global_load_v11i32(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T4.X, T0.Z,
+; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    40(5.605194e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; EG-NEXT:     MOV * T5.X, T0.Z,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T6.X, T3.X, literal.x,
+; EG-NEXT:     ADD_INT * T7.X, T3.X, literal.y,
+; EG-NEXT:    10(1.401298e-44), 4(5.605194e-45)
 ;
 ; GCN-HSA-LABEL: global_load_v11i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -938,12 +924,12 @@ define amdgpu_kernel void @global_load_v12i32(ptr addrspace(1) %out, ptr addrspa
 ;
 ; EG-LABEL: global_load_v12i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 7, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 4, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 2 @8
-; EG-NEXT:    ALU 1, @22, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
+; EG-NEXT:    ALU 1, @19, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -951,17 +937,14 @@ define amdgpu_kernel void @global_load_v12i32(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:     VTX_READ_128 T4.XYZW, T2.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T2.XYZW, T2.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 14:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
 ; EG-NEXT:     MOV * T2.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 22:
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 19:
+; EG-NEXT:     ADD_INT * T5.X, T0.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v12i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -1088,13 +1071,13 @@ define amdgpu_kernel void @global_load_v16i32(ptr addrspace(1) %out, ptr addrspa
 ;
 ; EG-LABEL: global_load_v16i32:
 ; EG:       ; %bb.0: ; %entry
-; EG-NEXT:    ALU 11, @16, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 5, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @8
-; EG-NEXT:    ALU 1, @28, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @22, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T4.XYZW, T3.X, 32, #1
@@ -1102,21 +1085,15 @@ define amdgpu_kernel void @global_load_v16i32(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:     VTX_READ_128 T6.XYZW, T3.X, 0, #1
 ; EG-NEXT:     VTX_READ_128 T3.XYZW, T3.X, 16, #1
 ; EG-NEXT:    ALU clause starting at 16:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
 ; EG-NEXT:     MOV * T3.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 28:
-; EG-NEXT:     LSHR * T7.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 22:
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v16i32:
 ; GCN-HSA:       ; %bb.0: ; %entry
@@ -1776,7 +1753,7 @@ define amdgpu_kernel void @global_zextload_v4i32_to_v4i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 12, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
@@ -1793,11 +1770,10 @@ define amdgpu_kernel void @global_zextload_v4i32_to_v4i64(ptr addrspace(1) %out,
 ; EG-NEXT:     MOV T1.W, 0.0,
 ; EG-NEXT:     MOV * T2.Z, T0.Y,
 ; EG-NEXT:     MOV * T2.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_zextload_v4i32_to_v4i64:
 ; GCN-HSA:       ; %bb.0:
@@ -1907,31 +1883,30 @@ define amdgpu_kernel void @global_sextload_v4i32_to_v4i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 15, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T2.X, 1
+; EG-NEXT:    ALU 14, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     ASHR * T1.W, T0.Y, literal.x,
+; EG-NEXT:     ASHR * T1.W, T0.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ASHR T1.Y, T0.X, literal.y,
-; EG-NEXT:     ASHR T3.W, T0.W, literal.y,
-; EG-NEXT:     MOV * T1.X, T0.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     ASHR * T3.Y, T0.Z, literal.x,
+; EG-NEXT:     ASHR T1.Y, T0.Z, literal.x,
+; EG-NEXT:     ASHR * T2.W, T0.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T3.X, T0.Z,
-; EG-NEXT:     MOV T1.Z, T0.Y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T3.Z, T0.W,
+; EG-NEXT:     MOV T1.X, T0.Z,
+; EG-NEXT:     ASHR T2.Y, T0.X, literal.x,
+; EG-NEXT:     MOV * T2.X, T0.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T2.Z, T0.Y,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; EG-NEXT:     MOV * T1.Z, T0.W,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_sextload_v4i32_to_v4i64:
 ; GCN-HSA:       ; %bb.0:
@@ -2078,7 +2053,7 @@ define amdgpu_kernel void @global_zextload_v8i32_to_v8i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 26, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 22, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 0
@@ -2106,17 +2081,13 @@ define amdgpu_kernel void @global_zextload_v8i32_to_v8i64(ptr addrspace(1) %out,
 ; EG-NEXT:     MOV T4.W, 0.0,
 ; EG-NEXT:     MOV * T5.Z, T0.Y,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_zextload_v8i32_to_v8i64:
 ; GCN-HSA:       ; %bb.0:
@@ -2283,7 +2254,7 @@ define amdgpu_kernel void @global_sextload_v8i32_to_v8i64(ptr addrspace(1) %out,
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @12, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @8
-; EG-NEXT:    ALU 31, @13, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 27, @13, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T0.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T5.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T3.X, 0
@@ -2295,38 +2266,34 @@ define amdgpu_kernel void @global_sextload_v8i32_to_v8i64(ptr addrspace(1) %out,
 ; EG-NEXT:    ALU clause starting at 12:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 13:
-; EG-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T4.W, T0.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T4.W, T0.Y, literal.y,
+; EG-NEXT:     ADD_INT * T5.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T4.Y, T0.X, literal.x,
+; EG-NEXT:     ASHR * T6.W, T0.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T4.Y, T0.X, literal.y,
-; EG-NEXT:     ASHR T6.W, T0.W, literal.y,
-; EG-NEXT:     MOV * T4.X, T0.X,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     MOV T4.X, T0.X,
 ; EG-NEXT:     ASHR T6.Y, T0.Z, literal.x,
-; EG-NEXT:     ASHR * T7.W, T1.Y, literal.x,
+; EG-NEXT:     ASHR T7.W, T1.Y, literal.x,
+; EG-NEXT:     MOV * T6.X, T0.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T6.X, T0.Z,
 ; EG-NEXT:     ASHR T7.Y, T1.X, literal.x,
 ; EG-NEXT:     MOV T4.Z, T0.Y,
-; EG-NEXT:     ASHR T8.W, T1.W, literal.x,
-; EG-NEXT:     MOV * T7.X, T1.X,
+; EG-NEXT:     ASHR * T8.W, T1.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T7.X, T1.X,
 ; EG-NEXT:     ASHR T8.Y, T1.Z, literal.x,
-; EG-NEXT:     MOV * T6.Z, T0.W,
+; EG-NEXT:     MOV T6.Z, T0.W,
+; EG-NEXT:     MOV * T8.X, T1.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T8.X, T1.Z,
-; EG-NEXT:     MOV T7.Z, T1.Y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T7.Z, T1.Y,
+; EG-NEXT:     ADD_INT T0.X, T2.X, literal.x,
 ; EG-NEXT:     MOV * T8.Z, T1.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_sextload_v8i32_to_v8i64:
 ; GCN-HSA:       ; %bb.0:
@@ -2594,15 +2561,15 @@ define amdgpu_kernel void @global_sextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 64, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 53, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T1.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T9.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T6.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T4.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T4.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T5.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 48, #1
@@ -2612,71 +2579,60 @@ define amdgpu_kernel void @global_sextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; EG-NEXT:    ALU clause starting at 20:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 21:
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T4.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T4.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T10.W, T0.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
+; EG-NEXT:     ADD_INT T5.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T7.X, T4.X, literal.x,
+; EG-NEXT:     ADD_INT * T8.X, T4.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T9.X, T4.X, literal.x,
+; EG-NEXT:     ASHR T10.W, T0.W, literal.y,
+; EG-NEXT:     ADD_INT * T11.X, T4.X, literal.z,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T10.Y, T0.Z, literal.x,
+; EG-NEXT:     ASHR * T12.W, T0.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T10.Y, T0.Z, literal.y,
-; EG-NEXT:     ASHR T12.W, T0.Y, literal.y,
-; EG-NEXT:     MOV * T10.X, T0.Z,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     MOV T10.X, T0.Z,
 ; EG-NEXT:     ASHR T12.Y, T0.X, literal.x,
-; EG-NEXT:     ASHR * T13.W, T3.W, literal.x,
+; EG-NEXT:     ASHR T13.W, T3.W, literal.x,
+; EG-NEXT:     MOV * T12.X, T0.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T12.X, T0.X,
 ; EG-NEXT:     ASHR T13.Y, T3.Z, literal.x,
 ; EG-NEXT:     MOV T10.Z, T0.W,
-; EG-NEXT:     ASHR T14.W, T3.Y, literal.x,
-; EG-NEXT:     MOV * T13.X, T3.Z,
+; EG-NEXT:     ASHR * T14.W, T3.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T13.X, T3.Z,
 ; EG-NEXT:     ASHR T14.Y, T3.X, literal.x,
 ; EG-NEXT:     MOV T12.Z, T0.Y,
-; EG-NEXT:     ASHR * T0.W, T2.W, literal.x,
+; EG-NEXT:     ASHR T0.W, T2.W, literal.x,
+; EG-NEXT:     MOV * T14.X, T3.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T14.X, T3.X,
 ; EG-NEXT:     ASHR T0.Y, T2.Z, literal.x,
 ; EG-NEXT:     MOV T13.Z, T3.W,
-; EG-NEXT:     ASHR T15.W, T2.Y, literal.x,
-; EG-NEXT:     MOV * T0.X, T2.Z,
+; EG-NEXT:     ASHR * T15.W, T2.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T0.X, T2.Z,
 ; EG-NEXT:     ASHR T15.Y, T2.X, literal.x,
 ; EG-NEXT:     MOV T14.Z, T3.Y,
-; EG-NEXT:     ASHR * T3.W, T1.W, literal.x,
+; EG-NEXT:     ASHR T3.W, T1.W, literal.x,
+; EG-NEXT:     MOV * T15.X, T2.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T15.X, T2.X,
 ; EG-NEXT:     ASHR T3.Y, T1.Z, literal.x,
 ; EG-NEXT:     MOV T0.Z, T2.W,
-; EG-NEXT:     ASHR T16.W, T1.Y, literal.x,
-; EG-NEXT:     MOV * T3.X, T1.Z,
+; EG-NEXT:     ASHR * T16.W, T1.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV T3.X, T1.Z,
 ; EG-NEXT:     ASHR T16.Y, T1.X, literal.x,
-; EG-NEXT:     MOV * T15.Z, T2.Y,
+; EG-NEXT:     MOV T15.Z, T2.Y,
+; EG-NEXT:     MOV * T16.X, T1.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T16.X, T1.X,
-; EG-NEXT:     MOV T3.Z, T1.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T3.Z, T1.W,
+; EG-NEXT:     ADD_INT T1.X, T4.X, literal.x,
 ; EG-NEXT:     MOV * T16.Z, T1.Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_sextload_v16i32_to_v16i64:
 ; GCN-HSA:       ; %bb.0:
@@ -2934,15 +2890,15 @@ define amdgpu_kernel void @global_zextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @20, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @12
-; EG-NEXT:    ALU 55, @21, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 44, @21, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T15.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T0.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 48, #1
@@ -2983,31 +2939,20 @@ define amdgpu_kernel void @global_zextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV T10.Z, T2.Y,
 ; EG-NEXT:     MOV T10.W, 0.0,
 ; EG-NEXT:     MOV * T11.Z, T2.W,
-; EG-NEXT:     MOV T11.W, 0.0,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PS, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR * T15.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T12.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T13.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T14.X, T0.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_zextload_v16i32_to_v16i64:
 ; GCN-HSA:       ; %bb.0:
@@ -3493,168 +3438,144 @@ define amdgpu_kernel void @global_sextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ;
 ; EG-LABEL: global_sextload_v32i32_to_v32i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 33, @36, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 10, @36, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @20
-; EG-NEXT:    ALU 96, @70, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T23.X, 0
+; EG-NEXT:    ALU 95, @47, KC0[], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T32.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T23.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T21.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T20.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T20.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T19.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T10.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T9.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T18.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T17.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T16.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T15.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T5.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T4.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T0.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 20:
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T13.XYZW, T11.X, 96, #1
-; EG-NEXT:     VTX_READ_128 T14.XYZW, T11.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T15.XYZW, T11.X, 64, #1
-; EG-NEXT:     VTX_READ_128 T16.XYZW, T11.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T17.XYZW, T11.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T18.XYZW, T11.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T7.XYZW, T6.X, 112, #1
+; EG-NEXT:     VTX_READ_128 T8.XYZW, T6.X, 96, #1
+; EG-NEXT:     VTX_READ_128 T9.XYZW, T6.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T10.XYZW, T6.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T11.XYZW, T6.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T12.XYZW, T6.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T13.XYZW, T6.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T6.XYZW, T6.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 36:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     MOV * T6.X, KC0[2].Z,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T11.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 70:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:     ASHR * T22.W, T11.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
+; EG-NEXT:    ALU clause starting at 47:
+; EG-NEXT:     ADD_INT T14.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T16.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T0.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T18.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T0.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T20.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T0.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 48(6.726233e-44)
+; EG-NEXT:     ASHR * T22.W, T6.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T22.Y, T11.Z, literal.y,
-; EG-NEXT:     ASHR T24.W, T11.Y, literal.y,
-; EG-NEXT:     MOV * T22.X, T11.Z,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     ASHR T24.Y, T11.X, literal.x,
-; EG-NEXT:     ASHR * T25.W, T18.W, literal.x,
+; EG-NEXT:     ADD_INT T23.X, T0.X, literal.x,
+; EG-NEXT:     ASHR T22.Y, T6.Z, literal.y,
+; EG-NEXT:     ASHR T24.W, T6.Y, literal.y,
+; EG-NEXT:     MOV * T22.X, T6.Z,
+; EG-NEXT:    60(8.407791e-44), 31(4.344025e-44)
+; EG-NEXT:     ASHR T24.Y, T6.X, literal.x,
+; EG-NEXT:     ASHR * T25.W, T13.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T24.X, T11.X,
-; EG-NEXT:     ASHR T25.Y, T18.Z, literal.x,
-; EG-NEXT:     MOV T22.Z, T11.W,
-; EG-NEXT:     ASHR T26.W, T18.Y, literal.x,
-; EG-NEXT:     MOV * T25.X, T18.Z,
+; EG-NEXT:     MOV T24.X, T6.X,
+; EG-NEXT:     ASHR T25.Y, T13.Z, literal.x,
+; EG-NEXT:     MOV T22.Z, T6.W,
+; EG-NEXT:     ASHR T26.W, T13.Y, literal.x,
+; EG-NEXT:     MOV * T25.X, T13.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T26.Y, T18.X, literal.x,
-; EG-NEXT:     MOV T24.Z, T11.Y,
-; EG-NEXT:     ASHR * T11.W, T17.W, literal.x,
+; EG-NEXT:     ASHR T26.Y, T13.X, literal.x,
+; EG-NEXT:     MOV T24.Z, T6.Y,
+; EG-NEXT:     ASHR * T6.W, T12.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T26.X, T18.X,
-; EG-NEXT:     ASHR T11.Y, T17.Z, literal.x,
-; EG-NEXT:     MOV T25.Z, T18.W,
-; EG-NEXT:     ASHR T27.W, T17.Y, literal.x,
-; EG-NEXT:     MOV * T11.X, T17.Z,
+; EG-NEXT:     MOV T26.X, T13.X,
+; EG-NEXT:     ASHR T6.Y, T12.Z, literal.x,
+; EG-NEXT:     MOV T25.Z, T13.W,
+; EG-NEXT:     ASHR T27.W, T12.Y, literal.x,
+; EG-NEXT:     MOV * T6.X, T12.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T27.Y, T17.X, literal.x,
-; EG-NEXT:     MOV T26.Z, T18.Y,
-; EG-NEXT:     ASHR * T18.W, T16.W, literal.x,
+; EG-NEXT:     ASHR T27.Y, T12.X, literal.x,
+; EG-NEXT:     MOV T26.Z, T13.Y,
+; EG-NEXT:     ASHR * T13.W, T11.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T27.X, T17.X,
-; EG-NEXT:     ASHR T18.Y, T16.Z, literal.x,
-; EG-NEXT:     MOV T11.Z, T17.W,
-; EG-NEXT:     ASHR T28.W, T16.Y, literal.x,
-; EG-NEXT:     MOV * T18.X, T16.Z,
+; EG-NEXT:     MOV T27.X, T12.X,
+; EG-NEXT:     ASHR T13.Y, T11.Z, literal.x,
+; EG-NEXT:     MOV T6.Z, T12.W,
+; EG-NEXT:     ASHR T28.W, T11.Y, literal.x,
+; EG-NEXT:     MOV * T13.X, T11.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T28.Y, T16.X, literal.x,
-; EG-NEXT:     MOV T27.Z, T17.Y,
-; EG-NEXT:     ASHR * T17.W, T15.W, literal.x,
+; EG-NEXT:     ASHR T28.Y, T11.X, literal.x,
+; EG-NEXT:     MOV T27.Z, T12.Y,
+; EG-NEXT:     ASHR * T12.W, T10.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T28.X, T16.X,
-; EG-NEXT:     ASHR T17.Y, T15.Z, literal.x,
-; EG-NEXT:     MOV T18.Z, T16.W,
-; EG-NEXT:     ASHR T29.W, T15.Y, literal.x,
-; EG-NEXT:     MOV * T17.X, T15.Z,
+; EG-NEXT:     MOV T28.X, T11.X,
+; EG-NEXT:     ASHR T12.Y, T10.Z, literal.x,
+; EG-NEXT:     MOV T13.Z, T11.W,
+; EG-NEXT:     ASHR T29.W, T10.Y, literal.x,
+; EG-NEXT:     MOV * T12.X, T10.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T29.Y, T15.X, literal.x,
-; EG-NEXT:     MOV T28.Z, T16.Y,
-; EG-NEXT:     ASHR * T16.W, T14.W, literal.x,
+; EG-NEXT:     ASHR T29.Y, T10.X, literal.x,
+; EG-NEXT:     MOV T28.Z, T11.Y,
+; EG-NEXT:     ASHR * T11.W, T9.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T29.X, T15.X,
-; EG-NEXT:     ASHR T16.Y, T14.Z, literal.x,
-; EG-NEXT:     MOV T17.Z, T15.W,
-; EG-NEXT:     ASHR T30.W, T14.Y, literal.x,
-; EG-NEXT:     MOV * T16.X, T14.Z,
+; EG-NEXT:     MOV T29.X, T10.X,
+; EG-NEXT:     ASHR T11.Y, T9.Z, literal.x,
+; EG-NEXT:     MOV T12.Z, T10.W,
+; EG-NEXT:     ASHR T30.W, T9.Y, literal.x,
+; EG-NEXT:     MOV * T11.X, T9.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T30.Y, T14.X, literal.x,
-; EG-NEXT:     MOV T29.Z, T15.Y,
-; EG-NEXT:     ASHR * T15.W, T13.W, literal.x,
+; EG-NEXT:     ASHR T30.Y, T9.X, literal.x,
+; EG-NEXT:     MOV T29.Z, T10.Y,
+; EG-NEXT:     ASHR * T10.W, T8.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T30.X, T14.X,
-; EG-NEXT:     ASHR T15.Y, T13.Z, literal.x,
-; EG-NEXT:     MOV T16.Z, T14.W,
-; EG-NEXT:     ASHR T31.W, T13.Y, literal.x,
-; EG-NEXT:     MOV * T15.X, T13.Z,
+; EG-NEXT:     MOV T30.X, T9.X,
+; EG-NEXT:     ASHR T10.Y, T8.Z, literal.x,
+; EG-NEXT:     MOV T11.Z, T9.W,
+; EG-NEXT:     ASHR T31.W, T8.Y, literal.x,
+; EG-NEXT:     MOV * T10.X, T8.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T31.Y, T13.X, literal.x,
-; EG-NEXT:     MOV T30.Z, T14.Y,
-; EG-NEXT:     ASHR * T14.W, T12.W, literal.x,
+; EG-NEXT:     ASHR T31.Y, T8.X, literal.x,
+; EG-NEXT:     MOV T30.Z, T9.Y,
+; EG-NEXT:     ASHR * T9.W, T7.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T31.X, T13.X,
-; EG-NEXT:     ASHR T14.Y, T12.Z, literal.x,
-; EG-NEXT:     MOV T15.Z, T13.W,
-; EG-NEXT:     ASHR T32.W, T12.Y, literal.x,
-; EG-NEXT:     MOV * T14.X, T12.Z,
+; EG-NEXT:     MOV T31.X, T8.X,
+; EG-NEXT:     ASHR T9.Y, T7.Z, literal.x,
+; EG-NEXT:     MOV T10.Z, T8.W,
+; EG-NEXT:     ASHR T32.W, T7.Y, literal.x,
+; EG-NEXT:     MOV * T9.X, T7.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T32.Y, T12.X, literal.x,
-; EG-NEXT:     MOV * T31.Z, T13.Y,
+; EG-NEXT:     ASHR T32.Y, T7.X, literal.x,
+; EG-NEXT:     MOV * T31.Z, T8.Y,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     MOV T32.X, T12.X,
-; EG-NEXT:     MOV T14.Z, T12.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     MOV * T32.Z, T12.Y,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     MOV T32.X, T7.X,
+; EG-NEXT:     MOV T9.Z, T7.W,
+; EG-NEXT:     ADD_INT * T7.X, T0.X, literal.x,
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     MOV * T32.Z, T7.Y,
 ;
 ; GCN-GFX900-HSA-LABEL: global_sextload_v32i32_to_v32i64:
 ; GCN-GFX900-HSA:       ; %bb.0:
@@ -4236,154 +4157,127 @@ define amdgpu_kernel void @global_zextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ;
 ; EG-LABEL: global_zextload_v32i32_to_v32i64:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 0, @38, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 2 @22
-; EG-NEXT:    ALU 10, @39, KC0[], KC1[]
-; EG-NEXT:    TEX 4 @28
-; EG-NEXT:    ALU 100, @50, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T31.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T30.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T26.X, 0
+; EG-NEXT:    ALU 0, @36, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 7 @20
+; EG-NEXT:    ALU 88, @37, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T31.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T30.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T29.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T13.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T11.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T10.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T16.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T6.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T5.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T0.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
-; EG-NEXT:    Fetch clause starting at 22:
+; EG-NEXT:    Fetch clause starting at 20:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 112, #1
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 80, #1
-; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 96, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T10.XYZW, T0.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T0.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T0.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T13.XYZW, T0.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 64, #1
-; EG-NEXT:    ALU clause starting at 38:
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T4.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T5.XYZW, T0.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T6.XYZW, T0.X, 64, #1
+; EG-NEXT:     VTX_READ_128 T7.XYZW, T0.X, 80, #1
+; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 96, #1
+; EG-NEXT:    ALU clause starting at 36:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
-; EG-NEXT:    ALU clause starting at 39:
-; EG-NEXT:     MOV T4.X, T1.X,
-; EG-NEXT:     MOV T4.Y, 0.0,
-; EG-NEXT:     MOV * T5.X, T1.Z,
-; EG-NEXT:     MOV * T5.Y, 0.0,
-; EG-NEXT:     MOV T6.X, T3.X,
-; EG-NEXT:     MOV T6.Y, 0.0,
-; EG-NEXT:     MOV * T7.X, T3.Z,
-; EG-NEXT:     MOV * T7.Y, 0.0,
-; EG-NEXT:     MOV T8.X, T2.X,
+; EG-NEXT:    ALU clause starting at 37:
+; EG-NEXT:     MOV T8.X, T1.X,
 ; EG-NEXT:     MOV T8.Y, 0.0,
-; EG-NEXT:     MOV * T9.X, T2.Z,
-; EG-NEXT:    ALU clause starting at 50:
+; EG-NEXT:     MOV * T9.X, T1.Z,
 ; EG-NEXT:     MOV * T9.Y, 0.0,
-; EG-NEXT:     MOV T14.X, T0.X,
+; EG-NEXT:     MOV T10.X, T0.X,
+; EG-NEXT:     MOV T10.Y, 0.0,
+; EG-NEXT:     MOV * T11.X, T0.Z,
+; EG-NEXT:     MOV * T11.Y, 0.0,
+; EG-NEXT:     MOV T12.X, T7.X,
+; EG-NEXT:     MOV T12.Y, 0.0,
+; EG-NEXT:     MOV * T13.X, T7.Z,
+; EG-NEXT:     MOV * T13.Y, 0.0,
+; EG-NEXT:     MOV T14.X, T6.X,
 ; EG-NEXT:     MOV T14.Y, 0.0,
-; EG-NEXT:     MOV * T15.X, T0.Z,
+; EG-NEXT:     MOV * T15.X, T6.Z,
 ; EG-NEXT:     MOV * T15.Y, 0.0,
-; EG-NEXT:     MOV T16.X, T13.X,
+; EG-NEXT:     MOV T16.X, T5.X,
 ; EG-NEXT:     MOV T16.Y, 0.0,
-; EG-NEXT:     MOV * T17.X, T13.Z,
+; EG-NEXT:     MOV * T17.X, T5.Z,
 ; EG-NEXT:     MOV * T17.Y, 0.0,
-; EG-NEXT:     MOV T18.X, T12.X,
+; EG-NEXT:     MOV T18.X, T4.X,
 ; EG-NEXT:     MOV T18.Y, 0.0,
-; EG-NEXT:     MOV * T19.X, T12.Z,
+; EG-NEXT:     MOV * T19.X, T4.Z,
 ; EG-NEXT:     MOV * T19.Y, 0.0,
-; EG-NEXT:     MOV T20.X, T11.X,
+; EG-NEXT:     MOV T20.X, T3.X,
 ; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     MOV * T21.X, T11.Z,
+; EG-NEXT:     MOV * T21.X, T3.Z,
 ; EG-NEXT:     MOV * T21.Y, 0.0,
-; EG-NEXT:     MOV T22.X, T10.X,
+; EG-NEXT:     MOV T22.X, T2.X,
 ; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     MOV * T23.X, T10.Z,
+; EG-NEXT:     MOV * T23.X, T2.Z,
 ; EG-NEXT:     MOV T23.Y, 0.0,
-; EG-NEXT:     MOV T4.Z, T1.Y,
-; EG-NEXT:     MOV T4.W, 0.0,
-; EG-NEXT:     MOV * T5.Z, T1.W,
-; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     MOV T6.Z, T3.Y,
-; EG-NEXT:     MOV T6.W, 0.0,
-; EG-NEXT:     MOV * T7.Z, T3.W,
-; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     MOV T8.Z, T2.Y,
+; EG-NEXT:     MOV T8.Z, T1.Y,
 ; EG-NEXT:     MOV T8.W, 0.0,
-; EG-NEXT:     MOV * T9.Z, T2.W,
+; EG-NEXT:     MOV * T9.Z, T1.W,
 ; EG-NEXT:     MOV * T9.W, 0.0,
-; EG-NEXT:     MOV T14.Z, T0.Y,
+; EG-NEXT:     MOV T10.Z, T0.Y,
+; EG-NEXT:     MOV T10.W, 0.0,
+; EG-NEXT:     MOV * T11.Z, T0.W,
+; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     MOV T12.Z, T7.Y,
+; EG-NEXT:     MOV T12.W, 0.0,
+; EG-NEXT:     MOV * T13.Z, T7.W,
+; EG-NEXT:     MOV * T13.W, 0.0,
+; EG-NEXT:     MOV T14.Z, T6.Y,
 ; EG-NEXT:     MOV T14.W, 0.0,
-; EG-NEXT:     MOV * T15.Z, T0.W,
+; EG-NEXT:     MOV * T15.Z, T6.W,
 ; EG-NEXT:     MOV * T15.W, 0.0,
-; EG-NEXT:     MOV T16.Z, T13.Y,
+; EG-NEXT:     MOV T16.Z, T5.Y,
 ; EG-NEXT:     MOV T16.W, 0.0,
-; EG-NEXT:     MOV * T17.Z, T13.W,
+; EG-NEXT:     MOV * T17.Z, T5.W,
 ; EG-NEXT:     MOV * T17.W, 0.0,
-; EG-NEXT:     MOV T18.Z, T12.Y,
+; EG-NEXT:     MOV T18.Z, T4.Y,
 ; EG-NEXT:     MOV T18.W, 0.0,
-; EG-NEXT:     MOV * T19.Z, T12.W,
+; EG-NEXT:     MOV * T19.Z, T4.W,
 ; EG-NEXT:     MOV * T19.W, 0.0,
-; EG-NEXT:     MOV T20.Z, T11.Y,
+; EG-NEXT:     MOV T20.Z, T3.Y,
 ; EG-NEXT:     MOV T20.W, 0.0,
-; EG-NEXT:     MOV * T21.Z, T11.W,
+; EG-NEXT:     MOV * T21.Z, T3.W,
 ; EG-NEXT:     MOV * T21.W, 0.0,
-; EG-NEXT:     MOV T22.Z, T10.Y,
+; EG-NEXT:     MOV T22.Z, T2.Y,
 ; EG-NEXT:     MOV T22.W, 0.0,
-; EG-NEXT:     MOV * T23.Z, T10.W,
-; EG-NEXT:     MOV T23.W, 0.0,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PS, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T23.Z, T2.W,
+; EG-NEXT:     MOV * T23.W, 0.0,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR * T31.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, T0.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T7.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T24.X, T0.X, literal.y,
+; EG-NEXT:    24(3.363116e-44), 36(5.044674e-44)
+; EG-NEXT:     ADD_INT T25.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T26.X, T0.X, literal.y,
+; EG-NEXT:    32(4.484155e-44), 44(6.165713e-44)
+; EG-NEXT:     ADD_INT T27.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T28.X, T0.X, literal.y,
+; EG-NEXT:    40(5.605194e-44), 52(7.286752e-44)
+; EG-NEXT:     ADD_INT T29.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T30.X, T0.X, literal.y,
+; EG-NEXT:    48(6.726233e-44), 60(8.407791e-44)
+; EG-NEXT:     ADD_INT * T31.X, T0.X, literal.x,
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_zextload_v32i32_to_v32i64:
 ; GCN-HSA:       ; %bb.0:
@@ -4637,17 +4531,17 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 ;
 ; EG-LABEL: global_load_v32i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 23, @28, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 11, @28, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 7 @12
-; EG-NEXT:    ALU 1, @52, KC0[], KC1[]
+; EG-NEXT:    ALU 1, @40, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T15.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T6.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T5.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T4.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T3.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T2.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T0.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 12:
 ; EG-NEXT:     VTX_READ_128 T8.XYZW, T7.X, 96, #1
@@ -4659,33 +4553,21 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 ; EG-NEXT:     VTX_READ_128 T14.XYZW, T7.X, 0, #1
 ; EG-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 16, #1
 ; EG-NEXT:    ALU clause starting at 28:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T3.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T4.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T5.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T6.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T2.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T4.X, T0.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T5.X, T0.X, literal.x,
+; EG-NEXT:     ADD_INT * T6.X, T0.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 52:
-; EG-NEXT:     LSHR * T15.X, T0.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 40:
+; EG-NEXT:     ADD_INT * T15.X, T0.X, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ;
 ; GCN-HSA-LABEL: global_load_v32i32:
 ; GCN-HSA:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/load-global-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-global-i8.ll
@@ -1299,7 +1299,7 @@ define amdgpu_kernel void @global_zextload_v3i8_to_v3i32(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0: ; %entry
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 10, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.X, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XY, T6.X, 1
 ; EG-NEXT:    CF_END
@@ -1312,22 +1312,21 @@ define amdgpu_kernel void @global_zextload_v3i8_to_v3i32(ptr addrspace(1) %out, 
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT * T5.Y, T4.X, literal.x, PV.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T5.X, T4.X, literal.x,
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.y,
-; EG-NEXT:    255(3.573311e-43), 2(2.802597e-45)
+; EG-NEXT:     AND_INT * T5.X, T4.X, literal.x,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T4.X, T4.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT * T7.X, PS, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v3i8_to_v3i32:
 ; CM:       ; %bb.0: ; %entry
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5.X, T6.X
+; CM-NEXT:    ALU 10, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T6.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5.X, T7.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
@@ -1336,16 +1335,15 @@ define amdgpu_kernel void @global_zextload_v3i8_to_v3i32(ptr addrspace(1) %out, 
 ; CM-NEXT:    ALU clause starting at 9:
 ; CM-NEXT:     MOV * T0.W, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T5.X, T4.X, literal.x, PV.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; CM-NEXT:     LSHR T6.X, PV.W, literal.x,
+; CM-NEXT:     BFE_UINT * T5.X, T4.X, literal.x, PV.W,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T7.X, PV.X, literal.x,
 ; CM-NEXT:     BFE_UINT * T4.Y, T4.X, literal.y, T0.W,
 ; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
 ; CM-NEXT:     AND_INT * T4.X, T4.X, literal.x,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 entry:
   %ld = load <3 x i8>, ptr addrspace(1) %in
   %ext = zext <3 x i8> %ld to <3 x i32>
@@ -1420,34 +1418,34 @@ define amdgpu_kernel void @global_sextload_v3i8_to_v3i32(ptr addrspace(1) %out, 
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
 ; EG-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.X, T4.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XY, T5.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.X, T4.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XY, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T4.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     LSHR T5.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR * T0.W, T4.X, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT * T6.X, PV.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.x,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T5.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T4.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T0.W, T4.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T6.X, T4.X, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    8(1.121039e-44), 2(2.802597e-45)
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T4.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
+; EG-NEXT:     ADD_INT T4.X, T7.X, literal.x,
+; EG-NEXT:     BFE_INT * T6.Y, PV.W, 0.0, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
 ;
 ; CM-LABEL: global_sextload_v3i8_to_v3i32:
 ; CM:       ; %bb.0: ; %entry
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 12, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T4.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5.X, T6.X
+; CM-NEXT:    ALU 11, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5.X, T4.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
@@ -1456,16 +1454,15 @@ define amdgpu_kernel void @global_sextload_v3i8_to_v3i32(ptr addrspace(1) %out, 
 ; CM-NEXT:    ALU clause starting at 9:
 ; CM-NEXT:     LSHR * T0.W, T4.X, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T5.X, PV.W, 0.0, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_INT * T5.X, PV.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T6.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T7.X, T4.X, 0.0, literal.x,
-; CM-NEXT:     LSHR * T0.W, T4.X, literal.x,
+; CM-NEXT:     BFE_INT * T6.X, T4.X, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T4.X, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
+; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHR * T0.W, T4.X, literal.y,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T4.X, PV.X, literal.x,
+; CM-NEXT:     BFE_INT * T6.Y, PV.W, 0.0, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
 entry:
   %ld = load <3 x i8>, ptr addrspace(1) %in
@@ -1800,7 +1797,7 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 20, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T5.X, 1
 ; EG-NEXT:    CF_END
@@ -1814,30 +1811,27 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; EG-NEXT:     BFE_UINT * T6.Z, T5.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T6.Y, T5.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T7.Z, T5.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T6.W, T5.X, literal.z,
+; EG-NEXT:     BFE_UINT * T7.Z, T5.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T7.Y, T5.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T6.W, T5.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T6.X, T5.X, literal.x,
-; EG-NEXT:     BFE_UINT T7.Y, T5.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T7.W, T5.Y, literal.y,
+; EG-NEXT:     AND_INT * T7.X, T5.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T7.W, T5.Y, literal.x,
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T7.X, T5.Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    255(3.573311e-43), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T8.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T8.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v8i8_to_v8i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 20, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T8.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T7.X
+; CM-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T8.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
@@ -1849,22 +1843,19 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; CM-NEXT:     BFE_UINT * T6.Z, T5.Y, literal.x, PV.W,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_UINT T6.Y, T5.Y, literal.x, T0.W,
-; CM-NEXT:     BFE_UINT T5.Z, T5.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T6.W, T5.Y, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T6.W, T5.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT T6.X, T5.Y, literal.x,
-; CM-NEXT:     BFE_UINT T5.Y, T5.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T7.X, PV.W, literal.x,
+; CM-NEXT:     BFE_UINT * T5.Z, T5.X, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_UINT * T5.Y, T5.X, literal.y, T0.W,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T8.X, PV.X, literal.x,
 ; CM-NEXT:     LSHR * T5.W, T5.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; CM-NEXT:    4(5.605194e-45), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT * T5.X, T5.X, literal.x,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %load = load <8 x i8>, ptr addrspace(1) %in
   %ext = zext <8 x i8> %load to <8 x i32>
   store <8 x i32> %ext, ptr addrspace(1) %out
@@ -1958,7 +1949,7 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 23, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T8.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T5.X, 1
 ; EG-NEXT:    CF_END
@@ -1984,21 +1975,19 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; EG-NEXT:     LSHR T5.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     BFE_INT T6.Y, PS, 0.0, literal.y,
 ; EG-NEXT:     BFE_INT T7.Z, PV.Y, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.W, T5.Y, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR * T0.W, T5.Y, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T8.X, PS, literal.x,
+; EG-NEXT:     ADD_INT T8.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
 ;
 ; CM-LABEL: global_sextload_v8i8_to_v8i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 23, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T5.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T9.X
+; CM-NEXT:    ALU 21, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T9.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T5.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
@@ -2006,29 +1995,27 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i32(ptr addrspace(1) %out, 
 ; CM-NEXT:     MOV * T5.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 9:
 ; CM-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
-; CM-NEXT:     LSHR T0.Z, T5.X, literal.y,
-; CM-NEXT:     LSHR * T0.W, T5.Y, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T0.W, T5.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:     BFE_INT T7.X, T5.X, 0.0, literal.x,
 ; CM-NEXT:     LSHR T0.Y, T5.X, literal.y,
-; CM-NEXT:     LSHR T1.Z, T5.Y, literal.z,
+; CM-NEXT:     LSHR T0.Z, T5.Y, literal.z,
 ; CM-NEXT:     BFE_INT * T6.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T8.X, T5.Y, literal.x,
-; CM-NEXT:     ADD_INT T1.Y, KC0[2].Y, literal.y,
-; CM-NEXT:     BFE_INT T6.Z, PV.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T7.W, PV.Y, 0.0, literal.x,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:     LSHR T9.X, PV.Y, literal.x,
-; CM-NEXT:     BFE_INT T6.Y, PV.X, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T7.Z, T0.Z, 0.0, literal.y,
+; CM-NEXT:     LSHR T8.X, T5.X, literal.x,
+; CM-NEXT:     LSHR T1.Y, T5.Y, literal.y,
+; CM-NEXT:     BFE_INT T6.Z, PV.Z, 0.0, literal.y,
+; CM-NEXT:     BFE_INT * T7.W, PV.Y, 0.0, literal.y,
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_INT T6.Y, PV.Y, 0.0, literal.y,
+; CM-NEXT:     BFE_INT T7.Z, PV.X, 0.0, literal.y,
 ; CM-NEXT:     LSHR * T0.W, T5.X, literal.y,
 ; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T5.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T5.X, PV.X, literal.x,
 ; CM-NEXT:     BFE_INT * T7.Y, PV.W, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:    4(5.605194e-45), 8(1.121039e-44)
   %load = load <8 x i8>, ptr addrspace(1) %in
   %ext = sext <8 x i8> %load to <8 x i32>
   store <8 x i32> %ext, ptr addrspace(1) %out
@@ -2160,7 +2147,7 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 39, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T13.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T11.X, 0
@@ -2176,51 +2163,45 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i32(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_UINT * T8.Z, T7.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T8.Y, T7.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T9.Z, T7.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T8.W, T7.X, literal.z,
+; EG-NEXT:     BFE_UINT * T9.Z, T7.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T9.Y, T7.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T8.W, T7.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T8.X, T7.X, literal.x,
-; EG-NEXT:     BFE_UINT T9.Y, T7.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T10.Z, T7.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T9.W, T7.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T9.X, T7.Y, literal.x,
-; EG-NEXT:     BFE_UINT T10.Y, T7.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T9.W, T7.Y, literal.y,
+; EG-NEXT:     AND_INT * T9.X, T7.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T10.Z, T7.Z, literal.x, T0.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT * T10.Y, T7.Z, literal.y, T0.W,
+; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T11.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_UINT T12.Z, T7.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T10.W, T7.Z, literal.z,
 ; EG-NEXT:     AND_INT * T10.X, T7.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T12.Y, T7.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T13.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T12.Y, T7.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T13.X, T7.X, literal.x,
 ; EG-NEXT:     LSHR T12.W, T7.W, literal.y,
 ; EG-NEXT:     AND_INT * T12.X, T7.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T14.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T14.X, T7.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v16i8_to_v16i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 40, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T13.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T10.X
+; CM-NEXT:    ALU 33, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T10.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T14.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T11.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
@@ -2232,42 +2213,35 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i32(ptr addrspace(1) %out
 ; CM-NEXT:     BFE_UINT * T8.Z, T7.W, literal.x, PV.W,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_UINT T8.Y, T7.W, literal.x, T0.W,
-; CM-NEXT:     BFE_UINT T9.Z, T7.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T8.W, T7.W, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T8.W, T7.W, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT T8.X, T7.W, literal.x,
-; CM-NEXT:     BFE_UINT T9.Y, T7.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T10.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T11.Z, T7.Y, literal.y, T0.W,
+; CM-NEXT:     BFE_UINT * T9.Z, T7.Z, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; CM-NEXT:     LSHR T10.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_UINT * T9.Y, T7.Z, literal.y, T0.W,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T11.X, PV.X, literal.x,
+; CM-NEXT:     BFE_UINT T12.Z, T7.Y, literal.y, T0.W,
 ; CM-NEXT:     LSHR * T9.W, T7.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T9.X, T7.Z, literal.x,
-; CM-NEXT:     BFE_UINT T11.Y, T7.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     BFE_UINT * T12.Y, T7.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T12.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T7.Z, T7.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T11.W, T7.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T13.X, T10.X, literal.x,
+; CM-NEXT:     BFE_UINT T7.Z, T7.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T12.W, T7.Y, literal.z,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T11.X, T7.Y, literal.x,
-; CM-NEXT:     BFE_UINT T7.Y, T7.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T12.X, T7.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T7.Y, T7.X, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.X, PV.W, literal.x,
-; CM-NEXT:     LSHR * T7.W, T7.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; CM-NEXT:     ADD_INT T14.X, T10.X, literal.x,
+; CM-NEXT:     LSHR * T7.W, T7.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    4(5.605194e-45), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT * T7.X, T7.X, literal.x,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T14.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %load = load <16 x i8>, ptr addrspace(1) %in
   %ext = zext <16 x i8> %load to <16 x i32>
   store <16 x i32> %ext, ptr addrspace(1) %out
@@ -2399,130 +2373,119 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 47, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T14.X, 0
+; EG-NEXT:    ALU 41, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T14.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T13.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T8.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T12.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     LSHR T0.W, T7.W, literal.y,
-; EG-NEXT:     LSHR * T1.W, T7.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     BFE_INT * T8.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T9.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T7.W, literal.y,
-; EG-NEXT:     LSHR T0.Z, T7.Z, literal.z,
-; EG-NEXT:     LSHR T2.W, T7.Y, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.y,
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T0.Z, T7.W, literal.z,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.y,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T10.X, T7.Y, 0.0, literal.x,
 ; EG-NEXT:     LSHR T1.Y, T7.Z, literal.y,
 ; EG-NEXT:     LSHR T1.Z, T7.Y, literal.y,
 ; EG-NEXT:     BFE_INT T9.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.z,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T11.X, T7.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR T2.Y, T7.Y, literal.y,
 ; EG-NEXT:     BFE_INT T9.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T10.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T3.W, T7.X, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T12.X, T7.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T9.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T10.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.W, T1.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T7.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T10.Y, T2.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T11.Z, T0.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T12.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.z,
+; EG-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_INT T9.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T10.Z, PV.Y, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.W, T1.Y, 0.0, literal.y,
+; EG-NEXT:     LSHR * T1.W, T7.Y, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T13.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T11.Y, T1.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T12.Z, T0.W, 0.0, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T0.W, T7.W, literal.y, BS:VEC_201
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T14.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T12.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T12.X, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T10.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.Z, T0.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T8.W, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Z, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T13.X, T7.X, literal.x,
+; EG-NEXT:     BFE_INT T11.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T8.Z, T0.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.W, T7.W, literal.x,
+; EG-NEXT:     ADD_INT * T14.X, T7.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 12(1.681558e-44)
+; EG-NEXT:     BFE_INT * T8.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v16i8_to_v16i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 48, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T15.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T9.X
+; CM-NEXT:    ALU 43, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T12.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T14.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T13.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 10:
 ; CM-NEXT:     MOV * T7.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 11:
-; CM-NEXT:     LSHR * T0.W, T7.X, literal.x,
+; CM-NEXT:     LSHR T0.Z, T7.X, literal.x,
+; CM-NEXT:     LSHR * T0.W, T7.Y, literal.y,
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     BFE_INT T8.X, T7.X, 0.0, literal.x,
+; CM-NEXT:     LSHR T0.Y, T7.X, literal.y,
+; CM-NEXT:     LSHR T1.Z, T7.Y, literal.z,
+; CM-NEXT:     LSHR * T1.W, T7.Z, literal.x,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T8.X, T7.Y, literal.x,
-; CM-NEXT:     ADD_INT T0.Y, KC0[2].Y, literal.y,
-; CM-NEXT:     LSHR T0.Z, T7.X, literal.z,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 48(6.726233e-44)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
+; CM-NEXT:     BFE_INT T9.X, T7.W, 0.0, literal.x,
 ; CM-NEXT:     LSHR T1.Y, T7.Y, literal.y,
-; CM-NEXT:     LSHR T1.Z, T7.Z, literal.z,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; CM-NEXT:     BFE_INT T10.X, T7.W, 0.0, literal.x,
-; CM-NEXT:     LSHR T2.Y, T7.Y, literal.y,
 ; CM-NEXT:     LSHR T2.Z, T7.Z, literal.z,
 ; CM-NEXT:     LSHR * T2.W, T7.W, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T11.X, T7.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T3.Y, T7.Z, literal.y,
+; CM-NEXT:     BFE_INT T10.X, T7.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR T2.Y, T7.Z, literal.y,
 ; CM-NEXT:     LSHR T3.Z, T7.W, literal.z,
-; CM-NEXT:     BFE_INT * T10.W, PV.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T9.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T12.X, T7.Y, 0.0, literal.x,
-; CM-NEXT:     LSHR T4.Y, T7.W, literal.x,
-; CM-NEXT:     BFE_INT T10.Z, PV.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T11.W, PV.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T11.X, T7.Y, 0.0, literal.x,
+; CM-NEXT:     LSHR T3.Y, T7.W, literal.x,
+; CM-NEXT:     BFE_INT T9.Z, PV.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T10.W, PV.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T13.X, T7.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T10.Y, PV.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T11.Z, T2.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T12.W, T2.Y, 0.0, literal.x,
+; CM-NEXT:     LSHR T12.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_INT T9.Y, PV.Y, 0.0, literal.y,
+; CM-NEXT:     BFE_INT T10.Z, T2.Z, 0.0, literal.y,
+; CM-NEXT:     BFE_INT * T11.W, T1.Y, 0.0, literal.y,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T13.X, PV.X, literal.x,
+; CM-NEXT:     BFE_INT T10.Y, T1.W, 0.0, literal.y,
+; CM-NEXT:     BFE_INT T11.Z, T1.Z, 0.0, literal.y,
+; CM-NEXT:     BFE_INT * T8.W, T0.Y, 0.0, literal.y,
+; CM-NEXT:    12(1.681558e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T14.X, T12.X, literal.x,
+; CM-NEXT:     BFE_INT T11.Y, T0.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T8.Z, T0.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR * T0.W, T7.X, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T14.X, T1.W, literal.x,
-; CM-NEXT:     BFE_INT T11.Y, T1.Z, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T12.Z, T1.Y, 0.0, literal.y,
-; CM-NEXT:     BFE_INT * T13.W, T0.Z, 0.0, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T15.X, T0.Y, literal.x,
-; CM-NEXT:     BFE_INT T12.Y, T8.X, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T13.Z, T0.W, 0.0, literal.y,
-; CM-NEXT:     LSHR * T0.W, T7.X, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT * T13.Y, PV.W, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T7.X, T12.X, literal.x,
+; CM-NEXT:     BFE_INT * T8.Y, PV.W, 0.0, literal.y,
+; CM-NEXT:    4(5.605194e-45), 8(1.121039e-44)
   %load = load <16 x i8>, ptr addrspace(1) %in
   %ext = sext <16 x i8> %load to <16 x i32>
   store <16 x i32> %ext, ptr addrspace(1) %out
@@ -2740,7 +2703,7 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @12
-; EG-NEXT:    ALU 75, @17, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 64, @17, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T23.X, 0
@@ -2761,91 +2724,80 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_UINT * T13.Z, T11.X, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T13.Y, T11.X, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T14.Z, T11.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T13.W, T11.X, literal.z,
+; EG-NEXT:     BFE_UINT * T14.Z, T11.Y, literal.y, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T14.Y, T11.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T13.W, T11.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T13.X, T11.X, literal.x,
-; EG-NEXT:     BFE_UINT T14.Y, T11.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR * T11.X, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T15.Z, T11.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T14.W, T11.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T14.X, T11.Y, literal.x,
-; EG-NEXT:     BFE_UINT T15.Y, T11.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:     LSHR T14.W, T11.Y, literal.y,
+; EG-NEXT:     AND_INT * T14.X, T11.Y, literal.x,
+; EG-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T15.Z, T11.Z, literal.x, T0.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
+; EG-NEXT:     LSHR T11.X, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT * T15.Y, T11.Z, literal.y, T0.W,
+; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
 ; EG-NEXT:     BFE_UINT T17.Z, T11.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T15.W, T11.Z, literal.z,
 ; EG-NEXT:     AND_INT * T15.X, T11.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    4(5.605194e-45), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T17.Y, T11.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T19.Z, T12.X, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T17.W, T11.W, literal.z,
+; EG-NEXT:     BFE_UINT * T17.Y, T11.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T18.X, T11.X, literal.x,
+; EG-NEXT:     BFE_UINT T19.Z, T12.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T17.W, T11.W, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     AND_INT * T17.X, T11.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T19.Y, T12.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T19.Y, T12.X, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T20.X, T11.X, literal.x,
 ; EG-NEXT:     BFE_UINT T21.Z, T12.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T19.W, T12.X, literal.z,
+; EG-NEXT:     LSHR T19.W, T12.X, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     AND_INT * T19.X, T12.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T21.Y, T12.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 64(8.968310e-44)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T22.Z, T12.Z, literal.y, T0.W,
-; EG-NEXT:     LSHR T21.W, T12.Y, literal.z,
-; EG-NEXT:     AND_INT * T21.X, T12.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T22.Y, T12.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
+; EG-NEXT:     BFE_UINT * T21.Y, T12.Y, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, T11.X, literal.x,
+; EG-NEXT:     BFE_UINT T22.Z, T12.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR T21.W, T12.Y, literal.y,
+; EG-NEXT:     AND_INT * T21.X, T12.Y, literal.z,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T22.Y, T12.Z, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T23.X, T11.X, literal.x,
 ; EG-NEXT:     BFE_UINT T24.Z, T12.W, literal.y, T0.W,
 ; EG-NEXT:     LSHR T22.W, T12.Z, literal.z,
 ; EG-NEXT:     AND_INT * T22.X, T12.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T24.Y, T12.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T24.W, T12.W, literal.y,
-; EG-NEXT:     AND_INT * T24.X, T12.W, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T26.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T24.Y, T12.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T25.X, T11.X, literal.x,
+; EG-NEXT:     LSHR T24.W, T12.W, literal.x,
+; EG-NEXT:     AND_INT * T24.X, T12.W, literal.y,
+; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
+; EG-NEXT:     ADD_INT * T26.X, T11.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v32i8_to_v32i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @16, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @12
-; CM-NEXT:    ALU 80, @17, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T25.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T24.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T15.X
+; CM-NEXT:    ALU 63, @17, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T16.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -2858,82 +2810,65 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; CM-NEXT:     BFE_UINT * T13.Z, T11.W, literal.x, PV.W,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_UINT T13.Y, T11.W, literal.x, T0.W,
-; CM-NEXT:     BFE_UINT T14.Z, T11.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T13.W, T11.W, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T13.W, T11.W, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT T13.X, T11.W, literal.x,
-; CM-NEXT:     BFE_UINT T14.Y, T11.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T16.Z, T11.Y, literal.y, T0.W,
+; CM-NEXT:     BFE_UINT * T14.Z, T11.Z, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; CM-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_UINT * T14.Y, T11.Z, literal.y, T0.W,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; CM-NEXT:     BFE_UINT T17.Z, T11.Y, literal.y, T0.W,
 ; CM-NEXT:     LSHR * T14.W, T11.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T14.X, T11.Z, literal.x,
-; CM-NEXT:     BFE_UINT T16.Y, T11.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     BFE_UINT * T17.Y, T11.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T11.Z, T11.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T16.W, T11.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T16.X, T11.Y, literal.x,
-; CM-NEXT:     BFE_UINT T11.Y, T11.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     ADD_INT T18.X, T15.X, literal.x,
+; CM-NEXT:     BFE_UINT T11.Z, T11.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T17.W, T11.Y, literal.x,
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T17.X, T11.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T11.Y, T11.X, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T18.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T19.Z, T12.W, literal.y, T0.W,
-; CM-NEXT:     LSHR * T11.W, T11.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T19.X, T15.X, literal.x,
+; CM-NEXT:     BFE_UINT T20.Z, T12.W, literal.y, T0.W,
+; CM-NEXT:     LSHR * T11.W, T11.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T11.X, T11.X, literal.x,
-; CM-NEXT:     BFE_UINT T19.Y, T12.W, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     BFE_UINT * T20.Y, T12.W, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T21.Z, T12.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T19.W, T12.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T21.X, T15.X, literal.x,
+; CM-NEXT:     BFE_UINT T22.Z, T12.Z, literal.x, T0.W,
+; CM-NEXT:     LSHR * T20.W, T12.W, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     AND_INT T20.X, T12.W, literal.x,
+; CM-NEXT:     BFE_UINT * T22.Y, T12.Z, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T23.X, T15.X, literal.x,
+; CM-NEXT:     BFE_UINT T24.Z, T12.Y, literal.y, T0.W,
+; CM-NEXT:     LSHR * T22.W, T12.Z, literal.z,
+; CM-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T19.X, T12.W, literal.x,
-; CM-NEXT:     BFE_UINT T21.Y, T12.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T22.X, T12.Z, literal.x,
+; CM-NEXT:     BFE_UINT * T24.Y, T12.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T23.Z, T12.Y, literal.y, T0.W,
-; CM-NEXT:     LSHR * T21.W, T12.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T25.X, T15.X, literal.x,
+; CM-NEXT:     BFE_UINT T12.Z, T12.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T24.W, T12.Y, literal.z,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T21.X, T12.Z, literal.x,
-; CM-NEXT:     BFE_UINT T23.Y, T12.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T24.X, T12.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T12.Y, T12.X, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T24.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T12.Z, T12.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T23.W, T12.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T23.X, T12.Y, literal.x,
-; CM-NEXT:     BFE_UINT T12.Y, T12.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T25.X, PV.W, literal.x,
-; CM-NEXT:     LSHR * T12.W, T12.X, literal.y,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; CM-NEXT:     ADD_INT T26.X, T15.X, literal.x,
+; CM-NEXT:     LSHR * T12.W, T12.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    4(5.605194e-45), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT * T12.X, T12.X, literal.x,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T26.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %load = load <32 x i8>, ptr addrspace(1) %in
   %ext = zext <32 x i8> %load to <32 x i32>
   store <32 x i32> %ext, ptr addrspace(1) %out
@@ -3151,9 +3086,9 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @18, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @14
-; EG-NEXT:    ALU 18, @19, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 9, @19, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @16
-; EG-NEXT:    ALU 75, @38, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 73, @29, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T26.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T23.XYZW, T25.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T12.X, 0
@@ -3170,118 +3105,107 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 18:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 19:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T0.Z, T12.W, literal.y,
-; EG-NEXT:     LSHR T0.W, T12.Z, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PS, literal.x,
-; EG-NEXT:     LSHR T0.Y, T12.W, literal.y,
-; EG-NEXT:     LSHR T1.Z, T12.Z, literal.z,
-; EG-NEXT:     LSHR T1.W, T12.Y, literal.w,
-; EG-NEXT:     LSHR * T2.W, T12.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; EG-NEXT:    ALU clause starting at 38:
-; EG-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.x,
-; EG-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T12.Y, literal.y,
-; EG-NEXT:     LSHR T2.Z, T12.Y, literal.z,
-; EG-NEXT:     LSHR T3.W, T12.X, literal.y,
-; EG-NEXT:     LSHR * T4.W, T12.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T12.W, literal.y,
+; EG-NEXT:     LSHR * T1.W, T12.W, literal.z,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 29:
+; EG-NEXT:     LSHR T2.W, T12.Z, literal.x,
+; EG-NEXT:     LSHR * T3.W, T12.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T17.X, T13.X, literal.x,
+; EG-NEXT:     LSHR T0.Y, T12.Y, literal.x,
+; EG-NEXT:     LSHR T0.Z, T12.Y, literal.y,
+; EG-NEXT:     LSHR T4.W, T12.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T5.W, T12.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     BFE_INT T18.X, T11.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.Y, T11.W, literal.y,
-; EG-NEXT:     LSHR T3.Z, T11.W, literal.z,
-; EG-NEXT:     LSHR T5.W, T11.Z, literal.y,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.z,
+; EG-NEXT:     LSHR T1.Y, T11.W, literal.y,
+; EG-NEXT:     LSHR T1.Z, T11.W, literal.z,
+; EG-NEXT:     LSHR T6.W, T11.Z, literal.y,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T19.X, T11.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR T3.Y, T11.Z, literal.y,
-; EG-NEXT:     LSHR T4.Z, T11.Y, literal.y,
+; EG-NEXT:     LSHR T2.Y, T11.Z, literal.y,
+; EG-NEXT:     LSHR T2.Z, T11.Y, literal.y,
 ; EG-NEXT:     BFE_INT T18.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.z,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.X, T11.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR T4.Y, T11.Y, literal.y,
+; EG-NEXT:     LSHR T3.Y, T11.Y, literal.y,
 ; EG-NEXT:     BFE_INT T18.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.X, literal.x,
+; EG-NEXT:     LSHR * T7.W, T11.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T21.X, T11.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T18.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.W, T3.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T11.Y, literal.x,
+; EG-NEXT:     BFE_INT T20.W, T2.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.W, T11.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T22.X, T12.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T19.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T20.Z, T5.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.W, T3.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T5.W, T11.Z, literal.x,
+; EG-NEXT:     BFE_INT T20.Z, T6.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T21.W, T1.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T6.W, T11.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T11.X, T12.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Z, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T22.W, T4.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T4.W, T11.W, literal.x,
+; EG-NEXT:     BFE_INT T21.Z, T1.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T22.W, T5.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T5.W, T11.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T23.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T21.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T22.Z, T3.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.W, T2.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.W, T12.X, literal.x,
+; EG-NEXT:     BFE_INT T22.Z, T4.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T11.W, T0.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T4.W, T12.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T24.X, T12.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T22.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T11.Z, T1.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T23.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T12.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T11.Y, T1.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T23.Z, T1.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T24.W, T0.Y, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T25.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T23.Y, T0.W, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T24.Z, T0.Z, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T11.Z, T0.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T23.W, T3.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T12.Y, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T12.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T11.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T23.Z, T2.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T24.W, T1.W, 0.0, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T1.W, T12.Z, literal.y,
+; EG-NEXT:    20(2.802597e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T25.X, T13.X, literal.x,
+; EG-NEXT:     BFE_INT T23.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T24.Z, T0.W, 0.0, literal.y,
 ; EG-NEXT:     LSHR T0.W, T12.W, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T26.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T24.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T26.X, T13.X, literal.z,
+; EG-NEXT:    24(3.363116e-44), 8(1.121039e-44)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T24.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v32i8_to_v32i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @18, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @14
-; CM-NEXT:    ALU 19, @19, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 8, @19, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @16
-; CM-NEXT:    ALU 78, @39, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T27.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T19.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T15.X
+; CM-NEXT:    ALU 78, @28, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T12.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T17.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T16.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T14.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 14:
 ; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
@@ -3290,106 +3214,95 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i32(ptr addrspace(1) %out
 ; CM-NEXT:    ALU clause starting at 18:
 ; CM-NEXT:     MOV * T11.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 19:
-; CM-NEXT:     LSHR * T0.W, T12.X, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.X, T12.Y, literal.x,
-; CM-NEXT:     ADD_INT T0.Y, KC0[2].Y, literal.y,
-; CM-NEXT:     LSHR T0.Z, T12.X, literal.z,
-; CM-NEXT:     LSHR * T1.W, T12.Y, literal.y,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T14.X, T12.Z, literal.x,
-; CM-NEXT:     ADD_INT T1.Y, KC0[2].Y, literal.y,
+; CM-NEXT:     LSHR T0.Z, T12.X, literal.x,
+; CM-NEXT:     LSHR * T0.W, T12.Y, literal.y,
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHR T0.Y, T12.X, literal.y,
 ; CM-NEXT:     LSHR T1.Z, T12.Y, literal.z,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; CM-NEXT:    24(3.363116e-44), 112(1.569454e-43)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T2.Y, T12.Z, literal.y,
-; CM-NEXT:     LSHR T2.Z, T12.W, literal.z,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; CM-NEXT:    ALU clause starting at 39:
-; CM-NEXT:     LSHR T16.X, T2.W, literal.x,
-; CM-NEXT:     LSHR T3.Y, T12.Z, literal.y,
-; CM-NEXT:     LSHR T3.Z, T12.W, literal.z, BS:VEC_120/SCL_212
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:    16(2.242078e-44), 80(1.121039e-43)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T4.Y, T11.X, literal.y,
-; CM-NEXT:     LSHR T4.Z, T12.W, literal.z,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 64(8.968310e-44)
-; CM-NEXT:     LSHR T18.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T5.Y, T11.X, literal.y,
-; CM-NEXT:     LSHR T5.Z, T11.Y, literal.z,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; CM-NEXT:     LSHR T19.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T6.Y, T11.X, literal.y,
-; CM-NEXT:     LSHR T6.Z, T11.Y, literal.z,
-; CM-NEXT:     LSHR * T2.W, T11.Z, literal.w,
+; CM-NEXT:     LSHR * T1.W, T12.Z, literal.w,
 ; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; CM-NEXT:     BFE_INT T20.X, T11.W, 0.0, literal.x,
-; CM-NEXT:     LSHR T7.Y, T11.Y, literal.y,
-; CM-NEXT:     LSHR T7.Z, T11.Z, literal.z,
-; CM-NEXT:     LSHR * T3.W, T11.W, literal.y,
+; CM-NEXT:    ALU clause starting at 28:
+; CM-NEXT:     ADD_INT T14.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T1.Y, T12.Y, literal.y,
+; CM-NEXT:     LSHR T2.Z, T12.Z, literal.z,
+; CM-NEXT:     LSHR * T2.W, T12.W, literal.w,
+; CM-NEXT:    28(3.923636e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T15.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T2.Y, T12.Z, literal.x,
+; CM-NEXT:     LSHR T3.Z, T12.W, literal.y,
+; CM-NEXT:     LSHR * T3.W, T11.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T3.Y, T12.W, literal.y,
+; CM-NEXT:     LSHR T4.Z, T11.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T4.W, T11.Y, literal.w,
+; CM-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T17.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T4.Y, T11.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T5.Z, T11.Y, literal.x,
+; CM-NEXT:     LSHR * T5.W, T11.Z, literal.z,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T18.X, T11.W, 0.0, literal.x,
+; CM-NEXT:     LSHR T5.Y, T11.Y, literal.y,
+; CM-NEXT:     LSHR T6.Z, T11.Z, literal.z,
+; CM-NEXT:     LSHR * T6.W, T11.W, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T21.X, T11.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T8.Y, T11.Z, literal.y,
-; CM-NEXT:     LSHR T8.Z, T11.W, literal.z,
-; CM-NEXT:     BFE_INT * T20.W, PV.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T19.X, T11.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR T6.Y, T11.Z, literal.y,
+; CM-NEXT:     LSHR T7.Z, T11.W, literal.z,
+; CM-NEXT:     BFE_INT * T18.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T22.X, T11.Y, 0.0, literal.x,
-; CM-NEXT:     LSHR T9.Y, T11.W, literal.x,
-; CM-NEXT:     BFE_INT T20.Z, PV.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T21.W, PV.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.X, T11.Y, 0.0, literal.x,
+; CM-NEXT:     LSHR T7.Y, T11.W, literal.x,
+; CM-NEXT:     BFE_INT T18.Z, PV.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T19.W, PV.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T11.X, T11.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T20.Y, PV.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T21.Z, T7.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T22.W, T7.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T18.Y, PV.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T19.Z, T6.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T20.W, T5.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T23.X, T12.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T21.Y, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T22.Z, T6.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T11.W, T6.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.X, T12.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T19.Y, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T20.Z, T5.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T11.W, T4.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T24.X, T12.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T22.Y, T5.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T11.Z, T5.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T23.W, T4.Z, 0.0, literal.x, BS:VEC_201
+; CM-NEXT:     BFE_INT T22.X, T12.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.Y, T4.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T11.Z, T4.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T21.W, T3.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T25.X, T12.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T11.Y, T4.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT T23.Z, T3.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T24.W, T3.Y, 0.0, literal.x, BS:VEC_201
+; CM-NEXT:     BFE_INT T23.X, T12.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T11.Y, T3.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.Z, T3.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T22.W, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T26.X, T12.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T23.Y, T2.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T24.Z, T2.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T25.W, T1.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T24.X, T12.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.Y, T2.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T22.Z, T2.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T23.W, T1.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T27.X, T1.Y, literal.x,
-; CM-NEXT:     BFE_INT T24.Y, T14.X, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T25.Z, T1.W, 0.0, literal.y,
-; CM-NEXT:     BFE_INT * T26.W, T0.Z, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T14.X, T0.Y, literal.x,
-; CM-NEXT:     BFE_INT T25.Y, T13.X, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T26.Z, T0.W, 0.0, literal.y,
-; CM-NEXT:     LSHR * T0.W, T12.X, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T12.X, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT * T26.Y, PV.W, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T25.X, T13.X, literal.x,
+; CM-NEXT:     BFE_INT T22.Y, T1.W, 0.0, literal.y,
+; CM-NEXT:     BFE_INT T23.Z, T1.Z, 0.0, literal.y,
+; CM-NEXT:     BFE_INT * T24.W, T0.Y, 0.0, literal.y,
+; CM-NEXT:    12(1.681558e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T26.X, T13.X, literal.x,
+; CM-NEXT:     BFE_INT T23.Y, T0.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T24.Z, T0.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR * T0.W, T12.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T12.X, T13.X, literal.x,
+; CM-NEXT:     BFE_INT * T24.Y, PV.W, 0.0, literal.y,
+; CM-NEXT:    4(5.605194e-45), 8(1.121039e-44)
   %load = load <32 x i8>, ptr addrspace(1) %in
   %ext = sext <32 x i8> %load to <32 x i32>
   store <32 x i32> %ext, ptr addrspace(1) %out
@@ -3806,32 +3719,32 @@ define amdgpu_kernel void @global_zextload_v64i8_to_v64i32(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 59, @31, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 37, @31, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @26
-; EG-NEXT:    ALU 88, @91, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 92, @69, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T49.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T32.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T46.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T44.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T42.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T33.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T39.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T34.XYZW, T37.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T35.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T28.XYZW, T31.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T23.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T24.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T33.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T22.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T32.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T27.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T26.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 22:
 ; EG-NEXT:     VTX_READ_128 T22.XYZW, T21.X, 16, #1
 ; EG-NEXT:     VTX_READ_128 T23.XYZW, T21.X, 0, #1
 ; EG-NEXT:    Fetch clause starting at 26:
-; EG-NEXT:     VTX_READ_128 T32.XYZW, T21.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T33.XYZW, T21.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T29.XYZW, T21.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T30.XYZW, T21.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 30:
 ; EG-NEXT:     MOV * T21.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 31:
@@ -3840,182 +3753,164 @@ define amdgpu_kernel void @global_zextload_v64i8_to_v64i32(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_UINT * T19.Z, T23.Y, literal.x, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_UINT T19.Y, T23.Y, literal.x, T0.W,
-; EG-NEXT:     BFE_UINT T20.Z, T23.X, literal.y, T0.W,
-; EG-NEXT:     LSHR * T19.W, T23.Y, literal.z,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T19.W, T23.Y, literal.y,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:     AND_INT T19.X, T23.Y, literal.x,
-; EG-NEXT:     BFE_UINT T20.Y, T23.X, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     BFE_UINT T20.Z, T23.X, literal.y, T0.W,
+; EG-NEXT:     LSHR * T24.X, KC0[2].Y, literal.z,
+; EG-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T20.Y, T23.X, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T25.Z, T23.W, literal.y, T0.W,
+; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T26.X, T24.X, literal.x,
+; EG-NEXT:     BFE_UINT T25.Y, T23.W, literal.y, T0.W,
+; EG-NEXT:     LSHR T20.W, T23.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     AND_INT * T20.X, T23.X, literal.w,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
+; EG-NEXT:     BFE_UINT T27.Z, T23.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T25.W, T23.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T25.X, T23.W, literal.x,
+; EG-NEXT:     BFE_UINT T27.Y, T23.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T23.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T27.W, T23.Z, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T27.X, T23.Z, literal.x,
+; EG-NEXT:     BFE_UINT T21.Z, T22.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T28.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T21.Y, T22.Y, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 69:
+; EG-NEXT:     BFE_UINT T31.Z, T22.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T21.W, T22.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T21.X, T22.Y, literal.x,
+; EG-NEXT:     BFE_UINT T31.Y, T22.X, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T32.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T33.Z, T22.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T31.W, T22.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T31.X, T22.X, literal.x,
+; EG-NEXT:     BFE_UINT T33.Y, T22.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T22.X, T24.X, literal.z,
 ; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T25.Z, T23.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T20.W, T23.X, literal.z,
-; EG-NEXT:     AND_INT * T20.X, T23.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT * T25.Y, T23.W, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T23.X, KC0[2].Y, literal.x,
-; EG-NEXT:     BFE_UINT T26.Z, T23.Z, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T25.W, T23.W, literal.z,
-; EG-NEXT:     AND_INT * T25.X, T23.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T26.Y, T23.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T28.Z, T22.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T26.W, T23.Z, literal.z,
-; EG-NEXT:     AND_INT * T26.X, T23.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T28.Y, T22.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T30.Z, T22.X, literal.y, T0.W,
-; EG-NEXT:     LSHR T28.W, T22.Y, literal.z,
-; EG-NEXT:     AND_INT * T28.X, T22.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T30.Y, T22.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 80(1.121039e-43)
-; EG-NEXT:     LSHR T31.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T30.W, T22.X, literal.y,
-; EG-NEXT:     AND_INT * T30.X, T22.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T21.Z, T22.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 64(8.968310e-44)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT * T21.Y, T22.W, literal.y, T0.W,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    ALU clause starting at 91:
 ; EG-NEXT:     BFE_UINT T34.Z, T22.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T21.W, T22.W, literal.y,
+; EG-NEXT:     LSHR * T33.W, T22.W, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     AND_INT T21.X, T22.W, literal.x,
+; EG-NEXT:     AND_INT T33.X, T22.W, literal.x,
 ; EG-NEXT:     BFE_UINT T34.Y, T22.Z, literal.y, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T35.X, T24.X, literal.z,
 ; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T36.Z, T33.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T34.W, T22.Z, literal.z,
-; EG-NEXT:     AND_INT * T34.X, T22.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T36.Y, T33.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T38.Z, T33.X, literal.y, T0.W,
-; EG-NEXT:     LSHR T36.W, T33.Y, literal.z,
-; EG-NEXT:     AND_INT * T36.X, T33.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T38.Y, T33.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 144(2.017870e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T40.Z, T33.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T38.W, T33.X, literal.z,
-; EG-NEXT:     AND_INT * T38.X, T33.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T40.Y, T33.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 128(1.793662e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T41.Z, T33.Z, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T40.W, T33.W, literal.z,
-; EG-NEXT:     AND_INT * T40.X, T33.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T41.Y, T33.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 176(2.466285e-43)
-; EG-NEXT:     LSHR T42.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T43.Z, T32.Y, literal.y, T0.W,
-; EG-NEXT:     LSHR T41.W, T33.Z, literal.z,
-; EG-NEXT:     AND_INT * T41.X, T33.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T43.Y, T32.Y, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 160(2.242078e-43)
-; EG-NEXT:     LSHR T44.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T45.Z, T32.X, literal.y, T0.W,
-; EG-NEXT:     LSHR T43.W, T32.Y, literal.z,
-; EG-NEXT:     AND_INT * T43.X, T32.Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T45.Y, T32.X, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 208(2.914701e-43)
-; EG-NEXT:     LSHR T46.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T47.Z, T32.W, literal.y, T0.W,
-; EG-NEXT:     LSHR T45.W, T32.X, literal.z,
-; EG-NEXT:     AND_INT * T45.X, T32.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T47.Y, T32.W, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 192(2.690493e-43)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     BFE_UINT T48.Z, T32.Z, literal.y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHR T47.W, T32.W, literal.z,
-; EG-NEXT:     AND_INT * T47.X, T32.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 255(3.573311e-43)
-; EG-NEXT:     BFE_UINT T48.Y, T32.Z, literal.x, T0.W,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 240(3.363116e-43)
-; EG-NEXT:     LSHR T49.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T48.W, T32.Z, literal.y,
-; EG-NEXT:     AND_INT * T48.X, T32.Z, literal.z,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T36.Z, T30.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T34.W, T22.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T34.X, T22.Z, literal.x,
+; EG-NEXT:     BFE_UINT T36.Y, T30.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T37.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T38.Z, T30.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T36.W, T30.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T36.X, T30.Y, literal.x,
+; EG-NEXT:     BFE_UINT T38.Y, T30.X, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T39.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T40.Z, T30.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T38.W, T30.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T38.X, T30.X, literal.x,
+; EG-NEXT:     BFE_UINT T40.Y, T30.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T30.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T41.Z, T30.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T40.W, T30.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T40.X, T30.W, literal.x,
+; EG-NEXT:     BFE_UINT T41.Y, T30.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T42.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T43.Z, T29.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T41.W, T30.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T41.X, T30.Z, literal.x,
+; EG-NEXT:     BFE_UINT T43.Y, T29.Y, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T44.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T45.Z, T29.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T43.W, T29.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T43.X, T29.Y, literal.x,
+; EG-NEXT:     BFE_UINT T45.Y, T29.X, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T46.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T47.Z, T29.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T45.W, T29.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T45.X, T29.X, literal.x,
+; EG-NEXT:     BFE_UINT T47.Y, T29.W, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T29.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T48.Z, T29.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T47.W, T29.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     AND_INT T47.X, T29.W, literal.x,
+; EG-NEXT:     BFE_UINT T48.Y, T29.Z, literal.y, T0.W,
+; EG-NEXT:     ADD_INT * T49.X, T24.X, literal.z,
+; EG-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR * T48.W, T29.Z, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T48.X, T29.Z, literal.x,
+; EG-NEXT:     ADD_INT * T50.X, T24.X, literal.y,
+; EG-NEXT:    255(3.573311e-43), 56(7.847271e-44)
 ;
 ; CM-LABEL: global_zextload_v64i8_to_v64i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @30, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @22
-; CM-NEXT:    ALU 63, @31, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 36, @31, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @26
-; CM-NEXT:    ALU 95, @95, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T49, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T32.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T48.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T46.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T44.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T33.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T41.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T39.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T37.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T30, T34.X
+; CM-NEXT:    ALU 91, @68, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T49, T29.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T48, T24.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T46, T50.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T47.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T45.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T42.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T40.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T38.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T34, T20.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T35.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T33.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T31.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T29.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T24.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T25.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 22:
 ; CM-NEXT:     VTX_READ_128 T20.XYZW, T19.X, 32, #1
 ; CM-NEXT:     VTX_READ_128 T21.XYZW, T19.X, 48, #1
 ; CM-NEXT:    Fetch clause starting at 26:
-; CM-NEXT:     VTX_READ_128 T32.XYZW, T19.X, 0, #1
-; CM-NEXT:     VTX_READ_128 T33.XYZW, T19.X, 16, #1
+; CM-NEXT:     VTX_READ_128 T29.XYZW, T19.X, 0, #1
+; CM-NEXT:     VTX_READ_128 T30.XYZW, T19.X, 16, #1
 ; CM-NEXT:    ALU clause starting at 30:
 ; CM-NEXT:     MOV * T19.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 31:
@@ -4024,162 +3919,131 @@ define amdgpu_kernel void @global_zextload_v64i8_to_v64i32(ptr addrspace(1) %out
 ; CM-NEXT:     BFE_UINT * T22.Z, T21.Z, literal.x, PV.W,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_UINT T22.Y, T21.Z, literal.x, T0.W,
-; CM-NEXT:     BFE_UINT T23.Z, T21.W, literal.y, T0.W,
-; CM-NEXT:     LSHR * T22.W, T21.Z, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T22.W, T21.Z, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:     AND_INT T22.X, T21.Z, literal.x,
-; CM-NEXT:     BFE_UINT T23.Y, T21.W, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T24.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T25.Z, T21.X, literal.y, T0.W,
+; CM-NEXT:     BFE_UINT * T23.Z, T21.W, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 16(2.242078e-44)
+; CM-NEXT:     LSHR T24.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_UINT * T23.Y, T21.W, literal.y, T0.W,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T25.X, PV.X, literal.x,
+; CM-NEXT:     BFE_UINT T26.Z, T21.X, literal.y, T0.W,
 ; CM-NEXT:     LSHR * T23.W, T21.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    56(7.847271e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; CM-NEXT:     AND_INT T23.X, T21.W, literal.x,
-; CM-NEXT:     BFE_UINT T25.Y, T21.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     BFE_UINT * T26.Y, T21.X, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T26.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T27.Z, T21.Y, literal.y, T0.W,
-; CM-NEXT:     LSHR * T25.W, T21.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T27.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T28.Z, T21.Y, literal.y, T0.W,
+; CM-NEXT:     LSHR * T26.W, T21.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    60(8.407791e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T25.X, T21.X, literal.x,
-; CM-NEXT:     BFE_UINT T27.Y, T21.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T26.X, T21.X, literal.x,
+; CM-NEXT:     BFE_UINT * T28.Y, T21.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    192(2.690493e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T21.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T28.Z, T20.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T27.W, T21.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T21.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T19.Z, T20.Z, literal.y, T0.W,
+; CM-NEXT:     LSHR * T28.W, T21.Y, literal.z,
+; CM-NEXT:    48(6.726233e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T27.X, T21.Y, literal.x,
-; CM-NEXT:     BFE_UINT T28.Y, T20.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T28.X, T21.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T19.Y, T20.Z, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T29.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T30.Z, T20.W, literal.y, T0.W,
-; CM-NEXT:     LSHR * T28.W, T20.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    ALU clause starting at 68:
+; CM-NEXT:     ADD_INT T31.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T32.Z, T20.W, literal.y, T0.W,
+; CM-NEXT:     LSHR * T19.W, T20.Z, literal.z,
+; CM-NEXT:    52(7.286752e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T28.X, T20.Z, literal.x,
-; CM-NEXT:     BFE_UINT T30.Y, T20.W, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T19.X, T20.Z, literal.x,
+; CM-NEXT:     BFE_UINT * T32.Y, T20.W, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    160(2.242078e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T31.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T19.Z, T20.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T30.W, T20.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T33.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T34.Z, T20.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T32.W, T20.W, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    40(5.605194e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T30.X, T20.W, literal.x,
-; CM-NEXT:     BFE_UINT T19.Y, T20.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T32.X, T20.W, literal.x,
+; CM-NEXT:     BFE_UINT * T34.Y, T20.X, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    176(2.466285e-43), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 95:
-; CM-NEXT:     LSHR T34.X, T1.W, literal.x,
-; CM-NEXT:     BFE_UINT T35.Z, T20.Y, literal.y, T0.W,
-; CM-NEXT:     LSHR * T19.W, T20.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T35.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T36.Z, T20.Y, literal.y, T0.W,
+; CM-NEXT:     LSHR * T34.W, T20.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    44(6.165713e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T19.X, T20.X, literal.x,
-; CM-NEXT:     BFE_UINT T35.Y, T20.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T34.X, T20.X, literal.x,
+; CM-NEXT:     BFE_UINT * T36.Y, T20.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    128(1.793662e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T36.Z, T33.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T35.W, T20.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T20.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T37.Z, T30.Z, literal.y, T0.W,
+; CM-NEXT:     LSHR * T36.W, T20.Y, literal.z,
+; CM-NEXT:    32(4.484155e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T35.X, T20.Y, literal.x,
-; CM-NEXT:     BFE_UINT T36.Y, T33.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T36.X, T20.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T37.Y, T30.Z, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T37.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T38.Z, T33.W, literal.y, T0.W,
-; CM-NEXT:     LSHR * T36.W, T33.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T38.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T39.Z, T30.W, literal.y, T0.W,
+; CM-NEXT:     LSHR * T37.W, T30.Z, literal.z,
+; CM-NEXT:    36(5.044674e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T36.X, T33.Z, literal.x,
-; CM-NEXT:     BFE_UINT T38.Y, T33.W, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T37.X, T30.Z, literal.x,
+; CM-NEXT:     BFE_UINT * T39.Y, T30.W, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T40.Z, T33.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T38.W, T33.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T40.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T41.Z, T30.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T39.W, T30.W, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:     AND_INT T39.X, T30.W, literal.x,
+; CM-NEXT:     BFE_UINT * T41.Y, T30.X, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T42.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T43.Z, T30.Y, literal.y, T0.W,
+; CM-NEXT:     LSHR * T41.W, T30.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    28(3.923636e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T38.X, T33.W, literal.x,
-; CM-NEXT:     BFE_UINT T40.Y, T33.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T41.X, T30.X, literal.x,
+; CM-NEXT:     BFE_UINT * T43.Y, T30.Y, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T41.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T42.Z, T33.Y, literal.y, T0.W,
-; CM-NEXT:     LSHR * T40.W, T33.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T30.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T44.Z, T29.Z, literal.x, T0.W,
+; CM-NEXT:     LSHR * T43.W, T30.Y, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     AND_INT T43.X, T30.Y, literal.x,
+; CM-NEXT:     BFE_UINT * T44.Y, T29.Z, literal.y, T0.W,
+; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T45.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T46.Z, T29.W, literal.y, T0.W,
+; CM-NEXT:     LSHR * T44.W, T29.Z, literal.z,
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T40.X, T33.X, literal.x,
-; CM-NEXT:     BFE_UINT T42.Y, T33.Y, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T44.X, T29.Z, literal.x,
+; CM-NEXT:     BFE_UINT * T46.Y, T29.W, literal.y, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    64(8.968310e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T33.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T43.Z, T32.Z, literal.y, T0.W,
-; CM-NEXT:     LSHR * T42.W, T33.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     ADD_INT T47.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T48.Z, T29.X, literal.y, T0.W, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T46.W, T29.W, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T42.X, T33.Y, literal.x,
-; CM-NEXT:     BFE_UINT T43.Y, T32.Z, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T46.X, T29.W, literal.x,
+; CM-NEXT:     BFE_UINT T48.Y, T29.X, literal.y, T0.W,
+; CM-NEXT:     BFE_UINT * T49.Z, T29.Y, literal.z, T0.W,
 ; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T44.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T45.Z, T32.W, literal.y, T0.W,
-; CM-NEXT:     LSHR * T43.W, T32.Z, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T50.X, T24.X, literal.x,
+; CM-NEXT:     BFE_UINT T49.Y, T29.Y, literal.y, T0.W,
+; CM-NEXT:     LSHR * T48.W, T29.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    12(1.681558e-44), 8(1.121039e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T43.X, T32.Z, literal.x,
-; CM-NEXT:     BFE_UINT T45.Y, T32.W, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T46.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T47.Z, T32.X, literal.y, T0.W,
-; CM-NEXT:     LSHR * T45.W, T32.W, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T45.X, T32.W, literal.x,
-; CM-NEXT:     BFE_UINT T47.Y, T32.X, literal.y, T0.W,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T48.X, PV.W, literal.x,
-; CM-NEXT:     BFE_UINT T49.Z, T32.Y, literal.y, T0.W,
-; CM-NEXT:     LSHR * T47.W, T32.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T47.X, T32.X, literal.x,
-; CM-NEXT:     BFE_UINT * T49.Y, T32.Y, literal.y, T0.W,
-; CM-NEXT:    255(3.573311e-43), 8(1.121039e-44)
-; CM-NEXT:     LSHR T32.X, KC0[2].Y, literal.x,
-; CM-NEXT:     LSHR * T49.W, T32.Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:     AND_INT T49.X, T32.Y, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    255(3.573311e-43), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T50.X, PV.W, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T48.X, T29.X, literal.x,
+; CM-NEXT:     LSHR * T49.W, T29.Y, literal.y,
+; CM-NEXT:    255(3.573311e-43), 24(3.363116e-44)
+; CM-NEXT:     AND_INT * T49.X, T29.Y, literal.x,
+; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T29.X, T24.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <64 x i8>, ptr addrspace(1) %in
   %ext = zext <64 x i8> %load to <64 x i32>
   store <64 x i32> %ext, ptr addrspace(1) %out
@@ -4596,11 +4460,11 @@ define amdgpu_kernel void @global_sextload_v64i8_to_v64i32(ptr addrspace(1) %out
 ; EG-LABEL: global_sextload_v64i8_to_v64i32:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @32, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @24
-; EG-NEXT:    ALU 41, @33, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @28
-; EG-NEXT:    ALU 76, @75, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 72, @152, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @24
+; EG-NEXT:    ALU 16, @33, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 2 @26
+; EG-NEXT:    ALU 76, @50, KC0[], KC1[]
+; EG-NEXT:    ALU 71, @127, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T48.XYZW, T50.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T47.XYZW, T49.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T46.XYZW, T19.X, 0
@@ -4608,457 +4472,408 @@ define amdgpu_kernel void @global_sextload_v64i8_to_v64i32(ptr addrspace(1) %out
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T45.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T44.XYZW, T33.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T43.XYZW, T32.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T30.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T29.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T27.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T31.XYZW, T26.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T25.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T24.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T30.XYZW, T31.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T42.XYZW, T28.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T27.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T26.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T29.XYZW, T25.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T39.XYZW, T24.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T23.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 24:
-; EG-NEXT:     VTX_READ_128 T20.XYZW, T21.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T19.XYZW, T21.X, 48, #1
-; EG-NEXT:    Fetch clause starting at 28:
-; EG-NEXT:     VTX_READ_128 T31.XYZW, T21.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T21.XYZW, T21.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T19.XYZW, T20.X, 48, #1
+; EG-NEXT:    Fetch clause starting at 26:
+; EG-NEXT:     VTX_READ_128 T29.XYZW, T20.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T30.XYZW, T20.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T20.XYZW, T20.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 32:
-; EG-NEXT:     MOV * T21.X, KC0[2].Z,
+; EG-NEXT:     MOV * T20.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 33:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T23.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHR * T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T25.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T26.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T27.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 12(1.681558e-44)
+; EG-NEXT:     ADD_INT T24.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T21.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 20(2.802597e-44)
+; EG-NEXT:     ADD_INT T26.X, T21.X, literal.x,
+; EG-NEXT:     ADD_INT * T27.X, T21.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 28(3.923636e-44)
+; EG-NEXT:     ADD_INT T28.X, T21.X, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T19.Z, literal.y,
-; EG-NEXT:     LSHR T0.Z, T19.W, literal.z,
-; EG-NEXT:     LSHR * T0.W, T19.Z, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T1.Y, T19.W, literal.y,
-; EG-NEXT:     LSHR T1.Z, T19.X, literal.z,
-; EG-NEXT:     LSHR * T1.W, T19.W, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
-; EG-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.x,
-; EG-NEXT:    144(2.017870e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     LSHR T2.Y, T19.X, literal.y,
-; EG-NEXT:     LSHR T2.Z, T19.X, literal.z,
+; EG-NEXT:     LSHR T0.Z, T19.Z, literal.x,
+; EG-NEXT:     LSHR T0.W, T19.W, literal.y,
+; EG-NEXT:     LSHR * T1.W, T19.W, literal.x,
+; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; EG-NEXT:    ALU clause starting at 50:
+; EG-NEXT:     ADD_INT T31.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T1.Y, T19.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T1.Z, T19.X, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     LSHR T2.W, T19.Y, literal.y,
 ; EG-NEXT:     LSHR * T3.W, T19.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:    36(5.044674e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 75:
-; EG-NEXT:     LSHR T3.Y, T20.Z, literal.x,
-; EG-NEXT:     LSHR T3.Z, T20.Z, literal.y,
-; EG-NEXT:     LSHR T4.W, T20.W, literal.x,
-; EG-NEXT:     ADD_INT * T5.W, KC0[2].Y, literal.z,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:    128(1.793662e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T32.X, PS, literal.x,
-; EG-NEXT:     LSHR T4.Y, T20.W, literal.y,
-; EG-NEXT:     LSHR T4.Z, T20.X, literal.z,
-; EG-NEXT:     LSHR T5.W, T20.X, literal.y,
-; EG-NEXT:     ADD_INT * T6.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 176(2.466285e-43)
-; EG-NEXT:     LSHR T33.X, PS, literal.x,
-; EG-NEXT:     LSHR T5.Y, T20.Y, literal.y,
-; EG-NEXT:     LSHR T5.Z, T20.Y, literal.z,
-; EG-NEXT:     LSHR T6.W, T21.Z, literal.y,
-; EG-NEXT:     ADD_INT * T7.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:    24(3.363116e-44), 160(2.242078e-43)
-; EG-NEXT:     LSHR T34.X, PS, literal.x,
-; EG-NEXT:     LSHR T6.Y, T21.Z, literal.y,
-; EG-NEXT:     LSHR T6.Z, T21.W, literal.z,
-; EG-NEXT:     LSHR T7.W, T21.W, literal.y,
-; EG-NEXT:     ADD_INT * T8.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; EG-NEXT:    16(2.242078e-44), 208(2.914701e-43)
-; EG-NEXT:     LSHR T35.X, PS, literal.x,
-; EG-NEXT:     LSHR T7.Y, T21.X, literal.y,
-; EG-NEXT:     LSHR T7.Z, T21.X, literal.z,
-; EG-NEXT:     LSHR T8.W, T21.Y, literal.y,
-; EG-NEXT:     LSHR * T9.W, T21.Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T32.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T2.Y, T20.Z, literal.y,
+; EG-NEXT:     LSHR T2.Z, T20.Z, literal.z,
+; EG-NEXT:     LSHR T4.W, T20.W, literal.y,
+; EG-NEXT:     LSHR * T5.W, T20.W, literal.z,
+; EG-NEXT:    32(4.484155e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T36.X, T31.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR T8.Y, T31.Z, literal.y,
-; EG-NEXT:     LSHR T8.Z, T31.Z, literal.z,
-; EG-NEXT:     LSHR T10.W, T31.W, literal.y,
-; EG-NEXT:     LSHR * T11.W, T31.Y, literal.z,
+; EG-NEXT:     ADD_INT T33.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T3.Y, T20.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T3.Z, T20.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T6.W, T20.Y, literal.y,
+; EG-NEXT:     LSHR * T7.W, T20.Y, literal.z,
+; EG-NEXT:    44(6.165713e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T4.Y, T30.Z, literal.y,
+; EG-NEXT:     LSHR T4.Z, T30.Z, literal.z,
+; EG-NEXT:     LSHR T8.W, T30.W, literal.y,
+; EG-NEXT:     LSHR * T9.W, T30.W, literal.z,
+; EG-NEXT:    40(5.605194e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T35.X, T21.X, literal.x,
+; EG-NEXT:     LSHR T5.Y, T30.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T5.Z, T30.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T10.W, T30.Y, literal.y,
+; EG-NEXT:     LSHR * T11.W, T30.Y, literal.z,
+; EG-NEXT:    52(7.286752e-44), 16(2.242078e-44)
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T36.X, T29.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR T6.Y, T29.Z, literal.y,
+; EG-NEXT:     LSHR T6.Z, T29.Z, literal.z,
+; EG-NEXT:     LSHR T12.W, T29.W, literal.y,
+; EG-NEXT:     LSHR * T13.W, T29.Y, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T37.X, T31.X, 0.0, literal.x,
-; EG-NEXT:     LSHR T9.Y, T31.W, literal.y,
-; EG-NEXT:     LSHR T9.Z, T31.X, literal.y,
+; EG-NEXT:     BFE_INT T37.X, T29.X, 0.0, literal.x,
+; EG-NEXT:     LSHR T7.Y, T29.W, literal.y,
+; EG-NEXT:     LSHR T7.Z, T29.X, literal.y,
 ; EG-NEXT:     BFE_INT T36.W, PS, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.Y, literal.z,
+; EG-NEXT:     LSHR * T13.W, T29.Y, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T38.X, T31.W, 0.0, literal.x,
-; EG-NEXT:     LSHR T10.Y, T31.X, literal.y,
+; EG-NEXT:     BFE_INT T38.X, T29.W, 0.0, literal.x,
+; EG-NEXT:     LSHR T8.Y, T29.X, literal.y,
 ; EG-NEXT:     BFE_INT T36.Z, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.W, PV.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.Y, literal.x,
+; EG-NEXT:     LSHR * T13.W, T29.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T39.X, T31.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.X, T29.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T36.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.Z, PV.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T38.W, T9.Y, 0.0, literal.x,
-; EG-NEXT:     LSHR * T11.W, T31.X, literal.x,
+; EG-NEXT:     BFE_INT T38.W, T7.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T13.W, T29.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T31.X, T21.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.X, T30.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T37.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T38.Z, T10.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T39.W, T8.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T10.W, T31.W, literal.x,
+; EG-NEXT:     BFE_INT T38.Z, T12.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T39.W, T6.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T12.W, T29.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T40.X, T21.X, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.X, T30.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T38.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T39.Z, T8.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.W, T9.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T9.W, T31.Z, literal.x,
+; EG-NEXT:     BFE_INT T39.Z, T6.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.W, T11.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T11.W, T29.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T41.X, T21.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T30.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T39.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.Z, T8.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT * T40.W, T7.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT * T29.Z, T10.W, 0.0, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 152:
-; EG-NEXT:     LSHR * T8.W, T21.Y, literal.x,
+; EG-NEXT:    ALU clause starting at 127:
+; EG-NEXT:     BFE_INT T40.W, T5.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T10.W, T30.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T42.X, T21.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T31.Y, PV.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T40.Z, T7.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T41.W, T7.W, 0.0, literal.x,
-; EG-NEXT:     LSHR * T7.W, T21.X, literal.x,
+; EG-NEXT:     BFE_INT T42.X, T30.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T29.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.Z, T5.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.W, T9.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T9.W, T30.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T21.X, T20.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.X, T20.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T40.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T41.Z, T6.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.W, T6.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T7.W, T21.W, literal.x,
+; EG-NEXT:     BFE_INT T41.Z, T8.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T42.W, T4.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T8.W, T30.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T43.X, T20.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T41.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T42.Z, T6.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.W, T5.Z, 0.0, literal.x,
-; EG-NEXT:     LSHR * T6.W, T21.Z, literal.x,
+; EG-NEXT:     BFE_INT T42.Z, T4.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.W, T7.W, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.W, T30.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T44.X, T20.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T42.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Z, T5.Y, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.W, T5.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T5.W, T20.Y, literal.x,
+; EG-NEXT:     BFE_INT T30.Z, T6.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T43.W, T3.Z, 0.0, literal.x,
+; EG-NEXT:     LSHR * T6.W, T20.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T45.X, T20.Z, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T21.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T43.Z, T4.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T44.W, T4.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T30.Y, PS, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T43.Z, T3.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T44.W, T5.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T5.W, T20.X, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T20.X, T19.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T43.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T44.Z, T4.W, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.W, T3.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T45.W, T2.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T4.W, T20.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T46.X, T19.X, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T44.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T45.Z, T3.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T45.Z, T2.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T20.W, T3.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T3.W, T20.Z, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T47.X, T19.W, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T45.Y, PS, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T20.Z, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BFE_INT T46.W, T2.Z, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T46.W, T1.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR * T2.W, T19.Y, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T48.X, T19.Z, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T20.Y, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T46.Z, T2.Y, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T46.Z, T1.Y, 0.0, literal.x,
 ; EG-NEXT:     BFE_INT T47.W, T1.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 192(2.690493e-43)
-; EG-NEXT:     LSHR T19.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T46.Y, T1.Z, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T47.Z, T1.Y, 0.0, literal.y,
-; EG-NEXT:     BFE_INT T48.W, T0.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T49.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T47.Y, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T1.W, T19.X, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T19.X, T21.X, literal.x,
+; EG-NEXT:     BFE_INT T46.Y, PS, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T47.Z, T0.W, 0.0, literal.y,
+; EG-NEXT:     BFE_INT T48.W, T0.Z, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T19.W, literal.y,
+; EG-NEXT:    48(6.726233e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T49.X, T21.X, literal.x,
+; EG-NEXT:     BFE_INT T47.Y, PS, 0.0, literal.y,
 ; EG-NEXT:     BFE_INT T48.Z, T0.Y, 0.0, literal.y,
-; EG-NEXT:     LSHR T0.W, T19.Z, literal.y, BS:VEC_120/SCL_212
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    224(3.138909e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T50.X, PS, literal.x,
-; EG-NEXT:     BFE_INT * T48.Y, PV.W, 0.0, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     LSHR T0.W, T19.Z, literal.y,
+; EG-NEXT:     ADD_INT * T50.X, T21.X, literal.z,
+; EG-NEXT:    60(8.407791e-44), 8(1.121039e-44)
+; EG-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT * T48.Y, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v64i8_to_v64i32:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @32, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 1 @24
-; CM-NEXT:    ALU 39, @33, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 1 @28
-; CM-NEXT:    ALU 84, @73, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 73, @158, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T50.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T49, T23.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T48, T38.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T37.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T36.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T46, T35.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T34.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T33.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T32.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T31.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T30.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T29.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T27.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T26.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T25.X
+; CM-NEXT:    TEX 0 @24
+; CM-NEXT:    ALU 17, @33, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    TEX 2 @26
+; CM-NEXT:    ALU 84, @51, KC0[], KC1[]
+; CM-NEXT:    ALU 72, @136, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T50.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T47, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T46, T49.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T45, T48.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T44, T35.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T34.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T43, T33.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T42, T32.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T31.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T29.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T28.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T26.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T22.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    Fetch clause starting at 24:
-; CM-NEXT:     VTX_READ_128 T19.XYZW, T22.X, 0, #1
-; CM-NEXT:     VTX_READ_128 T20.XYZW, T22.X, 16, #1
-; CM-NEXT:    Fetch clause starting at 28:
-; CM-NEXT:     VTX_READ_128 T28.XYZW, T22.X, 48, #1
-; CM-NEXT:     VTX_READ_128 T22.XYZW, T22.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T19.XYZW, T20.X, 0, #1
+; CM-NEXT:    Fetch clause starting at 26:
+; CM-NEXT:     VTX_READ_128 T24.XYZW, T20.X, 48, #1
+; CM-NEXT:     VTX_READ_128 T25.XYZW, T20.X, 32, #1
+; CM-NEXT:     VTX_READ_128 T20.XYZW, T20.X, 16, #1
 ; CM-NEXT:    ALU clause starting at 32:
-; CM-NEXT:     MOV * T22.X, KC0[2].Z,
+; CM-NEXT:     MOV * T20.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 33:
-; CM-NEXT:     LSHR T0.Y, T19.Y, literal.x,
-; CM-NEXT:     LSHR T0.Z, T19.Y, literal.y,
-; CM-NEXT:     LSHR * T0.W, T19.X, literal.x,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:     LSHR T21.X, T19.Y, literal.x,
+; CM-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHR T0.Y, T19.Y, literal.y,
+; CM-NEXT:     LSHR T0.Z, T19.X, literal.z,
+; CM-NEXT:     LSHR * T0.W, T19.Y, literal.w,
+; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; CM-NEXT:     ADD_INT T22.X, PV.X, literal.x,
 ; CM-NEXT:     LSHR T1.Y, T19.X, literal.y,
 ; CM-NEXT:     LSHR T1.Z, T19.W, literal.z,
-; CM-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; CM-NEXT:     LSHR T23.X, T19.X, literal.x,
+; CM-NEXT:     LSHR * T1.W, T19.X, literal.w,
+; CM-NEXT:    56(7.847271e-44), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; CM-NEXT:     ADD_INT T23.X, T21.X, literal.x,
 ; CM-NEXT:     LSHR T2.Y, T19.W, literal.y,
 ; CM-NEXT:     LSHR T2.Z, T19.Z, literal.z,
-; CM-NEXT:     LSHR * T2.W, T19.W, literal.x,
-; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T24.X, T19.Z, literal.x,
-; CM-NEXT:     LSHR T3.Y, T20.Y, literal.y,
-; CM-NEXT:     LSHR T3.Z, T19.Z, literal.z,
-; CM-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.w,
+; CM-NEXT:     LSHR * T2.W, T19.W, literal.w,
+; CM-NEXT:    60(8.407791e-44), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; CM-NEXT:    ALU clause starting at 51:
+; CM-NEXT:     LSHR T3.Z, T19.Z, literal.x,
+; CM-NEXT:     LSHR * T3.W, T20.Y, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 224(3.138909e-43)
-; CM-NEXT:     LSHR T25.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T26.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T3.Y, T19.Z, literal.y,
+; CM-NEXT:     LSHR T4.Z, T20.Y, literal.z,
+; CM-NEXT:     LSHR * T4.W, T20.X, literal.w, BS:VEC_120/SCL_212
+; CM-NEXT:    48(6.726233e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T27.X, T21.X, literal.x,
 ; CM-NEXT:     LSHR T4.Y, T20.Y, literal.y,
-; CM-NEXT:     LSHR T4.Z, T20.X, literal.z,
-; CM-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 240(3.363116e-43)
-; CM-NEXT:     LSHR T26.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T5.Y, T20.Y, literal.y,
-; CM-NEXT:     LSHR T5.Z, T20.X, literal.z,
-; CM-NEXT:     ADD_INT * T3.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:    16(2.242078e-44), 192(2.690493e-43)
-; CM-NEXT:     LSHR T27.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T6.Y, T20.W, literal.y,
-; CM-NEXT:     LSHR T6.Z, T20.X, literal.z,
-; CM-NEXT:     LSHR * T3.W, T20.W, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; CM-NEXT:    ALU clause starting at 73:
-; CM-NEXT:     LSHR T7.Z, T20.Z, literal.x,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.y,
-; CM-NEXT:    8(1.121039e-44), 208(2.914701e-43)
-; CM-NEXT:     LSHR T29.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T7.Y, T20.W, literal.y,
-; CM-NEXT:     LSHR T8.Z, T20.Z, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:    16(2.242078e-44), 160(2.242078e-43)
-; CM-NEXT:     LSHR T30.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T8.Y, T22.Y, literal.y,
-; CM-NEXT:     LSHR T9.Z, T20.Z, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 176(2.466285e-43)
-; CM-NEXT:     LSHR T31.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T9.Y, T22.Y, literal.y,
-; CM-NEXT:     LSHR T10.Z, T22.X, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 128(1.793662e-43)
-; CM-NEXT:     LSHR T32.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T10.Y, T22.Y, literal.y,
-; CM-NEXT:     LSHR T11.Z, T22.X, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:    16(2.242078e-44), 144(2.017870e-43)
-; CM-NEXT:     LSHR T33.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T11.Y, T22.W, literal.y,
-; CM-NEXT:     LSHR T12.Z, T22.X, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 96(1.345247e-43)
-; CM-NEXT:     LSHR T34.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T12.Y, T22.W, literal.y,
-; CM-NEXT:     LSHR T13.Z, T22.Z, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 112(1.569454e-43)
-; CM-NEXT:     LSHR T35.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T13.Y, T22.W, literal.y,
-; CM-NEXT:     LSHR T14.Z, T22.Z, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:    16(2.242078e-44), 64(8.968310e-44)
-; CM-NEXT:     LSHR T36.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T14.Y, T28.Y, literal.y,
-; CM-NEXT:     LSHR T15.Z, T22.Z, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    24(3.363116e-44), 80(1.121039e-43)
-; CM-NEXT:     LSHR T37.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T15.Y, T28.Y, literal.y,
-; CM-NEXT:     LSHR T16.Z, T28.X, literal.z,
-; CM-NEXT:     ADD_INT * T4.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; CM-NEXT:     LSHR T38.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T16.Y, T28.Y, literal.y,
-; CM-NEXT:     LSHR T17.Z, T28.X, literal.z,
-; CM-NEXT:     LSHR * T4.W, T28.W, literal.w,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
+; CM-NEXT:     LSHR T5.Z, T20.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T5.W, T20.W, literal.w,
+; CM-NEXT:    52(7.286752e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
-; CM-NEXT:     BFE_INT T39.X, T28.Z, 0.0, literal.x,
-; CM-NEXT:     LSHR T17.Y, T28.X, literal.y,
-; CM-NEXT:     LSHR T18.Z, T28.W, literal.z,
-; CM-NEXT:     LSHR * T5.W, T28.Z, literal.y,
+; CM-NEXT:     ADD_INT T28.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T5.Y, T20.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T6.Z, T20.W, literal.z,
+; CM-NEXT:     LSHR * T6.W, T20.Z, literal.w,
+; CM-NEXT:    40(5.605194e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T29.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T6.Y, T20.W, literal.y,
+; CM-NEXT:     LSHR T7.Z, T20.Z, literal.z,
+; CM-NEXT:     LSHR * T7.W, T25.Y, literal.w,
+; CM-NEXT:    44(6.165713e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T30.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T7.Y, T20.Z, literal.y,
+; CM-NEXT:     LSHR T8.Z, T25.Y, literal.z,
+; CM-NEXT:     LSHR * T8.W, T25.X, literal.w, BS:VEC_120/SCL_212
+; CM-NEXT:    32(4.484155e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T31.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T8.Y, T25.Y, literal.y,
+; CM-NEXT:     LSHR T9.Z, T25.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T9.W, T25.W, literal.w,
+; CM-NEXT:    36(5.044674e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T32.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T9.Y, T25.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T10.Z, T25.W, literal.y,
+; CM-NEXT:     LSHR * T10.W, T25.Z, literal.z,
+; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T33.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T10.Y, T25.W, literal.y,
+; CM-NEXT:     LSHR T11.Z, T25.Z, literal.z,
+; CM-NEXT:     LSHR * T11.W, T24.Y, literal.w,
+; CM-NEXT:    28(3.923636e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T34.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T11.Y, T25.Z, literal.y,
+; CM-NEXT:     LSHR T12.Z, T24.Y, literal.x,
+; CM-NEXT:     LSHR * T12.W, T24.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T35.X, T21.X, literal.x,
+; CM-NEXT:     LSHR T12.Y, T24.Y, literal.y,
+; CM-NEXT:     LSHR T13.Z, T24.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T13.W, T24.W, literal.w,
+; CM-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; CM-NEXT:     BFE_INT T36.X, T24.Z, 0.0, literal.x,
+; CM-NEXT:     LSHR T13.Y, T24.X, literal.y,
+; CM-NEXT:     LSHR T14.Z, T24.W, literal.z,
+; CM-NEXT:     LSHR * T14.W, T24.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T40.X, T28.W, 0.0, literal.x,
-; CM-NEXT:     LSHR T18.Y, T28.W, literal.y,
-; CM-NEXT:     LSHR T21.Z, T28.Z, literal.z,
-; CM-NEXT:     BFE_INT * T39.W, PV.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.X, T24.W, 0.0, literal.x,
+; CM-NEXT:     LSHR T14.Y, T24.W, literal.y,
+; CM-NEXT:     LSHR T15.Z, T24.Z, literal.z,
+; CM-NEXT:     BFE_INT * T36.W, PV.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T28.X, T28.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T21.Y, T28.Z, literal.x,
-; CM-NEXT:     BFE_INT T39.Z, PV.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T40.W, PV.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T24.X, T24.X, 0.0, literal.x,
+; CM-NEXT:     LSHR T15.Y, T24.Z, literal.x,
+; CM-NEXT:     BFE_INT T36.Z, PV.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T37.W, PV.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T41.X, T28.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T39.Y, PV.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T40.Z, T18.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T28.W, T17.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T38.X, T24.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T36.Y, PV.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.Z, T14.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T24.W, T13.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:    ALU clause starting at 158:
-; CM-NEXT:     BFE_INT T42.X, T22.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T40.Y, T4.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T28.Z, T17.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T41.W, T16.Y, 0.0, literal.x,
+; CM-NEXT:    ALU clause starting at 136:
+; CM-NEXT:     BFE_INT T39.X, T25.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.Y, T13.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T24.Z, T13.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T38.W, T12.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T43.X, T22.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T28.Y, T16.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T41.Z, T15.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T42.W, T15.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T40.X, T25.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T24.Y, T12.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T38.Z, T12.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T39.W, T11.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T22.X, T22.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T41.Y, T14.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T42.Z, T14.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T43.W, T13.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T25.X, T25.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T38.Y, T11.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.Z, T11.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T40.W, T10.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T44.X, T22.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T42.Y, T13.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T43.Z, T12.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T22.W, T12.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T41.X, T25.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.Y, T10.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.Z, T10.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T25.W, T9.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T45.X, T20.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T43.Y, T11.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T22.Z, T11.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T44.W, T10.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T42.X, T20.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.Y, T9.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T25.Z, T9.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T41.W, T8.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T46.X, T20.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T22.Y, T10.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T44.Z, T9.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T45.W, T9.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T43.X, T20.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T25.Y, T8.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T41.Z, T8.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T42.W, T7.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T20.X, T20.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T44.Y, T8.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T45.Z, T8.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T46.W, T7.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T41.Y, T7.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T42.Z, T7.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T43.W, T6.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T47.X, T20.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T45.Y, T7.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T46.Z, T3.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T20.W, T6.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T44.X, T20.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T42.Y, T6.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T43.Z, T6.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T20.W, T5.Y, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T48.X, T19.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T46.Y, T6.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T45.X, T19.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T43.Y, T5.W, 0.0, literal.x,
 ; CM-NEXT:     BFE_INT T20.Z, T5.Z, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T47.W, T5.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T44.W, T4.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T49.X, T19.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T20.Y, T4.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T47.Z, T4.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T48.W, T3.Z, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T46.X, T19.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.Y, T4.W, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T44.Z, T4.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T45.W, T3.Y, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T19.X, T19.X, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T47.Y, T3.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T48.Z, T24.X, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T49.W, T2.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T47.X, T19.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T44.Y, T3.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T45.Z, T3.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T46.W, T2.W, 0.0, literal.x, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T24.X, T19.Y, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T48.Y, T2.Z, 0.0, literal.x,
-; CM-NEXT:     BFE_INT T49.Z, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
-; CM-NEXT:     BFE_INT * T19.W, T23.X, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T19.X, T19.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T45.Y, T2.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T46.Z, T2.Y, 0.0, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT * T47.W, T1.W, 0.0, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T23.X, T1.W, literal.x,
-; CM-NEXT:     BFE_INT T49.Y, T1.Z, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T19.Z, T1.Y, 0.0, literal.y,
-; CM-NEXT:     BFE_INT * T24.W, T21.X, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; CM-NEXT:     BFE_INT T19.Y, T0.W, 0.0, literal.y,
-; CM-NEXT:     BFE_INT T24.Z, T0.Z, 0.0, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T50.X, PV.W, literal.x,
-; CM-NEXT:     BFE_INT * T24.Y, T0.Y, 0.0, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T48.X, T21.X, literal.x,
+; CM-NEXT:     BFE_INT T46.Y, T1.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T47.Z, T1.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT * T19.W, T0.W, 0.0, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T49.X, T21.X, literal.x,
+; CM-NEXT:     BFE_INT T47.Y, T0.Z, 0.0, literal.y,
+; CM-NEXT:     BFE_INT T19.Z, T0.Y, 0.0, literal.y,
+; CM-NEXT:     LSHR * T0.W, T19.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:    12(1.681558e-44), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T50.X, T21.X, literal.x,
+; CM-NEXT:     BFE_INT * T19.Y, PV.W, 0.0, literal.y,
+; CM-NEXT:    4(5.605194e-45), 8(1.121039e-44)
   %load = load <64 x i8>, ptr addrspace(1) %in
   %ext = sext <64 x i8> %load to <64 x i32>
   store <64 x i32> %ext, ptr addrspace(1) %out
@@ -5799,7 +5614,7 @@ define amdgpu_kernel void @global_zextload_v4i8_to_v4i64(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
-; EG-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T6.X, 1
 ; EG-NEXT:    CF_END
@@ -5821,19 +5636,18 @@ define amdgpu_kernel void @global_zextload_v4i8_to_v4i64(ptr addrspace(1) %out, 
 ; EG-NEXT:     MOV T5.W, 0.0,
 ; EG-NEXT:     MOV * T4.W, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR * T7.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T7.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v4i8_to_v4i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T4.X
+; CM-NEXT:    ALU 16, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T4.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T7.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
@@ -5853,12 +5667,10 @@ define amdgpu_kernel void @global_zextload_v4i8_to_v4i64(ptr addrspace(1) %out, 
 ; CM-NEXT:     MOV T6.Y, 0.0,
 ; CM-NEXT:     MOV * T5.W, 0.0,
 ; CM-NEXT:     MOV * T6.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T4.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T4.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T7.X, PV.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <4 x i8>, ptr addrspace(1) %in
   %ext = zext <4 x i8> %load to <4 x i64>
   store <4 x i64> %ext, ptr addrspace(1) %out
@@ -5961,66 +5773,65 @@ define amdgpu_kernel void @global_sextload_v4i8_to_v4i64(ptr addrspace(1) %out, 
 ; EG-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @6
 ; EG-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T7.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T6.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T7.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T4.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 8:
 ; EG-NEXT:     MOV * T4.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 9:
-; EG-NEXT:     BFE_INT T5.X, T4.X, 0.0, literal.x,
-; EG-NEXT:     ASHR T4.W, T4.X, literal.y,
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.z,
+; EG-NEXT:     ASHR * T5.W, T4.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.X, T4.X, 0.0, literal.x,
+; EG-NEXT:     ASHR T5.Z, T4.X, literal.y,
+; EG-NEXT:     LSHR * T0.W, T4.X, literal.z,
+; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T5.X, PV.W, 0.0, literal.x,
+; EG-NEXT:     ASHR T6.Y, PV.X, literal.y,
+; EG-NEXT:     LSHR T0.W, T4.X, literal.x,
+; EG-NEXT:     LSHR * T4.X, KC0[2].Y, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.x,
-; EG-NEXT:     ASHR T4.Z, T4.X, literal.y,
-; EG-NEXT:     LSHR T0.W, T4.X, literal.z,
-; EG-NEXT:     LSHR * T1.W, T4.X, literal.w,
-; EG-NEXT:    31(4.344025e-44), 24(3.363116e-44)
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T4.X, PS, 0.0, literal.x,
-; EG-NEXT:     BFE_INT T5.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T7.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T4.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR * T5.W, PV.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT * T6.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T7.X, T4.X, literal.x,
+; EG-NEXT:     ASHR T5.Y, T5.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ASHR * T6.W, PV.Z, literal.y,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
 ;
 ; CM-LABEL: global_sextload_v4i8_to_v4i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @8, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @6
-; CM-NEXT:    ALU 18, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 17, @9, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T4.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T6.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 6:
 ; CM-NEXT:     VTX_READ_32 T4.X, T4.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 8:
 ; CM-NEXT:     MOV * T4.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 9:
-; CM-NEXT:     BFE_INT T5.X, T4.X, 0.0, literal.x,
-; CM-NEXT:     LSHR T0.Y, T4.X, literal.x,
-; CM-NEXT:     ADD_INT T0.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     ASHR * T4.W, T4.X, literal.z,
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:     ASHR * T5.W, T4.X, literal.x,
 ; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T6.X, PV.Z, literal.x,
-; CM-NEXT:     ASHR T5.Y, PV.X, literal.y,
-; CM-NEXT:     ASHR T4.Z, T4.X, literal.z,
-; CM-NEXT:     LSHR * T0.W, T4.X, literal.w,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; CM-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; CM-NEXT:     BFE_INT T4.X, PV.W, 0.0, literal.x,
-; CM-NEXT:     BFE_INT * T5.Z, T0.Y, 0.0, literal.x,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:     ASHR T4.Y, PV.X, literal.y,
-; CM-NEXT:     ASHR * T5.W, PV.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:     BFE_INT T6.X, T4.X, 0.0, literal.x,
+; CM-NEXT:     ASHR T5.Z, T4.X, literal.y,
+; CM-NEXT:     LSHR * T0.W, T4.X, literal.z,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     BFE_INT T5.X, PV.W, 0.0, literal.x,
+; CM-NEXT:     ASHR T6.Y, PV.X, literal.y,
+; CM-NEXT:     LSHR * T0.W, T4.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; CM-NEXT:     LSHR T4.X, KC0[2].Y, literal.x,
+; CM-NEXT:     BFE_INT * T6.Z, PV.W, 0.0, literal.y,
+; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     ADD_INT T7.X, PV.X, literal.x,
+; CM-NEXT:     ASHR T5.Y, T5.X, literal.y,
+; CM-NEXT:     ASHR * T6.W, PV.Z, literal.y,
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <4 x i8>, ptr addrspace(1) %in
   %ext = sext <4 x i8> %load to <4 x i64>
   store <4 x i64> %ext, ptr addrspace(1) %out
@@ -6151,7 +5962,7 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 34, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 30, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T12.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T11.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T10.X, 0
@@ -6186,27 +5997,23 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
 ; EG-NEXT:     MOV T8.W, 0.0,
 ; EG-NEXT:     MOV * T5.W, 0.0,
-; EG-NEXT:     LSHR T9.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR * T12.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T9.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T10.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T11.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT * T12.X, T9.X, literal.x,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v8i8_to_v8i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 35, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T11.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T10.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T9.X
+; CM-NEXT:    ALU 31, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T9.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T12.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T11.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T10.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
@@ -6237,18 +6044,14 @@ define amdgpu_kernel void @global_zextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; CM-NEXT:     MOV * T7.W, 0.0,
 ; CM-NEXT:     MOV * T8.W, 0.0,
 ; CM-NEXT:     MOV * T5.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T10.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T11.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T9.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T12.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T10.X, PV.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T11.X, T9.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T12.X, T9.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <8 x i8>, ptr addrspace(1) %in
   %ext = zext <8 x i8> %load to <8 x i64>
   store <8 x i64> %ext, ptr addrspace(1) %out
@@ -6439,33 +6242,29 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
-; EG-NEXT:    ALU 39, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 34, @11, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T12.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T9.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T6.XYZW, T9.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T8.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T6.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T7.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 8:
 ; EG-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 10:
 ; EG-NEXT:     MOV * T5.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 11:
-; EG-NEXT:     LSHR * T6.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T7.X, T5.Y, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T8.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T7.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T6.X, T5.Y, 0.0, literal.x,
+; EG-NEXT:     LSHR * T7.X, KC0[2].Y, literal.y,
+; EG-NEXT:    8(1.121039e-44), 2(2.802597e-45)
+; EG-NEXT:     ADD_INT T8.X, PS, literal.x,
+; EG-NEXT:     ASHR T6.Y, PV.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T5.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T9.X, PS, literal.x,
-; EG-NEXT:     BFE_INT T7.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ASHR * T10.W, T5.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T9.X, PS, literal.z,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T6.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:     ASHR * T10.W, T5.X, literal.y,
+; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T11.X, T5.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T10.Z, T5.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T5.X, literal.z,
@@ -6482,49 +6281,43 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; EG-NEXT:     BFE_INT T5.X, PS, 0.0, literal.x,
 ; EG-NEXT:     ASHR T10.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T11.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T12.X, T7.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T12.X, PV.W, literal.x,
-; EG-NEXT:     ASHR T5.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR T11.W, PV.Z, literal.y,
-; EG-NEXT:     ASHR * T7.W, T7.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T5.Y, PV.X, literal.x,
+; EG-NEXT:     ASHR T11.W, PV.Z, literal.x,
+; EG-NEXT:     ASHR * T6.W, T6.Z, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_sextload_v8i8_to_v8i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
-; CM-NEXT:    ALU 39, @11, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T9.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T8.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T6.X
+; CM-NEXT:    ALU 34, @11, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T7.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T5, T12.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T6, T9.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T8.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 8:
 ; CM-NEXT:     VTX_READ_64 T5.XY, T5.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 10:
 ; CM-NEXT:     MOV * T5.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 11:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T6.X, PV.W, literal.x,
+; CM-NEXT:     BFE_INT * T6.X, T5.Y, 0.0, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T7.X, T5.Y, 0.0, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    8(1.121039e-44), 32(4.484155e-44)
-; CM-NEXT:     LSHR T8.X, PV.W, literal.x,
-; CM-NEXT:     ASHR T7.Y, PV.X, literal.y,
-; CM-NEXT:     LSHR T0.Z, T5.Y, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Y, T5.X, literal.y,
-; CM-NEXT:     BFE_INT T7.Z, PV.Z, 0.0, literal.y,
-; CM-NEXT:     ASHR * T10.W, T5.Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T8.X, PV.X, literal.x,
+; CM-NEXT:     ASHR T6.Y, T6.X, literal.y,
+; CM-NEXT:     LSHR * T0.W, T5.Y, literal.z,
+; CM-NEXT:    12(1.681558e-44), 31(4.344025e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T9.X, T7.X, literal.x,
+; CM-NEXT:     LSHR T0.Y, T5.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T6.Z, PV.W, 0.0, literal.x,
+; CM-NEXT:     ASHR * T10.W, T5.Y, literal.y,
+; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:     BFE_INT T11.X, T5.X, 0.0, literal.x,
 ; CM-NEXT:     LSHR T1.Y, T5.Y, literal.y,
 ; CM-NEXT:     ASHR T10.Z, T5.Y, literal.z,
@@ -6540,12 +6333,12 @@ define amdgpu_kernel void @global_sextload_v8i8_to_v8i64(ptr addrspace(1) %out, 
 ; CM-NEXT:     BFE_INT T5.X, PV.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T10.Y, PV.X, literal.y,
 ; CM-NEXT:     BFE_INT T11.Z, T0.Y, 0.0, literal.x,
-; CM-NEXT:     ASHR * T7.W, T7.Z, literal.y,
+; CM-NEXT:     ASHR * T6.W, T6.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T12.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T12.X, T7.X, literal.x,
 ; CM-NEXT:     ASHR T5.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR * T11.W, PV.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <8 x i8>, ptr addrspace(1) %in
   %ext = sext <8 x i8> %load to <8 x i64>
   store <8 x i64> %ext, ptr addrspace(1) %out
@@ -6752,7 +6545,7 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 68, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 58, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T8.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T9.XYZW, T21.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T10.XYZW, T20.X, 0
@@ -6813,43 +6606,33 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV * T13.W, 0.0,
 ; EG-NEXT:     MOV T14.W, 0.0,
 ; EG-NEXT:     MOV * T7.W, 0.0,
-; EG-NEXT:     LSHR T15.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR * T22.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T15.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T16.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T18.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T15.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T20.X, T15.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T15.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT * T22.X, T15.X, literal.x,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v16i8_to_v16i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @12
-; CM-NEXT:    ALU 69, @15, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T19.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T15.X
+; CM-NEXT:    ALU 61, @15, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T8, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T9, T22.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T10, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T20.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T17.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T16.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
@@ -6902,30 +6685,22 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; CM-NEXT:     MOV * T7.W, 0.0,
 ; CM-NEXT:     MOV * T13.W, 0.0,
 ; CM-NEXT:     MOV * T14.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T16.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T18.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T19.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T21.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T15.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T22.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T16.X, PV.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T17.X, T15.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T18.X, T15.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T19.X, T15.X, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T20.X, T15.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T21.X, T15.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T22.X, T15.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <16 x i8>, ptr addrspace(1) %in
   %ext = zext <16 x i8> %load to <16 x i64>
   store <16 x i64> %ext, ptr addrspace(1) %out
@@ -7248,7 +7023,7 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @12
-; EG-NEXT:    ALU 78, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 67, @15, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T22.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T16.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T15.X, 0
@@ -7263,39 +7038,30 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T7.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     LSHR T8.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T9.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T10.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T11.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR * T12.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T9.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T10.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T11.X, T8.X, literal.x,
+; EG-NEXT:     ADD_INT * T12.X, T8.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT * T13.X, T7.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T14.X, T7.Y, 0.0, literal.x,
 ; EG-NEXT:     ASHR T13.Y, PV.X, literal.y,
 ; EG-NEXT:     LSHR T0.W, T7.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T15.X, T8.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T15.X, PS, literal.x,
-; EG-NEXT:     ASHR T14.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T13.Z, PV.W, 0.0, literal.z,
-; EG-NEXT:     LSHR T0.W, T7.Y, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 96(1.345247e-43)
-; EG-NEXT:     LSHR T16.X, PS, literal.x,
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T14.Y, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T13.Z, PV.W, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T7.Y, literal.y,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T8.X, literal.x,
 ; EG-NEXT:     BFE_INT T14.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ASHR * T17.W, T7.X, literal.z,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; EG-NEXT:     ASHR * T17.W, T7.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:    24(3.363116e-44), 8(1.121039e-44)
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T18.X, T7.X, 0.0, literal.x,
 ; EG-NEXT:     ASHR T17.Z, T7.X, literal.y,
@@ -7313,22 +7079,20 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG-NEXT:     BFE_INT T19.X, PS, 0.0, literal.x,
 ; EG-NEXT:     ASHR T17.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T18.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.z,
 ; EG-NEXT:     ASHR * T20.W, T7.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    112(1.569454e-43), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T7.X, T7.Z, 0.0, literal.x,
 ; EG-NEXT:     ASHR T19.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T20.Z, T7.Z, literal.z,
-; EG-NEXT:     LSHR T1.W, T7.Z, literal.w,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.w,
 ; EG-NEXT:     ASHR * T21.W, T7.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T20.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T7.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T21.Z, T7.W, literal.z,
-; EG-NEXT:     LSHR T1.W, T7.Z, literal.x,
-; EG-NEXT:     LSHR * T2.W, T7.W, literal.w,
+; EG-NEXT:     LSHR T0.W, T7.Z, literal.x,
+; EG-NEXT:     LSHR * T1.W, T7.W, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T21.X, PS, 0.0, literal.x,
@@ -7337,73 +7101,63 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; EG-NEXT:     ASHR T18.W, T18.Z, literal.y,
 ; EG-NEXT:     ASHR * T14.W, T14.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T22.X, T0.W, literal.x,
+; EG-NEXT:     ADD_INT T22.X, T8.X, literal.x,
 ; EG-NEXT:     ASHR T21.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T7.W, PV.Z, literal.y,
 ; EG-NEXT:     ASHR * T13.W, T13.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    28(3.923636e-44), 31(4.344025e-44)
 ;
 ; CM-LABEL: global_sextload_v16i8_to_v16i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @12
-; CM-NEXT:    ALU 79, @15, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T15.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T12.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T11.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T10.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T9.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T8.X
+; CM-NEXT:    ALU 69, @15, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T8.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T7, T22.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T16.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T12.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T11.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T10.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T9.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 12:
 ; CM-NEXT:     VTX_READ_128 T7.XYZW, T7.X, 0, #1
 ; CM-NEXT:    ALU clause starting at 14:
 ; CM-NEXT:     MOV * T7.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 15:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    112(1.569454e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T8.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T9.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T10.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T11.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T12.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Z, T7.X, literal.y,
-; CM-NEXT:     LSHR * T0.W, T7.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
+; CM-NEXT:     LSHR * T8.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T9.X, PV.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T10.X, T8.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T11.X, T8.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T12.X, T8.X, literal.x,
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T13.X, T7.Y, 0.0, literal.x,
-; CM-NEXT:     LSHR T0.Y, T7.Y, literal.y,
-; CM-NEXT:     LSHR T1.Z, T7.Z, literal.x,
-; CM-NEXT:     LSHR * T1.W, T7.W, literal.x,
+; CM-NEXT:     LSHR T0.Y, T7.X, literal.x,
+; CM-NEXT:     LSHR T0.Z, T7.X, literal.y,
+; CM-NEXT:     LSHR * T0.W, T7.Y, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:     BFE_INT T14.X, T7.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T13.Y, PV.X, literal.y,
-; CM-NEXT:     LSHR T2.Z, T7.Y, literal.x,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.z,
+; CM-NEXT:     LSHR T1.Z, T7.Z, literal.x,
+; CM-NEXT:     LSHR * T1.W, T7.Y, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
+; CM-NEXT:     ADD_INT T15.X, T8.X, literal.x,
 ; CM-NEXT:     ASHR T14.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T13.Z, PV.Z, 0.0, literal.z,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; CM-NEXT:     LSHR T16.X, PV.W, literal.x,
+; CM-NEXT:     BFE_INT T13.Z, PV.W, 0.0, literal.z,
+; CM-NEXT:     LSHR * T1.W, T7.W, literal.z,
+; CM-NEXT:    12(1.681558e-44), 31(4.344025e-44)
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T16.X, T8.X, literal.x,
 ; CM-NEXT:     LSHR T1.Y, T7.Z, literal.y,
-; CM-NEXT:     BFE_INT T14.Z, T1.W, 0.0, literal.z,
-; CM-NEXT:     ASHR * T17.W, T7.W, literal.w, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; CM-NEXT:     BFE_INT T14.Z, PV.W, 0.0, literal.x,
+; CM-NEXT:     ASHR * T17.W, T7.W, literal.z,
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T18.X, T7.Z, 0.0, literal.x,
 ; CM-NEXT:     LSHR T2.Y, T7.W, literal.y,
 ; CM-NEXT:     ASHR T17.Z, T7.W, literal.z,
@@ -7427,21 +7181,21 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i64(ptr addrspace(1) %out
 ; CM-NEXT:     ASHR * T7.W, T7.X, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T20.X, T0.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T20.X, T0.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T21.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR T7.Z, T7.X, literal.z,
 ; CM-NEXT:     ASHR * T18.W, T18.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T7.X, T0.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T7.X, T0.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR T20.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T21.Z, T0.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T21.Z, T0.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T13.W, T13.Z, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T22.X, T8.X, literal.x,
 ; CM-NEXT:     ASHR T7.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR * T21.W, PV.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <16 x i8>, ptr addrspace(1) %in
   %ext = sext <16 x i8> %load to <16 x i64>
   store <16 x i64> %ext, ptr addrspace(1) %out
@@ -7838,9 +7592,10 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-LABEL: global_zextload_v32i8_to_v32i64:
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 103, @27, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 33, @131, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    TEX 0 @22
+; EG-NEXT:    ALU 12, @27, KC0[], KC1[]
+; EG-NEXT:    TEX 0 @24
+; EG-NEXT:    ALU 102, @40, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T13.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T14.XYZW, T41.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T15.XYZW, T40.X, 0
@@ -7848,7 +7603,7 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T17.XYZW, T38.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T18.XYZW, T37.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T36.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T35.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T35.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T34.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T21.XYZW, T33.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T22.XYZW, T32.X, 0
@@ -7856,88 +7611,90 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T24.XYZW, T30.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T25.XYZW, T29.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T28.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T12.XYZW, T27.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T11.XYZW, T27.X, 1
 ; EG-NEXT:    CF_END
-; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 22:
-; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
-; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 16, #1
+; EG-NEXT:    Fetch clause starting at 24:
+; EG-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 0, #1
 ; EG-NEXT:    ALU clause starting at 26:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 27:
 ; EG-NEXT:     MOV * T0.W, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T13.X, T11.W, literal.x, PV.W,
-; EG-NEXT:     LSHR * T13.Z, T11.W, literal.y,
+; EG-NEXT:     BFE_UINT T13.X, T12.W, literal.x, PV.W,
+; EG-NEXT:     LSHR * T13.Z, T12.W, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T13.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T14.Z, T11.W, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T14.Z, T12.W, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T14.X, T11.W, literal.x,
+; EG-NEXT:     AND_INT T14.X, T12.W, literal.x,
 ; EG-NEXT:     MOV * T14.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T15.X, T11.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T15.Z, T11.Z, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     BFE_UINT * T15.X, T12.Z, literal.x, T0.W,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 40:
+; EG-NEXT:     LSHR * T15.Z, T12.Z, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T15.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T16.Z, T11.Z, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T16.Z, T12.Z, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T16.X, T11.Z, literal.x,
+; EG-NEXT:     AND_INT T16.X, T12.Z, literal.x,
 ; EG-NEXT:     MOV * T16.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T17.X, T11.Y, literal.x, T0.W,
-; EG-NEXT:     LSHR * T17.Z, T11.Y, literal.y,
+; EG-NEXT:     BFE_UINT T17.X, T12.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T17.Z, T12.Y, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T17.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T18.Z, T11.Y, literal.x, T0.W,
+; EG-NEXT:     BFE_UINT * T18.Z, T12.Y, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T18.X, T11.Y, literal.x,
+; EG-NEXT:     AND_INT T18.X, T12.Y, literal.x,
 ; EG-NEXT:     MOV * T18.Y, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T19.X, T11.X, literal.x, T0.W,
-; EG-NEXT:     LSHR * T19.Z, T11.X, literal.y,
+; EG-NEXT:     BFE_UINT T19.X, T12.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T19.Z, T12.X, literal.y,
 ; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; EG-NEXT:     MOV T19.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T11.Z, T11.X, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T11.X, T11.X, literal.x,
-; EG-NEXT:     MOV * T11.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T20.X, T12.W, literal.x, T0.W,
-; EG-NEXT:     LSHR * T20.Z, T12.W, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T20.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T21.Z, T12.W, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T21.X, T12.W, literal.x,
-; EG-NEXT:     MOV * T21.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T22.X, T12.Z, literal.x, T0.W,
-; EG-NEXT:     LSHR * T22.Z, T12.Z, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T22.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T23.Z, T12.Z, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T23.X, T12.Z, literal.x,
-; EG-NEXT:     MOV * T23.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T24.X, T12.Y, literal.x, T0.W,
-; EG-NEXT:     LSHR * T24.Z, T12.Y, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T24.Y, 0.0,
-; EG-NEXT:     BFE_UINT * T25.Z, T12.Y, literal.x, T0.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     AND_INT T25.X, T12.Y, literal.x,
-; EG-NEXT:     MOV * T25.Y, 0.0,
-; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T26.X, T12.X, literal.x, T0.W,
-; EG-NEXT:     LSHR * T26.Z, T12.X, literal.y,
-; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; EG-NEXT:     MOV T26.Y, 0.0,
 ; EG-NEXT:     BFE_UINT * T12.Z, T12.X, literal.x, T0.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     AND_INT T12.X, T12.X, literal.x,
-; EG-NEXT:     MOV T12.Y, 0.0,
+; EG-NEXT:     MOV * T12.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T20.X, T11.W, literal.x, T0.W,
+; EG-NEXT:     LSHR * T20.Z, T11.W, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T20.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T21.Z, T11.W, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T21.X, T11.W, literal.x,
+; EG-NEXT:     MOV * T21.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T22.X, T11.Z, literal.x, T0.W,
+; EG-NEXT:     LSHR * T22.Z, T11.Z, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T22.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T23.Z, T11.Z, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T23.X, T11.Z, literal.x,
+; EG-NEXT:     MOV * T23.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T24.X, T11.Y, literal.x, T0.W,
+; EG-NEXT:     LSHR * T24.Z, T11.Y, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T24.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T25.Z, T11.Y, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T25.X, T11.Y, literal.x,
+; EG-NEXT:     MOV * T25.Y, 0.0,
+; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T26.X, T11.X, literal.x, T0.W,
+; EG-NEXT:     LSHR * T26.Z, T11.X, literal.y,
+; EG-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; EG-NEXT:     MOV T26.Y, 0.0,
+; EG-NEXT:     BFE_UINT * T11.Z, T11.X, literal.x, T0.W,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T11.X, T11.X, literal.x,
+; EG-NEXT:     MOV T11.Y, 0.0,
 ; EG-NEXT:     MOV T13.W, 0.0,
 ; EG-NEXT:     MOV * T14.W, 0.0,
 ; EG-NEXT:    255(3.573311e-43), 0(0.000000e+00)
@@ -7946,7 +7703,7 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV T17.W, 0.0,
 ; EG-NEXT:     MOV * T18.W, 0.0,
 ; EG-NEXT:     MOV T19.W, 0.0,
-; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     MOV * T12.W, 0.0,
 ; EG-NEXT:     MOV T20.W, 0.0,
 ; EG-NEXT:     MOV * T21.W, 0.0,
 ; EG-NEXT:     MOV T22.W, 0.0,
@@ -7954,167 +7711,145 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:     MOV T24.W, 0.0,
 ; EG-NEXT:     MOV * T25.W, 0.0,
 ; EG-NEXT:     MOV T26.W, 0.0,
-; EG-NEXT:     MOV * T12.W, 0.0,
-; EG-NEXT:     LSHR T27.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T28.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T29.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T30.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR * T31.X, PV.W, literal.x,
+; EG-NEXT:     MOV * T11.W, 0.0,
+; EG-NEXT:     LSHR * T27.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 131:
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T32.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T33.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T34.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T35.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T36.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T37.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T38.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; EG-NEXT:     LSHR T40.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; EG-NEXT:     LSHR T41.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 240(3.363116e-43)
-; EG-NEXT:     LSHR * T42.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T28.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T29.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T30.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T31.X, T27.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T32.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T33.X, T27.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T34.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T35.X, T27.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T36.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T37.X, T27.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T38.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T39.X, T27.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
+; EG-NEXT:     ADD_INT T40.X, T27.X, literal.x,
+; EG-NEXT:     ADD_INT * T41.X, T27.X, literal.y,
+; EG-NEXT:    52(7.286752e-44), 56(7.847271e-44)
+; EG-NEXT:     ADD_INT * T42.X, T27.X, literal.x,
+; EG-NEXT:    60(8.407791e-44), 0(0.000000e+00)
 ;
 ; CM-LABEL: global_zextload_v32i8_to_v32i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    TEX 1 @22
-; CM-NEXT:    ALU 103, @27, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 33, @131, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T42.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T41.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T40.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T39.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T38.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T37.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T36.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T35.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T34.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T33.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T32.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T31.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T30.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T29.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T28.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T27.X
+; CM-NEXT:    TEX 0 @22
+; CM-NEXT:    ALU 12, @27, KC0[], KC1[]
+; CM-NEXT:    TEX 0 @24
+; CM-NEXT:    ALU 108, @40, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T13, T27.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T14, T42.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T41.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T16, T40.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T17, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T38.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T18, T37.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T36.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T35.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T21, T34.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T22, T33.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T23, T32.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T24, T31.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T15, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T25, T29.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T28.X
 ; CM-NEXT:    CF_END
-; CM-NEXT:    PAD
 ; CM-NEXT:    Fetch clause starting at 22:
-; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 16, #1
-; CM-NEXT:     VTX_READ_128 T11.XYZW, T11.X, 0, #1
+; CM-NEXT:     VTX_READ_128 T12.XYZW, T11.X, 0, #1
+; CM-NEXT:    Fetch clause starting at 24:
+; CM-NEXT:     VTX_READ_128 T15.XYZW, T11.X, 16, #1
 ; CM-NEXT:    ALU clause starting at 26:
 ; CM-NEXT:     MOV * T11.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 27:
 ; CM-NEXT:     MOV * T0.W, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT * T13.Z, T11.X, literal.x, PV.W,
+; CM-NEXT:     BFE_UINT * T13.Z, T12.X, literal.x, PV.W,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T13.X, T11.X, literal.x,
+; CM-NEXT:     AND_INT T13.X, T12.X, literal.x,
 ; CM-NEXT:     MOV * T13.Y, 0.0,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T14.X, T11.X, literal.x, T0.W,
-; CM-NEXT:     LSHR * T14.Z, T11.X, literal.y,
+; CM-NEXT:     BFE_UINT T14.X, T12.X, literal.x, T0.W,
+; CM-NEXT:     LSHR * T14.Z, T12.X, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; CM-NEXT:     MOV T14.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T15.Z, T11.Y, literal.x, T0.W,
+; CM-NEXT:     BFE_UINT * T11.Z, T12.Y, literal.x, T0.W,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T15.X, T11.Y, literal.x,
-; CM-NEXT:     MOV * T15.Y, 0.0,
+; CM-NEXT:    ALU clause starting at 40:
+; CM-NEXT:     AND_INT T11.X, T12.Y, literal.x,
+; CM-NEXT:     MOV * T11.Y, 0.0,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T16.X, T11.Y, literal.x, T0.W,
-; CM-NEXT:     LSHR * T16.Z, T11.Y, literal.y,
+; CM-NEXT:     BFE_UINT T16.X, T12.Y, literal.x, T0.W,
+; CM-NEXT:     LSHR * T16.Z, T12.Y, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; CM-NEXT:     MOV T16.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T17.Z, T11.Z, literal.x, T0.W,
+; CM-NEXT:     BFE_UINT * T17.Z, T12.Z, literal.x, T0.W,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T17.X, T11.Z, literal.x,
+; CM-NEXT:     AND_INT T17.X, T12.Z, literal.x,
 ; CM-NEXT:     MOV * T17.Y, 0.0,
-; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T11.X, T11.Z, literal.x, T0.W,
-; CM-NEXT:     LSHR * T11.Z, T11.Z, literal.y,
-; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; CM-NEXT:     MOV T11.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T18.Z, T11.W, literal.x, T0.W,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T18.X, T11.W, literal.x,
-; CM-NEXT:     MOV * T18.Y, 0.0,
-; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T19.X, T11.W, literal.x, T0.W,
-; CM-NEXT:     LSHR * T19.Z, T11.W, literal.y,
-; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; CM-NEXT:     MOV T19.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T20.Z, T12.X, literal.x, T0.W,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T20.X, T12.X, literal.x,
-; CM-NEXT:     MOV * T20.Y, 0.0,
-; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T21.X, T12.X, literal.x, T0.W,
-; CM-NEXT:     LSHR * T21.Z, T12.X, literal.y,
-; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; CM-NEXT:     MOV T21.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T22.Z, T12.Y, literal.x, T0.W,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T22.X, T12.Y, literal.x,
-; CM-NEXT:     MOV * T22.Y, 0.0,
-; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T23.X, T12.Y, literal.x, T0.W,
-; CM-NEXT:     LSHR * T23.Z, T12.Y, literal.y,
-; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
-; CM-NEXT:     MOV T23.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T24.Z, T12.Z, literal.x, T0.W,
-; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T24.X, T12.Z, literal.x,
-; CM-NEXT:     MOV * T24.Y, 0.0,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
 ; CM-NEXT:     BFE_UINT T12.X, T12.Z, literal.x, T0.W,
 ; CM-NEXT:     LSHR * T12.Z, T12.Z, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; CM-NEXT:     MOV T12.Y, 0.0,
-; CM-NEXT:     BFE_UINT * T25.Z, T12.W, literal.x, T0.W,
+; CM-NEXT:     BFE_UINT * T18.Z, T12.W, literal.x, T0.W,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     AND_INT T25.X, T12.W, literal.x,
+; CM-NEXT:     AND_INT T18.X, T12.W, literal.x,
+; CM-NEXT:     MOV * T18.Y, 0.0,
+; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; CM-NEXT:     BFE_UINT T19.X, T12.W, literal.x, T0.W,
+; CM-NEXT:     LSHR * T19.Z, T12.W, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     MOV T19.Y, 0.0,
+; CM-NEXT:     BFE_UINT * T20.Z, T15.X, literal.x, T0.W,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T20.X, T15.X, literal.x,
+; CM-NEXT:     MOV * T20.Y, 0.0,
+; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; CM-NEXT:     BFE_UINT T21.X, T15.X, literal.x, T0.W,
+; CM-NEXT:     LSHR * T21.Z, T15.X, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     MOV T21.Y, 0.0,
+; CM-NEXT:     BFE_UINT * T22.Z, T15.Y, literal.x, T0.W,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T22.X, T15.Y, literal.x,
+; CM-NEXT:     MOV * T22.Y, 0.0,
+; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; CM-NEXT:     BFE_UINT T23.X, T15.Y, literal.x, T0.W,
+; CM-NEXT:     LSHR * T23.Z, T15.Y, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     MOV T23.Y, 0.0,
+; CM-NEXT:     BFE_UINT * T24.Z, T15.Z, literal.x, T0.W,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T24.X, T15.Z, literal.x,
+; CM-NEXT:     MOV * T24.Y, 0.0,
+; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
+; CM-NEXT:     BFE_UINT T15.X, T15.Z, literal.x, T0.W,
+; CM-NEXT:     LSHR * T15.Z, T15.Z, literal.y,
+; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
+; CM-NEXT:     MOV T15.Y, 0.0,
+; CM-NEXT:     BFE_UINT * T25.Z, T15.W, literal.x, T0.W,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     AND_INT T25.X, T15.W, literal.x,
 ; CM-NEXT:     MOV * T25.Y, 0.0,
 ; CM-NEXT:    255(3.573311e-43), 0(0.000000e+00)
-; CM-NEXT:     BFE_UINT T26.X, T12.W, literal.x, T0.W,
-; CM-NEXT:     LSHR * T26.Z, T12.W, literal.y,
+; CM-NEXT:     BFE_UINT T26.X, T15.W, literal.x, T0.W,
+; CM-NEXT:     LSHR * T26.Z, T15.W, literal.y,
 ; CM-NEXT:    16(2.242078e-44), 24(3.363116e-44)
 ; CM-NEXT:     MOV T26.Y, 0.0,
 ; CM-NEXT:     MOV * T13.W, 0.0,
 ; CM-NEXT:     MOV * T14.W, 0.0,
-; CM-NEXT:     MOV * T15.W, 0.0,
+; CM-NEXT:     MOV * T11.W, 0.0,
 ; CM-NEXT:     MOV * T16.W, 0.0,
 ; CM-NEXT:     MOV * T17.W, 0.0,
-; CM-NEXT:     MOV * T11.W, 0.0,
+; CM-NEXT:     MOV * T12.W, 0.0,
 ; CM-NEXT:     MOV * T18.W, 0.0,
 ; CM-NEXT:     MOV * T19.W, 0.0,
 ; CM-NEXT:     MOV * T20.W, 0.0,
@@ -8122,58 +7857,41 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; CM-NEXT:     MOV * T22.W, 0.0,
 ; CM-NEXT:     MOV * T23.W, 0.0,
 ; CM-NEXT:     MOV * T24.W, 0.0,
-; CM-NEXT:     MOV * T12.W, 0.0,
+; CM-NEXT:     MOV * T15.W, 0.0,
 ; CM-NEXT:     MOV * T25.W, 0.0,
 ; CM-NEXT:     MOV * T26.W, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T27.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; CM-NEXT:     LSHR T28.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; CM-NEXT:     LSHR T29.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; CM-NEXT:     LSHR T30.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; CM-NEXT:    ALU clause starting at 131:
-; CM-NEXT:     LSHR T31.X, T0.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; CM-NEXT:     LSHR T32.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; CM-NEXT:     LSHR T33.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; CM-NEXT:     LSHR T34.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; CM-NEXT:     LSHR T35.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; CM-NEXT:     LSHR T36.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; CM-NEXT:     LSHR T37.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; CM-NEXT:     LSHR T38.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; CM-NEXT:     LSHR T40.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:     LSHR * T41.X, PV.W, literal.x,
+; CM-NEXT:     LSHR * T27.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; CM-NEXT:     LSHR * T42.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T28.X, PV.X, literal.x,
+; CM-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T29.X, T27.X, literal.x,
+; CM-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T30.X, T27.X, literal.x,
+; CM-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T31.X, T27.X, literal.x,
+; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T32.X, T27.X, literal.x,
+; CM-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T33.X, T27.X, literal.x,
+; CM-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T34.X, T27.X, literal.x,
+; CM-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T35.X, T27.X, literal.x,
+; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T36.X, T27.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T37.X, T27.X, literal.x,
+; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T38.X, T27.X, literal.x,
+; CM-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T39.X, T27.X, literal.x,
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T40.X, T27.X, literal.x,
+; CM-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T41.X, T27.X, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T42.X, T27.X, literal.x,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %load = load <32 x i8>, ptr addrspace(1) %in
   %ext = zext <32 x i8> %load to <32 x i64>
   store <32 x i64> %ext, ptr addrspace(1) %out
@@ -8782,8 +8500,8 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @22
-; EG-NEXT:    ALU 84, @27, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    ALU 71, @112, KC0[], KC1[]
+; EG-NEXT:    ALU 83, @27, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 50, @111, KC0[], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T41.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T26.XYZW, T31.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T40.XYZW, T30.X, 0
@@ -8808,44 +8526,26 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:    ALU clause starting at 26:
 ; EG-NEXT:     MOV * T11.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 27:
-; EG-NEXT:     LSHR T13.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; EG-NEXT:     LSHR T14.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 32(4.484155e-44)
-; EG-NEXT:     LSHR T15.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; EG-NEXT:     LSHR T16.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 64(8.968310e-44)
-; EG-NEXT:     LSHR T17.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 80(1.121039e-43)
-; EG-NEXT:     LSHR T18.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 96(1.345247e-43)
-; EG-NEXT:     LSHR T19.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; EG-NEXT:     LSHR T20.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; EG-NEXT:     LSHR T21.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; EG-NEXT:     LSHR T22.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; EG-NEXT:     LSHR T23.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; EG-NEXT:     LSHR T24.X, PV.W, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; EG-NEXT:     LSHR * T25.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T14.X, PV.X, literal.x,
+; EG-NEXT:     ADD_INT * T15.X, PV.X, literal.y,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T16.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T17.X, T13.X, literal.y,
+; EG-NEXT:    12(1.681558e-44), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T18.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T19.X, T13.X, literal.y,
+; EG-NEXT:    20(2.802597e-44), 24(3.363116e-44)
+; EG-NEXT:     ADD_INT T20.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T21.X, T13.X, literal.y,
+; EG-NEXT:    28(3.923636e-44), 32(4.484155e-44)
+; EG-NEXT:     ADD_INT T22.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T23.X, T13.X, literal.y,
+; EG-NEXT:    36(5.044674e-44), 40(5.605194e-44)
+; EG-NEXT:     ADD_INT T24.X, T13.X, literal.x,
+; EG-NEXT:     ADD_INT * T25.X, T13.X, literal.y,
+; EG-NEXT:    44(6.165713e-44), 48(6.726233e-44)
 ; EG-NEXT:     BFE_INT * T26.X, T11.W, 0.0, literal.x,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T27.X, T11.Y, 0.0, literal.x,
@@ -8861,78 +8561,74 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:     ASHR T28.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T27.Z, PV.W, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.W, T11.X, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.z,
+; EG-NEXT:     ADD_INT * T30.X, T13.X, literal.z,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:    208(2.914701e-43), 0(0.000000e+00)
-; EG-NEXT:     LSHR T30.X, PS, literal.x,
-; EG-NEXT:     ASHR T29.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T28.Z, PV.W, 0.0, literal.z,
-; EG-NEXT:     LSHR T0.W, T12.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:    8(1.121039e-44), 224(3.138909e-43)
-; EG-NEXT:     LSHR T31.X, PS, literal.x,
+; EG-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; EG-NEXT:     ASHR T29.Y, PV.X, literal.x,
+; EG-NEXT:     BFE_INT T28.Z, PV.W, 0.0, literal.y,
+; EG-NEXT:     LSHR * T0.W, T12.W, literal.y,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     ADD_INT T31.X, T13.X, literal.x,
 ; EG-NEXT:     BFE_INT T29.Z, PV.W, 0.0, literal.y,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.z,
-; EG-NEXT:     ASHR * T32.W, T12.X, literal.w,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:    240(3.363116e-43), 31(4.344025e-44)
+; EG-NEXT:     ASHR * T32.W, T12.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:    56(7.847271e-44), 8(1.121039e-44)
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T33.X, T12.Z, 0.0, literal.x,
 ; EG-NEXT:     LSHR T0.Y, T11.Z, literal.x, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR T32.Z, T12.X, literal.y,
-; EG-NEXT:     LSHR T1.W, T12.X, literal.z,
+; EG-NEXT:     LSHR T0.W, T12.X, literal.z,
 ; EG-NEXT:     ASHR * T34.W, T12.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 24(3.363116e-44)
 ; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
 ; EG-NEXT:     BFE_INT T32.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T33.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T34.Z, T12.Y, literal.z,
-; EG-NEXT:     LSHR T1.W, T12.Z, literal.x,
-; EG-NEXT:     LSHR * T2.W, T12.Y, literal.w,
+; EG-NEXT:     LSHR T0.W, T12.Z, literal.x,
+; EG-NEXT:     LSHR * T1.W, T12.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT * T34.X, PS, 0.0, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 112:
-; EG-NEXT:     ASHR T32.Y, T32.X, literal.x,
-; EG-NEXT:     BFE_INT T33.Z, T1.W, 0.0, literal.y,
-; EG-NEXT:     LSHR T1.W, T11.W, literal.z, BS:VEC_120/SCL_212
-; EG-NEXT:     ASHR * T35.W, T12.Z, literal.x,
-; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
+; EG-NEXT:     BFE_INT T34.X, PS, 0.0, literal.x,
+; EG-NEXT:     ASHR T32.Y, PV.X, literal.y,
+; EG-NEXT:     BFE_INT T33.Z, PV.W, 0.0, literal.x,
+; EG-NEXT:     LSHR T0.W, T11.W, literal.z,
+; EG-NEXT:     ASHR * T35.W, T12.Z, literal.y,
+; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T36.X, T12.X, 0.0, literal.x,
-; EG-NEXT:     ASHR T34.Y, T34.X, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     ASHR T34.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T35.Z, T12.Z, literal.z,
-; EG-NEXT:     LSHR T2.W, T12.Z, literal.w,
+; EG-NEXT:     LSHR T1.W, T12.Z, literal.w,
 ; EG-NEXT:     ASHR * T37.W, T12.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T35.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T36.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T37.Z, T12.W, literal.z,
-; EG-NEXT:     LSHR T2.W, T12.X, literal.x,
-; EG-NEXT:     LSHR * T3.W, T12.W, literal.w,
+; EG-NEXT:     LSHR T1.W, T12.X, literal.x,
+; EG-NEXT:     LSHR * T2.W, T12.W, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     BFE_INT T37.X, PS, 0.0, literal.x,
-; EG-NEXT:     ASHR T35.Y, PV.X, literal.y,
-; EG-NEXT:     BFE_INT T36.Z, PV.W, 0.0, literal.x,
-; EG-NEXT:     LSHR T2.W, T11.Z, literal.z,
-; EG-NEXT:     ASHR * T12.W, T11.X, literal.y,
-; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_INT * T37.X, PS, 0.0, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 111:
+; EG-NEXT:     ASHR T35.Y, T35.X, literal.x,
+; EG-NEXT:     BFE_INT T36.Z, T1.W, 0.0, literal.y,
+; EG-NEXT:     LSHR T1.W, T11.Z, literal.z,
+; EG-NEXT:     ASHR * T12.W, T11.X, literal.x,
+; EG-NEXT:    31(4.344025e-44), 8(1.121039e-44)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
 ; EG-NEXT:     BFE_INT T38.X, T12.Y, 0.0, literal.x,
-; EG-NEXT:     ASHR T37.Y, PV.X, literal.y,
-; EG-NEXT:     ASHR T12.Z, T11.X, literal.z,
-; EG-NEXT:     LSHR T3.W, T11.X, literal.w,
+; EG-NEXT:     ASHR T37.Y, T37.X, literal.y,
+; EG-NEXT:     ASHR T12.Z, T11.X, literal.z, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T2.W, T11.X, literal.w, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR * T39.W, T11.Y, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T12.X, PV.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T38.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T39.Z, T11.Y, literal.z,
-; EG-NEXT:     LSHR T3.W, T12.Y, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T4.W, T11.Y, literal.w,
+; EG-NEXT:     LSHR T2.W, T12.Y, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR * T3.W, T11.Y, literal.w,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
 ; EG-NEXT:     BFE_INT T39.X, PS, 0.0, literal.x,
@@ -8948,47 +8644,47 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; EG-NEXT:     ASHR * T41.W, T11.W, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T40.X, T2.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T40.X, T1.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T11.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T41.Z, T11.W, literal.z, BS:VEC_120/SCL_212
 ; EG-NEXT:     ASHR T33.W, T33.Z, literal.y,
 ; EG-NEXT:     ASHR * T29.W, T29.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_INT T41.X, T1.W, 0.0, literal.x,
+; EG-NEXT:     BFE_INT T41.X, T0.W, 0.0, literal.x,
 ; EG-NEXT:     ASHR T40.Y, PV.X, literal.y,
 ; EG-NEXT:     BFE_INT T11.Z, T0.Y, 0.0, literal.x,
 ; EG-NEXT:     ASHR T28.W, T28.Z, literal.y,
 ; EG-NEXT:     ASHR * T27.W, T27.Z, literal.y,
 ; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHR T42.X, T0.W, literal.x,
+; EG-NEXT:     ADD_INT T42.X, T13.X, literal.x,
 ; EG-NEXT:     ASHR T41.Y, PV.X, literal.y,
 ; EG-NEXT:     ASHR T11.W, PV.Z, literal.y,
 ; EG-NEXT:     ASHR * T26.W, T26.Z, literal.y,
-; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:    60(8.407791e-44), 31(4.344025e-44)
 ;
 ; CM-LABEL: global_sextload_v32i8_to_v32i64:
 ; CM:       ; %bb.0:
 ; CM-NEXT:    ALU 0, @26, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 1 @22
-; CM-NEXT:    ALU 84, @27, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    ALU 74, @112, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T42.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T31.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T30.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T25.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T24.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T23.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T22.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T21.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T20.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T19.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T18.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T17.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T16.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T34, T15.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T14.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T13.X
+; CM-NEXT:    ALU 86, @27, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 52, @114, KC0[], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T41, T13.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T11, T42.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T28, T31.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T40, T30.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T25.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T39, T24.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T23.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T22.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T33, T21.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T12, T20.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T29, T19.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T18.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T27, T17.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T34, T16.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T26, T15.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T32, T14.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    Fetch clause starting at 22:
@@ -8997,95 +8693,74 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; CM-NEXT:    ALU clause starting at 26:
 ; CM-NEXT:     MOV * T11.X, KC0[2].Z,
 ; CM-NEXT:    ALU clause starting at 27:
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    240(3.363116e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T13.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 224(3.138909e-43)
-; CM-NEXT:     LSHR T14.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 208(2.914701e-43)
-; CM-NEXT:     LSHR T15.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 192(2.690493e-43)
-; CM-NEXT:     LSHR T16.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 176(2.466285e-43)
-; CM-NEXT:     LSHR T17.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 160(2.242078e-43)
-; CM-NEXT:     LSHR T18.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 144(2.017870e-43)
-; CM-NEXT:     LSHR T19.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 128(1.793662e-43)
-; CM-NEXT:     LSHR T20.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 112(1.569454e-43)
-; CM-NEXT:     LSHR T21.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Z, T11.X, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    96(1.345247e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T0.Y, T11.X, literal.y,
-; CM-NEXT:     LSHR T1.Z, T11.Y, literal.y,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    80(1.121039e-43), 0(0.000000e+00)
-; CM-NEXT:     LSHR T23.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T1.Y, T11.Z, literal.y,
-; CM-NEXT:     LSHR T2.Z, T11.Z, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:    16(2.242078e-44), 64(8.968310e-44)
-; CM-NEXT:     LSHR T24.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T2.Y, T11.W, literal.y,
-; CM-NEXT:     LSHR T3.Z, T11.W, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; CM-NEXT:     LSHR T25.X, PV.W, literal.x,
-; CM-NEXT:     LSHR T3.Y, T12.X, literal.y,
-; CM-NEXT:     LSHR T4.Z, T12.Y, literal.y,
-; CM-NEXT:     LSHR * T0.W, T12.X, literal.z,
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
+; CM-NEXT:     LSHR * T13.X, KC0[2].Y, literal.x,
+; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T14.X, PV.X, literal.x,
+; CM-NEXT:    60(8.407791e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T15.X, T13.X, literal.x,
+; CM-NEXT:    56(7.847271e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T16.X, T13.X, literal.x,
+; CM-NEXT:    52(7.286752e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T17.X, T13.X, literal.x,
+; CM-NEXT:    48(6.726233e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T18.X, T13.X, literal.x,
+; CM-NEXT:    44(6.165713e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T19.X, T13.X, literal.x,
+; CM-NEXT:    40(5.605194e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T20.X, T13.X, literal.x,
+; CM-NEXT:    36(5.044674e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T21.X, T13.X, literal.x,
+; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT * T22.X, T13.X, literal.x,
+; CM-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T23.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T0.Z, T11.X, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR * T0.W, T11.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    24(3.363116e-44), 8(1.121039e-44)
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T24.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T0.Y, T11.Y, literal.y,
+; CM-NEXT:     LSHR T1.Z, T11.Z, literal.z,
+; CM-NEXT:     LSHR * T1.W, T11.Z, literal.y,
+; CM-NEXT:    20(2.802597e-44), 16(2.242078e-44)
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T25.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T1.Y, T11.W, literal.x,
+; CM-NEXT:     LSHR T2.Z, T11.W, literal.y,
+; CM-NEXT:     LSHR * T2.W, T12.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    16(2.242078e-44), 8(1.121039e-44)
 ; CM-NEXT:     BFE_INT T26.X, T12.W, 0.0, literal.x,
-; CM-NEXT:     LSHR T4.Y, T12.Y, literal.x,
-; CM-NEXT:     ADD_INT T5.Z, KC0[2].Y, literal.y,
-; CM-NEXT:     LSHR * T1.W, T11.Y, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:     LSHR T2.Y, T12.Y, literal.y,
+; CM-NEXT:     LSHR T3.Z, T12.X, literal.x,
+; CM-NEXT:     LSHR * T3.W, T12.Y, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
 ; CM-NEXT:     BFE_INT T27.X, T12.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR T26.Y, PV.X, literal.y,
-; CM-NEXT:     ADD_INT T6.Z, KC0[2].Y, literal.z,
-; CM-NEXT:     LSHR * T2.W, T12.W, literal.x,
+; CM-NEXT:     LSHR T4.Z, T11.Y, literal.x,
+; CM-NEXT:     LSHR * T4.W, T12.W, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T28.X, T11.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR T27.Y, PV.X, literal.y,
 ; CM-NEXT:     BFE_INT T26.Z, PV.W, 0.0, literal.x,
-; CM-NEXT:     LSHR * T2.W, T12.Z, literal.x,
+; CM-NEXT:     LSHR * T4.W, T12.Z, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:     BFE_INT T29.X, T12.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR T28.Y, PV.X, literal.y,
 ; CM-NEXT:     BFE_INT T27.Z, PV.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T26.W, PV.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T30.X, T6.Z, literal.x,
+; CM-NEXT:     ADD_INT T30.X, T13.X, literal.x,
 ; CM-NEXT:     ASHR T29.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T28.Z, T1.W, 0.0, literal.z,
+; CM-NEXT:     BFE_INT T28.Z, T4.Z, 0.0, literal.z,
 ; CM-NEXT:     ASHR * T27.W, PV.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    12(1.681558e-44), 31(4.344025e-44)
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T31.X, T5.Z, literal.x,
-; CM-NEXT:     LSHR * T5.Y, T12.Z, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    2(2.802597e-45), 16(2.242078e-44)
-; CM-NEXT:    ALU clause starting at 112:
-; CM-NEXT:     BFE_INT T29.Z, T4.Y, 0.0, literal.x,
-; CM-NEXT:     ASHR * T32.W, T12.W, literal.y,
-; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
+; CM-NEXT:     ADD_INT T31.X, T13.X, literal.x,
+; CM-NEXT:     LSHR T3.Y, T12.Z, literal.y,
+; CM-NEXT:     BFE_INT T29.Z, T3.W, 0.0, literal.x,
+; CM-NEXT:     ASHR * T32.W, T12.W, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:    8(1.121039e-44), 16(2.242078e-44)
+; CM-NEXT:    31(4.344025e-44), 0(0.000000e+00)
 ; CM-NEXT:     BFE_INT T33.X, T12.X, 0.0, literal.x,
 ; CM-NEXT:     LSHR T4.Y, T12.W, literal.y,
 ; CM-NEXT:     ASHR T32.Z, T12.W, literal.z,
@@ -9098,27 +8773,28 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; CM-NEXT:     ASHR * T29.W, T29.Z, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T34.X, T5.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T34.X, T3.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR T32.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T33.Z, T0.W, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T33.Z, T3.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T35.W, T12.Y, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:     BFE_INT T36.X, T11.W, 0.0, literal.x,
-; CM-NEXT:     ASHR T34.Y, PV.X, literal.y,
-; CM-NEXT:     ASHR T35.Z, T12.Y, literal.z,
-; CM-NEXT:     ASHR * T12.W, T12.X, literal.y,
+; CM-NEXT:     BFE_INT * T36.X, T11.W, 0.0, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:    ALU clause starting at 114:
+; CM-NEXT:     ASHR T34.Y, T34.X, literal.x,
+; CM-NEXT:     ASHR T35.Z, T12.Y, literal.y,
+; CM-NEXT:     ASHR * T12.W, T12.X, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    31(4.344025e-44), 24(3.363116e-44)
+; CM-NEXT:     BFE_INT T35.X, T2.Y, 0.0, literal.x,
+; CM-NEXT:     ASHR T36.Y, T36.X, literal.y,
+; CM-NEXT:     ASHR T12.Z, T12.X, literal.z, BS:VEC_120/SCL_212
+; CM-NEXT:     ASHR * T33.W, T33.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T35.X, T4.Z, 0.0, literal.x,
-; CM-NEXT:     ASHR T36.Y, PV.X, literal.y,
-; CM-NEXT:     ASHR T12.Z, T12.X, literal.z,
-; CM-NEXT:     ASHR * T33.W, T33.Z, literal.y, BS:VEC_120/SCL_212
-; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T12.X, T3.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T12.X, T2.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T35.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T36.Z, T3.Z, 0.0, literal.x,
-; CM-NEXT:     ASHR * T37.W, T11.W, literal.y,
+; CM-NEXT:     BFE_INT T36.Z, T2.Z, 0.0, literal.x,
+; CM-NEXT:     ASHR * T37.W, T11.W, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:     BFE_INT T38.X, T11.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR T12.Y, PV.X, literal.y,
@@ -9126,16 +8802,16 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; CM-NEXT:     ASHR * T39.W, T11.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T37.X, T2.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T37.X, T1.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR T38.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR T39.Z, T11.Z, literal.z,
 ; CM-NEXT:     ASHR * T36.W, T36.Z, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T39.X, T2.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T39.X, T1.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T37.Y, PV.X, literal.y,
-; CM-NEXT:     BFE_INT T38.Z, T1.Y, 0.0, literal.x,
-; CM-NEXT:     ASHR * T40.W, T11.Y, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     BFE_INT T38.Z, T1.Z, 0.0, literal.x,
+; CM-NEXT:     ASHR * T40.W, T11.Y, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:     BFE_INT T41.X, T11.X, 0.0, literal.x,
 ; CM-NEXT:     ASHR T39.Y, PV.X, literal.y,
@@ -9143,21 +8819,21 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i64(ptr addrspace(1) %out
 ; CM-NEXT:     ASHR * T11.W, T11.X, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T40.X, T1.Z, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T40.X, T0.Y, 0.0, literal.x,
 ; CM-NEXT:     ASHR T41.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR T11.Z, T11.X, literal.z,
-; CM-NEXT:     ASHR * T38.W, T38.Z, literal.y, BS:VEC_120/SCL_212
+; CM-NEXT:     ASHR * T38.W, T38.Z, literal.y,
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; CM-NEXT:     BFE_INT T11.X, T0.Y, 0.0, literal.x,
+; CM-NEXT:     BFE_INT T11.X, T0.W, 0.0, literal.x,
 ; CM-NEXT:     ASHR T40.Y, PV.X, literal.y,
 ; CM-NEXT:     BFE_INT T41.Z, T0.Z, 0.0, literal.x,
 ; CM-NEXT:     ASHR * T28.W, T28.Z, literal.y, BS:VEC_120/SCL_212
 ; CM-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; CM-NEXT:     LSHR T42.X, KC0[2].Y, literal.x,
+; CM-NEXT:     ADD_INT T42.X, T13.X, literal.x,
 ; CM-NEXT:     ASHR T11.Y, PV.X, literal.y,
 ; CM-NEXT:     ASHR * T41.W, PV.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; CM-NEXT:    4(5.605194e-45), 31(4.344025e-44)
   %load = load <32 x i8>, ptr addrspace(1) %in
   %ext = sext <32 x i8> %load to <32 x i64>
   store <32 x i64> %ext, ptr addrspace(1) %out
@@ -10994,9 +10670,9 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; EG-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
 ; EG-NEXT:    ALU 103, @12, KC0[], KC1[]
-; EG-NEXT:    ALU 20, @116, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T21.X, 1
+; EG-NEXT:    ALU 19, @116, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -11115,17 +10791,16 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; EG-NEXT:     OR_INT * T0.W, PV.W, T0.W,
 ; EG-NEXT:     MOV * T5.X, PV.W,
 ; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     LSHR T0.W, T19.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T21.X, PS, literal.x,
+; EG-NEXT:     LSHR * T0.W, T19.W, literal.x,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     AND_INT T1.W, PV.Y, literal.y,
 ; EG-NEXT:     AND_INT * T0.W, PV.W, literal.z,
 ; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
 ; EG-NEXT:    16711680(2.341805e-38), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
 ; EG-NEXT:     OR_INT * T19.W, PV.W, PS,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T5.X, PV.W,
 ; EG-NEXT:     MOV * T20.X, T16.X,
 ; EG-NEXT:     MOV * T20.Z, T12.X,
@@ -11137,7 +10812,7 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; CM-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
 ; CM-NEXT:    ALU 101, @12, KC0[], KC1[]
-; CM-NEXT:    ALU 20, @114, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 19, @114, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T22.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T21.X
 ; CM-NEXT:    CF_END
@@ -11259,14 +10934,13 @@ define amdgpu_kernel void @global_zextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; CM-NEXT:     LSHR * T0.W, T19.W, literal.x,
 ; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; CM-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; CM-NEXT:     AND_INT T0.Y, PV.Y, literal.y,
-; CM-NEXT:     AND_INT T0.Z, PV.W, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.w,
+; CM-NEXT:     AND_INT T0.Z, PV.Y, literal.y,
+; CM-NEXT:     AND_INT * T0.W, PV.W, literal.z,
 ; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; CM-NEXT:    16711680(2.341805e-38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     OR_INT * T19.W, PV.Y, PV.Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:    16711680(2.341805e-38), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; CM-NEXT:     OR_INT * T19.W, PV.Z, PV.W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T5.X, PV.W,
 ; CM-NEXT:     MOV T20.X, T16.X,
 ; CM-NEXT:     MOV * T20.Z, T12.X, BS:VEC_120/SCL_212
@@ -11507,9 +11181,9 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; EG-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 0 @8
 ; EG-NEXT:    ALU 104, @12, KC0[], KC1[]
-; EG-NEXT:    ALU 46, @117, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T22.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T21.X, 1
+; EG-NEXT:    ALU 45, @117, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T20.XYZW, T21.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T19.XYZW, T22.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 8:
@@ -11655,17 +11329,16 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; EG-NEXT:     OR_INT * T0.W, T1.W, PV.W,
 ; EG-NEXT:     MOV * T5.X, PV.W,
 ; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ASHR T0.W, T19.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    24(3.363116e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T21.X, PS, literal.x,
+; EG-NEXT:     ASHR * T0.W, T19.W, literal.x,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
 ; EG-NEXT:     AND_INT T1.W, PV.Y, literal.y,
 ; EG-NEXT:     LSHL * T0.W, PV.W, literal.z,
 ; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T22.X, KC0[2].Y, literal.x,
+; EG-NEXT:     ADD_INT T22.X, PV.X, literal.x,
 ; EG-NEXT:     OR_INT * T19.W, PV.W, PS,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; EG-NEXT:     MOV T5.X, PV.W,
 ; EG-NEXT:     MOV * T20.X, T16.X,
 ; EG-NEXT:     MOV * T20.Z, T12.X,
@@ -11677,7 +11350,7 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; CM-NEXT:    ALU 1, @10, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    TEX 0 @8
 ; CM-NEXT:    ALU 104, @12, KC0[], KC1[]
-; CM-NEXT:    ALU 46, @117, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 45, @117, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T19, T22.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T20, T21.X
 ; CM-NEXT:    CF_END
@@ -11828,14 +11501,13 @@ define amdgpu_kernel void @global_sextload_v16i8_to_v16i16(ptr addrspace(1) %out
 ; CM-NEXT:     ASHR * T0.W, T19.W, literal.x,
 ; CM-NEXT:    24(3.363116e-44), 0(0.000000e+00)
 ; CM-NEXT:     LSHR T21.X, KC0[2].Y, literal.x,
-; CM-NEXT:     AND_INT T0.Y, PV.Y, literal.y,
-; CM-NEXT:     LSHL T0.Z, PV.W, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
+; CM-NEXT:     AND_INT T0.Z, PV.Y, literal.y,
+; CM-NEXT:     LSHL * T0.W, PV.W, literal.z,
 ; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
 ; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T22.X, PV.W, literal.x,
-; CM-NEXT:     OR_INT * T19.W, PV.Y, PV.Z,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T22.X, PV.X, literal.x,
+; CM-NEXT:     OR_INT * T19.W, PV.Z, PV.W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T5.X, PV.W,
 ; CM-NEXT:     MOV T20.X, T16.X,
 ; CM-NEXT:     MOV * T20.Z, T12.X, BS:VEC_120/SCL_212
@@ -12182,11 +11854,11 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; EG-NEXT:    TEX 1 @10
 ; EG-NEXT:    ALU 103, @16, KC0[], KC1[]
 ; EG-NEXT:    ALU 104, @120, KC0[], KC1[]
-; EG-NEXT:    ALU 41, @225, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 37, @225, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T39.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T40.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 10:
 ; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -12421,24 +12093,20 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; EG-NEXT:    -65536(nan), 0(0.000000e+00)
 ; EG-NEXT:     OR_INT * T0.W, PV.W, T0.W,
 ; EG-NEXT:     MOV * T21.X, PV.W,
-; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T40.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T0.Y, PV.X,
+; EG-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.W, T35.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    8(1.121039e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
-; EG-NEXT:     AND_INT T0.W, PV.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    16711680(2.341805e-38), 32(4.484155e-44)
-; EG-NEXT:     LSHR T42.X, PS, literal.x,
-; EG-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; EG-NEXT:     LSHR T0.W, T35.W, literal.y,
+; EG-NEXT:     ADD_INT * T41.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 8(1.121039e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T1.W, T0.Y, literal.x,
+; EG-NEXT:     AND_INT * T0.W, PV.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16711680(2.341805e-38)
+; EG-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; EG-NEXT:     OR_INT * T35.W, PV.W, PS,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T21.X, PV.W,
 ; EG-NEXT:     MOV * T36.X, T16.X,
 ; EG-NEXT:     MOV * T36.Z, T12.X,
@@ -12455,11 +12123,11 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; CM-NEXT:    TEX 1 @10
 ; CM-NEXT:    ALU 101, @16, KC0[], KC1[]
 ; CM-NEXT:    ALU 101, @118, KC0[], KC1[]
-; CM-NEXT:    ALU 40, @220, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 36, @220, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T42.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T41.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T40.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T41.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T40.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 10:
 ; CM-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -12688,24 +12356,20 @@ define amdgpu_kernel void @global_zextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; CM-NEXT:    -65536(nan), 16(2.242078e-44)
 ; CM-NEXT:     OR_INT * T0.W, PV.Z, PV.W,
 ; CM-NEXT:     MOV * T21.X, PV.W,
-; CM-NEXT:     MOV T0.Y, PV.X,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T40.X, PV.W, literal.x,
-; CM-NEXT:     LSHR * T0.W, T35.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; CM-NEXT:     LSHR T41.X, KC0[2].Y, literal.x,
-; CM-NEXT:     AND_INT T0.Y, T0.Y, literal.y,
-; CM-NEXT:     AND_INT T0.Z, PV.W, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.w,
-; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; CM-NEXT:    16711680(2.341805e-38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T42.X, PV.W, literal.x,
-; CM-NEXT:     OR_INT * T35.W, PV.Y, PV.Z,
+; CM-NEXT:     MOV * T0.Y, PV.X,
+; CM-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; CM-NEXT:     LSHR * T0.W, T35.W, literal.x,
+; CM-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T41.X, T39.X, literal.x,
+; CM-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
+; CM-NEXT:     AND_INT * T0.W, PV.W, literal.z,
+; CM-NEXT:    12(1.681558e-44), 65535(9.183409e-41)
+; CM-NEXT:    16711680(2.341805e-38), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; CM-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T21.X, PV.W,
 ; CM-NEXT:     MOV T36.X, T16.X,
 ; CM-NEXT:     MOV * T36.Z, T12.X, BS:VEC_120/SCL_212
@@ -13146,11 +12810,11 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; EG-NEXT:    TEX 1 @10
 ; EG-NEXT:    ALU 104, @16, KC0[], KC1[]
 ; EG-NEXT:    ALU 104, @121, KC0[], KC1[]
-; EG-NEXT:    ALU 95, @226, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 91, @226, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T36.XYZW, T42.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T37.XYZW, T41.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T40.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T39.X, 1
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T38.XYZW, T39.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T35.XYZW, T40.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 10:
 ; EG-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -13440,24 +13104,20 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; EG-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
 ; EG-NEXT:     OR_INT * T0.W, T1.W, PV.W,
 ; EG-NEXT:     MOV * T21.X, PV.W,
-; EG-NEXT:     MOV T0.Y, PV.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T39.X, PV.W, literal.x,
-; EG-NEXT:     LSHR * T40.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MOV * T0.Y, PV.X,
+; EG-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ASHR T0.W, T35.W, literal.x,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.y,
-; EG-NEXT:    24(3.363116e-44), 48(6.726233e-44)
-; EG-NEXT:     LSHR T41.X, PS, literal.x,
-; EG-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
-; EG-NEXT:     LSHL T0.W, PV.W, literal.z,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.w,
-; EG-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; EG-NEXT:    16(2.242078e-44), 32(4.484155e-44)
-; EG-NEXT:     LSHR T42.X, PS, literal.x,
-; EG-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; EG-NEXT:     ASHR T0.W, T35.W, literal.y,
+; EG-NEXT:     ADD_INT * T41.X, PV.X, literal.z,
+; EG-NEXT:    4(5.605194e-45), 24(3.363116e-44)
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     AND_INT T1.W, T0.Y, literal.x,
+; EG-NEXT:     LSHL * T0.W, PV.W, literal.y,
+; EG-NEXT:    65535(9.183409e-41), 16(2.242078e-44)
+; EG-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; EG-NEXT:     OR_INT * T35.W, PV.W, PS,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
 ; EG-NEXT:     MOV T21.X, PV.W,
 ; EG-NEXT:     MOV * T36.X, T16.X,
 ; EG-NEXT:     MOV * T36.Z, T12.X,
@@ -13474,11 +13134,11 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; CM-NEXT:    TEX 1 @10
 ; CM-NEXT:    ALU 104, @16, KC0[], KC1[]
 ; CM-NEXT:    ALU 104, @121, KC0[], KC1[]
-; CM-NEXT:    ALU 95, @226, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 91, @226, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T35, T42.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T41.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T40.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T38, T39.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T37, T41.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T36, T40.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    Fetch clause starting at 10:
 ; CM-NEXT:     VTX_READ_128 T37.XYZW, T35.X, 16, #1
@@ -13768,24 +13428,20 @@ define amdgpu_kernel void @global_sextload_v32i8_to_v32i16(ptr addrspace(1) %out
 ; CM-NEXT:    -65536(nan), 65535(9.183409e-41)
 ; CM-NEXT:     OR_INT * T0.W, PV.Z, PV.W,
 ; CM-NEXT:     MOV * T21.X, PV.W,
-; CM-NEXT:     MOV T0.Y, PV.X,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; CM-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T39.X, PV.W, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    2(2.802597e-45), 48(6.726233e-44)
-; CM-NEXT:     LSHR T40.X, PV.W, literal.x,
-; CM-NEXT:     ASHR * T0.W, T35.W, literal.y,
-; CM-NEXT:    2(2.802597e-45), 24(3.363116e-44)
-; CM-NEXT:     LSHR T41.X, KC0[2].Y, literal.x,
-; CM-NEXT:     AND_INT T0.Y, T0.Y, literal.y,
-; CM-NEXT:     LSHL T0.Z, PV.W, literal.z,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.z,
-; CM-NEXT:    2(2.802597e-45), 65535(9.183409e-41)
-; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; CM-NEXT:     LSHR T42.X, PV.W, literal.x,
-; CM-NEXT:     OR_INT * T35.W, PV.Y, PV.Z,
+; CM-NEXT:     MOV * T0.Y, PV.X,
+; CM-NEXT:     LSHR * T39.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T40.X, PV.X, literal.x,
+; CM-NEXT:     ASHR * T0.W, T35.W, literal.y,
+; CM-NEXT:    8(1.121039e-44), 24(3.363116e-44)
+; CM-NEXT:     ADD_INT T41.X, T39.X, literal.x,
+; CM-NEXT:     AND_INT T0.Z, T0.Y, literal.y,
+; CM-NEXT:     LSHL * T0.W, PV.W, literal.z,
+; CM-NEXT:    12(1.681558e-44), 65535(9.183409e-41)
+; CM-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T42.X, T39.X, literal.x,
+; CM-NEXT:     OR_INT * T35.W, PV.Z, PV.W,
+; CM-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ; CM-NEXT:     MOV * T21.X, PV.W,
 ; CM-NEXT:     MOV T36.X, T16.X,
 ; CM-NEXT:     MOV * T36.Z, T12.X, BS:VEC_120/SCL_212

--- a/llvm/test/CodeGen/AMDGPU/max.ll
+++ b/llvm/test/CodeGen/AMDGPU/max.ll
@@ -664,17 +664,16 @@ define amdgpu_kernel void @s_test_umax_uge_v3i32(ptr addrspace(1) %out, <3 x i32
 ;
 ; EG-LABEL: s_test_umax_uge_v3i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 7, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    ALU 6, @4, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.X, T2.X, 0
 ; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 4:
 ; EG-NEXT:     MAX_UINT * T0.Y, KC0[3].Z, KC0[4].Z,
 ; EG-NEXT:     MAX_UINT * T0.X, KC0[3].Y, KC0[4].Y,
-; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; EG-NEXT:    2(2.802597e-45), 8(1.121039e-44)
-; EG-NEXT:     LSHR T2.X, PV.W, literal.x,
+; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T2.X, PV.X, literal.x,
 ; EG-NEXT:     MAX_UINT * T3.X, KC0[3].W, KC0[4].W,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %cmp = icmp uge <3 x i32> %a, %b

--- a/llvm/test/CodeGen/AMDGPU/min.ll
+++ b/llvm/test/CodeGen/AMDGPU/min.ll
@@ -2069,9 +2069,9 @@ define amdgpu_kernel void @v_test_umin_ule_v3i32(ptr addrspace(1) %out, ptr addr
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 3, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 9, @14, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.X, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T1.X, 1
+; EG-NEXT:    ALU 7, @14, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.X, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XY, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T1.X, 0, #1
@@ -2084,13 +2084,11 @@ define amdgpu_kernel void @v_test_umin_ule_v3i32(ptr addrspace(1) %out, ptr addr
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MIN_UINT * T0.Y, T2.Y, T1.Y,
 ; EG-NEXT:     MIN_UINT T0.X, T2.X, T1.X,
+; EG-NEXT:     MIN_UINT * T1.X, T2.Z, T1.Z,
 ; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, T0.W,
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     MIN_UINT * T2.X, T2.Z, T1.Z,
+; EG-NEXT:     LSHR * T2.X, PV.W, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T0.W, T0.W, literal.x,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
 ; CI-LABEL: v_test_umin_ule_v3i32:
@@ -3390,25 +3388,23 @@ define amdgpu_kernel void @s_test_umin_ult_v1i32(ptr addrspace(1) %out, <1 x i32
 define amdgpu_kernel void @s_test_umin_ult_v8i32(ptr addrspace(1) %out, <8 x i32> %a, <8 x i32> %b) #0 {
 ; EG-LABEL: s_test_umin_ult_v8i32:
 ; EG:       ; %bb.0:
-; EG-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T1.X, 1
+; EG-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    ALU clause starting at 4:
 ; EG-NEXT:     MIN_UINT * T0.W, KC0[5].X, KC0[7].X,
 ; EG-NEXT:     MIN_UINT * T0.Z, KC0[4].W, KC0[6].W,
 ; EG-NEXT:     MIN_UINT * T0.Y, KC0[4].Z, KC0[6].Z,
 ; EG-NEXT:     MIN_UINT * T0.X, KC0[4].Y, KC0[6].Y,
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     MIN_UINT * T1.W, KC0[6].X, KC0[8].X,
+; EG-NEXT:     MIN_UINT * T1.Z, KC0[5].W, KC0[7].W,
+; EG-NEXT:     MIN_UINT * T1.Y, KC0[5].Z, KC0[7].Z,
+; EG-NEXT:     MIN_UINT * T1.X, KC0[5].Y, KC0[7].Y,
+; EG-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     MIN_UINT * T2.W, KC0[6].X, KC0[8].X,
-; EG-NEXT:     MIN_UINT * T2.Z, KC0[5].W, KC0[7].W,
-; EG-NEXT:     MIN_UINT * T2.Y, KC0[5].Z, KC0[7].Z,
-; EG-NEXT:     MIN_UINT * T2.X, KC0[5].Y, KC0[7].Y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T3.X, PV.W, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; CI-LABEL: s_test_umin_ult_v8i32:
 ; CI:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/r600.llvm.is.fpclass.ll
+++ b/llvm/test/CodeGen/AMDGPU/r600.llvm.is.fpclass.ll
@@ -69,27 +69,25 @@ define amdgpu_kernel void @issue135083_v2f32(ptr addrspace(1) %out, <2 x float> 
 define amdgpu_kernel void @issue135083_v3f32(ptr addrspace(1) %out, <3 x float> %x) {
 ; CM-LABEL: issue135083_v3f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 15, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T1.X
+; CM-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T1.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
 ; CM-NEXT:     LSHL * T0.W, KC0[3].W, 1,
-; CM-NEXT:     LSHL T0.Z, KC0[3].Z, 1,
 ; CM-NEXT:     SETGT_UINT * T0.W, PV.W, literal.x,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
 ; CM-NEXT:     CNDE_INT T0.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHL T0.Y, KC0[3].Y, 1,
-; CM-NEXT:     SETGT_UINT T0.Z, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 8(1.121039e-44)
-; CM-NEXT:     LSHR T1.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T2.Y, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.y,
+; CM-NEXT:     LSHL * T0.W, KC0[3].Z, 1,
+; CM-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHL T0.Z, KC0[3].Y, 1,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.W, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
-; CM-NEXT:     CNDE_INT * T2.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T2.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T3.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Z, literal.y,
+; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     CNDE_INT * T3.X, PV.W, 1, 0.0,
   %result = call <3 x i1> @llvm.is.fpclass.v3f32(<3 x float> %x, i32 504)
   %zext = zext <3 x i1> %result to <3 x i32>
   store <3 x i32> %zext, ptr addrspace(1) %out, align 16
@@ -131,34 +129,32 @@ define amdgpu_kernel void @issue135083_v4f32(ptr addrspace(1) %out, <4 x float> 
 define amdgpu_kernel void @issue135083_v5f32(ptr addrspace(1) %out, <5 x float> %x) {
 ; CM-LABEL: issue135083_v5f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 22, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2.X, T0.X
+; CM-NEXT:    ALU 20, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     LSHL T0.Z, KC0[4].Y, 1,
+; CM-NEXT:     LSHL T0.Z, KC0[5].Y, 1,
 ; CM-NEXT:     LSHL * T0.W, KC0[5].X, 1,
 ; CM-NEXT:     SETGT_UINT T0.Y, PV.W, literal.x,
-; CM-NEXT:     LSHL T1.Z, KC0[5].Y, 1,
-; CM-NEXT:     LSHL * T0.W, KC0[4].W, 1,
+; CM-NEXT:     LSHL T1.Z, KC0[4].W, 1,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Z, literal.x,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     SETGT_UINT T0.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T0.X, PV.W, 1, 0.0,
 ; CM-NEXT:     LSHL T1.Y, KC0[4].Z, 1,
-; CM-NEXT:     SETGT_UINT T1.Z, PV.Z, literal.x,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.Z, literal.x,
 ; CM-NEXT:     CNDE_INT * T1.W, PV.Y, 1, 0.0,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T2.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T0.Y, PV.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Z, PV.X, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T0.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.y,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHL T0.Y, KC0[4].Y, 1,
+; CM-NEXT:     CNDE_INT T1.Z, PV.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T1.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.y,
+; CM-NEXT:    4(5.605194e-45), -16777217(-1.701412e+38)
 ; CM-NEXT:     CNDE_INT * T1.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %result = call <5 x i1> @llvm.is.fpclass.v5f32(<5 x float> %x, i32 504)
   %zext = zext <5 x i1> %result to <5 x i32>
   store <5 x i32> %zext, ptr addrspace(1) %out, align 32
@@ -168,37 +164,36 @@ define amdgpu_kernel void @issue135083_v5f32(ptr addrspace(1) %out, <5 x float> 
 define amdgpu_kernel void @issue135083_v6f32(ptr addrspace(1) %out, <6 x float> %x) {
 ; CM-LABEL: issue135083_v6f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 25, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 24, @4, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T2.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T3.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T0.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     LSHL T0.Z, KC0[4].Y, 1,
 ; CM-NEXT:     LSHL * T0.W, KC0[5].Z, 1,
-; CM-NEXT:     LSHL T1.Z, KC0[5].X, 1,
-; CM-NEXT:     LSHL * T1.W, KC0[4].W, 1,
+; CM-NEXT:     LSHL T0.Y, KC0[5].Y, 1,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.W, literal.x,
+; CM-NEXT:     LSHL * T0.W, KC0[5].X, 1,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
 ; CM-NEXT:     SETGT_UINT T0.X, PV.W, literal.x,
-; CM-NEXT:     SETGT_UINT T0.Y, PV.Z, literal.x,
-; CM-NEXT:     LSHL T1.Z, KC0[5].Y, 1,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.W, literal.x,
+; CM-NEXT:     CNDE_INT T1.Y, PV.Z, 1, 0.0,
+; CM-NEXT:     LSHL T0.Z, KC0[4].W, 1,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.x,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T1.X, KC0[4].Z, 1,
-; CM-NEXT:     CNDE_INT T2.Y, PV.W, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T1.Z, PV.Z, literal.x,
-; CM-NEXT:     CNDE_INT * T1.W, PV.Y, 1, 0.0,
+; CM-NEXT:     CNDE_INT T1.X, PV.W, 1, 0.0,
+; CM-NEXT:     LSHL T0.Y, KC0[4].Z, 1,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.Z, literal.x,
+; CM-NEXT:     CNDE_INT * T0.W, PV.X, 1, 0.0,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T2.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T0.Y, PV.X, literal.x,
-; CM-NEXT:     CNDE_INT T1.Z, T0.X, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T0.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.y,
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHL T2.Y, KC0[4].Y, 1,
+; CM-NEXT:     CNDE_INT T0.Z, PV.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T1.W, PV.Y, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
-; CM-NEXT:     CNDE_INT * T1.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T1.W, PV.Y, literal.y,
+; CM-NEXT:    4(5.605194e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     CNDE_INT * T0.X, PV.W, 1, 0.0,
   %result = call <6 x i1> @llvm.is.fpclass.v6f32(<6 x float> %x, i32 504)
   %zext = zext <6 x i1> %result to <6 x i32>
   store <6 x i32> %zext, ptr addrspace(1) %out, align 32
@@ -208,46 +203,43 @@ define amdgpu_kernel void @issue135083_v6f32(ptr addrspace(1) %out, <6 x float> 
 define amdgpu_kernel void @issue135083_v7f32(ptr addrspace(1) %out, <7 x float> %x) {
 ; CM-LABEL: issue135083_v7f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 32, @6, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T5.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T0.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1.X, T2.X
+; CM-NEXT:    ALU 29, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T1.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0.X, T2.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    PAD
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     LSHL T0.Z, KC0[4].Y, 1,
-; CM-NEXT:     LSHL * T0.W, KC0[4].W, 1,
-; CM-NEXT:     SETGT_UINT T0.Y, PV.W, literal.x,
-; CM-NEXT:     LSHL T1.Z, KC0[5].W, 1,
+; CM-NEXT:     LSHL * T0.W, KC0[5].W, 1,
+; CM-NEXT:     LSHL T0.Y, KC0[4].Z, 1,
+; CM-NEXT:     LSHL T0.Z, KC0[4].W, 1,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.W, literal.x,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T0.X, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T1.Y, PV.Z, literal.x,
+; CM-NEXT:     LSHL T0.Z, KC0[5].Z, 1,
 ; CM-NEXT:     LSHL * T0.W, KC0[5].X, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T0.X, KC0[4].Z, 1,
-; CM-NEXT:     SETGT_UINT T1.Y, PV.W, literal.x,
-; CM-NEXT:     LSHL T2.Z, KC0[5].Z, 1,
-; CM-NEXT:     SETGT_UINT * T0.W, PV.Z, literal.x,
-; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T1.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHL T2.Y, KC0[5].Y, 1,
-; CM-NEXT:     SETGT_UINT T1.Z, PV.Z, literal.x,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 24(3.363116e-44)
-; CM-NEXT:     LSHR T2.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T3.Y, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T1.Z, PV.Y, literal.y,
-; CM-NEXT:     CNDE_INT * T4.W, T1.Y, 1, 0.0,
+; CM-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; CM-NEXT:     SETGT_UINT T2.Y, PV.W, literal.y,
+; CM-NEXT:     LSHL T1.Z, KC0[5].Y, 1,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Z, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     ADD_INT T2.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T3.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.Z, literal.y,
+; CM-NEXT:     CNDE_INT * T4.W, PV.Y, 1, 0.0,
+; CM-NEXT:    6(8.407791e-45), -16777217(-1.701412e+38)
 ; CM-NEXT:     CNDE_INT T3.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T1.Y, T0.X, literal.x,
-; CM-NEXT:     CNDE_INT T4.Z, T0.Y, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T0.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T4.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     LSHL T2.Y, KC0[4].Y, 1,
+; CM-NEXT:     CNDE_INT T4.Z, T1.Y, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, T0.Y, literal.x, BS:VEC_120/SCL_212
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T5.X, T1.X, literal.x,
+; CM-NEXT:     CNDE_INT T4.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.y,
+; CM-NEXT:    4(5.605194e-45), -16777217(-1.701412e+38)
 ; CM-NEXT:     CNDE_INT * T4.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T5.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
   %result = call <7 x i1> @llvm.is.fpclass.v7f32(<7 x float> %x, i32 504)
   %zext = zext <7 x i1> %result to <7 x i32>
   store <7 x i32> %zext, ptr addrspace(1) %out, align 32
@@ -257,45 +249,44 @@ define amdgpu_kernel void @issue135083_v7f32(ptr addrspace(1) %out, <7 x float> 
 define amdgpu_kernel void @issue135083_v8f32(ptr addrspace(1) %out, <8 x float> %x) {
 ; CM-LABEL: issue135083_v8f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 33, @4, KC0[CB0:0-32], KC1[]
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
+; CM-NEXT:    ALU 32, @4, KC0[CB0:0-32], KC1[]
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T2.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T3.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 4:
-; CM-NEXT:     LSHL T0.Z, KC0[6].X, 1,
-; CM-NEXT:     LSHL * T0.W, KC0[4].W, 1,
-; CM-NEXT:     LSHL T0.X, KC0[4].Y, 1,
-; CM-NEXT:     SETGT_UINT T0.Y, PV.W, literal.x,
-; CM-NEXT:     SETGT_UINT T0.Z, PV.Z, literal.x,
+; CM-NEXT:     LSHL * T0.W, KC0[6].X, 1,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.W, literal.x,
 ; CM-NEXT:     LSHL * T0.W, KC0[5].W, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T1.X, KC0[5].Z, 1,
-; CM-NEXT:     SETGT_UINT T1.Y, PV.W, literal.x,
-; CM-NEXT:     LSHL T1.Z, KC0[5].X, 1,
-; CM-NEXT:     CNDE_INT * T1.W, PV.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T0.Y, PV.W, literal.x,
+; CM-NEXT:     LSHL T1.Z, KC0[5].Z, 1,
+; CM-NEXT:     CNDE_INT * T0.W, PV.Z, 1, 0.0,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     SETGT_UINT T2.X, PV.Z, literal.x,
-; CM-NEXT:     LSHL T2.Y, KC0[5].Y, 1,
-; CM-NEXT:     CNDE_INT T1.Z, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, PV.X, literal.x,
+; CM-NEXT:     LSHL T0.X, KC0[5].Y, 1,
+; CM-NEXT:     SETGT_UINT T1.Y, PV.Z, literal.x,
+; CM-NEXT:     CNDE_INT T0.Z, PV.Y, 1, 0.0,
+; CM-NEXT:     LSHL * T1.W, KC0[5].X, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T3.X, KC0[4].Z, 1,
-; CM-NEXT:     CNDE_INT T1.Y, PV.W, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T0.Z, PV.Y, literal.x,
-; CM-NEXT:     CNDE_INT * T0.W, PV.X, 1, 0.0,
-; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T1.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T2.Y, PV.X, literal.x,
-; CM-NEXT:     CNDE_INT T0.Z, T0.Y, 1, 0.0,
-; CM-NEXT:     ADD_INT * T2.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T2.X, PV.W, literal.x,
+; CM-NEXT:     SETGT_UINT T1.X, PV.W, literal.x,
 ; CM-NEXT:     CNDE_INT T0.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T2.W, T0.X, literal.y,
+; CM-NEXT:     LSHL T1.Z, KC0[4].W, 1,
+; CM-NEXT:     SETGT_UINT * T1.W, PV.X, literal.x,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     CNDE_INT T0.X, PV.W, 1, 0.0,
+; CM-NEXT:     LSHL T1.Y, KC0[4].Z, 1,
+; CM-NEXT:     SETGT_UINT T1.Z, PV.Z, literal.x,
+; CM-NEXT:     CNDE_INT * T1.W, PV.X, 1, 0.0,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     LSHR T2.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHL T2.Y, KC0[4].Y, 1,
+; CM-NEXT:     CNDE_INT T1.Z, PV.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T2.W, PV.Y, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
-; CM-NEXT:     CNDE_INT * T0.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T3.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T1.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T2.W, PV.Y, literal.y,
+; CM-NEXT:    4(5.605194e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     CNDE_INT * T1.X, PV.W, 1, 0.0,
   %result = call <8 x i1> @llvm.is.fpclass.v3f32(<8 x float> %x, i32 504)
   %zext = zext <8 x i1> %result to <8 x i32>
   store <8 x i32> %zext, ptr addrspace(1) %out, align 32
@@ -305,82 +296,78 @@ define amdgpu_kernel void @issue135083_v8f32(ptr addrspace(1) %out, <8 x float> 
 define amdgpu_kernel void @issue135083_v16f32(ptr addrspace(1) %out, <16 x float> %x) {
 ; CM-LABEL: issue135083_v16f32:
 ; CM:       ; %bb.0:
-; CM-NEXT:    ALU 68, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    ALU 64, @6, KC0[CB0:0-32], KC1[]
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T0, T4.X
 ; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T1, T7.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T0.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T6.X
-; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T4, T5.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T2, T6.X
+; CM-NEXT:    MEM_RAT_CACHELESS STORE_DWORD T3, T5.X
 ; CM-NEXT:    CF_END
 ; CM-NEXT:    ALU clause starting at 6:
-; CM-NEXT:     LSHL T0.Z, KC0[6].Y, 1,
 ; CM-NEXT:     LSHL * T0.W, KC0[6].W, 1,
-; CM-NEXT:     SETGT_UINT T0.X, PV.W, literal.x,
 ; CM-NEXT:     LSHL T0.Y, KC0[6].Z, 1,
-; CM-NEXT:     LSHL T1.Z, KC0[7].Y, 1,
+; CM-NEXT:     SETGT_UINT T0.Z, PV.W, literal.x,
 ; CM-NEXT:     LSHL * T0.W, KC0[7].X, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     SETGT_UINT T1.X, PV.W, literal.x,
+; CM-NEXT:     SETGT_UINT T0.X, PV.W, literal.x,
 ; CM-NEXT:     LSHL T1.Y, KC0[7].Z, 1,
-; CM-NEXT:     LSHL T2.Z, KC0[8].X, 1,
+; CM-NEXT:     LSHL T1.Z, KC0[10].X, 1,
 ; CM-NEXT:     LSHL * T0.W, KC0[7].W, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     SETGT_UINT T2.X, PV.W, literal.x,
+; CM-NEXT:     SETGT_UINT T1.X, PV.W, literal.x,
 ; CM-NEXT:     SETGT_UINT T2.Y, PV.Z, literal.x,
-; CM-NEXT:     LSHL T2.Z, KC0[10].X, 1,
-; CM-NEXT:     LSHL * T0.W, KC0[8].W, 1,
+; CM-NEXT:     LSHL T1.Z, KC0[9].W, 1,
+; CM-NEXT:     LSHL * T0.W, KC0[8].X, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T3.X, KC0[8].Y, 1,
-; CM-NEXT:     SETGT_UINT T3.Y, PV.W, literal.x,
-; CM-NEXT:     SETGT_UINT T2.Z, PV.Z, literal.x,
-; CM-NEXT:     LSHL * T0.W, KC0[9].W, 1,
+; CM-NEXT:     SETGT_UINT T2.X, PV.W, literal.x,
+; CM-NEXT:     SETGT_UINT T3.Y, PV.Z, literal.x,
+; CM-NEXT:     LSHL T1.Z, KC0[9].Z, 1,
+; CM-NEXT:     CNDE_INT * T3.W, PV.Y, 1, 0.0,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T4.X, KC0[9].Z, 1,
-; CM-NEXT:     SETGT_UINT T4.Y, PV.W, literal.x,
-; CM-NEXT:     LSHL T3.Z, KC0[9].X, 1,
-; CM-NEXT:     CNDE_INT * T4.W, PV.Z, 1, 0.0,
+; CM-NEXT:     LSHL T3.X, KC0[9].Y, 1,
+; CM-NEXT:     SETGT_UINT T2.Y, PV.Z, literal.x,
+; CM-NEXT:     CNDE_INT T3.Z, PV.Y, 1, 0.0,
+; CM-NEXT:     LSHL * T0.W, KC0[9].X, 1,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     SETGT_UINT T5.X, PV.Z, literal.x,
-; CM-NEXT:     LSHL T5.Y, KC0[9].Y, 1,
-; CM-NEXT:     CNDE_INT T4.Z, PV.Y, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T4.X, PV.W, literal.x,
+; CM-NEXT:     CNDE_INT T3.Y, PV.Y, 1, 0.0,
+; CM-NEXT:     LSHL T1.Z, KC0[8].W, 1,
 ; CM-NEXT:     SETGT_UINT * T0.W, PV.X, literal.x,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     LSHL T6.X, KC0[8].Z, 1,
-; CM-NEXT:     CNDE_INT T4.Y, PV.W, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T2.Z, PV.Y, literal.x,
-; CM-NEXT:     CNDE_INT * T3.W, PV.X, 1, 0.0,
+; CM-NEXT:     CNDE_INT T3.X, PV.W, 1, 0.0,
+; CM-NEXT:     LSHL T2.Y, KC0[8].Z, 1,
+; CM-NEXT:     SETGT_UINT T1.Z, PV.Z, literal.x,
+; CM-NEXT:     CNDE_INT * T2.W, PV.X, 1, 0.0,
 ; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
-; CM-NEXT:     CNDE_INT T4.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T5.Y, PV.X, literal.x,
-; CM-NEXT:     CNDE_INT T3.Z, T3.Y, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 48(6.726233e-44)
-; CM-NEXT:     LSHR T5.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T3.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T2.Z, T3.X, literal.y,
-; CM-NEXT:     CNDE_INT * T2.W, T2.Y, 1, 0.0,
+; CM-NEXT:     LSHR T4.X, KC0[2].Y, literal.x,
+; CM-NEXT:     LSHL T4.Y, KC0[8].Y, 1,
+; CM-NEXT:     CNDE_INT T2.Z, PV.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, PV.Y, literal.y,
 ; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
-; CM-NEXT:     CNDE_INT T3.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T1.Y, T1.Y, literal.x,
-; CM-NEXT:     CNDE_INT T2.Z, T2.X, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 32(4.484155e-44)
-; CM-NEXT:     LSHR T6.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T2.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T1.Z, T1.Z, literal.y,
-; CM-NEXT:     CNDE_INT * T1.W, T1.X, 1, 0.0,
-; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     ADD_INT T5.X, PV.X, literal.x,
+; CM-NEXT:     CNDE_INT T2.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T1.Z, PV.Y, literal.y,
+; CM-NEXT:     CNDE_INT * T1.W, T2.X, 1, 0.0,
+; CM-NEXT:    12(1.681558e-44), -16777217(-1.701412e+38)
 ; CM-NEXT:     CNDE_INT T2.X, PV.Z, 1, 0.0,
-; CM-NEXT:     SETGT_UINT T0.Y, T0.Y, literal.x,
-; CM-NEXT:     CNDE_INT T1.Z, T0.X, 1, 0.0,
-; CM-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.y,
-; CM-NEXT:    -16777217(-1.701412e+38), 16(2.242078e-44)
-; CM-NEXT:     LSHR T0.X, PV.W, literal.x,
-; CM-NEXT:     CNDE_INT T1.Y, PV.Y, 1, 0.0,
-; CM-NEXT:     SETGT_UINT * T0.W, T0.Z, literal.y,
-; CM-NEXT:    2(2.802597e-45), -16777217(-1.701412e+38)
-; CM-NEXT:     CNDE_INT * T1.X, PV.W, 1, 0.0,
-; CM-NEXT:     LSHR * T7.X, KC0[2].Y, literal.x,
-; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; CM-NEXT:     LSHL T4.Y, KC0[7].Y, 1,
+; CM-NEXT:     CNDE_INT T1.Z, T1.X, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T0.W, T1.Y, literal.x,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T6.X, T4.X, literal.x,
+; CM-NEXT:     CNDE_INT T1.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT T4.Z, PV.Y, literal.y,
+; CM-NEXT:     CNDE_INT * T0.W, T0.X, 1, 0.0, BS:VEC_120/SCL_212
+; CM-NEXT:    8(1.121039e-44), -16777217(-1.701412e+38)
+; CM-NEXT:     CNDE_INT T1.X, PV.Z, 1, 0.0,
+; CM-NEXT:     LSHL T4.Y, KC0[6].Y, 1,
+; CM-NEXT:     CNDE_INT T0.Z, T0.Z, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T4.W, T0.Y, literal.x,
+; CM-NEXT:    -16777217(-1.701412e+38), 0(0.000000e+00)
+; CM-NEXT:     ADD_INT T7.X, T4.X, literal.x,
+; CM-NEXT:     CNDE_INT T0.Y, PV.W, 1, 0.0,
+; CM-NEXT:     SETGT_UINT * T4.W, PV.Y, literal.y,
+; CM-NEXT:    4(5.605194e-45), -16777217(-1.701412e+38)
+; CM-NEXT:     CNDE_INT * T0.X, PV.W, 1, 0.0,
   %result = call <16 x i1> @llvm.is.fpclass.v3f32(<16 x float> %x, i32 504)
   %zext = zext <16 x i1> %result to <16 x i32>
   store <16 x i32> %zext, ptr addrspace(1) %out, align 64

--- a/llvm/test/CodeGen/AMDGPU/rotr.ll
+++ b/llvm/test/CodeGen/AMDGPU/rotr.ll
@@ -312,25 +312,23 @@ entry:
 define amdgpu_kernel void @rotr_v8i32(ptr addrspace(1) %in, <8 x i32> %x, <8 x i32> %y) {
 ; R600-LABEL: rotr_v8i32:
 ; R600:       ; %bb.0: ; %entry
-; R600-NEXT:    ALU 13, @4, KC0[CB0:0-32], KC1[]
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 0
-; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T1.X, 1
+; R600-NEXT:    ALU 11, @4, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
+; R600-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T2.X, 1
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    ALU clause starting at 4:
 ; R600-NEXT:     BIT_ALIGN_INT * T0.W, KC0[5].X, KC0[5].X, KC0[7].X,
 ; R600-NEXT:     BIT_ALIGN_INT * T0.Z, KC0[4].W, KC0[4].W, KC0[6].W,
 ; R600-NEXT:     BIT_ALIGN_INT * T0.Y, KC0[4].Z, KC0[4].Z, KC0[6].Z,
 ; R600-NEXT:     BIT_ALIGN_INT * T0.X, KC0[4].Y, KC0[4].Y, KC0[6].Y,
-; R600-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; R600-NEXT:     BIT_ALIGN_INT * T1.W, KC0[6].X, KC0[6].X, KC0[8].X,
+; R600-NEXT:     BIT_ALIGN_INT * T1.Z, KC0[5].W, KC0[5].W, KC0[7].W,
+; R600-NEXT:     BIT_ALIGN_INT * T1.Y, KC0[5].Z, KC0[5].Z, KC0[7].Z,
+; R600-NEXT:     BIT_ALIGN_INT * T1.X, KC0[5].Y, KC0[5].Y, KC0[7].Y,
+; R600-NEXT:     LSHR * T2.X, KC0[2].Y, literal.x,
 ; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; R600-NEXT:     BIT_ALIGN_INT * T2.W, KC0[6].X, KC0[6].X, KC0[8].X,
-; R600-NEXT:     BIT_ALIGN_INT * T2.Z, KC0[5].W, KC0[5].W, KC0[7].W,
-; R600-NEXT:     BIT_ALIGN_INT * T2.Y, KC0[5].Z, KC0[5].Z, KC0[7].Z,
-; R600-NEXT:     BIT_ALIGN_INT * T2.X, KC0[5].Y, KC0[5].Y, KC0[7].Y,
-; R600-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; R600-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR * T3.X, PV.W, literal.x,
-; R600-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; R600-NEXT:     ADD_INT * T3.X, PV.X, literal.x,
+; R600-NEXT:    4(5.605194e-45), 0(0.000000e+00)
 ;
 ; SI-LABEL: rotr_v8i32:
 ; SI:       ; %bb.0: ; %entry

--- a/llvm/test/CodeGen/AMDGPU/shl.ll
+++ b/llvm/test/CodeGen/AMDGPU/shl.ll
@@ -956,67 +956,65 @@ define amdgpu_kernel void @shl_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %in
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 48, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 1
+; EG-NEXT:    ALU 46, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
-; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 48, #1
-; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T3.XYZW, T0.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T0.XYZW, T0.X, 32, #1
 ; EG-NEXT:    ALU clause starting at 14:
 ; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 15:
-; EG-NEXT:     AND_INT * T1.W, T1.Z, literal.x,
+; EG-NEXT:     LSHR T0.Y, T1.W, 1,
+; EG-NEXT:     NOT_INT T4.Z, T0.Z,
+; EG-NEXT:     BIT_ALIGN_INT T0.W, T1.W, T1.Z, 1,
+; EG-NEXT:     AND_INT * T1.W, T3.Z, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHL * T1.W, T0.Z, PV.W,
-; EG-NEXT:     AND_INT T4.X, T1.Z, literal.x,
-; EG-NEXT:     LSHR T1.Y, T3.W, 1,
-; EG-NEXT:     NOT_INT T4.Z, T2.Z, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T2.W, T3.W, T3.Z, 1,
-; EG-NEXT:     AND_INT * T3.W, T2.Z, literal.y,
-; EG-NEXT:    32(4.484155e-44), 31(4.344025e-44)
-; EG-NEXT:     LSHL T5.X, T3.Z, PS,
-; EG-NEXT:     AND_INT T2.Y, T2.Z, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.Y, PV.W, PV.Z,
-; EG-NEXT:     LSHR T2.W, T3.Y, 1,
-; EG-NEXT:     NOT_INT * T3.W, T2.X,
+; EG-NEXT:     LSHL T4.X, T2.Z, PS,
+; EG-NEXT:     AND_INT T3.Y, T3.Z, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHR T5.Z, T2.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, T2.W, T2.Z, 1, BS:VEC_102/SCL_221
+; EG-NEXT:     NOT_INT * T2.W, T3.Z,
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T6.X, T3.Y, T3.X, 1,
-; EG-NEXT:     AND_INT T1.Y, T2.X, literal.x,
-; EG-NEXT:     LSHR T3.Z, T0.W, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.W, T0.W, T0.Z, 1,
-; EG-NEXT:     NOT_INT * T4.W, T1.Z,
+; EG-NEXT:     BIT_ALIGN_INT T5.X, PV.Z, PV.W, PS,
+; EG-NEXT:     LSHR T4.Y, T2.Y, 1,
+; EG-NEXT:     NOT_INT T2.Z, T3.X,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, T2.Y, T2.X, 1,
+; EG-NEXT:     AND_INT * T2.W, T3.X, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T7.X, PV.Z, PV.W, PS,
-; EG-NEXT:     LSHL T1.Y, T3.X, PV.Y, BS:VEC_120/SCL_212
-; EG-NEXT:     AND_INT T0.Z, T2.X, literal.x, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T0.W, T2.W, PV.X, T3.W,
-; EG-NEXT:     CNDE_INT * T3.W, T2.Y, T2.Z, T5.X,
+; EG-NEXT:     AND_INT T6.X, T0.Z, literal.x,
+; EG-NEXT:     LSHL T2.Y, T2.X, PS, BS:VEC_120/SCL_212
+; EG-NEXT:     AND_INT T3.Z, T3.X, literal.y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PV.Y, PV.W, PV.Z,
+; EG-NEXT:     CNDE_INT * T4.W, T3.Y, PV.X, T4.X,
+; EG-NEXT:    31(4.344025e-44), 32(4.484155e-44)
+; EG-NEXT:     CNDE_INT T4.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     LSHL T1.Z, T1.Z, PV.X,
+; EG-NEXT:     BIT_ALIGN_INT T0.W, T0.Y, T0.W, T4.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     AND_INT * T1.W, T0.Z, literal.x,
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T2.X, T0.Y, 1,
-; EG-NEXT:     CNDE_INT T3.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     NOT_INT T1.Z, T1.X,
-; EG-NEXT:     BIT_ALIGN_INT T0.W, T0.Y, T0.X, 1,
-; EG-NEXT:     AND_INT * T2.W, T1.X, literal.x,
+; EG-NEXT:     LSHR T2.X, T1.Y, 1,
+; EG-NEXT:     NOT_INT T0.Y, T0.X, BS:VEC_201
+; EG-NEXT:     CNDE_INT T4.Z, T3.Y, T4.X, 0.0, BS:VEC_102/SCL_221
+; EG-NEXT:     BIT_ALIGN_INT T2.W, T1.Y, T1.X, 1,
+; EG-NEXT:     AND_INT * T3.W, T0.X, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHL T0.X, T0.X, PS,
-; EG-NEXT:     AND_INT T0.Y, T1.X, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT T3.Z, T2.Y, T5.X, 0.0, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT * T0.W, PV.X, PV.W, PV.Z,
+; EG-NEXT:     CNDE_INT T4.X, T3.Z, T2.Y, 0.0, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHL T1.Y, T1.X, PS,
+; EG-NEXT:     AND_INT T0.Z, T0.X, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T2.W, PV.X, PV.W, PV.Y,
+; EG-NEXT:     CNDE_INT * T3.W, T1.W, T0.W, T1.Z,
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T2.W, T4.X, T7.X, T1.W,
-; EG-NEXT:     CNDE_INT T3.X, T0.Z, T1.Y, 0.0,
-; EG-NEXT:     CNDE_INT T2.Y, T0.Y, T0.W, T0.X,
-; EG-NEXT:     ADD_INT * T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     CNDE_INT T2.Z, T4.X, T1.W, 0.0,
-; EG-NEXT:     CNDE_INT * T2.X, T0.Y, T0.X, 0.0,
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     CNDE_INT * T3.Y, PV.Z, PV.W, PV.Y,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     CNDE_INT T3.Z, T1.W, T1.Z, 0.0,
+; EG-NEXT:     CNDE_INT * T3.X, T0.Z, T1.Y, 0.0,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %b_ptr = getelementptr <4 x i64>, ptr addrspace(1) %in, i64 1
   %a = load <4 x i64>, ptr addrspace(1) %in
   %b = load <4 x i64>, ptr addrspace(1) %b_ptr

--- a/llvm/test/CodeGen/AMDGPU/sra.ll
+++ b/llvm/test/CodeGen/AMDGPU/sra.ll
@@ -648,9 +648,9 @@ define amdgpu_kernel void @ashr_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 39, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T1.X, 1
+; EG-NEXT:    ALU 38, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T1.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T0.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 32, #1
@@ -687,19 +687,18 @@ define amdgpu_kernel void @ashr_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:     AND_INT * T4.W, T1.X, literal.x,
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
 ; EG-NEXT:     CNDE_INT T2.X, PS, PV.W, PV.Y,
-; EG-NEXT:     ASHR T6.Y, T3.W, literal.x,
-; EG-NEXT:     ASHR T3.Z, T0.Y, literal.x, BS:VEC_201
-; EG-NEXT:     ADD_INT T3.W, KC0[2].Y, literal.y,
+; EG-NEXT:     ASHR T3.Z, T3.W, literal.x,
+; EG-NEXT:     ASHR T3.W, T0.Y, literal.x, BS:VEC_201
 ; EG-NEXT:     CNDE_INT * T0.W, T1.Z, T2.Y, T1.Y,
-; EG-NEXT:    31(4.344025e-44), 16(2.242078e-44)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     CNDE_INT T0.Y, T2.W, T4.Y, PV.Z,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     CNDE_INT T0.Y, T2.W, T4.Y, PV.W,
 ; EG-NEXT:     ASHR T3.W, T3.Y, literal.y,
-; EG-NEXT:     CNDE_INT * T2.W, T1.W, T4.Z, PV.Y,
+; EG-NEXT:     CNDE_INT * T2.W, T1.W, T4.Z, PV.Z,
 ; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     LSHR T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     ADD_INT T3.X, PV.X, literal.x,
 ; EG-NEXT:     CNDE_INT * T2.Y, T4.W, T5.Y, PV.W,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %b_ptr = getelementptr <4 x i64>, ptr addrspace(1) %in, i64 1
   %a = load <4 x i64>, ptr addrspace(1) %in
   %b = load <4 x i64>, ptr addrspace(1) %b_ptr

--- a/llvm/test/CodeGen/AMDGPU/srem.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem.ll
@@ -6691,2217 +6691,2213 @@ define amdgpu_kernel void @srem_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:    ALU 114, @35, KC0[], KC1[]
 ; EG-NEXT:    ALU 115, @150, KC0[], KC1[]
 ; EG-NEXT:    ALU 115, @266, KC0[], KC1[]
-; EG-NEXT:    ALU 111, @382, KC0[], KC1[]
+; EG-NEXT:    ALU 109, @382, KC0[], KC1[]
 ; EG-NEXT:    TEX 1 @30
-; EG-NEXT:    ALU 114, @494, KC0[], KC1[]
-; EG-NEXT:    ALU 113, @609, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @723, KC0[], KC1[]
-; EG-NEXT:    ALU 113, @838, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @952, KC0[], KC1[]
-; EG-NEXT:    ALU 113, @1067, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @1181, KC0[], KC1[]
-; EG-NEXT:    ALU 113, @1296, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @1410, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @1525, KC0[], KC1[]
-; EG-NEXT:    ALU 114, @1640, KC0[], KC1[]
-; EG-NEXT:    ALU 115, @1755, KC0[], KC1[]
-; EG-NEXT:    ALU 113, @1871, KC0[], KC1[]
-; EG-NEXT:    ALU 112, @1985, KC0[], KC1[]
-; EG-NEXT:    ALU 99, @2098, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T7.XYZW, T0.X, 1
+; EG-NEXT:    ALU 114, @492, KC0[], KC1[]
+; EG-NEXT:    ALU 112, @607, KC0[], KC1[]
+; EG-NEXT:    ALU 113, @720, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @834, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @949, KC0[], KC1[]
+; EG-NEXT:    ALU 113, @1064, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @1178, KC0[], KC1[]
+; EG-NEXT:    ALU 113, @1293, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @1407, KC0[], KC1[]
+; EG-NEXT:    ALU 113, @1522, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @1636, KC0[], KC1[]
+; EG-NEXT:    ALU 113, @1751, KC0[], KC1[]
+; EG-NEXT:    ALU 112, @1865, KC0[], KC1[]
+; EG-NEXT:    ALU 114, @1978, KC0[], KC1[]
+; EG-NEXT:    ALU 100, @2093, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T5.XYZW, T1.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    PAD
 ; EG-NEXT:    Fetch clause starting at 26:
-; EG-NEXT:     VTX_READ_128 T1.XYZW, T2.X, 32, #1
-; EG-NEXT:     VTX_READ_128 T0.XYZW, T2.X, 0, #1
+; EG-NEXT:     VTX_READ_128 T2.XYZW, T0.X, 32, #1
+; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 0, #1
 ; EG-NEXT:    Fetch clause starting at 30:
-; EG-NEXT:     VTX_READ_128 T9.XYZW, T2.X, 16, #1
-; EG-NEXT:     VTX_READ_128 T10.XYZW, T2.X, 48, #1
+; EG-NEXT:     VTX_READ_128 T8.XYZW, T0.X, 16, #1
+; EG-NEXT:     VTX_READ_128 T9.XYZW, T0.X, 48, #1
 ; EG-NEXT:    ALU clause starting at 34:
-; EG-NEXT:     MOV * T2.X, KC0[2].Z,
+; EG-NEXT:     MOV * T0.X, KC0[2].Z,
 ; EG-NEXT:    ALU clause starting at 35:
-; EG-NEXT:     ASHR * T3.W, T1.Y, literal.x,
+; EG-NEXT:     ASHR * T3.W, T2.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT * T2.W, T1.X, PV.W,
-; EG-NEXT:     XOR_INT * T7.W, PV.W, T3.W,
-; EG-NEXT:     SUB_INT T2.Z, 0.0, PV.W,
-; EG-NEXT:     ASHR T2.W, T0.Y, literal.x,
-; EG-NEXT:     RECIP_UINT * T2.Y, PV.W,
+; EG-NEXT:     ADD_INT * T0.W, T2.Z, PV.W,
+; EG-NEXT:     XOR_INT * T6.W, PV.W, T3.W,
+; EG-NEXT:     SUB_INT T0.Z, 0.0, PV.W,
+; EG-NEXT:     ASHR T0.W, T1.W, literal.x,
+; EG-NEXT:     RECIP_UINT * T0.Y, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T3.Z, T0.Y, PV.W,
-; EG-NEXT:     ADDC_UINT T4.W, T0.X, PV.W,
-; EG-NEXT:     MULLO_INT * T0.Y, PV.Z, PS,
-; EG-NEXT:     ADD_INT T4.W, PV.Z, PV.W,
-; EG-NEXT:     MULHI * T0.Y, T2.Y, PS,
-; EG-NEXT:     ADD_INT T5.W, T2.Y, PS,
-; EG-NEXT:     XOR_INT * T4.W, PV.W, T2.W,
+; EG-NEXT:     ADD_INT T3.Z, T1.W, PV.W,
+; EG-NEXT:     ADDC_UINT T1.W, T1.Z, PV.W,
+; EG-NEXT:     MULLO_INT * T0.Z, PV.Z, PS,
+; EG-NEXT:     ADD_INT T1.W, PV.Z, PV.W,
+; EG-NEXT:     MULHI * T0.Z, T0.Y, PS,
+; EG-NEXT:     ADD_INT T4.W, T0.Y, PS,
+; EG-NEXT:     XOR_INT * T1.W, PV.W, T0.W,
 ; EG-NEXT:     MULHI * T0.Y, PS, PV.W,
-; EG-NEXT:     MULLO_INT * T0.Y, PS, T7.W,
-; EG-NEXT:     SUB_INT * T5.W, T4.W, PS,
-; EG-NEXT:     SETGE_UINT T6.W, PV.W, T7.W,
-; EG-NEXT:     SUB_INT * T8.W, PV.W, T7.W,
-; EG-NEXT:     CNDE_INT T2.Z, PV.W, T5.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     ADD_INT T5.W, T1.Y, T3.W,
-; EG-NEXT:     ADDC_UINT * T6.W, T1.X, T3.W,
-; EG-NEXT:     ADD_INT T3.Z, PV.W, PS,
-; EG-NEXT:     SETGE_UINT T5.W, PV.Z, T7.W,
-; EG-NEXT:     SUB_INT * T6.W, PV.Z, T7.W,
-; EG-NEXT:     ADD_INT T4.Z, T0.X, T2.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T5.W, PV.W, T2.Z, PS,
-; EG-NEXT:     XOR_INT * T6.W, PV.Z, T3.W,
-; EG-NEXT:     CNDE_INT T3.W, PS, PV.W, T4.W,
-; EG-NEXT:     XOR_INT * T8.W, PV.Z, T2.W,
-; EG-NEXT:     BIT_ALIGN_INT T4.W, PV.W, PS, literal.x,
-; EG-NEXT:     LSHR * T3.W, PV.W, literal.x,
+; EG-NEXT:     MULLO_INT * T0.Y, PS, T6.W,
+; EG-NEXT:     SUB_INT * T4.W, T1.W, PS,
+; EG-NEXT:     SETGE_UINT T5.W, PV.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, PV.W, T6.W,
+; EG-NEXT:     CNDE_INT T0.Z, PV.W, T4.W, PS, BS:VEC_021/SCL_122
+; EG-NEXT:     ADD_INT T2.W, T2.W, T3.W,
+; EG-NEXT:     ADDC_UINT * T4.W, T2.Z, T3.W,
+; EG-NEXT:     ADD_INT T2.Z, PV.W, PS,
+; EG-NEXT:     SETGE_UINT T2.W, PV.Z, T6.W,
+; EG-NEXT:     SUB_INT * T4.W, PV.Z, T6.W,
+; EG-NEXT:     ADD_INT T1.Z, T1.Z, T0.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T2.W, PV.W, T0.Z, PS,
+; EG-NEXT:     XOR_INT * T4.W, PV.Z, T3.W,
+; EG-NEXT:     CNDE_INT T1.W, PS, PV.W, T1.W,
+; EG-NEXT:     XOR_INT * T5.W, PV.Z, T0.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.W, PV.W, PS, literal.x,
+; EG-NEXT:     LSHR * T1.W, PV.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETE_INT T2.Z, PS, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.W, PS, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T7.W,
+; EG-NEXT:     SETE_INT T0.Z, PS, T4.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T3.W, PS, T4.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T6.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.Z, PV.W, PS,
-; EG-NEXT:     SUB_INT * T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T5.W, T3.W, T6.W,
-; EG-NEXT:     SUBB_UINT * T9.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT T5.W, T5.W, PV.W,
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT * T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T3.W, T1.W, T4.W,
+; EG-NEXT:     SUBB_UINT * T7.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT T3.W, T3.W, PV.W,
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT * T2.Z, PS, T7.W,
+; EG-NEXT:     SETGE_UINT * T0.Z, PS, T6.W,
 ; EG-NEXT:    ALU clause starting at 150:
-; EG-NEXT:     SETE_INT T5.W, T3.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, T3.W, T6.W,
-; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, T2.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SETE_INT T3.W, T1.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, T1.W, T4.W,
+; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, T0.Z,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    25(3.503246e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T2.Z, T4.W, T7.W,
+; EG-NEXT:     SUB_INT * T0.Z, T2.W, T6.W,
 ; EG-NEXT:    ALU clause starting at 266:
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
 ; EG-NEXT:    ALU clause starting at 382:
-; EG-NEXT:     LSHL T2.Z, T4.W, 1,
-; EG-NEXT:     BFE_UINT * T9.W, T8.W, literal.x, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     LSHL T0.Z, T2.W, 1,
+; EG-NEXT:     BFE_UINT * T7.W, T5.W, literal.x, 1, BS:VEC_120/SCL_212
 ; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, T5.W,
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PV.W, T4.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T4.W, T2.Z, T9.W,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PV.W, T2.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T2.W, T0.Z, T7.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T9.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T9.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:    ALU clause starting at 494:
-; EG-NEXT:     LSHL T2.Z, T4.W, 1,
-; EG-NEXT:     BFE_UINT * T11.W, T8.W, literal.x, 1, BS:VEC_120/SCL_212
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:    ALU clause starting at 492:
+; EG-NEXT:     SUB_INT T3.W, T7.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, T5.W,
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PV.W, T4.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T4.W, T2.Z, T11.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T11.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T2.Z, PS, 1,
-; EG-NEXT:     BFE_UINT T11.W, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T3.W, T0.Y, T3.W, PV.W,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T0.Z, PS, 1,
+; EG-NEXT:     BFE_UINT T7.W, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T1.W, PV.W,
 ; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T3.W, PS, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T4.W, PV.Z, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T1.W, PS, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T2.W, PV.Z, PV.W,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.Z, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.W, PV.W, T6.W,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.W, T6.W,
+; EG-NEXT:     SETGE_UINT T0.Z, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.W, PV.W, T4.W,
+; EG-NEXT:     SETGE_UINT * T7.W, PV.W, T4.W,
 ; EG-NEXT:     CNDE_INT T0.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Z, T4.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T5.W, T4.W, T7.W,
-; EG-NEXT:     SUB_INT * T11.W, T3.W, T6.W,
-; EG-NEXT:     SUB_INT T5.W, PV.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T4.W, T0.Y, T4.W, T2.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1,
-; EG-NEXT:     CNDE_INT T3.W, T0.Y, T3.W, PV.W,
-; EG-NEXT:     ASHR * T11.W, T10.Y, literal.y,
+; EG-NEXT:     SUB_INT T0.Z, T2.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T3.W, T2.W, T6.W,
+; EG-NEXT:     SUB_INT * T7.W, T1.W, T4.W,
+; EG-NEXT:     SUB_INT T3.W, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T2.W, T0.Y, T2.W, T0.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T0.Z, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T1.W, T0.Y, T1.W, PV.W,
+; EG-NEXT:     ASHR * T7.W, T9.W, literal.y,
 ; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
-; EG-NEXT:     ADD_INT T3.Z, T10.X, PS,
-; EG-NEXT:     BIT_ALIGN_INT T5.W, PV.W, T4.W, literal.x,
-; EG-NEXT:     OR_INT * T12.W, PV.Y, PV.Z,
+; EG-NEXT:     ADD_INT T1.Z, T9.Z, PS,
+; EG-NEXT:     BIT_ALIGN_INT T3.W, PV.W, T2.W, literal.x,
+; EG-NEXT:     OR_INT * T10.W, PV.Y, PV.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T0.Y, PS, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T2.Z, PV.W, T6.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T3.W, PV.W, T6.W, BS:VEC_102/SCL_221
-; EG-NEXT:     XOR_INT * T4.W, PV.Z, T11.W,
-; EG-NEXT:     SUB_INT T13.W, 0.0, PS,
-; EG-NEXT:     CNDE_INT * T14.W, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.X, T12.W, T7.W,
-; EG-NEXT:     SUBB_UINT * T0.Y, T12.W, T7.W,
-; EG-NEXT:     SUB_INT T2.Z, T5.W, T6.W,
-; EG-NEXT:     ASHR T3.W, T9.Y, literal.x,
-; EG-NEXT:     RECIP_UINT * T1.X, T4.W,
+; EG-NEXT:     SETGE_UINT T0.Y, PS, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T0.Z, PV.W, T4.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T1.W, PV.W, T4.W, BS:VEC_102/SCL_221
+; EG-NEXT:     XOR_INT * T2.W, PV.Z, T7.W,
+; EG-NEXT:     SUB_INT T11.W, 0.0, PS,
+; EG-NEXT:     CNDE_INT * T12.W, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T0.X, T10.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T0.Y, T10.W, T6.W,
+; EG-NEXT:     SUB_INT T0.Z, T3.W, T4.W,
+; EG-NEXT:     ASHR * T1.W, T8.W, literal.x, BS:VEC_201
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T1.Y, T9.Y, PV.W,
-; EG-NEXT:     SUB_INT T2.Z, PV.Z, T0.Y,
-; EG-NEXT:     CNDE_INT T12.W, T14.W, T12.W, T0.X,
-; EG-NEXT:     MULLO_INT * T0.X, T13.W, PS,
-; EG-NEXT:     ADDC_UINT T2.X, T9.X, T3.W,
+; EG-NEXT:     RECIP_UINT * T1.Z, T2.W,
+; EG-NEXT:     ADD_INT T3.Y, T8.W, T1.W,
+; EG-NEXT:     SUB_INT * T0.Z, T0.Z, T0.Y,
+; EG-NEXT:     CNDE_INT T8.W, T12.W, T10.W, T0.X,
+; EG-NEXT:     MULLO_INT * T0.X, T11.W, T1.Z,
+; EG-NEXT:     ADDC_UINT T3.X, T8.Z, T1.W,
 ; EG-NEXT:     LSHL T0.Y, PV.W, 1,
-; EG-NEXT:     BFE_UINT * T3.Z, T8.W, 1, 1,
-; EG-NEXT:     CNDE_INT T5.W, T14.W, T5.W, T2.Z,
-; EG-NEXT:     MULHI * T0.X, T1.X, T0.X,
-; EG-NEXT:     ADD_INT T2.Y, T1.X, PS,
-; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T12.W, literal.x,
-; EG-NEXT:     OR_INT T12.W, T0.Y, T3.Z,
-; EG-NEXT:     ADD_INT * T5.W, T1.Y, T2.X,
+; EG-NEXT:     BFE_UINT * T2.Z, T5.W, 1, 1,
+; EG-NEXT:     CNDE_INT T3.W, T12.W, T3.W, T0.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     MULHI * T0.X, T1.Z, T0.X,
+; EG-NEXT:     ADD_INT T0.X, T1.Z, PS,
+; EG-NEXT:     BIT_ALIGN_INT T4.Y, PV.W, T8.W, literal.x,
+; EG-NEXT:     OR_INT T0.Z, T0.Y, T2.Z,
+; EG-NEXT:     ASHR T8.W, T2.Y, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT * T3.W, T3.Y, T3.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T1.X, PS, T3.W,
-; EG-NEXT:     ASHR T0.Y, T10.W, literal.x,
-; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T7.W, BS:VEC_021/SCL_122
+; EG-NEXT:     XOR_INT T3.X, PS, T1.W, BS:VEC_021/SCL_122
+; EG-NEXT:     ADD_INT T0.Y, T2.X, PV.W,
+; EG-NEXT:     SETGE_UINT T1.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETE_INT T3.W, PV.Y, T4.W,
+; EG-NEXT:     SETGE_UINT * T10.W, PV.Y, T4.W,
+; EG-NEXT:     CNDE_INT T4.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T0.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUBB_UINT T1.Z, T0.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T10.W, T4.Y, T4.W, BS:VEC_102/SCL_221
+; EG-NEXT:     XOR_INT * T3.W, PV.Y, T8.W,
+; EG-NEXT:     SUB_INT T5.X, 0.0, PS,
+; EG-NEXT:     ASHR T5.Y, T9.Y, literal.x,
+; EG-NEXT:     SUB_INT T1.Z, PV.W, PV.Z,
+; EG-NEXT:     CNDE_INT T10.W, PV.X, T0.Z, PV.Y,
+; EG-NEXT:     RECIP_UINT * T2.Z, PS,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETE_INT T5.W, T4.Z, T6.W,
-; EG-NEXT:     SETGE_UINT * T13.W, T4.Z, T6.W,
-; EG-NEXT:     CNDE_INT T1.Y, PV.W, PS, T2.Z,
-; EG-NEXT:     SUB_INT T3.Z, T12.W, T7.W,
-; EG-NEXT:     ADD_INT T5.W, T10.Z, T0.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     MULHI * T0.X, T1.X, T2.Y,
-; EG-NEXT:     SUBB_UINT T2.X, T12.W, T7.W,
-; EG-NEXT:     SUB_INT T2.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     XOR_INT * T2.Z, PV.W, T0.Y,
-; EG-NEXT:     ASHR T5.W, T9.W, literal.x,
-; EG-NEXT:     MULLO_INT * T0.X, T0.X, T4.W,
+; EG-NEXT:     LSHL T6.X, PV.W, 1,
+; EG-NEXT:     AND_INT T3.Y, T5.W, 1,
+; EG-NEXT:     CNDE_INT T0.Z, T4.X, T4.Y, PV.Z,
+; EG-NEXT:     ADD_INT T5.W, T9.X, PV.Y, BS:VEC_120/SCL_212
+; EG-NEXT:     MULLO_INT * T1.Z, PV.X, PS,
+; EG-NEXT:     XOR_INT T0.Y, PV.W, T5.Y,
+; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Z, T10.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, PV.X, PV.Y,
+; EG-NEXT:     MULHI * T3.Y, T3.X, T0.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T3.X, T9.W, PV.W,
-; EG-NEXT:     SUB_INT T3.Y, 0.0, T2.Z,
-; EG-NEXT:     SUB_INT T5.Z, T2.Y, T2.X,
-; EG-NEXT:     CNDE_INT T9.W, T1.Y, T12.W, T3.Z, BS:VEC_120/SCL_212
-; EG-NEXT:     RECIP_UINT * T2.X, T2.Z,
-; EG-NEXT:     ADDC_UINT T4.X, T9.Z, T5.W,
-; EG-NEXT:     LSHL T2.Y, PV.W, 1,
-; EG-NEXT:     AND_INT T3.Z, T8.W, 1,
-; EG-NEXT:     CNDE_INT T8.W, T1.Y, T4.Z, PV.Z,
-; EG-NEXT:     MULLO_INT * T1.Y, PV.Y, PS,
-; EG-NEXT:     BIT_ALIGN_INT T3.Y, PV.W, T9.W, literal.x,
-; EG-NEXT:     OR_INT T5.Z, PV.Y, PV.Z,
-; EG-NEXT:     ADD_INT T8.W, T3.X, PV.X,
-; EG-NEXT:     MULHI * T1.Y, T2.X, PS,
+; EG-NEXT:     SETGE_UINT T4.Y, PV.W, T6.W,
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T4.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T5.W, 0.0, PV.Y,
+; EG-NEXT:     RECIP_UINT * T4.X, PV.Y,
+; EG-NEXT:     SETGE_UINT T0.X, T0.Z, T4.W,
+; EG-NEXT:     SUBB_UINT T6.Y, T10.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T4.Z, T0.Z, T4.W,
+; EG-NEXT:     ASHR T4.W, T8.Y, literal.x,
+; EG-NEXT:     MULLO_INT * T5.X, PV.W, PS,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T2.X, T2.X, PS,
-; EG-NEXT:     XOR_INT T1.Y, PV.W, T5.W,
-; EG-NEXT:     SETGE_UINT T3.Z, PV.Z, T7.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Y, T6.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT * T9.W, T1.X, T0.X,
-; EG-NEXT:     SETGE_UINT T0.X, T3.Y, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUBB_UINT T2.Y, T5.Z, T7.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT T4.Z, T3.Y, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.W, PS, T4.W,
-; EG-NEXT:     SUB_INT * T12.W, PS, T4.W,
-; EG-NEXT:     CNDE_INT T3.X, PV.W, T9.W, PS,
-; EG-NEXT:     ADD_INT T4.Y, T10.Y, T11.W, BS:VEC_102/SCL_221
-; EG-NEXT:     ADDC_UINT T6.Z, T10.X, T11.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT T6.W, PV.Z, PV.Y,
-; EG-NEXT:     CNDE_INT * T8.W, T8.W, PV.X, T3.Z,
-; EG-NEXT:     CNDE_INT T0.X, PS, T3.Y, PV.W,
-; EG-NEXT:     ADD_INT * T2.Y, PV.Y, PV.Z,
-; EG-NEXT:    ALU clause starting at 609:
-; EG-NEXT:     SETGE_UINT T3.Z, T3.X, T4.W,
-; EG-NEXT:     SUB_INT T6.W, T3.X, T4.W,
-; EG-NEXT:     MULHI * T2.X, T1.Y, T2.X,
-; EG-NEXT:     ASHR T4.X, T1.W, literal.x,
-; EG-NEXT:     CNDE_INT T3.Y, PV.Z, T3.X, PV.W,
-; EG-NEXT:     XOR_INT T3.Z, T2.Y, T11.W,
-; EG-NEXT:     ADD_INT T6.W, T9.Z, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     MULLO_INT * T2.X, PS, T2.Z,
+; EG-NEXT:     ADD_INT T6.X, T8.Y, PV.W,
+; EG-NEXT:     ADDC_UINT T7.Y, T8.X, PV.W,
+; EG-NEXT:     SUB_INT T4.Z, PV.Z, PV.Y,
+; EG-NEXT:     CNDE_INT T11.W, T3.Z, PV.X, T4.Y,
+; EG-NEXT:     MULHI * T3.Z, T4.X, PS,
+; EG-NEXT:     CNDE_INT T0.X, PV.W, T0.Z, PV.Z,
+; EG-NEXT:     ADD_INT T4.Y, T4.X, PS,
+; EG-NEXT:     ASHR * T0.Z, T1.Y, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     XOR_INT T3.X, PV.W, T5.W,
-; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.Y, T1.X,
-; EG-NEXT:     ADD_INT T4.Z, T1.Z, PV.X,
-; EG-NEXT:     SUB_INT T9.W, T1.Y, PS,
-; EG-NEXT:     ASHR * T6.W, T0.W, literal.x,
+; EG-NEXT:    ALU clause starting at 607:
+; EG-NEXT:     ADD_INT T5.W, T6.X, T7.Y,
+; EG-NEXT:     MULLO_INT * T3.Y, T3.Y, T2.W,
+; EG-NEXT:     XOR_INT T4.X, PV.W, T4.W,
+; EG-NEXT:     ADD_INT T1.Y, T1.Y, T0.Z, BS:VEC_102/SCL_221
+; EG-NEXT:     ADDC_UINT T3.Z, T1.X, T0.Z, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT T5.W, T3.X, PS,
+; EG-NEXT:     MULHI * T1.Z, T2.Z, T1.Z,
+; EG-NEXT:     ADD_INT T5.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T3.Y, PV.W, T2.W,
+; EG-NEXT:     SUB_INT T1.Z, PV.W, T2.W,
+; EG-NEXT:     ADD_INT T12.W, PV.Y, PV.Z,
+; EG-NEXT:     MULHI * T1.Y, PV.X, T4.Y,
+; EG-NEXT:     XOR_INT T6.X, PV.W, T0.Z,
+; EG-NEXT:     CNDE_INT T3.Y, PV.Y, T5.W, PV.Z,
+; EG-NEXT:     ADD_INT T1.Z, T9.W, T7.W, BS:VEC_021/SCL_122
+; EG-NEXT:     ADDC_UINT T5.W, T9.Z, T7.W, BS:VEC_021/SCL_122
+; EG-NEXT:     MULLO_INT * T1.Y, PS, T0.Y,
+; EG-NEXT:     ADD_INT T7.X, T8.X, T4.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T1.Y, T4.X, PS, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT T1.Z, PV.Z, PV.W,
+; EG-NEXT:     SETGE_UINT T5.W, PV.Y, T2.W,
+; EG-NEXT:     SUB_INT * T9.W, PV.Y, T2.W,
+; EG-NEXT:     ADD_INT T8.X, T8.Z, T1.W,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, T3.Y, PS, BS:VEC_021/SCL_122
+; EG-NEXT:     XOR_INT T1.Z, PV.Z, T7.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.W, PV.Y, T0.Y,
+; EG-NEXT:     SUB_INT * T7.W, PV.Y, T0.Y,
+; EG-NEXT:     CNDE_INT T10.X, PV.W, T1.Y, PS,
+; EG-NEXT:     ADD_INT T1.Y, T9.Y, T5.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     ADDC_UINT T2.Z, T9.X, T5.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T5.W, PV.Z, PV.Y, T3.X,
+; EG-NEXT:     XOR_INT * T7.W, PV.X, T1.W,
+; EG-NEXT:     BIT_ALIGN_INT T8.X, PV.W, PS, literal.x,
+; EG-NEXT:     LSHR T3.Y, PV.W, literal.x,
+; EG-NEXT:     ADD_INT T2.Z, PV.Y, PV.Z,
+; EG-NEXT:     SETGE_UINT T5.W, PV.X, T0.Y,
+; EG-NEXT:     SUB_INT * T9.W, PV.X, T0.Y,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ADD_INT T1.X, T0.W, PS,
-; EG-NEXT:     ADDC_UINT T3.Y, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T6.Z, PV.W, T2.Z,
-; EG-NEXT:     SUB_INT T11.W, PV.W, T2.Z,
-; EG-NEXT:     XOR_INT * T0.W, PV.Z, T4.X,
-; EG-NEXT:     SUB_INT T2.X, 0.0, PS,
-; EG-NEXT:     CNDE_INT T4.Y, PV.Z, T9.W, PV.W,
-; EG-NEXT:     ADD_INT T4.Z, T10.W, T0.Y,
-; EG-NEXT:     ADDC_UINT T9.W, T10.Z, T0.Y,
-; EG-NEXT:     RECIP_UINT * T5.X, PS,
-; EG-NEXT:     ADD_INT T6.X, PV.Z, PV.W,
-; EG-NEXT:     SETGE_UINT T5.Y, PV.Y, T2.Z,
-; EG-NEXT:     SUB_INT T4.Z, PV.Y, T2.Z,
-; EG-NEXT:     ADD_INT T9.W, T9.X, T3.W,
-; EG-NEXT:     MULLO_INT * T6.Y, PV.X, PS,
-; EG-NEXT:     XOR_INT T2.X, PV.W, T3.W,
-; EG-NEXT:     CNDE_INT T4.Y, PV.Y, T4.Y, PV.Z,
-; EG-NEXT:     XOR_INT T4.Z, PV.X, T0.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     ADD_INT T9.W, T1.X, T3.Y, BS:VEC_102/SCL_221
-; EG-NEXT:     MULHI * T0.Y, T5.X, PS,
-; EG-NEXT:     ADD_INT T1.X, T5.X, PS,
-; EG-NEXT:     XOR_INT T0.Y, PV.W, T6.W,
-; EG-NEXT:     CNDE_INT T6.Z, PV.Z, PV.Y, T1.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T9.W, T2.Y, PV.X, literal.x,
-; EG-NEXT:     LSHR * T10.W, T2.Y, literal.x,
+; EG-NEXT:     CNDE_INT T3.X, PV.W, T10.X, PS,
+; EG-NEXT:     XOR_INT T1.Y, PV.Z, T5.Y,
+; EG-NEXT:     SETE_INT T2.Z, PV.Y, T1.Z,
+; EG-NEXT:     SETGE_UINT T5.W, PV.Y, T1.Z,
+; EG-NEXT:     SETGE_UINT * T9.W, PV.X, T2.W,
+; EG-NEXT:     CNDE_INT T9.X, PV.Z, PV.W, PS,
+; EG-NEXT:     SUB_INT T4.Y, T8.X, T2.W,
+; EG-NEXT:     CNDE_INT T2.Z, PV.Y, PV.X, T4.X,
+; EG-NEXT:     XOR_INT * T5.W, T7.X, T4.W, BS:VEC_120/SCL_212
+; EG-NEXT:     SUB_INT * T6.W, T10.W, T6.W,
+; EG-NEXT:     CNDE_INT T3.X, T11.W, T10.W, PV.W,
+; EG-NEXT:     BIT_ALIGN_INT T5.Y, T2.Z, T5.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     LSHR T2.Z, T2.Z, literal.x,
+; EG-NEXT:     CNDE_INT * T9.W, T9.X, T8.X, T4.Y,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETE_INT T5.X, PS, T3.Z,
-; EG-NEXT:     SETGE_UINT T1.Y, PS, T3.Z,
-; EG-NEXT:     SETGE_UINT T7.Z, PV.W, T4.W,
-; EG-NEXT:     LSHR T11.W, PV.Z, literal.x,
-; EG-NEXT:     MULHI * T1.X, PV.Y, PV.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETE_INT T6.X, PV.W, T4.Z,
-; EG-NEXT:     CNDE_INT T1.Y, PV.X, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT T7.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T12.W, T6.Z, T3.X, literal.x,
-; EG-NEXT:     MULLO_INT * T1.X, PS, T0.W,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T5.X, T11.W, T4.Z,
-; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T2.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT T6.Z, T0.Y, PS,
-; EG-NEXT:     CNDE_INT T13.W, PV.Y, T9.W, PV.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T7.W, T5.Z, T7.W,
-; EG-NEXT:     CNDE_INT T1.X, T8.W, T5.Z, PS,
-; EG-NEXT:     LSHL T3.Y, PV.W, 1,
-; EG-NEXT:     SETGE_UINT T5.Z, PV.Z, T0.W,
-; EG-NEXT:     SUB_INT T7.W, PV.Z, T0.W,
-; EG-NEXT:     CNDE_INT * T8.W, T6.X, PV.X, PV.Y,
-; EG-NEXT:     SUB_INT T5.X, T12.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T11.W, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SUBB_UINT T7.Z, T12.W, T2.Z,
-; EG-NEXT:     ADD_INT T1.W, T1.W, T4.X, BS:VEC_201
-; EG-NEXT:     ADDC_UINT * T14.W, T1.Z, T4.X,
-; EG-NEXT:     BFE_UINT T6.X, T2.X, literal.x, 1,
-; EG-NEXT:     ADD_INT T4.Y, PV.W, PS,
-; EG-NEXT:     SUB_INT T1.Z, PV.Y, PV.Z,
-; EG-NEXT:     CNDE_INT T1.W, T8.W, T12.W, PV.X, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T7.W, T5.Z, T6.Z, T7.W,
+; EG-NEXT:     MULHI * T3.Z, T6.X, T5.X,
+; EG-NEXT:     LSHL T4.X, T9.W, 1,
+; EG-NEXT:     SETE_INT T4.Y, T2.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT T4.Z, T2.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT T6.W, T5.Y, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     MULLO_INT * T3.Z, PS, T3.W,
+; EG-NEXT:     CNDE_INT T5.X, PV.Y, PV.Z, PV.W,
+; EG-NEXT:     SUB_INT T4.Y, T5.Y, T0.Y,
+; EG-NEXT:     SUB_INT T4.Z, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SUBB_UINT T6.W, T5.Y, T0.Y,
+; EG-NEXT:     SUB_INT * T10.W, T6.X, PS,
+; EG-NEXT:     BFE_UINT T7.X, T7.W, literal.x, 1,
+; EG-NEXT:     SETGE_UINT T6.Y, PS, T3.W,
+; EG-NEXT:     SUB_INT T3.Z, PS, T3.W,
+; EG-NEXT:     SUB_INT T6.W, PV.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, PV.X, T5.Y, PV.Y,
 ; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T5.X, PS, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT T2.Y, PS, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     LSHL T5.Z, PV.W, 1,
-; EG-NEXT:     BFE_UINT T12.W, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T8.W, T8.W, T11.W, PV.Z,
+; EG-NEXT:     LSHL T10.X, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Y, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Z, T5.X, T2.Z, PV.W,
+; EG-NEXT:     ADD_INT T6.W, T2.Y, T8.W,
+; EG-NEXT:     ADDC_UINT * T12.W, T2.X, T8.W,
 ; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T7.X, PS, T1.W, literal.x,
-; EG-NEXT:     OR_INT T5.Y, PV.Z, PV.W,
-; EG-NEXT:     ADD_INT T0.Z, T0.Z, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T7.W, PV.X, T7.W, PV.Y, BS:VEC_102/SCL_221
-; EG-NEXT:     XOR_INT * T1.W, T4.Y, T4.X,
+; EG-NEXT:     SUB_INT T2.X, T3.Y, T1.Z,
+; EG-NEXT:     ADD_INT T2.Y, PV.W, PS,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.Z, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T11.W, PV.X, PV.Y,
+; EG-NEXT:     CNDE_INT * T6.W, T6.Y, T10.W, T3.Z,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, PS, PV.W, T0.Y,
-; EG-NEXT:     XOR_INT T0.Y, PV.Z, T6.W,
-; EG-NEXT:     SETGE_UINT T0.Z, PV.Y, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.X, T4.Z,
-; EG-NEXT:     SETGE_UINT * T8.W, PV.X, T4.Z,
-; EG-NEXT:     SUB_INT T5.X, T10.W, T3.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T0.Z, T5.Y, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T7.W, PV.X, PV.Y, literal.x,
-; EG-NEXT:     LSHR * T8.W, PV.X, literal.x,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T5.Y, T2.Z,
-; EG-NEXT:     SUB_INT T4.Y, T7.X, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T1.Z, PS, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T11.W, PS, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT * T12.W, PV.W, T0.W,
-; EG-NEXT:     SUB_INT T8.X, T8.W, T1.W,
-; EG-NEXT:     CNDE_INT * T6.Y, PV.Z, PV.W, PS,
-; EG-NEXT:     SUB_INT T1.Z, T7.W, T0.W,
-; EG-NEXT:     SUB_INT T11.W, T4.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T12.W, T2.Y, T5.Y, T0.Z,
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.X, PS, T3.W,
+; EG-NEXT:     SUB_INT T4.Y, PS, T3.W,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.Y,
+; EG-NEXT:     CNDE_INT T10.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Y, T11.W, T0.Y,
+; EG-NEXT:     ADD_INT T3.Z, T1.X, T0.Z,
+; EG-NEXT:     CNDE_INT T10.W, PV.X, T6.W, PV.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     XOR_INT * T6.W, T2.Y, T8.W,
+; EG-NEXT:     SUBB_UINT T1.X, T11.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Z, PS, PV.W, T6.X,
+; EG-NEXT:     XOR_INT T8.W, PV.Z, T0.Z,
+; EG-NEXT:     CNDE_INT * T10.W, PV.X, T11.W, PV.Y,
+; EG-NEXT:     SUBB_UINT T5.X, T8.X, T2.W,
 ; EG-NEXT:     LSHL T4.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T2.Y, T7.X, PV.W,
-; EG-NEXT:     CNDE_INT * T7.W, T6.Y, T7.W, PV.Z,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Z, PV.W, literal.x,
+; EG-NEXT:     LSHR T11.W, PV.Z, literal.x,
+; EG-NEXT:     SUB_INT * T12.W, PV.Y, PV.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T10.X, T2.Z, PS,
+; EG-NEXT:     SETE_INT T2.Z, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T12.W, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T3.W,
 ; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT * T7.X, T9.W, T4.W,
-; EG-NEXT:    ALU clause starting at 723:
-; EG-NEXT:     LSHL T2.Y, T7.W, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, T11.W, T12.W, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     OR_INT T9.W, T4.Y, T0.Z,
+; EG-NEXT:     CNDE_INT T6.X, PV.Z, PV.W, PS,
+; EG-NEXT:     SUB_INT T5.Y, T3.Z, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT * T2.Z, PV.Y, T10.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 720:
+; EG-NEXT:     OR_INT T10.W, T4.Y, T1.X, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT * T12.W, T2.X, T5.X,
+; EG-NEXT:     CNDE_INT T1.X, T9.X, T3.Y, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T4.Z, T2.Z, T1.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT * T12.W, T2.Z, T1.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T13.W, T6.X, T3.Z, T5.Y,
+; EG-NEXT:     LSHL T2.X, PV.W, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T4.Z, T12.W, T2.Y,
+; EG-NEXT:     SUB_INT T4.Z, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T1.X, T9.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T3.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T8.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    30(4.203895e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T4.X, T11.W, T6.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T10.W, T0.Y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T12.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T7.X, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T4.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T8.X, T3.Z, T3.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T12.W, T4.X, T8.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T11.W, PS, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T2.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETE_INT T4.Z, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Z,
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T4.Z, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T3.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, T11.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T6.W,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T14.W, T2.Y, T3.Z, PV.W,
+; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T13.W, T5.Z,
+; EG-NEXT:     BFE_UINT T5.X, T5.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T14.W, T9.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T9.W, T3.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T14.W, T1.X, T2.X,
+; EG-NEXT:    26(3.643376e-44), 31(4.344025e-44)
+; EG-NEXT:    ALU clause starting at 834:
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T3.Y, T4.Y, T11.W, T14.W,
+; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T4.Z, T9.W, T2.W,
+; EG-NEXT:     SETE_INT T11.W, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, T3.Z, T1.Z,
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T9.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, T10.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T10.W, T6.W,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T13.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T6.W,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T3.Z, PV.W,
+; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T8.X, T2.Z, T1.Y,
+; EG-NEXT:     LSHL T4.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T13.W, T9.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T2.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T13.W, T1.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T1.Z,
+; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T3.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T0.Y,
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Y,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T7.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    25(3.503246e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T11.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T2.Z, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T2.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T12.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T0.Y,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T0.Y,
+; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Y,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T12.W, T4.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T3.Z, T1.Z,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T10.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T12.W, PV.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT * T1.X, T5.W, literal.x, 1,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 949:
+; EG-NEXT:     CNDE_INT * T2.Y, T3.Y, T9.W, T12.W,
+; EG-NEXT:     SETGE_UINT T2.Z, T10.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T12.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, T4.Y, T1.X, BS:VEC_102/SCL_221
 ; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T4.Y, T6.Y, T8.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T4.Z,
-; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T5.Y, T9.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, T2.Y, PV.X,
-; EG-NEXT:     SUB_INT * T8.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T1.Y, T10.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT * T8.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, T8.X, T9.W, T5.Y,
-; EG-NEXT:     LSHL T5.X, PV.W, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T5.Z, T8.W, T1.Y,
-; EG-NEXT:     SUB_INT * T5.Z, T7.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T4.X, T13.W, literal.x,
-; EG-NEXT:     OR_INT * T11.W, T3.Y, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T11.W, T4.W,
-; EG-NEXT:     SETE_INT T12.W, T8.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T13.W, T8.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T3.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T3.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    28(3.923636e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T8.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.W,
-; EG-NEXT:    29(4.063766e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T5.Z, T7.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T1.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T9.W, T4.W,
-; EG-NEXT:     SETE_INT T11.W, T8.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T3.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T1.W,
-; EG-NEXT:    28(3.923636e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T2.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, T9.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT * T6.Z, T10.W, T2.Z,
-; EG-NEXT:    ALU clause starting at 838:
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T10.W, T3.Y, T10.W, T6.Z,
-; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T0.Y, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    27(3.783506e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T3.Z,
-; EG-NEXT:    27(3.783506e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T0.W,
-; EG-NEXT:     CNDE_INT * T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T1.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T10.W, T7.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T2.Z,
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T4.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T0.Z, T1.W,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T3.Z,
-; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T0.Z, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.Z, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T13.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    25(3.503246e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T4.Z,
-; EG-NEXT:    26(3.643376e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T4.W,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T0.Z, T7.W, T2.Z, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T1.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T11.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T0.W,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T0.W,
-; EG-NEXT:     SUB_INT * T11.W, PV.Y, PV.X,
-; EG-NEXT:    ALU clause starting at 952:
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T1.W,
-; EG-NEXT:     LSHL T1.Y, PV.W, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T1.Z, T11.W,
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T6.Z,
-; EG-NEXT:     SUB_INT T10.X, T5.Z, T3.Z,
-; EG-NEXT:     LSHL T3.Y, PV.W, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, T11.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, T1.Y, T0.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T11.W, T4.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T4.Z,
-; EG-NEXT:    25(3.503246e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T9.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T5.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T8.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T10.W, T4.W,
-; EG-NEXT:     SETE_INT T12.W, T9.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T3.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T3.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    23(3.222986e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.W,
-; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T5.Z, T8.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T0.W,
-; EG-NEXT:     SUB_INT * T1.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T9.W, T4.W,
-; EG-NEXT:     SETE_INT T10.W, T7.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T3.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T8.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T1.W,
-; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T1.Z, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 1067:
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T4.W,
-; EG-NEXT:     SUB_INT T2.Y, T5.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT * T6.Z, T11.W, T2.Z, BS:VEC_210
-; EG-NEXT:     SETE_INT T12.W, T9.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T2.Z,
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T0.Y, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    22(3.082857e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T3.Z,
-; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T0.W,
-; EG-NEXT:     CNDE_INT * T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T1.Z, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T4.W,
-; EG-NEXT:     SUB_INT T1.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T11.W, T8.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T2.Z,
-; EG-NEXT:     SUB_INT T11.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T4.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T0.Z, T1.W,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T7.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T3.Z,
-; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T0.Z, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.Z, T8.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T13.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T4.Z,
-; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T4.W,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T0.Z, T8.W, T2.Z, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT * T4.X, T8.W, T2.Z,
-; EG-NEXT:    ALU clause starting at 1181:
-; EG-NEXT:     SUB_INT T1.Y, T1.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, T9.W, T0.W,
-; EG-NEXT:     SETE_INT T10.W, T7.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T1.W,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T5.Z, T3.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T8.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T4.Z,
-; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T9.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T5.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T7.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T11.W, T4.W,
-; EG-NEXT:     SETE_INT T12.W, T9.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T3.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T3.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    18(2.522337e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.W,
-; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T5.Z, T7.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T1.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T9.W, T4.W,
-; EG-NEXT:     SETE_INT T11.W, T8.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T3.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T1.W,
-; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T4.W,
-; EG-NEXT:     SETE_INT * T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:    ALU clause starting at 1296:
-; EG-NEXT:     SETGE_UINT T9.W, T5.Z, T3.Z,
-; EG-NEXT:     CNDE_INT * T11.W, T9.X, T7.W, T2.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T1.Z, PV.W, T1.Y,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, T4.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T2.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, T9.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T2.Z,
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T0.Y, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    17(2.382207e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T3.Z,
-; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T0.W,
-; EG-NEXT:     CNDE_INT * T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T1.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T10.W, T7.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T2.Z,
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T4.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T0.Z, T1.W,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T3.Z,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T0.Z, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.Z, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T13.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    15(2.101948e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z,
-; EG-NEXT:     SETE_INT * T9.W, PV.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 1410:
-; EG-NEXT:     SETGE_UINT * T12.W, T1.Z, T4.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T4.W,
-; EG-NEXT:     CNDE_INT * T3.Y, T9.W, PV.W, T0.Z, BS:VEC_201
-; EG-NEXT:     SUB_INT T0.Z, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T1.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T11.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T5.Z, T3.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T4.Z,
-; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T9.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T5.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T8.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T10.W, T4.W,
-; EG-NEXT:     SETE_INT T12.W, T9.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T3.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T3.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    13(1.821688e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.W,
-; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T5.Z, T8.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T0.W,
-; EG-NEXT:     SUB_INT * T1.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T9.W, T4.W,
-; EG-NEXT:     SETE_INT T10.W, T7.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T3.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T8.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T1.W,
-; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:    ALU clause starting at 1525:
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, T1.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, T3.Y, T4.X, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T10.W, T8.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T1.Z, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T4.W,
-; EG-NEXT:     SUB_INT T2.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, T9.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T2.Z,
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T0.Y, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    12(1.681558e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T3.Z,
-; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T0.W,
-; EG-NEXT:     CNDE_INT * T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T1.Z, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T4.W,
-; EG-NEXT:     SUB_INT T1.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T11.W, T8.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T2.Z,
-; EG-NEXT:     SUB_INT T11.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T4.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T0.Z, T1.W,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T7.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T3.Z,
-; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T0.Z, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.Z, T8.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T13.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT * T1.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:    10(1.401298e-44), 31(4.344025e-44)
-; EG-NEXT:    ALU clause starting at 1640:
-; EG-NEXT:     OR_INT T8.W, T2.Y, T0.Z,
-; EG-NEXT:     SUB_INT * T12.W, T4.X, T5.X,
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T9.W, T1.Z, T4.Z, BS:VEC_210
-; EG-NEXT:     SETGE_UINT * T12.W, T1.Z, T4.Z,
-; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T4.W,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T0.Z, T8.W, T2.Z, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T2.Z,
-; EG-NEXT:     SUB_INT T1.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T10.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T10.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T5.Z, T3.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T8.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T4.Z,
-; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T9.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T5.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T7.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T11.W, T4.W,
-; EG-NEXT:     SETE_INT T12.W, T9.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T3.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
-; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T3.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T6.X,
-; EG-NEXT:    8(1.121039e-44), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.W,
-; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T5.Z, T7.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T0.W,
-; EG-NEXT:     SUB_INT * T1.Y, T0.Z, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, T9.W, T4.W,
-; EG-NEXT:     SETE_INT T11.W, T8.W, T3.Z, BS:VEC_201
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T5.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T3.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T0.Z, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 1755:
-; EG-NEXT:     BFE_UINT T4.X, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T1.Y, T2.Y, T8.W, T11.W,
-; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T5.Z, T7.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, T0.Z, T1.W,
-; EG-NEXT:     SETGE_UINT * T11.W, T0.Z, T1.W,
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, T1.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, T3.Y, T4.X, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T2.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, T9.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T13.W, T9.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T5.X, T10.W, T2.Z,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T10.W, T2.Z,
-; EG-NEXT:     SUB_INT T12.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.Z,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T10.W, PV.Y, T10.W, PV.Z,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T7.X, T0.Y, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T12.W, PV.X, T5.X,
-; EG-NEXT:    7(9.809089e-45), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T3.Z,
-; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T5.X, T7.W, T0.W,
-; EG-NEXT:     CNDE_INT * T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T7.W, T2.Y, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T8.W, T4.W,
-; EG-NEXT:     SUB_INT T1.Y, T5.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T6.Z, PS, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T10.W, T7.W, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, T7.W, T4.Z,
-; EG-NEXT:     SUBB_UINT T8.X, T9.W, T2.Z,
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, T6.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T2.Z,
-; EG-NEXT:     SUB_INT T10.W, T1.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T1.Z,
-; EG-NEXT:     SUB_INT T4.X, T7.W, T4.Z,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T1.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T10.W, T3.Y, T5.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T0.Z, T1.W,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T5.Z, PV.W, T8.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T10.W, PV.X, T8.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T7.W, PS,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.W, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.Z, T3.Z,
-; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T8.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T8.W, T4.W,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T7.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T5.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T9.X, T0.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T0.Z, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T4.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T10.W, PV.X, T8.W, PV.Y,
-; EG-NEXT:     LSHL T5.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T0.Z, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T11.W, T6.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T2.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T12.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T13.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T6.X, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T11.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T1.W,
-; EG-NEXT:     LSHL T2.Y, PS, 1,
-; EG-NEXT:     BFE_UINT * T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
-; EG-NEXT:    ALU clause starting at 1871:
-; EG-NEXT:     CNDE_INT T12.W, T1.Y, T1.Z, T12.W,
-; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T6.Z,
-; EG-NEXT:     BFE_UINT T7.X, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T7.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, T2.Y, T0.Z,
-; EG-NEXT:     SUB_INT * T12.W, T4.X, T6.X,
-; EG-NEXT:    5(7.006492e-45), 31(4.344025e-44)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T4.Z,
-; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T6.X, T8.W, T4.W,
-; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T0.Z, T7.W, T2.Z, BS:VEC_201
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T2.Y, T11.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T1.Y, T4.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T4.X, T7.W, T2.Z,
-; EG-NEXT:     SUB_INT T1.Y, T1.Z, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T6.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T11.W, PV.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, PV.W, T1.W,
-; EG-NEXT:     SUBB_UINT T9.X, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T2.Y, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T6.Z, T9.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, PV.Y, PV.X,
-; EG-NEXT:     CNDE_INT * T7.W, T3.Y, T7.W, T0.Z,
-; EG-NEXT:     SUB_INT T4.X, T8.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T0.Z, T3.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T11.W, T3.Y, T1.Z, PV.W,
-; EG-NEXT:     CNDE_INT * T9.W, PV.Y, T9.W, PV.Z,
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T10.X, T5.Z, T3.Z,
-; EG-NEXT:     LSHL T3.Y, PS, 1,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.W, T7.W, literal.x,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T11.W, PV.X, T9.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T2.Y, T8.W, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, PV.Z, T4.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T4.Z,
-; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T9.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.Y, T9.W, literal.x,
-; EG-NEXT:     OR_INT T8.W, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T10.X, T6.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT T4.X, T8.X, T5.Z, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.W, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T11.W, PV.X, T7.W, PV.Y,
-; EG-NEXT:     LSHL T6.X, PS, 1,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T8.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T10.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T10.W, T5.X, T7.X,
-; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T4.X, T3.X, literal.x, 1,
-; EG-NEXT:     SETGE_UINT T2.Y, PS, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T6.Z, PV.W, T3.Z,
-; EG-NEXT:     SETGE_UINT T12.W, PV.W, T3.Z,
-; EG-NEXT:     CNDE_INT * T13.W, PV.Y, T8.W, PV.Z,
-; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHL T5.X, PS, 1,
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T3.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
 ; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
-; EG-NEXT:     SUB_INT T5.Z, T10.W, T4.W,
-; EG-NEXT:     SUBB_UINT T12.W, T10.W, T4.W,
-; EG-NEXT:     SUB_INT * T14.W, T9.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T7.X, T7.W, T2.Z,
-; EG-NEXT:     SUBB_UINT * T3.Y, T8.W, T0.W, BS:VEC_120/SCL_212
-; EG-NEXT:     SUB_INT T6.Z, T0.Z, T1.W,
-; EG-NEXT:     SUB_INT * T7.W, T14.W, T12.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T8.W, T2.Y, T10.W, T5.Z,
-; EG-NEXT:     SUB_INT T8.X, T1.Z, T4.Z,
-; EG-NEXT:     LSHL T4.Y, PV.W, 1,
-; EG-NEXT:     BFE_UINT T5.Z, T2.X, literal.x, 1,
-; EG-NEXT:     CNDE_INT T7.W, T2.Y, T9.W, T7.W,
-; EG-NEXT:     SUB_INT * T9.W, T6.Z, T3.Y,
-; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
-; EG-NEXT:     BFE_UINT T10.X, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT T1.Y, T1.Y, T0.Z, PS, BS:VEC_120/SCL_212
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, PV.W, T8.W, literal.y,
-; EG-NEXT:     OR_INT T7.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT * T8.W, PV.X, T7.X,
-; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
-; EG-NEXT:     CNDE_INT T7.X, T9.X, T1.Z, PS,
-; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T4.W,
-; EG-NEXT:     SETE_INT T1.Z, PV.Z, T3.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T8.W, PV.Y, T13.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT * T9.W, T5.X, PV.X,
+; EG-NEXT:     SUB_INT T3.Z, T9.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T5.X, T0.Z, T3.Z,
-; EG-NEXT:     SUBB_UINT T1.Y, T7.W, T4.W,
-; EG-NEXT:     SETGE_UINT * T5.Z, PS, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T10.W, T8.W, T1.W,
-; EG-NEXT:     SETGE_UINT * T12.W, T8.W, T1.W,
-; EG-NEXT:     SUB_INT T8.X, T0.Z, T3.Z,
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T0.Y,
+; EG-NEXT:     SUB_INT T3.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.Y, T13.W, PV.Z,
+; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T8.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T9.W, literal.y,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T2.X,
+; EG-NEXT:    25(3.503246e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T3.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T3.Z, T9.W, T0.Y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T13.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T13.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T13.W, T4.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T4.Z, T6.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T9.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T13.W, PV.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T1.Y,
+; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Y, T11.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T4.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T4.Z, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T4.Z, T10.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T2.W,
+; EG-NEXT:     SUB_INT T3.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, T11.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T6.W,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T14.W, T2.Y, T3.Z, PV.W,
+; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 1064:
+; EG-NEXT:     CNDE_INT * T12.W, T4.Y, T12.W, T5.Z,
+; EG-NEXT:     BFE_UINT T5.X, T5.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T14.W, T10.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T10.W, T3.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T14.W, T1.X, T4.X,
+; EG-NEXT:    21(2.942727e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Z,
+; EG-NEXT:    24(3.363116e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T10.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T2.W,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T12.W, T9.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T9.W, T6.W,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T3.W, BS:VEC_021/SCL_122
 ; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T5.Z,
-; EG-NEXT:     SUB_INT T5.Z, T9.W, T0.W,
-; EG-NEXT:     SUBB_UINT * T10.W, T9.W, T0.W,
-; EG-NEXT:     SUB_INT * T12.W, T8.W, T1.W,
-; EG-NEXT:     SUB_INT T9.X, PV.W, T10.W,
-; EG-NEXT:     CNDE_INT * T4.Y, T3.Y, T9.W, T5.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T5.Z, T7.W, T4.W,
-; EG-NEXT:     SUB_INT T9.W, T8.X, T1.Y,
-; EG-NEXT:     CNDE_INT * T10.W, T1.Z, T5.X, T2.Y,
-; EG-NEXT:    ALU clause starting at 1985:
-; EG-NEXT:     CNDE_INT T5.X, T10.W, T0.Z, T9.W,
-; EG-NEXT:     CNDE_INT T1.Y, T10.W, T7.W, T5.Z,
-; EG-NEXT:     LSHL T0.Z, T4.Y, 1,
-; EG-NEXT:     BFE_UINT * T7.W, T0.Y, literal.x, 1, BS:VEC_120/SCL_212
-; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T8.W, T3.Y, T8.W, T9.X,
-; EG-NEXT:     BIT_ALIGN_INT T8.X, PV.W, T4.Y, literal.x,
-; EG-NEXT:     OR_INT T2.Y, T0.Z, T7.W,
-; EG-NEXT:     BIT_ALIGN_INT T0.Z, T5.X, T1.Y, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT * T7.W, T7.X, T11.W, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T12.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T6.W,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T12.W, T4.Y, T3.Z, PV.W,
+; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T8.X, T2.Z, T1.Y,
+; EG-NEXT:     LSHL T4.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T12.W, T10.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, T2.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T12.W, T1.X, T7.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     OR_INT * T8.W, T6.X, T4.X,
-; EG-NEXT:     SETGE_UINT T4.X, PV.W, T2.Z,
-; EG-NEXT:     SETE_INT T3.Y, T7.W, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T1.Z, T7.W, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     BFE_UINT T9.W, T2.X, literal.x, 1,
-; EG-NEXT:     LSHL * T10.W, T1.Y, 1,
-; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; EG-NEXT:     OR_INT T5.X, PS, PV.W,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Y, PV.Z, PV.X,
-; EG-NEXT:     SUB_INT T1.Z, T8.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUBB_UINT T9.W, T8.W, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T10.W, T7.W, T4.Z,
-; EG-NEXT:     SUB_INT T4.X, PS, PV.W,
-; EG-NEXT:     CNDE_INT T3.Y, PV.Y, T8.W, PV.Z,
-; EG-NEXT:     SETGE_UINT T1.Z, PV.X, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T8.W, T0.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T9.W, T0.Z, T3.Z,
-; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT T4.Y, T5.X, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     LSHL T1.Z, PV.Y, 1,
-; EG-NEXT:     BFE_UINT T8.W, T3.X, literal.x, 1, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT * T7.W, T1.Y, T7.W, PV.X,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     BIT_ALIGN_INT T4.X, PS, T3.Y, literal.x,
-; EG-NEXT:     OR_INT T1.Y, PV.Z, PV.W,
-; EG-NEXT:     CNDE_INT T1.Z, PV.X, T5.X, PV.Y,
-; EG-NEXT:     SUBB_UINT T7.W, T2.Y, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T8.W, T8.X, T1.W,
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.Z,
+; EG-NEXT:    23(3.222986e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T7.X, PS, PV.W,
-; EG-NEXT:     LSHL T3.Y, PV.Z, 1,
-; EG-NEXT:     SETGE_UINT T5.Z, PV.Y, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T7.W, PV.X, T4.Z,
-; EG-NEXT:     SETGE_UINT * T8.W, PV.X, T4.Z,
-; EG-NEXT:     BFE_UINT T9.X, T2.X, literal.x, 1,
-; EG-NEXT:     SETGE_UINT T4.Y, T2.Y, T0.W,
-; EG-NEXT:     SETE_INT T6.Z, T8.X, T1.W, BS:VEC_120/SCL_212
-; EG-NEXT:     CNDE_INT T7.W, PV.W, PS, PV.Z,
-; EG-NEXT:     SUB_INT * T8.W, T1.Y, T2.Z,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T10.X, T1.Y, T2.Z,
-; EG-NEXT:     SUB_INT T5.Y, T4.X, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUBB_UINT * T5.Z, T5.X, T4.W, BS:VEC_120/SCL_212
-; EG-NEXT:     SUB_INT T9.W, T0.Z, T3.Z,
-; EG-NEXT:     CNDE_INT * T8.W, T7.W, T1.Y, T8.W,
-; EG-NEXT:     SETGE_UINT T5.X, T8.X, T1.W,
-; EG-NEXT:     LSHL T1.Y, PS, 1,
-; EG-NEXT:     BFE_UINT T7.Z, T3.X, 1, 1, BS:VEC_201
-; EG-NEXT:     SUB_INT T9.W, PV.W, T5.Z,
-; EG-NEXT:     SUB_INT * T10.W, T5.Y, T10.X,
-; EG-NEXT:     CNDE_INT T4.X, T7.W, T4.X, PS,
-; EG-NEXT:     CNDE_INT T5.Y, T6.X, T0.Z, PV.W,
-; EG-NEXT:     OR_INT T0.Z, PV.Y, PV.Z,
-; EG-NEXT:     CNDE_INT T7.W, T6.Z, PV.X, T4.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T9.W, T2.Y, T0.W,
-; EG-NEXT:     CNDE_INT T5.X, PV.W, T2.Y, PS,
-; EG-NEXT:     SETGE_UINT T1.Y, PV.Z, T2.Z,
-; EG-NEXT:     BIT_ALIGN_INT T1.Z, PV.Y, T1.Z, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T8.W, PV.X, T8.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T3.Y, T9.X,
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETE_INT T4.X, PV.W, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PS, T4.W,
-; EG-NEXT:     SETE_INT T10.W, PV.Z, T3.Z,
-; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T3.Z,
-; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
-; EG-NEXT:     CNDE_INT T1.Y, PV.X, PV.Y, T1.Y,
-; EG-NEXT:     LSHL T5.Z, T5.X, 1, BS:VEC_201
-; EG-NEXT:     BFE_UINT T10.W, T0.Y, literal.x, 1,
-; EG-NEXT:     CNDE_INT * T7.W, T7.W, T8.X, T7.X,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T4.X, T0.Z, T2.Z,
-; EG-NEXT:     SUBB_UINT T2.Y, T0.Z, T2.Z,
-; EG-NEXT:     SUB_INT T6.Z, T8.W, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T7.W, PS, T5.X, literal.x,
-; EG-NEXT:     OR_INT * T10.W, PV.Z, PV.W,
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T3.W,
+; EG-NEXT:     SUB_INT T3.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T0.Y,
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Y,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T13.W, PV.Y, T13.W, PV.Z,
+; EG-NEXT:    22(3.082857e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T7.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T9.W, literal.y,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T2.X,
+; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    20(2.802597e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T11.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T2.Z, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T5.X, PS, T0.W,
-; EG-NEXT:     SETE_INT T3.Y, PV.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T11.W, PV.Z, PV.Y,
-; EG-NEXT:     CNDE_INT * T12.W, T1.Y, T0.Z, PV.X,
-; EG-NEXT:     SUBB_UINT * T4.X, T10.W, T0.W,
-; EG-NEXT:     SUB_INT T2.Y, T7.W, T1.W,
-; EG-NEXT:     LSHL T0.Z, T12.W, 1, BS:VEC_201
-; EG-NEXT:     AND_INT * T13.W, T3.X, 1,
-; EG-NEXT:     CNDE_INT * T8.W, T1.Y, T8.W, T11.W,
-; EG-NEXT:     SUB_INT T3.X, T10.W, T0.W,
-; EG-NEXT:     BIT_ALIGN_INT * T1.Y, PV.W, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T3.W,
+; EG-NEXT:     SUB_INT T2.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T0.Y,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T0.Y,
+; EG-NEXT:     SUB_INT T13.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T1.Y,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T13.W, T4.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    21(2.942727e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 1178:
+; EG-NEXT:     SUB_INT T8.X, T3.Z, T1.Z,
+; EG-NEXT:     LSHL T4.Y, T11.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, T13.W, T9.W, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T9.W, T2.Y, T2.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T13.W, T1.X, T6.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     OR_INT T0.Z, T0.Z, T13.W,
-; EG-NEXT:     SUB_INT T8.W, T2.Y, T4.X,
-; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T5.Z, T5.X,
-; EG-NEXT:     SUB_INT T4.X, T9.W, T4.W,
-; EG-NEXT:     CNDE_INT T2.Y, PS, T7.W, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T5.Z, PV.Z, T2.Z,
-; EG-NEXT:     SETE_INT * T7.W, T1.Y, T4.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT * T8.W, T11.W, T10.W, T3.X,
-; EG-NEXT:     SETGE_UINT T3.X, T1.Y, T4.Z,
-; EG-NEXT:     SUBB_UINT T3.Y, T0.Z, T2.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T4.Z, T1.Y, T4.Z,
-; EG-NEXT:    ALU clause starting at 2098:
-; EG-NEXT:     BFE_UINT T10.W, T0.Y, 1, 1,
-; EG-NEXT:     LSHL * T11.W, T8.W, 1,
-; EG-NEXT:     SUBB_UINT T5.X, T9.W, T4.W,
-; EG-NEXT:     SUB_INT T4.Y, T1.Z, T3.Z,
-; EG-NEXT:     OR_INT T6.Z, PS, PV.W,
-; EG-NEXT:     SUB_INT * T10.W, T4.Z, T3.Y, BS:VEC_201
-; EG-NEXT:     CNDE_INT * T7.W, T7.W, T3.X, T5.Z,
-; EG-NEXT:     CNDE_INT T3.X, PV.W, T1.Y, T10.W,
-; EG-NEXT:     SETGE_UINT T1.Y, T6.Z, T0.W,
-; EG-NEXT:     SUB_INT T4.Z, T4.Y, T5.X,
-; EG-NEXT:     BIT_ALIGN_INT * T8.W, T2.Y, T8.W, literal.x, BS:VEC_201
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T10.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T13.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, T4.Y, T1.X, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     CNDE_INT * T9.W, T6.X, T9.W, T4.X,
-; EG-NEXT:     SETE_INT T4.X, T8.W, T1.W,
-; EG-NEXT:     SETGE_UINT T2.Y, T8.W, T1.W,
-; EG-NEXT:     LSHL T5.Z, PV.W, 1,
-; EG-NEXT:     BFE_UINT T10.W, T2.X, 1, 1,
-; EG-NEXT:     CNDE_INT * T11.W, T6.X, T1.Z, T4.Z,
-; EG-NEXT:     BIT_ALIGN_INT T5.X, PS, T9.W, literal.x, BS:VEC_021/SCL_122
-; EG-NEXT:     OR_INT T3.Y, PV.Z, PV.W,
-; EG-NEXT:     CNDE_INT T1.Z, PV.X, PV.Y, T1.Y,
-; EG-NEXT:     SUB_INT T9.W, T6.Z, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     XOR_INT * T10.W, T3.X, T5.W,
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T3.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T3.Z, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SUB_INT T3.X, PS, T5.W,
-; EG-NEXT:     CNDE_INT T1.Y, PV.Z, T6.Z, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT T4.Z, PV.Y, T4.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETE_INT T9.W, PV.X, T3.Z,
-; EG-NEXT:     SETGE_UINT * T10.W, PV.X, T3.Z,
-; EG-NEXT:     CNDE_INT T4.X, PV.W, PS, PV.Z,
-; EG-NEXT:     LSHL T2.Y, PV.Y, 1,
-; EG-NEXT:     AND_INT T4.Z, T0.Y, 1,
-; EG-NEXT:     SUBB_UINT T9.W, T6.Z, T0.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT * T10.W, T8.W, T1.W,
-; EG-NEXT:     SUB_INT T6.X, T3.Y, T4.W,
-; EG-NEXT:     SUB_INT T0.Y, PS, PV.W,
-; EG-NEXT:     SUBB_UINT T5.Z, T3.Y, T4.W,
-; EG-NEXT:     SUB_INT T9.W, T5.X, T3.Z,
-; EG-NEXT:     OR_INT * T10.W, PV.Y, PV.Z,
-; EG-NEXT:     SUB_INT T7.X, PS, T0.W,
-; EG-NEXT:     SUB_INT T2.Y, PV.W, PV.Z,
-; EG-NEXT:     CNDE_INT T1.Z, T1.Z, T8.W, PV.Y, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T8.W, T4.X, T3.Y, PV.X,
-; EG-NEXT:     SUB_INT * T9.W, T0.Z, T2.Z,
-; EG-NEXT:     CNDE_INT T6.X, T7.W, T0.Z, PS,
-; EG-NEXT:     LSHL T0.Y, PV.W, 1,
-; EG-NEXT:     AND_INT T0.Z, T2.X, 1,
-; EG-NEXT:     BIT_ALIGN_INT T7.W, PV.Z, T1.Y, literal.x,
-; EG-NEXT:     CNDE_INT * T9.W, T4.X, T5.X, PV.Y,
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T3.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T8.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    20(2.802597e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T3.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T3.Z, T10.W, T0.Y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T2.X, T10.W, T0.W,
-; EG-NEXT:     SETE_INT T1.Y, PV.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SETGE_UINT * T1.Z, PV.W, T1.W, BS:VEC_021/SCL_122
-; EG-NEXT:     BIT_ALIGN_INT T8.W, T9.W, T8.W, literal.x,
-; EG-NEXT:     OR_INT * T9.W, T0.Y, T0.Z,
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T12.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T12.W, T4.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T4.Z, T6.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T12.W, PV.X, T7.X,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     SETGE_UINT T4.X, PS, T4.W,
-; EG-NEXT:     SETE_INT T0.Y, PV.W, T3.Z,
-; EG-NEXT:     SETGE_UINT T0.Z, PV.W, T3.Z,
-; EG-NEXT:     SUBB_UINT T11.W, PS, T4.W,
-; EG-NEXT:     SUB_INT * T12.W, PV.W, T3.Z,
-; EG-NEXT:     SUBB_UINT * T5.X, T10.W, T0.W,
-; EG-NEXT:     SUB_INT * T2.Y, T7.W, T1.W,
-; EG-NEXT:     SUB_INT * T2.Z, T9.W, T4.W,
-; EG-NEXT:     SUB_INT T0.W, T12.W, T11.W,
-; EG-NEXT:     CNDE_INT * T1.W, T0.Y, T0.Z, T4.X,
-; EG-NEXT:     CNDE_INT T4.X, PS, T8.W, PV.W, BS:VEC_021/SCL_122
-; EG-NEXT:     CNDE_INT T0.Y, PS, T9.W, T2.Z, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT T0.Z, T2.Y, T5.X,
-; EG-NEXT:     CNDE_INT T0.W, T1.Y, T1.Z, T2.X, BS:VEC_210
-; EG-NEXT:     XOR_INT * T1.W, T6.X, T5.W,
-; EG-NEXT:     SUBB_UINT T2.X, PS, T5.W,
-; EG-NEXT:     CNDE_INT T1.Y, PV.W, T7.W, PV.Z, BS:VEC_021/SCL_122
-; EG-NEXT:     XOR_INT T0.Z, PV.Y, T3.W, BS:VEC_102/SCL_221
-; EG-NEXT:     XOR_INT * T4.W, PV.X, T3.W, BS:VEC_102/SCL_221
-; EG-NEXT:     CNDE_INT * T0.W, T0.W, T10.W, T7.X,
-; EG-NEXT:     XOR_INT T4.X, PV.W, T6.W,
-; EG-NEXT:     SUB_INT T0.Y, T4.W, T3.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUBB_UINT T1.Z, T0.Z, T3.W, BS:VEC_021/SCL_122
-; EG-NEXT:     XOR_INT T0.W, T1.Y, T6.W,
-; EG-NEXT:     SUB_INT * T7.W, T3.X, T2.X,
-; EG-NEXT:     SUB_INT T2.X, PV.W, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT T7.Y, PV.Y, PV.Z,
-; EG-NEXT:     SUBB_UINT T1.Z, PV.X, T6.W, BS:VEC_021/SCL_122
-; EG-NEXT:     XOR_INT T0.W, T1.X, T2.W,
-; EG-NEXT:     XOR_INT * T4.W, T0.X, T2.W,
-; EG-NEXT:     SUB_INT T0.Y, PS, T2.W,
-; EG-NEXT:     SUB_INT T7.Z, T1.W, T5.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUBB_UINT T1.W, PV.W, T2.W,
-; EG-NEXT:     SUB_INT * T4.W, PV.X, PV.Z,
-; EG-NEXT:     SUB_INT T7.X, T0.Z, T3.W,
-; EG-NEXT:     SUB_INT T4.Y, PV.Y, PV.W,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.Y,
+; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Y, T11.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T4.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T4.Z, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T4.Z, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T3.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, T11.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T3.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T5.Z,
+; EG-NEXT:    ALU clause starting at 1293:
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T6.W,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T14.W, T2.Y, T3.Z, PV.W,
+; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T13.W, T5.Z,
+; EG-NEXT:     BFE_UINT T5.X, T5.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T14.W, T9.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T9.W, T3.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T14.W, T1.X, T2.X,
+; EG-NEXT:    16(2.242078e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Z,
+; EG-NEXT:    19(2.662467e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T9.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, T10.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T10.W, T6.W,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T13.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T6.W,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T3.Z, PV.W,
 ; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     SUB_INT T4.Z, T4.X, T6.W, BS:VEC_102/SCL_221
-; EG-NEXT:     SUB_INT * T4.X, T0.W, T2.W,
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T8.X, T2.Z, T1.Y,
+; EG-NEXT:     LSHL T4.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T13.W, T9.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T2.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T13.W, T1.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T1.Z,
+; EG-NEXT:    18(2.522337e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T3.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T0.Y,
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Y,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    17(2.382207e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T7.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    15(2.101948e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    15(2.101948e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T11.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T2.Z, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T2.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T12.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T0.Y,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T5.Z, T11.W, T0.Y,
+; EG-NEXT:    ALU clause starting at 1407:
+; EG-NEXT:     SUB_INT T12.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Y,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T12.W, T4.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T3.Z, T1.Z,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T10.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T12.W, PV.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T9.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T12.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, T4.Y, T1.X, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T3.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T3.Z, T9.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T0.Y,
+; EG-NEXT:     SUB_INT T3.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.Y, T13.W, PV.Z,
+; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T8.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T9.W, literal.y,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T2.X,
+; EG-NEXT:    15(2.101948e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T3.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T3.Z, T9.W, T0.Y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T13.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T13.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T13.W, T4.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T4.Z, T6.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T9.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T13.W, PV.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T1.Y,
+; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Y, T11.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T4.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T4.Z, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T4.Z, T10.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT * T11.W, PV.X, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 1522:
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T2.W,
+; EG-NEXT:     SUB_INT T3.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, T11.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T6.W,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T14.W, T2.Y, T3.Z, PV.W,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T12.W, T4.Y, T12.W, T5.Z,
+; EG-NEXT:     BFE_UINT T5.X, T5.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T14.W, T10.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T10.W, T3.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T14.W, T1.X, T4.X,
+; EG-NEXT:    11(1.541428e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Z,
+; EG-NEXT:    14(1.961818e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T10.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T2.W,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T12.W, T9.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T9.W, T6.W,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T12.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T6.W,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T12.W, T4.Y, T3.Z, PV.W,
+; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T8.X, T2.Z, T1.Y,
+; EG-NEXT:     LSHL T4.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T12.W, T10.W, literal.x,
+; EG-NEXT:     OR_INT T10.W, T2.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T12.W, T1.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.Z,
+; EG-NEXT:    13(1.821688e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T9.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T12.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T3.W,
+; EG-NEXT:     SUB_INT T3.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T0.Y,
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Y,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T13.W, PV.Y, T13.W, PV.Z,
+; EG-NEXT:    12(1.681558e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T7.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T9.W, literal.y,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T2.X,
+; EG-NEXT:    10(1.401298e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    10(1.401298e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T11.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T2.Z, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 1636:
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T3.W,
+; EG-NEXT:     SUB_INT * T2.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, T11.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, T10.W, T1.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT * T14.W, T10.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T0.Y,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T0.Y,
+; EG-NEXT:     SUB_INT T13.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T1.Y,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T13.W, T4.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    11(1.541428e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T3.Z, T1.Z,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T9.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T13.W, PV.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T10.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T13.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, T2.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, T4.Y, T1.X, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T3.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T3.Z, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T3.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Z,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T8.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    10(1.401298e-44), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Y,
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T4.X, T9.W, T3.W,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T3.Z, T10.W, T0.Y, BS:VEC_201
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T3.Y, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T2.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T2.W,
+; EG-NEXT:     SETE_INT T12.W, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T7.X, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T12.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T4.Y, T10.W, T3.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Z, T5.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T12.W, T4.Y, T2.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T11.W, PV.Y, T11.W, PV.Z,
+; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T8.X, T4.Z, T6.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T12.W, PV.X, T7.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T3.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T9.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T12.W, PV.Z, T1.Y,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T7.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T10.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.Y, T11.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T4.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T6.X, T4.Z, PS,
+; EG-NEXT:     SETGE_UINT * T2.Y, PV.W, T2.W,
+; EG-NEXT:    ALU clause starting at 1751:
+; EG-NEXT:     SETE_INT T4.Z, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT T11.W, T3.Z, T1.Z,
+; EG-NEXT:     CNDE_INT * T12.W, T7.X, T10.W, T3.Y,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, T2.Y,
+; EG-NEXT:     SUB_INT T4.Z, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, T1.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T13.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T3.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, T11.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:     SUBB_UINT T2.X, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T14.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T2.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T6.W,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T14.W, T2.Y, T3.Z, PV.W,
+; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T13.W, T5.Z,
+; EG-NEXT:     BFE_UINT T5.X, T5.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T14.W, T9.W, literal.y, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT T9.W, T3.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T14.W, T1.X, T2.X,
+; EG-NEXT:    6(8.407791e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T11.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T14.W, PV.Z, T1.Z,
+; EG-NEXT:    9(1.261169e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT * T4.Z, T9.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T11.W, T2.Y, T1.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T9.W, T2.W,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T5.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, T10.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T10.W, T6.W,
+; EG-NEXT:     SUBB_UINT T6.X, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, T5.Z,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T13.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T9.W, T4.Y, T9.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T10.W, T6.W,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T7.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T13.W, T4.Y, T3.Z, PV.W,
+; EG-NEXT:    6(8.407791e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T11.W, T3.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T8.X, T2.Z, T1.Y,
+; EG-NEXT:     LSHL T4.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T13.W, T9.W, literal.x,
+; EG-NEXT:     OR_INT T9.W, T2.Y, T4.Z,
+; EG-NEXT:     SUB_INT * T13.W, T1.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Z,
+; EG-NEXT:     SETGE_UINT * T13.W, PV.Z, T1.Z,
+; EG-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T3.Y, T9.W, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.Y, T11.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T10.W, T4.Y, PV.X,
+; EG-NEXT:     SUB_INT * T11.W, T8.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T7.X, T2.Z, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT T11.W, PV.Z, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T13.W, PV.X, T9.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T3.Y, T4.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T14.W, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T4.X, T12.W, T0.Y,
+; EG-NEXT:     CNDE_INT T4.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Z, T12.W, T0.Y,
+; EG-NEXT:     SUB_INT T14.W, PV.Y, PV.X,
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T10.W, T2.Z,
+; EG-NEXT:     SUB_INT T1.X, T11.W, T1.Y,
+; EG-NEXT:     LSHL T3.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T2.Z, T8.W, literal.x, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T14.W, T2.Y, T4.Z, PV.W,
+; EG-NEXT:     CNDE_INT * T12.W, PV.Y, T12.W, PV.Z,
+; EG-NEXT:    7(9.809089e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T5.X, T7.W, literal.x, 1,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BIT_ALIGN_INT T4.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T10.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T14.W, PV.X, T4.X,
+; EG-NEXT:    5(7.006492e-45), 31(4.344025e-44)
+; EG-NEXT:     BFE_UINT T1.X, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Y, T11.W, PS,
+; EG-NEXT:     SETGE_UINT * T2.Z, PV.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:    ALU clause starting at 1865:
+; EG-NEXT:     SETE_INT T11.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T4.X, PV.W, PS, T2.Z,
+; EG-NEXT:     SUB_INT T4.Y, T10.W, T3.W,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, T3.Y, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT T11.W, T2.Y, T1.X, BS:VEC_102/SCL_221
+; EG-NEXT:     OR_INT * T12.W, T2.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T1.X, PS, T2.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T5.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T14.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T15.W, PV.X, T10.W, PV.Y,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T5.Z, T11.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SUBB_UINT T14.W, T11.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T16.W, T2.Z, T1.Y,
+; EG-NEXT:     SUBB_UINT * T5.X, T10.W, T3.W,
+; EG-NEXT:     SUBB_UINT T3.Y, T9.W, T2.W,
+; EG-NEXT:     SUB_INT * T6.Z, T3.Z, T1.Z,
+; EG-NEXT:     SUB_INT T9.W, T16.W, T14.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T10.W, T2.Y, T11.W, T5.Z,
+; EG-NEXT:     SUB_INT T7.X, T4.Z, T6.W,
+; EG-NEXT:     LSHL T4.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T5.Z, T5.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T9.W, T2.Y, T2.Z, PV.W,
+; EG-NEXT:     SUB_INT * T11.W, T6.Z, T3.Y,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T8.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T6.X, T3.Z, PS,
+; EG-NEXT:     BIT_ALIGN_INT T2.Z, PV.W, T10.W, literal.y,
+; EG-NEXT:     OR_INT T9.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T10.W, PV.X, T5.X,
+; EG-NEXT:    6(8.407791e-45), 31(4.344025e-44)
+; EG-NEXT:     CNDE_INT T4.X, T4.X, T4.Z, PS,
+; EG-NEXT:     SETGE_UINT T3.Y, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T3.Z, PV.Z, T1.Y,
+; EG-NEXT:     BIT_ALIGN_INT T10.W, PV.Y, T13.W, literal.x,
+; EG-NEXT:     SETGE_UINT * T11.W, PV.Z, T1.Y,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T5.X, PV.W, T1.Z,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PS, PV.Y,
+; EG-NEXT:     SUB_INT T3.Z, T9.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, PV.X, T15.W, literal.x,
+; EG-NEXT:     OR_INT * T13.W, T2.X, T8.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T2.X, T10.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T3.Y, PS, T3.W,
+; EG-NEXT:     SETE_INT T4.Z, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT * T14.W, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T15.W, T2.Y, T9.W, T3.Z,
+; EG-NEXT:     LSHL T4.X, PV.W, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T4.Z, T14.W, T3.Y,
+; EG-NEXT:     SUB_INT T3.Z, T13.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T14.W, T5.X, T2.X, T1.X,
+; EG-NEXT:     SUB_INT * T16.W, T12.W, T2.W,
+; EG-NEXT:     SUBB_UINT T1.X, T12.W, T2.W,
+; EG-NEXT:     SUB_INT * T4.Y, T10.W, T1.Z, BS:VEC_201
+; EG-NEXT:     SUBB_UINT * T4.Z, T13.W, T3.W,
+; EG-NEXT:     SUB_INT * T17.W, T11.W, T6.W,
+; EG-NEXT:     CNDE_INT * T12.W, T14.W, T12.W, T16.W,
+; EG-NEXT:     LSHL T2.X, PV.W, 1,
+; EG-NEXT:     BFE_UINT T5.Y, T7.W, literal.x, 1,
+; EG-NEXT:     SUB_INT T4.Z, T17.W, T4.Z, BS:VEC_210
+; EG-NEXT:     SUB_INT T16.W, T4.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T13.W, T3.Y, T13.W, T3.Z,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
+; EG-NEXT:     LSHL T1.X, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Y, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T3.Z, T14.W, T10.W, PV.W, BS:VEC_120/SCL_212
+; EG-NEXT:    5(7.006492e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T10.W, T3.Y, T11.W, T4.Z,
+; EG-NEXT:     OR_INT * T11.W, T2.X, T5.Y,
+; EG-NEXT:     BFE_UINT T2.X, T5.W, literal.x, 1,
+; EG-NEXT:     SETGE_UINT T3.Y, PS, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT * T4.Z, PV.W, T13.W, literal.y, BS:VEC_021/SCL_122
+; EG-NEXT:    3(4.203895e-45), 31(4.344025e-44)
+; EG-NEXT:     BIT_ALIGN_INT T10.W, T3.Z, T12.W, literal.x,
+; EG-NEXT:     OR_INT * T12.W, T1.X, T4.Y,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T1.X, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T4.Y, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T3.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T13.W, T4.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T14.W, T4.Z, T6.W,
+; EG-NEXT:     CNDE_INT T5.X, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T5.Y, T12.W, T3.W,
+; EG-NEXT:     CNDE_INT * T3.Z, PV.X, PV.Y, T3.Y,
+; EG-NEXT:     SUB_INT T13.W, T11.W, T2.W,
+; EG-NEXT:     OR_INT * T14.W, T4.X, T2.X,
+; EG-NEXT:     SETGE_UINT T1.X, PS, T0.Y,
+; EG-NEXT:     SUBB_UINT T3.Y, T11.W, T2.W,
+; EG-NEXT:     SUB_INT T5.Z, T10.W, T1.Z, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T11.W, T3.Z, T11.W, PV.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT * T13.W, T5.X, T12.W, T5.Y,
+; EG-NEXT:     LSHL T2.X, PV.W, 1,
+; EG-NEXT:     LSHL T4.Y, T11.W, 1,
+; EG-NEXT:     SUBB_UINT * T6.Z, T12.W, T3.W, BS:VEC_120/SCL_212
+; EG-NEXT:     SUB_INT T12.W, T4.Z, T6.W,
+; EG-NEXT:     SUB_INT * T16.W, T5.Z, T3.Y,
+; EG-NEXT:     BFE_UINT T4.X, T7.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Y, T3.Z, T10.W, PS,
+; EG-NEXT:     SUBB_UINT T3.Z, T9.W, T0.Y, BS:VEC_201
+; EG-NEXT:     SUB_INT T9.W, T2.Z, T1.Y, BS:VEC_210
+; EG-NEXT:     SUB_INT * T10.W, PV.W, T6.Z,
+; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T6.X, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T5.Y, T5.X, T4.Z, PS,
+; EG-NEXT:     SUB_INT T3.Z, PV.W, PV.Z,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.Y, T11.W, literal.y,
+; EG-NEXT:     OR_INT * T10.W, T4.Y, PV.X,
+; EG-NEXT:    4(5.605194e-45), 31(4.344025e-44)
+; EG-NEXT:    ALU clause starting at 1978:
+; EG-NEXT:     SETGE_UINT T4.X, T10.W, T2.W,
+; EG-NEXT:     SETE_INT T3.Y, T9.W, T1.Z, BS:VEC_201
+; EG-NEXT:     CNDE_INT * T2.Z, T2.Y, T2.Z, T3.Z,
+; EG-NEXT:     BIT_ALIGN_INT T11.W, T5.Y, T13.W, literal.x,
+; EG-NEXT:     OR_INT * T12.W, T2.X, T6.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T2.X, T9.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T2.Y, PS, T3.W,
+; EG-NEXT:     SETE_INT * T3.Z, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     BIT_ALIGN_INT T13.W, T2.Z, T15.W, literal.x, BS:VEC_102/SCL_221
+; EG-NEXT:     SETGE_UINT * T15.W, T11.W, T6.W,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T5.X, PV.W, T1.Y,
+; EG-NEXT:     CNDE_INT T2.Y, T3.Z, PS, T2.Y,
+; EG-NEXT:     SUB_INT T2.Z, T12.W, T3.W,
+; EG-NEXT:     CNDE_INT * T15.W, T3.Y, T2.X, T4.X,
+; EG-NEXT:     SUB_INT * T16.W, T10.W, T2.W,
+; EG-NEXT:     SUBB_UINT T2.X, T10.W, T2.W,
+; EG-NEXT:     SUB_INT * T3.Y, T9.W, T1.Z, BS:VEC_201
+; EG-NEXT:     SUBB_UINT * T3.Z, T12.W, T3.W,
+; EG-NEXT:     SUB_INT * T17.W, T11.W, T6.W,
+; EG-NEXT:     CNDE_INT * T10.W, T15.W, T10.W, T16.W,
+; EG-NEXT:     LSHL T4.X, PV.W, 1,
+; EG-NEXT:     BFE_UINT T4.Y, T7.W, literal.x, 1,
+; EG-NEXT:     SUB_INT T3.Z, T17.W, T3.Z, BS:VEC_210
+; EG-NEXT:     SUB_INT T16.W, T3.Y, T2.X,
+; EG-NEXT:     CNDE_INT * T12.W, T2.Y, T12.W, T2.Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     LSHL T2.X, PS, 1,
+; EG-NEXT:     BFE_UINT T3.Y, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT * T2.Z, T15.W, T9.W, PV.W, BS:VEC_120/SCL_212
+; EG-NEXT:    3(4.203895e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T9.W, T2.Y, T11.W, T3.Z,
+; EG-NEXT:     OR_INT * T11.W, T4.X, T4.Y,
+; EG-NEXT:     SETGE_UINT T4.X, T13.W, T1.Y,
+; EG-NEXT:     SETGE_UINT T2.Y, PS, T2.W,
+; EG-NEXT:     BIT_ALIGN_INT * T3.Z, PV.W, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T2.Z, T10.W, literal.x,
+; EG-NEXT:     OR_INT * T10.W, T2.X, T3.Y,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETE_INT T2.X, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T3.Y, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T2.Z, PS, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T12.W, T3.Z, T6.W,
+; EG-NEXT:     SETGE_UINT * T15.W, T3.Z, T6.W,
+; EG-NEXT:     CNDE_INT T6.X, PV.W, PS, PV.Z,
+; EG-NEXT:     CNDE_INT T2.Y, PV.X, PV.Y, T2.Y,
+; EG-NEXT:     SUB_INT T2.Z, T11.W, T2.W,
+; EG-NEXT:     SUBB_UINT T12.W, T11.W, T2.W,
+; EG-NEXT:     SUB_INT * T15.W, T9.W, T1.Z,
+; EG-NEXT:     SUB_INT T2.X, T10.W, T3.W,
+; EG-NEXT:     SUBB_UINT T3.Y, T10.W, T3.W,
+; EG-NEXT:     SUB_INT T4.Z, T3.Z, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T12.W, PS, PV.W,
+; EG-NEXT:     CNDE_INT * T11.W, T2.Y, T11.W, T2.Z,
+; EG-NEXT:     LSHL T7.X, PV.W, 1,
+; EG-NEXT:     BFE_UINT T4.Y, T7.W, 1, 1,
+; EG-NEXT:     CNDE_INT T2.Z, T2.Y, T9.W, T12.W,
+; EG-NEXT:     SUB_INT * T9.W, T4.Z, T3.Y,
+; EG-NEXT:     CNDE_INT * T10.W, T6.X, T10.W, T2.X,
+; EG-NEXT:     LSHL T2.X, PV.W, 1,
+; EG-NEXT:     BFE_UINT T2.Y, T8.W, literal.x, 1,
+; EG-NEXT:     CNDE_INT T3.Z, T6.X, T3.Z, T9.W,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, T2.Z, T11.W, literal.y,
+; EG-NEXT:     OR_INT * T11.W, T7.X, T4.Y,
+; EG-NEXT:    2(2.802597e-45), 31(4.344025e-44)
+; EG-NEXT:     SETGE_UINT T6.X, PS, T2.W,
+; EG-NEXT:     SETE_INT T3.Y, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T2.Z, PV.W, T1.Z,
+; EG-NEXT:     BIT_ALIGN_INT T10.W, PV.Z, T10.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, PV.X, PV.Y,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T2.X, PS, T3.W,
+; EG-NEXT:     SUB_INT T2.Y, PV.W, T6.W, BS:VEC_102/SCL_221
+; EG-NEXT:     CNDE_INT T2.Z, PV.Y, PV.Z, PV.X,
+; EG-NEXT:     CNDE_INT T15.W, T5.X, T4.X, T1.X,
+; EG-NEXT:     SUB_INT * T16.W, T14.W, T0.Y,
+; EG-NEXT:     SUBB_UINT T1.X, T14.W, T0.Y,
+; EG-NEXT:     SUB_INT * T3.Y, T13.W, T1.Y, BS:VEC_120/SCL_212
+; EG-NEXT:     SETGE_UINT * T3.Z, T12.W, T3.W,
+; EG-NEXT:     SETE_INT T17.W, T10.W, T6.W,
+; EG-NEXT:     SETGE_UINT * T18.W, T10.W, T6.W,
+; EG-NEXT:     SUB_INT T4.X, T11.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, PV.W, PS, T3.Z,
+; EG-NEXT:     SUB_INT T3.Z, T12.W, T3.W,
+; EG-NEXT:     SUB_INT * T17.W, T3.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T14.W, T15.W, T14.W, T16.W,
+; EG-NEXT:     LSHL T1.X, PV.W, 1,
+; EG-NEXT:     BFE_UINT * T3.Y, T5.W, literal.x, 1,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT * T4.Z, T15.W, T13.W, T17.W,
+; EG-NEXT:     CNDE_INT T12.W, T4.Y, T12.W, T3.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T13.W, T2.Z, T11.W, T4.X,
+; EG-NEXT:     LSHL T4.X, PS, 1,
+; EG-NEXT:     LSHL T5.Y, PV.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, T4.Z, T14.W, literal.x,
+; EG-NEXT:     OR_INT T14.W, T1.X, T3.Y,
+; EG-NEXT:     SUB_INT * T15.W, T2.Y, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_UINT T1.X, T8.W, 1, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T4.Y, T10.W, PS,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T10.W, PV.Z, T1.Y,
+; EG-NEXT:     SETGE_UINT * T15.W, PV.Z, T1.Y,
+; EG-NEXT:     AND_INT T2.X, T7.W, 1,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, PS, PV.Z,
+; EG-NEXT:     SUB_INT T4.Z, T14.W, T0.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     BIT_ALIGN_INT T7.W, PV.Y, T12.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T10.W, T5.Y, PV.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, T14.W, T0.Y,
+; EG-NEXT:     SUB_INT T2.Y, T3.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T5.Z, PS, T3.W,
+; EG-NEXT:     SETE_INT * T12.W, PV.W, T6.W, BS:VEC_021/SCL_122
+; EG-NEXT:    ALU clause starting at 2093:
+; EG-NEXT:     SETGE_UINT * T15.W, T7.W, T6.W,
+; EG-NEXT:     SUBB_UINT T5.X, T11.W, T2.W,
+; EG-NEXT:     CNDE_INT * T4.Y, T12.W, PV.W, T5.Z, BS:VEC_201
+; EG-NEXT:     SUB_INT T5.Z, T10.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T11.W, T2.Y, T1.X,
+; EG-NEXT:     CNDE_INT * T12.W, T3.Y, T14.W, T4.Z,
+; EG-NEXT:     SUB_INT T1.X, T9.W, T1.Z,
+; EG-NEXT:     LSHL T2.Y, PS, 1,
+; EG-NEXT:     BFE_UINT T4.Z, T5.W, 1, 1, BS:VEC_201
+; EG-NEXT:     CNDE_INT T11.W, T3.Y, T3.Z, PV.W, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T14.W, T4.Y, T10.W, PV.Z,
+; EG-NEXT:     LSHL T6.X, PS, 1,
+; EG-NEXT:     AND_INT T3.Y, T8.W, 1,
+; EG-NEXT:     BIT_ALIGN_INT T3.Z, PV.W, T12.W, literal.x,
+; EG-NEXT:     OR_INT T8.W, PV.Y, PV.Z,
+; EG-NEXT:     SUB_INT * T11.W, PV.X, T5.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T1.X, T2.Z, T9.W, PS,
+; EG-NEXT:     SETGE_UINT T2.Y, PV.W, T0.Y,
+; EG-NEXT:     SETE_INT T2.Z, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETGE_UINT T9.W, PV.Z, T1.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T11.W, PV.X, PV.Y,
+; EG-NEXT:     SUB_INT T5.X, PS, T3.W,
+; EG-NEXT:     CNDE_INT T2.Y, PV.Z, PV.W, PV.Y,
+; EG-NEXT:     SUB_INT T2.Z, T8.W, T0.Y,
+; EG-NEXT:     BIT_ALIGN_INT T9.W, PV.X, T13.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     OR_INT * T12.W, T4.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T1.X, PS, T2.W,
+; EG-NEXT:     SETE_INT T3.Y, PV.W, T1.Z,
+; EG-NEXT:     SETGE_UINT T4.Z, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T13.W, PS, T2.W,
+; EG-NEXT:     SUB_INT * T15.W, PV.W, T1.Z,
+; EG-NEXT:     SUBB_UINT T2.X, T8.W, T0.Y,
+; EG-NEXT:     SUB_INT T5.Y, T3.Z, T1.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT T1.Z, PS, PV.W,
+; EG-NEXT:     CNDE_INT T13.W, PV.Y, PV.Z, PV.X,
+; EG-NEXT:     CNDE_INT * T8.W, T2.Y, T8.W, T2.Z,
+; EG-NEXT:     LSHL T1.X, PS, 1,
+; EG-NEXT:     CNDE_INT T3.Y, PV.W, T9.W, PV.Z,
+; EG-NEXT:     SUBB_UINT * T1.Z, T10.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T9.W, T7.W, T6.W,
+; EG-NEXT:     SUB_INT * T10.W, T5.Y, T2.X,
+; EG-NEXT:     AND_INT T2.X, T5.W, 1,
+; EG-NEXT:     CNDE_INT T2.Y, T2.Y, T3.Z, PS,
+; EG-NEXT:     SUB_INT T1.Z, PV.W, T1.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T2.W, T12.W, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     XOR_INT * T5.W, T3.Y, T1.W,
+; EG-NEXT:     SUB_INT * T4.X, PV.W, T1.W,
+; EG-NEXT:     CNDE_INT * T3.Y, T13.W, T12.W, T2.W,
+; EG-NEXT:     CNDE_INT T1.Z, T4.Y, T7.W, T1.Z,
+; EG-NEXT:     BIT_ALIGN_INT T2.W, T2.Y, T8.W, literal.x, BS:VEC_120/SCL_212
+; EG-NEXT:     OR_INT * T5.W, T1.X, T2.X,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SETGE_UINT T1.X, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T2.Y, PV.W, T1.Y,
+; EG-NEXT:     SETGE_UINT T2.Z, PV.W, T1.Y,
+; EG-NEXT:     SUBB_UINT T7.W, PS, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T8.W, PV.W, T1.Y,
+; EG-NEXT:     SUB_INT T2.X, T5.W, T0.Y,
+; EG-NEXT:     SUB_INT T0.Y, PS, PV.W,
+; EG-NEXT:     CNDE_INT T2.Z, PV.Y, PV.Z, PV.X,
+; EG-NEXT:     BIT_ALIGN_INT T7.W, T1.Z, T14.W, literal.x, BS:VEC_021/SCL_122
+; EG-NEXT:     XOR_INT * T8.W, T3.Y, T1.W,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     SUBB_UINT T1.X, PS, T1.W,
+; EG-NEXT:     SETGE_UINT * T1.Y, T11.W, T3.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SETE_INT T1.Z, T7.W, T6.W,
+; EG-NEXT:     CNDE_INT * T2.W, T2.Z, T2.W, T0.Y, BS:VEC_021/SCL_122
+; EG-NEXT:     CNDE_INT * T5.W, T2.Z, T5.W, T2.X,
+; EG-NEXT:     SETGE_UINT * T2.X, T7.W, T6.W,
+; EG-NEXT:     SUBB_UINT * T0.Y, T11.W, T3.W,
+; EG-NEXT:     SUB_INT * T2.Z, T7.W, T6.W,
+; EG-NEXT:     XOR_INT T3.W, T5.W, T4.W,
+; EG-NEXT:     XOR_INT * T2.W, T2.W, T4.W,
+; EG-NEXT:     SUB_INT T6.X, PS, T4.W,
+; EG-NEXT:     SUBB_UINT T2.Y, PV.W, T4.W,
+; EG-NEXT:     SUB_INT T2.Z, T2.Z, T0.Y,
+; EG-NEXT:     CNDE_INT T2.W, T1.Z, T2.X, T1.Y, BS:VEC_102/SCL_221
+; EG-NEXT:     SUB_INT * T5.W, T4.X, T1.X,
+; EG-NEXT:     CNDE_INT T1.X, PV.W, T7.W, PV.Z, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT T5.Y, PV.X, PV.Y,
+; EG-NEXT:     CNDE_INT T1.Z, PV.W, T11.W, T5.X, BS:VEC_201
+; EG-NEXT:     XOR_INT T2.W, T3.X, T0.W,
+; EG-NEXT:     XOR_INT * T6.W, T0.X, T0.W,
+; EG-NEXT:     SUB_INT T0.X, PS, T0.W,
+; EG-NEXT:     SUBB_UINT T0.Y, PV.W, T0.W,
+; EG-NEXT:     SUB_INT T5.Z, T8.W, T1.W, BS:VEC_021/SCL_122
+; EG-NEXT:     XOR_INT T1.W, PV.Z, T0.Z,
+; EG-NEXT:     XOR_INT * T6.W, PV.X, T0.Z,
+; EG-NEXT:     SUB_INT T5.X, T3.W, T4.W,
+; EG-NEXT:     SUB_INT T1.Z, PS, T0.Z,
+; EG-NEXT:     SUBB_UINT T3.W, PV.W, T0.Z,
+; EG-NEXT:     SUB_INT * T4.W, PV.X, PV.Y,
+; EG-NEXT:     LSHR T0.X, KC0[2].Y, literal.x,
+; EG-NEXT:     SUB_INT * T4.Y, PV.Z, PV.W,
+; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T1.X, PV.X, literal.x,
+; EG-NEXT:     SUB_INT T4.Z, T2.W, T0.W,
+; EG-NEXT:     SUB_INT * T4.X, T1.W, T0.Z,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %den_ptr = getelementptr <4 x i64>, ptr addrspace(1) %in, i64 1
   %num = load <4 x i64>, ptr addrspace(1) %in
   %den = load <4 x i64>, ptr addrspace(1) %den_ptr
@@ -9056,9 +9052,9 @@ define amdgpu_kernel void @srem_v4i64_4(ptr addrspace(1) %out, ptr addrspace(1) 
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @10, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 1 @6
-; EG-NEXT:    ALU 48, @11, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T0.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T1.X, 1
+; EG-NEXT:    ALU 49, @11, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T3.XYZW, T1.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T4.XYZW, T2.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 16, #1
@@ -9068,53 +9064,54 @@ define amdgpu_kernel void @srem_v4i64_4(ptr addrspace(1) %out, ptr addrspace(1) 
 ; EG-NEXT:    ALU clause starting at 11:
 ; EG-NEXT:     ASHR * T1.W, T1.W, literal.x,
 ; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
-; EG-NEXT:     ASHR T2.Z, T0.Y, literal.x,
-; EG-NEXT:     ASHR T2.W, T1.Y, literal.x, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T1.W, PV.W, literal.y,
-; EG-NEXT:    31(4.344025e-44), 30(4.203895e-44)
-; EG-NEXT:     ADD_INT T0.Y, T1.Z, PS,
-; EG-NEXT:     ASHR T3.Z, T0.W, literal.x,
-; EG-NEXT:     LSHR T0.W, PV.W, literal.y,
-; EG-NEXT:     LSHR * T2.W, PV.Z, literal.y,
-; EG-NEXT:    31(4.344025e-44), 30(4.203895e-44)
-; EG-NEXT:     ADD_INT T2.X, T0.X, PS,
-; EG-NEXT:     ADD_INT T1.Y, T1.X, PV.W, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR T2.Z, PV.Z, literal.x,
-; EG-NEXT:     ADDC_UINT T1.W, T1.Z, T1.W,
-; EG-NEXT:     AND_INT * T3.W, PV.Y, literal.y,
+; EG-NEXT:     LSHR * T1.W, PV.W, literal.x,
+; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T2.W, T1.Z, PV.W,
+; EG-NEXT:     ASHR * T3.W, T1.Y, literal.x,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     LSHR T3.W, PS, literal.x,
+; EG-NEXT:     AND_INT * T2.W, PV.W, literal.y,
 ; EG-NEXT:    30(4.203895e-44), -4(nan)
-; EG-NEXT:     SUBB_UINT T3.X, T1.Z, PS,
-; EG-NEXT:     BFE_INT T0.Y, PV.W, 0.0, 1,
-; EG-NEXT:     ADD_INT T3.Z, T0.Z, PV.Z, BS:VEC_120/SCL_212
-; EG-NEXT:     ADDC_UINT T0.W, T1.X, T0.W,
-; EG-NEXT:     AND_INT * T1.W, PV.Y, literal.x,
+; EG-NEXT:     SUBB_UINT T1.Y, T1.Z, PS,
+; EG-NEXT:     ASHR T2.Z, T0.W, literal.x,
+; EG-NEXT:     ADD_INT T0.W, T1.X, PV.W,
+; EG-NEXT:     ADDC_UINT * T1.W, T1.Z, T1.W,
+; EG-NEXT:    31(4.344025e-44), 0(0.000000e+00)
+; EG-NEXT:     BFE_INT T2.X, PS, 0.0, 1,
+; EG-NEXT:     ADDC_UINT T2.Y, T1.X, T3.W,
+; EG-NEXT:     AND_INT T3.Z, PV.W, literal.x,
+; EG-NEXT:     ASHR T0.W, T0.Y, literal.y,
+; EG-NEXT:     LSHR * T1.W, PV.Z, literal.z,
+; EG-NEXT:    -4(nan), 31(4.344025e-44)
+; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T3.X, T0.Z, PS,
+; EG-NEXT:     LSHR T0.Y, PV.W, literal.x,
+; EG-NEXT:     SUBB_UINT T2.Z, T1.X, PV.Z,
+; EG-NEXT:     BFE_INT T0.W, PV.Y, 0.0, 1,
+; EG-NEXT:     SUB_INT * T4.W, PV.X, T1.Y,
+; EG-NEXT:    30(4.203895e-44), 0(0.000000e+00)
+; EG-NEXT:     SUB_INT T4.Y, PV.W, PV.Z,
+; EG-NEXT:     ADD_INT T2.Z, T0.X, PV.Y,
+; EG-NEXT:     ADDC_UINT T0.W, T0.Z, T1.W,
+; EG-NEXT:     AND_INT * T1.W, PV.X, literal.x,
 ; EG-NEXT:    -4(nan), 0(0.000000e+00)
-; EG-NEXT:     ADDC_UINT T4.X, T0.Z, T2.Z,
-; EG-NEXT:     SUBB_UINT T1.Y, T1.X, PS,
-; EG-NEXT:     BFE_INT T2.Z, PV.W, 0.0, 1,
-; EG-NEXT:     AND_INT T0.W, PV.Z, literal.x,
-; EG-NEXT:     SUB_INT * T4.W, PV.Y, PV.X,
+; EG-NEXT:     SUBB_UINT T2.X, T0.Z, PS,
+; EG-NEXT:     BFE_INT T1.Y, PV.W, 0.0, 1,
+; EG-NEXT:     SUB_INT T4.Z, T1.Z, T2.W, BS:VEC_120/SCL_212
+; EG-NEXT:     ADDC_UINT T0.W, T0.X, T0.Y,
+; EG-NEXT:     AND_INT * T2.W, PV.Z, literal.x,
 ; EG-NEXT:    -4(nan), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T3.X, T0.Z, PV.W,
-; EG-NEXT:     SUB_INT T4.Y, PV.Z, PV.Y,
-; EG-NEXT:     BFE_INT T2.Z, PV.X, 0.0, 1,
-; EG-NEXT:     ADDC_UINT T2.W, T0.X, T2.W,
-; EG-NEXT:     AND_INT * T5.W, T2.X, literal.x,
-; EG-NEXT:    -4(nan), 0(0.000000e+00)
-; EG-NEXT:     SUBB_UINT T0.Y, T0.X, PS,
-; EG-NEXT:     SUB_INT T4.Z, T1.Z, T3.W,
-; EG-NEXT:     BFE_INT T2.W, PV.W, 0.0, 1,
-; EG-NEXT:     SUB_INT * T3.W, PV.Z, PV.X,
-; EG-NEXT:     SUB_INT T4.X, T1.X, T1.W,
-; EG-NEXT:     SUB_INT T3.Y, PV.W, PV.Y,
-; EG-NEXT:     ADD_INT * T1.W, KC0[2].Y, literal.x,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T1.X, PV.W, literal.x,
-; EG-NEXT:     SUB_INT T3.Z, T0.Z, T0.W, BS:VEC_021/SCL_122
-; EG-NEXT:     SUB_INT * T3.X, T0.X, T5.W,
+; EG-NEXT:     SUB_INT T4.X, T1.X, T3.Z,
+; EG-NEXT:     SUBB_UINT T1.Z, T0.X, PS, BS:VEC_120/SCL_212
+; EG-NEXT:     BFE_INT T0.W, PV.W, 0.0, 1,
+; EG-NEXT:     SUB_INT * T3.W, PV.Y, PV.X,
+; EG-NEXT:     LSHR T1.X, KC0[2].Y, literal.x,
+; EG-NEXT:     SUB_INT * T3.Y, PV.W, PV.Z,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
-; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     ADD_INT T2.X, PV.X, literal.x,
+; EG-NEXT:     SUB_INT T3.Z, T0.Z, T1.W, BS:VEC_021/SCL_122
+; EG-NEXT:     SUB_INT * T3.X, T0.X, T2.W,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %num = load <4 x i64>, ptr addrspace(1) %in
   %result = srem <4 x i64> %num, <i64 4, i64 4, i64 4, i64 4>
   store <4 x i64> %result, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/srl.ll
+++ b/llvm/test/CodeGen/AMDGPU/srl.ll
@@ -311,9 +311,9 @@ define amdgpu_kernel void @lshr_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG:       ; %bb.0:
 ; EG-NEXT:    ALU 0, @14, KC0[CB0:0-32], KC1[]
 ; EG-NEXT:    TEX 3 @6
-; EG-NEXT:    ALU 34, @15, KC0[CB0:0-32], KC1[]
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T3.X, 0
-; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T0.X, 1
+; EG-NEXT:    ALU 33, @15, KC0[CB0:0-32], KC1[]
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T1.XYZW, T0.X, 0
+; EG-NEXT:    MEM_RAT_CACHELESS STORE_RAW T2.XYZW, T3.X, 1
 ; EG-NEXT:    CF_END
 ; EG-NEXT:    Fetch clause starting at 6:
 ; EG-NEXT:     VTX_READ_128 T1.XYZW, T0.X, 32, #1
@@ -349,15 +349,14 @@ define amdgpu_kernel void @lshr_v4i64(ptr addrspace(1) %out, ptr addrspace(1) %i
 ; EG-NEXT:     AND_INT * T4.W, T1.X, literal.x,
 ; EG-NEXT:    32(4.484155e-44), 0(0.000000e+00)
 ; EG-NEXT:     CNDE_INT T1.X, PS, PV.W, PV.Y,
-; EG-NEXT:     ADD_INT T0.W, KC0[2].Y, literal.x,
-; EG-NEXT:     CNDE_INT * T2.W, T0.Z, T1.Y, 0.0,
-; EG-NEXT:    16(2.242078e-44), 0(0.000000e+00)
-; EG-NEXT:     LSHR T0.X, PV.W, literal.x,
-; EG-NEXT:     CNDE_INT T2.Y, T3.W, T3.Y, 0.0,
-; EG-NEXT:     CNDE_INT T1.W, T1.W, T4.Z, 0.0, BS:VEC_120/SCL_212
-; EG-NEXT:     LSHR * T3.X, KC0[2].Y, literal.x,
+; EG-NEXT:     CNDE_INT T2.W, T0.Z, T1.Y, 0.0,
+; EG-NEXT:     LSHR * T0.X, KC0[2].Y, literal.x,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
+; EG-NEXT:     CNDE_INT T2.Y, T3.W, T3.Y, 0.0,
+; EG-NEXT:     CNDE_INT * T1.W, T1.W, T4.Z, 0.0, BS:VEC_120/SCL_212
+; EG-NEXT:     ADD_INT T3.X, T0.X, literal.x,
 ; EG-NEXT:     CNDE_INT * T1.Y, T4.W, T4.Y, 0.0,
+; EG-NEXT:    4(5.605194e-45), 0(0.000000e+00)
   %b_ptr = getelementptr <4 x i64>, ptr addrspace(1) %in, i64 1
   %a = load <4 x i64>, ptr addrspace(1) %in
   %b = load <4 x i64>, ptr addrspace(1) %b_ptr

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vscnt.ll
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vscnt.ll
@@ -48,16 +48,17 @@ bb:
 define amdgpu_kernel void @barrier_vscnt_global(ptr addrspace(1) %arg) {
 ; GFX8-LABEL: barrier_vscnt_global:
 ; GFX8:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, 2, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, 0
-; GFX8-NEXT:    v_lshrrev_b64 v[1:2], 30, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX8-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v3, s1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s0, v1
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, v3, v2, vcc
-; GFX8-NEXT:    flat_store_dword v[1:2], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, -4, v1
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, -1, v2, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, s0, v0
+; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 8, v3
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
+; GFX8-NEXT:    flat_store_dword v[0:1], v2
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v3
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 1
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_barrier
@@ -67,17 +68,13 @@ define amdgpu_kernel void @barrier_vscnt_global(ptr addrspace(1) %arg) {
 ; GFX9-LABEL: barrier_vscnt_global:
 ; GFX9:         s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0
-; GFX9-NEXT:    v_add_u32_e32 v2, 2, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 30, v[1:2]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, s0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v0, v3, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v0, 1
-; GFX9-NEXT:    global_store_dword v[2:3], v1, off
+; GFX9-NEXT:    global_store_dword v0, v1, s[0:1] offset:8
+; GFX9-NEXT:    v_mov_b32_e32 v1, 1
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_barrier
-; GFX9-NEXT:    global_store_dword v[2:3], v0, off offset:-4
+; GFX9-NEXT:    global_store_dword v0, v1, s[0:1] offset:4
 ; GFX9-NEXT:    s_endpgm
 bb:
   %tmp = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -100,39 +97,34 @@ bb:
 define amdgpu_kernel void @barrier_vmcnt_vscnt_global(ptr addrspace(1) %arg) {
 ; GFX8-LABEL: barrier_vmcnt_vscnt_global:
 ; GFX8:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, 2, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, 0
-; GFX8-NEXT:    v_lshrrev_b64 v[1:2], 30, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX8-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v3, s1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s0, v1
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, v3, v2, vcc
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, -8, v1
-; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, -1, v2, vcc
-; GFX8-NEXT:    flat_load_dword v3, v[3:4]
-; GFX8-NEXT:    flat_store_dword v[1:2], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, -4, v1
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, -1, v2, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, s0, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_load_dword v4, v[0:1]
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 8, v0
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_store_dword v[2:3], v5
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_barrier
-; GFX8-NEXT:    flat_store_dword v[0:1], v3
+; GFX8-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8-NEXT:    s_endpgm
 ;
 ; GFX9-LABEL: barrier_vmcnt_vscnt_global:
 ; GFX9:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0
-; GFX9-NEXT:    v_add_u32_e32 v2, 2, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 30, v[1:2]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, s0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v0, v3, vcc
-; GFX9-NEXT:    global_load_dword v0, v[2:3], off offset:-8
+; GFX9-NEXT:    global_load_dword v1, v0, s[0:1]
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    global_store_dword v[2:3], v1, off
+; GFX9-NEXT:    global_store_dword v0, v2, s[0:1] offset:8
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_barrier
-; GFX9-NEXT:    global_store_dword v[2:3], v0, off offset:-4
+; GFX9-NEXT:    global_store_dword v0, v1, s[0:1] offset:4
 ; GFX9-NEXT:    s_endpgm
 bb:
   %tmp = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -201,16 +193,17 @@ bb:
 define amdgpu_kernel void @barrier_vscnt_flat(ptr %arg) {
 ; GFX8-LABEL: barrier_vscnt_flat:
 ; GFX8:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, 2, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, 0
-; GFX8-NEXT:    v_lshrrev_b64 v[1:2], 30, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX8-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v3, s1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s0, v1
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, v3, v2, vcc
-; GFX8-NEXT:    flat_store_dword v[1:2], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, -4, v1
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, -1, v2, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, s0, v0
+; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 8, v3
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
+; GFX8-NEXT:    flat_store_dword v[0:1], v2
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v3
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v4, vcc
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 1
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    s_barrier
@@ -219,16 +212,15 @@ define amdgpu_kernel void @barrier_vscnt_flat(ptr %arg) {
 ;
 ; GFX9-LABEL: barrier_vscnt_flat:
 ; GFX9:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0
-; GFX9-NEXT:    v_add_u32_e32 v2, 2, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 30, v[1:2]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX9-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, s0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, -4, v2
-; GFX9-NEXT:    flat_store_dword v[2:3], v1
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, -1, v3, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, s1
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, s0, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 4, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    flat_store_dword v[0:1], v2 offset:4
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 1
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_barrier
@@ -255,42 +247,38 @@ bb:
 define amdgpu_kernel void @barrier_vmcnt_vscnt_flat(ptr %arg) {
 ; GFX8-LABEL: barrier_vmcnt_vscnt_flat:
 ; GFX8:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, 2, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, 0
-; GFX8-NEXT:    v_lshrrev_b64 v[1:2], 30, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX8-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v3, s1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s0, v1
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, v3, v2, vcc
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, -8, v1
-; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, -1, v2, vcc
-; GFX8-NEXT:    flat_load_dword v3, v[3:4]
-; GFX8-NEXT:    flat_store_dword v[1:2], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, -4, v1
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, -1, v2, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, s0, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_load_dword v4, v[0:1]
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 8, v0
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_store_dword v[2:3], v5
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    s_barrier
-; GFX8-NEXT:    flat_store_dword v[0:1], v3
+; GFX8-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8-NEXT:    s_endpgm
 ;
 ; GFX9-LABEL: barrier_vmcnt_vscnt_flat:
 ; GFX9:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0
-; GFX9-NEXT:    v_add_u32_e32 v2, 2, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 30, v[1:2]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX9-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, s0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, -8, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, -1, v3, vcc
-; GFX9-NEXT:    flat_load_dword v4, v[4:5]
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, -4, v2
-; GFX9-NEXT:    flat_store_dword v[2:3], v1
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, -1, v3, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, s1
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, s0, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    flat_load_dword v2, v[0:1]
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 4, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    flat_store_dword v[0:1], v3 offset:4
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_barrier
-; GFX9-NEXT:    flat_store_dword v[0:1], v4
+; GFX9-NEXT:    flat_store_dword v[0:1], v2
 ; GFX9-NEXT:    s_endpgm
 bb:
   %tmp = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -315,42 +303,38 @@ bb:
 define amdgpu_kernel void @barrier_vmcnt_vscnt_flat_workgroup(ptr %arg) {
 ; GFX8-LABEL: barrier_vmcnt_vscnt_flat_workgroup:
 ; GFX8:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, 2, v0
-; GFX8-NEXT:    v_mov_b32_e32 v0, 0
-; GFX8-NEXT:    v_lshrrev_b64 v[1:2], 30, v[0:1]
+; GFX8-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX8-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v3, s1
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, s0, v1
-; GFX8-NEXT:    v_addc_u32_e32 v2, vcc, v3, v2, vcc
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, -8, v1
-; GFX8-NEXT:    v_addc_u32_e32 v4, vcc, -1, v2, vcc
-; GFX8-NEXT:    flat_load_dword v3, v[3:4]
-; GFX8-NEXT:    flat_store_dword v[1:2], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, -4, v1
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, -1, v2, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, s0, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_load_dword v4, v[0:1]
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 8, v0
+; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v1, vcc
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v0
+; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
+; GFX8-NEXT:    flat_store_dword v[2:3], v5
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    s_barrier
-; GFX8-NEXT:    flat_store_dword v[0:1], v3
+; GFX8-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8-NEXT:    s_endpgm
 ;
 ; GFX9-LABEL: barrier_vmcnt_vscnt_flat_workgroup:
 ; GFX9:         s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0
-; GFX9-NEXT:    v_add_u32_e32 v2, 2, v0
-; GFX9-NEXT:    v_lshrrev_b64 v[2:3], 30, v[1:2]
+; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX9-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_mov_b32_e32 v0, s1
-; GFX9-NEXT:    v_add_co_u32_e32 v2, vcc, s0, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v3, vcc, v0, v3, vcc
-; GFX9-NEXT:    v_add_co_u32_e32 v4, vcc, -8, v2
-; GFX9-NEXT:    v_addc_co_u32_e32 v5, vcc, -1, v3, vcc
-; GFX9-NEXT:    flat_load_dword v4, v[4:5]
-; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, -4, v2
-; GFX9-NEXT:    flat_store_dword v[2:3], v1
-; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, -1, v3, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, s1
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, s0, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    flat_load_dword v2, v[0:1]
+; GFX9-NEXT:    v_add_co_u32_e32 v0, vcc, 4, v0
+; GFX9-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
+; GFX9-NEXT:    flat_store_dword v[0:1], v3 offset:4
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_barrier
-; GFX9-NEXT:    flat_store_dword v[0:1], v4
+; GFX9-NEXT:    flat_store_dword v[0:1], v2
 ; GFX9-NEXT:    s_endpgm
 bb:
   %tmp = tail call i32 @llvm.amdgcn.workitem.id.x()


### PR DESCRIPTION
Additional precondition:
* The LSBs of c are 0; equivalently: c >> d is exact

Alive2 for
* unsigned case: https://alive2.llvm.org/ce/z/YcJ8qA
* signed case: https://alive2.llvm.org/ce/z/fgpvyE

We already canonicalize (shl (add ...) ...) to (add (shl ...) ...).

Restrict this combine to the single-use case to minimize risk for now.
The main target of this combine is a fan-out tree of `add`s that all end
up being shifted by the same amount at the leaves. This change happens to
improve a bunch of existing CodeGen tests in AMDGPU.

v2:
- remove a redundant check on the shift amount -- large shift amounts
results in poison anyway