### PR TITLE
[StackColoring] Treat all stack slots as conservative with `returns_twice` call-sites

### DIFF
--- a/llvm/lib/CodeGen/StackColoring.cpp
+++ b/llvm/lib/CodeGen/StackColoring.cpp
@@ -719,6 +719,11 @@ unsigned StackColoring::collectMarkers(unsigned NumSlot) {
             H.CatchObj.FrameIndex >= 0)
           ConservativeSlots.set(H.CatchObj.FrameIndex);
 
+  // Treat all stack slots as conservative if we happen to have calls to
+  // setjmp/sigsetjmp, as longjmp may re-enter the function on a different path.
+  if (MF->exposesReturnsTwice())
+    ConservativeSlots.set();
+
   LLVM_DEBUG(dumpBV("Conservative slots", ConservativeSlots));
 
   // Step 2: compute begin/end sets for each block

--- a/llvm/test/CodeGen/X86/sjlj-do-not-merge-stack-slots.ll
+++ b/llvm/test/CodeGen/X86/sjlj-do-not-merge-stack-slots.ll
@@ -4,19 +4,20 @@
 define void @sjlj_do_not_merge_stack_slots() nounwind {
 ; CHECK-LABEL: sjlj_do_not_merge_stack_slots:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    subq $24, %rsp
+; CHECK-NEXT:    subq $40, %rsp
 ; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rdi
 ; CHECK-NEXT:    callq setjmp@PLT
-; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rdi
 ; CHECK-NEXT:    testl %eax, %eax
 ; CHECK-NEXT:    je .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %else
+; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rdi
 ; CHECK-NEXT:    callq opaque@PLT
-; CHECK-NEXT:    addq $24, %rsp
+; CHECK-NEXT:    addq $40, %rsp
 ; CHECK-NEXT:    retq
 ; CHECK-NEXT:  .LBB0_1: # %then
+; CHECK-NEXT:    leaq {{[0-9]+}}(%rsp), %rdi
 ; CHECK-NEXT:    callq escape@PLT
-; CHECK-NEXT:    addq $24, %rsp
+; CHECK-NEXT:    addq $40, %rsp
 ; CHECK-NEXT:    retq
 entry:
   %obj = alloca [8 x i8], align 4


### PR DESCRIPTION
Do not merge stack slots on disjoint paths if the function may call setjmp/sigsetjmp, as the current algorithm defaults to computing liveness analysis from the actual uses propagated through the CFG, rather than leveraging lifetime markers, thus making it unsound with `returns_twice` calls.

Fixes: https://github.com/llvm/llvm-project/issues/196468.