### PR TITLE
[z/OS] Mark 19 tests UNSUPPORTED on z/OS due to an issue in printf.

### DIFF
--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -1,7 +1,8 @@
 # Test various error cases
 
-# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-# causing the magic bytes to be incorrect.
+# On z/OS, ebcdic output from printf is converted into utf-8 as
+# the output being redirected, causing the magic bytes to be incorrect.
+# TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 # Synthesize a header only cgdata.

--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -3,7 +3,7 @@
 # On z/OS, ebcdic output from printf is converted into utf-8 as
 # the output being redirected, causing the magic bytes to be incorrect.
 # TODO: use a builtin version of printf
-# UNSUPPORTED: system-zos
+UNSUPPORTED: system-zos
 
 # Synthesize a header only cgdata.
 # struct Header {

--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -1,5 +1,9 @@
 # Test various error cases
 
+# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+# causing the magic bytes to be incorrect.
+# UNSUPPORTED: system-zos
+
 # Synthesize a header only cgdata.
 # struct Header {
 #   uint64_t Magic;

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -3,7 +3,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-UNSUPPORTED: system-zos
+# UNSUPPORTED: system-zos
 
 ## Add [namesz, descsz, type, name, desc] for a build id.
 

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -3,7 +3,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-# UNSUPPORTED: system-zos
+UNSUPPORTED: system-zos
 
 ## Add [namesz, descsz, type, name, desc] for a build id.
 

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -1,8 +1,8 @@
 ## Verify that --add-section warns on invalid note sections.
 
-# On z/OS, ebcdic output from printf is converted into utf-8 as
-# the output being redirected, causing the values to be incorrect.
-# TODO: use a builtin version of printf
+## On z/OS, ebcdic output from printf is converted into utf-8 as
+## the output being redirected, causing the values to be incorrect.
+## TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 ## Add [namesz, descsz, type, name, desc] for a build id.

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -1,5 +1,9 @@
 ## Verify that --add-section warns on invalid note sections.
 
+# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+# causing the values to be incorrect.
+# UNSUPPORTED: system-zos
+
 ## Add [namesz, descsz, type, name, desc] for a build id.
 
 ## Notes should be padded to 8 bytes.

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -1,7 +1,8 @@
 ## Verify that --add-section warns on invalid note sections.
 
-# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-# causing the values to be incorrect.
+# On z/OS, ebcdic output from printf is converted into utf-8 as
+# the output being redirected, causing the values to be incorrect.
+# TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 ## Add [namesz, descsz, type, name, desc] for a build id.

--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -1,4 +1,4 @@
-: On z/OS, ebcdic output from printf is converted into utf-8 as
+; On z/OS, ebcdic output from printf is converted into utf-8 as
 ; the output being redirected, causing the magic bytes to be incorrect.
 ; TODO: use a builtin version of printf
 ; UNSUPPORTED: system-zos

--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -1,3 +1,8 @@
+: On z/OS, ebcdic output from printf is converted into utf-8 as
+; the output being redirected, causing the magic bytes to be incorrect.
+; TODO: use a builtin version of printf
+; UNSUPPORTED: system-zos
+
 ; RUN: llvm-offload-binary -o %t --image=file=%s,arch=abc,triple=x-y-z
 ; RUN: llvm-objdump --offloading %t | FileCheck %s
 ; RUN: llvm-offload-binary %t --image=file=%t2,arch=abc,triple=x-y-z

--- a/llvm/test/tools/llvm-profdata/binary-ids-padding.test
+++ b/llvm/test/tools/llvm-profdata/binary-ids-padding.test
@@ -16,8 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/binary-ids-padding.test
+++ b/llvm/test/tools/llvm-profdata/binary-ids-padding.test
@@ -16,7 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 // There will be 2 20-byte binary IDs, so the total Binary IDs size will be 64 bytes.

