### PR TITLE
[flang] dummy arguments used as function calls

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4836,6 +4836,11 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
       name.symbol = nullptr;
     } else if (auto *entity{ultimate.detailsIf<EntityDetails>()};
                entity && !ultimate.has<ProcEntityDetails>()) {
+      if (entity->isDummy()) {
+        Say(name,
+            "Dummy argument '%s' may not be used as a statement function"_err_en_US);
+        return false;
+      }
       resultType = entity->type();
       ultimate.details() = UnknownDetails{}; // will be replaced below
     } else {

--- a/flang/test/Semantics/stmt-func01.f90
+++ b/flang/test/Semantics/stmt-func01.f90
@@ -98,3 +98,9 @@ subroutine s5
   !ERROR: 'k' is already declared in this scoping unit
   k() = 0.0
 end
+
+subroutine s6(b)
+  !ERROR: Dummy argument 'b' may not be used as a statement function
+  !ERROR: 'b' is not a callable procedure
+  b(c) = 0
+end

--- a/flang/test/Semantics/stmt-func01.f90
+++ b/flang/test/Semantics/stmt-func01.f90
@@ -104,3 +104,16 @@ subroutine s6(b)
   !ERROR: 'b' is not a callable procedure
   b(c) = 0
 end
+
+subroutine s7
+  entry e7(b)
+  !ERROR: Dummy argument 'b' may not be used as a statement function
+  !ERROR: 'b' is not a callable procedure
+  b(c) = 0
+end
+
+subroutine s8(p)
+  external p
+  !ERROR: 'p' has not been declared as an array or pointer-valued function
+  p(c) = 0
+end


### PR DESCRIPTION
 Adding an error when a dummy argument is used as a statement function.
 
```
SUBROUTINE a(foo)
foo(c) = 0
END SUBROUTINE a
```
This PR now points out:
   1) Dummy argument 'foo' may not be used as a statement function
   2) 'foo' is not a callable procedure
   
   Handles issue [196424](https://github.com/llvm/llvm-project/issues/196424)