### PR TITLE
[LLVM] Rename `Type::getTruncatedType()` and `Type::getExtendedType()`

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -1256,7 +1256,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   }
   case NEON::BI__builtin_neon_vaddhn_v: {
     llvm::FixedVectorType *SrcTy =
-        llvm::FixedVectorType::getExtendedElementVectorType(VTy);
+        llvm::FixedVectorType::getDoubleWidthElementVectorType(VTy);
 
     // %sum = add <4 x i32> %lhs, %rhs
     Ops[0] = Builder.CreateBitCast(Ops[0], SrcTy);
@@ -1455,7 +1455,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
     return EmitNeonCall(CGM.getIntrinsic(LLVMIntrinsic, Tys), Ops, NameHint);
   }
   case NEON::BI__builtin_neon_vcvtx_f32_v: {
-    llvm::Type *Tys[2] = { VTy->getTruncatedElementVectorType(VTy), Ty};
+    llvm::Type *Tys[2] = {VTy->getHalfWidthElementVectorType(VTy), Ty};
     return EmitNeonCall(CGM.getIntrinsic(LLVMIntrinsic, Tys), Ops, NameHint);
 
   }
@@ -1541,7 +1541,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   }
   case NEON::BI__builtin_neon_vmovl_v: {
     llvm::FixedVectorType *DTy =
-        llvm::FixedVectorType::getTruncatedElementVectorType(VTy);
+        llvm::FixedVectorType::getHalfWidthElementVectorType(VTy);
     Ops[0] = Builder.CreateBitCast(Ops[0], DTy);
     if (Usgn)
       return Builder.CreateZExt(Ops[0], Ty, "vmovl");
@@ -1549,7 +1549,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   }
   case NEON::BI__builtin_neon_vmovn_v: {
     llvm::FixedVectorType *QTy =
-        llvm::FixedVectorType::getExtendedElementVectorType(VTy);
+        llvm::FixedVectorType::getDoubleWidthElementVectorType(VTy);
     Ops[0] = Builder.CreateBitCast(Ops[0], QTy);
     return Builder.CreateTrunc(Ops[0], Ty, "vmovn");
   }