--- a/llvm/test/tools/llvm-profdata/insufficient-binary-ids-size.test
+++ b/llvm/test/tools/llvm-profdata/insufficient-binary-ids-size.test
@@ -1,3 +1,6 @@
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\10\0\0\0\0\0\0\0' >> %t.profraw
 // We should fail on this because the data buffer (profraw file) is not long

--- a/llvm/test/tools/llvm-profdata/insufficient-binary-ids-size.test
+++ b/llvm/test/tools/llvm-profdata/insufficient-binary-ids-size.test
@@ -1,5 +1,6 @@
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\10\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/large-binary-id-size.test
+++ b/llvm/test/tools/llvm-profdata/large-binary-id-size.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\40\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/large-binary-id-size.test
+++ b/llvm/test/tools/llvm-profdata/large-binary-id-size.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
+++ b/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
@@ -16,8 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
+++ b/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
@@ -16,7 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-num-counters-zero.test
+++ b/llvm/test/tools/llvm-profdata/malformed-num-counters-zero.test
@@ -16,8 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-num-counters-zero.test
+++ b/llvm/test/tools/llvm-profdata/malformed-num-counters-zero.test
@@ -16,7 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
+++ b/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
@@ -16,8 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
+++ b/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
@@ -16,7 +16,9 @@
 
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/misaligned-binary-ids-size.test
+++ b/llvm/test/tools/llvm-profdata/misaligned-binary-ids-size.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw
 // We should fail on this because the binary IDs is not a multiple of 8 bytes.

--- a/llvm/test/tools/llvm-profdata/misaligned-binary-ids-size.test
+++ b/llvm/test/tools/llvm-profdata/misaligned-binary-ids-size.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/mismatched-raw-profile-header.test
+++ b/llvm/test/tools/llvm-profdata/mismatched-raw-profile-header.test
@@ -1,5 +1,6 @@
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-zos
 // Magic
 RUN: printf '\377lprofr\201' > %t

--- a/llvm/test/tools/llvm-profdata/mismatched-raw-profile-header.test
+++ b/llvm/test/tools/llvm-profdata/mismatched-raw-profile-header.test
@@ -1,3 +1,6 @@
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-zos
 // Magic
 RUN: printf '\377lprofr\201' > %t
 // Version

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 // Header
 RUN: printf '\377lprofR\201' > %t
 RUN: printf '\0\0\0\0\0\0\0\12' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 // Header
 RUN: printf '\377lprofR\201' > %t

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201Rforpl\377' > %t
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201Rforpl\377' > %t
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\377lprofr\201' > %t
 RUN: printf '\0\0\0\0\0\0\0\12' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\377lprofr\201' > %t
 RUN: printf '\0\0\0\0\0\0\0\12' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-magic-but-no-header.test
+++ b/llvm/test/tools/llvm-profdata/raw-magic-but-no-header.test
@@ -1,3 +1,6 @@
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-zos
 RUN: printf '\201rforpl\377' > %t
 RUN: not llvm-profdata show %t 2>&1 | FileCheck %s
 RUN: printf '\377lprofr\201' > %t

--- a/llvm/test/tools/llvm-profdata/raw-magic-but-no-header.test
+++ b/llvm/test/tools/llvm-profdata/raw-magic-but-no-header.test
@@ -1,5 +1,6 @@
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-zos
 RUN: printf '\201rforpl\377' > %t
 RUN: not llvm-profdata show %t 2>&1 | FileCheck %s

--- a/llvm/test/tools/llvm-profdata/raw-two-profiles.test
+++ b/llvm/test/tools/llvm-profdata/raw-two-profiles.test
@@ -1,6 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-UNSUPPORTED: system-windows
+// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+// causing the magic bytes to be incorrect.
+UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t-foo.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t-foo.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t-foo.profraw

--- a/llvm/test/tools/llvm-profdata/raw-two-profiles.test
+++ b/llvm/test/tools/llvm-profdata/raw-two-profiles.test
@@ -1,7 +1,8 @@
 // gnuwin32 printf does not work for this test because it will print \15 (CR)
 // whenever \12 (LF) is in the input string.
