### PR TITLE
[Clang][HLSL] Fix -Wunused-variable

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -3188,7 +3188,8 @@ NamedDecl *SemaHLSL::getConstantBufferConversionFunction(QualType Type,
           CanQualType::CreateUnsafe(ReturnTy));
   LookupResult ConvR(SemaRef, ConvName, SourceLocation(),
                      Sema::LookupOrdinaryName);
-  bool LookupSucceeded = SemaRef.LookupQualifiedName(ConvR, RD);
+  [[maybe_unused]] bool LookupSucceeded =
+      SemaRef.LookupQualifiedName(ConvR, RD);
   assert(LookupSucceeded);
 
   for (NamedDecl *D : ConvR) {


### PR DESCRIPTION
LookupSucceeded is only used in an assertion. Mark it [[maybe_unused]]
so we do not get -Wunused-variable in non-assertions builds.