### PR TITLE
[clang] Add flag for relaxed pointer subtraction

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -113,6 +113,9 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### New Compiler Flags
 
+- New option `-fstable-pointer-subtraction` added to preserve stable semantics
+  when subtracting pointers to unrelated objects.
+
 ### Deprecated Compiler Flags
 
 ### Modified Compiler Flags

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -113,7 +113,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### New Compiler Flags
 
-- New option `-fstable-pointer-subtraction` added to preserve stable semantics
+- New option `-fdefined-pointer-subtraction` added to preserve stable semantics
   when subtracting pointers to unrelated objects.
 
 ### Deprecated Compiler Flags

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -2972,6 +2972,22 @@ are listed below.
    ``aligned`` attribute, this option is ignored.
 ```
 
+```{eval-rst}
+.. option:: -fstable-pointer-subtraction
+
+  The C and C++ standards require both operands of a pointer subtraction to
+  refer to elements of the same array object. Clang normally exploits this
+  rule when lowering pointer subtraction operations, for example by emitting
+  IR constructs such as ``sdiv exact`` that rely on the computed byte offset
+  being an exact multiple of the pointee size.
+
+  ``-fstable-pointer-subtraction`` disables these assumptions and emits IR
+  that preserves the behavior of pointer subtraction even when the standard
+  requirements are violated. This is primarily intended for low-level code,
+  such as kernels and boot loaders, that performs pointer arithmetic over
+  externally defined memory layouts rather than ordinary C or C++ objects.
+```
+
 (strict_aliasing)=
 (strict-aliasing)=
 

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -2973,7 +2973,7 @@ are listed below.
 ```
 
 ```{eval-rst}
-.. option:: -fstable-pointer-subtraction
+.. option:: -fdefined-pointer-subtraction
 
   The C and C++ standards require both operands of a pointer subtraction to
   refer to elements of the same array object. Clang normally exploits this
@@ -2981,7 +2981,7 @@ are listed below.
   IR constructs such as ``sdiv exact`` that rely on the computed byte offset
   being an exact multiple of the pointee size.
 
-  ``-fstable-pointer-subtraction`` disables these assumptions and emits IR
+  ``-fdefined-pointer-subtraction`` disables these assumptions and emits IR
   that preserves the behavior of pointer subtraction even when the standard
   requirements are violated. This is primarily intended for low-level code,
   such as kernels and boot loaders, that performs pointer arithmetic over

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -534,6 +534,8 @@ LANGOPT(EnableLifetimeSafetyTUAnalysis, 1, 0, Benign, "Lifetime safety at transl
 LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 LANGOPT(Reflection      , 1, 0, NotCompatible, "C++26 Reflection")
 
+LANGOPT(StablePointerSubtraction, 1, 0, NotCompatible, "Make unaligned pointer subtraction stable")
+
 #undef LANGOPT
 #undef ENUM_LANGOPT
 #undef VALUE_LANGOPT

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4901,6 +4901,12 @@ def fstable_pointer_subtraction :
   HelpText<
     "Allow stable subtraction of pointers not aligned to object boundaries"
   >,
+  DocBrief<
+    "When subtracting two pointers, do not assume that the byte difference is an "
+    "exact multiple of the pointee type size. The computed result is rounded "
+    "toward zero instead of producing a poison value. Users should prefer casting "
+    "pointers to ``char *`` before subtracting instead of relying on this flag."
+  >,
   MarshallingInfoFlag<LangOpts<"StablePointerSubtraction">>;
 def fno_wrapv_pointer : Flag<["-"], "fno-wrapv-pointer">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, FlangOption]>;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4895,6 +4895,13 @@ def fno_wrapv : Flag<["-"], "fno-wrapv">, Group<f_Group>,
 def fwrapv_pointer : Flag<["-"], "fwrapv-pointer">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Treat pointer overflow as two's complement">;
+def fstable_pointer_subtraction :
+  Flag<["-"], "fstable-pointer-subtraction">, Group<f_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Allow stable subtraction of pointers not aligned to object boundaries"
+  >,
+  MarshallingInfoFlag<LangOpts<"StablePointerSubtraction">>;
 def fno_wrapv_pointer : Flag<["-"], "fno-wrapv-pointer">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, FlangOption]>;
 def fwritable_strings : Flag<["-"], "fwritable-strings">, Group<f_Group>,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4895,17 +4895,17 @@ def fno_wrapv : Flag<["-"], "fno-wrapv">, Group<f_Group>,
 def fwrapv_pointer : Flag<["-"], "fwrapv-pointer">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Treat pointer overflow as two's complement">;
-def fstable_pointer_subtraction :
-  Flag<["-"], "fstable-pointer-subtraction">, Group<f_Group>,
+def fdefined_pointer_subtraction :
+  Flag<["-"], "fdefined-pointer-subtraction">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<
-    "Allow stable subtraction of pointers not aligned to object boundaries"
+    "Define subtraction of pointers not aligned to object boundaries"
   >,
   DocBrief<
     "When subtracting two pointers, do not assume that the byte difference is an "
-    "exact multiple of the pointee type size. The computed result is rounded "
-    "toward zero instead of producing a poison value. Users should prefer casting "
-    "pointers to ``char *`` before subtracting instead of relying on this flag."
+    "exact multiple of the pointee type size, thereby preventing such subtraction "
+    "from resulting in undefined behavior. Users should prefer casting pointers "
+    "to ``char *`` before subtracting them rather than relying on this flag."
   >,
   MarshallingInfoFlag<LangOpts<"StablePointerSubtraction">>;
 def fno_wrapv_pointer : Flag<["-"], "fno-wrapv-pointer">, Group<f_Group>,

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -5021,6 +5021,8 @@ Value *ScalarExprEmitter::EmitSub(const BinOpInfo &op) {
     divisor = CGF.CGM.getSize(elementSize);
   }
 
+  if (CGF.getLangOpts().StablePointerSubtraction)
+    return Builder.CreateSDiv(diffInChars, divisor, "sub.ptr.div");
   // Otherwise, do a full sdiv. This uses the "exact" form of sdiv, since
   // pointer difference in C is only defined in the case where both operands
   // are pointing to elements of an array.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5382,6 +5382,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-funified-lto");
   }
 
+  if (Args.hasArg(options::OPT_fstable_pointer_subtraction))
+    CmdArgs.push_back("-fstable-pointer-subtraction");
+
   // If CollectArgsForIntegratedAssembler() isn't called below, claim the args
   // it claims when not running an assembler. Otherwise, clang would emit
   // "argument unused" warnings for assembler flags when e.g. adding "-E" to

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5382,8 +5382,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-funified-lto");
   }
 
-  if (Args.hasArg(options::OPT_fstable_pointer_subtraction))
-    CmdArgs.push_back("-fstable-pointer-subtraction");
+  if (Args.hasArg(options::OPT_fdefined_pointer_subtraction))
+    CmdArgs.push_back("-fdefined-pointer-subtraction");
 
   // If CollectArgsForIntegratedAssembler() isn't called below, claim the args
   // it claims when not running an assembler. Otherwise, clang would emit

--- a/clang/test/CodeGen/ptr-subtract-stable.c
+++ b/clang/test/CodeGen/ptr-subtract-stable.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -emit-llvm -O2 -triple x86_64-windows-msvc -fstable-pointer-subtraction -fms-extensions %s -o - | FileCheck %s
+
+// Check that pointer subtraction isn't nuw/nsv and sdiv isn't exact
+// CHECK-LABEL: i64 @sub(ptr noundef %p, ptr noundef %q)
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    %sub.ptr.lhs.cast = ptrtoint ptr %p to i64
+// CHECK-NEXT:    %sub.ptr.rhs.cast = ptrtoint ptr %q to i64
+// CHECK-NEXT:    %sub.ptr.sub = sub i64 %sub.ptr.lhs.cast, %sub.ptr.rhs.cast
+// CHECK-NEXT:    %sub.ptr.div = sdiv i64 %sub.ptr.sub, 4
+// CHECK-NEXT:    ret i64 %sub.ptr.div
+
+__declspec(noinline) long long sub(long* p, long* q) {
+  return p - q;
+}
+

--- a/clang/test/CodeGen/ptr-subtract-stable.c
+++ b/clang/test/CodeGen/ptr-subtract-stable.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm -O2 -triple x86_64-windows-msvc -fstable-pointer-subtraction -fms-extensions %s -o - | FileCheck %s
+// RUN: %clang -S -emit-llvm -O2 --target=x86_64-windows-msvc -fstable-pointer-subtraction -fms-extensions %s -o - | FileCheck %s
 
 // Check that pointer subtraction isn't nuw/nsv and sdiv isn't exact
 // CHECK-LABEL: i64 @sub(ptr noundef %p, ptr noundef %q)

--- a/clang/test/CodeGen/ptr-subtract-stable.c
+++ b/clang/test/CodeGen/ptr-subtract-stable.c
@@ -1,4 +1,4 @@
-// RUN: %clang -S -emit-llvm -O2 --target=x86_64-windows-msvc -fstable-pointer-subtraction -fms-extensions %s -o - | FileCheck %s
+// RUN: %clang -S -emit-llvm -O2 --target=x86_64-windows-msvc -fdefined-pointer-subtraction -fms-extensions %s -o - | FileCheck %s
 
 // Check that pointer subtraction isn't nuw/nsv and sdiv isn't exact
 // CHECK-LABEL: i64 @sub(ptr noundef %p, ptr noundef %q)


### PR DESCRIPTION
The C and C++ standards require both operands of pointer subtraction to refer to elements of the same array object. Clang/LLVM currently relies on this rule in several optimizations:

- `inbounds` GEP introduces UB assumptions once the computed address escapes the originating object bounds.

- `sdiv exact` assumes %op1 is divisable by %op2 otherwise it is a poison value. 

The first issue may be addressed with -fwrapv-pointer command line option, however there is no option in clang to mitigate the second issue. Patch adds a new -fstable-pointer-subtraction to address this.