### PR TITLE
libclc: Pass LLVM_NATIVE_TOOL_DIR to runtime builds

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -582,6 +582,12 @@ if(build_runtimes)
         list(APPEND extra_deps ${dep})
       endif()
     endforeach()
+    # Pass the location of LLVM tools to the runtime build so libclc can find them
+    if (LLVM_NATIVE_TOOL_DIR)
+      list(APPEND extra_cmake_args "-DLLVM_NATIVE_TOOL_DIR=${LLVM_NATIVE_TOOL_DIR}")
+    else()
+      list(APPEND extra_cmake_args "-DLLVM_NATIVE_TOOL_DIR=${LLVM_RUNTIME_OUTPUT_INTDIR}")
+    endif()
   endif()
   # Tools needed by build_symbolizer.sh.
   if("compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES AND COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER)


### PR DESCRIPTION
This patch sets `LLVM_NATIVE_TOOL_DIR` in the runtime build configuration to point to the directory containing the just-built LLVM tools, allowing libclc to find them without requiring them to be installed on the host system.

Fixes build errors like:

```
  Error evaluating generator expression: $<TARGET_FILE:opt>
  No target "opt"
```

A few lines above this change, `extra_deps` list of dependencies for libclc is created. But those tools don't get build in the runtime build. We build libclc in the monolithic build and there we have all the tools which is why I've added the path to discover the tools.