### PR TITLE
[llvm][Instrumentor] Fix expected error message

### DIFF
--- a/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
+++ b/llvm/test/Instrumentation/Instrumentor/generate_bad_rt.ll
@@ -1,3 +1,3 @@
 ; RUN: not opt < %s -passes=instrumentor -instrumentor-read-config-file=%S/bad_rt_config.json 2>&1 | FileCheck %s --ignore-case
 
-; CHECK: error: failed to open instrumentor stub runtime file for writing: Is a directory
+; CHECK: error: failed to open instrumentor stub runtime file for writing: {{.*}}


### PR DESCRIPTION
The test checks that passing the current directory for the stub runtime file path is detected an error. However, the specific error message depends on the OS.