### PR TITLE
[clang][NFC] Remove alignment checks from test/CodeGen/c-strings.c

### DIFF
--- a/clang/test/CodeGen/c-strings.c
+++ b/clang/test/CodeGen/c-strings.c
@@ -4,37 +4,15 @@
 // Should be 3 hello strings, two global (of different sizes), the rest are
 // shared.
 
-// CHECK: @align = {{(dso_local )?}}global i8 [[ALIGN:[0-9]+]]
 // ITANIUM: @.str = private unnamed_addr constant [6 x i8] c"hello\00"
-// MSABI: @"??_C@_05CJBACGMB@hello?$AA@" = linkonce_odr dso_local unnamed_addr constant [6 x i8] c"hello\00", comdat, align 1
+// MSABI: @"??_C@_05CJBACGMB@hello?$AA@" = linkonce_odr dso_local unnamed_addr constant [6 x i8] c"hello\00", comdat
 // ITANIUM: @f1.x = internal global ptr @.str
 // MSABI: @f1.x = internal global ptr @"??_C@_05CJBACGMB@hello?$AA@"
-// CHECK: @f2.x = internal global [6 x i8] c"hello\00", align [[ALIGN]]
-// CHECK: @f3.x = internal global [8 x i8] c"hello\00\00\00", align [[ALIGN]]
+// CHECK: @f2.x = internal global [6 x i8] c"hello\00"
+// CHECK: @f3.x = internal global [8 x i8] c"hello\00\00\00"
 // ITANIUM: @f4.x = internal global %struct.s { ptr @.str }
 // MSABI: @f4.x = internal global %struct.s { ptr @"??_C@_05CJBACGMB@hello?$AA@" }
-// CHECK: @x = {{(dso_local )?}}global [3 x i8] c"ola", align [[ALIGN]]
-
-// XFAIL: target=aarch64-{{.*}}-windows-msvc, target=arm64ec-{{.*}}-windows-msvc
-// Arm64 in MSVC mode aligns arrays to either 32-bit or 64-bit boundaries, which fails
-// various checks above, since ALIGN is derived from the alignment of a single
-// i8, which is still 1.
-
-// XFAIL: target=hexagon-{{.*}}
-// Hexagon aligns arrays of size 8+ bytes to a 64-bit boundary, which
-// fails the check for "@f3.x = ... align [ALIGN]", since ALIGN is derived
-// from the alignment of a single i8, which is still 1.
-
-// XFAIL: target=csky{{.*}}
-// CSKY aligns arrays of size 4+ bytes to a 32-bit boundary, which
-// fails the check for "@f2.x = ... align [ALIGN]", since ALIGN is derived
-// from the alignment of a single i8, which is still 1.
-
-#if defined(__s390x__)
-unsigned char align = 2;
-#else
-unsigned char align = 1;
-#endif
+// CHECK: @x = {{(dso_local )?}}global [3 x i8] c"ola"
 
 void bar(const char *);
 


### PR DESCRIPTION
and re-enable it on more targets.

I don't think this test was intended to check for alignment. Those expectations were added as part of FileCheck-izing the test in e29dadb6403c8b0d3658f9bbbe2f5fbde5431fdb and we've been working around them or xfailing the test since.