### PR TITLE
AMDGPU: Validate VOPD/VOPD3 physical source registers against operand RC

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -34,6 +34,32 @@ using namespace llvm;
 
 #define DEBUG_TYPE "gcn-vopd-utils"
 
+// Check if physical register from src<SrcIdx> operand of MI<CompIdx> matches
+// register class constraints in corresponding VOPDOpc operand with name
+// src/vsrc<SrcIdx><CompIdx>.
+bool isValidVOPDSrc(const SIInstrInfo &TII, int VOPDOpc, unsigned CompIdx,
+                    unsigned SrcIdx, Register PhysSrcReg) {
+  static const AMDGPU::OpName Src0X[] = {AMDGPU::OpName::src0X};
+  static const AMDGPU::OpName Src1X[] = {AMDGPU::OpName::vsrc1X};
+  static const AMDGPU::OpName Src2X[] = {AMDGPU::OpName::vsrc2X,
+                                         AMDGPU::OpName::src2X};
+  static const AMDGPU::OpName Src0Y[] = {AMDGPU::OpName::src0Y};
+  static const AMDGPU::OpName Src1Y[] = {AMDGPU::OpName::vsrc1Y};
+  static const AMDGPU::OpName Src2Y[] = {AMDGPU::OpName::vsrc2Y,
+                                         AMDGPU::OpName::src2Y};
+  static const ArrayRef<AMDGPU::OpName> SrcNames[2][3] = {
+      {Src0X, Src1X, Src2X}, {Src0Y, Src1Y, Src2Y}};
+
+  int Idx = -1;
+  for (AMDGPU::OpName Name : SrcNames[CompIdx][SrcIdx]) {
+    Idx = getNamedOperandIdx(VOPDOpc, Name);
+    if (Idx > 0)
+      break;
+  }
+
+  return TII.getRegClass(TII.get(VOPDOpc), Idx)->contains(PhysSrcReg);
+}
+
 bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
                                    const MachineInstr &MIX,
                                    const MachineInstr &MIY, bool IsVOPD3,
@@ -63,6 +89,11 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
   };
   SmallSet<Register, 4> UniqueScalarRegs;
 
