### PR TITLE
[Compiler-rt][CMake][BoundsSafety] Add `COMPILER_RT_ENABLE_TEST_SUITES` to control which test suites are enabled

### DIFF
--- a/compiler-rt/docs/BuildingCompilerRT.rst
+++ b/compiler-rt/docs/BuildingCompilerRT.rst
@@ -80,6 +80,21 @@ Compiler-RT specific options
   Path where Compiler-RT data should be installed. If a relative
   path, relative to ``COMPILER_RT_INSTALL_PATH``.
 
+.. option:: COMPILER_RT_INCLUDE_TESTS:BOOL
+
+  **Default**: ``LLVM_INCLUDE_TESTS`` in LLVM builds, ``OFF`` in standalone builds.
+
+  Generate and build compiler-rt tests. If ``OFF``,
+  ``COMPILER_RT_ENABLE_TEST_SUITES`` has no effect.
+
+.. option:: COMPILER_RT_ENABLE_TEST_SUITES:STRING
+
+  **Default**: ``all``
+
+  Semicolon-separated list of test suites to enable, or ``all`` to enable all
+  test suites.
+  Example: ``-DCOMPILER_RT_ENABLE_TEST_SUITES="asan;ubsan;lsan"``
+
 .. _LLVM-specific variables:
 
 LLVM-specific options

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -57,16 +57,69 @@ endif()
 
 umbrella_lit_testsuite_begin(check-compiler-rt)
 
