### PR TITLE
[CodeGen] Increase offset when calculating MBB hash

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
@@ -82,8 +82,9 @@ MachineBlockHashInfoResult::MachineBlockHashInfoResult(
   // Initialize hash components
   for (const MachineBasicBlock &MBB : F) {
     auto &HashInfo = HashInfos[&MBB];
+    Offset += MBB.size();
     // offset of the machine basic block
-    HashInfo.Offset = Offset + MBB.size();
+    HashInfo.Offset = Offset;
     // Hashing opcodes
     HashInfo.OpcodeHash = hashBlock(MBB, /*HashOperands=*/false);
     // Hash complete instructions

--- a/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
@@ -82,9 +82,9 @@ MachineBlockHashInfoResult::MachineBlockHashInfoResult(
   // Initialize hash components
   for (const MachineBasicBlock &MBB : F) {
     auto &HashInfo = HashInfos[&MBB];
-    Offset += MBB.size();
     // offset of the machine basic block
     HashInfo.Offset = Offset;
+    Offset += MBB.size();
     // Hashing opcodes
     HashInfo.OpcodeHash = hashBlock(MBB, /*HashOperands=*/false);
     // Hash complete instructions

--- a/llvm/test/CodeGen/X86/machine-block-hash.mir
+++ b/llvm/test/CodeGen/X86/machine-block-hash.mir
@@ -3,8 +3,10 @@
 name:            foo
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: foo
-  ; HASH-NEXT:  BB#0: 0xf33ebf30f33e0002
-  ; HASH-NEXT:  BB#1: 0xf33ee99ef33e0002
+  ; HASH-NEXT:  BB#0: [[#%#.4x,NB0:]][[#%.4x,INS:]][[#%.4x,OP0:]][[#%.4x,OFF0:]]
+  ; HASH-NOT:   [[#INS]]
+  ; HASH-NOT:   [[#OFF0]]
+  ; HASH-NEXT:  BB#1: [[#NB0]][[#%.4x,]][[#OP0]][[#%.4x,]]
   bb.0:
     $eax = MOV32ri 1
     RET 0
@@ -17,8 +19,10 @@ body:             |
 name:            func_mbb
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_mbb
-  ; HASH-NEXT:  BB#0: 0xf60abf30f33e0002
-  ; HASH-NEXT:  BB#1: 0xf60ae99ef33e0002
+  ; HASH-NEXT:  BB#0: [[#%#.4x,NB1:]][[#%.4x,INS:]][[#OP0]][[#%.4x,OFF1:]]
+  ; HASH-NOT:   [[#INS]]
+  ; HASH-NOT:   [[#OFF1]]
+  ; HASH-NEXT:  BB#1: [[#NB1]][[#%.4x,]][[#OP0]][[#%.4x,]]
   bb.0:
     successors: %bb.1
     $eax = MOV32ri 1
@@ -32,7 +36,8 @@ body:             |
 name:            func_global
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_global
-  ; HASH-NEXT:  BB#0: 0x7e32df2f7e320002
+  ; HASH-NOT:   [[#OP0]]
+  ; HASH-NEXT:  BB#0: [[#%#.8x,]][[#%.4x,OP1:]][[#%.4x,]]
   bb.0:
     $rax = MOV64rm $rip, 1, $noreg, @foo, $noreg
     RET 0
@@ -41,7 +46,9 @@ body:             |
 name:            func_fp
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_fp
-  ; HASH-NEXT:  BB#0: 0x3e6b0e5c3e6b0002
+  ; HASH-NOT:   [[#OP0]]
+  ; HASH-NOT:   [[#OP1]]
+  ; HASH-NEXT:  BB#0: [[#%#.16x,]]
   bb.0:
     $xmm0 = MOVSSrm $rip, 1, $noreg, %const.0, $noreg
     RET 0

--- a/llvm/test/CodeGen/X86/machine-block-hash.mir
+++ b/llvm/test/CodeGen/X86/machine-block-hash.mir
@@ -3,10 +3,8 @@
 name:            foo
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: foo
-  ; HASH-NEXT:  BB#0: [[#%#.4x,NB0:]][[#%.4x,INS:]][[#%.4x,OP0:]][[#%.4x,OFF0:]]
-  ; HASH-NOT:   [[#INS]]
-  ; HASH-NOT:   [[#OFF0]]
-  ; HASH-NEXT:  BB#1: [[#NB0]][[#%.4x,]][[#OP0]][[#%.4x,]]
+  ; HASH-NEXT:  BB#0: 0xf33ebf30f33e0000
+  ; HASH-NEXT:  BB#1: 0xf33ee99ef33e0002
   bb.0:
     $eax = MOV32ri 1
     RET 0
@@ -19,10 +17,8 @@ body:             |
 name:            func_mbb
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_mbb
-  ; HASH-NEXT:  BB#0: [[#%#.4x,NB1:]][[#%.4x,INS:]][[#OP0]][[#%.4x,OFF1:]]
-  ; HASH-NOT:   [[#INS]]
-  ; HASH-NOT:   [[#OFF1]]
-  ; HASH-NEXT:  BB#1: [[#NB1]][[#%.4x,]][[#OP0]][[#%.4x,]]
+  ; HASH-NEXT:  BB#0: 0xf60abf30f33e0000
+  ; HASH-NEXT:  BB#1: 0xf60ae99ef33e0002
   bb.0:
     successors: %bb.1
     $eax = MOV32ri 1
@@ -36,8 +32,7 @@ body:             |
 name:            func_global
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_global
-  ; HASH-NOT:   [[#OP0]]
-  ; HASH-NEXT:  BB#0: [[#%#.8x,]][[#%.4x,OP1:]][[#%.4x,]]
+  ; HASH-NEXT:  BB#0: 0x7e32df2f7e320000
   bb.0:
     $rax = MOV64rm $rip, 1, $noreg, @foo, $noreg
     RET 0
@@ -46,9 +41,7 @@ body:             |
 name:            func_fp
 body:             |
   ; HASH-LABEL: Machine Block Hash Info for function: func_fp
-  ; HASH-NOT:   [[#OP0]]
-  ; HASH-NOT:   [[#OP1]]
-  ; HASH-NEXT:  BB#0: [[#%#.16x,]]
+  ; HASH-NEXT:  BB#0: 0x3e6b0e5c3e6b0000
   bb.0:
     $xmm0 = MOVSSrm $rip, 1, $noreg, %const.0, $noreg
     RET 0


### PR DESCRIPTION
Initially I was refactoring the test to not constantly update the hash values for new GlobalISel nodes but I noticed that Offset is always zero and assumed it should've been increased after each MBB. Fixing the constant offset during MBB hash calculation.