### PR TITLE
[lldb] Rename GetInstanceVariableName to GetInstanceName (NFC)

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -269,13 +269,13 @@ public:
   ///     represented by this symbol context object, nullptr otherwise.
   Block *GetFunctionBlock();
 
-  /// Determines the name of the instance variable for the this decl context.
+  /// Determines the name of the instance for this decl context.
   ///
   /// For C++ the name is "this", for Objective-C the name is "self".
   ///
   /// \return
-  ///     Returns a StringRef for the name of the instance variable.
-  llvm::StringRef GetInstanceVariableName();
+  ///     Returns a StringRef for the name of the instance.
+  llvm::StringRef GetInstanceName();
 
   /// Sorts the types in TypeMap according to SymbolContext to TypeList
   ///

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -468,7 +468,7 @@ public:
     return ConstString();
   }
 
-  virtual llvm::StringRef GetInstanceVariableName() { return {}; }
+  virtual llvm::StringRef GetInstanceName() { return {}; }
 
   /// Given a symbol context list of matches which supposedly represent the
   /// same file and line number in a CU, erases those that should be ignored

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -229,7 +229,7 @@ public:
   static llvm::Expected<ConstString>
   SubstituteStructorAliases_ItaniumMangle(llvm::StringRef mangled_name);
 
-  llvm::StringRef GetInstanceVariableName() override { return "this"; }
+  llvm::StringRef GetInstanceName() override { return "this"; }
 
   FormatEntity::Entry GetFunctionNameFormat() const override;
 

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
@@ -184,7 +184,7 @@ public:
       return false;
   }
 
-  llvm::StringRef GetInstanceVariableName() override { return "self"; }
+  llvm::StringRef GetInstanceName() override { return "self"; }
 
   virtual std::optional<bool>
   GetBooleanFromString(llvm::StringRef str) const override;

--- a/lldb/source/Plugins/Language/ObjCPlusPlus/ObjCPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/ObjCPlusPlus/ObjCPlusPlusLanguage.h
@@ -37,7 +37,7 @@ public:
 
   static lldb_private::Language *CreateInstance(lldb::LanguageType language);
 
-  llvm::StringRef GetInstanceVariableName() override { return "self"; }
+  llvm::StringRef GetInstanceName() override { return "self"; }
 
   virtual std::optional<bool>
   GetBooleanFromString(llvm::StringRef str) const override;

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -530,7 +530,7 @@ Block *SymbolContext::GetFunctionBlock() {
   return nullptr;
 }
 
-llvm::StringRef SymbolContext::GetInstanceVariableName() {
+llvm::StringRef SymbolContext::GetInstanceName() {
   LanguageType lang_type = eLanguageTypeUnknown;
 
   if (Block *function_block = GetFunctionBlock())
@@ -541,7 +541,7 @@ llvm::StringRef SymbolContext::GetInstanceVariableName() {
     lang_type = GetLanguage();
 
   if (auto *lang = Language::FindPlugin(lang_type))
-    return lang->GetInstanceVariableName();
+    return lang->GetInstanceName();
 
   return {};
 }

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -637,9 +637,9 @@ ValueObjectSP StackFrame::LegacyGetValueForVariableExpressionPath(
     // Check for direct ivars access which helps us with implicit access to
     // ivars using "this" or "self".
     GetSymbolContext(eSymbolContextFunction | eSymbolContextBlock);
-    llvm::StringRef instance_var_name = m_sc.GetInstanceVariableName();
-    if (!instance_var_name.empty()) {
-      var_sp = variable_list->FindVariable(ConstString(instance_var_name));
+    llvm::StringRef instance_name = m_sc.GetInstanceName();
+    if (!instance_name.empty()) {
+      var_sp = variable_list->FindVariable(ConstString(instance_name));
       if (var_sp) {
         separator_idx = 0;
         if (Type *var_type = var_sp->GetType())

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -358,8 +358,8 @@ lldb::ValueObjectSP LookupIdentifier(llvm::StringRef name_ref,
     // Try looking for an instance variable (class member).
     SymbolContext sc = stack_frame->GetSymbolContext(
         lldb::eSymbolContextFunction | lldb::eSymbolContextBlock);
-    llvm::StringRef ivar_name = sc.GetInstanceVariableName();
-    value_sp = stack_frame->FindVariable(ConstString(ivar_name));
+    llvm::StringRef instance_name = sc.GetInstanceName();
+    value_sp = stack_frame->FindVariable(ConstString(instance_name));
     if (value_sp)
       value_sp = value_sp->GetChildMemberWithName(name_ref);
 


### PR DESCRIPTION
Based on Jim's comments (https://github.com/llvm/llvm-project/pull/195187#discussion_r3205135577) which highlights that it is incorrect to call this/self an "instance variable".

I went with "instance name" to leave out the word "object", since not all instances values are objects.