-function(compiler_rt_test_runtime runtime)
-  string(TOUPPER ${runtime} runtime_uppercase)
-  if(COMPILER_RT_HAS_${runtime_uppercase} AND COMPILER_RT_INCLUDE_TESTS)
-    if (${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
-      # CFI tests require diagnostic mode, which is implemented in UBSan.
-    elseif (${runtime} STREQUAL scudo_standalone)
-      add_subdirectory(scudo/standalone)
-    else()
-      add_subdirectory(${runtime})
+set(COMPILER_RT_KNOWN_TEST_SUITES
+    builtins;ctx_profile;fuzzer;interception;lsan;memprof;metadata
+    ;orc;profile;sanitizer_common;shadowcallstack
+    ;ubsan;xray)
+list(APPEND COMPILER_RT_KNOWN_TEST_SUITES ${ALL_SANITIZERS})
+list(REMOVE_DUPLICATES COMPILER_RT_KNOWN_TEST_SUITES)
+# Sort the list so that's easier to read when emitting errors.
+list(SORT COMPILER_RT_KNOWN_TEST_SUITES)
+
+set(COMPILER_RT_ENABLE_TEST_SUITES "all" CACHE STRING
+    "List of test suites to enable (semicolon-separated), or \"all\" to enable all test suites. Known test suites: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+
+# Validate COMPILER_RT_ENABLE_TEST_SUITES values.
+if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+  foreach(suite ${COMPILER_RT_ENABLE_TEST_SUITES})
+    if(NOT "${suite}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+      message(FATAL_ERROR "Unknown test suite '${suite}' in COMPILER_RT_ENABLE_TEST_SUITES. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
     endif()
+  endforeach()
+endif()
+
+function(compiler_rt_test_runtime runtime)
+  cmake_parse_arguments(ARG "NO_COMPILER_RT_HAS_GUARD" "" "" ${ARGN})
+
+  # Validate that the test suite name is known.
+  if(NOT "${runtime}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+    message(FATAL_ERROR "'${runtime}' is not a known test suite. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+  endif()
+
+  # If COMPILER_RT_ENABLE_TEST_SUITES is not "all", check that this runtime
+  # is in the enabled list.
+  if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+    if(NOT "${runtime}" IN_LIST COMPILER_RT_ENABLE_TEST_SUITES)
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  # FIXME: The old code had this but we should probably remove it
+  # because it's unreachable because `compiler-rt/test` is guarded
+  # by `if(COMPILER_RT_INCLUDE_TESTS)`.
+  if(NOT COMPILER_RT_INCLUDE_TESTS)
+    message(STATUS "Skipping compiler-rt ${runtime} test directory")
+    return()
+  endif()
+
+  if(NOT ARG_NO_COMPILER_RT_HAS_GUARD)
+    string(TOUPPER ${runtime} runtime_uppercase)
+    if(NOT COMPILER_RT_HAS_${runtime_uppercase})
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  if(${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
+    # CFI tests require diagnostic mode, which is implemented in UBSan.
+    message(STATUS "Skipping ${runtime} test directory")
+  elseif(${runtime} STREQUAL scudo_standalone)
+    message(STATUS "Adding scudo/standalone test directory")
+    add_subdirectory(scudo/standalone)
+  else()
+    message(STATUS "Adding compiler-rt ${runtime} test directory")
+    add_subdirectory(${runtime})
   endif()
 endfunction()
 
@@ -77,7 +130,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   # in an independent build. This option is only indended to be used by
   # LLVM_ENABLE_RUNTIMES-based builds.
   if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_EXTERNAL_BUILTINS)
-    add_subdirectory(builtins)
+    compiler_rt_test_runtime(builtins NO_COMPILER_RT_HAS_GUARD)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)
     compiler_rt_test_runtime(interception)
@@ -91,7 +144,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
       compiler_rt_test_runtime(fuzzer)
 
       # These tests don't need an additional runtime but use asan runtime.
-      add_subdirectory(metadata)
+      compiler_rt_test_runtime(metadata NO_COMPILER_RT_HAS_GUARD)
     endif()
 
     foreach(sanitizer ${COMPILER_RT_SANITIZERS_TO_BUILD})
@@ -116,7 +169,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   endif()
   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
   # include their own minimal runtime
-  add_subdirectory(shadowcallstack)
+  compiler_rt_test_runtime(shadowcallstack NO_COMPILER_RT_HAS_GUARD)
 endif()
 
 # Now that we've traversed all the directories and know all the lit testsuites,

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -57,16 +57,68 @@ endif()
 
 umbrella_lit_testsuite_begin(check-compiler-rt)
 
-function(compiler_rt_test_runtime runtime)
-  string(TOUPPER ${runtime} runtime_uppercase)
-  if(COMPILER_RT_HAS_${runtime_uppercase} AND COMPILER_RT_INCLUDE_TESTS)
-    if (${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
-      # CFI tests require diagnostic mode, which is implemented in UBSan.
-    elseif (${runtime} STREQUAL scudo_standalone)
-      add_subdirectory(scudo/standalone)
-    else()
-      add_subdirectory(${runtime})
+set(COMPILER_RT_KNOWN_TEST_SUITES
+    builtins;ctx_profile;fuzzer;interception;lsan;memprof;metadata
+    ;orc;profile;sanitizer_common;shadowcallstack
+    ;ubsan;xray)
+list(APPEND COMPILER_RT_KNOWN_TEST_SUITES ${COMPILER_RT_SANITIZERS_TO_BUILD})
+# Sort the list so that's easier to read when emitting errors.
+list(SORT COMPILER_RT_KNOWN_TEST_SUITES)
+
+set(COMPILER_RT_ENABLE_TEST_SUITES "all" CACHE STRING
+    "List of test suites to enable (semicolon-separated), or \"all\" to enable all test suites. Known test suites: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+
+# Validate COMPILER_RT_ENABLE_TEST_SUITES values.
+if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+  foreach(suite ${COMPILER_RT_ENABLE_TEST_SUITES})
+    if(NOT "${suite}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+      message(FATAL_ERROR "Unknown test suite '${suite}' in COMPILER_RT_ENABLE_TEST_SUITES. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
     endif()
+  endforeach()
+endif()
+
+function(compiler_rt_test_runtime runtime)
+  cmake_parse_arguments(ARG "NO_COMPILER_RT_HAS_GUARD" "" "" ${ARGN})
+
+  # Validate that the test suite name is known.
+  if(NOT "${runtime}" IN_LIST COMPILER_RT_KNOWN_TEST_SUITES)
+    message(FATAL_ERROR "'${runtime}' is not a known test suite. Known test suites are: ${COMPILER_RT_KNOWN_TEST_SUITES}")
+  endif()
+
+  # If COMPILER_RT_ENABLE_TEST_SUITES is not "all", check that this runtime
+  # is in the enabled list.
+  if(NOT "${COMPILER_RT_ENABLE_TEST_SUITES}" STREQUAL "all")
+    if(NOT "${runtime}" IN_LIST COMPILER_RT_ENABLE_TEST_SUITES)
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  # FIXME: The old code had this but we should probably remove it
+  # because it's unreachable because `compiler-rt/test` is guarded
+  # by `if(COMPILER_RT_INCLUDE_TESTS)`.
+  if(NOT COMPILER_RT_INCLUDE_TESTS)
+    message(STATUS "Skipping compiler-rt ${runtime} test directory")
+    return()
+  endif()
+
+  if(NOT ARG_NO_COMPILER_RT_HAS_GUARD)
+    string(TOUPPER ${runtime} runtime_uppercase)
+    if(NOT COMPILER_RT_HAS_${runtime_uppercase})
+      message(STATUS "Skipping compiler-rt ${runtime} test directory")
+      return()
+    endif()
+  endif()
+
+  if(${runtime} STREQUAL cfi AND NOT COMPILER_RT_HAS_UBSAN)
+    # CFI tests require diagnostic mode, which is implemented in UBSan.
+    message(STATUS "Skipping ${runtime} test directory")
+  elseif(${runtime} STREQUAL scudo_standalone)
+    message(STATUS "Adding scudo/standalone test directory")
+    add_subdirectory(scudo/standalone)
+  else()
+    message(STATUS "Adding compiler-rt ${runtime} test directory")
+    add_subdirectory(${runtime})
   endif()
 endfunction()
 
@@ -77,7 +129,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   # in an independent build. This option is only indended to be used by
   # LLVM_ENABLE_RUNTIMES-based builds.
   if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_EXTERNAL_BUILTINS)
-    add_subdirectory(builtins)
+    compiler_rt_test_runtime(builtins NO_COMPILER_RT_HAS_GUARD)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)
     compiler_rt_test_runtime(interception)
@@ -91,7 +143,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
       compiler_rt_test_runtime(fuzzer)
 
       # These tests don't need an additional runtime but use asan runtime.
-      add_subdirectory(metadata)
+      compiler_rt_test_runtime(metadata NO_COMPILER_RT_HAS_GUARD)
     endif()
 
     foreach(sanitizer ${COMPILER_RT_SANITIZERS_TO_BUILD})
@@ -116,7 +168,7 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   endif()
   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
   # include their own minimal runtime
-  add_subdirectory(shadowcallstack)
+  compiler_rt_test_runtime(shadowcallstack NO_COMPILER_RT_HAS_GUARD)
 endif()
 
 # Now that we've traversed all the directories and know all the lit testsuites,


### PR DESCRIPTION
This change introduces a new CMake cache variable
`COMPILER_RT_ENABLE_TEST_SUITES` that allows users to have fine-grained
control over which test suites are included and therefore run when
running `ninja check-all`.

For example building with `COMPILER_RT_ENABLE_TEST_SUITES=builtins;asan`
will only enable the builtins and asan tests under `compiler-rt/tests`.

The default value of `COMPILER_RT_INCLUDE_TESTS` is `all` which is a
special value that includes everything and it being the default means
this patch preserves existing behavior. Note this new option only has
affect when `COMPILER_RT_INCLUDE_TESTS` is On.

The primary use case for this change is it allows controlling tests that
don't have a corresponding runtime to be enabled/disabled. An example of
this is the `shadowcallstack` test suite. `-fbounds-safety` also has a
downstream test suite in compiler-rt like this. Previously there was no
way to disable including these tests when `COMPILER_RT_INCLUDE_TESTS`
was on.

The `-fbounds-safety` test suite will be upstreamed once the necessary
clang pieces exist upstream.

A side benefit of this change is it allows building runtimes but not
testing some of them which can be useful in some testing environments
(e.g. smoke-test). It is not the primary motivation though.

While the existing `COMPILER_RT_BUILD_<NAME>` options can be used to
prevent running tests (by not building corresponding runtimes) that
isn't a good solution because it:

* Doesn't work for tests that have no corresponding runtime to be built
  like `shadowcallstack` because there's no CMake option for it.
* Requires specifying multiple CMake options to disable building each
  runtime that we don't want tested. This approach disallows "building
  but not testing certain runtimes" and also is annoying to maintain
  because its effectively a subtractive list (you say what you don't
  want) that has to be updated everytime a new runtime is introduced
  whereas COMPILER_RT_ENABLE_TEST_SUITES is an additive list (you say
  what you want) that doesn't need modifying everytime a new runtime is
  introduced.

To implement this all test directories in `compiler-rt/test` are now
added through the `compiler_rt_test_runtime()` function which has been
adapted to accommodate all use cases.

Assisted-by: Claude Code

rdar://176477660

