### PR TITLE
[lldb] Skip ptr_refs tests on arm64e

### DIFF
--- a/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
+++ b/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
@@ -13,7 +13,7 @@ class TestPtrRefs(TestBase):
     @skipIfAsan  # The output looks different under ASAN.
     @skipIfMTE  # Heap scanning reads tagged memory with untagged pointers.
     @skipUnlessDarwin
-    @skipIf(archs=["arm64e"]) # ptr_refs does not work with pointer authentication
+    @skipIf(archs=["arm64e"])  # ptr_refs does not work with pointer authentication
     def test_ptr_refs(self):
         """Test format string functionality."""
         self.build()

--- a/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
+++ b/lldb/test/API/functionalities/ptr_refs/TestPtrRefs.py
@@ -13,6 +13,7 @@ class TestPtrRefs(TestBase):
     @skipIfAsan  # The output looks different under ASAN.
     @skipIfMTE  # Heap scanning reads tagged memory with untagged pointers.
     @skipUnlessDarwin
+    @skipIf(archs=["arm64e"]) # ptr_refs does not work with pointer authentication
     def test_ptr_refs(self):
         """Test format string functionality."""
         self.build()

--- a/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
+++ b/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class TestPtrRefsObjC(TestBase):
     @skipIfAsan  # The output looks different under ASAN.
     @skipIfMTE  # Heap scanning reads tagged memory with untagged pointers.
+    @skipIf(archs=["arm64e"]) # ptr_refs does not work with pointer authentication
     def test_ptr_refs(self):
         """Test the ptr_refs tool on Darwin with Objective-C"""
         self.build()

--- a/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
+++ b/lldb/test/API/lang/objc/ptr_refs/TestPtrRefsObjC.py
@@ -12,7 +12,7 @@ from lldbsuite.test import lldbutil
 class TestPtrRefsObjC(TestBase):
     @skipIfAsan  # The output looks different under ASAN.
     @skipIfMTE  # Heap scanning reads tagged memory with untagged pointers.
-    @skipIf(archs=["arm64e"]) # ptr_refs does not work with pointer authentication
+    @skipIf(archs=["arm64e"])  # ptr_refs does not work with pointer authentication
     def test_ptr_refs(self):
         """Test the ptr_refs tool on Darwin with Objective-C"""
         self.build()


### PR DESCRIPTION
The ptr_refs utility does not work with pointer authentication