### PR TITLE
[libc++] Remove _LIBCPP_HIDE_FROM_ABI from <__utility/pair.h>

### DIFF
--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -55,22 +55,22 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _T1, class _T2>
 struct __check_pair_construction {
   template <int&...>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_implicit_default() {
+  static constexpr bool __enable_implicit_default() {
     return __is_implicitly_default_constructible<_T1>::value && __is_implicitly_default_constructible<_T2>::value;
   }
 
   template <int&...>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_default() {
+  static constexpr bool __enable_default() {
     return is_default_constructible<_T1>::value && is_default_constructible<_T2>::value;
   }
 
   template <class _U1, class _U2>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __is_pair_constructible() {
+  static constexpr bool __is_pair_constructible() {
     return is_constructible<_T1, _U1>::value && is_constructible<_T2, _U2>::value;
   }
 
   template <class _U1, class _U2>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __is_implicit() {
+  static constexpr bool __is_implicit() {
     return is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value;
   }
 };
@@ -79,9 +79,8 @@ struct __check_pair_construction {
 
 template <class, class>
 struct __non_trivially_copyable_base {
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI __non_trivially_copyable_base() _NOEXCEPT {}
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
-  __non_trivially_copyable_base(__non_trivially_copyable_base const&) _NOEXCEPT {}
+  _LIBCPP_CONSTEXPR __non_trivially_copyable_base() _NOEXCEPT {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __non_trivially_copyable_base(__non_trivially_copyable_base const&) _NOEXCEPT {}
 };
 
 template <class _T1, class _T2>
@@ -101,18 +100,18 @@ struct pair
                       pair,
                       void>;
 
-  _LIBCPP_HIDE_FROM_ABI pair(pair const&) = default;
-  _LIBCPP_HIDE_FROM_ABI pair(pair&&)      = default;
+  pair(pair const&) = default;
+  pair(pair&&)      = default;
 
 #ifdef _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI pair() : first(), second() {}
+  pair() : first(), second() {}
 
-  _LIBCPP_HIDE_FROM_ABI pair(_T1 const& __t1, _T2 const& __t2) : first(__t1), second(__t2) {}
+  pair(_T1 const& __t1, _T2 const& __t2) : first(__t1), second(__t2) {}
 
   template <class _U1, class _U2>
-  _LIBCPP_HIDE_FROM_ABI pair(const pair<_U1, _U2>& __p) : first(__p.first), second(__p.second) {}
+  pair(const pair<_U1, _U2>& __p) : first(__p.first), second(__p.second) {}
 
-  _LIBCPP_HIDE_FROM_ABI pair& operator=(pair const& __p) {
+  pair& operator=(pair const& __p) {
     first  = __p.first;
     second = __p.second;
     return *this;
@@ -126,7 +125,7 @@ struct pair
       class _U2,
       __enable_if_t<is_assignable<first_type&, _U1 const&>::value && is_assignable<second_type&, _U2 const&>::value,
                     int> = 0>
-  _LIBCPP_HIDE_FROM_ABI pair& operator=(pair<_U1, _U2> const& __p) {
+  pair& operator=(pair<_U1, _U2> const& __p) {
     first  = __p.first;
     second = __p.second;
     return *this;
@@ -134,13 +133,12 @@ struct pair
 #else
   template <class _CheckArgsDep                                   = __check_pair_construction<_T1, _T2>,
             __enable_if_t<_CheckArgsDep::__enable_default(), int> = 0>
-  explicit(!_CheckArgsDep::__enable_implicit_default()) _LIBCPP_HIDE_FROM_ABI constexpr pair() noexcept(
+  explicit(!_CheckArgsDep::__enable_implicit_default()) constexpr pair() noexcept(
       is_nothrow_default_constructible<first_type>::value && is_nothrow_default_constructible<second_type>::value)
       : first(), second() {}
 
   template <class _CheckArgsDep = __check_pair_construction<_T1, _T2>,
             __enable_if_t<_CheckArgsDep::template __is_pair_constructible<_T1 const&, _T2 const&>(), int> = 0>
-  _LIBCPP_HIDE_FROM_ABI
   _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(!_CheckArgsDep::template __is_implicit<_T1 const&, _T2 const&>())
       pair(_T1 const& __t1, _T2 const& __t2) noexcept(is_nothrow_copy_constructible<first_type>::value &&
                                                       is_nothrow_copy_constructible<second_type>::value)
@@ -155,7 +153,6 @@ struct pair
       class _U2,
 #  endif
       __enable_if_t<__check_pair_construction<_T1, _T2>::template __is_pair_constructible<_U1, _U2>(), int> = 0 >
-  _LIBCPP_HIDE_FROM_ABI
   _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(!__check_pair_construction<_T1, _T2>::template __is_implicit<_U1, _U2>())
       pair(_U1&& __u1, _U2&& __u2) noexcept(is_nothrow_constructible<first_type, _U1>::value &&
                                             is_nothrow_constructible<second_type, _U2>::value)
@@ -166,7 +163,7 @@ struct pair
   template <class _U1,
             class _U2,
             __enable_if_t<__check_pair_construction<_T1, _T2>::template __is_pair_constructible<_U1&, _U2&>(), int> = 0>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit(!__check_pair_construction<_T1, _T2>::template __is_implicit<_U1&, _U2&>())
+  constexpr explicit(!__check_pair_construction<_T1, _T2>::template __is_implicit<_U1&, _U2&>())
       pair(pair<_U1, _U2>& __p) noexcept((is_nothrow_constructible<first_type, _U1&>::value &&
                                           is_nothrow_constructible<second_type, _U2&>::value))
       : first(__p.first), second(__p.second) {}
@@ -177,7 +174,7 @@ struct pair
       class _U2,
       __enable_if_t<__check_pair_construction<_T1, _T2>::template __is_pair_constructible<_U1 const&, _U2 const&>(),
                     int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
       !__check_pair_construction<_T1, _T2>::template __is_implicit<_U1 const&, _U2 const&>())
       pair(pair<_U1, _U2> const& __p) noexcept(is_nothrow_constructible<first_type, _U1 const&>::value &&
                                                is_nothrow_constructible<second_type, _U2 const&>::value)
@@ -186,7 +183,6 @@ struct pair
   template <class _U1,
             class _U2,
             __enable_if_t<__check_pair_construction<_T1, _T2>::template __is_pair_constructible<_U1, _U2>(), int> = 0>
-  _LIBCPP_HIDE_FROM_ABI
   _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(!__check_pair_construction<_T1, _T2>::template __is_implicit<_U1, _U2>())
       pair(pair<_U1, _U2>&& __p) noexcept(is_nothrow_constructible<first_type, _U1&&>::value &&
                                           is_nothrow_constructible<second_type, _U2&&>::value)
@@ -198,8 +194,7 @@ struct pair
       class _U2,
       __enable_if_t<__check_pair_construction<_T1, _T2>::template __is_pair_constructible<const _U1&&, const _U2&&>(),
                     int> = 0>
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit(
-      !__check_pair_construction<_T1, _T2>::template __is_implicit<const _U1&&, const _U2&&>())
+  constexpr explicit(!__check_pair_construction<_T1, _T2>::template __is_implicit<const _U1&&, const _U2&&>())
       pair(const pair<_U1, _U2>&& __p) noexcept(is_nothrow_constructible<first_type, const _U1&&>::value &&
                                                 is_nothrow_constructible<second_type, const _U2&&>::value)
       : first(std::move(__p.first)), second(std::move(__p.second)) {}
@@ -209,19 +204,19 @@ struct pair
   template <__pair_like_no_subrange _PairLike>
     requires(is_constructible_v<first_type, decltype(std::get<0>(std::declval<_PairLike &&>()))> &&
              is_constructible_v<second_type, decltype(std::get<1>(std::declval<_PairLike &&>()))>)
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit(
-      !is_convertible_v<decltype(std::get<0>(std::declval<_PairLike&&>())), first_type> ||
-      !is_convertible_v<decltype(std::get<1>(std::declval<_PairLike&&>())), second_type>) pair(_PairLike&& __p)
+  constexpr explicit(!is_convertible_v<decltype(std::get<0>(std::declval<_PairLike&&>())), first_type> ||
+                     !is_convertible_v<decltype(std::get<1>(std::declval<_PairLike&&>())), second_type>)
+      pair(_PairLike&& __p)
       : first(std::get<0>(std::forward<_PairLike>(__p))), second(std::get<1>(std::forward<_PairLike>(__p))) {}
 #  endif
 
   template <class... _Args1, class... _Args2>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
+  _LIBCPP_CONSTEXPR_SINCE_CXX20
   pair(piecewise_construct_t __pc, tuple<_Args1...> __first_args, tuple<_Args2...> __second_args) noexcept(
       is_nothrow_constructible<first_type, _Args1...>::value && is_nothrow_constructible<second_type, _Args2...>::value)
       : pair(__pc, __first_args, __second_args, __index_sequence_for<_Args1...>(), __index_sequence_for<_Args2...>()) {}
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair&
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 pair&
   operator=(__conditional_t<is_copy_assignable<first_type>::value && is_copy_assignable<second_type>::value,
                             pair,
                             __nat> const& __p) noexcept(is_nothrow_copy_assignable<first_type>::value &&
@@ -231,7 +226,7 @@ struct pair
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(
       __conditional_t<is_move_assignable<first_type>::value && is_move_assignable<second_type>::value, pair, __nat>&&
           __p) noexcept(is_nothrow_move_assignable<first_type>::value &&
                         is_nothrow_move_assignable<second_type>::value) {
@@ -245,7 +240,7 @@ struct pair
       class _U2,
       __enable_if_t<is_assignable<first_type&, _U1 const&>::value && is_assignable<second_type&, _U2 const&>::value,
                     int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2> const& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2> const& __p) {
     first  = __p.first;
     second = __p.second;
     return *this;
@@ -254,7 +249,7 @@ struct pair
   template <class _U1,
             class _U2,
             __enable_if_t<is_assignable<first_type&, _U1>::value && is_assignable<second_type&, _U2>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2>&& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 pair& operator=(pair<_U1, _U2>&& __p) {
     first  = std::forward<_U1>(__p.first);
     second = std::forward<_U2>(__p.second);
     return *this;
@@ -262,7 +257,7 @@ struct pair
 
 #  if _LIBCPP_STD_VER >= 23
   template <class = void>
-  _LIBCPP_HIDE_FROM_ABI constexpr const pair& operator=(pair const& __p) const
+  constexpr const pair& operator=(pair const& __p) const
       noexcept(is_nothrow_copy_assignable_v<const first_type> && is_nothrow_copy_assignable_v<const second_type>)
     requires(is_copy_assignable_v<const first_type> && is_copy_assignable_v<const second_type>)
   {
@@ -272,7 +267,7 @@ struct pair
   }
 
   template <class = void>
-  _LIBCPP_HIDE_FROM_ABI constexpr const pair& operator=(pair&& __p) const
+  constexpr const pair& operator=(pair&& __p) const
       noexcept(is_nothrow_assignable_v<const first_type&, first_type> &&
                is_nothrow_assignable_v<const second_type&, second_type>)
     requires(is_assignable_v<const first_type&, first_type> && is_assignable_v<const second_type&, second_type>)
@@ -283,7 +278,7 @@ struct pair
   }
 
   template <class _U1, class _U2>
-  _LIBCPP_HIDE_FROM_ABI constexpr const pair& operator=(const pair<_U1, _U2>& __p) const
+  constexpr const pair& operator=(const pair<_U1, _U2>& __p) const
     requires(is_assignable_v<const first_type&, const _U1&> && is_assignable_v<const second_type&, const _U2&>)
   {
     first  = __p.first;
@@ -292,7 +287,7 @@ struct pair
   }
 
   template <class _U1, class _U2>
-  _LIBCPP_HIDE_FROM_ABI constexpr const pair& operator=(pair<_U1, _U2>&& __p) const
+  constexpr const pair& operator=(pair<_U1, _U2>&& __p) const
     requires(is_assignable_v<const first_type&, _U1> && is_assignable_v<const second_type&, _U2>)
   {
     first  = std::forward<_U1>(__p.first);
@@ -304,7 +299,7 @@ struct pair
     requires(__different_from<_PairLike, pair> &&
              is_assignable_v<first_type&, decltype(std::get<0>(std::declval<_PairLike>()))> &&
              is_assignable_v<second_type&, decltype(std::get<1>(std::declval<_PairLike>()))>)
-  _LIBCPP_HIDE_FROM_ABI constexpr pair& operator=(_PairLike&& __p) {
+  constexpr pair& operator=(_PairLike&& __p) {
     first  = std::get<0>(std::forward<_PairLike>(__p));
     second = std::get<1>(std::forward<_PairLike>(__p));
     return *this;
@@ -314,7 +309,7 @@ struct pair
     requires(__different_from<_PairLike, pair> &&
              is_assignable_v<first_type const&, decltype(std::get<0>(std::declval<_PairLike>()))> &&
              is_assignable_v<second_type const&, decltype(std::get<1>(std::declval<_PairLike>()))>)
-  _LIBCPP_HIDE_FROM_ABI constexpr pair const& operator=(_PairLike&& __p) const {
+  constexpr pair const& operator=(_PairLike&& __p) const {
     first  = std::get<0>(std::forward<_PairLike>(__p));
     second = std::get<1>(std::forward<_PairLike>(__p));
     return *this;
@@ -328,34 +323,33 @@ struct pair
   template <class _U1,
             class _U2,
             __enable_if_t<is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2> const& __p)
-      : first(std::get<0>(__p)), second(std::get<1>(__p)) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2> const& __p) : first(std::get<0>(__p)), second(std::get<1>(__p)) {}
 
   template < class _U1,
              class _U2,
              __enable_if_t<is_constructible<_T1, _U1 const&>::value && is_constructible<_T2, _U2 const&>::value &&
                                !(is_convertible<_U1 const&, _T1>::value && is_convertible<_U2 const&, _T2>::value),
                            int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2> const& __p)
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2> const& __p)
       : first(std::get<0>(__p)), second(std::get<1>(__p)) {}
 
   template <class _U1,
             class _U2,
             __enable_if_t<is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2>&& __p)
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(tuple<_U1, _U2>&& __p)
       : first(std::get<0>(std::move(__p))), second(std::get<1>(std::move(__p))) {}
 
   template <class _U1,
             class _U2,
             __enable_if_t<is_constructible<_T1, _U1>::value && is_constructible<_T2, _U2>::value &&
                           !(is_convertible<_U1, _T1>::value && is_convertible<_U2, _T2>::value) > = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2>&& __p)
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(tuple<_U1, _U2>&& __p)
       : first(std::get<0>(std::move(__p))), second(std::get<1>(std::move(__p))) {}
 
   template <class _U1,
             class _U2,
             __enable_if_t<is_assignable<_T1&, _U1 const&>::value && is_assignable<_T2&, _U2 const&>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2> const& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2> const& __p) {
     first  = std::get<0>(__p);
     second = std::get<1>(__p);
     return *this;
@@ -364,7 +358,7 @@ struct pair
   template <class _U1,
             class _U2,
             __enable_if_t<is_assignable<_T1&, _U1&&>::value && is_assignable<_T2&, _U2&&>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2>&& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(tuple<_U1, _U2>&& __p) {
     first  = std::get<0>(std::move(__p));
     second = std::get<1>(std::move(__p));
     return *this;
@@ -373,36 +367,34 @@ struct pair
   // from std::array
   template <class _Up,
             __enable_if_t<is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2> const& __p) : first(__p[0]), second(__p[1]) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2> const& __p) : first(__p[0]), second(__p[1]) {}
 
   template <class _Up,
             __enable_if_t<is_constructible<_T1, _Up const&>::value && is_constructible<_T2, _Up const&>::value &&
                               !(is_convertible<_Up const&, _T1>::value && is_convertible<_Up const&, _T2>::value),
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2> const& __p)
-      : first(__p[0]), second(__p[1]) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2> const& __p) : first(__p[0]), second(__p[1]) {}
 
   template <class _Up, __enable_if_t< is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2>&& __p)
-      : first(std::move(__p)[0]), second(std::move(__p)[1]) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair(array<_Up, 2>&& __p) : first(std::move(__p)[0]), second(std::move(__p)[1]) {}
 
   template <class _Up,
             __enable_if_t<is_constructible<_T1, _Up>::value && is_constructible<_T2, _Up>::value &&
                               !(is_convertible<_Up, _T1>::value && is_convertible<_Up, _T2>::value),
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2>&& __p)
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit pair(array<_Up, 2>&& __p)
       : first(std::move(__p)[0]), second(std::move(__p)[1]) {}
 
   template <class _Up,
             __enable_if_t<is_assignable<_T1&, _Up const&>::value && is_assignable<_T2&, _Up const&>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2> const& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2> const& __p) {
     first  = std::get<0>(__p);
     second = std::get<1>(__p);
     return *this;
   }
 
   template <class _Up, __enable_if_t<is_assignable<_T1&, _Up>::value && is_assignable<_T2&, _Up>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2>&& __p) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 pair& operator=(array<_Up, 2>&& __p) {
     first  = std::get<0>(std::move(__p));
     second = std::get<1>(std::move(__p));
     return *this;
@@ -410,7 +402,7 @@ struct pair
 #  endif // _LIBCPP_STD_VER < 23
 #endif   // _LIBCPP_CXX03_LANG
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair& __p)
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair& __p)
       _NOEXCEPT_(__is_nothrow_swappable_v<first_type>&& __is_nothrow_swappable_v<second_type>) {
     using std::swap;
     swap(first, __p.first);
@@ -418,7 +410,7 @@ struct pair
   }
 
 #if _LIBCPP_STD_VER >= 23
-  _LIBCPP_HIDE_FROM_ABI constexpr void swap(const pair& __p) const
+  constexpr void swap(const pair& __p) const
       noexcept(__is_nothrow_swappable_v<const first_type> && __is_nothrow_swappable_v<const second_type>) {
     using std::swap;
     swap(first, __p.first);
@@ -429,7 +421,7 @@ struct pair
 private:
 #ifndef _LIBCPP_CXX03_LANG
   template <class... _Args1, class... _Args2, size_t... _I1, size_t... _I2>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
+  _LIBCPP_CONSTEXPR_SINCE_CXX20
   pair(piecewise_construct_t,
        tuple<_Args1...>& __first_args,
        tuple<_Args2...>& __second_args,
@@ -448,8 +440,7 @@ pair(_T1, _T2) -> pair<_T1, _T2>;
 // [pairs.spec], specialized algorithms
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
 #if _LIBCPP_STD_VER >= 26
   requires requires {
     { __x.first == __y.first } -> __boolean_testable;
@@ -463,8 +454,7 @@ operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
 #if _LIBCPP_STD_VER >= 20
 
 template <class _T1, class _T2, class _U1, class _U2>
-_LIBCPP_HIDE_FROM_ABI constexpr common_comparison_category_t< __synth_three_way_result<_T1, _U1>,
-                                                              __synth_three_way_result<_T2, _U2> >
+constexpr common_comparison_category_t< __synth_three_way_result<_T1, _U1>, __synth_three_way_result<_T2, _U2> >
 operator<=>(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   if (auto __c = std::__synth_three_way(__x.first, __y.first); __c != 0) {
     return __c;
@@ -475,32 +465,27 @@ operator<=>(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
 #else // _LIBCPP_STD_VER >= 20
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator!=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator!=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   return !(__x == __y);
 }
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator<(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   return __x.first < __y.first || (!(__y.first < __x.first) && __x.second < __y.second);
 }
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator>(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   return __y < __x;
 }
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator>=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator>=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   return !(__x < __y);
 }
 
 template <class _T1, class _T2, class _U1, class _U2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-operator<=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator<=(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y) {
   return !(__y < __x);
 }
 
@@ -524,7 +509,7 @@ struct common_type<pair<_T1, _T2>, pair<_U1, _U2>> {
 #endif // _LIBCPP_STD_VER >= 23
 
 template <class _T1, class _T2, __enable_if_t<__is_swappable_v<_T1> && __is_swappable_v<_T2>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair<_T1, _T2>& __x, pair<_T1, _T2>& __y)
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair<_T1, _T2>& __x, pair<_T1, _T2>& __y)
     _NOEXCEPT_(__is_nothrow_swappable_v<_T1>&& __is_nothrow_swappable_v<_T2>) {
   __x.swap(__y);
 }
@@ -532,15 +517,14 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair<_T1, _
 #if _LIBCPP_STD_VER >= 23
 template <class _T1, class _T2>
   requires(__is_swappable_v<const _T1> && __is_swappable_v<const _T2>)
-_LIBCPP_HIDE_FROM_ABI constexpr void
-swap(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y) noexcept(noexcept(__x.swap(__y))) {
+constexpr void swap(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y) noexcept(noexcept(__x.swap(__y))) {
   __x.swap(__y);
 }
 #endif
 
 template <class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-pair<__unwrap_ref_decay_t<_T1>, __unwrap_ref_decay_t<_T2> > make_pair(_T1&& __t1, _T2&& __t2) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<__unwrap_ref_decay_t<_T1>, __unwrap_ref_decay_t<_T2> >
+make_pair(_T1&& __t1, _T2&& __t2) {
   return pair<__unwrap_ref_decay_t<_T1>, __unwrap_ref_decay_t<_T2> >(std::forward<_T1>(__t1), std::forward<_T2>(__t2));
 }
 
@@ -568,22 +552,22 @@ struct __get_pair;
 template <>
 struct __get_pair<0> {
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _T1& get(pair<_T1, _T2>& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 _T1& get(pair<_T1, _T2>& __p) _NOEXCEPT {
     return __p.first;
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T1& get(const pair<_T1, _T2>& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T1& get(const pair<_T1, _T2>& __p) _NOEXCEPT {
     return __p.first;
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _T1&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 _T1&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
     return std::forward<_T1>(__p.first);
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T1&& get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T1&& get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
     return std::forward<const _T1>(__p.first);
   }
 };
@@ -591,92 +575,88 @@ struct __get_pair<0> {
 template <>
 struct __get_pair<1> {
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _T2& get(pair<_T1, _T2>& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 _T2& get(pair<_T1, _T2>& __p) _NOEXCEPT {
     return __p.second;
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T2& get(const pair<_T1, _T2>& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T2& get(const pair<_T1, _T2>& __p) _NOEXCEPT {
     return __p.second;
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _T2&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 _T2&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
     return std::forward<_T2>(__p.second);
   }
 
   template <class _T1, class _T2>
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T2&& get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 const _T2&& get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
     return std::forward<const _T2>(__p.second);
   }
 };
 
 template <size_t _Ip, class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-typename tuple_element<_Ip, pair<_T1, _T2> >::type&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&
 get(pair<_T1, _T2>& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(__p);
 }
 
 template <size_t _Ip, class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
 get(const pair<_T1, _T2>& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(__p);
 }
 
 template <size_t _Ip, class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
 get(pair<_T1, _T2>&& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(std::move(__p));
 }
 
 template <size_t _Ip, class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
 get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(std::move(__p));
 }
 
 #if _LIBCPP_STD_VER >= 14
 template <class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T1& get(pair<_T1, _T2>& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T1& get(pair<_T1, _T2>& __p) _NOEXCEPT {
   return __p.first;
 }
 
 template <class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const& get(pair<_T1, _T2> const& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T1 const& get(pair<_T1, _T2> const& __p) _NOEXCEPT {
   return __p.first;
 }
 
 template <class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T1&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T1&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
   return std::forward<_T1&&>(__p.first);
 }
 
 template <class _T1, class _T2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const&& get(pair<_T1, _T2> const&& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T1 const&& get(pair<_T1, _T2> const&& __p) _NOEXCEPT {
   return std::forward<_T1 const&&>(__p.first);
 }
 
 template <class _T2, class _T1>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T2& get(pair<_T1, _T2>& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T2& get(pair<_T1, _T2>& __p) _NOEXCEPT {
   return __p.second;
 }
 
 template <class _T2, class _T1>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T2 const& get(pair<_T1, _T2> const& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T2 const& get(pair<_T1, _T2> const& __p) _NOEXCEPT {
   return __p.second;
 }
 
 template <class _T2, class _T1>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T2&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T2&& get(pair<_T1, _T2>&& __p) _NOEXCEPT {
   return std::forward<_T2&&>(__p.second);
 }
 
 template <class _T2, class _T1>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI constexpr _T2 const&& get(pair<_T1, _T2> const&& __p) _NOEXCEPT {
+[[__nodiscard__]] inline constexpr _T2 const&& get(pair<_T1, _T2> const&& __p) _NOEXCEPT {
   return std::forward<_T2 const&&>(__p.second);
 }
 


### PR DESCRIPTION
This is a follow-up to #193045. This only drops `_LIBCPP_HIDE_FROM_ABI` in a small part of the code base to make sure everything works as expected. Once this has been in trunk for a while and there aren't any problems, there will be larger follow-up patches to remove `_LIBCPP_HIDE_FROM_ABI` throughout the code base.