### PR TITLE
[lld][ELF] Allow explicit address expressions on .tbss output sections

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -1185,7 +1185,7 @@ bool LinkerScript::assignOffsets(OutputSection *sec) {
   if (!(sec->flags & SHF_ALLOC)) {
     // Non-SHF_ALLOC sections have zero addresses.
     dot = 0;
-  } else if (isTbss) {
+  } else if (isTbss && !sec->addrExpr) {
     // Allow consecutive SHF_TLS SHT_NOBITS output sections. The address range
     // starts from the end address of the previous tbss section.
     if (state->tbssAddr == 0)

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -1189,7 +1189,7 @@ bool LinkerScript::assignOffsets(OutputSection *sec) {
   if (!(sec->flags & SHF_ALLOC)) {
     // Non-SHF_ALLOC sections have zero addresses.
     dot = 0;
-  } else if (isTbss) {
+  } else if (isTbss && !sec->addrExpr) {
     // Allow consecutive SHF_TLS SHT_NOBITS output sections. The address range
     // starts from the end address of the previous tbss section.
     if (state->tbssAddr == 0)

--- a/lld/test/ELF/linkerscript/tbss-addr-expr.s
+++ b/lld/test/ELF/linkerscript/tbss-addr-expr.s
@@ -1,0 +1,48 @@
+# REQUIRES: x86
+## Test that an explicit address expression on a .tbss section is respected,
+## and that TLS offsets and PT_TLS are generated correctly when one is specified.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+
+# RUN: ld.lld -T explicit.t a.o -o explicit
+# RUN: llvm-readelf -Sl explicit | FileCheck %s --check-prefixes=EXPLICIT,PHDR
+# RUN: llvm-objdump -d --no-show-raw-insn explicit | FileCheck %s --check-prefix=DIS
+
+## An explicit address on a .tbss output section is honored.
+# EXPLICIT:      .tdata PROGBITS 0000000000100000 {{[0-9a-f]+}} 000004
+# EXPLICIT:      .tbss  NOBITS   0000000000200000 {{[0-9a-f]+}} 000004
+
+# PHDR: TLS 0x002000 0x0000000000100000 0x0000000000100000 0x000004 0x100004 R   0x1
+
+# DIS:      movl	%fs:-0x100004, %eax
+# DIS-NEXT: movl	%fs:-0x4, %eax
+
+#--- a.s
+.globl _start
+_start:
+  movl %fs:x@tpoff, %eax
+  movl %fs:y@tpoff, %eax
+
+.section .tdata,"awT",@progbits
+.globl x
+x:
+  .long 1
+
+.section .tbss,"awT",@nobits
+.globl y
+y:
+  .long 0
+
+#--- explicit.t
+MEMORY {
+  text_mem (rx) : ORIGIN = 0xFFFFFFFFFFF00000, LENGTH = 0x10000
+  tdata_mem (rw) : ORIGIN = 0x100000, LENGTH = 0x1000
+  tbss_mem (rw) : ORIGIN = 0x200000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .text : { *(.text) } >text_mem AT>text_mem
+  .tdata 0x100000 : { *(.tdata) } >tdata_mem AT>tdata_mem
+  .tbss 0x200000 (NOLOAD) : { *(.tbss) } >tbss_mem AT>tbss_mem
+}

--- a/lld/test/ELF/linkerscript/tbss-addr-expr.s
+++ b/lld/test/ELF/linkerscript/tbss-addr-expr.s
@@ -1,46 +1,37 @@
 # REQUIRES: x86
 ## Test that an explicit address expression on a .tbss section is respected.
 
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %t/a.s -o %t/a.o
 
-## Test that an explicit address on a tbss section is honored.
-# RUN: echo 'SECTIONS { \
-# RUN:   . = SIZEOF_HEADERS; \
-# RUN:   .text : { *(.text) } \
-# RUN:   .tbss 0x1000 : { *(.tbss) } \
-# RUN:   .data : { *(.data) } \
-# RUN: }' > %t.lds
-# RUN: ld.lld -T %t.lds %t.o -o %t
-# RUN: llvm-readelf -S %t | FileCheck %s
+# RUN: ld.lld -T %t/explicit.t %t/a.o -o %t/explicit
+# RUN: llvm-readelf -S %t/explicit | FileCheck %s --check-prefix=EXPLICIT
 
-# CHECK:      .tbss NOBITS 0000000000001000 {{[0-9a-f]+}} 000004
+# RUN: ld.lld -T %t/dataafter.t %t/a.o -o %t/dataafter
+# RUN: llvm-readelf -S %t/dataafter | FileCheck %s --check-prefix=DATAAFTER
 
-## Test that an expression (not just a constant) works for tbss address.
-# RUN: echo 'SECTIONS { \
-# RUN:   . = SIZEOF_HEADERS; \
-# RUN:   .text : { *(.text) } \
-# RUN:   .tbss (0x800 + 0x800) : { *(.tbss) } \
-# RUN:   .data : { *(.data) } \
-# RUN: }' > %t2.lds
-# RUN: ld.lld -T %t2.lds %t.o -o %t2
-# RUN: llvm-readelf -S %t2 | FileCheck %s --check-prefix=CHECK2
+# RUN: ld.lld -T %t/consec.t %t/a.o -o %t/consec
+# RUN: llvm-readelf -S %t/consec | FileCheck %s --check-prefix=CONSEC
 
-# CHECK2:      .tbss NOBITS 0000000000001000 {{[0-9a-f]+}} 000004
+## An explicit address on a .tbss output section is honored.
+# EXPLICIT: .tbss NOBITS 0000000000001000 {{[0-9a-f]+}} 000004
 
-## Test that .data follows .text, not .tbss (since tbss is SHT_NOBITS).
-# RUN: echo 'SECTIONS { \
-# RUN:   .text 0x1000 : { *(.text) } \
-# RUN:   .tbss 0x2000 : { *(.tbss) } \
-# RUN:   .data : { *(.data) } \
-# RUN: }' > %t3.lds
-# RUN: ld.lld -T %t3.lds %t.o -o %t3
-# RUN: llvm-readelf -S %t3 | FileCheck %s --check-prefix=CHECK3
+## .data follows .text, not .tbss — SHT_NOBITS doesn't push the location counter.
+# DATAAFTER: .text PROGBITS 0000000000001000
+# DATAAFTER: .tbss NOBITS   0000000000002000
+# DATAAFTER: .data PROGBITS 0000000000001001
 
-## .data should follow .text at 0x1001, not .tbss at 0x2004
-# CHECK3:      .text PROGBITS 0000000000001000
-# CHECK3:      .tbss NOBITS   0000000000002000
-# CHECK3:      .data PROGBITS 0000000000001001
+## When the initial tbss output section has a defined address, subsequent tbss
+## output sections without addrExprs stack consecutively from its end (per the
+## existing comment in LinkerScript::assignOffsets: "The address range starts
+## from the end address of the previous tbss section"). .data still follows
+## .text, unaffected by tbss layout.
+# CONSEC: .text  PROGBITS 0000000000000100
+# CONSEC: .tbss1 NOBITS   0000000000001000
+# CONSEC: .tbss2 NOBITS   0000000000001004
+# CONSEC: .data  PROGBITS 0000000000000101
 
+#--- a.s
 .globl _start
 _start:
   nop
@@ -48,5 +39,37 @@ _start:
 .section .tbss,"awT",@nobits
   .long 0
 
+.section .tbss1,"awT",@nobits
+  .long 0
+
+.section .tbss2,"awT",@nobits
+  .long 0
+
 .section .data,"aw"
   .long 0
+
+#--- explicit.t
+SECTIONS {
+  . = SIZEOF_HEADERS;
+  .text : { *(.text) }
+  .tbss 0x1000 : { *(.tbss) }
+  .data : { *(.data) }
+  /DISCARD/ : { *(.tbss1) *(.tbss2) }
+}
+
+#--- dataafter.t
+SECTIONS {
+  .text 0x1000 : { *(.text) }
+  .tbss 0x2000 : { *(.tbss) }
+  .data : { *(.data) }
+  /DISCARD/ : { *(.tbss1) *(.tbss2) }
+}
+
+#--- consec.t
+SECTIONS {
+  .text 0x100 : { *(.text) }
+  .tbss1 0x1000 : { *(.tbss1) }
+  .tbss2 : { *(.tbss2) }
+  .data : { *(.data) }
+  /DISCARD/ : { *(.tbss) }
+}

--- a/lld/test/ELF/linkerscript/tbss-addr-expr.s
+++ b/lld/test/ELF/linkerscript/tbss-addr-expr.s
@@ -1,0 +1,52 @@
+# REQUIRES: x86
+## Test that an explicit address expression on a .tbss section is respected.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
+
+## Test that an explicit address on a tbss section is honored.
+# RUN: echo 'SECTIONS { \
+# RUN:   . = SIZEOF_HEADERS; \
+# RUN:   .text : { *(.text) } \
+# RUN:   .tbss 0x1000 : { *(.tbss) } \
+# RUN:   .data : { *(.data) } \
+# RUN: }' > %t.lds
+# RUN: ld.lld -T %t.lds %t.o -o %t
+# RUN: llvm-readelf -S %t | FileCheck %s
+
+# CHECK:      .tbss NOBITS 0000000000001000 {{[0-9a-f]+}} 000004
+
+## Test that an expression (not just a constant) works for tbss address.
+# RUN: echo 'SECTIONS { \
+# RUN:   . = SIZEOF_HEADERS; \
+# RUN:   .text : { *(.text) } \
+# RUN:   .tbss (0x800 + 0x800) : { *(.tbss) } \
+# RUN:   .data : { *(.data) } \
+# RUN: }' > %t2.lds
+# RUN: ld.lld -T %t2.lds %t.o -o %t2
+# RUN: llvm-readelf -S %t2 | FileCheck %s --check-prefix=CHECK2
+
+# CHECK2:      .tbss NOBITS 0000000000001000 {{[0-9a-f]+}} 000004
+
+## Test that .data follows .text, not .tbss (since tbss is SHT_NOBITS).
+# RUN: echo 'SECTIONS { \
+# RUN:   .text 0x1000 : { *(.text) } \
+# RUN:   .tbss 0x2000 : { *(.tbss) } \
+# RUN:   .data : { *(.data) } \
+# RUN: }' > %t3.lds
+# RUN: ld.lld -T %t3.lds %t.o -o %t3
+# RUN: llvm-readelf -S %t3 | FileCheck %s --check-prefix=CHECK3
+
+## .data should follow .text at 0x1001, not .tbss at 0x2004
+# CHECK3:      .text PROGBITS 0000000000001000
+# CHECK3:      .tbss NOBITS   0000000000002000
+# CHECK3:      .data PROGBITS 0000000000001001
+
+.globl _start
+_start:
+  nop
+
+.section .tbss,"awT",@nobits
+  .long 0
+
+.section .data,"aw"
+  .long 0


### PR DESCRIPTION
D107208 allows consecutive SHF_TLS SHT_NOBITS (.tbss) output sections by making
each .tbss start at the end address of the previous one (state->tbssAddr). This
happens unconditionally, so an explicit output section address
(`.tbss ADDR : { ... }`) is silently ignored, unlike GNU ld.

Apply the tbssAddr fallback only when the section has no address expression.

Some embedded/RTOS applications link the kernel and several mutually isolated
tasks into a single ELF and require every section, .tbss included, to sit at a
specific address matching the memory map. Placing a task's .tbss in its own
protected region is a security boundary: one task must not be able to modify
another's TLS. Previously lld placed .tbss adjacent to .text in RX memory
instead of where the linker script directed it, in RW memory.