+  unsigned EncodingFamily = AMDGPU::getVOPDEncodingFamily(ST);
+  unsigned XOpc = AMDGPU::getVOPDOpcode(MIX.getOpcode(), IsVOPD3);
+  unsigned YOpc = AMDGPU::getVOPDOpcode(MIY.getOpcode(), IsVOPD3);
+  int VOPDOpc = AMDGPU::getVOPDFull(XOpc, YOpc, EncodingFamily, IsVOPD3);
+
   auto InstInfo = AMDGPU::getVOPDInstInfo(MIX.getDesc(), MIY.getDesc());
 
   for (auto CompIdx : VOPD::COMPONENTS) {
@@ -73,6 +104,8 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
       if (!TRI->isVectorRegister(MRI, Src0.getReg())) {
         UniqueScalarRegs.insert(Src0.getReg());
       }
+      if (!isValidVOPDSrc(TII, VOPDOpc, CompIdx, 0, Src0.getReg()))
+        return false;
     } else if (!TII.isInlineConstant(Src0)) {
       if (IsVOPD3)
         return false;
@@ -90,13 +123,16 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
     if (MI.getDesc().hasImplicitUseOfPhysReg(AMDGPU::VCC))
       UniqueScalarRegs.insert(AMDGPU::VCC_LO);
 
-    if (IsVOPD3) {
-      if (const MachineOperand *Src1 =
-              TII.getNamedOperand(MI, AMDGPU::OpName::src1)) {
-        if (!Src1->isReg() || !TRI->isVGPR(MRI, Src1->getReg()))
-          return false;
-      }
+    if (const MachineOperand *Src1 =
+            TII.getNamedOperand(MI, AMDGPU::OpName::src1)) {
+      if (IsVOPD3 && !Src1->isReg())
+        return false;
+      if (Src1->isReg() &&
+          !isValidVOPDSrc(TII, VOPDOpc, CompIdx, 1, Src1->getReg()))
+        return false;
+    }
 
+    if (IsVOPD3) {
       if (const MachineOperand *Src2 =
               TII.getNamedOperand(MI, AMDGPU::OpName::src2)) {
         if (AMDGPU::hasNamedOperand(MI.getOpcode(), AMDGPU::OpName::bitop3)) {
@@ -105,7 +141,8 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
             return false;
         } else if (MI.getOpcode() == AMDGPU::V_CNDMASK_B32_e64) {
           UniqueScalarRegs.insert(Src2->getReg());
-        } else if (!Src2->isReg() || !TRI->isVGPR(MRI, Src2->getReg())) {
+        } else if (!Src2->isReg() ||
+                   !isValidVOPDSrc(TII, VOPDOpc, CompIdx, 2, Src2->getReg())) {
           return false;
         }
       }

--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -34,6 +34,35 @@ using namespace llvm;
 
 #define DEBUG_TYPE "gcn-vopd-utils"
 
+// Check if physical register from src<SrcIdx> operand of MI<CompIdx> matches
+// register class constraints in corresponding VOPDOpc operand with name
+// src/vsrc<SrcIdx><CompIdx>.
+static bool isValidVOPDSrc(const SIInstrInfo &TII, int VOPDOpc,
+                           unsigned CompIdx, unsigned SrcIdx,
+                           Register PhysSrcReg) {
+  using namespace AMDGPU;
+  int OpIdx = -1;
+  const bool IsX = CompIdx == VOPD::X;
+  switch (SrcIdx) {
+  case 0:
+    OpIdx = getNamedOperandIdx(VOPDOpc, IsX ? OpName::src0X : OpName::src0Y);
+    break;
+  case 1:
+    OpIdx = getNamedOperandIdx(VOPDOpc, IsX ? OpName::vsrc1X : OpName::vsrc1Y);
+    break;
+  case 2:
+    OpIdx = getNamedOperandIdx(VOPDOpc, IsX ? OpName::vsrc2X : OpName::vsrc2Y);
+    if (OpIdx == -1)
+      OpIdx = getNamedOperandIdx(VOPDOpc, IsX ? OpName::src2X : OpName::src2Y);
+    break;
+  default:
+    llvm_unreachable("unexpected VOPD source index");
+  }
+
+  assert(OpIdx != -1);
+  return TII.getRegClass(TII.get(VOPDOpc), OpIdx)->contains(PhysSrcReg);
+}
+
 bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
                                    const MachineInstr &MIX,
                                    const MachineInstr &MIY, bool IsVOPD3,
@@ -63,6 +92,12 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
   };
   SmallSet<Register, 4> UniqueScalarRegs;
 
+  unsigned EncodingFamily = AMDGPU::getVOPDEncodingFamily(ST);
+  unsigned XOpc = AMDGPU::getVOPDOpcode(MIX.getOpcode(), IsVOPD3);
+  unsigned YOpc = AMDGPU::getVOPDOpcode(MIY.getOpcode(), IsVOPD3);
+  int VOPDOpc = AMDGPU::getVOPDFull(XOpc, YOpc, EncodingFamily, IsVOPD3);
+  assert(VOPDOpc != -1);
+
   auto InstInfo = AMDGPU::getVOPDInstInfo(MIX.getDesc(), MIY.getDesc());
 
   for (auto CompIdx : VOPD::COMPONENTS) {
@@ -70,9 +105,10 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
 
     const MachineOperand &Src0 = *TII.getNamedOperand(MI, AMDGPU::OpName::src0);
     if (Src0.isReg()) {
-      if (!TRI->isVectorRegister(MRI, Src0.getReg())) {
+      if (!isValidVOPDSrc(TII, VOPDOpc, CompIdx, 0, Src0.getReg()))
+        return false;
+      if (!TRI->isVectorRegister(MRI, Src0.getReg()))
         UniqueScalarRegs.insert(Src0.getReg());
-      }
     } else if (!TII.isInlineConstant(Src0)) {
       if (IsVOPD3)
         return false;
@@ -90,23 +126,33 @@ bool llvm::checkVOPDRegConstraints(const SIInstrInfo &TII,
     if (MI.getDesc().hasImplicitUseOfPhysReg(AMDGPU::VCC))
       UniqueScalarRegs.insert(AMDGPU::VCC_LO);
 
-    if (IsVOPD3) {
-      if (const MachineOperand *Src1 =
-              TII.getNamedOperand(MI, AMDGPU::OpName::src1)) {
-        if (!Src1->isReg() || !TRI->isVGPR(MRI, Src1->getReg()))
+    if (const MachineOperand *Src1 =
+            TII.getNamedOperand(MI, AMDGPU::OpName::src1)) {
+      if (Src1->isReg()) {
+        if (!isValidVOPDSrc(TII, VOPDOpc, CompIdx, 1, Src1->getReg()))
           return false;
+        assert(TRI->isVectorRegister(MRI, Src1->getReg()));
+      } else if (IsVOPD3) {
+        return false;
       }
+    }
 
+    if (IsVOPD3) {
       if (const MachineOperand *Src2 =
               TII.getNamedOperand(MI, AMDGPU::OpName::src2)) {
         if (AMDGPU::hasNamedOperand(MI.getOpcode(), AMDGPU::OpName::bitop3)) {
           // BITOP3 can be converted to DUAL_BITOP2 when src2 is zero.
           if (!Src2->isImm() || Src2->getImm())
             return false;
-        } else if (MI.getOpcode() == AMDGPU::V_CNDMASK_B32_e64) {
-          UniqueScalarRegs.insert(Src2->getReg());
-        } else if (!Src2->isReg() || !TRI->isVGPR(MRI, Src2->getReg())) {
-          return false;
+        } else {
+          if (!Src2->isReg())
+            return false;
+          if (!isValidVOPDSrc(TII, VOPDOpc, CompIdx, 2, Src2->getReg()))
+            return false;
+          if (!TRI->isVectorRegister(MRI, Src2->getReg())) {
+            assert(MI.getOpcode() == AMDGPU::V_CNDMASK_B32_e64);
+            UniqueScalarRegs.insert(Src2->getReg());
+          }
         }
       }
       for (auto OpName : {AMDGPU::OpName::clamp, AMDGPU::OpName::omod,


### PR DESCRIPTION
Replace isVGPR checks with isValidVOPDSrc that validates physical source
registers against the actual combined VOPD/VOPD3 instruction's operand
register classes. Now we also validate operands for VOPD instructions.