### PR TITLE
[LoongArch] Use vector extend for sitofp/uitofp

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -498,6 +498,7 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
   // Set DAG combine for LA32 and LA64.
   if (Subtarget.hasBasicF()) {
     setTargetDAGCombine(ISD::SINT_TO_FP);
+    setTargetDAGCombine(ISD::UINT_TO_FP);
   }
 
   setTargetDAGCombine(ISD::AND);
@@ -7749,6 +7750,25 @@ static SDValue performSINT_TO_FPCombine(SDNode *N, SelectionDAG &DAG,
   SDLoc DL(N);
   EVT VT = N->getValueType(0);
 
+  // Sign-extend src to avoid scalarization.
+  if (VT.isVector()) {
+    SDValue Src = N->getOperand(0);
+    EVT SrcVT = Src.getValueType();
+
+    unsigned DstElts = VT.getVectorNumElements();
+    unsigned SrcEltBits = SrcVT.getScalarSizeInBits();
+    unsigned DstEltBits = VT.getScalarSizeInBits();
+
+    if (SrcEltBits >= DstEltBits)
+      return SDValue();
+
+    MVT WidenEltVT = MVT::getIntegerVT(DstEltBits);
+    MVT WidenSrcVT = MVT::getVectorVT(WidenEltVT, DstElts);
+
+    SDValue Extend = DAG.getNode(ISD::SIGN_EXTEND, DL, WidenSrcVT, Src);
+    return DAG.getNode(ISD::SINT_TO_FP, DL, VT, Extend);
+  }
+
   if (VT != MVT::f32 && VT != MVT::f64)
     return SDValue();
   if (VT == MVT::f32 && !Subtarget.hasBasicF())
@@ -7777,6 +7797,34 @@ static SDValue performSINT_TO_FPCombine(SDNode *N, SelectionDAG &DAG,
     // to use the new Chain.
     DAG.ReplaceAllUsesOfValueWith(SDValue(LN0, 1), Load.getValue(1));
     return DAG.getNode(LoongArchISD::SITOF, SDLoc(N), VT, Load);
+  }
+
+  return SDValue();
+}
+
+static SDValue performUINT_TO_FPCombine(SDNode *N, SelectionDAG &DAG,
+                                        TargetLowering::DAGCombinerInfo &DCI,
+                                        const LoongArchSubtarget &Subtarget) {
+  SDLoc DL(N);
+  EVT VT = N->getValueType(0);
+
+  // Zero-extend src to avoid scalarization.
+  if (VT.isVector()) {
+    SDValue Src = N->getOperand(0);
+    EVT SrcVT = Src.getValueType();
+
+    unsigned DstElts = VT.getVectorNumElements();
+    unsigned SrcEltBits = SrcVT.getScalarSizeInBits();
+    unsigned DstEltBits = VT.getScalarSizeInBits();
+
+    if (SrcEltBits >= DstEltBits)
+      return SDValue();
+
+    MVT WidenEltVT = MVT::getIntegerVT(DstEltBits);
+    MVT WidenSrcVT = MVT::getVectorVT(WidenEltVT, DstElts);
+
+    SDValue Extend = DAG.getNode(ISD::ZERO_EXTEND, DL, WidenSrcVT, Src);
+    return DAG.getNode(ISD::UINT_TO_FP, DL, VT, Extend);
   }
 
   return SDValue();
@@ -8067,6 +8115,8 @@ SDValue LoongArchTargetLowering::PerformDAGCombine(SDNode *N,
     return performEXTENDCombine(N, DAG, DCI, Subtarget);
   case ISD::SINT_TO_FP:
     return performSINT_TO_FPCombine(N, DAG, DCI, Subtarget);
+  case ISD::UINT_TO_FP:
+    return performUINT_TO_FPCombine(N, DAG, DCI, Subtarget);
   case LoongArchISD::BITREV_W:
     return performBITREV_WCombine(N, DAG, DCI, Subtarget);
   case LoongArchISD::BR_CC:

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/sitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/sitofp.ll
@@ -82,15 +82,9 @@ define <2 x double> @sitofp_v4i32_v2f64(<4 x i32> %a) {
 define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v2i16_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.d.h $xr0, $xr0
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <2 x i32> <i32 0, i32 1>
   %cvt = sitofp <2 x i16> %shuf to <2 x double>
@@ -100,16 +94,11 @@ define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
 define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v8i16_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
-; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.w.h $xr0, $xr0
+; CHECK-NEXT:    vext2xv.d.w $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 killed $xr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <8 x i16> %a to <8 x double>
   %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -119,15 +108,9 @@ define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
 define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v2i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.d.b $xr0, $xr0
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
   %cvt = sitofp <2 x i8> %shuf to <2 x double>
@@ -137,16 +120,12 @@ define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
 define <2 x double> @sitofp_v16i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v16i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
-; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.h.b $xr0, $xr0
+; CHECK-NEXT:    vext2xv.w.h $xr0, $xr0
+; CHECK-NEXT:    vext2xv.d.w $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 killed $xr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -165,25 +144,9 @@ define <4 x double> @sitofp_v4i64_v4f64(<4 x i64> %a) {
 define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v4i16_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.d.h $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = sitofp <4 x i16> %shuf to <4 x double>
@@ -193,25 +156,10 @@ define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
 define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v8i16_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.w.h $xr0, $xr0
+; CHECK-NEXT:    vext2xv.d.w $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <8 x i16> %a to <8 x double>
   %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -221,25 +169,9 @@ define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
 define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v4i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.d.b $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = sitofp <4 x i8> %shuf to <4 x double>
@@ -249,25 +181,11 @@ define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
 define <4 x double> @sitofp_v16i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v16i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.h.b $xr0, $xr0
+; CHECK-NEXT:    vext2xv.w.h $xr0, $xr0
+; CHECK-NEXT:    vext2xv.d.w $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/sitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/sitofp.ll
@@ -56,3 +56,220 @@ define void @sitofp_v4i32_v4f64(ptr %res, ptr %in){
   store <4 x double> %v1, ptr %res
   ret void
 }
+
+define <2 x float> @sitofp_v2i32_v2f32(<2 x i32> %a) {
+; CHECK-LABEL: sitofp_v2i32_v2f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vffint.s.w $vr0, $vr0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <2 x i32> %a to <2 x float>
+  ret <2 x float> %cvt
+}
+
+define <2 x double> @sitofp_v4i32_v2f64(<4 x i32> %a) {
+; CHECK-LABEL: sitofp_v4i32_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.d.w $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 killed $xr0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <4 x i32> %a to <4 x double>
+  %shuf = shufflevector <4 x double> %cvt, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v2i16_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = sitofp <2 x i16> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v8i16_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
+; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <8 x i16> %a to <8 x double>
+  %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v2i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = sitofp <2 x i8> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @sitofp_v16i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v16i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
+; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <4 x double> @sitofp_v4i64_v4f64(<4 x i64> %a) {
+; CHECK-LABEL: sitofp_v4i64_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xvffint.d.l $xr0, $xr0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <4 x i64> %a to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v4i16_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = sitofp <4 x i16> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v8i16_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %cvt = sitofp <8 x i16> %a to <8 x double>
+  %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}
+
+define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v4i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = sitofp <4 x i8> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v16i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v16i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %cvt = sitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/uitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/uitofp.ll
@@ -60,15 +60,9 @@ define void @uitofp_v4i32_v4f64(ptr %res, ptr %in){
 define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v2i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.du.bu $xr0, $xr0
+; CHECK-NEXT:    vffint.d.lu $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
   %cvt = uitofp <2 x i8> %shuf to <2 x double>
@@ -78,16 +72,12 @@ define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
 define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v16i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
-; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.hu.bu $xr0, $xr0
+; CHECK-NEXT:    vext2xv.wu.hu $xr0, $xr0
+; CHECK-NEXT:    vext2xv.du.wu $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.lu $xr0, $xr0
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 killed $xr0
 ; CHECK-NEXT:    ret
   %cvt = uitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -97,25 +87,9 @@ define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
 define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v4i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.du.bu $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.lu $xr0, $xr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = uitofp <4 x i8> %shuf to <4 x double>
@@ -125,25 +99,11 @@ define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
 define <4 x double> @uitofp_v16i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v16i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    # kill: def $vr0 killed $vr0 def $xr0
+; CHECK-NEXT:    vext2xv.hu.bu $xr0, $xr0
+; CHECK-NEXT:    vext2xv.wu.hu $xr0, $xr0
+; CHECK-NEXT:    vext2xv.du.wu $xr0, $xr0
+; CHECK-NEXT:    xvffint.d.lu $xr0, $xr0
 ; CHECK-NEXT:    ret
   %cvt = uitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/uitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/uitofp.ll
@@ -56,3 +56,96 @@ define void @uitofp_v4i32_v4f64(ptr %res, ptr %in){
   store <4 x double> %v1, ptr %res
   ret void
 }
+
+define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v2i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = uitofp <2 x i8> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v16i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr0, 16
+; CHECK-NEXT:    vori.b $vr0, $vr1, 0
+; CHECK-NEXT:    ret
+  %cvt = uitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v4i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = uitofp <4 x i8> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @uitofp_v16i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v16i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    xvpermi.q $xr0, $xr2, 2
+; CHECK-NEXT:    ret
+  %cvt = uitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}

--- a/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/sitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/sitofp.ll
@@ -27,3 +27,245 @@ define void @sitofp_v2i64_v2f64(ptr %res, ptr %in){
   store <2 x double> %v1, ptr %res
   ret void
 }
+
+define <4 x double> @sitofp_v4i64_v4f64(<4 x i64> %a) {
+; CHECK-LABEL: sitofp_v4i64_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
+; CHECK-NEXT:    vffint.d.l $vr1, $vr1
+; CHECK-NEXT:    ret
+  %cvt = sitofp <4 x i64> %a to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v4i32_v4f64(<4 x i32> %a) {
+; CHECK-LABEL: sitofp_v4i32_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 1
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 3
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 2
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <4 x i32> %a to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <2 x float> @sitofp_v2i32_v2f32(<2 x i32> %a) {
+; CHECK-LABEL: sitofp_v2i32_v2f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vffint.s.w $vr0, $vr0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <2 x i32> %a to <2 x float>
+  ret <2 x float> %cvt
+}
+
+define <2 x double> @sitofp_v4i32_v2f64(<4 x i32> %a) {
+; CHECK-LABEL: sitofp_v4i32_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 1
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %cvt = sitofp <4 x i32> %a to <4 x double>
+  %shuf = shufflevector <4 x double> %cvt, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v2i16_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = sitofp <2 x i16> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v8i16_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %cvt = sitofp <8 x i16> %a to <8 x double>
+  %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v2i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = sitofp <2 x i8> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @sitofp_v16i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v16i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %cvt = sitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v4i16_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = sitofp <4 x i16> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
+; CHECK-LABEL: sitofp_v8i16_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.h $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <8 x i16> %a to <8 x double>
+  %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}
+
+define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v4i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = sitofp <4 x i8> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @sitofp_v16i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: sitofp_v16i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    ext.w.b $a0, $a0
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %cvt = sitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}

--- a/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/sitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/sitofp.ll
@@ -41,20 +41,11 @@ define <4 x double> @sitofp_v4i64_v4f64(<4 x i64> %a) {
 define <4 x double> @sitofp_v4i32_v4f64(<4 x i32> %a) {
 ; CHECK-LABEL: sitofp_v4i32_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 1
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 3
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 2
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vslti.w $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.w $vr2, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.l $vr2, $vr2
+; CHECK-NEXT:    vilvh.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.l $vr1, $vr0
 ; CHECK-NEXT:    vori.b $vr0, $vr2, 0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <4 x i32> %a to <4 x double>
@@ -73,13 +64,9 @@ define <2 x float> @sitofp_v2i32_v2f32(<2 x i32> %a) {
 define <2 x double> @sitofp_v4i32_v2f64(<4 x i32> %a) {
 ; CHECK-LABEL: sitofp_v4i32_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 1
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.w $a0, $vr0, 0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vslti.w $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <4 x i32> %a to <4 x double>
   %shuf = shufflevector <4 x double> %cvt, <4 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -89,15 +76,10 @@ define <2 x double> @sitofp_v4i32_v2f64(<4 x i32> %a) {
 define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v2i16_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vextrins.h $vr0, $vr0, 65
+; CHECK-NEXT:    vslli.d $vr0, $vr0, 48
+; CHECK-NEXT:    vsrai.d $vr0, $vr0, 48
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <2 x i32> <i32 0, i32 1>
   %cvt = sitofp <2 x i16> %shuf to <2 x double>
@@ -107,15 +89,11 @@ define <2 x double> @sitofp_v2i16_v2f64(<8 x i16> %a) {
 define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v8i16_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vslti.h $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.h $vr0, $vr1, $vr0
+; CHECK-NEXT:    vslti.w $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <8 x i16> %a to <8 x double>
   %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -125,15 +103,10 @@ define <2 x double> @sitofp_v8i16_v2f64(<8 x i16> %a) {
 define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v2i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vextrins.b $vr0, $vr0, 129
+; CHECK-NEXT:    vslli.d $vr0, $vr0, 56
+; CHECK-NEXT:    vsrai.d $vr0, $vr0, 56
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
   %cvt = sitofp <2 x i8> %shuf to <2 x double>
@@ -143,15 +116,13 @@ define <2 x double> @sitofp_v2i8_v2f64(<16 x i8> %a) {
 define <2 x double> @sitofp_v16i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v16i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vslti.b $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vslti.h $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.h $vr0, $vr1, $vr0
+; CHECK-NEXT:    vslti.w $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
 ; CHECK-NEXT:    ret
   %cvt = sitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -161,25 +132,13 @@ define <2 x double> @sitofp_v16i8_v2f64(<16 x i8> %a) {
 define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v4i16_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vslti.h $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.h $vr1, $vr1, $vr0
+; CHECK-NEXT:    vslti.w $vr2, $vr1, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr1, $vr1
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <8 x i16> %a, <8 x i16> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = sitofp <4 x i16> %shuf to <4 x double>
@@ -189,25 +148,13 @@ define <4 x double> @sitofp_v4i16_v4f64(<8 x i16> %a) {
 define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
 ; CHECK-LABEL: sitofp_v8i16_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.h $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.h $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vslti.h $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.h $vr1, $vr1, $vr0
+; CHECK-NEXT:    vslti.w $vr2, $vr1, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr1, $vr1
 ; CHECK-NEXT:    ret
   %cvt = sitofp <8 x i16> %a to <8 x double>
   %shuf = shufflevector <8 x double> %cvt, <8 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -217,25 +164,15 @@ define <4 x double> @sitofp_v8i16_v4f64(<8 x i16> %a) {
 define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v4i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr0, $vr0
+; CHECK-NEXT:    vilvl.h $vr0, $vr0, $vr0
+; CHECK-NEXT:    vslli.w $vr0, $vr0, 24
+; CHECK-NEXT:    vsrai.w $vr1, $vr0, 24
+; CHECK-NEXT:    vslti.w $vr2, $vr1, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr1, $vr1
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = sitofp <4 x i8> %shuf to <4 x double>
@@ -245,25 +182,15 @@ define <4 x double> @sitofp_v4i8_v4f64(<16 x i8> %a) {
 define <4 x double> @sitofp_v16i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: sitofp_v16i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    ext.w.b $a0, $a0
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vslti.b $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vslti.h $vr1, $vr0, 0
+; CHECK-NEXT:    vilvl.h $vr1, $vr1, $vr0
+; CHECK-NEXT:    vslti.w $vr2, $vr1, 0
+; CHECK-NEXT:    vilvl.w $vr0, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr2, $vr1
+; CHECK-NEXT:    vffint.d.l $vr1, $vr1
 ; CHECK-NEXT:    ret
   %cvt = sitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/uitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/uitofp.ll
@@ -27,3 +27,95 @@ define void @uitofp_v2i64_v2f64(ptr %res, ptr %in){
   store <2 x double> %v1, ptr %res
   ret void
 }
+
+define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v2i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
+  %cvt = uitofp <2 x i8> %shuf to <2 x double>
+  ret <2 x double> %cvt
+}
+
+define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v16i8_v2f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa0, $fa0
+; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    ret
+  %cvt = uitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
+  ret <2 x double> %shuf
+}
+
+define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v4i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %cvt = uitofp <4 x i8> %shuf to <4 x double>
+  ret <4 x double> %cvt
+}
+
+define <4 x double> @uitofp_v16i8_v4f64(<16 x i8> %a) {
+; CHECK-LABEL: uitofp_v16i8_v4f64:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa2, $a0
+; CHECK-NEXT:    ffint.d.w $fa2, $fa2
+; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa1, $a0
+; CHECK-NEXT:    ffint.d.w $fa3, $fa1
+; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
+; CHECK-NEXT:    andi $a0, $a0, 255
+; CHECK-NEXT:    movgr2fr.w $fa0, $a0
+; CHECK-NEXT:    ffint.d.w $fa1, $fa0
+; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
+; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    ret
+  %cvt = uitofp <16 x i8> %a to <16 x double>
+  %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %shuf
+}

--- a/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/uitofp.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/ir-instruction/uitofp.ll
@@ -31,15 +31,11 @@ define void @uitofp_v2i64_v2f64(ptr %res, ptr %in){
 define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v2i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vrepli.b $vr1, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.h $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.lu $vr0, $vr0
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <2 x i32> <i32 0, i32 1>
   %cvt = uitofp <2 x i8> %shuf to <2 x double>
@@ -49,15 +45,11 @@ define <2 x double> @uitofp_v2i8_v2f64(<16 x i8> %a) {
 define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v16i8_v2f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa0, $fa0
-; CHECK-NEXT:    vextrins.d $vr0, $vr1, 16
+; CHECK-NEXT:    vrepli.b $vr1, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.h $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr0
+; CHECK-NEXT:    vffint.d.lu $vr0, $vr0
 ; CHECK-NEXT:    ret
   %cvt = uitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <2 x i32> <i32 0, i32 1>
@@ -67,25 +59,13 @@ define <2 x double> @uitofp_v16i8_v2f64(<16 x i8> %a) {
 define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v4i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vrepli.b $vr1, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.h $vr2, $vr1, $vr0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr2
+; CHECK-NEXT:    vffint.d.lu $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr1, $vr2
+; CHECK-NEXT:    vffint.d.lu $vr1, $vr1
 ; CHECK-NEXT:    ret
   %shuf = shufflevector <16 x i8> %a, <16 x i8> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
   %cvt = uitofp <4 x i8> %shuf to <4 x double>
@@ -95,25 +75,13 @@ define <4 x double> @uitofp_v4i8_v4f64(<16 x i8> %a) {
 define <4 x double> @uitofp_v16i8_v4f64(<16 x i8> %a) {
 ; CHECK-LABEL: uitofp_v16i8_v4f64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 1
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 0
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa2, $a0
-; CHECK-NEXT:    ffint.d.w $fa2, $fa2
-; CHECK-NEXT:    vextrins.d $vr2, $vr1, 16
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 3
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa1, $a0
-; CHECK-NEXT:    ffint.d.w $fa3, $fa1
-; CHECK-NEXT:    vpickve2gr.b $a0, $vr0, 2
-; CHECK-NEXT:    andi $a0, $a0, 255
-; CHECK-NEXT:    movgr2fr.w $fa0, $a0
-; CHECK-NEXT:    ffint.d.w $fa1, $fa0
-; CHECK-NEXT:    vextrins.d $vr1, $vr3, 16
-; CHECK-NEXT:    vori.b $vr0, $vr2, 0
+; CHECK-NEXT:    vrepli.b $vr1, 0
+; CHECK-NEXT:    vilvl.b $vr0, $vr1, $vr0
+; CHECK-NEXT:    vilvl.h $vr2, $vr1, $vr0
+; CHECK-NEXT:    vilvl.w $vr0, $vr1, $vr2
+; CHECK-NEXT:    vffint.d.lu $vr0, $vr0
+; CHECK-NEXT:    vilvh.w $vr1, $vr1, $vr2
+; CHECK-NEXT:    vffint.d.lu $vr1, $vr1
 ; CHECK-NEXT:    ret
   %cvt = uitofp <16 x i8> %a to <16 x double>
   %shuf = shufflevector <16 x double> %cvt, <16 x double> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>


### PR DESCRIPTION
This enables vector sign/zero extend for vector sitofp/uitofp, avoid inefficient scalarization.