### PR TITLE
[lld][ELF] Exclude SHT_NOBITS sections from LMA overlap checks

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2726,12 +2726,18 @@ template <class ELFT> void Writer<ELFT>::checkSections() {
       vmas.push_back({sec, sec->addr});
   checkOverlap(ctx, "virtual address", vmas, true);
 
-  // Finally, check that the load addresses don't overlap. This will usually be
-  // the same as the virtual addresses but can be different when using a linker
-  // script with AT().
+  // Finally, check that the load addresses don't overlap. This will
+  // usually be the same as the virtual addresses but can be different
+  // when using a linker script with AT(). SHT_NOBITS sections consume
+  // no space in the file so their load address is normally unimportant.
+  // Following GNU ld we permit the load address of a SHT_PROGBITS section
+  // to overlap the load address of a SHT_NOBITS section. This is used
+  // by embedded systems that copy the SHT_PROGBITS sections to a
+  // non-overlapping VMA before the SHT_NOBITS section is zero-initialized.
   std::vector<SectionOffset> lmas;
   for (OutputSection *sec : ctx.outputSections)
-    if (sec->size > 0 && (sec->flags & SHF_ALLOC) && !(sec->flags & SHF_TLS))
+    if (sec->size > 0 && (sec->type != SHT_NOBITS) &&
+        (sec->flags & SHF_ALLOC) && !(sec->flags & SHF_TLS))
       lmas.push_back({sec, sec->getLMA()});
   checkOverlap(ctx, "load address", lmas, false);
 }

--- a/lld/test/ELF/linkerscript/overlap-nobits.s
+++ b/lld/test/ELF/linkerscript/overlap-nobits.s
@@ -1,0 +1,91 @@
+# REQUIRES: x86
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+
+## Check we can overlap a NOLOAD output section containing a NOBITS input section.
+# RUN: ld.lld --script nobits.lds a.o -o out
+# RUN: llvm-readelf -S -l out | FileCheck %s -check-prefix OVERLAP-NOBITS
+# OVERLAP-NOBITS:      Name      Type     Address          Off               Size
+# OVERLAP-NOBITS:      .bss      NOBITS   0000000000101000 [[OFF:[0-9a-f]+]] 001000
+# OVERLAP-NOBITS-NEXT: .overlap  PROGBITS 0000000000200000 [[OFF]]           000001
+
+# OVERLAP-NOBITS:      Type Offset   VirtAddr           PhysAddr           FileSiz  MemSiz
+# OVERLAP-NOBITS:      LOAD 0x002000 0x0000000000101000 0x0000000000101000 0x000000 0x001000
+# OVERLAP-NOBITS-NEXT: LOAD 0x002000 0x0000000000200000 0x0000000000101000 0x000001 0x000001
+
+# OVERLAP-NOBITS: Section to Segment mapping:
+# OVERLAP-NOBITS: 01 .bss
+# OVERLAP-NOBITS: 02 .overlap
+
+## Check we can overlap a NOLOAD output section containing a PROGBITS input section.
+# RUN: ld.lld --script noload.lds a.o -o out
+# RUN: llvm-readelf -S -l out | FileCheck %s -check-prefix OVERLAP-NOLOAD
+
+# OVERLAP-NOLOAD:      Name      Type     Address          Off               Size
+# OVERLAP-NOLOAD:      .data     NOBITS   0000000000101000 [[OFF:[0-9a-f]+]] 001000
+# OVERLAP-NOLOAD-NEXT: .overlap  PROGBITS 0000000000200000 [[OFF]]           000001
+
+# OVERLAP-NOLOAD:      Type Offset   VirtAddr           PhysAddr           FileSiz  MemSiz
+# OVERLAP-NOLOAD:      LOAD 0x002000 0x0000000000101000 0x0000000000101000 0x000000 0x001000
+# OVERLAP-NOLOAD-NEXT: LOAD 0x002000 0x0000000000200000 0x0000000000101000 0x000001 0x000001
+
+# OVERLAP-NOLOAD:      Section to Segment mapping:
+# OVERLAP-NOLOAD:      01 .data
+# OVERLAP-NOLOAD-NEXT: 02 .overlap
+
+## Check that we cannot overlap the memory occupied by a NOBITS input section
+## that is assigned to a PROGBITS output section.
+# RUN: not ld.lld --script progbits.lds a.o -o /dev/null 2>&1 | FileCheck %s -check-prefix ERR-PROGBITS-TYPE
+# ERR-PROGBITS-TYPE: error: section .progbits load address range overlaps with .overlap
+
+#--- a.s
+.section .text,"ax",@progbits
+  nop
+.org 4096
+
+.section .data,"aw",@progbits
+.fill 4096, 1, 0xFF
+
+.section .bss,"aw",@nobits
+.zero 4096
+
+.section .overlap,"aw",@progbits
+.byte 1
+
+#--- nobits.lds
+MEMORY {
+    RAM1 : ORIGIN = 0x100000, LENGTH = 1M
+    RAM2 : ORIGIN = 0x200000, LENGTH = 1M
+}
+
+SECTIONS {
+  .text : { *(.text); _start = .; } > RAM1
+  .bss : { *(.bss); } > RAM1
+  .overlap : AT(LOADADDR(.bss)) { *(.overlap); } > RAM2
+  /DISCARD/ : { *(.data); *(.nobits); }
+}
+
+#--- noload.lds
+MEMORY {
+    RAM1 : ORIGIN = 0x100000, LENGTH = 1M
+    RAM2 : ORIGIN = 0x200000, LENGTH = 1M
+}
+
+SECTIONS {
+  .text : { *(.text); _start = .; } > RAM1
+  .data (NOLOAD) : { *(.data); } > RAM1
+  .overlap : AT(LOADADDR(.data)) { *(.overlap); } > RAM2
+  /DISCARD/ : { *(.bss); *(.nobits); }
+}
+
+#--- progbits.lds
+MEMORY {
+    RAM1 : ORIGIN = 0x100000, LENGTH = 1M
+    RAM2 : ORIGIN = 0x200000, LENGTH = 1M
+}
+
+SECTIONS {
+  .progbits : { *(.text); _start = .; *(.bss); } > RAM1
+  .overlap : AT(_start) { *(.overlap); } > RAM2
+  /DISCARD/ : { *(.data); }
+}


### PR DESCRIPTION
In embedded applications it's sometimes useful to load a section at the same virtual address as the .bss section. For example, one possible use case is for temporary code/data that is only needed for a short time when the program is starting up:

    REGIONS {
        RAM  : ORIGIN = 0x100000, LENGTH = 1M
        INIT : ORIGIN = 0x200000, LENGTH = 1M
    }

    .text { *(.text); } > RAM
    .bss (NOLOAD) : { *(.bss); } > RAM
    .init : AT(LOADADDR(.bss)) { *(.init); } > INIT

The .init section gets placed in the file immediately after the .text section. At startup the .init section contents are copied to the INIT region before zeroing .bss. Once the .init section is no longer needed its memory can be reused, eg. as heap memory.

Currently, lld does not support this and prints an error because the LMAs of .bss and .init overlap. There are two workarounds:

1. Use --no-check-sections to disable all overlap checks, but this also disables VMA and file offset checks, which might not be desired.
2. Assign a fake LMA to the .bss section, which doesn't overlap with the LMA of any other section. However, this is not very intuitive and affects the generated program headers (because a second Phdr is needed now that .bss has a unique p_paddr), which might not be acceptable.

These ugly workarounds can be avoided by ignoring LMA overlaps involving SHT_NOBITS sections. This is also what binutils does, which is why the example above works under GNU ld.