### PR TITLE
[z/OS] Add --ignore-case to FileCheck on output from od.

### DIFF
--- a/llvm/test/tools/llvm-objcopy/DXContainer/dump-section.yaml
+++ b/llvm/test/tools/llvm-objcopy/DXContainer/dump-section.yaml
@@ -11,7 +11,7 @@
 ## Dump the PSV0 part and verify its size.
 # RUN: llvm-objcopy --dump-section=PSV0=%t.psv0 %t.dxbc
 # RUN: wc -c %t.psv0 | FileCheck %s --check-prefix=PSV0-SIZE
-# RUN: od -v -Ax -t x1 %t.psv0 | FileCheck %s --check-prefix=PSV0-CONTENTS
+# RUN: od -v -Ax -t x1 %t.psv0 | FileCheck %s --check-prefix=PSV0-CONTENTS --ignore-case
 # PSV0-SIZE: 76
 
 # For a compute shader the structure size is encoded followed by a bunch of 00'd


### PR DESCRIPTION
This test fails on z/OS because `od` outputs upper case letters on z/OS.