### PR TITLE
[IR] Add option to skip printing intrinsic declarations

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -876,8 +876,8 @@ public:
   /// uselistorder directives so that use-lists can be recreated when reading
   /// the assembly.
   void print(raw_ostream &OS, AssemblyAnnotationWriter *AAW,
-             bool ShouldPreserveUseListOrder = false,
-             bool IsForDebug = false) const;
+             bool ShouldPreserveUseListOrder = false, bool IsForDebug = false,
+             bool ShouldSkipIntrinsicDeclarations = false) const;
 
   /// Dump the module to stderr (for debugging).
   void dump() const;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2879,6 +2879,7 @@ class AssemblyWriter {
   SetVector<const Comdat *> Comdats;
   bool IsForDebug;
   bool ShouldPreserveUseListOrder;
+  bool ShouldSkipIntrinsicDeclarations;
   UseListOrderMap UseListOrders;
   SmallVector<StringRef, 8> MDNames;
   /// Synchronization scope names registered with LLVMContext.
@@ -2889,7 +2890,8 @@ public:
   /// Construct an AssemblyWriter with an external SlotTracker
   AssemblyWriter(formatted_raw_ostream &o, SlotTracker &Mac, const Module *M,
                  AssemblyAnnotationWriter *AAW, bool IsForDebug,
-                 bool ShouldPreserveUseListOrder = false);
+                 bool ShouldPreserveUseListOrder = false,
+                 bool ShouldSkipIntrinsicDeclarations = false);
 
   AssemblyWriter(formatted_raw_ostream &o, SlotTracker &Mac,
                  const ModuleSummaryIndex *Index, bool IsForDebug);
@@ -2978,13 +2980,15 @@ private:
 
 AssemblyWriter::AssemblyWriter(formatted_raw_ostream &o, SlotTracker &Mac,
                                const Module *M, AssemblyAnnotationWriter *AAW,
-                               bool IsForDebug, bool ShouldPreserveUseListOrder)
+                               bool IsForDebug, bool ShouldPreserveUseListOrder,
+                               bool ShouldSkipIntrinsicDeclarations)
     : Out(o), TheModule(M), Machine(Mac), TypePrinter(M), AnnotationWriter(AAW),
       IsForDebug(IsForDebug),
       ShouldPreserveUseListOrder(
           PreserveAssemblyUseListOrder.getNumOccurrences()
               ? PreserveAssemblyUseListOrder
-              : ShouldPreserveUseListOrder) {
+              : ShouldPreserveUseListOrder),
+      ShouldSkipIntrinsicDeclarations(ShouldSkipIntrinsicDeclarations) {
   if (!TheModule)
     return;
   for (const GlobalObject &GO : TheModule->global_objects())
@@ -3169,6 +3173,8 @@ void AssemblyWriter::printModule(const Module *M) {
 
   // Output all of the functions.
   for (const Function &F : *M) {
+    if (ShouldSkipIntrinsicDeclarations && F.isIntrinsic() && F.isDeclaration())
+      continue;
     Out << '\n';
     printFunction(&F);
   }
@@ -5090,11 +5096,12 @@ void BasicBlock::print(raw_ostream &ROS, AssemblyAnnotationWriter *AAW,
 }
 
 void Module::print(raw_ostream &ROS, AssemblyAnnotationWriter *AAW,
-                   bool ShouldPreserveUseListOrder, bool IsForDebug) const {
+                   bool ShouldPreserveUseListOrder, bool IsForDebug,
+                   bool ShouldSkipIntrinsicDeclarations) const {
   SlotTracker SlotTable(this);
   formatted_raw_ostream OS(ROS);
   AssemblyWriter W(OS, SlotTable, this, AAW, IsForDebug,
-                   ShouldPreserveUseListOrder);
+                   ShouldPreserveUseListOrder, ShouldSkipIntrinsicDeclarations);
   W.printModule(this);
 }
 

--- a/llvm/unittests/IR/AsmWriterTest.cpp
+++ b/llvm/unittests/IR/AsmWriterTest.cpp
@@ -17,6 +17,7 @@
 
 using namespace llvm;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 namespace {
 
@@ -102,5 +103,34 @@ TEST(AsmWriterTest, PrintNullOperandBundle) {
   raw_string_ostream OS(S);
   Invoke->print(OS);
   EXPECT_THAT(S, HasSubstr("<null operand bundle!>"));
+}
+
+TEST(AsmWriterTest, SkipIntrinsicsIfRequested) {
+  LLVMContext Ctx;
+  Module M("test module", Ctx);
+
+  FunctionType *FooType =
+      FunctionType::get(Type::getVoidTy(Ctx), {Type::getInt1Ty(Ctx)}, false);
+  Function *Foo =
+      Function::Create(FooType, Function::ExternalLinkage, "foo", &M);
+  BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", Foo);
+  IRBuilder<> Builder(EntryBB);
+  Builder.CreateIntrinsic(Intrinsic::assume, {Foo->getArg(0)});
+  Builder.CreateRetVoid();
+
+  std::string TextWithIntrinsic;
+  raw_string_ostream TextWithIntrinsicOS(TextWithIntrinsic);
+  M.print(TextWithIntrinsicOS, nullptr, /*ShouldPreserveUseListOrder=*/false,
+          /*IsForDebug=*/false, /*ShouldSkipIntrinsicDeclarations=*/false);
+  EXPECT_THAT(TextWithIntrinsic, HasSubstr("call void @llvm.assume"));
+  EXPECT_THAT(TextWithIntrinsic, HasSubstr("declare void @llvm.assume"));
+
+  std::string TextWithoutIntrinsic;
+  raw_string_ostream TextWithoutIntrinsicOS(TextWithoutIntrinsic);
+  M.print(TextWithoutIntrinsicOS, nullptr, /*ShouldPreserveUseListOrder=*/false,
+          /*IsForDebug=*/false, /*ShouldSkipIntrinsicDeclarations=*/true);
+  EXPECT_THAT(TextWithoutIntrinsic, HasSubstr("call void @llvm.assume"));
+  EXPECT_THAT(TextWithoutIntrinsic,
+              Not(HasSubstr("declare void @llvm.assume")));
 }
 }


### PR DESCRIPTION
This patch adds a new option when printing modules to avoid printing
intrinsic declarations. These are not necessary now for loading textual
IR (e.g., in tests). The intended use case for this is within
llvm-reduce, where we want to produce a nice minimal test case, which
now includes stripping intrinsic declarations.

Initial implementation done with Gemini in Windsurf.
