### PR TITLE
[compiler-rt][profile][NFC] Introduce INSTR_PROF_INSTRUMENT_GPU_FUNC macro

### DIFF
--- a/compiler-rt/include/profile/InstrProfData.inc
+++ b/compiler-rt/include/profile/InstrProfData.inc
@@ -893,6 +893,9 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
 #define INSTR_PROF_VALUE_PROF_MEMOP_FUNC __llvm_profile_instrument_memop
 #define INSTR_PROF_VALUE_PROF_MEMOP_FUNC_STR                                   \
   INSTR_PROF_QUOTE(INSTR_PROF_VALUE_PROF_MEMOP_FUNC)
+#define INSTR_PROF_INSTRUMENT_GPU_FUNC __llvm_profile_instrument_gpu
+#define INSTR_PROF_INSTRUMENT_GPU_FUNC_STR                                     \
+  INSTR_PROF_QUOTE(INSTR_PROF_INSTRUMENT_GPU_FUNC)
 
 /* InstrProfile per-function control data alignment.  */
 #define INSTR_PROF_DATA_ALIGNMENT 8

--- a/compiler-rt/lib/profile/InstrProfiling.h
+++ b/compiler-rt/lib/profile/InstrProfiling.h
@@ -178,8 +178,8 @@ void __llvm_profile_instrument_target_value(uint64_t TargetValue, void *Data,
  * perform the counter update. \c Uniform is an optional counter tracking the
  * number of uniform.
  */
-void __llvm_profile_instrument_gpu(uint64_t *Counter, uint64_t *Uniform,
-                                   uint64_t Step);
+void INSTR_PROF_INSTRUMENT_GPU_FUNC(uint64_t *Counter, uint64_t *Uniform,
+                                    uint64_t Step);
 
 /*!
  * \brief Write instrumentation data to the current file.

--- a/compiler-rt/lib/profile/InstrProfilingPlatformGPU.c
+++ b/compiler-rt/lib/profile/InstrProfilingPlatformGPU.c
@@ -29,9 +29,9 @@ static int is_uniform(uint64_t mask) {
 // Wave-cooperative counter increment. The instrumentation pass emits calls to
 // this in place of the default non-atomic load/add/store or atomicrmw sequence.
 // The optional uniform counter allows calculating wave uniformity if present.
-COMPILER_RT_VISIBILITY void __llvm_profile_instrument_gpu(uint64_t *counter,
-                                                          uint64_t *uniform,
-                                                          uint64_t step) {
+COMPILER_RT_VISIBILITY void INSTR_PROF_INSTRUMENT_GPU_FUNC(uint64_t *counter,
+                                                           uint64_t *uniform,
+                                                           uint64_t step) {
   uint64_t mask = __gpu_lane_mask();
   if (__gpu_is_first_in_lane(mask)) {
     __scoped_atomic_fetch_add(counter, step * __builtin_popcountg(mask),

--- a/llvm/include/llvm/ProfileData/InstrProfData.inc
+++ b/llvm/include/llvm/ProfileData/InstrProfData.inc
@@ -893,6 +893,9 @@ serializeValueProfDataFrom(ValueProfRecordClosure *Closure,
 #define INSTR_PROF_VALUE_PROF_MEMOP_FUNC __llvm_profile_instrument_memop
 #define INSTR_PROF_VALUE_PROF_MEMOP_FUNC_STR                                   \
   INSTR_PROF_QUOTE(INSTR_PROF_VALUE_PROF_MEMOP_FUNC)
+#define INSTR_PROF_INSTRUMENT_GPU_FUNC __llvm_profile_instrument_gpu
+#define INSTR_PROF_INSTRUMENT_GPU_FUNC_STR                                     \
+  INSTR_PROF_QUOTE(INSTR_PROF_INSTRUMENT_GPU_FUNC)
 
 /* InstrProfile per-function control data alignment.  */
 #define INSTR_PROF_DATA_ALIGNMENT 8


### PR DESCRIPTION
Add a macro INSTR_PROF_INSTRUMENT_GPU_FUNC for the name of the GPU
profiling function __llvm_profile_instrument_gpu (added in #187136),
following the same pattern as INSTR_PROF_VALUE_PROF_MEMOP_FUNC. Use the
macro in both the declaration in InstrProfiling.h and the definition in
InstrProfilingPlatformGPU.c.

This prepares the upcoming HIP/AMDGPU offload PGO patch (#177665) to use
the same macro when calling this function.

