### PR TITLE
[clang-format] Handle more Verilog attributes

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1451,6 +1451,17 @@ void UnwrappedLineParser::parseStructuralElement(
     while (FormatTok->is(tok::l_square) && handleCppAttributes()) {
     }
   } else if (Style.isVerilog()) {
+    // Skip attributes.
+    while (FormatTok->is(tok::l_paren) &&
+           Tokens->peekNextToken()->is(tok::star)) {
+      parseParens();
+    }
+    // Skip things that can exist before keywords like 'if' and 'case'.
+    if (FormatTok->isOneOf(Keywords.kw_priority, Keywords.kw_unique,
+                           Keywords.kw_unique0)) {
+      nextToken();
+    }
+
     if (Keywords.isVerilogStructuredProcedure(*FormatTok)) {
       parseForOrWhileLoop(/*HasParens=*/false);
       return;
@@ -1463,19 +1474,6 @@ void UnwrappedLineParser::parseStructuralElement(
                            Keywords.kw_assume, Keywords.kw_cover)) {
       parseIfThenElse(IfKind, /*KeepBraces=*/false, /*IsVerilogAssert=*/true);
       return;
-    }
-
-    // Skip things that can exist before keywords like 'if' and 'case'.
-    while (true) {
-      if (FormatTok->isOneOf(Keywords.kw_priority, Keywords.kw_unique,
-                             Keywords.kw_unique0)) {
-        nextToken();
-      } else if (FormatTok->is(tok::l_paren) &&
-                 Tokens->peekNextToken()->is(tok::star)) {
-        parseParens();
-      } else {
-        break;
-      }
     }
   }
 

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -1013,6 +1013,8 @@ TEST_F(FormatTestVerilog, Instantiation) {
 TEST_F(FormatTestVerilog, Loop) {
   verifyFormat("foreach (x[x])\n"
                "  x = x;");
+  verifyFormat("(* x = \"x\" *) foreach (x[x])\n"
+               "  x = x;");
   verifyFormat("repeat (x)\n"
                "  x = x;");
   verifyFormat("foreach (x[x]) begin\n"


### PR DESCRIPTION
before

```SystemVerilog
(* x = "x" *) foreach(x[x]) x = x;
```

after

```SystemVerilog
(* x = "x" *) foreach (x[x])
  x = x;
```

The code for handling statements like the `foreach` preceded the part for handling the attributes inside `(* *)`.  So there was a problem with some of the statements following attributes.  The patch moves the part for the statements down.  The loop in the code was also unnecessary.