### PR TITLE
[DWARFLinker] Preserve source order of member subprograms

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1317,7 +1317,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
     const DWARFDebugInfoEntry *InputDieEntry, TypeEntry *ClonedParentTypeDIE,
     uint64_t OutOffset, std::optional<int64_t> FuncAddressAdjustment,
     std::optional<int64_t> VarAddressAdjustment, BumpPtrAllocator &Allocator,
-    TypeUnit *ArtificialTypeUnit) {
+    TypeUnit *ArtificialTypeUnit, uint32_t SiblingOrdinal) {
   uint32_t InputDieIdx = getDIEIndex(InputDieEntry);
   CompileUnit::DIEInfo &Info = getDIEInfo(InputDieIdx);
 
@@ -1344,7 +1344,7 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
 
     ClonedDIE.second = createTypeDIEandCloneAttributes(
         InputDieEntry, TypeDIEGenerator, ClonedParentTypeDIE,
-        ArtificialTypeUnit);
+        ArtificialTypeUnit, SiblingOrdinal);
   }
   TypeEntry *TypeParentForChild =
       ClonedDIE.second ? ClonedDIE.second : ClonedParentTypeDIE;
@@ -1359,13 +1359,14 @@ std::pair<DIE *, TypeEntry *> CompileUnit::cloneDIE(
 
   // Recursively clone children.
   if (HasPlainChildrenToClone || HasTypeChildrenToClone) {
+    uint32_t ChildOrdinal = 0;
     for (const DWARFDebugInfoEntry *CurChild =
              getFirstChildEntry(InputDieEntry);
          CurChild && CurChild->getAbbreviationDeclarationPtr();
-         CurChild = getSiblingEntry(CurChild)) {
+         CurChild = getSiblingEntry(CurChild), ++ChildOrdinal) {
       std::pair<DIE *, TypeEntry *> ClonedChild = cloneDIE(
           CurChild, TypeParentForChild, OutOffset, FuncAddressAdjustment,
-          VarAddressAdjustment, Allocator, ArtificialTypeUnit);
+          VarAddressAdjustment, Allocator, ArtificialTypeUnit, ChildOrdinal);
 
       if (ClonedChild.first) {
         OutOffset =
@@ -1502,7 +1503,8 @@ DIE *CompileUnit::allocateTypeDie(TypeEntryBody *TypeDescriptor,
 
 TypeEntry *CompileUnit::createTypeDIEandCloneAttributes(
     const DWARFDebugInfoEntry *InputDieEntry, DIEGenerator &TypeDIEGenerator,
-    TypeEntry *ClonedParentTypeDIE, TypeUnit *ArtificialTypeUnit) {
+    TypeEntry *ClonedParentTypeDIE, TypeUnit *ArtificialTypeUnit,
+    uint32_t SiblingOrdinal) {
   assert(ArtificialTypeUnit != nullptr);
   uint32_t InputDieIdx = getDIEIndex(InputDieEntry);
 
@@ -1513,6 +1515,25 @@ TypeEntry *CompileUnit::createTypeDIEandCloneAttributes(
       ArtificialTypeUnit->getTypePool().getOrCreateTypeEntryBody(
           Entry, ClonedParentTypeDIE);
   assert(EntryBody);
+
+  // Min-merge this child's ordinal in its parent's child list so children of
+  // record-like types (class/struct/union/interface) sort in source order.
+  // Min across CUs because Clang appends template instantiations lazily, so
+  // positions vary between CUs.
+  if (std::optional<uint32_t> ParentIdx = InputDieEntry->getParentIdx()) {
+    dwarf::Tag ParentTag = getDebugInfoEntry(*ParentIdx)->getTag();
+    if (ParentTag == dwarf::DW_TAG_structure_type ||
+        ParentTag == dwarf::DW_TAG_class_type ||
+        ParentTag == dwarf::DW_TAG_union_type ||
+        ParentTag == dwarf::DW_TAG_interface_type) {
+      uint32_t Prev = EntryBody->SortKey.load(std::memory_order_relaxed);
+      while (SiblingOrdinal < Prev &&
+             !EntryBody->SortKey.compare_exchange_weak(
+                 Prev, SiblingOrdinal, std::memory_order_relaxed,
+                 std::memory_order_relaxed))
+        ;
+    }
+  }
 
   bool IsDeclaration =
       dwarf::toUnsigned(find(InputDieEntry, dwarf::DW_AT_declaration), 0);

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -439,13 +439,15 @@ public:
   /// Clone and emit debug macros(.debug_macinfo/.debug_macro).
   Error cloneAndEmitDebugMacro();
 
-  // Clone input DIE entry.
+  // Clone input DIE entry. \p SiblingOrdinal is this DIE's position in its
+  // parent's child list, or UINT32_MAX for the unit DIE.
   std::pair<DIE *, TypeEntry *>
   cloneDIE(const DWARFDebugInfoEntry *InputDieEntry,
            TypeEntry *ClonedParentTypeDIE, uint64_t OutOffset,
            std::optional<int64_t> FuncAddressAdjustment,
            std::optional<int64_t> VarAddressAdjustment,
-           BumpPtrAllocator &Allocator, TypeUnit *ArtificialTypeUnit);
+           BumpPtrAllocator &Allocator, TypeUnit *ArtificialTypeUnit,
+           uint32_t SiblingOrdinal = std::numeric_limits<uint32_t>::max());
 
   // Clone and emit line table.
   Error cloneAndEmitLineTable(const Triple &TargetTriple);
@@ -718,9 +720,11 @@ private:
       std::optional<int64_t> &VarAddressAdjustment);
 
   /// Creates DIE which would be placed into the "Type" compile unit.
+  /// \p SiblingOrdinal is the input DIE's position in its parent's child list.
   TypeEntry *createTypeDIEandCloneAttributes(
       const DWARFDebugInfoEntry *InputDieEntry, DIEGenerator &TypeDIEGenerator,
-      TypeEntry *ClonedParentTypeDIE, TypeUnit *ArtificialTypeUnit);
+      TypeEntry *ClonedParentTypeDIE, TypeUnit *ArtificialTypeUnit,
+      uint32_t SiblingOrdinal);
 
   /// Create output DIE inside specified \p TypeDescriptor.
   DIE *allocateTypeDie(TypeEntryBody *TypeDescriptor,

--- a/llvm/lib/DWARFLinker/Parallel/TypePool.h
+++ b/llvm/lib/DWARFLinker/Parallel/TypePool.h
@@ -76,6 +76,11 @@ public:
   // Spinlock for deterministic type DIE allocation.
   std::atomic_flag Lock = {};
 
+  // Primary key for the comparator: ordinal of this child in its parent's
+  // child list, min-merged across CUs to keep record-like type members in
+  // source order. Sentinel UINT32_MAX sorts after any real observation.
+  std::atomic<uint32_t> SortKey = {std::numeric_limits<uint32_t>::max()};
+
   /// Children for current type.
   ArrayList<TypeEntry *, 5> Children;
 
@@ -139,6 +144,9 @@ public:
 
   /// Create or return existing type entry body for the specified \p Entry.
   /// Link that entry as child for the specified \p ParentEntry.
+  /// The returned body's \c SortKey starts at the sentinel; callers that want
+  /// the entry to participate in source-order sorting must min-merge their
+  /// per-CU observation into it.
   /// \returns The existing or created type entry body.
   TypeEntryBody *getOrCreateTypeEntryBody(TypeEntry *Entry,
                                           TypeEntry *ParentEntry) {
@@ -177,6 +185,12 @@ public:
 protected:
   std::function<bool(const TypeEntry *LHS, const TypeEntry *RHS)>
       TypesComparator = [](const TypeEntry *LHS, const TypeEntry *RHS) -> bool {
+    uint32_t LK =
+        LHS->getValue().load()->SortKey.load(std::memory_order_relaxed);
+    uint32_t RK =
+        RHS->getValue().load()->SortKey.load(std::memory_order_relaxed);
+    if (LK != RK)
+      return LK < RK;
     return LHS->getKey() < RHS->getKey();
   };
 

--- a/llvm/lib/DWARFLinker/Parallel/TypePool.h
+++ b/llvm/lib/DWARFLinker/Parallel/TypePool.h
@@ -79,6 +79,7 @@ public:
   // Primary key for the comparator: ordinal of this child in its parent's
   // child list, min-merged across CUs to keep record-like type members in
   // source order. Sentinel UINT32_MAX sorts after any real observation.
+  // When set, overwrites the default getKey() in TypeComparator.
   std::atomic<uint32_t> SortKey = {std::numeric_limits<uint32_t>::max()};
 
   /// Children for current type.

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration2.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-fwd-declaration2.test
@@ -44,6 +44,12 @@ void foo() { A *ptr1 = 0; }
 // CHECK-NEXT: AT_name{{.*}}"bPtr"
 // CHECK-NEXT: DW_AT_type [DW_FORM_ref4] {{.*}}{0x[[PTR_B]]} "A::B *")
 
+// CHECK: 0x[[STRUCT_B]]: DW_TAG_structure_type
+// CHECK: AT_name{{.*}}"B"
+
+// CHECK: DW_TAG_member
+// CHECK: AT_name{{.*}}"x"
+
 // CHECK: DW_TAG_member
 // CHECK-NEXT: AT_name{{.*}}"bRef"
 // CHECK-NEXT: DW_AT_type [DW_FORM_ref4] {{.*}}{0x[[REF_B]]} "A::B &"
@@ -51,12 +57,6 @@ void foo() { A *ptr1 = 0; }
 // CHECK: DW_TAG_member
 // CHECK-NEXT: AT_name{{.*}}"bPtrToField"
 // CHECK-NEXT: DW_AT_type [DW_FORM_ref4] {{.*}}{0x[[PTR_TO_FIELD:[a-f0-9]*]]} "int A::B::*"
-
-// CHECK: 0x[[STRUCT_B]]: DW_TAG_structure_type
-// CHECK: AT_name{{.*}}"B"
-
-// CHECK: DW_TAG_member
-// CHECK: AT_name{{.*}}"x"
 
 // CHECK: 0x[[PTR_TO_FIELD]]: DW_TAG_ptr_to_member_type
 // CHECK-NEXT: DW_AT_type [DW_FORM_ref4]   {{.*}}{0x[[INT_BASE]]} "int"

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-member-functions.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-member-functions.cpp
@@ -37,6 +37,23 @@ void foo() { S s; }
 // CHECK: 0x[[STRUCT_S]]:{{.*}}DW_TAG_structure_type
 // CHECK-NEXT: DW_AT_name{{.*}}"S"
 
+// CHECK: 0x[[FOO_Ev:[0-9a-f]*]]:{{.*}}DW_TAG_subprogram
+// CHECK: DW_AT_MIPS_linkage_name{{.*}}"_ZN1S3fooEv"
+// CHECK: DW_AT_name{{.*}}"foo"
+
+// CHECK: DW_TAG_formal_parameter
+// CHECK-NEXT: DW_AT_type{{.*}}0x[[PTR_S]] "S *"
+
+// CHECK: 0x[[FOO_Ei:[0-9a-f]*]]:{{.*}}DW_TAG_subprogram
+// CHECK: DW_AT_MIPS_linkage_name{{.*}}"_ZN1S3fooEi"
+// CHECK: DW_AT_name{{.*}}"foo"
+
+// CHECK: DW_TAG_formal_parameter
+// CHECK-NEXT: DW_AT_type{{.*}}0x[[PTR_S]] "S *"
+
+// CHECK: DW_TAG_formal_parameter
+// CHECK-NEXT: DW_AT_type{{.*}}0x[[INT_BASE]] "int"
+
 // CHECK: DW_TAG_subprogram
 // CHECK: DW_AT_MIPS_linkage_name{{.*}}"_ZN1S3barEv"
 // CHECK: DW_AT_name{{.*}}"bar"
@@ -57,23 +74,6 @@ void foo() { S s; }
 // CHECK: DW_TAG_template_type_parameter
 // CHECK-NEXT: DW_AT_type{{.*}}0x[[INT_BASE]] "int"
 // CHECK-NEXT: DW_AT_name{{.*}}"T"
-
-// CHECK: 0x[[FOO_Ei:[0-9a-f]*]]:{{.*}}DW_TAG_subprogram
-// CHECK: DW_AT_MIPS_linkage_name{{.*}}"_ZN1S3fooEi"
-// CHECK: DW_AT_name{{.*}}"foo"
-
-// CHECK: DW_TAG_formal_parameter
-// CHECK-NEXT: DW_AT_type{{.*}}0x[[PTR_S]] "S *"
-
-// CHECK: DW_TAG_formal_parameter
-// CHECK-NEXT: DW_AT_type{{.*}}0x[[INT_BASE]] "int"
-
-// CHECK: 0x[[FOO_Ev:[0-9a-f]*]]:{{.*}}DW_TAG_subprogram
-// CHECK: DW_AT_MIPS_linkage_name{{.*}}"_ZN1S3fooEv"
-// CHECK: DW_AT_name{{.*}}"foo"
-
-// CHECK: DW_TAG_formal_parameter
-// CHECK-NEXT: DW_AT_type{{.*}}0x[[PTR_S]] "S *"
 
 // For the second unit check that it references structure "S"
 

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-static-member-decl.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-static-member-decl.test
@@ -59,11 +59,11 @@ objects:
 # PARALLEL: DW_AT_name{{.*}}"__artificial_type_unit"
 # PARALLEL: DW_TAG_structure_type
 # PARALLEL: DW_AT_name{{.*}}"S"
-# PARALLEL: DW_TAG_member
-# PARALLEL: DW_AT_name{{.*}}"y"
 # PARALLEL: DW_TAG_variable
 # PARALLEL: DW_AT_name{{.*}}"x"
 # PARALLEL: DW_AT_declaration
+# PARALLEL: DW_TAG_member
+# PARALLEL: DW_AT_name{{.*}}"y"
 
 # PARALLEL: DW_TAG_compile_unit
 # PARALLEL: DW_AT_name{{.*}}"a.cpp"

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-uniquing.cpp
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-uniquing.cpp
@@ -102,12 +102,12 @@ void foo() {
 // CHECK-DAG:DW_AT_decl_file [DW_FORM_data1] ("{{[\\/]}}tmp{{[\\/]}}odr-uniquing.cpp
 // CHECK-DAG:DW_AT_decl_line [DW_FORM_data1] (45)
 
-// CHECK:0x[[U_C_CLASS:[0-9a-f]*]]:{{.*}}DW_TAG_class_type
+// CHECK:0x[[U_C_MEMBER:[0-9a-f]*]]:{{.*}}DW_TAG_member
 // CHECK:DW_AT_name{{.*}}"C"
 // CHECK-DAG:DW_AT_decl_file [DW_FORM_data1] ("{{[\\/]}}tmp{{[\\/]}}odr-uniquing.cpp
 // CHECK-DAG:DW_AT_decl_line [DW_FORM_data1] (46)
 
-// CHECK:0x[[U_C_MEMBER:[0-9a-f]*]]:{{.*}}DW_TAG_member
+// CHECK:0x[[U_C_CLASS:[0-9a-f]*]]:{{.*}}DW_TAG_class_type
 // CHECK:DW_AT_name{{.*}}"C"
 // CHECK-DAG:DW_AT_decl_file [DW_FORM_data1] ("{{[\\/]}}tmp{{[\\/]}}odr-uniquing.cpp
 // CHECK-DAG:DW_AT_decl_line [DW_FORM_data1] (46)


### PR DESCRIPTION
Children of class/struct/union/interface DIEs in the parallel DWARFLinker's artificial type unit are sorted lexicographically by the TypePool synthetic-name key. Data members already get a positional slot through the synthetic name, but subprograms don't: they collapse to alphabetical-by-linkage-name order. That breaks LLDB's SBType::GetMemberFunctionAtIndex(N), which contractually returns members in DWARF order.

Add a uint32_t SortKey on TypeEntryBody, atomically min-merged across CUs with the input DIE's ordinal in its parent's child list, and consult it before the synthetic-name key in TypePool's comparator. The ordinal is computed by cloneDIE's existing child walk and threaded into createTypeDIEandCloneAttributes. Scoped to children of class/struct/union/interface so top-level types in the artificial type unit keep their existing sort order.