@@ -1652,7 +1652,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
                              "vshl_n");
   case NEON::BI__builtin_neon_vshll_n_v: {
     llvm::FixedVectorType *SrcTy =
-        llvm::FixedVectorType::getTruncatedElementVectorType(VTy);
+        llvm::FixedVectorType::getHalfWidthElementVectorType(VTy);
     Ops[0] = Builder.CreateBitCast(Ops[0], SrcTy);
     if (Usgn)
       Ops[0] = Builder.CreateZExt(Ops[0], VTy);
@@ -1663,7 +1663,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   }
   case NEON::BI__builtin_neon_vshrn_n_v: {
     llvm::FixedVectorType *SrcTy =
-        llvm::FixedVectorType::getExtendedElementVectorType(VTy);
+        llvm::FixedVectorType::getDoubleWidthElementVectorType(VTy);
     Ops[0] = Builder.CreateBitCast(Ops[0], SrcTy);
     Ops[1] = EmitNeonShiftVector(Ops[1], SrcTy, false);
     if (Usgn)
@@ -1728,7 +1728,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   }
   case NEON::BI__builtin_neon_vsubhn_v: {
     llvm::FixedVectorType *SrcTy =
-        llvm::FixedVectorType::getExtendedElementVectorType(VTy);
+        llvm::FixedVectorType::getDoubleWidthElementVectorType(VTy);
 
     // %sum = add <4 x i32> %lhs, %rhs
     Ops[0] = Builder.CreateBitCast(Ops[0], SrcTy);

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -66,12 +66,12 @@ public:
   LLVM_ABI static IntegerType *get(LLVMContext &C, unsigned NumBits);
 
   /// Returns type twice as wide the input type.
-  IntegerType *getExtendedType() const {
+  IntegerType *getDoubleWidthType() const {
     return Type::getIntNTy(getContext(), 2 * getBitWidth());
   }
 
   /// Returns type half as wide the input type.
-  IntegerType *getTruncatedType() const {
+  IntegerType *getHalfWidthType() const {
     unsigned BitWidth = getBitWidth();
     assert((BitWidth & 1) == 0 &&
            "Cannot truncate integer type with odd bit-width");
@@ -540,16 +540,16 @@ public:
 
   /// This static method is like getInteger except that the element types are
   /// twice as wide as the elements in the input type.
-  static VectorType *getExtendedElementVectorType(VectorType *VTy) {
+  static VectorType *getDoubleWidthElementVectorType(VectorType *VTy) {
     assert(VTy->isIntOrIntVectorTy() && "VTy expected to be a vector of ints.");
     auto *EltTy = cast<IntegerType>(VTy->getElementType());
-    return VectorType::get(EltTy->getExtendedType(), VTy->getElementCount());
+    return VectorType::get(EltTy->getDoubleWidthType(), VTy->getElementCount());
   }
 
   // This static method gets a VectorType with the same number of elements as
   // the input type, and the element type is an integer or float type which
   // is half as wide as the elements in the input type.
-  static VectorType *getTruncatedElementVectorType(VectorType *VTy) {
+  static VectorType *getHalfWidthElementVectorType(VectorType *VTy) {
     Type *EltTy = VTy->getElementType();
     if (EltTy->isFloatingPointTy()) {
       switch (EltTy->getTypeID()) {
@@ -563,7 +563,7 @@ public:
         llvm_unreachable("Cannot create narrower fp vector element type");
       }
     } else {
-      EltTy = cast<IntegerType>(EltTy)->getTruncatedType();
+      EltTy = cast<IntegerType>(EltTy)->getHalfWidthType();
     }
     return VectorType::get(EltTy, VTy->getElementCount());
   }
@@ -574,7 +574,7 @@ public:
   static VectorType *getSubdividedVectorType(VectorType *VTy, int NumSubdivs) {
     for (int i = 0; i < NumSubdivs; ++i) {
       VTy = VectorType::getDoubleElementsVectorType(VTy);
-      VTy = VectorType::getTruncatedElementVectorType(VTy);
+      VTy = VectorType::getHalfWidthElementVectorType(VTy);
     }
     return VTy;
   }
@@ -655,13 +655,15 @@ public:
     return cast<FixedVectorType>(VectorType::getInteger(VTy));
   }
 
-  static FixedVectorType *getExtendedElementVectorType(FixedVectorType *VTy) {
-    return cast<FixedVectorType>(VectorType::getExtendedElementVectorType(VTy));
+  static FixedVectorType *
+  getDoubleWidthElementVectorType(FixedVectorType *VTy) {
+    return cast<FixedVectorType>(
+        VectorType::getDoubleWidthElementVectorType(VTy));
   }
 
-  static FixedVectorType *getTruncatedElementVectorType(FixedVectorType *VTy) {
+  static FixedVectorType *getHalfWidthElementVectorType(FixedVectorType *VTy) {
     return cast<FixedVectorType>(
-        VectorType::getTruncatedElementVectorType(VTy));
+        VectorType::getHalfWidthElementVectorType(VTy));
   }
 
   static FixedVectorType *getSubdividedVectorType(FixedVectorType *VTy,
@@ -705,15 +707,15 @@ public:
   }
 
   static ScalableVectorType *
-  getExtendedElementVectorType(ScalableVectorType *VTy) {
+  getDoubleWidthElementVectorType(ScalableVectorType *VTy) {
     return cast<ScalableVectorType>(
-        VectorType::getExtendedElementVectorType(VTy));
+        VectorType::getDoubleWidthElementVectorType(VTy));
   }
 
   static ScalableVectorType *
-  getTruncatedElementVectorType(ScalableVectorType *VTy) {
+  getHalfWidthElementVectorType(ScalableVectorType *VTy) {
     return cast<ScalableVectorType>(
-        VectorType::getTruncatedElementVectorType(VTy));
+        VectorType::getHalfWidthElementVectorType(VTy));
   }
 
   static ScalableVectorType *getSubdividedVectorType(ScalableVectorType *VTy,
@@ -795,24 +797,24 @@ public:
   }
 };
 
-Type *Type::getExtendedType() const {
+Type *Type::getDoubleWidthType() const {
   assert(
       isIntOrIntVectorTy() &&
       "Original type expected to be a vector of integers or a scalar integer.");
   if (auto *VTy = dyn_cast<VectorType>(this))
-    return VectorType::getExtendedElementVectorType(
+    return VectorType::getDoubleWidthElementVectorType(
         const_cast<VectorType *>(VTy));
-  return cast<IntegerType>(this)->getExtendedType();
+  return cast<IntegerType>(this)->getDoubleWidthType();
 }
 
-Type *Type::getTruncatedType() const {
+Type *Type::getHalfWidthType() const {
   assert(
       isIntOrIntVectorTy() &&
       "Original type expected to be a vector of integers or a scalar integer.");
   if (auto *VTy = dyn_cast<VectorType>(this))
-    return VectorType::getTruncatedElementVectorType(
+    return VectorType::getHalfWidthElementVectorType(
         const_cast<VectorType *>(VTy));
-  return cast<IntegerType>(this)->getTruncatedType();
+  return cast<IntegerType>(this)->getHalfWidthType();
 }
 
 Type *Type::getWithNewType(Type *EltTy) const {

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -442,11 +442,11 @@ public:
 
   /// Given scalar/vector integer type, returns a type with elements twice as
   /// wide as in the original type. For vectors, preserves element count.
-  LLVM_ABI inline Type *getExtendedType() const;
+  LLVM_ABI inline Type *getDoubleWidthType() const;
 
   /// Given scalar/vector integer type, returns a type with elements half as
   /// wide as in the original type. For vectors, preserves element count.
-  LLVM_ABI inline Type *getTruncatedType() const;
+  LLVM_ABI inline Type *getHalfWidthType() const;
 
   /// Get the address space of this pointer or pointer vector type.
   LLVM_ABI inline unsigned getPointerAddressSpace() const;

--- a/llvm/include/llvm/SandboxIR/Type.h
+++ b/llvm/include/llvm/SandboxIR/Type.h
@@ -346,8 +346,8 @@ public:
     return cast<llvm::VectorType>(LLVMTy)->getElementCount();
   }
   LLVM_ABI static VectorType *getInteger(VectorType *VTy);
-  LLVM_ABI static VectorType *getExtendedElementVectorType(VectorType *VTy);
-  LLVM_ABI static VectorType *getTruncatedElementVectorType(VectorType *VTy);
+  LLVM_ABI static VectorType *getDoubleWidthElementVectorType(VectorType *VTy);
+  LLVM_ABI static VectorType *getHalfWidthElementVectorType(VectorType *VTy);
   LLVM_ABI static VectorType *getSubdividedVectorType(VectorType *VTy,
                                                       int NumSubdivs);
   LLVM_ABI static VectorType *getHalfElementsVectorType(VectorType *VTy);
@@ -371,13 +371,15 @@ public:
     return cast<FixedVectorType>(VectorType::getInteger(VTy));
   }
 
-  static FixedVectorType *getExtendedElementVectorType(FixedVectorType *VTy) {
-    return cast<FixedVectorType>(VectorType::getExtendedElementVectorType(VTy));
+  static FixedVectorType *
+  getDoubleWidthElementVectorType(FixedVectorType *VTy) {
+    return cast<FixedVectorType>(
+        VectorType::getDoubleWidthElementVectorType(VTy));
   }
 
-  static FixedVectorType *getTruncatedElementVectorType(FixedVectorType *VTy) {
+  static FixedVectorType *getHalfWidthElementVectorType(FixedVectorType *VTy) {
     return cast<FixedVectorType>(
-        VectorType::getTruncatedElementVectorType(VTy));
+        VectorType::getHalfWidthElementVectorType(VTy));
   }
 
   static FixedVectorType *getSubdividedVectorType(FixedVectorType *VTy,
@@ -418,15 +420,15 @@ public:
   }
 
   static ScalableVectorType *
-  getExtendedElementVectorType(ScalableVectorType *VTy) {
+  getDoubleWidthElementVectorType(ScalableVectorType *VTy) {
     return cast<ScalableVectorType>(
-        VectorType::getExtendedElementVectorType(VTy));
+        VectorType::getDoubleWidthElementVectorType(VTy));
   }
 
   static ScalableVectorType *
-  getTruncatedElementVectorType(ScalableVectorType *VTy) {
+  getHalfWidthElementVectorType(ScalableVectorType *VTy) {
     return cast<ScalableVectorType>(
-        VectorType::getTruncatedElementVectorType(VTy));
+        VectorType::getHalfWidthElementVectorType(VTy));
   }
 
   static ScalableVectorType *getSubdividedVectorType(ScalableVectorType *VTy,

--- a/llvm/lib/Analysis/LoopCacheAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopCacheAnalysis.cpp
@@ -329,7 +329,7 @@ CacheCostTy IndexedReference::computeRefCost(const Loop &L,
           computeTripCount(*AR->getLoop(), *Sizes.back(), SE);
       Type *WiderType = SE.getWiderType(RefCost->getType(), TripCount->getType());
       // For the multiplication result to fit, request a type twice as wide.
-      WiderType = WiderType->getExtendedType();
+      WiderType = WiderType->getDoubleWidthType();
       RefCost = SE.getMulExpr(SE.getNoopOrZeroExtend(RefCost, WiderType),
                               SE.getNoopOrZeroExtend(TripCount, WiderType));
     }

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -555,9 +555,9 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::VecOfAnyPtrsToElt:
     return OverloadTys[D.getOverloadIndex()];
   case IITDescriptor::Extend:
-    return OverloadTys[D.getOverloadIndex()]->getExtendedType();
+    return OverloadTys[D.getOverloadIndex()]->getDoubleWidthType();
   case IITDescriptor::Trunc:
-    return OverloadTys[D.getOverloadIndex()]->getTruncatedType();
+    return OverloadTys[D.getOverloadIndex()]->getHalfWidthType();
   case IITDescriptor::Subdivide2:
   case IITDescriptor::Subdivide4: {
     Type *Ty = OverloadTys[D.getOverloadIndex()];
@@ -948,7 +948,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
 
-    Type *NewTy = OverloadTys[D.getOverloadIndex()]->getExtendedType();
+    Type *NewTy = OverloadTys[D.getOverloadIndex()]->getDoubleWidthType();
     return Ty != NewTy;
   }
   case IITDescriptor::Trunc: {
@@ -956,7 +956,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     if (D.getOverloadIndex() >= OverloadTys.size())
       return IsDeferredCheck || DeferCheck(Ty);
 
-    Type *NewTy = OverloadTys[D.getOverloadIndex()]->getTruncatedType();
+    Type *NewTy = OverloadTys[D.getOverloadIndex()]->getHalfWidthType();
     return Ty != NewTy;
   }
   case IITDescriptor::OneNthEltsVec: {

--- a/llvm/lib/SandboxIR/Type.cpp
+++ b/llvm/lib/SandboxIR/Type.cpp
@@ -80,14 +80,14 @@ VectorType *VectorType::getInteger(VectorType *VTy) {
   return cast<VectorType>(VTy->getContext().getType(
       llvm::VectorType::getInteger(cast<llvm::VectorType>(VTy->LLVMTy))));
 }
-VectorType *VectorType::getExtendedElementVectorType(VectorType *VTy) {
-  return cast<VectorType>(
-      VTy->getContext().getType(llvm::VectorType::getExtendedElementVectorType(
+VectorType *VectorType::getDoubleWidthElementVectorType(VectorType *VTy) {
+  return cast<VectorType>(VTy->getContext().getType(
+      llvm::VectorType::getDoubleWidthElementVectorType(
           cast<llvm::VectorType>(VTy->LLVMTy))));
 }
-VectorType *VectorType::getTruncatedElementVectorType(VectorType *VTy) {
+VectorType *VectorType::getHalfWidthElementVectorType(VectorType *VTy) {
   return cast<VectorType>(
-      VTy->getContext().getType(llvm::VectorType::getTruncatedElementVectorType(
+      VTy->getContext().getType(llvm::VectorType::getHalfWidthElementVectorType(
           cast<llvm::VectorType>(VTy->LLVMTy))));
 }
 VectorType *VectorType::getSubdividedVectorType(VectorType *VTy,

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -18232,7 +18232,7 @@ bool AArch64TargetLowering::optimizeExtendOrTruncateConversion(
       return false;
 
     auto *TruncDstType =
-        cast<FixedVectorType>(VectorType::getTruncatedElementVectorType(DstTy));
+        cast<FixedVectorType>(VectorType::getHalfWidthElementVectorType(DstTy));
     // If the ZExt can be lowered to a single ZExt to the next power-of-2 and
     // the remaining ZExt folded into the user, don't use tbl lowering.
     auto SrcWidth = SrcTy->getElementType()->getScalarSizeInBits();

--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -532,7 +532,7 @@ static Value *simplifyX86pmulh(IntrinsicInst &II,
   // Extend to twice the width and multiply.
   auto Cast =
       IsSigned ? Instruction::CastOps::SExt : Instruction::CastOps::ZExt;
-  auto *ExtTy = FixedVectorType::getExtendedElementVectorType(ArgTy);
+  auto *ExtTy = FixedVectorType::getDoubleWidthElementVectorType(ArgTy);
   Value *LHS = Builder.CreateCast(Cast, Arg0, ExtTy);
   Value *RHS = Builder.CreateCast(Cast, Arg1, ExtTy);
   Value *Mul = Builder.CreateMul(LHS, RHS);

--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -260,7 +260,7 @@ InstructionCost X86TTIImpl::getArithmeticInstrCost(
   if (Opcode == Instruction::Mul && Ty->isVectorTy() &&
       Ty->getPrimitiveSizeInBits() <= 64 && Ty->getScalarSizeInBits() == 8) {
     Type *WideVecTy =
-        VectorType::getExtendedElementVectorType(cast<VectorType>(Ty));
+        VectorType::getDoubleWidthElementVectorType(cast<VectorType>(Ty));
     return getCastInstrCost(Instruction::ZExt, WideVecTy, Ty,
                             TargetTransformInfo::CastContextHint::None,
                             CostKind) +

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1008,7 +1008,7 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
   // vectorization factors.
   if (auto *DestITy = dyn_cast<IntegerType>(DestTy)) {
     if (DestWidth * 2 < SrcWidth) {
-      auto *NewDestTy = DestITy->getExtendedType();
+      auto *NewDestTy = DestITy->getDoubleWidthType();
       if (shouldChangeType(SrcTy, NewDestTy) &&
           TypeEvaluationHelper::canEvaluateTruncated(Src, NewDestTy, *this,
                                                      &Trunc)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -213,7 +213,7 @@ dropRedundantMaskingOfLeftShiftInput(BinaryOperator *OuterShift,
 
   // The mask must be computed in a type twice as wide to ensure
   // that no bits are lost if the sum-of-shifts is wider than the base type.
-  Type *ExtendedTy = WidestTy->getExtendedType();
+  Type *ExtendedTy = WidestTy->getDoubleWidthType();
 
   Value *MaskShAmt;
 

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -5512,7 +5512,7 @@ bool VectorCombine::foldInterleaveIntrinsics(Instruction &I) {
 
   auto *VTy =
       cast<VectorType>(cast<IntrinsicInst>(I).getArgOperand(0)->getType());
-  auto *ExtVTy = VectorType::getExtendedElementVectorType(VTy);
+  auto *ExtVTy = VectorType::getDoubleWidthElementVectorType(VTy);
   unsigned Width = VTy->getElementType()->getIntegerBitWidth();
 
   // Just in case the cost of interleave2 intrinsic and bitcast are both

--- a/llvm/unittests/IR/VectorTypesTest.cpp
+++ b/llvm/unittests/IR/VectorTypesTest.cpp
@@ -94,13 +94,13 @@ TEST(VectorTypesTest, FixedLength) {
   EXPECT_EQ(V4Float64Ty->getElementType()->getScalarSizeInBits(), 64U);
 
   auto *ExtTy = dyn_cast<FixedVectorType>(
-      VectorType::getExtendedElementVectorType(V8Int16Ty));
+      VectorType::getDoubleWidthElementVectorType(V8Int16Ty));
   EXPECT_VTY_EQ(ExtTy, V8Int32Ty);
   EXPECT_EQ(ExtTy->getNumElements(), 8U);
   EXPECT_EQ(ExtTy->getElementType()->getScalarSizeInBits(), 32U);
 
   auto *TruncTy = dyn_cast<FixedVectorType>(
-      VectorType::getTruncatedElementVectorType(V8Int32Ty));
+      VectorType::getHalfWidthElementVectorType(V8Int32Ty));
   EXPECT_VTY_EQ(TruncTy, V8Int16Ty);
   EXPECT_EQ(TruncTy->getNumElements(), 8U);
   EXPECT_EQ(TruncTy->getElementType()->getScalarSizeInBits(), 16U);
@@ -193,13 +193,13 @@ TEST(VectorTypesTest, Scalable) {
   EXPECT_EQ(ScV4Float64Ty->getElementType()->getScalarSizeInBits(), 64U);
 
   auto *ExtTy = dyn_cast<ScalableVectorType>(
-      VectorType::getExtendedElementVectorType(ScV8Int16Ty));
+      VectorType::getDoubleWidthElementVectorType(ScV8Int16Ty));
   EXPECT_VTY_EQ(ExtTy, ScV8Int32Ty);
   EXPECT_EQ(ExtTy->getMinNumElements(), 8U);
   EXPECT_EQ(ExtTy->getElementType()->getScalarSizeInBits(), 32U);
 
   auto *TruncTy = dyn_cast<ScalableVectorType>(
-      VectorType::getTruncatedElementVectorType(ScV8Int32Ty));
+      VectorType::getHalfWidthElementVectorType(ScV8Int32Ty));
   EXPECT_VTY_EQ(TruncTy, ScV8Int16Ty);
   EXPECT_EQ(TruncTy->getMinNumElements(), 8U);
   EXPECT_EQ(TruncTy->getElementType()->getScalarSizeInBits(), 16U);

--- a/llvm/unittests/SandboxIR/TypesTest.cpp
+++ b/llvm/unittests/SandboxIR/TypesTest.cpp
@@ -294,12 +294,13 @@ define void @foo(<4 x i16> %vi0, <4 x float> %vf1, i8 %i0) {
   EXPECT_TRUE(IVecTy->getElementType()->isIntegerTy(32));
   EXPECT_EQ(IVecTy->getElementCount(), FVecTy->getElementCount());
   // getExtendedElementCountVectorType
-  auto *ExtVecTy = sandboxir::VectorType::getExtendedElementVectorType(IVecTy);
+  auto *ExtVecTy =
+      sandboxir::VectorType::getDoubleWidthElementVectorType(IVecTy);
   EXPECT_TRUE(ExtVecTy->getElementType()->isIntegerTy(64));
   EXPECT_EQ(ExtVecTy->getElementCount(), VecTy->getElementCount());
-  // getTruncatedElementVectorType
+  // getHalfWidthElementVectorType
   auto *TruncVecTy =
-      sandboxir::VectorType::getTruncatedElementVectorType(IVecTy);
+      sandboxir::VectorType::getHalfWidthElementVectorType(IVecTy);
   EXPECT_TRUE(TruncVecTy->getElementType()->isIntegerTy(16));
   EXPECT_EQ(TruncVecTy->getElementCount(), VecTy->getElementCount());
   // getSubdividedVectorType
@@ -352,12 +353,12 @@ define void @foo(<4 x i16> %vi0, <4 x float> %vf1, i8 %i0) {
   EXPECT_EQ(Vec4i32Ty->getElementCount(), Vec4FTy->getElementCount());
   // getExtendedElementCountVectorType
   auto *Vec4i64Ty =
-      sandboxir::FixedVectorType::getExtendedElementVectorType(Vec4i16Ty);
+      sandboxir::FixedVectorType::getDoubleWidthElementVectorType(Vec4i16Ty);
   EXPECT_TRUE(Vec4i64Ty->getElementType()->isIntegerTy(32));
   EXPECT_EQ(Vec4i64Ty->getElementCount(), Vec4i16Ty->getElementCount());
-  // getTruncatedElementVectorType
+  // getHalfWidthElementVectorType
   auto *Vec4i8Ty =
-      sandboxir::FixedVectorType::getTruncatedElementVectorType(Vec4i16Ty);
+      sandboxir::FixedVectorType::getHalfWidthElementVectorType(Vec4i16Ty);
   EXPECT_TRUE(Vec4i8Ty->getElementType()->isIntegerTy(8));
   EXPECT_EQ(Vec4i8Ty->getElementCount(), Vec4i8Ty->getElementCount());
   // getSubdividedVectorType
@@ -411,12 +412,12 @@ define void @foo(<vscale x 4 x i16> %vi0, <vscale x 4 x float> %vf1, i8 %i0) {
   EXPECT_EQ(Vec4i32Ty->getMinNumElements(), Vec4FTy->getMinNumElements());
   // getExtendedElementCountVectorType
   auto *Vec4i64Ty =
-      sandboxir::ScalableVectorType::getExtendedElementVectorType(Vec4i16Ty);
+      sandboxir::ScalableVectorType::getDoubleWidthElementVectorType(Vec4i16Ty);
   EXPECT_TRUE(Vec4i64Ty->getElementType()->isIntegerTy(32));
   EXPECT_EQ(Vec4i64Ty->getMinNumElements(), Vec4i16Ty->getMinNumElements());
-  // getTruncatedElementVectorType
+  // getHalfWidthElementVectorType
   auto *Vec4i8Ty =
-      sandboxir::ScalableVectorType::getTruncatedElementVectorType(Vec4i16Ty);
+      sandboxir::ScalableVectorType::getHalfWidthElementVectorType(Vec4i16Ty);
   EXPECT_TRUE(Vec4i8Ty->getElementType()->isIntegerTy(8));
   EXPECT_EQ(Vec4i8Ty->getMinNumElements(), Vec4i8Ty->getMinNumElements());
   // getSubdividedVectorType


### PR DESCRIPTION
`getTruncatedType` and `getExtendedType` are too generic names, so rename them as follows:
* `getTruncatedType` -> `getHalfWidthType`
* `getExtendedType` -> `getDoubleWidthType`
* `getTruncatedElementVectorType` -> `getHalfWidthElementVectorType`
* `getExtendedElementVectorType` -> `getDoubleWidthElementVectorType`

These new names convey the semantics more precisely.