### PR TITLE
[RISCV] Make SFMM configuration instruction emit like VSETVLI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -158,33 +158,13 @@ void RISCVInsertVSETVLI::insertVSETVLI(MachineBasicBlock &MBB,
                                        const VSETVLIInfo &PrevInfo) {
   ++NumInsertedVSETVL;
 
-  if (Info.getTWiden()) {
-    if (Info.hasAVLVLMAX()) {
-      Register DestReg = MRI->createVirtualRegister(&RISCV::GPRNoX0RegClass);
-      auto MI = BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoSF_VSETTNTX0))
-                    .addReg(DestReg, RegState::Define | RegState::Dead)
-                    .addReg(RISCV::X0, RegState::Kill)
-                    .addImm(Info.encodeVTYPE());
-      if (LIS) {
-        LIS->InsertMachineInstrInMaps(*MI);
-        LIS->createAndComputeVirtRegInterval(DestReg);
-      }
-    } else {
-      auto MI = BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoSF_VSETTNT))
-                    .addReg(RISCV::X0, RegState::Define | RegState::Dead)
-                    .addReg(Info.getAVLReg())
-                    .addImm(Info.encodeVTYPE());
-      if (LIS)
-        LIS->InsertMachineInstrInMaps(*MI);
-    }
-    return;
-  }
-
   if (PrevInfo.isKnown()) {
     // Use X0, X0 form if the AVL is the same and the SEW+LMUL gives the same
     // VLMAX.
     if (Info.hasSameAVL(PrevInfo) && Info.hasSameVLMAX(PrevInfo)) {
-      auto MI = BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoVSETVLIX0X0))
+      auto MI = BuildMI(MBB, InsertPt, DL,
+                        TII->get(Info.getTWiden() ? RISCV::PseudoSF_VSETTNTX0X0
+                                                  : RISCV::PseudoVSETVLIX0X0))
                     .addReg(RISCV::X0, RegState::Define | RegState::Dead)
                     .addReg(RISCV::X0, RegState::Kill)
                     .addImm(Info.encodeVTYPE())
@@ -203,7 +183,9 @@ void RISCVInsertVSETVLI::insertVSETVLI(MachineBasicBlock &MBB,
         VSETVLIInfo DefInfo = VIA.getInfoForVSETVLI(*DefMI);
         if (DefInfo.hasSameAVL(PrevInfo) && DefInfo.hasSameVLMAX(PrevInfo)) {
           auto MI =
-              BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoVSETVLIX0X0))
+              BuildMI(MBB, InsertPt, DL,
+                      TII->get(Info.getTWiden() ? RISCV::PseudoSF_VSETTNTX0X0
+                                                : RISCV::PseudoVSETVLIX0X0))
                   .addReg(RISCV::X0, RegState::Define | RegState::Dead)
                   .addReg(RISCV::X0, RegState::Kill)
                   .addImm(Info.encodeVTYPE())
@@ -228,7 +210,9 @@ void RISCVInsertVSETVLI::insertVSETVLI(MachineBasicBlock &MBB,
 
   if (Info.hasAVLVLMAX()) {
     Register DestReg = MRI->createVirtualRegister(&RISCV::GPRNoX0RegClass);
-    auto MI = BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoVSETVLIX0))
+    auto MI = BuildMI(MBB, InsertPt, DL,
+                      TII->get(Info.getTWiden() ? RISCV::PseudoSF_VSETTNTX0
+                                                : RISCV::PseudoVSETVLIX0))
                   .addReg(DestReg, RegState::Define | RegState::Dead)
                   .addReg(RISCV::X0, RegState::Kill)
                   .addImm(Info.encodeVTYPE());
@@ -241,7 +225,9 @@ void RISCVInsertVSETVLI::insertVSETVLI(MachineBasicBlock &MBB,
 
   Register AVLReg = Info.getAVLReg();
   MRI->constrainRegClass(AVLReg, &RISCV::GPRNoX0RegClass);
-  auto MI = BuildMI(MBB, InsertPt, DL, TII->get(RISCV::PseudoVSETVLI))
+  auto MI = BuildMI(MBB, InsertPt, DL,
+                    TII->get(Info.getTWiden() ? RISCV::PseudoSF_VSETTNT
+                                              : RISCV::PseudoVSETVLI))
                 .addReg(RISCV::X0, RegState::Define | RegState::Dead)
                 .addReg(AVLReg)
                 .addImm(Info.encodeVTYPE());

--- a/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
+++ b/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
@@ -414,7 +414,11 @@ public:
            "Can't compare invalid VSETVLIInfos");
     assert(!isUnknown() && !Other.isUnknown() &&
            "Can't compare VTYPE in unknown state");
