### PR TITLE
[Instrumentor][test] Ensure dir is writeable

### DIFF
--- a/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_rt.ll
@@ -1,2 +1,3 @@
+; RUN: rm -rf %t && mkdir -p %t && cd %t
 ; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/rt_config.json -S
 ; RUN: diff -b rt.c %S/default_rt


### PR DESCRIPTION
When running the test in a runner where the source directory is read only, this test fails w/ `error: failed to open instrumentor stub runtime file for writing: Permission denied`. Run the test in a writeable test dir `%t` to ensure we can actually write to the current directory.