### PR TITLE
[Analysis] Replace SCEVCallbackVH with per-function InstructionListener

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -31,6 +31,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/ConstantRange.h"
+#include "llvm/IR/InstructionListener.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/ValueHandle.h"
@@ -1619,19 +1620,19 @@ public:
   };
 
 private:
-  /// A CallbackVH to arrange for ScalarEvolution to be notified whenever a
-  /// Value is deleted.
-  class LLVM_ABI SCEVCallbackVH final : public CallbackVH {
+  /// A per-function listener that invalidates SCEV caches when an instruction
+  /// is removed or RAUW'd. Replaces per-value SCEVCallbackVH handles.
+  class SCEVInstructionListener : public InstructionListener {
     ScalarEvolution *SE;
 
-    void deleted() override;
-    void allUsesReplacedWith(Value *New) override;
+    static void onRemoved(InstructionListener *Self, Instruction *I);
+    static void onRAUW(InstructionListener *Self, Instruction *Old, Value *New);
 
   public:
-    SCEVCallbackVH(Value *V, ScalarEvolution *SE = nullptr);
+    SCEVInstructionListener(Function &F, ScalarEvolution *SE)
+        : InstructionListener(F, &onRemoved, &onRAUW), SE(SE) {}
   };
 
-  friend class SCEVCallbackVH;
   friend class SCEVExpander;
   friend class SCEVUnknown;
 
@@ -1676,11 +1677,13 @@ private:
   ExprValueMapType ExprValueMap;
 
   /// The type for ValueExprMap.
-  using ValueExprMapType =
-      DenseMap<SCEVCallbackVH, const SCEV *, DenseMapInfo<Value *>>;
+  using ValueExprMapType = DenseMap<Value *, const SCEV *>;
 
   /// This is a cache of the values we have analyzed so far.
   ValueExprMapType ValueExprMap;
+
+  /// Listener that invalidates SCEV caches on instruction removal/RAUW.
+  SCEVInstructionListener InstListener;
 
   /// This is a cache for expressions that got folded to a different existing
   /// SCEV.

--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -18,6 +18,7 @@
 #define LLVM_IR_FUNCTION_H
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/ilist_node.h"
@@ -61,6 +62,7 @@ class Type;
 class User;
 class BranchProbabilityInfo;
 class BlockFrequencyInfo;
+class InstructionListener;
 
 class LLVM_ABI Function : public GlobalObject, public ilist_node<Function> {
 public:
@@ -112,7 +114,17 @@ private:
 
   friend class SymbolTableListTraits<Function>;
 
+  friend class InstructionListener;
+  friend class BasicBlock;
+  friend class Instruction;
+  friend class Value;
+  SmallVector<InstructionListener *, 2> InstructionListeners;
+
+  void addInstructionListener(InstructionListener *L);
+  void removeInstructionListener(InstructionListener *L);
+
 public:
+  bool hasInstructionListeners() const { return !InstructionListeners.empty(); }
   /// hasLazyArguments/CheckLazyArguments - The argument list of a function is
   /// built on demand, so that the list isn't allocated until the first client
   /// needs it.  The hasLazyArguments predicate returns true if the arg list

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -1081,6 +1081,10 @@ private:
                                      ilist_parent<BasicBlock>>;
   friend class BasicBlock; // For renumbering.
 
+  /// Overrides ilist-provided setParent to notify per-function
+  /// InstructionListeners when this instruction is removed.
+  void setParent(BasicBlock *P);
+
   // Shadow Value::setValueSubclassData with a private forwarding method so that
   // subclasses cannot accidentally use it.
   void setValueSubclassData(unsigned short D) {

--- a/llvm/include/llvm/IR/InstructionListener.h
+++ b/llvm/include/llvm/IR/InstructionListener.h
@@ -1,0 +1,82 @@
+//===- llvm/IR/InstructionListener.h - Per-function instruction listener --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares InstructionListener, a per-function interface that
+// notifies analyses when an Instruction is removed from a Function or
+// RAUW'd (replaced with another value). Think of it as "a value handle to
+// many values" — a single per-function registration replaces one handle per
+// tracked value.
+//
+// Registration and deregistration happen automatically via RAII: the
+// constructor registers with a Function, and the destructor deregisters.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IR_INSTRUCTIONLISTENER_H
+#define LLVM_IR_INSTRUCTIONLISTENER_H
+
+#include "llvm/IR/Function.h"
+#include "llvm/Support/Compiler.h"
+
+namespace llvm {
+
+class Instruction;
+class Value;
+
+/// A per-function listener notified when an Instruction is removed from its
+/// parent BasicBlock or when an Instruction is RAUW'd.
+///
+/// Subclasses implement the callbacks by passing static functions to the
+/// constructor, which static_casts the listener back to the derived type.
+/// This avoids virtual dispatch overhead while preserving type safety.
+///
+/// Lifetime is managed via RAII: the constructor registers with the
+/// Function, and the destructor deregisters.
+class InstructionListener {
+public:
+  using RemoveCallbackT = void (*)(InstructionListener *, Instruction *);
+  using RAUWCallbackT = void (*)(InstructionListener *, Instruction *Old,
+                                 Value *New);
+
+private:
+  Function *F;
+  RemoveCallbackT RemoveCallback;
+  RAUWCallbackT RAUWCallback;
+
+public:
+  InstructionListener(Function &F, RemoveCallbackT RemoveCB,
+                      RAUWCallbackT RAUWCB = nullptr)
+      : F(&F), RemoveCallback(RemoveCB), RAUWCallback(RAUWCB) {
+    F.addInstructionListener(this);
+  }
+  ~InstructionListener() {
+    if (F)
+      F->removeInstructionListener(this);
+  }
+
+  InstructionListener(const InstructionListener &) = delete;
+  InstructionListener &operator=(const InstructionListener &) = delete;
+
+  /// Called by ~Function() to detach the listener before the Function is
+  /// destroyed. After this call, the destructor becomes a no-op.
+  void detach() { F = nullptr; }
+
+  void instructionRemoved(Instruction *I) {
+    if (RemoveCallback)
+      RemoveCallback(this, I);
+  }
+  void instructionRAUW(Instruction *Old, Value *New) {
+    if (RAUWCallback)
+      RAUWCallback(this, Old, New);
+  }
+  Function *getFunction() const { return F; }
+};
+
+} // namespace llvm
+
+#endif // LLVM_IR_INSTRUCTIONLISTENER_H

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -4695,7 +4695,7 @@ ArrayRef<Value *> ScalarEvolution::getSCEVValues(const SCEV *S) {
 /// cannot be used separately. eraseValueFromMap should be used to remove
 /// V from ValueExprMap and ExprValueMap at the same time.
 void ScalarEvolution::eraseValueFromMap(Value *V) {
-  ValueExprMapType::iterator I = ValueExprMap.find_as(V);
+  ValueExprMapType::iterator I = ValueExprMap.find(V);
   if (I != ValueExprMap.end()) {
     auto EVIt = ExprValueMap.find(I->second);
     bool Removed = EVIt->second.remove(V);
@@ -4709,9 +4709,9 @@ void ScalarEvolution::insertValueToMap(Value *V, const SCEV *S) {
   // A recursive query may have already computed the SCEV. It should be
   // equivalent, but may not necessarily be exactly the same, e.g. due to lazily
   // inferred nowrap flags.
-  auto It = ValueExprMap.find_as(V);
+  auto It = ValueExprMap.find(V);
   if (It == ValueExprMap.end()) {
-    ValueExprMap.insert({SCEVCallbackVH(V, this), S});
+    ValueExprMap.insert({V, S});
     ExprValueMap[S].insert(V);
   }
 }
@@ -4729,7 +4729,7 @@ const SCEV *ScalarEvolution::getSCEV(Value *V) {
 const SCEV *ScalarEvolution::getExistingSCEV(Value *V) {
   assert(isSCEVable(V->getType()) && "Value is not SCEVable!");
 
-  ValueExprMapType::iterator I = ValueExprMap.find_as(V);
+  ValueExprMapType::iterator I = ValueExprMap.find(V);
   if (I != ValueExprMap.end()) {
     const SCEV *S = I->second;
     assert(checkValidity(S) &&
@@ -5966,7 +5966,7 @@ const SCEV *ScalarEvolution::createAddRecFromPHI(PHINode *PN) {
   if (!BEValueV || !StartValueV)
     return nullptr;
 
-  assert(ValueExprMap.find_as(PN) == ValueExprMap.end() &&
+  assert(ValueExprMap.find(PN) == ValueExprMap.end() &&
          "PHI node already processed?");
 
   // First, try to find AddRec expression without creating a fictituos symbolic
@@ -8752,8 +8752,7 @@ void ScalarEvolution::visitAndClearUsers(
     if (!isSCEVable(I->getType()) && !isa<WithOverflowInst>(I))
       continue;
 
-    ValueExprMapType::iterator It =
-        ValueExprMap.find_as(static_cast<Value *>(I));
+    ValueExprMapType::iterator It = ValueExprMap.find(static_cast<Value *>(I));
     if (It != ValueExprMap.end()) {
       eraseValueFromMap(It->first);
       ToForget.push_back(It->second);
@@ -13941,52 +13940,37 @@ const SCEV *ScalarEvolution::getElementSize(Instruction *Inst) {
 }
 
 //===----------------------------------------------------------------------===//
-//                   SCEVCallbackVH Class Implementation
+//                   SCEVInstructionListener Implementation
 //===----------------------------------------------------------------------===//
 
-void ScalarEvolution::SCEVCallbackVH::deleted() {
-  assert(SE && "SCEVCallbackVH called with a null ScalarEvolution!");
-  // Save SE locally because the operations below may destroy *this*: erasing
-  // from ValueExprMap (either via eraseValueFromMap below or transitively via
-  // forgetMemoizedResults) destroys the SCEVCallbackVH that is the map key,
-  // and that key is *this*. Once destroyed, accessing this->SE is UB.
-  ScalarEvolution *LocalSE = SE;
-  Value *V = getValPtr();
-  if (PHINode *PN = dyn_cast<PHINode>(V))
-    LocalSE->ConstantEvolutionLoopExitValue.erase(PN);
-  // Drop the SCEVUnknown for V (and any cached SCEVs that transitively depend
-  // on it) before V is destroyed. Without this, getDefiningScopeBound can
-  // later dereference an instruction whose parent BasicBlock pointer has been
-  // nulled out (e.g. SLPVectorizer's deferred deletion list), leading to a
-  // crash inside DominatorTree::dominates.
-  //
-  // Order matters: eraseValueFromMap(V) must run before forgetMemoizedResults
-  // so V is removed from ExprValueMap[S] first. Otherwise forgetMemoizedResults
-  // would walk ExprValueMap[S] and try to erase the ValueExprMap entry whose
-  // SCEVCallbackVH key is *this*, destroying us mid-execution.
-  if (LocalSE->isSCEVable(V->getType())) {
-    const SCEV *S = LocalSE->getExistingSCEV(V);
-    LocalSE->eraseValueFromMap(V);
+void ScalarEvolution::SCEVInstructionListener::onRemoved(
+    InstructionListener *Self, Instruction *I) {
+  ScalarEvolution *SE = static_cast<SCEVInstructionListener *>(Self)->SE;
+  if (PHINode *PN = dyn_cast<PHINode>(I))
+    SE->ConstantEvolutionLoopExitValue.erase(PN);
+  // Mirror SCEVCallbackVH::deleted(): drop the V <-> SCEV mapping first, then
+  // recursively forget any cached SCEVs that transitively depend on
+  // SCEVUnknown(I). The order is preserved from the CallbackVH path so this
+  // commit is a pure mechanism swap with no behavioral change.
+  if (SE->isSCEVable(I->getType())) {
+    const SCEV *S = SE->getExistingSCEV(I);
+    SE->eraseValueFromMap(I);
     if (S)
-      LocalSE->forgetMemoizedResults({S});
+      SE->forgetMemoizedResults({S});
   } else {
-    LocalSE->eraseValueFromMap(V);
+    SE->eraseValueFromMap(I);
   }
-  // this now dangles!
 }
 
-void ScalarEvolution::SCEVCallbackVH::allUsesReplacedWith(Value *V) {
-  assert(SE && "SCEVCallbackVH called with a null ScalarEvolution!");
-
-  // Forget all the expressions associated with users of the old value,
-  // so that future queries will recompute the expressions using the new
-  // value.
-  SE->forgetValue(getValPtr());
-  // this now dangles!
+void ScalarEvolution::SCEVInstructionListener::onRAUW(InstructionListener *Self,
+                                                      Instruction *Old,
+                                                      Value *) {
+  ScalarEvolution *SE = static_cast<SCEVInstructionListener *>(Self)->SE;
+  if (!SE->isSCEVable(Old->getType()))
+    return;
+  if (SE->ValueExprMap.count(Old))
+    SE->forgetValue(Old);
 }
-
-ScalarEvolution::SCEVCallbackVH::SCEVCallbackVH(Value *V, ScalarEvolution *se)
-  : CallbackVH(V), SE(se) {}
 
 //===----------------------------------------------------------------------===//
 //                   ScalarEvolution Class Implementation
@@ -13996,8 +13980,8 @@ ScalarEvolution::ScalarEvolution(Function &F, TargetLibraryInfo &TLI,
                                  AssumptionCache &AC, DominatorTree &DT,
                                  LoopInfo &LI)
     : F(F), DL(F.getDataLayout()), TLI(TLI), AC(AC), DT(DT), LI(LI),
-      CouldNotCompute(new SCEVCouldNotCompute()), ValuesAtScopes(64),
-      LoopDispositions(64), BlockDispositions(64) {
+      CouldNotCompute(new SCEVCouldNotCompute()), InstListener(F, this),
+      ValuesAtScopes(64), LoopDispositions(64), BlockDispositions(64) {
   // To use guards for proving predicates, we need to scan every instruction in
   // relevant basic blocks, and not just terminators.  Doing this is a waste of
   // time if the IR does not actually contain any calls to
@@ -14016,7 +14000,7 @@ ScalarEvolution::ScalarEvolution(Function &F, TargetLibraryInfo &TLI,
 ScalarEvolution::ScalarEvolution(ScalarEvolution &&Arg)
     : F(Arg.F), DL(Arg.DL), HasGuards(Arg.HasGuards), TLI(Arg.TLI), AC(Arg.AC),
       DT(Arg.DT), LI(Arg.LI), CouldNotCompute(std::move(Arg.CouldNotCompute)),
-      ValueExprMap(std::move(Arg.ValueExprMap)),
+      ValueExprMap(std::move(Arg.ValueExprMap)), InstListener(F, this),
       PendingLoopPredicates(std::move(Arg.PendingLoopPredicates)),
       PendingMerges(std::move(Arg.PendingMerges)),
       ConstantMultipleCache(std::move(Arg.ConstantMultipleCache)),
@@ -14608,7 +14592,7 @@ void ScalarEvolution::forgetMemoizedResultsImpl(const SCEV *S) {
   auto ExprIt = ExprValueMap.find(S);
   if (ExprIt != ExprValueMap.end()) {
     for (Value *V : ExprIt->second) {
-      auto ValueIt = ValueExprMap.find_as(V);
+      auto ValueIt = ValueExprMap.find(V);
       if (ValueIt != ValueExprMap.end())
         ValueExprMap.erase(ValueIt);
     }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -13946,9 +13946,32 @@ const SCEV *ScalarEvolution::getElementSize(Instruction *Inst) {
 
 void ScalarEvolution::SCEVCallbackVH::deleted() {
   assert(SE && "SCEVCallbackVH called with a null ScalarEvolution!");
-  if (PHINode *PN = dyn_cast<PHINode>(getValPtr()))
-    SE->ConstantEvolutionLoopExitValue.erase(PN);
-  SE->eraseValueFromMap(getValPtr());
+  // Save SE locally because the operations below may destroy *this*: erasing
+  // from ValueExprMap (either via eraseValueFromMap below or transitively via
+  // forgetMemoizedResults) destroys the SCEVCallbackVH that is the map key,
+  // and that key is *this*. Once destroyed, accessing this->SE is UB.
+  ScalarEvolution *LocalSE = SE;
+  Value *V = getValPtr();
+  if (PHINode *PN = dyn_cast<PHINode>(V))
+    LocalSE->ConstantEvolutionLoopExitValue.erase(PN);
+  // Drop the SCEVUnknown for V (and any cached SCEVs that transitively depend
+  // on it) before V is destroyed. Without this, getDefiningScopeBound can
+  // later dereference an instruction whose parent BasicBlock pointer has been
+  // nulled out (e.g. SLPVectorizer's deferred deletion list), leading to a
+  // crash inside DominatorTree::dominates.
+  //
+  // Order matters: eraseValueFromMap(V) must run before forgetMemoizedResults
+  // so V is removed from ExprValueMap[S] first. Otherwise forgetMemoizedResults
+  // would walk ExprValueMap[S] and try to erase the ValueExprMap entry whose
+  // SCEVCallbackVH key is *this*, destroying us mid-execution.
+  if (LocalSE->isSCEVable(V->getType())) {
+    const SCEV *S = LocalSE->getExistingSCEV(V);
+    LocalSE->eraseValueFromMap(V);
+    if (S)
+      LocalSE->forgetMemoizedResults({S});
+  } else {
+    LocalSE->eraseValueFromMap(V);
+  }
   // this now dangles!
 }
 

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -17,6 +17,8 @@
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugProgramInstruction.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InstructionListener.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/LLVMContext.h"
@@ -195,9 +197,14 @@ BasicBlock::~BasicBlock() {
 }
 
 void BasicBlock::setParent(Function *parent) {
-  // Set Parent=parent, updating instruction symtab entries as appropriate.
-  if (Parent != parent)
+  if (Parent != parent) {
+    if (Parent && Parent->hasInstructionListeners()) {
+      for (Instruction &I : *this)
+        for (InstructionListener *L : Parent->InstructionListeners)
+          L->instructionRemoved(&I);
+    }
     Number = parent ? parent->NextBlockNum++ : -1u;
+  }
   InstList.setSymTabObject(&Parent, parent);
 }
 

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -30,6 +30,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instruction.h"
+#include "llvm/IR/InstructionListener.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/LLVMContext.h"
@@ -61,6 +62,16 @@ using ProfileCount = Function::ProfileCount;
 // Explicit instantiations of SymbolTableListTraits since some of the methods
 // are not in the public header file...
 template class LLVM_EXPORT_TEMPLATE llvm::SymbolTableListTraits<BasicBlock>;
+
+void Function::addInstructionListener(InstructionListener *L) {
+  assert(!llvm::is_contained(InstructionListeners, L) &&
+         "Listener already registered");
+  InstructionListeners.push_back(L);
+}
+
+void Function::removeInstructionListener(InstructionListener *L) {
+  InstructionListeners.erase(llvm::find(InstructionListeners, L));
+}
 
 static cl::opt<int> NonGlobalValueMaxNameSize(
     "non-global-value-max-name-size", cl::Hidden, cl::init(1024),
@@ -516,6 +527,12 @@ Function::Function(FunctionType *Ty, LinkageTypes Linkage, unsigned AddrSpace,
 }
 
 Function::~Function() {
+  // Detach all instruction listeners before destruction so their destructors
+  // don't try to call back into this Function.
+  for (InstructionListener *L : InstructionListeners)
+    L->detach();
+  InstructionListeners.clear();
+
   validateBlockNumbers();
 
   dropAllReferences();    // After this it is safe to delete instructions.

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -16,7 +16,9 @@
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/InstructionListener.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
@@ -93,6 +95,20 @@ const Function *Instruction::getFunction() const {
 
 const DataLayout &Instruction::getDataLayout() const {
   return getModule()->getDataLayout();
+}
+
+void Instruction::setParent(BasicBlock *P) {
+  if (BasicBlock *OldBB = getParent()) {
+    Function *OldF = OldBB->getParent();
+    Function *NewF = P ? P->getParent() : nullptr;
+    if (OldF && OldF != NewF)
+      for (InstructionListener *L : OldF->InstructionListeners)
+        L->instructionRemoved(this);
+  }
+  using Base =
+      ilist_node_with_parent<Instruction, BasicBlock, ilist_iterator_bits<true>,
+                             ilist_parent<BasicBlock>>;
+  Base::setParent(P);
 }
 
 void Instruction::removeFromParent() {

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -22,6 +22,7 @@
 #include "llvm/IR/DerivedUser.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/InstructionListener.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
@@ -525,6 +526,13 @@ void Value::doRAUW(Value *New, ReplaceMetadataUses ReplaceMetaUses) {
   // Notify all ValueHandles (if present) that this value is going away.
   if (HasValueHandle)
     ValueHandleBase::ValueIsRAUWd(this, New);
+
+  if (Instruction *I = dyn_cast<Instruction>(this))
+    if (BasicBlock *BB = I->getParent())
+      if (Function *F = BB->getParent())
+        for (InstructionListener *L : F->InstructionListeners)
+          L->instructionRAUW(I, New);
+
   if (ReplaceMetaUses == ReplaceMetadataUses::Yes && isUsedByMetadata())
     ValueAsMetadata::handleRAUW(this, New);
 

--- a/llvm/unittests/IR/CMakeLists.txt
+++ b/llvm/unittests/IR/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_unittest(IRTests
   GlobalObjectTest.cpp
   PassBuilderCallbacksTest.cpp
   IRBuilderTest.cpp
+  InstructionListenerTest.cpp
   InstructionsTest.cpp
   IntrinsicsTest.cpp
   LegacyPassManagerTest.cpp

--- a/llvm/unittests/IR/InstructionListenerTest.cpp
+++ b/llvm/unittests/IR/InstructionListenerTest.cpp
@@ -1,0 +1,396 @@
+//===- InstructionListenerTest.cpp - per-Function instruction listener ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/InstructionListener.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+class TrackingListener : public InstructionListener {
+  DenseSet<const Value *> &UniformValuesRef;
+
+  static void onRemoved(InstructionListener *Self, Instruction *I) {
+    static_cast<TrackingListener *>(Self)->UniformValuesRef.erase(I);
+  }
+
+  static void onRAUW(InstructionListener *Self, Instruction *Old, Value *New) {
+    TrackingListener *This = static_cast<TrackingListener *>(Self);
+    This->UniformValuesRef.erase(Old);
+  }
+
+public:
+  TrackingListener(Function &F, DenseSet<const Value *> &UniformValues)
+      : InstructionListener(F, &onRemoved, &onRAUW),
+        UniformValuesRef(UniformValues) {}
+};
+
+static Function *createFunction(Module &M, const char *Name) {
+  Type *I32Ty = Type::getInt32Ty(M.getContext());
+  FunctionType *FTy = FunctionType::get(I32Ty, {I32Ty, I32Ty}, false);
+  return Function::Create(FTy, GlobalValue::ExternalLinkage, Name, &M);
+}
+
+TEST(InstructionListenerTest, EraseFromParent) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(F->getArg(0));
+
+  DenseSet<const Value *> UniformValues;
+  UniformValues.insert(Add);
+
+  TrackingListener Listener(*F, UniformValues);
+
+  EXPECT_TRUE(UniformValues.contains(Add));
+  Add->eraseFromParent();
+  EXPECT_FALSE(UniformValues.contains(Add));
+}
+
+TEST(InstructionListenerTest, RemoveAndDelete) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(F->getArg(0));
+
+  DenseSet<const Value *> UniformValues;
+  UniformValues.insert(Add);
+
+  TrackingListener Listener(*F, UniformValues);
+
+  EXPECT_TRUE(UniformValues.contains(Add));
+  Add->removeFromParent();
+  EXPECT_FALSE(UniformValues.contains(Add));
+  Add->deleteValue();
+}
+
+TEST(InstructionListenerTest, BasicBlockErasure) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  BasicBlock *Dead = BasicBlock::Create(C, "dead", F);
+  IRBuilder<> Builder(Entry);
+  Builder.CreateRet(F->getArg(0));
+
+  Builder.SetInsertPoint(Dead);
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateUnreachable();
+
+  DenseSet<const Value *> UniformValues;
+  UniformValues.insert(Add);
+
+  TrackingListener Listener(*F, UniformValues);
+
+  EXPECT_TRUE(UniformValues.contains(Add));
+  Dead->eraseFromParent();
+  EXPECT_FALSE(UniformValues.contains(Add));
+}
+
+TEST(InstructionListenerTest, ListenerScopeRAII) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+  Builder.CreateRet(F->getArg(0));
+
+  EXPECT_FALSE(F->hasInstructionListeners());
+  {
+    DenseSet<const Value *> UniformValues;
+    TrackingListener Listener(*F, UniformValues);
+    EXPECT_TRUE(F->hasInstructionListeners());
+  }
+  EXPECT_FALSE(F->hasInstructionListeners());
+}
+
+TEST(InstructionListenerTest, MultipleListeners) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(F->getArg(0));
+
+  DenseSet<const Value *> UniformValues1;
+  DenseSet<const Value *> UniformValues2;
+  UniformValues1.insert(Add);
+  UniformValues2.insert(Add);
+
+  TrackingListener L1(*F, UniformValues1);
+  TrackingListener L2(*F, UniformValues2);
+
+  EXPECT_TRUE(UniformValues1.contains(Add));
+  EXPECT_TRUE(UniformValues2.contains(Add));
+  Add->eraseFromParent();
+  EXPECT_FALSE(UniformValues1.contains(Add));
+  EXPECT_FALSE(UniformValues2.contains(Add));
+}
+
+TEST(InstructionListenerTest, PerFunctionIsolation) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F1 = createFunction(M, "f1");
+  Function *F2 = createFunction(M, "f2");
+
+  BasicBlock *BB1 = BasicBlock::Create(C, "entry", F1);
+  BasicBlock *BB2 = BasicBlock::Create(C, "entry", F2);
+
+  IRBuilder<> B1(BB1);
+  Instruction *Add1 =
+      cast<Instruction>(B1.CreateAdd(F1->getArg(0), F1->getArg(1)));
+  B1.CreateRet(F1->getArg(0));
+
+  IRBuilder<> B2(BB2);
+  Instruction *Add2 =
+      cast<Instruction>(B2.CreateAdd(F2->getArg(0), F2->getArg(1)));
+  B2.CreateRet(F2->getArg(0));
+
+  DenseSet<const Value *> UniformValues1;
+  DenseSet<const Value *> UniformValues2;
+  UniformValues1.insert(Add1);
+  UniformValues2.insert(Add2);
+
+  TrackingListener L1(*F1, UniformValues1);
+  TrackingListener L2(*F2, UniformValues2);
+
+  // Erasing from F1 should not affect F2's listener.
+  Add1->eraseFromParent();
+  EXPECT_FALSE(UniformValues1.contains(Add1));
+  EXPECT_TRUE(UniformValues2.contains(Add2));
+
+  Add2->eraseFromParent();
+  EXPECT_FALSE(UniformValues2.contains(Add2));
+}
+
+TEST(InstructionListenerTest, RAUWBasic) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(Add);
+
+  DenseSet<const Value *> UniformValues;
+  UniformValues.insert(Add);
+
+  TrackingListener Listener(*F, UniformValues);
+
+  EXPECT_TRUE(UniformValues.contains(Add));
+  Add->replaceAllUsesWith(F->getArg(0));
+  EXPECT_FALSE(UniformValues.contains(Add));
+}
+
+TEST(InstructionListenerTest, RAUWReceivesNewValue) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(Add);
+
+  Value *ReceivedOld = nullptr;
+  Value *ReceivedNew = nullptr;
+
+  class CapturingListener : public InstructionListener {
+    Value *&OldRef;
+    Value *&NewRef;
+
+    static void onRemoved(InstructionListener *, Instruction *) {}
+    static void onRAUW(InstructionListener *Self, Instruction *Old,
+                       Value *New) {
+      CapturingListener *This = static_cast<CapturingListener *>(Self);
+      This->OldRef = Old;
+      This->NewRef = New;
+    }
+
+  public:
+    CapturingListener(Function &F, Value *&Old, Value *&New)
+        : InstructionListener(F, &onRemoved, &onRAUW), OldRef(Old),
+          NewRef(New) {}
+  };
+
+  CapturingListener Listener(*F, ReceivedOld, ReceivedNew);
+
+  Value *Replacement = F->getArg(0);
+  Add->replaceAllUsesWith(Replacement);
+
+  EXPECT_EQ(ReceivedOld, Add);
+  EXPECT_EQ(ReceivedNew, Replacement);
+}
+
+TEST(InstructionListenerTest, RAUWWithoutCallback) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Builder.CreateRet(Add);
+
+  DenseSet<const Value *> UniformValues;
+  UniformValues.insert(Add);
+
+  class DeletionOnlyListener : public InstructionListener {
+    DenseSet<const Value *> &Ref;
+
+    static void onRemoved(InstructionListener *Self, Instruction *I) {
+      static_cast<DeletionOnlyListener *>(Self)->Ref.erase(I);
+    }
+
+  public:
+    DeletionOnlyListener(Function &F, DenseSet<const Value *> &S)
+        : InstructionListener(F, &onRemoved), Ref(S) {}
+  };
+
+  DeletionOnlyListener Listener(*F, UniformValues);
+
+  // RAUW should not crash even without a RAUW callback.
+  EXPECT_TRUE(UniformValues.contains(Add));
+  Add->replaceAllUsesWith(F->getArg(0));
+  // Set not updated since no RAUW callback — only deletion updates it.
+  EXPECT_TRUE(UniformValues.contains(Add));
+}
+
+TEST(InstructionListenerTest, RAUWPerFunctionIsolation) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F1 = createFunction(M, "f1");
+  Function *F2 = createFunction(M, "f2");
+
+  BasicBlock *BB1 = BasicBlock::Create(C, "entry", F1);
+  BasicBlock *BB2 = BasicBlock::Create(C, "entry", F2);
+
+  IRBuilder<> B1(BB1);
+  Instruction *Add1 =
+      cast<Instruction>(B1.CreateAdd(F1->getArg(0), F1->getArg(1)));
+  B1.CreateRet(Add1);
+
+  IRBuilder<> B2(BB2);
+  Instruction *Add2 =
+      cast<Instruction>(B2.CreateAdd(F2->getArg(0), F2->getArg(1)));
+  B2.CreateRet(Add2);
+
+  DenseSet<const Value *> UniformValues1;
+  DenseSet<const Value *> UniformValues2;
+  UniformValues1.insert(Add1);
+  UniformValues2.insert(Add2);
+
+  TrackingListener L1(*F1, UniformValues1);
+  TrackingListener L2(*F2, UniformValues2);
+
+  // RAUW in F1 should not affect F2's listener.
+  Add1->replaceAllUsesWith(F1->getArg(0));
+  EXPECT_FALSE(UniformValues1.contains(Add1));
+  EXPECT_TRUE(UniformValues2.contains(Add2));
+}
+
+/// Demonstrates replacing per-value CallbackVH with a single listener.
+/// This mirrors the pattern used by LazyValueInfo (LVIValueHandle) and
+/// similar analyses that cache per-value results in a DenseMap.
+TEST(InstructionListenerTest, CacheInvalidationPattern) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+
+  Instruction *Add1 =
+      cast<Instruction>(Builder.CreateAdd(F->getArg(0), F->getArg(1)));
+  Instruction *Add2 = cast<Instruction>(Builder.CreateAdd(F->getArg(0), Add1));
+  Builder.CreateRet(F->getArg(0));
+
+  // Simulate an analysis cache: maps Instruction* -> some cached result.
+  DenseMap<const Value *, int> Cache;
+  Cache[Add1] = 42;
+  Cache[Add2] = 99;
+
+  class CacheListener : public InstructionListener {
+    DenseMap<const Value *, int> &CacheRef;
+
+    static void onRemoved(InstructionListener *Self, Instruction *I) {
+      static_cast<CacheListener *>(Self)->CacheRef.erase(I);
+    }
+
+    static void onRAUW(InstructionListener *Self, Instruction *Old, Value *) {
+      static_cast<CacheListener *>(Self)->CacheRef.erase(Old);
+    }
+
+  public:
+    CacheListener(Function &F, DenseMap<const Value *, int> &C)
+        : InstructionListener(F, &onRemoved, &onRAUW), CacheRef(C) {}
+  };
+
+  CacheListener Listener(*F, Cache);
+
+  EXPECT_EQ(Cache.size(), 2u);
+
+  // RAUW Add1 with arg0 — cache entry for Add1 is invalidated.
+  Add1->replaceAllUsesWith(F->getArg(0));
+  EXPECT_EQ(Cache.size(), 1u);
+  EXPECT_FALSE(Cache.contains(Add1));
+  EXPECT_TRUE(Cache.contains(Add2));
+
+  // Erase Add1 — already removed from cache by RAUW, no effect.
+  Add1->eraseFromParent();
+  EXPECT_EQ(Cache.size(), 1u);
+
+  // Erase Add2 — triggers deletion callback, removes from cache.
+  Add2->eraseFromParent();
+  EXPECT_TRUE(Cache.empty());
+}
+
+TEST(InstructionListenerTest, FunctionErasedBeforeListener) {
+  LLVMContext C;
+  Module M("test", C);
+  Function *F = createFunction(M, "f");
+  BasicBlock *BB = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> Builder(BB);
+  Builder.CreateRet(F->getArg(0));
+
+  DenseSet<const Value *> UniformValues;
+  TrackingListener Listener(*F, UniformValues);
+
+  EXPECT_TRUE(F->hasInstructionListeners());
+  F->eraseFromParent();
+  // Listener outlives the Function. Its destructor must not crash.
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
This replaces the per-value `SCEVCallbackVH` mechanism in ScalarEvolution
with a single `InstructionListener` registration per function.

Instead of creating one CallbackVH per cached value in `ValueExprMap`
(O(N) handles, each with linked-list and DenseMap entries in LLVMContext),
a single listener handles deletion and RAUW notifications for all
instructions in the function.

Changes:
- Remove `SCEVCallbackVH` class
- Change `ValueExprMap` key from `SCEVCallbackVH` to plain `Value*`
- Add `SCEVInstructionListener` that calls `eraseValueFromMap()` on
  deletion and `forgetValue()` on RAUW
- Add `detach()` in `~Function()` to handle safe destruction ordering
  when module passes delete functions

`SCEVUnknown` retains its `CallbackVH` (wraps arbitrary Values including
Arguments, outside InstructionListener's scope).

Built on the InstructionListener infrastructure introduced in PR #193198.

**NOTE:** This is an **experimental** patch as per discussion in RFC: https://discourse.llvm.org/t/rfc-valuedeletionlistener-context-level-value-deletion-notifications/90624/23

CTT: https://llvm-compile-time-tracker.com/compare.php?stat=instructions%3Au&from=df6e1f485683dc9050d853bef510da012816b4a7&to=c0b055259f914d992a996c7e9dbafac5129b27a7