### PR TITLE
[libclc] Use spirv[64]-mesa-mesa3d triple in README.md

### DIFF
--- a/libclc/README.md
+++ b/libclc/README.md
@@ -61,9 +61,9 @@ cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
 #### Configure for SPIR-V targets
 ```
 cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release \
-  -DRUNTIMES_spirv-mesa3d-_LLVM_ENABLE_RUNTIMES=libclc \
-  -DRUNTIMES_spirv64-mesa3d-_LLVM_ENABLE_RUNTIMES=libclc \
-  -DLLVM_RUNTIME_TARGETS="spirv-mesa3d-;spirv64-mesa3d-"
+  -DRUNTIMES_spirv-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
+  -DRUNTIMES_spirv64-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
+  -DLLVM_RUNTIME_TARGETS="spirv-mesa-mesa3d;spirv64-mesa-mesa3d"
 ```
 
 To build multiple targets, pass them as a semicolon-separated list in


### PR DESCRIPTION
Now that #194607 landed we use a normalized triple in the README for the SPIRV targets. Before `spirv-mesa3d-` and `spirv64-mesa3d-` were being used and those will be normalized to `spirv-unknown-mesa3d` and `spirv64-unknown-mesa3d` by the following command in `runtimes/CMakeLists.txt` with this command:

```console
$ clang --target=spirv-mesa3d- -print-target-triple
spirv-unknown-mesa3d
```

This is because in `llvm/lib/TargetParser/Triple.cpp` the term `mesa3d` is recognized as an OS and placed in third position. The install path for `libclc.spv` there ends up in `spirv-unknown-mesa3d/libclc.spv`.

With this change we suggest to use triples that "survive" the normalization:

```console
$ clang --target=spirv-mesa-mesa3d -print-target-triple
spirv-mesa-mesa3d
```

See also this discussion: https://github.com/llvm/llvm-project/pull/194607#issuecomment-4378126607