### PR TITLE
[CodeGen] IMPLICIT_DEF must not contribute to Weight in LICM register cost computation

### DIFF
--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -969,6 +969,11 @@ MachineLICMImpl::calcRegisterCost(const MachineInstr *MI, bool ConsiderSeen,
     if (MO.isDef())
       RCCost = W.RegWeight;
     else {
+      // IMPLICIT_DEF contributes zero register pressure, so a vreg whose
+      // unique def is IMPLICIT_DEF must not reduce tracked pressure.
+      if (MachineInstr *DefMI = MRI->getUniqueVRegDef(Reg);
+          DefMI && DefMI->isImplicitDef())
+        continue;
       bool isKill = isOperandKill(MO, MRI);
       if (isNew && !isKill && ConsiderUnseenAsDef)
         // Haven't seen this, it must be a livein.

--- a/llvm/test/CodeGen/AArch64/dag-combine-concat-vectors.ll
+++ b/llvm/test/CodeGen/AArch64/dag-combine-concat-vectors.ll
@@ -22,41 +22,41 @@ define fastcc i8 @allocno_reload_assign(ptr %p) {
 ; CHECK-NEXT:    whilelo p0.b, xzr, x8
 ; CHECK-NEXT:    punpklo p1.h, p0.b
 ; CHECK-NEXT:    punpkhi p0.h, p0.b
-; CHECK-NEXT:    punpklo p2.h, p1.b
-; CHECK-NEXT:    punpkhi p4.h, p1.b
-; CHECK-NEXT:    punpklo p6.h, p0.b
-; CHECK-NEXT:    punpkhi p0.h, p0.b
-; CHECK-NEXT:    punpklo p1.h, p2.b
-; CHECK-NEXT:    punpkhi p2.h, p2.b
-; CHECK-NEXT:    punpklo p3.h, p4.b
-; CHECK-NEXT:    punpkhi p4.h, p4.b
-; CHECK-NEXT:    punpklo p5.h, p6.b
-; CHECK-NEXT:    punpkhi p6.h, p6.b
+; CHECK-NEXT:    punpklo p3.h, p1.b
+; CHECK-NEXT:    punpkhi p5.h, p1.b
 ; CHECK-NEXT:    punpklo p7.h, p0.b
-; CHECK-NEXT:    punpkhi p0.h, p0.b
+; CHECK-NEXT:    punpkhi p9.h, p0.b
+; CHECK-NEXT:    punpklo p2.h, p3.b
+; CHECK-NEXT:    punpkhi p3.h, p3.b
+; CHECK-NEXT:    punpklo p4.h, p5.b
+; CHECK-NEXT:    punpkhi p5.h, p5.b
+; CHECK-NEXT:    punpklo p6.h, p7.b
+; CHECK-NEXT:    punpkhi p7.h, p7.b
+; CHECK-NEXT:    punpklo p0.h, p9.b
 ; CHECK-NEXT:  .LBB0_1: // =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    uunpklo z1.h, z0.b
+; CHECK-NEXT:    punpkhi p1.h, p9.b
 ; CHECK-NEXT:    uunpklo z2.s, z1.h
 ; CHECK-NEXT:    uunpkhi z1.s, z1.h
 ; CHECK-NEXT:    uunpklo z3.d, z2.s
 ; CHECK-NEXT:    uunpkhi z2.d, z2.s
-; CHECK-NEXT:    st1b { z3.d }, p1, [z0.d]
-; CHECK-NEXT:    st1b { z2.d }, p2, [z0.d]
+; CHECK-NEXT:    st1b { z3.d }, p2, [z0.d]
+; CHECK-NEXT:    st1b { z2.d }, p3, [z0.d]
 ; CHECK-NEXT:    uunpklo z2.d, z1.s
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
-; CHECK-NEXT:    st1b { z2.d }, p3, [z0.d]
+; CHECK-NEXT:    st1b { z2.d }, p4, [z0.d]
 ; CHECK-NEXT:    uunpkhi z2.h, z0.b
 ; CHECK-NEXT:    uunpklo z3.s, z2.h
 ; CHECK-NEXT:    uunpkhi z2.s, z2.h
-; CHECK-NEXT:    st1b { z1.d }, p4, [z0.d]
-; CHECK-NEXT:    uunpklo z1.d, z3.s
 ; CHECK-NEXT:    st1b { z1.d }, p5, [z0.d]
-; CHECK-NEXT:    uunpkhi z1.d, z3.s
+; CHECK-NEXT:    uunpklo z1.d, z3.s
 ; CHECK-NEXT:    st1b { z1.d }, p6, [z0.d]
-; CHECK-NEXT:    uunpklo z1.d, z2.s
+; CHECK-NEXT:    uunpkhi z1.d, z3.s
 ; CHECK-NEXT:    st1b { z1.d }, p7, [z0.d]
-; CHECK-NEXT:    uunpkhi z1.d, z2.s
+; CHECK-NEXT:    uunpklo z1.d, z2.s
 ; CHECK-NEXT:    st1b { z1.d }, p0, [z0.d]
+; CHECK-NEXT:    uunpkhi z1.d, z2.s
+; CHECK-NEXT:    st1b { z1.d }, p1, [z0.d]
 ; CHECK-NEXT:    str p8, [x0]
 ; CHECK-NEXT:    b .LBB0_1
   br label %1

--- a/llvm/test/CodeGen/RISCV/rvv/pr165232.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/pr165232.ll
@@ -10,160 +10,163 @@ define i1 @main(ptr %var_117, ptr %arrayinit.element3045, ptr %arrayinit.element
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    csrr t0, vlenb
-; CHECK-NEXT:    slli t0, t0, 3
+; CHECK-NEXT:    slli t0, t0, 2
+; CHECK-NEXT:    mv t1, t0
+; CHECK-NEXT:    slli t0, t0, 2
+; CHECK-NEXT:    add t0, t0, t1
+; CHECK-NEXT:    sub sp, sp, t0
+; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x14, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 20 * vlenb
+; CHECK-NEXT:    csrr t0, vlenb
+; CHECK-NEXT:    slli t0, t0, 2
 ; CHECK-NEXT:    mv t1, t0
 ; CHECK-NEXT:    slli t0, t0, 1
 ; CHECK-NEXT:    add t0, t0, t1
-; CHECK-NEXT:    sub sp, sp, t0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x18, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 24 * vlenb
-; CHECK-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 4
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    addi a1, a1, 16
-; CHECK-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; CHECK-NEXT:    add t0, sp, t0
+; CHECK-NEXT:    addi t0, t0, 16
+; CHECK-NEXT:    vs4r.v v12, (t0) # vscale x 32-byte Folded Spill
+; CHECK-NEXT:    csrr t1, vlenb
+; CHECK-NEXT:    slli t1, t1, 2
+; CHECK-NEXT:    add t0, t0, t1
+; CHECK-NEXT:    vs4r.v v16, (t0) # vscale x 32-byte Folded Spill
+; CHECK-NEXT:    addi t0, sp, 16
+; CHECK-NEXT:    vs4r.v v8, (t0) # vscale x 32-byte Folded Spill
 ; CHECK-NEXT:    csrr t0, vlenb
 ; CHECK-NEXT:    slli t0, t0, 2
-; CHECK-NEXT:    add a1, a1, t0
-; CHECK-NEXT:    vs4r.v v16, (a1) # vscale x 32-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 2
-; CHECK-NEXT:    mv t0, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t0
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    addi a1, a1, 16
-; CHECK-NEXT:    vs4r.v v8, (a1) # vscale x 32-byte Folded Spill
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t0, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t0
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t0, 56(a1)
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t1, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t1
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t1, 48(a1)
-; CHECK-NEXT:    vsetvli t2, zero, e8, m1, ta, ma
+; CHECK-NEXT:    mv t1, t0
+; CHECK-NEXT:    slli t0, t0, 2
+; CHECK-NEXT:    add t0, t0, t1
+; CHECK-NEXT:    add t0, sp, t0
+; CHECK-NEXT:    ld t0, 56(t0)
+; CHECK-NEXT:    csrr t1, vlenb
+; CHECK-NEXT:    slli t1, t1, 2
+; CHECK-NEXT:    mv t2, t1
+; CHECK-NEXT:    slli t1, t1, 2
+; CHECK-NEXT:    add t1, t1, t2
+; CHECK-NEXT:    add t1, sp, t1
+; CHECK-NEXT:    ld t1, 48(t1)
+; CHECK-NEXT:    csrr t2, vlenb
+; CHECK-NEXT:    slli t2, t2, 2
+; CHECK-NEXT:    mv t3, t2
+; CHECK-NEXT:    slli t2, t2, 2
+; CHECK-NEXT:    add t2, t2, t3
+; CHECK-NEXT:    add t2, sp, t2
+; CHECK-NEXT:    ld t2, 40(t2)
+; CHECK-NEXT:    vsetvli t3, zero, e8, m1, ta, ma
 ; CHECK-NEXT:    vmv.v.i v9, 0
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t2, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t2
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t2, 40(a1)
+; CHECK-NEXT:    csrr t3, vlenb
+; CHECK-NEXT:    slli t3, t3, 2
+; CHECK-NEXT:    mv t4, t3
+; CHECK-NEXT:    slli t3, t3, 2
+; CHECK-NEXT:    add t3, t3, t4
+; CHECK-NEXT:    add t3, sp, t3
+; CHECK-NEXT:    ld t3, 32(t3)
 ; CHECK-NEXT:    # kill: def $v10 killed $v9 killed $vtype
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t3, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t3
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t3, 32(a1)
+; CHECK-NEXT:    csrr t4, vlenb
+; CHECK-NEXT:    slli t4, t4, 2
+; CHECK-NEXT:    mv t5, t4
+; CHECK-NEXT:    slli t4, t4, 2
+; CHECK-NEXT:    add t4, t4, t5
+; CHECK-NEXT:    add t4, sp, t4
+; CHECK-NEXT:    ld t4, 16(t4)
 ; CHECK-NEXT:    vmv.v.i v11, 0
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t4, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t4
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t4, 16(a1)
+; CHECK-NEXT:    csrr t5, vlenb
+; CHECK-NEXT:    slli t5, t5, 2
+; CHECK-NEXT:    mv t6, t5
+; CHECK-NEXT:    slli t5, t5, 2
+; CHECK-NEXT:    add t5, t5, t6
+; CHECK-NEXT:    add t5, sp, t5
+; CHECK-NEXT:    ld t5, 24(t5)
 ; CHECK-NEXT:    vmv.v.i v12, 0
-; CHECK-NEXT:    csrr a1, vlenb
-; CHECK-NEXT:    slli a1, a1, 3
-; CHECK-NEXT:    mv t5, a1
-; CHECK-NEXT:    slli a1, a1, 1
-; CHECK-NEXT:    add a1, a1, t5
-; CHECK-NEXT:    add a1, sp, a1
-; CHECK-NEXT:    ld t5, 24(a1)
-; CHECK-NEXT:    vmv.v.i v13, 0
-; CHECK-NEXT:    vsetvli t6, zero, e8, m2, ta, ma
-; CHECK-NEXT:    vmv.v.i v16, 0
-; CHECK-NEXT:    vmv1r.v v14, v9
 ; CHECK-NEXT:    sd zero, 0(a0)
-; CHECK-NEXT:    vmv.v.i v18, 0
-; CHECK-NEXT:    vmv1r.v v15, v9
-; CHECK-NEXT:    vmv1r.v v28, v9
-; CHECK-NEXT:    li t6, 1023
-; CHECK-NEXT:    vmv.v.i v20, 0
-; CHECK-NEXT:    vmv1r.v v29, v9
-; CHECK-NEXT:    slli t6, t6, 52
-; CHECK-NEXT:    vmv.v.i v22, 0
-; CHECK-NEXT:    addi a1, sp, 16
-; CHECK-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
-; CHECK-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    vmv1r.v v30, v9
-; CHECK-NEXT:    sd t6, 0(t5)
-; CHECK-NEXT:    vmv1r.v v21, v9
-; CHECK-NEXT:    vmv2r.v v22, v10
-; CHECK-NEXT:    vmv4r.v v24, v12
-; CHECK-NEXT:    vmv1r.v v31, v9
-; CHECK-NEXT:    csrr t5, vlenb
-; CHECK-NEXT:    slli t5, t5, 3
-; CHECK-NEXT:    add t5, sp, t5
-; CHECK-NEXT:    addi t5, t5, 16
-; CHECK-NEXT:    vs4r.v v28, (t5) # vscale x 32-byte Folded Spill
-; CHECK-NEXT:    vsetivli zero, 0, e32, m1, ta, ma
 ; CHECK-NEXT:    vmv.v.i v13, 0
-; CHECK-NEXT:    vmclr.m v14
-; CHECK-NEXT:  .LBB0_1: # %for.body
-; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vsetivli zero, 0, e64, m2, ta, ma
-; CHECK-NEXT:    vmv1r.v v0, v14
-; CHECK-NEXT:    vmv1r.v v17, v13
-; CHECK-NEXT:    vmv1r.v v15, v13
-; CHECK-NEXT:    vmv1r.v v9, v13
-; CHECK-NEXT:    vmv1r.v v16, v13
-; CHECK-NEXT:    vmv1r.v v19, v13
-; CHECK-NEXT:    vmv1r.v v28, v13
-; CHECK-NEXT:    vmv1r.v v12, v13
-; CHECK-NEXT:    vmv1r.v v2, v21
-; CHECK-NEXT:    vmv1r.v v4, v23
-; CHECK-NEXT:    vmv1r.v v5, v24
-; CHECK-NEXT:    vmv1r.v v6, v25
-; CHECK-NEXT:    vmv1r.v v7, v26
-; CHECK-NEXT:    vmv1r.v v8, v27
-; CHECK-NEXT:    vmv.v.i v10, 0
-; CHECK-NEXT:    vmv.v.i v30, 0
-; CHECK-NEXT:    vmv1r.v v29, v13
-; CHECK-NEXT:    vmv1r.v v18, v14
-; CHECK-NEXT:    vsetvli zero, zero, e32, m1, tu, ma
-; CHECK-NEXT:    vle32.v v17, (t4)
-; CHECK-NEXT:    vle32.v v15, (t1)
-; CHECK-NEXT:    vle32.v v28, (a7)
-; CHECK-NEXT:    vle64.v v30, (a4)
-; CHECK-NEXT:    vle32.v v9, (t2)
-; CHECK-NEXT:    vle32.v v16, (t3)
-; CHECK-NEXT:    vle32.v v19, (a6)
-; CHECK-NEXT:    vmv1r.v v3, v28
-; CHECK-NEXT:    vsetvli zero, zero, e64, m2, ta, mu
-; CHECK-NEXT:    vmflt.vv v18, v30, v10, v0.t
-; CHECK-NEXT:    vmv1r.v v19, v13
-; CHECK-NEXT:    vsetvli zero, zero, e32, m1, tu, mu
-; CHECK-NEXT:    vle32.v v29, (a2)
-; CHECK-NEXT:    vle32.v v19, (a3)
-; CHECK-NEXT:    vle32.v v12, (a5)
-; CHECK-NEXT:    vmv1r.v v1, v17
+; CHECK-NEXT:    li t6, 1023
+; CHECK-NEXT:    vmv.v.i v14, 0
+; CHECK-NEXT:    vsetivli zero, 0, e32, m1, ta, ma
+; CHECK-NEXT:    vmv.v.i v29, 0
+; CHECK-NEXT:    vmv1r.v v15, v9
+; CHECK-NEXT:    vmv1r.v v1, v9
+; CHECK-NEXT:    vsetvli zero, zero, e64, m2, ta, ma
+; CHECK-NEXT:    vmv.v.i v18, 0
+; CHECK-NEXT:    vmv1r.v v2, v9
+; CHECK-NEXT:    slli t6, t6, 52
+; CHECK-NEXT:    vmv1r.v v3, v9
+; CHECK-NEXT:    sd t6, 0(t5)
+; CHECK-NEXT:    vmv1r.v v20, v9
+; CHECK-NEXT:    vmv1r.v v21, v10
+; CHECK-NEXT:    vmv1r.v v22, v11
+; CHECK-NEXT:    vmv1r.v v23, v12
+; CHECK-NEXT:    vmv1r.v v24, v13
+; CHECK-NEXT:    vmv1r.v v25, v14
+; CHECK-NEXT:    vmv1r.v v26, v15
 ; CHECK-NEXT:    csrr t5, vlenb
-; CHECK-NEXT:    slli t5, t5, 3
+; CHECK-NEXT:    slli t5, t5, 2
 ; CHECK-NEXT:    add t5, sp, t5
 ; CHECK-NEXT:    addi t5, t5, 16
-; CHECK-NEXT:    vl1r.v v9, (t5) # vscale x 8-byte Folded Reload
+; CHECK-NEXT:    vs1r.v v19, (t5) # vscale x 8-byte Folded Spill
 ; CHECK-NEXT:    csrr t6, vlenb
 ; CHECK-NEXT:    add t5, t5, t6
-; CHECK-NEXT:    vl2r.v v10, (t5) # vscale x 16-byte Folded Reload
-; CHECK-NEXT:    slli t6, t6, 1
+; CHECK-NEXT:    vs4r.v v20, (t5) # vscale x 32-byte Folded Spill
+; CHECK-NEXT:    slli t6, t6, 2
 ; CHECK-NEXT:    add t5, t5, t6
-; CHECK-NEXT:    vl1r.v v12, (t5) # vscale x 8-byte Folded Reload
-; CHECK-NEXT:    vsseg4e32.v v9, (zero)
-; CHECK-NEXT:    vsseg8e32.v v1, (a1)
-; CHECK-NEXT:    vmv1r.v v0, v18
-; CHECK-NEXT:    vssub.vv v19, v13, v29, v0.t
+; CHECK-NEXT:    vs2r.v v24, (t5) # vscale x 16-byte Folded Spill
+; CHECK-NEXT:    srli t6, t6, 1
+; CHECK-NEXT:    add t5, t5, t6
+; CHECK-NEXT:    vs1r.v v26, (t5) # vscale x 8-byte Folded Spill
+; CHECK-NEXT:    vmv1r.v v4, v9
+; CHECK-NEXT:    vmclr.m v30
+; CHECK-NEXT:  .LBB0_1: # %for.body
+; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmv1r.v v0, v30
+; CHECK-NEXT:    vmv1r.v v26, v29
+; CHECK-NEXT:    vmv1r.v v20, v29
+; CHECK-NEXT:    vmv1r.v v21, v29
+; CHECK-NEXT:    vmv1r.v v22, v29
+; CHECK-NEXT:    vmv1r.v v23, v29
+; CHECK-NEXT:    vmv1r.v v24, v29
+; CHECK-NEXT:    vmv1r.v v25, v29
+; CHECK-NEXT:    csrr t5, vlenb
+; CHECK-NEXT:    slli t5, t5, 2
+; CHECK-NEXT:    add t5, sp, t5
+; CHECK-NEXT:    addi t5, t5, 16
+; CHECK-NEXT:    vl8r.v v8, (t5) # vscale x 64-byte Folded Reload
+; CHECK-NEXT:    vmv2r.v v6, v18
+; CHECK-NEXT:    vmv1r.v v27, v29
+; CHECK-NEXT:    vsetvli zero, zero, e32, m1, tu, ma
+; CHECK-NEXT:    vle32.v v20, (t1)
+; CHECK-NEXT:    vmv1r.v v5, v29
+; CHECK-NEXT:    vle32.v v21, (t2)
+; CHECK-NEXT:    vmv1r.v v28, v30
+; CHECK-NEXT:    vle32.v v26, (t4)
+; CHECK-NEXT:    vle32.v v22, (t3)
+; CHECK-NEXT:    vle32.v v23, (a6)
+; CHECK-NEXT:    vle32.v v24, (a7)
+; CHECK-NEXT:    vle64.v v6, (a4)
+; CHECK-NEXT:    vle32.v v25, (a5)
+; CHECK-NEXT:    vle32.v v27, (a2)
+; CHECK-NEXT:    vle32.v v5, (a3)
+; CHECK-NEXT:    vmv1r.v v10, v24
+; CHECK-NEXT:    vsetvli zero, zero, e64, m2, ta, mu
+; CHECK-NEXT:    vmflt.vv v28, v6, v18, v0.t
+; CHECK-NEXT:    vmv1r.v v8, v26
+; CHECK-NEXT:    vsetvli t5, zero, e8, m2, ta, ma
+; CHECK-NEXT:    vmv.v.i v20, 0
+; CHECK-NEXT:    vsetivli zero, 0, e32, m1, tu, mu
+; CHECK-NEXT:    vsseg4e32.v v1, (zero)
+; CHECK-NEXT:    vmv2r.v v22, v20
+; CHECK-NEXT:    vsseg8e32.v v8, (a1)
+; CHECK-NEXT:    vmv2r.v v24, v20
+; CHECK-NEXT:    vmv1r.v v0, v28
+; CHECK-NEXT:    vssub.vv v5, v29, v27, v0.t
+; CHECK-NEXT:    vmv2r.v v26, v20
+; CHECK-NEXT:    addi t5, sp, 16
+; CHECK-NEXT:    vl4r.v v8, (t5) # vscale x 32-byte Folded Reload
+; CHECK-NEXT:    vsetvli zero, t0, e64, m2, ta, ma
+; CHECK-NEXT:    vsseg2e64.v v8, (zero)
+; CHECK-NEXT:    vmv1r.v v0, v30
+; CHECK-NEXT:    vsetivli zero, 0, e64, m2, ta, ma
+; CHECK-NEXT:    vsseg4e64.v v20, (zero), v0.t
+; CHECK-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
+; CHECK-NEXT:    vsseg8e32.v v5, (a0)
 ; CHECK-NEXT:    csrr t5, vlenb
 ; CHECK-NEXT:    slli t5, t5, 2
 ; CHECK-NEXT:    mv t6, t5
@@ -171,30 +174,9 @@ define i1 @main(ptr %var_117, ptr %arrayinit.element3045, ptr %arrayinit.element
 ; CHECK-NEXT:    add t5, t5, t6
 ; CHECK-NEXT:    add t5, sp, t5
 ; CHECK-NEXT:    addi t5, t5, 16
-; CHECK-NEXT:    vl4r.v v28, (t5) # vscale x 32-byte Folded Reload
-; CHECK-NEXT:    vsetvli zero, t0, e64, m2, ta, ma
-; CHECK-NEXT:    vsseg2e64.v v28, (zero)
-; CHECK-NEXT:    vmv1r.v v0, v14
-; CHECK-NEXT:    addi t5, sp, 16
-; CHECK-NEXT:    vl2r.v v2, (t5) # vscale x 16-byte Folded Reload
-; CHECK-NEXT:    csrr t6, vlenb
-; CHECK-NEXT:    slli t6, t6, 1
-; CHECK-NEXT:    add t5, t5, t6
-; CHECK-NEXT:    vl4r.v v4, (t5) # vscale x 32-byte Folded Reload
-; CHECK-NEXT:    slli t6, t6, 1
-; CHECK-NEXT:    add t5, t5, t6
-; CHECK-NEXT:    vl2r.v v8, (t5) # vscale x 16-byte Folded Reload
-; CHECK-NEXT:    vsetivli zero, 0, e64, m2, ta, ma
-; CHECK-NEXT:    vsseg4e64.v v2, (zero), v0.t
-; CHECK-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vsseg8e32.v v19, (a0)
-; CHECK-NEXT:    csrr t5, vlenb
-; CHECK-NEXT:    slli t5, t5, 4
-; CHECK-NEXT:    add t5, sp, t5
-; CHECK-NEXT:    addi t5, t5, 16
-; CHECK-NEXT:    vl8r.v v0, (t5) # vscale x 64-byte Folded Reload
+; CHECK-NEXT:    vl8r.v v8, (t5) # vscale x 64-byte Folded Reload
 ; CHECK-NEXT:    vsetvli zero, zero, e64, m2, ta, ma
-; CHECK-NEXT:    vsseg4e64.v v0, (zero)
+; CHECK-NEXT:    vsseg4e64.v v8, (zero)
 ; CHECK-NEXT:    j .LBB0_1
 entry:
   store double 0.000000e+00, ptr %var_117, align 8

--- a/llvm/test/CodeGen/Thumb/pr42760.ll
+++ b/llvm/test/CodeGen/Thumb/pr42760.ll
@@ -5,7 +5,6 @@ define hidden void @test() {
 ; CHECK-LABEL: test:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    movs r0, #1
-; CHECK-NEXT:    lsls r1, r0, #2
 ; CHECK-NEXT:    b .LBB0_2
 ; CHECK-NEXT:  .LBB0_1: @ %bb2
 ; CHECK-NEXT:    @ in Loop: Header=BB0_2 Depth=1
@@ -13,9 +12,10 @@ define hidden void @test() {
 ; CHECK-NEXT:    bne .LBB0_6
 ; CHECK-NEXT:  .LBB0_2: @ %switch
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    lsls r1, r0, #2
 ; CHECK-NEXT:    adr r2, .LJTI0_0
-; CHECK-NEXT:    ldr r2, [r2, r1]
-; CHECK-NEXT:    mov pc, r2
+; CHECK-NEXT:    ldr r1, [r2, r1]
+; CHECK-NEXT:    mov pc, r1
 ; CHECK-NEXT:  @ %bb.3:
 ; CHECK-NEXT:    .p2align 2
 ; CHECK-NEXT:  .LJTI0_0:

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/fast-fp-loops.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/fast-fp-loops.ll
@@ -280,10 +280,10 @@ define arm_aapcs_vfpcc float @fast_float_half_mac(ptr nocapture readonly %b, ptr
 ; CHECK-NEXT:    bxeq lr
 ; CHECK-NEXT:  .LBB2_1: @ %vector.ph
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    sub sp, #8
 ; CHECK-NEXT:    adds r3, r2, #3
-; CHECK-NEXT:    vmov.i32 q5, #0x0
+; CHECK-NEXT:    vmov.i32 q4, #0x0
 ; CHECK-NEXT:    bic r3, r3, #3
 ; CHECK-NEXT:    sub.w r12, r3, #4
 ; CHECK-NEXT:    movs r3, #1
@@ -294,28 +294,27 @@ define arm_aapcs_vfpcc float @fast_float_half_mac(ptr nocapture readonly %b, ptr
 ; CHECK-NEXT:    vldrw.u32 q0, [r2]
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vdup.32 q1, r12
-; CHECK-NEXT:    vdup.32 q2, r12
 ; CHECK-NEXT:    b .LBB2_3
 ; CHECK-NEXT:  .LBB2_2: @ %else24
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vmul.f16 q5, q6, q5
+; CHECK-NEXT:    vmul.f16 q4, q5, q4
 ; CHECK-NEXT:    adds r0, #8
-; CHECK-NEXT:    vcvtt.f32.f16 s23, s21
-; CHECK-NEXT:    vcvtb.f32.f16 s22, s21
-; CHECK-NEXT:    vcvtt.f32.f16 s21, s20
-; CHECK-NEXT:    vcvtb.f32.f16 s20, s20
+; CHECK-NEXT:    vcvtt.f32.f16 s19, s17
+; CHECK-NEXT:    vcvtb.f32.f16 s18, s17
+; CHECK-NEXT:    vcvtt.f32.f16 s17, s16
+; CHECK-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-NEXT:    adds r1, #8
 ; CHECK-NEXT:    adds r3, #4
-; CHECK-NEXT:    vadd.f32 q5, q3, q5
+; CHECK-NEXT:    vadd.f32 q4, q2, q4
 ; CHECK-NEXT:    subs.w lr, lr, #1
 ; CHECK-NEXT:    bne .LBB2_3
 ; CHECK-NEXT:    b .LBB2_19
 ; CHECK-NEXT:  .LBB2_3: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vadd.i32 q4, q0, r3
-; CHECK-NEXT:    vmov q3, q5
-; CHECK-NEXT:    vcmp.u32 cs, q1, q4
-; CHECK-NEXT:    @ implicit-def: $q5
+; CHECK-NEXT:    vadd.i32 q3, q0, r3
+; CHECK-NEXT:    vmov q2, q4
+; CHECK-NEXT:    vcmp.u32 cs, q1, q3
+; CHECK-NEXT:    @ implicit-def: $q4
 ; CHECK-NEXT:    vmrs r4, p0
 ; CHECK-NEXT:    and r2, r4, #1
 ; CHECK-NEXT:    rsbs r5, r2, #0
@@ -346,12 +345,13 @@ define arm_aapcs_vfpcc float @fast_float_half_mac(ptr nocapture readonly %b, ptr
 ; CHECK-NEXT:    bpl .LBB2_8
 ; CHECK-NEXT:  .LBB2_7: @ %cond.load10
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s22, [r0, #6]
-; CHECK-NEXT:    vins.f16 s21, s22
+; CHECK-NEXT:    vldr.16 s18, [r0, #6]
+; CHECK-NEXT:    vins.f16 s17, s18
 ; CHECK-NEXT:  .LBB2_8: @ %else11
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vcmp.u32 cs, q2, q4
-; CHECK-NEXT:    @ implicit-def: $q6
+; CHECK-NEXT:    vdup.32 q5, r12
+; CHECK-NEXT:    vcmp.u32 cs, q5, q3
+; CHECK-NEXT:    @ implicit-def: $q5
 ; CHECK-NEXT:    vmrs r4, p0
 ; CHECK-NEXT:    and r2, r4, #1
 ; CHECK-NEXT:    rsbs r5, r2, #0
@@ -383,57 +383,57 @@ define arm_aapcs_vfpcc float @fast_float_half_mac(ptr nocapture readonly %b, ptr
 ; CHECK-NEXT:    b .LBB2_18
 ; CHECK-NEXT:  .LBB2_12: @ %cond.load
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s20, [r0]
+; CHECK-NEXT:    vldr.16 s16, [r0]
 ; CHECK-NEXT:    lsls r4, r2, #30
 ; CHECK-NEXT:    bpl .LBB2_5
 ; CHECK-NEXT:  .LBB2_13: @ %cond.load4
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s22, [r0, #2]
-; CHECK-NEXT:    vins.f16 s20, s22
+; CHECK-NEXT:    vldr.16 s18, [r0, #2]
+; CHECK-NEXT:    vins.f16 s16, s18
 ; CHECK-NEXT:    lsls r4, r2, #29
 ; CHECK-NEXT:    bpl .LBB2_6
 ; CHECK-NEXT:  .LBB2_14: @ %cond.load7
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s21, [r0, #4]
-; CHECK-NEXT:    vmovx.f16 s22, s0
-; CHECK-NEXT:    vins.f16 s21, s22
+; CHECK-NEXT:    vldr.16 s17, [r0, #4]
+; CHECK-NEXT:    vmovx.f16 s18, s0
+; CHECK-NEXT:    vins.f16 s17, s18
 ; CHECK-NEXT:    lsls r2, r2, #28
 ; CHECK-NEXT:    bmi .LBB2_7
 ; CHECK-NEXT:    b .LBB2_8
 ; CHECK-NEXT:  .LBB2_15: @ %cond.load14
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s24, [r1]
+; CHECK-NEXT:    vldr.16 s20, [r1]
 ; CHECK-NEXT:    lsls r4, r2, #30
 ; CHECK-NEXT:    bpl .LBB2_10
 ; CHECK-NEXT:  .LBB2_16: @ %cond.load17
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s26, [r1, #2]
-; CHECK-NEXT:    vins.f16 s24, s26
+; CHECK-NEXT:    vldr.16 s22, [r1, #2]
+; CHECK-NEXT:    vins.f16 s20, s22
 ; CHECK-NEXT:    lsls r4, r2, #29
 ; CHECK-NEXT:    bpl .LBB2_11
 ; CHECK-NEXT:  .LBB2_17: @ %cond.load20
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s25, [r1, #4]
-; CHECK-NEXT:    vmovx.f16 s26, s0
-; CHECK-NEXT:    vins.f16 s25, s26
+; CHECK-NEXT:    vldr.16 s21, [r1, #4]
+; CHECK-NEXT:    vmovx.f16 s22, s0
+; CHECK-NEXT:    vins.f16 s21, s22
 ; CHECK-NEXT:    lsls r2, r2, #28
 ; CHECK-NEXT:    bpl.w .LBB2_2
 ; CHECK-NEXT:  .LBB2_18: @ %cond.load23
 ; CHECK-NEXT:    @ in Loop: Header=BB2_3 Depth=1
-; CHECK-NEXT:    vldr.16 s26, [r1, #6]
-; CHECK-NEXT:    vins.f16 s25, s26
+; CHECK-NEXT:    vldr.16 s22, [r1, #6]
+; CHECK-NEXT:    vins.f16 s21, s22
 ; CHECK-NEXT:    b .LBB2_2
 ; CHECK-NEXT:  .LBB2_19: @ %middle.block
 ; CHECK-NEXT:    vdup.32 q0, r12
-; CHECK-NEXT:    vcmp.u32 cs, q0, q4
-; CHECK-NEXT:    vpsel q0, q5, q3
+; CHECK-NEXT:    vcmp.u32 cs, q0, q3
+; CHECK-NEXT:    vpsel q0, q4, q2
 ; CHECK-NEXT:    vmov.f32 s4, s2
 ; CHECK-NEXT:    vmov.f32 s5, s3
 ; CHECK-NEXT:    vadd.f32 q0, q0, q1
 ; CHECK-NEXT:    vmov r0, s1
 ; CHECK-NEXT:    vadd.f32 q0, q0, r0
 ; CHECK-NEXT:    add sp, #8
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.20:

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/memcall.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/memcall.ll
@@ -64,11 +64,11 @@ define void @test_memset(ptr nocapture %x, i32 %n, i32 %m) {
 ; CHECK-NEXT:    .save {r4, lr}
 ; CHECK-NEXT:    push {r4, lr}
 ; CHECK-NEXT:    lsl.w r12, r2, #2
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    b .LBB1_2
 ; CHECK-NEXT:  .LBB1_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB1_4 Depth 2
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    wlstp.8 lr, r2, .LBB1_3
 ; CHECK-NEXT:    b .LBB1_4

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/remat-vctp.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/remat-vctp.ll
@@ -5,39 +5,39 @@ define void @remat_vctp(ptr %arg, ptr %arg1, ptr %arg2, ptr %arg3, ptr %arg4, i1
 ; CHECK-LABEL: remat_vctp:
 ; CHECK:       @ %bb.0: @ %bb
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-NEXT:    ldrd r5, r12, [sp, #64]
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-NEXT:    ldrd r5, r12, [sp, #48]
 ; CHECK-NEXT:    vmvn.i32 q0, #0x80000000
-; CHECK-NEXT:    vmov.i32 q1, #0x3f
 ; CHECK-NEXT:    movs r4, #1
 ; CHECK-NEXT:    dlstp.32 lr, r12
 ; CHECK-NEXT:  .LBB0_1: @ %bb6
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.i32 q2, #0x3f
 ; CHECK-NEXT:    vldrw.u32 q3, [r1], #16
 ; CHECK-NEXT:    vabs.s32 q4, q3
-; CHECK-NEXT:    vcls.s32 q2, q4
-; CHECK-NEXT:    vshl.u32 q4, q4, q2
-; CHECK-NEXT:    vadd.i32 q2, q2, r4
+; CHECK-NEXT:    vcls.s32 q1, q4
+; CHECK-NEXT:    vshl.u32 q4, q4, q1
+; CHECK-NEXT:    vadd.i32 q1, q1, r4
 ; CHECK-NEXT:    vshr.u32 q5, q4, #24
-; CHECK-NEXT:    vand q5, q5, q1
-; CHECK-NEXT:    vldrw.u32 q6, [r5, q5, uxtw #2]
-; CHECK-NEXT:    vqrdmulh.s32 q5, q6, q4
-; CHECK-NEXT:    vqsub.s32 q5, q0, q5
-; CHECK-NEXT:    vqrdmulh.s32 q5, q6, q5
-; CHECK-NEXT:    vqshl.s32 q5, q5, #1
-; CHECK-NEXT:    vqrdmulh.s32 q4, q5, q4
+; CHECK-NEXT:    vand q2, q5, q2
+; CHECK-NEXT:    vldrw.u32 q5, [r5, q2, uxtw #2]
+; CHECK-NEXT:    vqrdmulh.s32 q2, q5, q4
+; CHECK-NEXT:    vqsub.s32 q2, q0, q2
+; CHECK-NEXT:    vqrdmulh.s32 q2, q5, q2
+; CHECK-NEXT:    vqshl.s32 q2, q2, #1
+; CHECK-NEXT:    vqrdmulh.s32 q4, q2, q4
 ; CHECK-NEXT:    vqsub.s32 q4, q0, q4
-; CHECK-NEXT:    vqrdmulh.s32 q4, q5, q4
-; CHECK-NEXT:    vqshl.s32 q4, q4, #1
+; CHECK-NEXT:    vqrdmulh.s32 q2, q2, q4
+; CHECK-NEXT:    vqshl.s32 q2, q2, #1
 ; CHECK-NEXT:    vpt.s32 lt, q3, zr
-; CHECK-NEXT:    vnegt.s32 q4, q4
+; CHECK-NEXT:    vnegt.s32 q2, q2
 ; CHECK-NEXT:    vldrw.u32 q3, [r0], #16
-; CHECK-NEXT:    vqrdmulh.s32 q3, q3, q4
-; CHECK-NEXT:    vstrw.32 q3, [r2], #16
-; CHECK-NEXT:    vstrw.32 q2, [r3], #16
+; CHECK-NEXT:    vqrdmulh.s32 q2, q3, q2
+; CHECK-NEXT:    vstrw.32 q2, [r2], #16
+; CHECK-NEXT:    vstrw.32 q1, [r3], #16
 ; CHECK-NEXT:    letp lr, .LBB0_1
 ; CHECK-NEXT:  @ %bb.2: @ %bb44
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 bb:
   %i = zext i16 %arg5 to i32
@@ -89,14 +89,13 @@ define void @dont_remat_predicated_vctp(ptr %arg, ptr %arg1, ptr %arg2, ptr %arg
 ; CHECK-LABEL: dont_remat_predicated_vctp:
 ; CHECK:       @ %bb.0: @ %bb
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    sub sp, #8
-; CHECK-NEXT:    ldrd r6, r12, [sp, #72]
+; CHECK-NEXT:    ldrd r6, r12, [sp, #56]
 ; CHECK-NEXT:    movs r4, #4
 ; CHECK-NEXT:    cmp.w r12, #4
 ; CHECK-NEXT:    vmvn.i32 q0, #0x80000000
 ; CHECK-NEXT:    csel r5, r12, r4, lt
-; CHECK-NEXT:    vmov.i32 q1, #0x3f
 ; CHECK-NEXT:    sub.w r5, r12, r5
 ; CHECK-NEXT:    add.w lr, r5, #3
 ; CHECK-NEXT:    movs r5, #1
@@ -104,40 +103,41 @@ define void @dont_remat_predicated_vctp(ptr %arg, ptr %arg1, ptr %arg2, ptr %arg
 ; CHECK-NEXT:  .LBB1_1: @ %bb6
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    vctp.32 r12
-; CHECK-NEXT:    sub.w r12, r12, #4
+; CHECK-NEXT:    vmov.i32 q2, #0x3f
 ; CHECK-NEXT:    vpst
 ; CHECK-NEXT:    vctpt.32 r4
+; CHECK-NEXT:    sub.w r12, r12, #4
 ; CHECK-NEXT:    vstr p0, [sp, #4] @ 4-byte Spill
 ; CHECK-NEXT:    vpst
 ; CHECK-NEXT:    vldrwt.u32 q3, [r1], #16
 ; CHECK-NEXT:    vabs.s32 q4, q3
-; CHECK-NEXT:    vcls.s32 q2, q4
-; CHECK-NEXT:    vshl.u32 q4, q4, q2
-; CHECK-NEXT:    vadd.i32 q2, q2, r5
+; CHECK-NEXT:    vcls.s32 q1, q4
+; CHECK-NEXT:    vshl.u32 q4, q4, q1
+; CHECK-NEXT:    vadd.i32 q1, q1, r5
 ; CHECK-NEXT:    vshr.u32 q5, q4, #24
-; CHECK-NEXT:    vand q5, q5, q1
-; CHECK-NEXT:    vldrw.u32 q6, [r6, q5, uxtw #2]
-; CHECK-NEXT:    vqrdmulh.s32 q5, q6, q4
-; CHECK-NEXT:    vqsub.s32 q5, q0, q5
-; CHECK-NEXT:    vqrdmulh.s32 q5, q6, q5
-; CHECK-NEXT:    vqshl.s32 q5, q5, #1
-; CHECK-NEXT:    vqrdmulh.s32 q4, q5, q4
+; CHECK-NEXT:    vand q2, q5, q2
+; CHECK-NEXT:    vldrw.u32 q5, [r6, q2, uxtw #2]
+; CHECK-NEXT:    vqrdmulh.s32 q2, q5, q4
+; CHECK-NEXT:    vqsub.s32 q2, q0, q2
+; CHECK-NEXT:    vqrdmulh.s32 q2, q5, q2
+; CHECK-NEXT:    vqshl.s32 q2, q2, #1
+; CHECK-NEXT:    vqrdmulh.s32 q4, q2, q4
 ; CHECK-NEXT:    vqsub.s32 q4, q0, q4
-; CHECK-NEXT:    vqrdmulh.s32 q4, q5, q4
-; CHECK-NEXT:    vqshl.s32 q4, q4, #1
+; CHECK-NEXT:    vqrdmulh.s32 q2, q2, q4
+; CHECK-NEXT:    vqshl.s32 q2, q2, #1
 ; CHECK-NEXT:    vpt.s32 lt, q3, zr
-; CHECK-NEXT:    vnegt.s32 q4, q4
+; CHECK-NEXT:    vnegt.s32 q2, q2
 ; CHECK-NEXT:    vldr p0, [sp, #4] @ 4-byte Reload
 ; CHECK-NEXT:    vpst
 ; CHECK-NEXT:    vldrwt.u32 q3, [r0], #16
-; CHECK-NEXT:    vqrdmulh.s32 q3, q3, q4
+; CHECK-NEXT:    vqrdmulh.s32 q2, q3, q2
 ; CHECK-NEXT:    vpstt
-; CHECK-NEXT:    vstrwt.32 q3, [r2], #16
-; CHECK-NEXT:    vstrwt.32 q2, [r3], #16
+; CHECK-NEXT:    vstrwt.32 q2, [r2], #16
+; CHECK-NEXT:    vstrwt.32 q1, [r3], #16
 ; CHECK-NEXT:    le lr, .LBB1_1
 ; CHECK-NEXT:  @ %bb.2: @ %bb44
 ; CHECK-NEXT:    add sp, #8
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 bb:
   %i = zext i16 %arg5 to i32

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/spillingmove.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/spillingmove.ll
@@ -13,81 +13,61 @@ define void @__arm_2d_impl_rgb16_colour_filling_with_alpha(ptr noalias nocapture
 ; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
 ; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    sub sp, #64
 ; CHECK-NEXT:    ldrsh.w r7, [r2]
 ; CHECK-NEXT:    cmp r7, #1
 ; CHECK-NEXT:    blt .LBB0_6
 ; CHECK-NEXT:  @ %bb.2: @ %for.cond3.preheader.us.preheader
-; CHECK-NEXT:    ldr r4, [sp, #152]
 ; CHECK-NEXT:    movs r2, #252
+; CHECK-NEXT:    ldr r4, [sp, #88]
 ; CHECK-NEXT:    and.w r6, r2, r3, lsr #3
 ; CHECK-NEXT:    movs r2, #120
 ; CHECK-NEXT:    and.w r5, r2, r3, lsr #9
 ; CHECK-NEXT:    lsls r3, r3, #3
-; CHECK-NEXT:    muls r6, r4, r6
 ; CHECK-NEXT:    uxtb r3, r3
+; CHECK-NEXT:    muls r6, r4, r6
 ; CHECK-NEXT:    rsb.w r2, r4, #256
-; CHECK-NEXT:    vmov.i16 q1, #0xfc
-; CHECK-NEXT:    vdup.16 q0, r6
 ; CHECK-NEXT:    mul lr, r5, r4
-; CHECK-NEXT:    mov.w r6, #2016
-; CHECK-NEXT:    vstrw.32 q0, [sp, #48] @ 16-byte Spill
-; CHECK-NEXT:    mul r5, r3, r4
-; CHECK-NEXT:    adds r3, r7, #7
 ; CHECK-NEXT:    vdup.16 q0, r6
-; CHECK-NEXT:    bic r3, r3, #7
-; CHECK-NEXT:    vstrw.32 q0, [sp, #32] @ 16-byte Spill
-; CHECK-NEXT:    vdup.16 q0, r5
-; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
-; CHECK-NEXT:    vdup.16 q0, lr
-; CHECK-NEXT:    subs r3, #8
-; CHECK-NEXT:    vstrw.32 q0, [sp] @ 16-byte Spill
-; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    vldrw.u32 q7, [sp, #32] @ 16-byte Reload
-; CHECK-NEXT:    add.w r3, r4, r3, lsr #3
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #16] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q2, [sp] @ 16-byte Reload
+; CHECK-NEXT:    mov.w r6, #2016
+; CHECK-NEXT:    mul r5, r3, r4
+; CHECK-NEXT:    vdup.16 q1, r6
 ; CHECK-NEXT:    lsls r1, r1, #1
+; CHECK-NEXT:    vdup.16 q2, r5
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vmov.i16 q4, #0xf8
+; CHECK-NEXT:    vdup.16 q3, lr
 ; CHECK-NEXT:  .LBB0_3: @ %vector.ph
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB0_4 Depth 2
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    mov r6, r7
-; CHECK-NEXT:    dls lr, r3
+; CHECK-NEXT:    dlstp.16 lr, r7
 ; CHECK-NEXT:  .LBB0_4: @ %vector.body
 ; CHECK-NEXT:    @ Parent Loop BB0_3 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vctp.16 r6
-; CHECK-NEXT:    vmov.i16 q5, #0xf800
-; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vldrht.u16 q0, [r5]
-; CHECK-NEXT:    subs r6, #8
-; CHECK-NEXT:    vshr.u16 q3, q0, #3
-; CHECK-NEXT:    vand q3, q3, q1
-; CHECK-NEXT:    vldrw.u32 q1, [sp, #48] @ 16-byte Reload
-; CHECK-NEXT:    vmla.i16 q1, q3, r2
-; CHECK-NEXT:    vshl.i16 q3, q0, #3
-; CHECK-NEXT:    vand q3, q3, q4
-; CHECK-NEXT:    vmov q4, q6
-; CHECK-NEXT:    vshr.u16 q1, q1, #5
-; CHECK-NEXT:    vmla.i16 q4, q3, r2
-; CHECK-NEXT:    vshr.u16 q3, q4, #11
-; CHECK-NEXT:    vand q1, q1, q7
-; CHECK-NEXT:    vorr q1, q1, q3
-; CHECK-NEXT:    vshr.u16 q0, q0, #9
-; CHECK-NEXT:    vmov.i16 q3, #0x78
-; CHECK-NEXT:    vmov.i16 q4, #0xf8
-; CHECK-NEXT:    vand q0, q0, q3
-; CHECK-NEXT:    vmov q3, q2
-; CHECK-NEXT:    vmla.i16 q3, q0, r2
-; CHECK-NEXT:    vand q0, q3, q5
-; CHECK-NEXT:    vorr q0, q1, q0
-; CHECK-NEXT:    vmov.i16 q1, #0xfc
-; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vstrht.16 q0, [r5], #16
-; CHECK-NEXT:    le lr, .LBB0_4
+; CHECK-NEXT:    vmov.i16 q6, #0xfc
+; CHECK-NEXT:    vldrh.u16 q4, [r5]
+; CHECK-NEXT:    vmov.i16 q7, #0xf8
+; CHECK-NEXT:    vshr.u16 q5, q4, #3
+; CHECK-NEXT:    vand q5, q5, q6
+; CHECK-NEXT:    vmov q6, q0
+; CHECK-NEXT:    vmla.i16 q6, q5, r2
+; CHECK-NEXT:    vshr.u16 q5, q6, #5
+; CHECK-NEXT:    vshl.i16 q6, q4, #3
+; CHECK-NEXT:    vand q6, q6, q7
+; CHECK-NEXT:    vmov q7, q2
+; CHECK-NEXT:    vmla.i16 q7, q6, r2
+; CHECK-NEXT:    vand q5, q5, q1
+; CHECK-NEXT:    vshr.u16 q6, q7, #11
+; CHECK-NEXT:    vshr.u16 q4, q4, #9
+; CHECK-NEXT:    vorr q5, q5, q6
+; CHECK-NEXT:    vmov.i16 q6, #0x78
+; CHECK-NEXT:    vand q4, q4, q6
+; CHECK-NEXT:    vmov q6, q3
+; CHECK-NEXT:    vmla.i16 q6, q4, r2
+; CHECK-NEXT:    vmov.i16 q4, #0xf800
+; CHECK-NEXT:    vand q4, q6, q4
+; CHECK-NEXT:    vorr q4, q5, q4
+; CHECK-NEXT:    vstrh.16 q4, [r5], #16
+; CHECK-NEXT:    letp lr, .LBB0_4
 ; CHECK-NEXT:  @ %bb.5: @ %for.cond3.for.cond.cleanup7_crit_edge.us
 ; CHECK-NEXT:    @ in Loop: Header=BB0_3 Depth=1
 ; CHECK-NEXT:    adds r4, #1
@@ -95,7 +75,6 @@ define void @__arm_2d_impl_rgb16_colour_filling_with_alpha(ptr noalias nocapture
 ; CHECK-NEXT:    cmp r4, r12
 ; CHECK-NEXT:    bne .LBB0_3
 ; CHECK-NEXT:  .LBB0_6:
-; CHECK-NEXT:    add sp, #64
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, lr}
@@ -195,70 +174,59 @@ define void @__arm_2d_impl_rgb16_colour_filling_with_alpha_sched(ptr noalias noc
 ; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
 ; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    ldr r7, [sp, #88]
 ; CHECK-NEXT:    movs r5, #120
-; CHECK-NEXT:    lsls r6, r3, #3
 ; CHECK-NEXT:    movs r4, #252
+; CHECK-NEXT:    ldr r7, [sp, #88]
+; CHECK-NEXT:    lsls r6, r3, #3
 ; CHECK-NEXT:    and.w r5, r5, r3, lsr #9
-; CHECK-NEXT:    uxtb r6, r6
 ; CHECK-NEXT:    and.w r3, r4, r3, lsr #3
-; CHECK-NEXT:    adds r4, r2, #7
+; CHECK-NEXT:    uxtb r6, r6
 ; CHECK-NEXT:    muls r6, r7, r6
-; CHECK-NEXT:    bic r4, r4, #7
-; CHECK-NEXT:    mul lr, r3, r7
-; CHECK-NEXT:    muls r5, r7, r5
+; CHECK-NEXT:    mul r4, r3, r7
+; CHECK-NEXT:    mul lr, r5, r7
 ; CHECK-NEXT:    rsb.w r3, r7, #256
 ; CHECK-NEXT:    lsls r7, r1, #1
-; CHECK-NEXT:    sub.w r1, r4, #8
-; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    vmov.i16 q2, #0xf8
-; CHECK-NEXT:    add.w r1, r4, r1, lsr #3
-; CHECK-NEXT:    vdup.16 q6, r6
+; CHECK-NEXT:    vdup.16 q0, r6
 ; CHECK-NEXT:    mov.w r6, #2016
+; CHECK-NEXT:    vdup.16 q1, r4
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vdup.16 q3, lr
-; CHECK-NEXT:    vdup.16 q5, r5
-; CHECK-NEXT:    vdup.16 q7, r6
+; CHECK-NEXT:    vdup.16 q2, lr
+; CHECK-NEXT:    vdup.16 q3, r6
 ; CHECK-NEXT:    .p2align 2
 ; CHECK-NEXT:  .LBB1_3: @ %vector.ph
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB1_4 Depth 2
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    mov r6, r2
-; CHECK-NEXT:    dls lr, r1
+; CHECK-NEXT:    dlstp.16 lr, r2
 ; CHECK-NEXT:    .p2align 2
 ; CHECK-NEXT:  .LBB1_4: @ %vector.body
 ; CHECK-NEXT:    @ Parent Loop BB1_3 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vctp.16 r6
-; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vldrht.u16 q0, [r5]
-; CHECK-NEXT:    vshl.i16 q1, q0, #3
-; CHECK-NEXT:    subs r6, #8
-; CHECK-NEXT:    vand q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x78
-; CHECK-NEXT:    vshr.u16 q4, q0, #9
-; CHECK-NEXT:    vand q4, q4, q2
-; CHECK-NEXT:    vmov q2, q6
-; CHECK-NEXT:    vmla.i16 q2, q1, r3
-; CHECK-NEXT:    vshr.u16 q0, q0, #3
-; CHECK-NEXT:    vmov.i16 q1, #0xfc
-; CHECK-NEXT:    vand q0, q0, q1
-; CHECK-NEXT:    vmov q1, q3
-; CHECK-NEXT:    vmla.i16 q1, q0, r3
-; CHECK-NEXT:    vshr.u16 q0, q2, #11
-; CHECK-NEXT:    vmov q2, q5
-; CHECK-NEXT:    vmla.i16 q2, q4, r3
-; CHECK-NEXT:    vshr.u16 q1, q1, #5
-; CHECK-NEXT:    vmov.i16 q4, #0xf800
-; CHECK-NEXT:    vand q1, q1, q7
-; CHECK-NEXT:    vorr q0, q1, q0
-; CHECK-NEXT:    vand q1, q2, q4
-; CHECK-NEXT:    vmov.i16 q2, #0xf8
-; CHECK-NEXT:    vorr q0, q0, q1
-; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vstrht.16 q0, [r5], #16
-; CHECK-NEXT:    le lr, .LBB1_4
+; CHECK-NEXT:    vldrh.u16 q4, [r5]
+; CHECK-NEXT:    vmov.i16 q6, #0xf8
+; CHECK-NEXT:    vshl.i16 q5, q4, #3
+; CHECK-NEXT:    vmov.i16 q7, #0x78
+; CHECK-NEXT:    vand q5, q5, q6
+; CHECK-NEXT:    vshr.u16 q6, q4, #9
+; CHECK-NEXT:    vand q6, q6, q7
+; CHECK-NEXT:    vmov.i16 q7, #0xfc
+; CHECK-NEXT:    vshr.u16 q4, q4, #3
+; CHECK-NEXT:    vand q4, q4, q7
+; CHECK-NEXT:    vmov q7, q0
+; CHECK-NEXT:    vmla.i16 q7, q5, r3
+; CHECK-NEXT:    vmov q5, q1
+; CHECK-NEXT:    vmla.i16 q5, q4, r3
+; CHECK-NEXT:    vshr.u16 q4, q7, #11
+; CHECK-NEXT:    vshr.u16 q5, q5, #5
+; CHECK-NEXT:    vand q5, q5, q3
+; CHECK-NEXT:    vmov q7, q2
+; CHECK-NEXT:    vmla.i16 q7, q6, r3
+; CHECK-NEXT:    vorr q4, q5, q4
+; CHECK-NEXT:    vmov.i16 q5, #0xf800
+; CHECK-NEXT:    vand q5, q7, q5
+; CHECK-NEXT:    vorr q4, q4, q5
+; CHECK-NEXT:    vstrh.16 q4, [r5], #16
+; CHECK-NEXT:    letp lr, .LBB1_4
 ; CHECK-NEXT:  @ %bb.5: @ %for.cond3.for.cond.cleanup7_crit_edge.us
 ; CHECK-NEXT:    @ in Loop: Header=BB1_3 Depth=1
 ; CHECK-NEXT:    adds r4, #1

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/vcmp-vpst-combination.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/vcmp-vpst-combination.ll
@@ -49,17 +49,17 @@ define i32 @vcmp_new_vpst_combination(i32 %len, ptr nocapture readonly %arr) {
 ; CHECK-NEXT:    cmp r0, #1
 ; CHECK-NEXT:    blt .LBB1_4
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
-; CHECK-NEXT:    vmov.i32 q0, #0x1
 ; CHECK-NEXT:    movs r2, #0
 ; CHECK-NEXT:    dlstp.32 lr, r0
 ; CHECK-NEXT:  .LBB1_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r1], #16
-; CHECK-NEXT:    vcmp.i32 ne, q1, zr
-; CHECK-NEXT:    vmov.i32 q1, #0x0
+; CHECK-NEXT:    vmov.i32 q1, #0x1
+; CHECK-NEXT:    vldrw.u32 q0, [r1], #16
+; CHECK-NEXT:    vcmp.i32 ne, q0, zr
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vmovt q1, q0
-; CHECK-NEXT:    vaddva.u32 r2, q1
+; CHECK-NEXT:    vmovt q0, q1
+; CHECK-NEXT:    vaddva.u32 r2, q0
 ; CHECK-NEXT:    letp lr, .LBB1_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    mov r0, r2

--- a/llvm/test/CodeGen/Thumb2/mve-float16regloops.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-float16regloops.ll
@@ -1347,12 +1347,11 @@ define void @arm_biquad_cascade_df2T_f16(ptr nocapture readonly %S, ptr nocaptur
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, lr}
 ; CHECK-NEXT:    .pad #4
 ; CHECK-NEXT:    sub sp, #4
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    ldrd r6, r12, [r0, #4]
-; CHECK-NEXT:    ldrb.w r9, [r0]
 ; CHECK-NEXT:    vldr.16 s0, .LCPI17_0
+; CHECK-NEXT:    ldrb.w r9, [r0]
 ; CHECK-NEXT:    lsr.w r8, r3, #1
 ; CHECK-NEXT:    b .LBB17_3
 ; CHECK-NEXT:  .LBB17_1: @ %if.else
@@ -1372,13 +1371,14 @@ define void @arm_biquad_cascade_df2T_f16(ptr nocapture readonly %S, ptr nocaptur
 ; CHECK-NEXT:    @ Child Loop BB17_5 Depth 2
 ; CHECK-NEXT:    vldrh.u16 q2, [r12]
 ; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vmov.i32 q6, #0x0
 ; CHECK-NEXT:    vmov q4, q2
 ; CHECK-NEXT:    vshlc q4, r5, #16
 ; CHECK-NEXT:    vldrh.u16 q3, [r12, #4]
 ; CHECK-NEXT:    vmov q5, q3
 ; CHECK-NEXT:    vshlc q5, r5, #16
 ; CHECK-NEXT:    vldrh.u16 q1, [r6]
-; CHECK-NEXT:    vmov.f32 s5, s1
+; CHECK-NEXT:    vmov.f32 s5, s25
 ; CHECK-NEXT:    mov r5, r2
 ; CHECK-NEXT:    wls lr, r8, .LBB17_6
 ; CHECK-NEXT:  @ %bb.4: @ %while.body.preheader
@@ -1417,7 +1417,7 @@ define void @arm_biquad_cascade_df2T_f16(ptr nocapture readonly %S, ptr nocaptur
 ; CHECK-NEXT:    vstr.16 s2, [r6]
 ; CHECK-NEXT:    b .LBB17_2
 ; CHECK-NEXT:  .LBB17_8: @ %do.end
-; CHECK-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, pc}
 ; CHECK-NEXT:    .p2align 1

--- a/llvm/test/CodeGen/Thumb2/mve-gather-increment.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-gather-increment.ll
@@ -769,8 +769,8 @@ define arm_aapcs_vfpcc void @gather_inc_v8i16_complex(ptr noalias nocapture read
 ; CHECK-NEXT:    vmov r4, r5, d1
 ; CHECK-NEXT:    vldrh.s32 q0, [r2]
 ; CHECK-NEXT:    vshl.i32 q0, q0, #1
-; CHECK-NEXT:    vadd.i32 q2, q0, r0
-; CHECK-NEXT:    vmov r6, r2, d4
+; CHECK-NEXT:    vadd.i32 q1, q0, r0
+; CHECK-NEXT:    vmov r6, r2, d2
 ; CHECK-NEXT:    ldrh r1, [r1]
 ; CHECK-NEXT:    ldrh.w r12, [r4]
 ; CHECK-NEXT:    add r4, sp, #72
@@ -782,74 +782,74 @@ define arm_aapcs_vfpcc void @gather_inc_v8i16_complex(ptr noalias nocapture read
 ; CHECK-NEXT:    vldrh.s32 q0, [r4]
 ; CHECK-NEXT:    vmov.16 q7[0], r5
 ; CHECK-NEXT:    vmov.16 q7[1], r2
+; CHECK-NEXT:    vldrh.s32 q2, [r4, #8]
 ; CHECK-NEXT:    vshl.i32 q0, q0, #1
 ; CHECK-NEXT:    vadd.i32 q0, q0, r0
+; CHECK-NEXT:    vshl.i32 q2, q2, #1
 ; CHECK-NEXT:    vmov r6, r9, d0
+; CHECK-NEXT:    vadd.i32 q2, q2, r0
 ; CHECK-NEXT:    vmov r2, r5, d1
-; CHECK-NEXT:    vldrh.s32 q0, [r4, #8]
-; CHECK-NEXT:    vshl.i32 q0, q0, #1
-; CHECK-NEXT:    vadd.i32 q0, q0, r0
 ; CHECK-NEXT:    ldrh r6, [r6]
 ; CHECK-NEXT:    ldrh r2, [r2]
-; CHECK-NEXT:    vmov.16 q1[0], r6
+; CHECK-NEXT:    vmov.16 q0[0], r6
 ; CHECK-NEXT:    ldrh.w r6, [r9]
 ; CHECK-NEXT:    ldrh r5, [r5]
-; CHECK-NEXT:    vmov.16 q1[1], r6
-; CHECK-NEXT:    vmov.16 q1[2], r2
-; CHECK-NEXT:    vmov r2, r6, d0
-; CHECK-NEXT:    vmov.16 q1[3], r5
+; CHECK-NEXT:    vmov.16 q0[1], r6
+; CHECK-NEXT:    vmov.16 q0[2], r2
+; CHECK-NEXT:    vmov r2, r6, d4
+; CHECK-NEXT:    vmov.16 q0[3], r5
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r6, [r6]
-; CHECK-NEXT:    vmov.16 q1[4], r2
-; CHECK-NEXT:    vmov r2, r5, d1
-; CHECK-NEXT:    vmov.16 q1[5], r6
+; CHECK-NEXT:    vmov.16 q0[4], r2
+; CHECK-NEXT:    vmov r2, r5, d5
+; CHECK-NEXT:    vmov.16 q0[5], r6
 ; CHECK-NEXT:    mov r6, r10
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r5, [r5]
 ; CHECK-NEXT:    vstrw.32 q4, [r10]
-; CHECK-NEXT:    vldrh.s32 q0, [r6]
-; CHECK-NEXT:    vmov.16 q1[6], r2
-; CHECK-NEXT:    vmov.16 q1[7], r5
-; CHECK-NEXT:    vshl.i32 q0, q0, #1
-; CHECK-NEXT:    vadd.i32 q0, q0, r0
-; CHECK-NEXT:    vmov r2, r5, d0
+; CHECK-NEXT:    vldrh.s32 q2, [r6]
+; CHECK-NEXT:    vmov.16 q0[6], r2
+; CHECK-NEXT:    vmov.16 q0[7], r5
+; CHECK-NEXT:    vshl.i32 q2, q2, #1
+; CHECK-NEXT:    vadd.i32 q3, q2, r0
+; CHECK-NEXT:    vmov r2, r5, d6
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r5, [r5]
-; CHECK-NEXT:    vmov.16 q3[0], r2
-; CHECK-NEXT:    vmov.16 q3[1], r5
-; CHECK-NEXT:    vmov r2, r5, d5
-; CHECK-NEXT:    vmov.i16 q2, #0x18
-; CHECK-NEXT:    vadd.i16 q6, q6, q2
-; CHECK-NEXT:    vadd.i16 q5, q5, q2
-; CHECK-NEXT:    vadd.i16 q4, q4, q2
+; CHECK-NEXT:    vmov.16 q2[0], r2
+; CHECK-NEXT:    vmov.16 q2[1], r5
+; CHECK-NEXT:    vmov r2, r5, d3
+; CHECK-NEXT:    vldrh.s32 q1, [r6, #8]
+; CHECK-NEXT:    vshl.i32 q1, q1, #1
+; CHECK-NEXT:    vadd.i32 q1, q1, r0
 ; CHECK-NEXT:    ldrh.w r9, [r2]
-; CHECK-NEXT:    vmov r2, r4, d1
-; CHECK-NEXT:    vldrh.s32 q0, [r6, #8]
+; CHECK-NEXT:    vmov r2, r4, d7
 ; CHECK-NEXT:    ldrh r5, [r5]
 ; CHECK-NEXT:    vmov.16 q7[2], r9
-; CHECK-NEXT:    vshl.i32 q0, q0, #1
 ; CHECK-NEXT:    vmov.16 q7[3], r5
-; CHECK-NEXT:    vadd.i32 q0, q0, r0
 ; CHECK-NEXT:    vmov.16 q7[4], r1
 ; CHECK-NEXT:    vmov.16 q7[5], r3
 ; CHECK-NEXT:    vmov.16 q7[6], r12
 ; CHECK-NEXT:    vmov.16 q7[7], r11
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r4, [r4]
-; CHECK-NEXT:    vmov.16 q3[2], r2
-; CHECK-NEXT:    vmov.16 q3[3], r4
-; CHECK-NEXT:    vmov r2, r4, d0
+; CHECK-NEXT:    vmov.16 q2[2], r2
+; CHECK-NEXT:    vmov.16 q2[3], r4
+; CHECK-NEXT:    vmov r2, r4, d2
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r4, [r4]
-; CHECK-NEXT:    vmov.16 q3[4], r2
-; CHECK-NEXT:    vmov.16 q3[5], r4
-; CHECK-NEXT:    vmov r2, r4, d1
+; CHECK-NEXT:    vmov.16 q2[4], r2
+; CHECK-NEXT:    vmov.16 q2[5], r4
+; CHECK-NEXT:    vmov r2, r4, d3
+; CHECK-NEXT:    vmov.i16 q1, #0x18
+; CHECK-NEXT:    vadd.i16 q6, q6, q1
+; CHECK-NEXT:    vadd.i16 q5, q5, q1
+; CHECK-NEXT:    vadd.i16 q4, q4, q1
 ; CHECK-NEXT:    ldrh r2, [r2]
 ; CHECK-NEXT:    ldrh r4, [r4]
-; CHECK-NEXT:    vmov.16 q3[6], r2
+; CHECK-NEXT:    vmov.16 q2[6], r2
 ; CHECK-NEXT:    mov r2, r8
-; CHECK-NEXT:    vmov.16 q3[7], r4
-; CHECK-NEXT:    vadd.i16 q0, q3, q1
+; CHECK-NEXT:    vmov.16 q2[7], r4
+; CHECK-NEXT:    vadd.i16 q0, q2, q0
 ; CHECK-NEXT:    vadd.i16 q0, q0, q7
 ; CHECK-NEXT:    vstrb.8 q0, [r7], #16
 ; CHECK-NEXT:    le lr, .LBB15_3
@@ -942,8 +942,8 @@ define arm_aapcs_vfpcc void @gather_inc_v16i8_complex(ptr noalias nocapture read
 ; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #312
-; CHECK-NEXT:    sub sp, #312
+; CHECK-NEXT:    .pad #296
+; CHECK-NEXT:    sub sp, #296
 ; CHECK-NEXT:    cmp r2, #1
 ; CHECK-NEXT:    str r1, [sp, #116] @ 4-byte Spill
 ; CHECK-NEXT:    blt.w .LBB16_5
@@ -973,220 +973,220 @@ define arm_aapcs_vfpcc void @gather_inc_v16i8_complex(ptr noalias nocapture read
 ; CHECK-NEXT:  .LBB16_2: @ %vector.ph
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB16_3 Depth 2
-; CHECK-NEXT:    vldrw.u32 q2, [sp, #16] @ 16-byte Reload
 ; CHECK-NEXT:    adr r1, .LCPI16_3
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #32] @ 16-byte Reload
 ; CHECK-NEXT:    vldrw.u32 q5, [r1]
 ; CHECK-NEXT:    adr r1, .LCPI16_4
-; CHECK-NEXT:    vstrw.32 q2, [sp, #296] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q2, [sp, #32] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q6, [r1]
+; CHECK-NEXT:    vldrw.u32 q0, [r1]
 ; CHECK-NEXT:    adr r1, .LCPI16_2
-; CHECK-NEXT:    vstrw.32 q2, [sp, #280] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q1, [r1]
-; CHECK-NEXT:    adr r1, .LCPI16_10
-; CHECK-NEXT:    vstrw.32 q2, [sp, #264] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q2, [sp, #80] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q3, [r1]
-; CHECK-NEXT:    adr r1, .LCPI16_11
 ; CHECK-NEXT:    ldr.w r8, [sp, #116] @ 4-byte Reload
-; CHECK-NEXT:    vstrw.32 q2, [sp, #248] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q2, [sp, #64] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q0, [sp, #96] @ 16-byte Reload
-; CHECK-NEXT:    vldrw.u32 q7, [r1]
-; CHECK-NEXT:    vldrw.u32 q4, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q4, [sp, #264] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q0, [sp, #232] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [r1]
+; CHECK-NEXT:    adr r1, .LCPI16_10
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q0, [sp, #280] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [r1]
+; CHECK-NEXT:    adr r1, .LCPI16_11
+; CHECK-NEXT:    vldrw.u32 q7, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q0, [sp, #248] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q3, [r1]
 ; CHECK-NEXT:    mov r11, r10
-; CHECK-NEXT:    vstrw.32 q2, [sp, #232] @ 16-byte Spill
 ; CHECK-NEXT:    vstrw.32 q0, [sp, #216] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q4, [sp, #200] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q0, [sp, #184] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q0, [sp, #168] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #96] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q0, [sp, #152] @ 16-byte Spill
 ; CHECK-NEXT:  .LBB16_3: @ %vector.body
 ; CHECK-NEXT:    @ Parent Loop BB16_2 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vmov q0, q7
-; CHECK-NEXT:    vstrw.32 q7, [sp, #184] @ 16-byte Spill
-; CHECK-NEXT:    vadd.i32 q7, q5, r0
-; CHECK-NEXT:    vstrw.32 q5, [sp, #200] @ 16-byte Spill
-; CHECK-NEXT:    vadd.i32 q5, q0, r0
-; CHECK-NEXT:    vmov q0, q6
-; CHECK-NEXT:    vadd.i32 q6, q4, r0
-; CHECK-NEXT:    vmov r5, r4, d11
-; CHECK-NEXT:    vmov r1, lr, d12
-; CHECK-NEXT:    vadd.i32 q2, q1, r0
-; CHECK-NEXT:    vmov r6, r7, d15
-; CHECK-NEXT:    vstrw.32 q1, [sp, #152] @ 16-byte Spill
-; CHECK-NEXT:    vmov q1, q3
-; CHECK-NEXT:    vstrw.32 q4, [sp, #168] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q4, [sp, #248] @ 16-byte Reload
-; CHECK-NEXT:    vstrw.32 q0, [sp, #120] @ 16-byte Spill
-; CHECK-NEXT:    vstrw.32 q3, [sp, #136] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q3, [sp, #184] @ 16-byte Reload
+; CHECK-NEXT:    vadd.i32 q1, q7, r0
+; CHECK-NEXT:    vadd.i32 q4, q3, r0
+; CHECK-NEXT:    vmov r1, lr, d2
+; CHECK-NEXT:    vadd.i32 q6, q5, r0
+; CHECK-NEXT:    vmov r5, r4, d9
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #280] @ 16-byte Reload
+; CHECK-NEXT:    vmov r6, r7, d13
+; CHECK-NEXT:    vstrw.32 q7, [sp, #120] @ 16-byte Spill
+; CHECK-NEXT:    vadd.i32 q7, q0, r0
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #248] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q5, [sp, #136] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #232] @ 16-byte Reload
+; CHECK-NEXT:    vadd.i32 q5, q2, r0
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #264] @ 16-byte Reload
 ; CHECK-NEXT:    subs.w r11, r11, #16
-; CHECK-NEXT:    ldrb r5, [r5]
 ; CHECK-NEXT:    ldrb.w r9, [r1]
-; CHECK-NEXT:    vmov r1, r3, d10
+; CHECK-NEXT:    vmov r1, r3, d8
+; CHECK-NEXT:    ldrb r5, [r5]
 ; CHECK-NEXT:    ldrb r7, [r7]
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q5[0], r1
+; CHECK-NEXT:    vmov.8 q4[0], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q5[1], r1
-; CHECK-NEXT:    vmov r1, r3, d14
-; CHECK-NEXT:    vmov.8 q5[2], r5
+; CHECK-NEXT:    vmov.8 q4[1], r1
+; CHECK-NEXT:    vmov r1, r3, d12
+; CHECK-NEXT:    vmov.8 q4[2], r5
 ; CHECK-NEXT:    ldrb r5, [r6]
 ; CHECK-NEXT:    ldrb r6, [r4]
-; CHECK-NEXT:    vmov.8 q5[3], r6
+; CHECK-NEXT:    vmov.8 q4[3], r6
 ; CHECK-NEXT:    ldrb r1, [r1]
 ; CHECK-NEXT:    ldrb r3, [r3]
-; CHECK-NEXT:    vmov.8 q7[0], r1
-; CHECK-NEXT:    vmov r6, r1, d4
-; CHECK-NEXT:    vmov.8 q7[1], r3
-; CHECK-NEXT:    vmov.8 q7[2], r5
-; CHECK-NEXT:    vmov.8 q7[3], r7
+; CHECK-NEXT:    vmov.8 q6[0], r1
+; CHECK-NEXT:    vmov r6, r1, d14
+; CHECK-NEXT:    vmov.8 q6[1], r3
+; CHECK-NEXT:    vmov.8 q6[2], r5
+; CHECK-NEXT:    vmov.8 q6[3], r7
 ; CHECK-NEXT:    ldrb.w r7, [lr]
-; CHECK-NEXT:    vmov.8 q7[4], r9
-; CHECK-NEXT:    vmov.8 q7[5], r7
+; CHECK-NEXT:    vmov.8 q6[4], r9
+; CHECK-NEXT:    vmov.8 q6[5], r7
 ; CHECK-NEXT:    ldrb r4, [r1]
-; CHECK-NEXT:    vmov r1, r5, d5
-; CHECK-NEXT:    vadd.i32 q2, q1, r0
-; CHECK-NEXT:    vldrw.u32 q1, [sp, #280] @ 16-byte Reload
+; CHECK-NEXT:    vmov r1, r5, d15
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #200] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb.w r12, [r1]
-; CHECK-NEXT:    vmov r1, r3, d13
+; CHECK-NEXT:    vmov r1, r3, d3
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #216] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r5, [r5]
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #232] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r1, [r1]
 ; CHECK-NEXT:    ldrb r3, [r3]
-; CHECK-NEXT:    vmov.8 q7[6], r1
-; CHECK-NEXT:    vmov r1, r7, d4
-; CHECK-NEXT:    vmov.8 q7[7], r3
+; CHECK-NEXT:    vmov.8 q6[6], r1
+; CHECK-NEXT:    vmov r1, r7, d10
+; CHECK-NEXT:    vmov.8 q6[7], r3
 ; CHECK-NEXT:    ldrb r1, [r1]
 ; CHECK-NEXT:    ldrb r7, [r7]
-; CHECK-NEXT:    vmov.8 q5[4], r1
-; CHECK-NEXT:    vmov r1, r3, d5
-; CHECK-NEXT:    vmov.8 q5[5], r7
-; CHECK-NEXT:    vadd.i32 q2, q1, r0
-; CHECK-NEXT:    vldrw.u32 q1, [sp, #296] @ 16-byte Reload
+; CHECK-NEXT:    vmov.8 q4[4], r1
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vmov.8 q4[5], r7
+; CHECK-NEXT:    vadd.i32 q5, q2, r0
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #168] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r1, [r1]
 ; CHECK-NEXT:    ldrb r3, [r3]
-; CHECK-NEXT:    vmov.8 q5[6], r1
+; CHECK-NEXT:    vmov.8 q4[6], r1
 ; CHECK-NEXT:    ldrb r1, [r6]
-; CHECK-NEXT:    vmov.8 q5[7], r3
-; CHECK-NEXT:    vmov r7, r6, d4
-; CHECK-NEXT:    vmov r3, lr, d5
-; CHECK-NEXT:    vmov.8 q5[8], r1
-; CHECK-NEXT:    vadd.i32 q2, q1, r0
-; CHECK-NEXT:    vmov.8 q5[9], r4
-; CHECK-NEXT:    vmov r4, r1, d4
-; CHECK-NEXT:    vmov.8 q5[10], r12
-; CHECK-NEXT:    vmov.8 q5[11], r5
-; CHECK-NEXT:    vldrw.u32 q1, [sp, #264] @ 16-byte Reload
+; CHECK-NEXT:    vmov.8 q4[7], r3
+; CHECK-NEXT:    vmov r7, r6, d10
+; CHECK-NEXT:    vmov r3, lr, d11
+; CHECK-NEXT:    vmov.8 q4[8], r1
+; CHECK-NEXT:    vadd.i32 q5, q1, r0
+; CHECK-NEXT:    vmov.8 q4[9], r4
+; CHECK-NEXT:    vmov r4, r1, d10
+; CHECK-NEXT:    vmov.8 q4[10], r12
+; CHECK-NEXT:    vmov.8 q4[11], r5
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #152] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r7, [r7]
 ; CHECK-NEXT:    ldrb r6, [r6]
 ; CHECK-NEXT:    ldrb r3, [r3]
 ; CHECK-NEXT:    ldrb r4, [r4]
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[8], r4
-; CHECK-NEXT:    vmov r5, r4, d5
-; CHECK-NEXT:    vmov.8 q7[9], r1
-; CHECK-NEXT:    vadd.i32 q2, q0, r0
-; CHECK-NEXT:    vldrw.u32 q0, [sp, #216] @ 16-byte Reload
+; CHECK-NEXT:    vmov.8 q6[8], r4
+; CHECK-NEXT:    vmov r5, r4, d11
+; CHECK-NEXT:    vmov.8 q6[9], r1
+; CHECK-NEXT:    vadd.i32 q5, q0, r0
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #184] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r5, [r5]
 ; CHECK-NEXT:    ldrb r4, [r4]
-; CHECK-NEXT:    vmov.8 q7[10], r5
-; CHECK-NEXT:    vmov.8 q7[11], r4
-; CHECK-NEXT:    vmov.8 q7[12], r7
-; CHECK-NEXT:    vmov.8 q7[13], r6
-; CHECK-NEXT:    vmov.8 q7[14], r3
-; CHECK-NEXT:    vmov r1, r3, d4
+; CHECK-NEXT:    vmov.8 q6[10], r5
+; CHECK-NEXT:    vmov.8 q6[11], r4
+; CHECK-NEXT:    vmov.8 q6[12], r7
+; CHECK-NEXT:    vmov.8 q6[13], r6
+; CHECK-NEXT:    vmov.8 q6[14], r3
+; CHECK-NEXT:    vmov r1, r3, d10
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q5[12], r1
+; CHECK-NEXT:    vmov.8 q4[12], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q5[13], r1
-; CHECK-NEXT:    vmov r1, r3, d5
-; CHECK-NEXT:    vadd.i32 q2, q1, r0
+; CHECK-NEXT:    vmov.8 q4[13], r1
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vadd.i32 q5, q7, r0
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q5[14], r1
+; CHECK-NEXT:    vmov.8 q4[14], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q5[15], r1
+; CHECK-NEXT:    vmov.8 q4[15], r1
 ; CHECK-NEXT:    ldrb.w r1, [lr]
-; CHECK-NEXT:    vmov.8 q7[15], r1
-; CHECK-NEXT:    vmov r1, r3, d4
-; CHECK-NEXT:    vadd.i8 q5, q7, q5
+; CHECK-NEXT:    vmov.8 q6[15], r1
+; CHECK-NEXT:    vmov r1, r3, d10
+; CHECK-NEXT:    vadd.i8 q4, q6, q4
 ; CHECK-NEXT:    ldrb r1, [r1]
 ; CHECK-NEXT:    ldrb r3, [r3]
-; CHECK-NEXT:    vmov.8 q7[0], r1
-; CHECK-NEXT:    vmov.8 q7[1], r3
-; CHECK-NEXT:    vmov r1, r3, d5
-; CHECK-NEXT:    vadd.i32 q2, q4, r0
+; CHECK-NEXT:    vmov.8 q6[0], r1
+; CHECK-NEXT:    vmov.8 q6[1], r3
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vadd.i32 q5, q0, r0
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[2], r1
+; CHECK-NEXT:    vmov.8 q6[2], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[3], r1
-; CHECK-NEXT:    vmov r1, r3, d4
+; CHECK-NEXT:    vmov.8 q6[3], r1
+; CHECK-NEXT:    vmov r1, r3, d10
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[4], r1
+; CHECK-NEXT:    vmov.8 q6[4], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[5], r1
-; CHECK-NEXT:    vmov r1, r3, d5
-; CHECK-NEXT:    vadd.i32 q2, q6, r0
+; CHECK-NEXT:    vmov.8 q6[5], r1
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vadd.i32 q5, q2, r0
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[6], r1
+; CHECK-NEXT:    vmov.8 q6[6], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[7], r1
-; CHECK-NEXT:    vmov r1, r3, d4
+; CHECK-NEXT:    vmov.8 q6[7], r1
+; CHECK-NEXT:    vmov r1, r3, d10
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[8], r1
+; CHECK-NEXT:    vmov.8 q6[8], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[9], r1
-; CHECK-NEXT:    vmov r1, r3, d5
-; CHECK-NEXT:    vadd.i32 q2, q0, r0
+; CHECK-NEXT:    vmov.8 q6[9], r1
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vadd.i32 q5, q1, r0
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[10], r1
+; CHECK-NEXT:    vmov.8 q6[10], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[11], r1
-; CHECK-NEXT:    vmov r1, r3, d4
+; CHECK-NEXT:    vmov.8 q6[11], r1
+; CHECK-NEXT:    vmov r1, r3, d10
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[12], r1
+; CHECK-NEXT:    vmov.8 q6[12], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[13], r1
-; CHECK-NEXT:    vmov r1, r3, d5
+; CHECK-NEXT:    vmov.8 q6[13], r1
+; CHECK-NEXT:    vmov r1, r3, d11
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #136] @ 16-byte Reload
 ; CHECK-NEXT:    ldrb r1, [r1]
-; CHECK-NEXT:    vmov.8 q7[14], r1
+; CHECK-NEXT:    vmov.8 q6[14], r1
 ; CHECK-NEXT:    ldrb r1, [r3]
-; CHECK-NEXT:    vmov.8 q7[15], r1
-; CHECK-NEXT:    vadd.i8 q2, q5, q7
-; CHECK-NEXT:    vldrw.u32 q5, [sp, #200] @ 16-byte Reload
-; CHECK-NEXT:    vstrb.8 q2, [r8], #16
-; CHECK-NEXT:    vmov.i32 q2, #0x30
-; CHECK-NEXT:    vadd.i32 q6, q6, q2
-; CHECK-NEXT:    vadd.i32 q3, q3, q2
-; CHECK-NEXT:    vstrw.32 q6, [sp, #232] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #296] @ 16-byte Reload
-; CHECK-NEXT:    vadd.i32 q1, q1, q2
-; CHECK-NEXT:    vadd.i32 q4, q4, q2
-; CHECK-NEXT:    vadd.i32 q6, q6, q2
-; CHECK-NEXT:    vadd.i32 q0, q0, q2
-; CHECK-NEXT:    vmov q7, q3
-; CHECK-NEXT:    vldrw.u32 q3, [sp, #136] @ 16-byte Reload
-; CHECK-NEXT:    vstrw.32 q1, [sp, #264] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q1, [sp, #152] @ 16-byte Reload
-; CHECK-NEXT:    vstrw.32 q4, [sp, #248] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q4, [sp, #168] @ 16-byte Reload
-; CHECK-NEXT:    vstrw.32 q6, [sp, #296] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #120] @ 16-byte Reload
-; CHECK-NEXT:    vstrw.32 q0, [sp, #216] @ 16-byte Spill
+; CHECK-NEXT:    vmov.8 q6[15], r1
+; CHECK-NEXT:    vadd.i8 q4, q4, q6
+; CHECK-NEXT:    vldrw.u32 q6, [sp, #248] @ 16-byte Reload
+; CHECK-NEXT:    vstrb.8 q4, [r8], #16
+; CHECK-NEXT:    vmov.i32 q4, #0x30
+; CHECK-NEXT:    vadd.i32 q0, q0, q4
+; CHECK-NEXT:    vadd.i32 q7, q7, q4
+; CHECK-NEXT:    vstrw.32 q0, [sp, #184] @ 16-byte Spill
 ; CHECK-NEXT:    vldrw.u32 q0, [sp, #280] @ 16-byte Reload
-; CHECK-NEXT:    vadd.i32 q5, q5, q2
-; CHECK-NEXT:    vadd.i32 q3, q3, q2
-; CHECK-NEXT:    vadd.i32 q0, q0, q2
-; CHECK-NEXT:    vadd.i32 q4, q4, q2
-; CHECK-NEXT:    vadd.i32 q1, q1, q2
-; CHECK-NEXT:    vadd.i32 q6, q6, q2
+; CHECK-NEXT:    vstrw.32 q7, [sp, #200] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #120] @ 16-byte Reload
+; CHECK-NEXT:    vadd.i32 q0, q0, q4
+; CHECK-NEXT:    vadd.i32 q6, q6, q4
 ; CHECK-NEXT:    vstrw.32 q0, [sp, #280] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #216] @ 16-byte Reload
+; CHECK-NEXT:    vadd.i32 q2, q2, q4
+; CHECK-NEXT:    vadd.i32 q1, q1, q4
+; CHECK-NEXT:    vadd.i32 q0, q0, q4
+; CHECK-NEXT:    vadd.i32 q3, q3, q4
+; CHECK-NEXT:    vstrw.32 q0, [sp, #216] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #232] @ 16-byte Reload
+; CHECK-NEXT:    vadd.i32 q5, q5, q4
+; CHECK-NEXT:    vadd.i32 q7, q7, q4
+; CHECK-NEXT:    vadd.i32 q0, q0, q4
+; CHECK-NEXT:    vstrw.32 q6, [sp, #248] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q0, [sp, #232] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #264] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q2, [sp, #168] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q1, [sp, #152] @ 16-byte Spill
+; CHECK-NEXT:    vadd.i32 q0, q0, q4
+; CHECK-NEXT:    vstrw.32 q0, [sp, #264] @ 16-byte Spill
 ; CHECK-NEXT:    bne.w .LBB16_3
 ; CHECK-NEXT:  @ %bb.4: @ %middle.block
 ; CHECK-NEXT:    @ in Loop: Header=BB16_2 Depth=1
 ; CHECK-NEXT:    cmp r10, r2
 ; CHECK-NEXT:    bne.w .LBB16_2
 ; CHECK-NEXT:  .LBB16_5: @ %for.cond.cleanup
-; CHECK-NEXT:    add sp, #312
+; CHECK-NEXT:    add sp, #296
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, pc}

--- a/llvm/test/CodeGen/Thumb2/mve-gather-scatter-optimisation.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-gather-scatter-optimisation.ll
@@ -602,46 +602,46 @@ define dso_local void @arm_mat_mult_q15(ptr noalias nocapture readonly %A, ptr n
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    .pad #4
 ; CHECK-NEXT:    sub sp, #4
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    .pad #32
 ; CHECK-NEXT:    sub sp, #32
 ; CHECK-NEXT:    strd r0, r2, [sp, #24] @ 8-byte Folded Spill
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    str r3, [sp, #8] @ 4-byte Spill
 ; CHECK-NEXT:    itt ne
-; CHECK-NEXT:    ldrne r0, [sp, #136]
+; CHECK-NEXT:    ldrne r0, [sp, #120]
 ; CHECK-NEXT:    cmpne r0, #0
 ; CHECK-NEXT:    bne .LBB10_2
 ; CHECK-NEXT:  .LBB10_1: @ %for.cond.cleanup
 ; CHECK-NEXT:    add sp, #32
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ; CHECK-NEXT:  .LBB10_2: @ %for.cond1.preheader.us.preheader
-; CHECK-NEXT:    ldr.w r12, [sp, #140]
+; CHECK-NEXT:    ldr.w r12, [sp, #124]
 ; CHECK-NEXT:    movs r7, #1
 ; CHECK-NEXT:    mov.w r11, #0
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    bic r2, r12, #3
 ; CHECK-NEXT:    subs r3, r2, #4
 ; CHECK-NEXT:    add.w r0, r7, r3, lsr #2
-; CHECK-NEXT:    ldr r7, [sp, #136]
+; CHECK-NEXT:    ldr r7, [sp, #120]
 ; CHECK-NEXT:    adr r3, .LCPI10_0
 ; CHECK-NEXT:    str r0, [sp, #16] @ 4-byte Spill
 ; CHECK-NEXT:    lsl.w r0, r12, #1
-; CHECK-NEXT:    vdup.32 q1, r7
-; CHECK-NEXT:    vldrw.u32 q2, [r3]
+; CHECK-NEXT:    vdup.32 q0, r7
+; CHECK-NEXT:    vldrw.u32 q1, [r3]
 ; CHECK-NEXT:    str r0, [sp, #4] @ 4-byte Spill
 ; CHECK-NEXT:    ldr r0, [sp, #24] @ 4-byte Reload
 ; CHECK-NEXT:    lsls r6, r7, #1
-; CHECK-NEXT:    vshl.i32 q3, q1, #2
+; CHECK-NEXT:    vshl.i32 q2, q0, #2
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    str r0, [sp, #20] @ 4-byte Spill
 ; CHECK-NEXT:    b .LBB10_5
 ; CHECK-NEXT:  .LBB10_3: @ %for.cond5.preheader.us73.preheader
 ; CHECK-NEXT:    @ in Loop: Header=BB10_5 Depth=1
 ; CHECK-NEXT:    ldr r0, [sp, #28] @ 4-byte Reload
+; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    add.w r3, r0, r5, lsl #1
 ; CHECK-NEXT:    wlstp.8 lr, r6, .LBB10_4
 ; CHECK-NEXT:    b .LBB10_15
@@ -693,25 +693,25 @@ define dso_local void @arm_mat_mult_q15(ptr noalias nocapture readonly %A, ptr n
 ; CHECK-NEXT:  .LBB10_10: @ %vector.ph
 ; CHECK-NEXT:    @ in Loop: Header=BB10_8 Depth=2
 ; CHECK-NEXT:    ldr r0, [sp, #16] @ 4-byte Reload
-; CHECK-NEXT:    vmov q5, q1
-; CHECK-NEXT:    vmov.i32 q4, #0x0
-; CHECK-NEXT:    vmlas.i32 q5, q2, r8
+; CHECK-NEXT:    vmov q4, q0
+; CHECK-NEXT:    vmov.i32 q3, #0x0
+; CHECK-NEXT:    vmlas.i32 q4, q1, r8
 ; CHECK-NEXT:    dls lr, r0
 ; CHECK-NEXT:    ldr r3, [sp, #20] @ 4-byte Reload
 ; CHECK-NEXT:  .LBB10_11: @ %vector.body
 ; CHECK-NEXT:    @ Parent Loop BB10_5 Depth=1
 ; CHECK-NEXT:    @ Parent Loop BB10_8 Depth=2
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=3
-; CHECK-NEXT:    vadd.i32 q6, q5, q3
-; CHECK-NEXT:    vldrh.s32 q7, [r1, q5, uxtw #1]
-; CHECK-NEXT:    vldrh.s32 q5, [r3], #8
-; CHECK-NEXT:    vmul.i32 q5, q7, q5
-; CHECK-NEXT:    vadd.i32 q4, q5, q4
-; CHECK-NEXT:    vmov q5, q6
+; CHECK-NEXT:    vadd.i32 q5, q4, q2
+; CHECK-NEXT:    vldrh.s32 q6, [r1, q4, uxtw #1]
+; CHECK-NEXT:    vldrh.s32 q4, [r3], #8
+; CHECK-NEXT:    vmul.i32 q4, q6, q4
+; CHECK-NEXT:    vadd.i32 q3, q4, q3
+; CHECK-NEXT:    vmov q4, q5
 ; CHECK-NEXT:    le lr, .LBB10_11
 ; CHECK-NEXT:  @ %bb.12: @ %middle.block
 ; CHECK-NEXT:    @ in Loop: Header=BB10_8 Depth=2
-; CHECK-NEXT:    vaddv.u32 r10, q4
+; CHECK-NEXT:    vaddv.u32 r10, q3
 ; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    cmp r2, r12
 ; CHECK-NEXT:    beq .LBB10_7
@@ -722,7 +722,7 @@ define dso_local void @arm_mat_mult_q15(ptr noalias nocapture readonly %A, ptr n
 ; CHECK-NEXT:    ldr r7, [sp, #24] @ 4-byte Reload
 ; CHECK-NEXT:    sub.w lr, r12, r4
 ; CHECK-NEXT:    add.w r9, r7, r0, lsl #1
-; CHECK-NEXT:    ldr r7, [sp, #136]
+; CHECK-NEXT:    ldr r7, [sp, #120]
 ; CHECK-NEXT:    add.w r3, r1, r3, lsl #1
 ; CHECK-NEXT:  .LBB10_14: @ %for.body8.us.us
 ; CHECK-NEXT:    @ Parent Loop BB10_5 Depth=1
@@ -736,7 +736,7 @@ define dso_local void @arm_mat_mult_q15(ptr noalias nocapture readonly %A, ptr n
 ; CHECK-NEXT:    b .LBB10_7
 ; CHECK-NEXT:  .LBB10_15: @ Parent Loop BB10_5 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q0, [r3], #16
+; CHECK-NEXT:    vstrb.8 q3, [r3], #16
 ; CHECK-NEXT:    letp lr, .LBB10_15
 ; CHECK-NEXT:    b .LBB10_4
 ; CHECK-NEXT:    .p2align 4

--- a/llvm/test/CodeGen/Thumb2/mve-memtp-branch.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-memtp-branch.ll
@@ -18,10 +18,6 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    movt r5, :upper16:arr_183
 ; CHECK-NEXT:    mov.w r12, #19
-; CHECK-NEXT:    vmov.i32 q0, #0x0
-; CHECK-NEXT:    vmov.i32 q1, #0x0
-; CHECK-NEXT:    vmov.i32 q2, #0x0
-; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    b .LBB0_3
 ; CHECK-NEXT:  .LBB0_2: @ %land.end.us.3
 ; CHECK-NEXT:    @ in Loop: Header=BB0_3 Depth=1
@@ -33,6 +29,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    @ Child Loop BB0_8 Depth 2
 ; CHECK-NEXT:    @ Child Loop BB0_11 Depth 2
 ; CHECK-NEXT:    ldr.w r0, [r2, r3, lsl #2]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r0, [r1, r3]
@@ -48,6 +45,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:  .LBB0_5: @ %land.end.us
 ; CHECK-NEXT:    @ in Loop: Header=BB0_3 Depth=1
 ; CHECK-NEXT:    ldr r0, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r0, [r1, #1]
@@ -58,11 +56,12 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    wlstp.8 lr, r0, .LBB0_7
 ; CHECK-NEXT:  .LBB0_6: @ Parent Loop BB0_3 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q1, [r3], #16
+; CHECK-NEXT:    vstrb.8 q0, [r3], #16
 ; CHECK-NEXT:    letp lr, .LBB0_6
 ; CHECK-NEXT:  .LBB0_7: @ %land.end.us.1
 ; CHECK-NEXT:    @ in Loop: Header=BB0_3 Depth=1
 ; CHECK-NEXT:    ldr r0, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r0, [r1, #1]
@@ -73,11 +72,12 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    wlstp.8 lr, r0, .LBB0_9
 ; CHECK-NEXT:  .LBB0_8: @ Parent Loop BB0_3 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q2, [r3], #16
+; CHECK-NEXT:    vstrb.8 q0, [r3], #16
 ; CHECK-NEXT:    letp lr, .LBB0_8
 ; CHECK-NEXT:  .LBB0_9: @ %land.end.us.2
 ; CHECK-NEXT:    @ in Loop: Header=BB0_3 Depth=1
 ; CHECK-NEXT:    ldr r0, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r0, [r1, #1]
@@ -94,20 +94,17 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    dlstp.8 lr, r0
 ; CHECK-NEXT:  .LBB0_11: @ Parent Loop BB0_3 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q3, [r3], #16
+; CHECK-NEXT:    vstrb.8 q0, [r3], #16
 ; CHECK-NEXT:    letp lr, .LBB0_11
 ; CHECK-NEXT:    b .LBB0_2
 ; CHECK-NEXT:  .LBB0_12:
 ; CHECK-NEXT:    movw r12, :lower16:arr_183
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    movt r12, :upper16:arr_183
-; CHECK-NEXT:    vmov.i32 q1, #0x0
-; CHECK-NEXT:    vmov.i32 q2, #0x0
-; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    b .LBB0_14
 ; CHECK-NEXT:  .LBB0_13: @ %for.body.lr.ph.3
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
 ; CHECK-NEXT:    ldr r3, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r3, [r1, #1]
@@ -128,6 +125,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:  @ %bb.15: @ %for.body.lr.ph
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
 ; CHECK-NEXT:    ldr r3, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r3, [r1, #1]
@@ -147,6 +145,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:  @ %bb.18: @ %for.body.lr.ph.1
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
 ; CHECK-NEXT:    ldr r3, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r3, [r1, #1]
@@ -157,7 +156,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    wlstp.8 lr, r3, .LBB0_20
 ; CHECK-NEXT:  .LBB0_19: @ Parent Loop BB0_14 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q1, [r4], #16
+; CHECK-NEXT:    vstrb.8 q0, [r4], #16
 ; CHECK-NEXT:    letp lr, .LBB0_19
 ; CHECK-NEXT:  .LBB0_20: @ %for.cond.backedge.1
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
@@ -166,6 +165,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:  @ %bb.21: @ %for.body.lr.ph.2
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
 ; CHECK-NEXT:    ldr r3, [r2, #4]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    ite ne
 ; CHECK-NEXT:    ldrbne r3, [r1, #1]
@@ -176,7 +176,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    wlstp.8 lr, r3, .LBB0_23
 ; CHECK-NEXT:  .LBB0_22: @ Parent Loop BB0_14 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q2, [r4], #16
+; CHECK-NEXT:    vstrb.8 q0, [r4], #16
 ; CHECK-NEXT:    letp lr, .LBB0_22
 ; CHECK-NEXT:  .LBB0_23: @ %for.cond.backedge.2
 ; CHECK-NEXT:    @ in Loop: Header=BB0_14 Depth=1
@@ -185,7 +185,7 @@ define i32 @a(i8 zeroext %b, ptr nocapture readonly %c, ptr nocapture readonly %
 ; CHECK-NEXT:    b .LBB0_13
 ; CHECK-NEXT:  .LBB0_24: @ Parent Loop BB0_14 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vstrb.8 q3, [r4], #16
+; CHECK-NEXT:    vstrb.8 q0, [r4], #16
 ; CHECK-NEXT:    letp lr, .LBB0_24
 ; CHECK-NEXT:    b .LBB0_14
 entry:

--- a/llvm/test/CodeGen/Thumb2/mve-memtp-loop.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-memtp-loop.ll
@@ -448,7 +448,6 @@ define void @multilooped_exit(i32 %b) {
 ; CHECK-NEXT:    .save {r4, lr}
 ; CHECK-NEXT:    push {r4, lr}
 ; CHECK-NEXT:    mov.w r4, #-1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    b .LBB18_3
 ; CHECK-NEXT:  .LBB18_2: @ %loop
 ; CHECK-NEXT:    @ in Loop: Header=BB18_3 Depth=1
@@ -464,6 +463,7 @@ define void @multilooped_exit(i32 %b) {
 ; CHECK-NEXT:    movw r3, :lower16:arr_56
 ; CHECK-NEXT:    add.w r1, r0, #15
 ; CHECK-NEXT:    movt r3, :upper16:arr_56
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    lsr.w r12, r1, #4
 ; CHECK-NEXT:    mov r2, r3
 ; CHECK-NEXT:    wlstp.8 lr, r0, .LBB18_5
@@ -567,14 +567,14 @@ define i32 @reverted(i1 zeroext %b) {
 ; CHECK-NEXT:    movw r6, :lower16:arr_20
 ; CHECK-NEXT:    mov.w r8, #327685
 ; CHECK-NEXT:    mov.w r9, #5
-; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    mov.w r10, #0
 ; CHECK-NEXT:    movt r6, :upper16:arr_20
 ; CHECK-NEXT:  .LBB19_3: @ %for.cond8.preheader
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    str r8, [r5, #-4]
-; CHECK-NEXT:    vstrh.16 q1, [r5, #-36]
 ; CHECK-NEXT:    strh.w r9, [r5]
+; CHECK-NEXT:    vstrh.16 q1, [r5, #-36]
 ; CHECK-NEXT:    vstrh.16 q1, [r5, #-20]
 ; CHECK-NEXT:    vstrw.32 q0, [r3]
 ; CHECK-NEXT:    vstrh.16 q0, [r12], #152
@@ -623,13 +623,13 @@ define i32 @reverted(i1 zeroext %b) {
 ; CHECK-NEXT:    mov.w r10, #5
 ; CHECK-NEXT:    dls lr, r6
 ; CHECK-NEXT:    mov.w r6, #327685
-; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    mov.w r11, #0
 ; CHECK-NEXT:  .LBB19_7: @ %for.cond8.preheader.1
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    str r6, [r0, #-4]
-; CHECK-NEXT:    vstrh.16 q1, [r0, #-36]
 ; CHECK-NEXT:    strh.w r10, [r0]
+; CHECK-NEXT:    vstrh.16 q1, [r0, #-36]
 ; CHECK-NEXT:    vstrh.16 q1, [r0, #-20]
 ; CHECK-NEXT:    vstrw.32 q0, [r3]
 ; CHECK-NEXT:    vstrh.16 q0, [r2], #152
@@ -680,13 +680,13 @@ define i32 @reverted(i1 zeroext %b) {
 ; CHECK-NEXT:    mov.w r10, #5
 ; CHECK-NEXT:    dls lr, r7
 ; CHECK-NEXT:    mov.w r7, #327685
-; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    mov.w r11, #0
 ; CHECK-NEXT:  .LBB19_11: @ %for.cond8.preheader.2
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    str r7, [r1, #-4]
-; CHECK-NEXT:    vstrh.16 q1, [r1, #-36]
 ; CHECK-NEXT:    strh.w r10, [r1]
+; CHECK-NEXT:    vstrh.16 q1, [r1, #-36]
 ; CHECK-NEXT:    vstrh.16 q1, [r1, #-20]
 ; CHECK-NEXT:    vstrw.32 q0, [r3]
 ; CHECK-NEXT:    vstrh.16 q0, [r0], #152
@@ -736,15 +736,15 @@ define i32 @reverted(i1 zeroext %b) {
 ; CHECK-NEXT:    add.w r6, r7, #21888
 ; CHECK-NEXT:    ldr r7, [sp, #8] @ 4-byte Reload
 ; CHECK-NEXT:    mov.w r10, #5
-; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    mov.w r11, #0
 ; CHECK-NEXT:    dls lr, r7
 ; CHECK-NEXT:    mov.w r7, #327685
 ; CHECK-NEXT:  .LBB19_15: @ %for.cond8.preheader.3
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.i16 q1, #0x5
 ; CHECK-NEXT:    str r7, [r2, #-4]
-; CHECK-NEXT:    vstrh.16 q1, [r2, #-36]
 ; CHECK-NEXT:    strh.w r10, [r2]
+; CHECK-NEXT:    vstrh.16 q1, [r2, #-36]
 ; CHECK-NEXT:    vstrh.16 q1, [r2, #-20]
 ; CHECK-NEXT:    vstrw.32 q0, [r0]
 ; CHECK-NEXT:    vstrh.16 q0, [r4], #152

--- a/llvm/test/CodeGen/Thumb2/mve-phireg.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-phireg.ll
@@ -8,37 +8,41 @@ define arm_aapcs_vfpcc void @k() {
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
+; CHECK-NEXT:    .vsave {d14}
+; CHECK-NEXT:    vpush {d14}
+; CHECK-NEXT:    .vsave {d12}
+; CHECK-NEXT:    vpush {d12}
+; CHECK-NEXT:    .vsave {d8, d9, d10}
+; CHECK-NEXT:    vpush {d8, d9, d10}
 ; CHECK-NEXT:    .pad #32
 ; CHECK-NEXT:    sub sp, #32
 ; CHECK-NEXT:    adr r5, .LCPI0_0
 ; CHECK-NEXT:    adr r4, .LCPI0_1
-; CHECK-NEXT:    vldrw.u32 q6, [r5]
-; CHECK-NEXT:    vldrw.u32 q5, [r4]
+; CHECK-NEXT:    vldrw.u32 q0, [r5]
+; CHECK-NEXT:    vldrw.u32 q1, [r4]
 ; CHECK-NEXT:    add r0, sp, #16
-; CHECK-NEXT:    vmov.i32 q0, #0x1
-; CHECK-NEXT:    vmov.i8 q1, #0x0
-; CHECK-NEXT:    vmov.i8 q2, #0xff
-; CHECK-NEXT:    vmov.i16 q3, #0x6
-; CHECK-NEXT:    vmov.i16 q4, #0x3
 ; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:  .LBB0_1: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vand q5, q5, q0
-; CHECK-NEXT:    vand q6, q6, q0
-; CHECK-NEXT:    vcmp.i32 eq, q5, zr
-; CHECK-NEXT:    vpsel q5, q2, q1
-; CHECK-NEXT:    vcmp.i32 eq, q6, zr
-; CHECK-NEXT:    vpsel q6, q2, q1
-; CHECK-NEXT:    vstrh.32 q5, [r0]
-; CHECK-NEXT:    vstrh.32 q6, [r0, #8]
-; CHECK-NEXT:    vldrw.u32 q5, [r0]
-; CHECK-NEXT:    vcmp.i16 ne, q5, zr
-; CHECK-NEXT:    vmov.i32 q5, #0x0
-; CHECK-NEXT:    vpsel q6, q4, q3
-; CHECK-NEXT:    vstrh.16 q6, [r0]
-; CHECK-NEXT:    vmov.i32 q6, #0x0
+; CHECK-NEXT:    vmov.i32 q2, #0x1
+; CHECK-NEXT:    vmov.i8 q3, #0xff
+; CHECK-NEXT:    vand q1, q1, q2
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vcmp.i32 eq, q1, zr
+; CHECK-NEXT:    vmov.i8 q1, #0x0
+; CHECK-NEXT:    vpsel q4, q3, q1
+; CHECK-NEXT:    vcmp.i32 eq, q0, zr
+; CHECK-NEXT:    vpsel q0, q3, q1
+; CHECK-NEXT:    vstrh.32 q4, [r0]
+; CHECK-NEXT:    vstrh.32 q0, [r0, #8]
+; CHECK-NEXT:    vmov.i16 q1, #0x6
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vmov.i16 q2, #0x3
+; CHECK-NEXT:    vcmp.i16 ne, q0, zr
+; CHECK-NEXT:    vpsel q0, q2, q1
+; CHECK-NEXT:    vmov.i32 q1, #0x0
+; CHECK-NEXT:    vstrh.16 q0, [r0]
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    cbz r1, .LBB0_2
 ; CHECK-NEXT:    le .LBB0_1
 ; CHECK-NEXT:  .LBB0_2: @ %for.cond4.preheader

--- a/llvm/test/CodeGen/Thumb2/mve-pred-threshold.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-pred-threshold.ll
@@ -13,15 +13,17 @@ define arm_aapcs_vfpcc void @thres_i32(ptr %data, i16 zeroext %N, i32 %T) {
 ; CHECK-NEXT:    mvn r3, #3
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #2
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #2
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB0_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-NEXT:    vpte.s32 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s32 le, q1, r1
-; CHECK-NEXT:    vstrwe.32 q0, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vpt.s32 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s32 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrwt.32 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB0_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -67,15 +69,17 @@ define arm_aapcs_vfpcc void @thresh_i16(ptr %data, i16 zeroext %N, i16 signext %
 ; CHECK-NEXT:    mvn r3, #7
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #3
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #3
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB1_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrh.u16 q1, [r0]
-; CHECK-NEXT:    vpte.s16 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s16 le, q1, r1
-; CHECK-NEXT:    vstrhe.16 q0, [r0], #16
+; CHECK-NEXT:    vldrh.u16 q0, [r0]
+; CHECK-NEXT:    vpt.s16 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s16 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrht.16 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB1_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -121,15 +125,17 @@ define arm_aapcs_vfpcc void @thresh_i8(ptr %data, i16 zeroext %N, i8 signext %T)
 ; CHECK-NEXT:    mvn r3, #15
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #4
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #4
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB2_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrb.u8 q1, [r0]
-; CHECK-NEXT:    vpte.s8 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s8 le, q1, r1
-; CHECK-NEXT:    vstrbe.8 q0, [r0], #16
+; CHECK-NEXT:    vldrb.u8 q0, [r0]
+; CHECK-NEXT:    vpt.s8 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s8 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrbt.8 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB2_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -177,14 +183,16 @@ define arm_aapcs_vfpcc void @thresh_f32(ptr %data, i16 zeroext %N, float %T) {
 ; CHECK-NEXT:    movs r2, #1
 ; CHECK-NEXT:    add.w lr, r2, r1, lsr #2
 ; CHECK-NEXT:    vmov r1, s0
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    eor r2, r1, #-2147483648
 ; CHECK-NEXT:  .LBB3_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-NEXT:    vpte.f32 ge, q1, r1
-; CHECK-NEXT:    vcmpt.f32 le, q1, r2
-; CHECK-NEXT:    vstrwe.32 q0, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vpt.f32 ge, q0, r1
+; CHECK-NEXT:    vcmpt.f32 le, q0, r2
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrwt.32 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB3_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -234,13 +242,15 @@ define arm_aapcs_vfpcc void @thresh_f16(ptr %data, i16 zeroext %N, float %T.coer
 ; CHECK-NEXT:    movs r3, #1
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #3
 ; CHECK-NEXT:    vmov.f16 r1, s0
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:  .LBB4_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrh.u16 q1, [r0]
-; CHECK-NEXT:    vpte.f16 ge, q1, r2
-; CHECK-NEXT:    vcmpt.f16 le, q1, r1
-; CHECK-NEXT:    vstrhe.16 q0, [r0], #16
+; CHECK-NEXT:    vldrh.u16 q0, [r0]
+; CHECK-NEXT:    vpt.f16 ge, q0, r2
+; CHECK-NEXT:    vcmpt.f16 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrht.16 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB4_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -291,15 +301,17 @@ define arm_aapcs_vfpcc void @thres_rev_i32(ptr %data, i16 zeroext %N, i32 %T) {
 ; CHECK-NEXT:    mvn r3, #3
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #2
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #2
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB5_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-NEXT:    vpte.s32 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s32 le, q1, r1
-; CHECK-NEXT:    vstrwe.32 q0, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vpt.s32 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s32 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrwt.32 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB5_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -345,15 +357,17 @@ define arm_aapcs_vfpcc void @thresh_rev_i16(ptr %data, i16 zeroext %N, i16 signe
 ; CHECK-NEXT:    mvn r3, #7
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #3
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #3
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB6_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrh.u16 q1, [r0]
-; CHECK-NEXT:    vpte.s16 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s16 le, q1, r1
-; CHECK-NEXT:    vstrhe.16 q0, [r0], #16
+; CHECK-NEXT:    vldrh.u16 q0, [r0]
+; CHECK-NEXT:    vpt.s16 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s16 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrht.16 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB6_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -399,15 +413,17 @@ define arm_aapcs_vfpcc void @thresh_rev_i8(ptr %data, i16 zeroext %N, i8 signext
 ; CHECK-NEXT:    mvn r3, #15
 ; CHECK-NEXT:    add.w r1, r3, r1, lsl #4
 ; CHECK-NEXT:    movs r3, #1
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #4
 ; CHECK-NEXT:    rsbs r1, r2, #0
 ; CHECK-NEXT:  .LBB7_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrb.u8 q1, [r0]
-; CHECK-NEXT:    vpte.s8 ge, q1, r2
-; CHECK-NEXT:    vcmpt.s8 le, q1, r1
-; CHECK-NEXT:    vstrbe.8 q0, [r0], #16
+; CHECK-NEXT:    vldrb.u8 q0, [r0]
+; CHECK-NEXT:    vpt.s8 ge, q0, r2
+; CHECK-NEXT:    vcmpt.s8 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrbt.8 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB7_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -455,14 +471,16 @@ define arm_aapcs_vfpcc void @thresh_rev_f32(ptr %data, i16 zeroext %N, float %T)
 ; CHECK-NEXT:    movs r2, #1
 ; CHECK-NEXT:    add.w lr, r2, r1, lsr #2
 ; CHECK-NEXT:    vmov r1, s0
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    eor r2, r1, #-2147483648
 ; CHECK-NEXT:  .LBB8_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0]
-; CHECK-NEXT:    vpte.f32 ge, q1, r1
-; CHECK-NEXT:    vcmpt.f32 le, q1, r2
-; CHECK-NEXT:    vstrwe.32 q0, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0]
+; CHECK-NEXT:    vpt.f32 ge, q0, r1
+; CHECK-NEXT:    vcmpt.f32 le, q0, r2
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrwt.32 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB8_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -512,13 +530,15 @@ define arm_aapcs_vfpcc void @thresh_rev_f16(ptr %data, i16 zeroext %N, float %T.
 ; CHECK-NEXT:    movs r3, #1
 ; CHECK-NEXT:    add.w lr, r3, r1, lsr #3
 ; CHECK-NEXT:    vmov.f16 r1, s0
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:  .LBB9_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrh.u16 q1, [r0]
-; CHECK-NEXT:    vpte.f16 ge, q1, r2
-; CHECK-NEXT:    vcmpt.f16 le, q1, r1
-; CHECK-NEXT:    vstrhe.16 q0, [r0], #16
+; CHECK-NEXT:    vldrh.u16 q0, [r0]
+; CHECK-NEXT:    vpt.f16 ge, q0, r2
+; CHECK-NEXT:    vcmpt.f16 le, q0, r1
+; CHECK-NEXT:    vmov.i32 q0, #0x0
+; CHECK-NEXT:    vpnot
+; CHECK-NEXT:    vpst
+; CHECK-NEXT:    vstrht.16 q0, [r0], #16
 ; CHECK-NEXT:    le lr, .LBB9_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}

--- a/llvm/test/CodeGen/Thumb2/mve-qrintrsplat.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-qrintrsplat.ll
@@ -1144,13 +1144,13 @@ define void @vaddqf(ptr %x, ptr %y, i32 %n) {
 ; CHECK-NEXT:    it lt
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB26_1: @ %for.body.preheader
-; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    dlstp.32 lr, r2
 ; CHECK-NEXT:  .LBB26_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
-; CHECK-NEXT:    vadd.f32 q1, q1, q0
-; CHECK-NEXT:    vstrw.32 q1, [r1], #16
+; CHECK-NEXT:    vadd.f32 q0, q1, q0
+; CHECK-NEXT:    vstrw.32 q0, [r1], #16
 ; CHECK-NEXT:    letp lr, .LBB26_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -1231,13 +1231,13 @@ define void @vsubqf(ptr %x, ptr %y, i32 %n) {
 ; CHECK-NEXT:    it lt
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB28_1: @ %for.body.preheader
-; CHECK-NEXT:    vmov.f32 q0, #-1.000000e+01
 ; CHECK-NEXT:    dlstp.32 lr, r2
 ; CHECK-NEXT:  .LBB28_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.f32 q0, #-1.000000e+01
 ; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
-; CHECK-NEXT:    vadd.f32 q1, q1, q0
-; CHECK-NEXT:    vstrw.32 q1, [r1], #16
+; CHECK-NEXT:    vadd.f32 q0, q1, q0
+; CHECK-NEXT:    vstrw.32 q0, [r1], #16
 ; CHECK-NEXT:    letp lr, .LBB28_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -1318,13 +1318,13 @@ define void @vmulqf(ptr %x, ptr %y, i32 %n) {
 ; CHECK-NEXT:    it lt
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB30_1: @ %for.body.preheader
-; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    dlstp.32 lr, r2
 ; CHECK-NEXT:  .LBB30_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
-; CHECK-NEXT:    vmul.f32 q1, q1, q0
-; CHECK-NEXT:    vstrw.32 q1, [r1], #16
+; CHECK-NEXT:    vmul.f32 q0, q1, q0
+; CHECK-NEXT:    vstrw.32 q0, [r1], #16
 ; CHECK-NEXT:    letp lr, .LBB30_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -1405,14 +1405,14 @@ define void @vfmaq(ptr %x, ptr %y, i32 %n) {
 ; CHECK-NEXT:    it lt
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB32_1: @ %for.body.preheader
-; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    dlstp.32 lr, r2
 ; CHECK-NEXT:  .LBB32_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r1]
-; CHECK-NEXT:    vldrw.u32 q2, [r0], #16
-; CHECK-NEXT:    vfma.f32 q2, q1, q0
-; CHECK-NEXT:    vstrw.32 q2, [r1], #16
+; CHECK-NEXT:    vmov.f32 q2, #1.000000e+01
+; CHECK-NEXT:    vldrw.u32 q0, [r1]
+; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
+; CHECK-NEXT:    vfma.f32 q1, q0, q2
+; CHECK-NEXT:    vstrw.32 q1, [r1], #16
 ; CHECK-NEXT:    letp lr, .LBB32_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -1450,14 +1450,14 @@ define void @vfma(ptr %s1, ptr %s2, i32 %N) {
 ; CHECK-NEXT:    it lt
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB33_1: @ %while.body.lr.ph
-; CHECK-NEXT:    vmov.f32 q0, #1.000000e+01
 ; CHECK-NEXT:    dlstp.32 lr, r2
 ; CHECK-NEXT:  .LBB33_2: @ %while.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r1]
-; CHECK-NEXT:    vldrw.u32 q2, [r0]
-; CHECK-NEXT:    vfma.f32 q2, q1, q0
-; CHECK-NEXT:    vstrw.32 q2, [r0], #16
+; CHECK-NEXT:    vmov.f32 q2, #1.000000e+01
+; CHECK-NEXT:    vldrw.u32 q0, [r1]
+; CHECK-NEXT:    vldrw.u32 q1, [r0]
+; CHECK-NEXT:    vfma.f32 q1, q0, q2
+; CHECK-NEXT:    vstrw.32 q1, [r0], #16
 ; CHECK-NEXT:    letp lr, .LBB33_2
 ; CHECK-NEXT:  @ %bb.3: @ %while.end
 ; CHECK-NEXT:    pop {r7, pc}
@@ -1600,11 +1600,9 @@ define void @rgbconvert(ptr noalias %pwSourceBase, i16 signext %iSourceStride, p
 ; CHECK-NEXT:    mov.w r11, #8388608
 ; CHECK-NEXT:    mov.w r4, #67108864
 ; CHECK-NEXT:    sxth.w r12, r2
-; CHECK-NEXT:    vmov.i32 q0, #0xf800
-; CHECK-NEXT:    vmov.i32 q1, #0x1f
 ; CHECK-NEXT:    mov.w r2, #2016
 ; CHECK-NEXT:    mov.w r7, #268435456
-; CHECK-NEXT:    vdup.32 q2, r2
+; CHECK-NEXT:    vdup.32 q0, r2
 ; CHECK-NEXT:  .LBB36_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB36_3 Depth 2
@@ -1614,16 +1612,18 @@ define void @rgbconvert(ptr noalias %pwSourceBase, i16 signext %iSourceStride, p
 ; CHECK-NEXT:  .LBB36_3: @ %do.body
 ; CHECK-NEXT:    @ Parent Loop BB36_2 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
+; CHECK-NEXT:    vmov.i32 q2, #0x1f
 ; CHECK-NEXT:    vldrw.u32 q3, [r5], #16
+; CHECK-NEXT:    vmov.i32 q1, #0xf800
 ; CHECK-NEXT:    vqdmulh.s32 q4, q3, r4
 ; CHECK-NEXT:    vqdmulh.s32 q5, q3, r7
 ; CHECK-NEXT:    vqdmulh.s32 q3, q3, r11
-; CHECK-NEXT:    vand q4, q4, q2
-; CHECK-NEXT:    vand q5, q5, q1
-; CHECK-NEXT:    vand q3, q3, q0
-; CHECK-NEXT:    vorr q4, q4, q5
-; CHECK-NEXT:    vorr q3, q4, q3
-; CHECK-NEXT:    vstrh.32 q3, [r2], #8
+; CHECK-NEXT:    vand q4, q4, q0
+; CHECK-NEXT:    vand q2, q5, q2
+; CHECK-NEXT:    vand q1, q3, q1
+; CHECK-NEXT:    vorr q2, q4, q2
+; CHECK-NEXT:    vorr q1, q2, q1
+; CHECK-NEXT:    vstrh.32 q1, [r2], #8
 ; CHECK-NEXT:    letp lr, .LBB36_3
 ; CHECK-NEXT:  @ %bb.4: @ %do.end
 ; CHECK-NEXT:    @ in Loop: Header=BB36_2 Depth=1

--- a/llvm/test/CodeGen/Thumb2/mve-satmul-loops.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-satmul-loops.ll
@@ -636,12 +636,12 @@ define arm_aapcs_vfpcc void @usatmul_2_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    add.w lr, r6, r7, lsr #1
 ; CHECK-NEXT:    add.w r10, r1, r3, lsl #2
 ; CHECK-NEXT:    add.w r12, r0, r3, lsl #2
-; CHECK-NEXT:    vmov.i64 q0, #0xffffffff
 ; CHECK-NEXT:  .LBB3_4: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    ldrd r4, r6, [r0], #8
 ; CHECK-NEXT:    mov.w r8, #0
 ; CHECK-NEXT:    ldrd r7, r3, [r1], #8
+; CHECK-NEXT:    vmov.i64 q1, #0xffffffff
 ; CHECK-NEXT:    umull r4, r9, r7, r4
 ; CHECK-NEXT:    lsrl r4, r9, #31
 ; CHECK-NEXT:    subs.w r5, r4, #-1
@@ -651,15 +651,15 @@ define arm_aapcs_vfpcc void @usatmul_2_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    umull r6, r5, r3, r6
 ; CHECK-NEXT:    lsrl r6, r5, #31
 ; CHECK-NEXT:    subs.w r7, r6, #-1
-; CHECK-NEXT:    vmov q1[2], q1[0], r4, r6
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r6
 ; CHECK-NEXT:    sbcs r3, r5, #0
-; CHECK-NEXT:    vmov q1[3], q1[1], r9, r5
+; CHECK-NEXT:    vmov q0[3], q0[1], r9, r5
 ; CHECK-NEXT:    csetm r3, lo
 ; CHECK-NEXT:    bfi r8, r3, #8, #8
 ; CHECK-NEXT:    vmsr p0, r8
-; CHECK-NEXT:    vpsel q1, q1, q0
-; CHECK-NEXT:    vmov r3, s6
-; CHECK-NEXT:    vmov r4, s4
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov r3, s2
+; CHECK-NEXT:    vmov r4, s0
 ; CHECK-NEXT:    strd r4, r3, [r2], #8
 ; CHECK-NEXT:    le lr, .LBB3_4
 ; CHECK-NEXT:  @ %bb.5: @ %middle.block
@@ -759,8 +759,8 @@ define arm_aapcs_vfpcc void @usatmul_4_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    .pad #4
 ; CHECK-NEXT:    sub sp, #4
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-NEXT:    .vsave {d8, d9}
+; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    .pad #16
 ; CHECK-NEXT:    sub sp, #16
 ; CHECK-NEXT:    cmp r3, #0
@@ -785,33 +785,33 @@ define arm_aapcs_vfpcc void @usatmul_4_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    add.w r7, r2, r3, lsl #2
 ; CHECK-NEXT:    str r7, [sp] @ 4-byte Spill
 ; CHECK-NEXT:    add.w r12, r0, r3, lsl #2
-; CHECK-NEXT:    vmov.i64 q0, #0xffffffff
 ; CHECK-NEXT:  .LBB4_4: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
-; CHECK-NEXT:    vldrw.u32 q2, [r1], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q1, [r1], #16
 ; CHECK-NEXT:    movs r6, #0
 ; CHECK-NEXT:    str r2, [sp, #12] @ 4-byte Spill
+; CHECK-NEXT:    vmov.f32 s8, s2
+; CHECK-NEXT:    vmov.f32 s10, s3
 ; CHECK-NEXT:    vmov.f32 s12, s6
 ; CHECK-NEXT:    vmov.f32 s14, s7
-; CHECK-NEXT:    vmov.f32 s16, s10
-; CHECK-NEXT:    vmov.f32 s18, s11
-; CHECK-NEXT:    vmullb.u32 q5, q4, q3
-; CHECK-NEXT:    vmov.f32 s6, s5
-; CHECK-NEXT:    vmov r4, r9, d10
+; CHECK-NEXT:    vmullb.u32 q4, q3, q2
+; CHECK-NEXT:    vmov.f32 s2, s1
+; CHECK-NEXT:    vmov r4, r9, d8
+; CHECK-NEXT:    vmov.i64 q3, #0xffffffff
 ; CHECK-NEXT:    lsrl r4, r9, #31
-; CHECK-NEXT:    vmov.f32 s10, s9
+; CHECK-NEXT:    vmov.f32 s6, s5
 ; CHECK-NEXT:    subs.w r5, r4, #-1
 ; CHECK-NEXT:    sbcs r5, r9, #0
-; CHECK-NEXT:    vmullb.u32 q4, q2, q1
 ; CHECK-NEXT:    csetm r5, lo
 ; CHECK-NEXT:    bfi r6, r5, #0, #8
-; CHECK-NEXT:    vmov r8, r5, d11
+; CHECK-NEXT:    vmov r8, r5, d9
 ; CHECK-NEXT:    lsrl r8, r5, #31
+; CHECK-NEXT:    vmullb.u32 q4, q1, q0
 ; CHECK-NEXT:    subs.w r11, r8, #-1
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r8
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r8
 ; CHECK-NEXT:    sbcs r7, r5, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r9, r5
+; CHECK-NEXT:    vmov q2[3], q2[1], r9, r5
 ; CHECK-NEXT:    csetm r7, lo
 ; CHECK-NEXT:    bfi r6, r7, #8, #8
 ; CHECK-NEXT:    vmov r4, r7, d8
@@ -820,24 +820,24 @@ define arm_aapcs_vfpcc void @usatmul_4_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    subs.w r5, r4, #-1
 ; CHECK-NEXT:    mov.w r6, #0
 ; CHECK-NEXT:    sbcs r5, r7, #0
-; CHECK-NEXT:    vpsel q3, q3, q0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    csetm r5, lo
 ; CHECK-NEXT:    bfi r6, r5, #0, #8
 ; CHECK-NEXT:    vmov r2, r5, d9
 ; CHECK-NEXT:    lsrl r2, r5, #31
 ; CHECK-NEXT:    subs.w r3, r2, #-1
-; CHECK-NEXT:    vmov q1[2], q1[0], r4, r2
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    sbcs r3, r5, #0
-; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
+; CHECK-NEXT:    vmov q0[3], q0[1], r7, r5
 ; CHECK-NEXT:    csetm r3, lo
 ; CHECK-NEXT:    bfi r6, r3, #8, #8
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    ldr r2, [sp, #12] @ 4-byte Reload
-; CHECK-NEXT:    vpsel q1, q1, q0
-; CHECK-NEXT:    vmov.f32 s5, s6
-; CHECK-NEXT:    vmov.f32 s6, s12
-; CHECK-NEXT:    vmov.f32 s7, s14
-; CHECK-NEXT:    vstrb.8 q1, [r2], #16
+; CHECK-NEXT:    vpsel q0, q0, q3
+; CHECK-NEXT:    vmov.f32 s1, s2
+; CHECK-NEXT:    vmov.f32 s2, s8
+; CHECK-NEXT:    vmov.f32 s3, s10
+; CHECK-NEXT:    vstrb.8 q0, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB4_4
 ; CHECK-NEXT:  @ %bb.5: @ %middle.block
 ; CHECK-NEXT:    ldrd r7, r3, [sp, #4] @ 8-byte Folded Reload
@@ -860,7 +860,7 @@ define arm_aapcs_vfpcc void @usatmul_4_q31(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    le lr, .LBB4_7
 ; CHECK-NEXT:  .LBB4_8: @ %for.cond.cleanup
 ; CHECK-NEXT:    add sp, #16
-; CHECK-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 entry:
@@ -1407,54 +1407,54 @@ define arm_aapcs_vfpcc void @ssatmul_8t_q15(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    .pad #16
 ; CHECK-NEXT:    sub sp, #16
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    beq .LBB9_3
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
 ; CHECK-NEXT:    adds r4, r3, #7
-; CHECK-NEXT:    vmov.i8 q2, #0x0
+; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    bic r4, r4, #7
-; CHECK-NEXT:    vmov.i8 q3, #0xff
 ; CHECK-NEXT:    sub.w r12, r4, #8
 ; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    add.w lr, r4, r12, lsr #3
 ; CHECK-NEXT:    adr r4, .LCPI9_0
 ; CHECK-NEXT:    vldrw.u32 q0, [r4]
 ; CHECK-NEXT:    adr r4, .LCPI9_1
 ; CHECK-NEXT:    sub.w r12, r3, #1
-; CHECK-NEXT:    vldrw.u32 q4, [r4]
+; CHECK-NEXT:    vldrw.u32 q2, [r4]
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vdup.32 q1, r12
 ; CHECK-NEXT:  .LBB9_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vdup.32 q5, r3
-; CHECK-NEXT:    adds r3, #8
-; CHECK-NEXT:    vorr q6, q5, q0
-; CHECK-NEXT:    vorr q5, q5, q4
-; CHECK-NEXT:    vcmp.u32 cs, q1, q6
-; CHECK-NEXT:    vpsel q6, q3, q2
-; CHECK-NEXT:    vcmp.u32 cs, q1, q5
-; CHECK-NEXT:    vpsel q5, q3, q2
+; CHECK-NEXT:    vdup.32 q3, r3
+; CHECK-NEXT:    vmov.i8 q5, #0xff
+; CHECK-NEXT:    vorr q4, q3, q0
+; CHECK-NEXT:    vorr q3, q3, q2
+; CHECK-NEXT:    vcmp.u32 cs, q1, q4
+; CHECK-NEXT:    vmov.i8 q4, #0x0
+; CHECK-NEXT:    vpsel q6, q5, q4
+; CHECK-NEXT:    vcmp.u32 cs, q1, q3
+; CHECK-NEXT:    vpsel q3, q5, q4
 ; CHECK-NEXT:    vstrh.32 q6, [r5, #8]
-; CHECK-NEXT:    vstrh.32 q5, [r5]
-; CHECK-NEXT:    vldrw.u32 q5, [r5]
-; CHECK-NEXT:    vptt.i16 ne, q5, zr
-; CHECK-NEXT:    vldrht.u16 q5, [r0], #16
-; CHECK-NEXT:    vldrht.u16 q6, [r1], #16
-; CHECK-NEXT:    vmullt.s16 q7, q6, q5
-; CHECK-NEXT:    vmullb.s16 q5, q6, q5
-; CHECK-NEXT:    vqshrnb.s32 q5, q5, #15
-; CHECK-NEXT:    vqshrnt.s32 q5, q7, #15
+; CHECK-NEXT:    vstrh.32 q3, [r5]
+; CHECK-NEXT:    adds r3, #8
+; CHECK-NEXT:    vldrw.u32 q3, [r5]
+; CHECK-NEXT:    vptt.i16 ne, q3, zr
+; CHECK-NEXT:    vldrht.u16 q3, [r0], #16
+; CHECK-NEXT:    vldrht.u16 q4, [r1], #16
+; CHECK-NEXT:    vmullt.s16 q5, q4, q3
+; CHECK-NEXT:    vmullb.s16 q3, q4, q3
+; CHECK-NEXT:    vqshrnb.s32 q3, q3, #15
+; CHECK-NEXT:    vqshrnt.s32 q3, q5, #15
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vstrht.16 q5, [r2], #16
+; CHECK-NEXT:    vstrht.16 q3, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB9_2
 ; CHECK-NEXT:  .LBB9_3: @ %for.cond.cleanup
 ; CHECK-NEXT:    add sp, #16
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
@@ -1514,54 +1514,54 @@ define arm_aapcs_vfpcc void @ssatmul_8ti_q15(ptr nocapture readonly %pSrcA, ptr 
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    .pad #16
 ; CHECK-NEXT:    sub sp, #16
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    beq .LBB10_3
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
 ; CHECK-NEXT:    adds r4, r3, #7
-; CHECK-NEXT:    vmov.i8 q2, #0x0
+; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    bic r4, r4, #7
-; CHECK-NEXT:    vmov.i8 q3, #0xff
 ; CHECK-NEXT:    sub.w r12, r4, #8
 ; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    add.w lr, r4, r12, lsr #3
 ; CHECK-NEXT:    adr r4, .LCPI10_0
 ; CHECK-NEXT:    vldrw.u32 q0, [r4]
 ; CHECK-NEXT:    adr r4, .LCPI10_1
 ; CHECK-NEXT:    sub.w r12, r3, #1
-; CHECK-NEXT:    vldrw.u32 q4, [r4]
+; CHECK-NEXT:    vldrw.u32 q2, [r4]
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vdup.32 q1, r12
 ; CHECK-NEXT:  .LBB10_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vdup.32 q5, r3
-; CHECK-NEXT:    adds r3, #8
-; CHECK-NEXT:    vorr q6, q5, q0
-; CHECK-NEXT:    vorr q5, q5, q4
-; CHECK-NEXT:    vcmp.u32 cs, q1, q6
-; CHECK-NEXT:    vpsel q6, q3, q2
-; CHECK-NEXT:    vcmp.u32 cs, q1, q5
-; CHECK-NEXT:    vpsel q5, q3, q2
+; CHECK-NEXT:    vdup.32 q3, r3
+; CHECK-NEXT:    vmov.i8 q5, #0xff
+; CHECK-NEXT:    vorr q4, q3, q0
+; CHECK-NEXT:    vorr q3, q3, q2
+; CHECK-NEXT:    vcmp.u32 cs, q1, q4
+; CHECK-NEXT:    vmov.i8 q4, #0x0
+; CHECK-NEXT:    vpsel q6, q5, q4
+; CHECK-NEXT:    vcmp.u32 cs, q1, q3
+; CHECK-NEXT:    vpsel q3, q5, q4
 ; CHECK-NEXT:    vstrh.32 q6, [r5, #8]
-; CHECK-NEXT:    vstrh.32 q5, [r5]
-; CHECK-NEXT:    vldrw.u32 q5, [r5]
-; CHECK-NEXT:    vptt.i16 ne, q5, zr
-; CHECK-NEXT:    vldrht.u16 q5, [r0], #16
-; CHECK-NEXT:    vldrht.u16 q6, [r1], #16
-; CHECK-NEXT:    vmullt.s16 q7, q6, q5
-; CHECK-NEXT:    vmullb.s16 q5, q6, q5
-; CHECK-NEXT:    vqshrnb.s32 q5, q5, #15
-; CHECK-NEXT:    vqshrnt.s32 q5, q7, #15
+; CHECK-NEXT:    vstrh.32 q3, [r5]
+; CHECK-NEXT:    adds r3, #8
+; CHECK-NEXT:    vldrw.u32 q3, [r5]
+; CHECK-NEXT:    vptt.i16 ne, q3, zr
+; CHECK-NEXT:    vldrht.u16 q3, [r0], #16
+; CHECK-NEXT:    vldrht.u16 q4, [r1], #16
+; CHECK-NEXT:    vmullt.s16 q5, q4, q3
+; CHECK-NEXT:    vmullb.s16 q3, q4, q3
+; CHECK-NEXT:    vqshrnb.s32 q3, q3, #15
+; CHECK-NEXT:    vqshrnt.s32 q3, q5, #15
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vstrht.16 q5, [r2], #16
+; CHECK-NEXT:    vstrht.16 q3, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB10_2
 ; CHECK-NEXT:  .LBB10_3: @ %for.cond.cleanup
 ; CHECK-NEXT:    add sp, #16
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
@@ -1904,19 +1904,19 @@ define arm_aapcs_vfpcc void @ssatmul_4_q7(ptr nocapture readonly %pSrcA, ptr noc
 ; CHECK-NEXT:    subs r6, r5, #4
 ; CHECK-NEXT:    add.w r12, r0, r5
 ; CHECK-NEXT:    vmvn.i32 q0, #0x7f
-; CHECK-NEXT:    vmov.i32 q1, #0x7f
 ; CHECK-NEXT:    add.w lr, r4, r6, lsr #2
 ; CHECK-NEXT:    adds r4, r2, r5
 ; CHECK-NEXT:    adds r6, r1, r5
 ; CHECK-NEXT:  .LBB13_4: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrb.s32 q2, [r0], #4
-; CHECK-NEXT:    vldrb.s32 q3, [r1], #4
-; CHECK-NEXT:    vmul.i32 q2, q3, q2
-; CHECK-NEXT:    vshr.s32 q2, q2, #7
-; CHECK-NEXT:    vmax.s32 q2, q2, q0
-; CHECK-NEXT:    vmin.s32 q2, q2, q1
-; CHECK-NEXT:    vstrb.32 q2, [r2], #4
+; CHECK-NEXT:    vldrb.s32 q1, [r0], #4
+; CHECK-NEXT:    vldrb.s32 q2, [r1], #4
+; CHECK-NEXT:    vmul.i32 q1, q2, q1
+; CHECK-NEXT:    vmov.i32 q2, #0x7f
+; CHECK-NEXT:    vshr.s32 q1, q1, #7
+; CHECK-NEXT:    vmax.s32 q1, q1, q0
+; CHECK-NEXT:    vmin.s32 q1, q1, q2
+; CHECK-NEXT:    vstrb.32 q1, [r2], #4
 ; CHECK-NEXT:    le lr, .LBB13_4
 ; CHECK-NEXT:  @ %bb.5: @ %middle.block
 ; CHECK-NEXT:    cmp r5, r3
@@ -2405,40 +2405,40 @@ define arm_aapcs_vfpcc void @ssatmul_8t_q7(ptr nocapture readonly %pSrcA, ptr no
 ; CHECK-NEXT:    beq .LBB17_3
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
 ; CHECK-NEXT:    adds r4, r3, #7
-; CHECK-NEXT:    vmov.i8 q2, #0x0
+; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    bic r4, r4, #7
-; CHECK-NEXT:    vmov.i8 q3, #0xff
 ; CHECK-NEXT:    sub.w r12, r4, #8
 ; CHECK-NEXT:    movs r4, #1
-; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    add.w lr, r4, r12, lsr #3
 ; CHECK-NEXT:    adr r4, .LCPI17_0
 ; CHECK-NEXT:    vldrw.u32 q0, [r4]
 ; CHECK-NEXT:    adr r4, .LCPI17_1
 ; CHECK-NEXT:    sub.w r12, r3, #1
-; CHECK-NEXT:    vldrw.u32 q4, [r4]
+; CHECK-NEXT:    vldrw.u32 q2, [r4]
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vdup.32 q1, r12
 ; CHECK-NEXT:  .LBB17_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vdup.32 q5, r3
-; CHECK-NEXT:    adds r3, #8
-; CHECK-NEXT:    vorr q6, q5, q0
-; CHECK-NEXT:    vorr q5, q5, q4
-; CHECK-NEXT:    vcmp.u32 cs, q1, q6
-; CHECK-NEXT:    vpsel q6, q3, q2
-; CHECK-NEXT:    vcmp.u32 cs, q1, q5
-; CHECK-NEXT:    vpsel q5, q3, q2
+; CHECK-NEXT:    vdup.32 q3, r3
+; CHECK-NEXT:    vmov.i8 q5, #0xff
+; CHECK-NEXT:    vorr q4, q3, q0
+; CHECK-NEXT:    vorr q3, q3, q2
+; CHECK-NEXT:    vcmp.u32 cs, q1, q4
+; CHECK-NEXT:    vmov.i8 q4, #0x0
+; CHECK-NEXT:    vpsel q6, q5, q4
+; CHECK-NEXT:    vcmp.u32 cs, q1, q3
+; CHECK-NEXT:    vpsel q3, q5, q4
 ; CHECK-NEXT:    vstrh.32 q6, [r5, #8]
-; CHECK-NEXT:    vstrh.32 q5, [r5]
-; CHECK-NEXT:    vldrw.u32 q5, [r5]
-; CHECK-NEXT:    vptt.i16 ne, q5, zr
-; CHECK-NEXT:    vldrbt.s16 q5, [r0], #8
-; CHECK-NEXT:    vldrbt.s16 q6, [r1], #8
-; CHECK-NEXT:    vmul.i16 q5, q6, q5
-; CHECK-NEXT:    vqshrnb.s16 q5, q5, #7
+; CHECK-NEXT:    vstrh.32 q3, [r5]
+; CHECK-NEXT:    adds r3, #8
+; CHECK-NEXT:    vldrw.u32 q3, [r5]
+; CHECK-NEXT:    vptt.i16 ne, q3, zr
+; CHECK-NEXT:    vldrbt.s16 q3, [r0], #8
+; CHECK-NEXT:    vldrbt.s16 q4, [r1], #8
+; CHECK-NEXT:    vmul.i16 q3, q4, q3
+; CHECK-NEXT:    vqshrnb.s16 q3, q3, #7
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vstrbt.16 q5, [r2], #8
+; CHECK-NEXT:    vstrbt.16 q3, [r2], #8
 ; CHECK-NEXT:    le lr, .LBB17_2
 ; CHECK-NEXT:  .LBB17_3: @ %for.cond.cleanup
 ; CHECK-NEXT:    add sp, #16
@@ -2504,77 +2504,75 @@ define arm_aapcs_vfpcc void @ssatmul_16t_q7(ptr nocapture readonly %pSrcA, ptr n
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #80
-; CHECK-NEXT:    sub sp, #80
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    beq .LBB18_3
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
 ; CHECK-NEXT:    add.w r6, r3, #15
 ; CHECK-NEXT:    movs r5, #1
 ; CHECK-NEXT:    bic r6, r6, #15
-; CHECK-NEXT:    add r4, sp, #48
+; CHECK-NEXT:    add r4, sp, #32
 ; CHECK-NEXT:    subs r6, #16
-; CHECK-NEXT:    vmov.i8 q2, #0x0
-; CHECK-NEXT:    vmov.i8 q3, #0xff
 ; CHECK-NEXT:    add.w lr, r5, r6, lsr #4
-; CHECK-NEXT:    adr r5, .LCPI18_0
 ; CHECK-NEXT:    subs r6, r3, #1
-; CHECK-NEXT:    vldrw.u32 q0, [r5]
 ; CHECK-NEXT:    vdup.32 q1, r6
 ; CHECK-NEXT:    adr r6, .LCPI18_1
-; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q0, [r6]
+; CHECK-NEXT:    vldrw.u32 q2, [r6]
 ; CHECK-NEXT:    adr r6, .LCPI18_2
-; CHECK-NEXT:    vldrw.u32 q5, [r6]
+; CHECK-NEXT:    adr r5, .LCPI18_0
+; CHECK-NEXT:    vldrw.u32 q3, [r6]
 ; CHECK-NEXT:    adr r6, .LCPI18_3
-; CHECK-NEXT:    vldrw.u32 q6, [r6]
-; CHECK-NEXT:    add r5, sp, #32
-; CHECK-NEXT:    add r6, sp, #64
+; CHECK-NEXT:    vldrw.u32 q0, [r5]
+; CHECK-NEXT:    vldrw.u32 q4, [r6]
+; CHECK-NEXT:    add r5, sp, #16
+; CHECK-NEXT:    add r6, sp, #48
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vstrw.32 q0, [sp] @ 16-byte Spill
 ; CHECK-NEXT:  .LBB18_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q0, [sp, #16] @ 16-byte Reload
-; CHECK-NEXT:    vdup.32 q7, r3
-; CHECK-NEXT:    adds r3, #16
-; CHECK-NEXT:    vorr q0, q7, q0
-; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
-; CHECK-NEXT:    vstrh.32 q0, [r4, #8]
 ; CHECK-NEXT:    vldrw.u32 q0, [sp] @ 16-byte Reload
-; CHECK-NEXT:    vorr q0, q7, q0
+; CHECK-NEXT:    vdup.32 q7, r3
+; CHECK-NEXT:    vmov.i8 q6, #0xff
+; CHECK-NEXT:    adds r3, #16
+; CHECK-NEXT:    vorr q5, q7, q0
+; CHECK-NEXT:    vcmp.u32 cs, q1, q5
+; CHECK-NEXT:    vmov.i8 q5, #0x0
+; CHECK-NEXT:    vpsel q0, q6, q5
+; CHECK-NEXT:    vstrh.32 q0, [r4, #8]
+; CHECK-NEXT:    vorr q0, q7, q2
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r4]
-; CHECK-NEXT:    vorr q0, q7, q5
+; CHECK-NEXT:    vorr q0, q7, q3
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r5, #8]
-; CHECK-NEXT:    vorr q0, q7, q6
+; CHECK-NEXT:    vorr q0, q7, q4
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r5]
 ; CHECK-NEXT:    vldrw.u32 q0, [r4]
 ; CHECK-NEXT:    vcmp.i16 ne, q0, zr
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrb.16 q0, [r6, #8]
 ; CHECK-NEXT:    vldrw.u32 q0, [r5]
 ; CHECK-NEXT:    vcmp.i16 ne, q0, zr
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrb.16 q0, [r6]
 ; CHECK-NEXT:    vldrw.u32 q0, [r6]
 ; CHECK-NEXT:    vptt.i8 ne, q0, zr
 ; CHECK-NEXT:    vldrbt.u8 q0, [r0], #16
-; CHECK-NEXT:    vldrbt.u8 q7, [r1], #16
-; CHECK-NEXT:    vmullt.s8 q4, q7, q0
-; CHECK-NEXT:    vmullb.s8 q0, q7, q0
+; CHECK-NEXT:    vldrbt.u8 q5, [r1], #16
+; CHECK-NEXT:    vmullt.s8 q6, q5, q0
+; CHECK-NEXT:    vmullb.s8 q0, q5, q0
 ; CHECK-NEXT:    vqshrnb.s16 q0, q0, #7
-; CHECK-NEXT:    vqshrnt.s16 q0, q4, #7
+; CHECK-NEXT:    vqshrnt.s16 q0, q6, #7
 ; CHECK-NEXT:    vpst
 ; CHECK-NEXT:    vstrbt.8 q0, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB18_2
 ; CHECK-NEXT:  .LBB18_3: @ %for.cond.cleanup
-; CHECK-NEXT:    add sp, #80
+; CHECK-NEXT:    add sp, #64
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 ; CHECK-NEXT:    .p2align 4
@@ -2647,77 +2645,75 @@ define arm_aapcs_vfpcc void @ssatmul_16ti_q7(ptr nocapture readonly %pSrcA, ptr 
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #80
-; CHECK-NEXT:    sub sp, #80
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    beq .LBB19_3
 ; CHECK-NEXT:  @ %bb.1: @ %vector.ph
 ; CHECK-NEXT:    add.w r6, r3, #15
 ; CHECK-NEXT:    movs r5, #1
 ; CHECK-NEXT:    bic r6, r6, #15
-; CHECK-NEXT:    add r4, sp, #48
+; CHECK-NEXT:    add r4, sp, #32
 ; CHECK-NEXT:    subs r6, #16
-; CHECK-NEXT:    vmov.i8 q2, #0x0
-; CHECK-NEXT:    vmov.i8 q3, #0xff
 ; CHECK-NEXT:    add.w lr, r5, r6, lsr #4
-; CHECK-NEXT:    adr r5, .LCPI19_0
 ; CHECK-NEXT:    subs r6, r3, #1
-; CHECK-NEXT:    vldrw.u32 q0, [r5]
 ; CHECK-NEXT:    vdup.32 q1, r6
 ; CHECK-NEXT:    adr r6, .LCPI19_1
-; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
-; CHECK-NEXT:    vldrw.u32 q0, [r6]
+; CHECK-NEXT:    vldrw.u32 q2, [r6]
 ; CHECK-NEXT:    adr r6, .LCPI19_2
-; CHECK-NEXT:    vldrw.u32 q5, [r6]
+; CHECK-NEXT:    adr r5, .LCPI19_0
+; CHECK-NEXT:    vldrw.u32 q3, [r6]
 ; CHECK-NEXT:    adr r6, .LCPI19_3
-; CHECK-NEXT:    vldrw.u32 q6, [r6]
-; CHECK-NEXT:    add r5, sp, #32
-; CHECK-NEXT:    add r6, sp, #64
+; CHECK-NEXT:    vldrw.u32 q0, [r5]
+; CHECK-NEXT:    vldrw.u32 q4, [r6]
+; CHECK-NEXT:    add r5, sp, #16
+; CHECK-NEXT:    add r6, sp, #48
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    vstrw.32 q0, [sp] @ 16-byte Spill
 ; CHECK-NEXT:  .LBB19_2: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q0, [sp, #16] @ 16-byte Reload
-; CHECK-NEXT:    vdup.32 q7, r3
-; CHECK-NEXT:    adds r3, #16
-; CHECK-NEXT:    vorr q0, q7, q0
-; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
-; CHECK-NEXT:    vstrh.32 q0, [r4, #8]
 ; CHECK-NEXT:    vldrw.u32 q0, [sp] @ 16-byte Reload
-; CHECK-NEXT:    vorr q0, q7, q0
+; CHECK-NEXT:    vdup.32 q7, r3
+; CHECK-NEXT:    vmov.i8 q6, #0xff
+; CHECK-NEXT:    adds r3, #16
+; CHECK-NEXT:    vorr q5, q7, q0
+; CHECK-NEXT:    vcmp.u32 cs, q1, q5
+; CHECK-NEXT:    vmov.i8 q5, #0x0
+; CHECK-NEXT:    vpsel q0, q6, q5
+; CHECK-NEXT:    vstrh.32 q0, [r4, #8]
+; CHECK-NEXT:    vorr q0, q7, q2
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r4]
-; CHECK-NEXT:    vorr q0, q7, q5
+; CHECK-NEXT:    vorr q0, q7, q3
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r5, #8]
-; CHECK-NEXT:    vorr q0, q7, q6
+; CHECK-NEXT:    vorr q0, q7, q4
 ; CHECK-NEXT:    vcmp.u32 cs, q1, q0
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrh.32 q0, [r5]
 ; CHECK-NEXT:    vldrw.u32 q0, [r4]
 ; CHECK-NEXT:    vcmp.i16 ne, q0, zr
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrb.16 q0, [r6, #8]
 ; CHECK-NEXT:    vldrw.u32 q0, [r5]
 ; CHECK-NEXT:    vcmp.i16 ne, q0, zr
-; CHECK-NEXT:    vpsel q0, q3, q2
+; CHECK-NEXT:    vpsel q0, q6, q5
 ; CHECK-NEXT:    vstrb.16 q0, [r6]
 ; CHECK-NEXT:    vldrw.u32 q0, [r6]
 ; CHECK-NEXT:    vptt.i8 ne, q0, zr
 ; CHECK-NEXT:    vldrbt.u8 q0, [r0], #16
-; CHECK-NEXT:    vldrbt.u8 q7, [r1], #16
-; CHECK-NEXT:    vmullt.s8 q4, q7, q0
-; CHECK-NEXT:    vmullb.s8 q0, q7, q0
+; CHECK-NEXT:    vldrbt.u8 q5, [r1], #16
+; CHECK-NEXT:    vmullt.s8 q6, q5, q0
+; CHECK-NEXT:    vmullb.s8 q0, q5, q0
 ; CHECK-NEXT:    vqshrnb.s16 q0, q0, #7
-; CHECK-NEXT:    vqshrnt.s16 q0, q4, #7
+; CHECK-NEXT:    vqshrnt.s16 q0, q6, #7
 ; CHECK-NEXT:    vpst
 ; CHECK-NEXT:    vstrbt.8 q0, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB19_2
 ; CHECK-NEXT:  .LBB19_3: @ %for.cond.cleanup
-; CHECK-NEXT:    add sp, #80
+; CHECK-NEXT:    add sp, #64
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 ; CHECK-NEXT:    .p2align 4

--- a/llvm/test/CodeGen/Thumb2/mve-tailpred-vptblock.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-tailpred-vptblock.ll
@@ -14,40 +14,40 @@ define void @convert_vptblock(ptr %pchTarget, i16 signext %iTargetStride, ptr %p
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    .pad #4
 ; CHECK-NEXT:    sub sp, #4
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    ldrsh.w r10, [r3]
 ; CHECK-NEXT:    mov.w r8, #0
-; CHECK-NEXT:    ldrd r4, r5, [sp, #88]
+; CHECK-NEXT:    ldrd r4, r5, [sp, #72]
 ; CHECK-NEXT:    mov r7, r0
 ; CHECK-NEXT:    mov.w r11, #0
 ; CHECK-NEXT:    vidup.u16 q0, r8, #4
-; CHECK-NEXT:    vmov.i32 q1, #0x0
-; CHECK-NEXT:    vmov.i16 q2, #0x100
-; CHECK-NEXT:    vmov.i16 q3, #0xff
 ; CHECK-NEXT:  .LBB0_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Loop Header: Depth=1
 ; CHECK-NEXT:    @ Child Loop BB0_3 Depth 2
-; CHECK-NEXT:    vmov q4, q0
+; CHECK-NEXT:    vmov q1, q0
 ; CHECK-NEXT:    mov r6, r8
 ; CHECK-NEXT:    mov r0, r7
 ; CHECK-NEXT:    dlstp.16 lr, r10
 ; CHECK-NEXT:  .LBB0_3: @ %do.body
 ; CHECK-NEXT:    @ Parent Loop BB0_2 Depth=1
 ; CHECK-NEXT:    @ => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    vldrb.u16 q5, [r2, q4]
-; CHECK-NEXT:    vmul.i16 q4, q5, r5
-; CHECK-NEXT:    vshr.u16 q4, q4, #8
-; CHECK-NEXT:    vsub.i16 q5, q2, q4
-; CHECK-NEXT:    vpt.i16 eq, q4, q3
-; CHECK-NEXT:    vmovt q5, q1
-; CHECK-NEXT:    vldrb.u16 q6, [r0]
-; CHECK-NEXT:    vsub.i16 q4, q2, q5
-; CHECK-NEXT:    vmul.i16 q5, q5, q6
-; CHECK-NEXT:    vmla.i16 q5, q4, r4
-; CHECK-NEXT:    vshr.u16 q4, q5, #8
-; CHECK-NEXT:    vstrb.16 q4, [r0], #8
-; CHECK-NEXT:    vidup.u16 q4, r6, #4
+; CHECK-NEXT:    vmov.i16 q3, #0x100
+; CHECK-NEXT:    vldrb.u16 q5, [r2, q1]
+; CHECK-NEXT:    vmov.i16 q4, #0xff
+; CHECK-NEXT:    vmov.i32 q2, #0x0
+; CHECK-NEXT:    vmul.i16 q1, q5, r5
+; CHECK-NEXT:    vshr.u16 q1, q1, #8
+; CHECK-NEXT:    vsub.i16 q5, q3, q1
+; CHECK-NEXT:    vpt.i16 eq, q1, q4
+; CHECK-NEXT:    vmovt q5, q2
+; CHECK-NEXT:    vldrb.u16 q2, [r0]
+; CHECK-NEXT:    vsub.i16 q1, q3, q5
+; CHECK-NEXT:    vmul.i16 q2, q5, q2
+; CHECK-NEXT:    vmla.i16 q2, q1, r4
+; CHECK-NEXT:    vshr.u16 q1, q2, #8
+; CHECK-NEXT:    vstrb.16 q1, [r0], #8
+; CHECK-NEXT:    vidup.u16 q1, r6, #4
 ; CHECK-NEXT:    letp lr, .LBB0_3
 ; CHECK-NEXT:  @ %bb.4: @ %do.end
 ; CHECK-NEXT:    @ in Loop: Header=BB0_2 Depth=1
@@ -57,7 +57,7 @@ define void @convert_vptblock(ptr %pchTarget, i16 signext %iTargetStride, ptr %p
 ; CHECK-NEXT:    cmp r11, r12
 ; CHECK-NEXT:    blt .LBB0_2
 ; CHECK-NEXT:  @ %bb.5:
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    add sp, #4
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-NEXT:    bx lr

--- a/llvm/test/CodeGen/Thumb2/mve-vabdus.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vabdus.ll
@@ -370,40 +370,40 @@ define void @vabd_loop_s32(ptr nocapture readonly %x, ptr nocapture readonly %y,
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, lr}
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, r9, lr}
 ; CHECK-NEXT:    mov.w lr, #256
-; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:  .LBB17_1: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q1, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q0, [r0], #16
+; CHECK-NEXT:    vmov.f32 s4, s2
+; CHECK-NEXT:    vmov r7, s0
+; CHECK-NEXT:    vmov.f32 s2, s3
+; CHECK-NEXT:    vmov r3, s4
+; CHECK-NEXT:    vldrw.u32 q1, [r1], #16
 ; CHECK-NEXT:    vmov.f32 s8, s6
-; CHECK-NEXT:    vmov r7, s4
-; CHECK-NEXT:    vmov.f32 s6, s7
-; CHECK-NEXT:    vmov r3, s8
-; CHECK-NEXT:    vldrw.u32 q2, [r1], #16
-; CHECK-NEXT:    vmov.f32 s12, s10
-; CHECK-NEXT:    vmov.f32 s10, s5
-; CHECK-NEXT:    vmov.f32 s14, s11
-; CHECK-NEXT:    vmov r4, s12
+; CHECK-NEXT:    vmov.f32 s6, s1
+; CHECK-NEXT:    vmov.f32 s10, s7
+; CHECK-NEXT:    vmov r4, s8
 ; CHECK-NEXT:    asr.w r12, r3, #31
 ; CHECK-NEXT:    subs.w r8, r3, r4
 ; CHECK-NEXT:    sbcs.w r4, r12, r4, asr #31
-; CHECK-NEXT:    vmov r4, s10
+; CHECK-NEXT:    vmov r4, s6
 ; CHECK-NEXT:    csetm r12, lt
-; CHECK-NEXT:    vmov.f32 s10, s9
-; CHECK-NEXT:    vmov r6, s10
+; CHECK-NEXT:    vmov.f32 s6, s5
+; CHECK-NEXT:    vmov r6, s6
 ; CHECK-NEXT:    asrs r5, r4, #31
 ; CHECK-NEXT:    subs r4, r4, r6
 ; CHECK-NEXT:    sbcs.w r5, r5, r6, asr #31
-; CHECK-NEXT:    vmov r6, s8
+; CHECK-NEXT:    vmov r6, s4
 ; CHECK-NEXT:    csetm r9, lt
-; CHECK-NEXT:    vmov r5, s6
+; CHECK-NEXT:    vmov r5, s2
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:    subs r3, r7, r6
 ; CHECK-NEXT:    asr.w r7, r7, #31
-; CHECK-NEXT:    vmov q2[2], q2[0], r3, r8
-; CHECK-NEXT:    vmov r3, s14
+; CHECK-NEXT:    vmov q1[2], q1[0], r3, r8
+; CHECK-NEXT:    vmov r3, s10
 ; CHECK-NEXT:    sbcs.w r6, r7, r6, asr #31
 ; CHECK-NEXT:    csetm r6, lt
 ; CHECK-NEXT:    subs r7, r5, r3
-; CHECK-NEXT:    vmov q2[3], q2[1], r4, r7
+; CHECK-NEXT:    vmov q1[3], q1[1], r4, r7
 ; CHECK-NEXT:    mov.w r4, #0
 ; CHECK-NEXT:    bfi r4, r6, #0, #4
 ; CHECK-NEXT:    asr.w r7, r5, #31
@@ -414,8 +414,8 @@ define void @vabd_loop_s32(ptr nocapture readonly %x, ptr nocapture readonly %y,
 ; CHECK-NEXT:    bfi r4, r3, #12, #4
 ; CHECK-NEXT:    vmsr p0, r4
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vsubt.i32 q2, q0, q2
-; CHECK-NEXT:    vstrb.8 q2, [r2], #16
+; CHECK-NEXT:    vsubt.i32 q1, q0, q1
+; CHECK-NEXT:    vstrb.8 q1, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB17_1
 ; CHECK-NEXT:  @ %bb.2: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, r9, pc}
@@ -532,71 +532,71 @@ define void @vabd_loop_u32(ptr nocapture readonly %x, ptr nocapture readonly %y,
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    mov.w lr, #256
-; CHECK-NEXT:    vmov.i64 q0, #0xffffffff
-; CHECK-NEXT:    vmov.i32 q1, #0x0
 ; CHECK-NEXT:  .LBB20_1: @ %vector.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vldrw.u32 q6, [r0], #16
-; CHECK-NEXT:    vldrw.u32 q5, [r1], #16
-; CHECK-NEXT:    vmov.f32 s12, s22
-; CHECK-NEXT:    vmov.f32 s16, s26
-; CHECK-NEXT:    vmov r4, s24
-; CHECK-NEXT:    vmov.f32 s14, s23
-; CHECK-NEXT:    vmov.f32 s18, s27
-; CHECK-NEXT:    vmov.f32 s22, s21
-; CHECK-NEXT:    vmov.f32 s26, s25
-; CHECK-NEXT:    vmov r12, s12
-; CHECK-NEXT:    vmov r3, s16
+; CHECK-NEXT:    vldrw.u32 q4, [r0], #16
+; CHECK-NEXT:    vldrw.u32 q3, [r1], #16
+; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
+; CHECK-NEXT:    vmov.f32 s4, s14
+; CHECK-NEXT:    vmov.f32 s8, s18
+; CHECK-NEXT:    vmov r4, s16
+; CHECK-NEXT:    vmov.f32 s6, s15
+; CHECK-NEXT:    vmov.f32 s10, s19
+; CHECK-NEXT:    vmov.f32 s14, s13
+; CHECK-NEXT:    vmov.f32 s18, s17
+; CHECK-NEXT:    vmov r12, s4
+; CHECK-NEXT:    vmov r3, s8
 ; CHECK-NEXT:    sub.w r12, r3, r12
-; CHECK-NEXT:    vmov r3, s20
+; CHECK-NEXT:    vmov r3, s12
 ; CHECK-NEXT:    subs r3, r4, r3
-; CHECK-NEXT:    vmov r4, s18
-; CHECK-NEXT:    vmov q2[2], q2[0], r3, r12
-; CHECK-NEXT:    vmov r3, s14
-; CHECK-NEXT:    vand q3, q3, q0
-; CHECK-NEXT:    vand q4, q4, q0
+; CHECK-NEXT:    vmov r4, s10
+; CHECK-NEXT:    vmov q0[2], q0[0], r3, r12
+; CHECK-NEXT:    vmov r3, s6
+; CHECK-NEXT:    vand q1, q1, q5
+; CHECK-NEXT:    vand q2, q2, q5
 ; CHECK-NEXT:    sub.w r12, r4, r3
-; CHECK-NEXT:    vmov r4, s22
-; CHECK-NEXT:    vmov r3, s26
-; CHECK-NEXT:    vand q5, q5, q0
-; CHECK-NEXT:    vand q6, q6, q0
+; CHECK-NEXT:    vmov r4, s14
+; CHECK-NEXT:    vmov r3, s18
+; CHECK-NEXT:    vand q3, q3, q5
+; CHECK-NEXT:    vand q4, q4, q5
 ; CHECK-NEXT:    subs r3, r3, r4
-; CHECK-NEXT:    vmov r4, r5, d12
-; CHECK-NEXT:    vmov q2[3], q2[1], r3, r12
-; CHECK-NEXT:    vmov r3, r12, d10
+; CHECK-NEXT:    vmov r4, r5, d8
+; CHECK-NEXT:    vmov q0[3], q0[1], r3, r12
+; CHECK-NEXT:    vmov r3, r12, d6
 ; CHECK-NEXT:    subs r3, r4, r3
-; CHECK-NEXT:    vmov r4, r6, d13
+; CHECK-NEXT:    vmov r4, r6, d9
 ; CHECK-NEXT:    sbcs.w r3, r5, r12
 ; CHECK-NEXT:    csetm r5, lt
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    bfi r3, r5, #0, #4
-; CHECK-NEXT:    vmov r5, r12, d11
+; CHECK-NEXT:    vmov r5, r12, d7
 ; CHECK-NEXT:    subs r4, r4, r5
 ; CHECK-NEXT:    sbcs.w r6, r6, r12
-; CHECK-NEXT:    vmov r4, r5, d8
+; CHECK-NEXT:    vmov r4, r5, d4
 ; CHECK-NEXT:    csetm r6, lt
 ; CHECK-NEXT:    bfi r3, r6, #4, #4
-; CHECK-NEXT:    vmov r6, r12, d6
+; CHECK-NEXT:    vmov r6, r12, d2
 ; CHECK-NEXT:    subs r4, r4, r6
 ; CHECK-NEXT:    sbcs.w r6, r5, r12
-; CHECK-NEXT:    vmov r4, r5, d9
+; CHECK-NEXT:    vmov r4, r5, d5
 ; CHECK-NEXT:    csetm r6, lt
 ; CHECK-NEXT:    bfi r3, r6, #8, #4
-; CHECK-NEXT:    vmov r6, r12, d7
+; CHECK-NEXT:    vmov r6, r12, d3
+; CHECK-NEXT:    vmov.i32 q1, #0x0
 ; CHECK-NEXT:    subs r4, r4, r6
 ; CHECK-NEXT:    sbcs.w r6, r5, r12
 ; CHECK-NEXT:    csetm r6, lt
 ; CHECK-NEXT:    bfi r3, r6, #12, #4
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    vpst
-; CHECK-NEXT:    vsubt.i32 q2, q1, q2
-; CHECK-NEXT:    vstrb.8 q2, [r2], #16
+; CHECK-NEXT:    vsubt.i32 q0, q1, q0
+; CHECK-NEXT:    vstrb.8 q0, [r2], #16
 ; CHECK-NEXT:    le lr, .LBB20_1
 ; CHECK-NEXT:  @ %bb.2: @ %for.cond.cleanup
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
   br label %vector.body

--- a/llvm/test/CodeGen/Thumb2/mve-vmovlloop.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-vmovlloop.ll
@@ -155,22 +155,22 @@ define void @sunken_vmovl(ptr noalias %pTarget, i16 signext %iTargetStride, ptr 
 ; CHECK-NEXT:    .save {r7, lr}
 ; CHECK-NEXT:    push {r7, lr}
 ; CHECK-NEXT:    ldrsh.w r1, [sp, #8]
-; CHECK-NEXT:    vmov.i16 q0, #0x100
 ; CHECK-NEXT:    vldrb.u16 q1, [r2], #8
-; CHECK-NEXT:    vldrb.u16 q2, [r0], #8
+; CHECK-NEXT:    vldrb.u16 q0, [r0], #8
 ; CHECK-NEXT:    ldr r3, [sp, #12]
 ; CHECK-NEXT:    dlstp.16 lr, r1
 ; CHECK-NEXT:  .LBB3_1: @ %do.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    vmovlb.u8 q1, q1
-; CHECK-NEXT:    vsub.i16 q3, q0, q1
-; CHECK-NEXT:    vmovlb.u8 q2, q2
-; CHECK-NEXT:    vmul.i16 q3, q2, q3
-; CHECK-NEXT:    vldrb.u16 q2, [r0], #8
-; CHECK-NEXT:    vmla.i16 q3, q1, r3
+; CHECK-NEXT:    vmov.i16 q2, #0x100
+; CHECK-NEXT:    vmovlb.u8 q0, q0
+; CHECK-NEXT:    vsub.i16 q2, q2, q1
+; CHECK-NEXT:    vmul.i16 q2, q0, q2
+; CHECK-NEXT:    vldrb.u16 q0, [r0], #8
+; CHECK-NEXT:    vmla.i16 q2, q1, r3
 ; CHECK-NEXT:    vldrb.u16 q1, [r2], #8
-; CHECK-NEXT:    vshr.u16 q3, q3, #8
-; CHECK-NEXT:    vstrb.16 q3, [r0, #-16]
+; CHECK-NEXT:    vshr.u16 q2, q2, #8
+; CHECK-NEXT:    vstrb.16 q2, [r0, #-16]
 ; CHECK-NEXT:    letp lr, .LBB3_1
 ; CHECK-NEXT:  @ %bb.2: @ %do.end
 ; CHECK-NEXT:    pop {r7, pc}

--- a/llvm/test/CodeGen/X86/machine-licm-implicit-def-kill.mir
+++ b/llvm/test/CodeGen/X86/machine-licm-implicit-def-kill.mir
@@ -1,0 +1,110 @@
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=early-machinelicm -o - %s | FileCheck %s
+
+# Verify that MachineLICM does not credit pressure relief for a use of a vreg
+# whose unique def is IMPLICIT_DEF.  GR pressure is saturated below, so if it
+# did, INSERT_SUBREG would hoist and cause a spill.
+
+# CHECK-LABEL: name: no_hoist_insert_subreg_of_implicit_def
+# IMPLICIT_DEF may hoist; INSERT_SUBREG must stay in the loop.
+# CHECK:      bb.0:
+# CHECK:        %{{[a-zA-Z0-9_.]+}}:gr64 = IMPLICIT_DEF
+# CHECK-NOT:    INSERT_SUBREG
+# CHECK:      bb.1:
+# CHECK:        %{{[a-zA-Z0-9_.]+}}:gr64 = INSERT_SUBREG %{{[a-zA-Z0-9_.]+}}, %{{[a-zA-Z0-9_.]+}}, %subreg.sub_32bit
+
+---
+name:            no_hoist_insert_subreg_of_implicit_def
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1(0x80000000)
+    liveins: $rdi
+
+    %0:gr64 = COPY $rdi
+    %1:gr64 = COPY $rdi
+    %2:gr64 = COPY $rdi
+    %3:gr64 = COPY $rdi
+    %4:gr64 = COPY $rdi
+    %5:gr64 = COPY $rdi
+    %6:gr64 = COPY $rdi
+    %7:gr64 = COPY $rdi
+    %8:gr64 = COPY $rdi
+    %9:gr64 = COPY $rdi
+    %10:gr64 = COPY $rdi
+    %11:gr64 = COPY $rdi
+    %12:gr64 = COPY $rdi
+    %13:gr64 = COPY $rdi
+    %14:gr64 = COPY $rdi
+    %15:gr64 = COPY $rdi
+    %16:gr64 = COPY $rdi
+    %17:gr64 = COPY $rdi
+    %18:gr64 = COPY $rdi
+    %19:gr64 = COPY $rdi
+    %20:gr64 = COPY $rdi
+    %21:gr64 = COPY $rdi
+    %22:gr64 = COPY $rdi
+    %23:gr64 = COPY $rdi
+    %24:gr64 = COPY $rdi
+    %25:gr64 = COPY $rdi
+    %26:gr64 = COPY $rdi
+    %27:gr64 = COPY $rdi
+    %28:gr64 = COPY $rdi
+    %29:gr64 = COPY $rdi
+    %30:gr64 = COPY $rdi
+    %31:gr64 = COPY $rdi
+    %32:gr64 = COPY $rdi
+    ; Multiple uses below so isOperandKill is false for %narrow at INSERT_SUBREG;
+    ; isolates the IMPLICIT_DEF case from a real GR32 -W kill.
+    %narrow:gr32 = COPY $edi
+
+  bb.1:
+    successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+
+    %impdef:gr64 = IMPLICIT_DEF
+    %ins:gr64 = INSERT_SUBREG %impdef, %narrow, %subreg.sub_32bit
+
+    ; Keep preheader vregs and %narrow live to saturate GR16/GR32/GR64
+    ; pressure while LICM decides whether to hoist %ins.
+    $rax = MOV64rr %0
+    $rax = ADD64rr $rax, %1, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %2, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %3, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %4, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %5, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %6, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %7, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %8, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %9, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %10, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %11, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %12, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %13, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %14, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %15, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %16, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %17, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %18, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %19, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %20, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %21, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %22, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %23, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %24, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %25, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %26, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %27, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %28, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %29, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %30, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %31, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %32, implicit-def dead $eflags
+    $rax = ADD64rr $rax, %ins, implicit-def dead $eflags
+    $eax = ADD32rr $eax, %narrow, implicit-def dead $eflags
+    $eax = ADD32rr $eax, %narrow, implicit-def dead $eflags
+    MOV64mr %0, 1, $noreg, 0, $noreg, $rax :: (store (s64) into `ptr undef`)
+    JCC_1 %bb.1, 5, implicit undef $eflags
+    JMP_1 %bb.2
+
+  bb.2:
+    RET 0
+...


### PR DESCRIPTION
IMPLICIT_DEF is always hoisted out of loop by LICM as it's trivially
rematerializable.

Any src operand inside the loop whose value is defined by an
IMPLICIT_DEF shouldn't contribute to reduction in register pressure
in the loop.

If we do this, we end up hoisting too many instructions out of the loop
that later causes spill.
