### PR TITLE
[lldb] Confine TestDlopenOtherExecutable.py to Darwin-{x86_64,arm64}

### DIFF
--- a/lldb/test/API/functionalities/dlopen_other_executable/TestDlopenOtherExecutable.py
+++ b/lldb/test/API/functionalities/dlopen_other_executable/TestDlopenOtherExecutable.py
@@ -6,14 +6,11 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @skipIfRemote
-    @skipIfWindows
+    @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64", "arm64$"]))
     # glibc's dlopen doesn't support opening executables.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=11754
-    @skipIfLinux
-    # freebsd's dlopen ditto
-    @expectedFailureAll(oslist=["freebsd"])
-    @expectedFailureNetBSD
-    @no_debug_info_test
+    @skipUnlessDarwin
     def test(self):
         self.build()
         # Launch and stop before the dlopen call.


### PR DESCRIPTION
First, I remove all the `skipIf` and `expectedFailure` in favor of `skipUnlessDarwin` because that appears to be the only supported platform here.

Next, I limit the architectures to x86_64 and arm64. Opening other executables is a hack that works in limited circumstances. arm64e is not supported.