### PR TITLE
[lldb] Fix TestPtrauthBRKc47xX16Invalid.py

### DIFF
--- a/lldb/test/API/functionalities/ptrauth_diagnostics/brkC47x_x16_invalid/brkC47x.c
+++ b/lldb/test/API/functionalities/ptrauth_diagnostics/brkC47x_x16_invalid/brkC47x.c
@@ -1,7 +1,7 @@
 int main() {
   //% self.filecheck("c", "brkC47x.c")
   // CHECK: stop reason = EXC_BAD_ACCESS
-  // CHECK-NOT: Note: Possible pointer authentication failure detected.
+  // CHECK-NEXT: Note: Possible pointer authentication failure detected.
   asm volatile (
       "mov x16, #0xbad \n"
       "brk 0xc470 \n"


### PR DESCRIPTION
LLDB correctly detects the pointer authentication failure.