-    return getSEWLMULRatio() == Other.getSEWLMULRatio();
+    if (getTWiden() != Other.getTWiden())
+      return false;
+    if (getTWiden() == 0)
+      return getSEWLMULRatio() == Other.getSEWLMULRatio();
+    return getSEW() == Other.getSEW();
   }
 
   bool hasCompatibleVTYPE(const DemandedFields &Used,

--- a/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
+++ b/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
@@ -416,9 +416,9 @@ public:
            "Can't compare VTYPE in unknown state");
     if (getTWiden() != Other.getTWiden())
       return false;
-    if (getTWiden() == 0)
-      return getSEWLMULRatio() == Other.getSEWLMULRatio();
-    return getSEW() == Other.getSEW();
+    if (getTWiden())
+      return getSEW() == Other.getSEW();
+    return getSEWLMULRatio() == Other.getSEWLMULRatio();
   }
 
   bool hasCompatibleVTYPE(const DemandedFields &Used,

--- a/llvm/test/CodeGen/RISCV/rvv/sifive-xsfmm-vset-insert.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/sifive-xsfmm-vset-insert.mir
@@ -172,7 +172,7 @@ body:             |
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY3]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 2 /* w2 */, implicit $frm, implicit $vl, implicit $vtype
-    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNT [[COPY1]], 1544 /* e16, w4 */, implicit-def $vl, implicit-def $vtype
+    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNTX0X0 killed $x0, 1544 /* e16, w4 */, implicit-def $vl, implicit-def $vtype, implicit $vl
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 4 /* w4 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 4 /* w4 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY3]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 4 /* w4 */, implicit $frm, implicit $vl, implicit $vtype
@@ -220,11 +220,11 @@ body:             |
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY4]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 2 /* w2 */, implicit $frm, implicit $vl, implicit $vtype
-    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNT [[COPY1]], 1288 /* e16, w2 */, implicit-def $vl, implicit-def $vtype
+    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNTX0X0 killed $x0, 1288 /* e16, w2 */, implicit-def $vl, implicit-def $vtype, implicit $vl
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F_ALT $t2, [[COPY3]], [[COPY3]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 2 /* w2 */, implicit $frm, implicit $vl, implicit $vtype
-    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNT [[COPY1]], 1032 /* e16, w2 */, implicit-def $vl, implicit-def $vtype
+    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNTX0X0 killed $x0, 1032 /* e16, w2 */, implicit-def $vl, implicit-def $vtype, implicit $vl
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY4]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 2 /* w2 */, implicit $frm, implicit $vl, implicit $vtype

--- a/llvm/test/CodeGen/RISCV/rvv/sifive-xsfmm-vset-insert.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/sifive-xsfmm-vset-insert.mir
@@ -172,7 +172,7 @@ body:             |
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 2 /* w2 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY3]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 2 /* w2 */, implicit $frm, implicit $vl, implicit $vtype
-    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNTX0X0 killed $x0, 1544 /* e16, w4 */, implicit-def $vl, implicit-def $vtype, implicit $vl
+    ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTNT [[COPY1]], 1544 /* e16, w4 */, implicit-def $vl, implicit-def $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTM [[COPY2]], 4 /* e16 */, 4 /* w4 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: dead $x0 = PseudoSF_VSETTK [[COPY]], 4 /* e16 */, 4 /* w4 */, implicit-def $vtype, implicit $vtype
     ; CHECK-NEXT: PseudoSF_MM_F_F $t2, [[COPY4]], [[COPY3]], 7 /* frm=dyn */, $noreg, $noreg, $noreg, 4 /* e16 */, 4 /* w4 */, implicit $frm, implicit $vl, implicit $vtype


### PR DESCRIPTION
Reuse the PseudoVSETVLI condition instead of its own condition.