-// z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-// causing the magic bytes to be incorrect.
+// On z/OS, ebcdic output from printf is converted into utf-8 as
+// the output being redirected, causing the magic bytes to be incorrect.
+// TODO: use a builtin version of printf
 UNSUPPORTED: system-windows, system-zos
 RUN: printf '\201rforpl\377' > %t-foo.profraw
 RUN: printf '\12\0\0\0\0\0\0\0' >> %t-foo.profraw

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -1,5 +1,9 @@
 ## Show that llvm-strings can handle stdin input properly.
 
+# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+# causing the values to be incorrect.
+# UNSUPPORTED: system-zos
+
 ## Case 1: output with single string.
 RUN: printf "abcdefg" | llvm-strings - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}
 CASE1: abcdefg

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -1,7 +1,8 @@
 ## Show that llvm-strings can handle stdin input properly.
 
-# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-# causing the values to be incorrect.
+# On z/OS, ebcdic output from printf is converted into utf-8 as
+# the output being redirected, causing the values to be incorrect.
+# TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 ## Case 1: output with single string.

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -3,7 +3,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-# UNSUPPORTED: system-zos
+UNSUPPORTED: system-zos
 
 ## Case 1: output with single string.
 RUN: printf "abcdefg" | llvm-strings - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -1,8 +1,8 @@
 ## Show that llvm-strings can handle stdin input properly.
 
-# On z/OS, ebcdic output from printf is converted into utf-8 as
-# the output being redirected, causing the values to be incorrect.
-# TODO: use a builtin version of printf
+## On z/OS, ebcdic output from printf is converted into utf-8 as
+## the output being redirected, causing the values to be incorrect.
+## TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 ## Case 1: output with single string.

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -3,7 +3,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-UNSUPPORTED: system-zos
+# UNSUPPORTED: system-zos
 
 ## Case 1: output with single string.
 RUN: printf "abcdefg" | llvm-strings - | FileCheck %s --check-prefix=CASE1 --implicit-check-not={{.}}

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,5 +1,6 @@
-# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
-# causing the values to be incorrect.
+# On z/OS, ebcdic output from printf is converted into utf-8 as
+# the output being redirected, causing the values to be incorrect.
+# TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 # RUN: yaml2obj %s -o %t1.o

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,7 +1,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-UNSUPPORTED: system-zos
+# UNSUPPORTED: system-zos
 
 # RUN: yaml2obj %s -o %t1.o
 # RUN: yaml2obj %s -o %t2.o

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,6 +1,6 @@
-# On z/OS, ebcdic output from printf is converted into utf-8 as
-# the output being redirected, causing the values to be incorrect.
-# TODO: use a builtin version of printf
+## On z/OS, ebcdic output from printf is converted into utf-8 as
+## the output being redirected, causing the values to be incorrect.
+## TODO: use a builtin version of printf
 # UNSUPPORTED: system-zos
 
 # RUN: yaml2obj %s -o %t1.o

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,3 +1,7 @@
+# z/OS printf interprets octal escape sequences in EBCDIC encoding, not ASCII,
+# causing the values to be incorrect.
+# UNSUPPORTED: system-zos
+
 # RUN: yaml2obj %s -o %t1.o
 # RUN: yaml2obj %s -o %t2.o
 

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,7 +1,7 @@
 ## On z/OS, ebcdic output from printf is converted into utf-8 as
 ## the output being redirected, causing the values to be incorrect.
 ## TODO: use a builtin version of printf
-# UNSUPPORTED: system-zos
+UNSUPPORTED: system-zos
 
 # RUN: yaml2obj %s -o %t1.o
 # RUN: yaml2obj %s -o %t2.o


### PR DESCRIPTION
Those tests fail on z/OS because printf interprets octal escape sequences as EBCDIC characters and converts them to ASCII, producing incorrect values in the output.