### PR TITLE
[compiler-rt] [Darwin] Internal lit shell support for Darwin.haswell-symbolication.cpp

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/haswell-symbolication.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/haswell-symbolication.cpp
@@ -17,16 +17,18 @@
 // RUN: dsymutil %t.fat.x86_64h
 
 // Check LLVM symbolizer
-// RUN: %env_asan_opts=external_symbolizer_path=$(which llvm-symbolizer) not %run %t.thin.x86_64  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which llvm-symbolizer) not %run %t.thin.x86_64h 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which llvm-symbolizer) not %run %t.fat.x86_64   2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which llvm-symbolizer) not %run %t.fat.x86_64h  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: which llvm-symbolizer | tr -d '\n' > %t.llvm_symbolizer_path
+// RUN: which atos | tr -d '\n' > %t.atos_path
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.llvm_symbolizer_path} not %run %t.thin.x86_64  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.llvm_symbolizer_path} not %run %t.thin.x86_64h 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.llvm_symbolizer_path} not %run %t.fat.x86_64   2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.llvm_symbolizer_path} not %run %t.fat.x86_64h  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
 
 // Check atos
-// RUN: %env_asan_opts=external_symbolizer_path=$(which atos) not %run %t.thin.x86_64  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which atos) not %run %t.thin.x86_64h 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which atos) not %run %t.fat.x86_64   2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
-// RUN: %env_asan_opts=external_symbolizer_path=$(which atos) not %run %t.fat.x86_64h  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.atos_path} not %run %t.thin.x86_64  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.atos_path} not %run %t.thin.x86_64h 2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.atos_path} not %run %t.fat.x86_64   2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
+// RUN: %env_asan_opts=external_symbolizer_path=%{readfile:%t.atos_path} not %run %t.fat.x86_64h  2>&1 | FileCheck %s --check-prefixes CHECK,CHECK-LI,CHECK-DATA
 
 // Check dladdr
 // RUN: %env_asan_opts=external_symbolizer_path= not %run %t.thin.x86_64  2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NOLI,CHECK-DATA


### PR DESCRIPTION
Somehow, #196152 fixed a bug where the x86_64h feature wasn't getting correctly set and so some tests that weren't running before started running. One such test is [AddressSanitizer-x86_64-darwin.TestCases/Darwin.haswell-symbolication.cpp](https://green.lab.llvm.org/job/llvm.org/job/clang-stage1-RA-cmake-incremental/job/main/872/testReport/AddressSanitizer-x86_64-darwin/TestCases_Darwin/haswell_symbolication_cpp/), which appears to have never been updated for the internal lit shell.

The internal lit shell does not support sub-shells, so the typical pattern appears to be to write results to a file and use `%{readfile:%t.whatever}`.

rdar://176390171