### PR TITLE
[lldb] Add --changed option to `settings show`

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -63,6 +63,7 @@ public:
     eDumpOptionRaw = (1u << 4),
     eDumpOptionCommand = (1u << 5),
     eDumpOptionDefaultValue = (1u << 6),
+    eDumpOptionOnlyChanged = (1u << 7),
     eDumpGroupValue = (eDumpOptionName | eDumpOptionType | eDumpOptionValue),
     eDumpGroupHelp =
         (eDumpOptionName | eDumpOptionType | eDumpOptionDescription),
@@ -248,6 +249,13 @@ public:
   bool OptionWasSet() const { return m_value_was_set; }
 
   void SetOptionWasSet() { m_value_was_set = true; }
+
+  /// Return true if the current value equals the default value.
+  ///
+  /// Subclasses that store a default value should override this to compare
+  /// against it. The base implementation falls back to `OptionWasSet()`, which
+  /// is a reasonable approximation for types without an explicit default.
+  virtual bool IsDefault() const { return !OptionWasSet(); }
 
   void SetParent(const lldb::OptionValueSP &parent_sp) {
     m_parent_wp = parent_sp;

--- a/lldb/include/lldb/Interpreter/OptionValueArch.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArch.h
@@ -49,6 +49,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   void AutoComplete(CommandInterpreter &interpreter,
                     lldb_private::CompletionRequest &request) override;
 

--- a/lldb/include/lldb/Interpreter/OptionValueBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionValueBoolean.h
@@ -45,6 +45,8 @@ public:
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   /// Convert to bool operator.

--- a/lldb/include/lldb/Interpreter/OptionValueChar.h
+++ b/lldb/include/lldb/Interpreter/OptionValueChar.h
@@ -43,6 +43,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   const char &operator=(char c) {

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -52,6 +52,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
@@ -53,6 +53,8 @@ public:
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   FileSpec &GetCurrentValue() { return m_current_value; }

--- a/lldb/include/lldb/Interpreter/OptionValueFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormat.h
@@ -42,6 +42,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   lldb::Format GetCurrentValue() const { return m_current_value; }

--- a/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
@@ -34,6 +34,10 @@ public:
 
   void Clear() override;
 
+  bool IsDefault() const override {
+    return m_current_format == m_default_format;
+  }
+
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 

--- a/lldb/include/lldb/Interpreter/OptionValueLanguage.h
+++ b/lldb/include/lldb/Interpreter/OptionValueLanguage.h
@@ -44,6 +44,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   lldb::LanguageType GetCurrentValue() const { return m_current_value; }

--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -46,6 +46,8 @@ public:
   void DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
                  uint32_t dump_mask) override;
 
+  bool IsDefault() const override;
+
   llvm::json::Value ToJSON(const ExecutionContext *exe_ctx) const override;
 
   llvm::StringRef GetName() const override { return m_name; }

--- a/lldb/include/lldb/Interpreter/OptionValueRegex.h
+++ b/lldb/include/lldb/Interpreter/OptionValueRegex.h
@@ -41,6 +41,10 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override {
+    return m_regex.GetText() == m_default_regex_str;
+  }
+
   // Subclass specific functions
   const RegularExpression *GetCurrentValue() const {
     return (m_regex.IsValid() ? &m_regex : nullptr);

--- a/lldb/include/lldb/Interpreter/OptionValueSInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueSInt64.h
@@ -48,6 +48,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   const int64_t &operator=(int64_t value) {

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -82,6 +82,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   Flags &GetOptions() { return m_options; }

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -51,6 +51,8 @@ public:
     m_value_was_set = false;
   }
 
+  bool IsDefault() const override { return m_current_value == m_default_value; }
+
   // Subclass specific functions
 
   const uint64_t &operator=(uint64_t value) {

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -264,6 +264,9 @@ public:
       case 'd':
         m_include_defaults = true;
         break;
+      case 'c':
+        m_only_changed = true;
+        break;
       default:
         llvm_unreachable("Unimplemented option");
       }
@@ -272,6 +275,7 @@ public:
 
     void OptionParsingStarting(ExecutionContext *execution_context) override {
       m_include_defaults = false;
+      m_only_changed = false;
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
@@ -279,6 +283,7 @@ public:
     }
 
     bool m_include_defaults = false;
+    bool m_only_changed = false;
   };
 
 protected:
@@ -288,9 +293,18 @@ protected:
     uint32_t dump_mask = OptionValue::eDumpGroupValue;
     if (m_options.m_include_defaults)
       dump_mask |= OptionValue::eDumpOptionDefaultValue;
+    if (m_options.m_only_changed)
+      dump_mask |= OptionValue::eDumpOptionOnlyChanged;
 
     if (!args.empty()) {
       for (const auto &arg : args) {
+        if (m_options.m_only_changed) {
+          Status lookup_error;
+          lldb::OptionValueSP value_sp = GetDebugger().GetPropertyValue(
+              &m_exe_ctx, arg.ref(), lookup_error);
+          if (value_sp && value_sp->IsDefault())
+            continue;
+        }
         Status error(GetDebugger().DumpPropertyValue(
             &m_exe_ctx, result.GetOutputStream(), arg.ref(), dump_mask));
         if (error.Success()) {

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -293,8 +293,10 @@ protected:
     uint32_t dump_mask = OptionValue::eDumpGroupValue;
     if (m_options.m_include_defaults)
       dump_mask |= OptionValue::eDumpOptionDefaultValue;
-    if (m_options.m_only_changed)
+    if (m_options.m_only_changed) {
       dump_mask |= OptionValue::eDumpOptionOnlyChanged;
+      dump_mask |= OptionValue::eDumpOptionDefaultValue;
+    }
 
     if (!args.empty()) {
       for (const auto &arg : args) {

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -71,6 +71,9 @@ let Command = "settings clear" in {
 let Command = "settings show" in {
   def setshow_defaults : Option<"defaults", "d">,
                          Desc<"Include ${d}efault values if defined.">;
+  def setshow_changed : Option<"changed", "c">,
+                        Desc<"Only show settings whose value differs from the "
+                             "default.">;
 }
 
 let Command = "breakpoint list" in {

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -342,12 +342,23 @@ void OptionValueProperties::DumpValue(const ExecutionContext *exe_ctx,
     if (property) {
       OptionValue *option_value = property->GetValue().get();
       assert(option_value);
+      if ((dump_mask & eDumpOptionOnlyChanged) && option_value->IsDefault())
+        continue;
       const bool transparent_value = option_value->ValueIsTransparent();
       property->Dump(exe_ctx, strm, dump_mask);
       if (!transparent_value)
         strm.EOL();
     }
   }
+}
+
+bool OptionValueProperties::IsDefault() const {
+  for (const Property &property : m_properties) {
+    if (OptionValue *value = property.GetValue().get())
+      if (!value->IsDefault())
+        return false;
+  }
+  return true;
 }
 
 llvm::json::Value

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -256,11 +256,12 @@ class SettingsCommandTestCase(TestBase):
             substrs=[setting],
         )
 
-        # After explicitly changing the setting, it should show up.
+        # After explicitly changing the setting, it should show up along with
+        # the default value.
         self.runCmd("settings set %s 42" % setting)
         self.expect(
             "settings show --changed",
-            substrs=["%s (unsigned) = 42" % setting],
+            substrs=["%s (unsigned) = 42 (default: 24)" % setting],
         )
 
         # After clearing, it should no longer show up.
@@ -278,11 +279,12 @@ class SettingsCommandTestCase(TestBase):
             substrs=[setting],
         )
 
-        # When the value has been changed, the explicit path prints normally.
+        # When the value has been changed, the explicit path prints the
+        # current value and default.
         self.runCmd("settings set %s 42" % setting)
         self.expect(
             "settings show --changed %s" % setting,
-            substrs=["%s (unsigned) = 42" % setting],
+            substrs=["%s (unsigned) = 42 (default: 24)" % setting],
         )
 
     @skipIf(archs=no_match(["x86_64", "i386", "i686"]))

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -287,6 +287,61 @@ class SettingsCommandTestCase(TestBase):
             substrs=["%s (unsigned) = 42 (default: 24)" % setting],
         )
 
+    def test_settings_show_changed_per_target(self):
+        """Test that `settings show --changed` reflects per-target values: a
+        per-target setting changed in target A should show as changed when A is
+        selected, and as unchanged when target B is selected."""
+        setting = "target.max-children-count"
+
+        def cleanup():
+            self.runCmd("settings clear %s" % setting, check=False)
+
+        self.addTearDownHook(cleanup)
+        self.runCmd("settings clear %s" % setting)
+
+        target_a = self.dbg.CreateTarget("")
+        self.assertTrue(target_a.IsValid(), "Created target A")
+        target_b = self.dbg.CreateTarget("")
+        self.assertTrue(target_b.IsValid(), "Created target B")
+
+        index_a = self.dbg.GetIndexOfTarget(target_a)
+        index_b = self.dbg.GetIndexOfTarget(target_b)
+
+        # Select target A and override the per-target setting there.
+        self.runCmd("target select %d" % index_a)
+        self.runCmd("settings set %s 42" % setting)
+
+        # With A selected, the changed listing should include the override.
+        self.expect(
+            "settings show --changed",
+            substrs=["%s (unsigned) = 42 (default: 24)" % setting],
+        )
+        self.expect(
+            "settings show --changed %s" % setting,
+            substrs=["%s (unsigned) = 42 (default: 24)" % setting],
+        )
+
+        # Switch to target B: the same setting is still at its default for B,
+        # so it must not appear in either form of the changed listing.
+        self.runCmd("target select %d" % index_b)
+        self.expect(
+            "settings show --changed",
+            matching=False,
+            substrs=[setting],
+        )
+        self.expect(
+            "settings show --changed %s" % setting,
+            matching=False,
+            substrs=[setting],
+        )
+
+        # Sanity check: switching back to A still shows the override.
+        self.runCmd("target select %d" % index_a)
+        self.expect(
+            "settings show --changed %s" % setting,
+            substrs=["%s (unsigned) = 42 (default: 24)" % setting],
+        )
+
     @skipIf(archs=no_match(["x86_64", "i386", "i686"]))
     def test_disassembler_settings(self):
         """Test that user options for the disassembler take effect."""

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -237,6 +237,54 @@ class SettingsCommandTestCase(TestBase):
             startstr="auto-confirm (boolean) = false",
         )
 
+    def test_settings_show_changed(self):
+        """Test `settings show --changed` filters the listing to non-default values."""
+        setting = "target.max-children-count"
+
+        def cleanup():
+            self.runCmd("settings clear %s" % setting, check=False)
+
+        self.addTearDownHook(cleanup)
+
+        # Ensure a clean slate for this setting.
+        self.runCmd("settings clear %s" % setting)
+
+        # With the setting at its default, it should not show up under --changed.
+        self.expect(
+            "settings show --changed",
+            matching=False,
+            substrs=[setting],
+        )
+
+        # After explicitly changing the setting, it should show up.
+        self.runCmd("settings set %s 42" % setting)
+        self.expect(
+            "settings show --changed",
+            substrs=["%s (unsigned) = 42" % setting],
+        )
+
+        # After clearing, it should no longer show up.
+        self.runCmd("settings clear %s" % setting)
+        self.expect(
+            "settings show --changed",
+            matching=False,
+            substrs=[setting],
+        )
+
+        # An explicit property path at its default prints nothing.
+        self.expect(
+            "settings show --changed %s" % setting,
+            matching=False,
+            substrs=[setting],
+        )
+
+        # When the value has been changed, the explicit path prints normally.
+        self.runCmd("settings set %s 42" % setting)
+        self.expect(
+            "settings show --changed %s" % setting,
+            substrs=["%s (unsigned) = 42" % setting],
+        )
+
     @skipIf(archs=no_match(["x86_64", "i386", "i686"]))
     def test_disassembler_settings(self):
         """Test that user options for the disassembler take effect."""


### PR DESCRIPTION
Add a `--changed`/`-c` flag to `settings show` that restricts the output to settings whose current value differs from the default. This makes it easy to inspect what has been customized in a session or config without scrolling through the full property tree.

One thing worth calling out is that this works as expected with explicit property paths, for example you can show only the modified settings belonging to `target`:

```
(lldb) set show -c target
target.load-script-from-symbol-file (enum) = true (default: trusted)
(lldb)
```

If nothing has been changed, the output is empty:

```
(lldb) sett show -c target.process
(lldb)
```

rdar://176483441