### PR TITLE
Fix PowerPC test failure from [AsmWriter] Change the output syntax of floating-point literals.

### DIFF
--- a/clang/test/C/C2y/n3364.c
+++ b/clang/test/C/C2y/n3364.c
@@ -39,4 +39,4 @@ long double ld2 = +LDBL_SNAN;
 long double ld3 = -LDBL_SNAN;
 // CHECK: @ld1 = {{.*}}global {{double|x86_fp80|fp128|ppc_fp128}} +snan(
 // CHECK: @ld2 = {{.*}}global {{double|x86_fp80|fp128|ppc_fp128}} +snan(
-// CHECK: @ld3 = {{.*}}global {{double|x86_fp80|fp128|ppc_fp128}} -snan(
+// CHECK: @ld3 = {{.*}}global {{double|x86_fp80|fp128|ppc_fp128}} {{-snan\(|f0x8000000000000000FFF4000000000000}}


### PR DESCRIPTION
The root cause of the failure is that the output syntax only outputs the +/-snan syntax for ppc_fp128 if the trailing double is 0. The clang test here is triggering -LDBL_SNAN, which is actually an fneg(snan constant), and the fneg causes the signs of both doubles in the ppc_fp128 to flip. As a result, only the ppc_fp128 form is output in the hexadecimal format rather than the -snan format, necessitating a change to the test output.