### PR TITLE
[SLSR] Avoid repeatedly calling canReuseInstruction for the same Basis

### DIFF
--- a/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
@@ -983,10 +983,8 @@ void StraightLineStrengthReduce::allocateCandidatesAndFindBasis(
   // doing this early we avoid calling canReuseInstruction repeatedly for the
   // same instruction. The DropList is stored on the Candidate so
   // candidatePredicate can drop the flags when a rewrite is being done.
-  if (!EnablePoisonReuseGuard) {
-    CandidateDict.add(Candidates.back());
-  } else if (SE->canReuseInstruction(SE->getSCEV(I), I,
-                                     Candidates.back().DropList)) {
+  if (!EnablePoisonReuseGuard ||
+      SE->canReuseInstruction(SE->getSCEV(I), I, Candidates.back().DropList)) {
     CandidateDict.add(Candidates.back());
   }
 }

--- a/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
@@ -217,6 +217,10 @@ public:
     // Points to (Y - X) that will be used to rewrite this candidate.
     Value *Delta = nullptr;
 
+    // List of instructions we need to drop poison generating annotations from.
+    // This is used so we can defer dropping until the candidate is evaluated.
+    SmallVector<Instruction *> DropList;
+
     /// Cost model: Evaluate the computational efficiency of the candidate.
     ///
     /// Efficiency levels (higher is better):
@@ -682,12 +686,7 @@ bool StraightLineStrengthReduce::isSimilar(Candidate &C, Candidate &Basis,
 bool StraightLineStrengthReduce::candidatePredicate(Candidate *Basis,
                                                     Candidate &C,
                                                     Candidate::DKind K) {
-  SmallVector<Instruction *> DropPoisonGeneratingInsts;
-  // Ensure the IR of Basis->Ins is not more poisonous than its SCEV.
-  if (!isSimilar(C, *Basis, K) ||
-      (EnablePoisonReuseGuard &&
-       !SE->canReuseInstruction(SE->getSCEV(Basis->Ins), Basis->Ins,
-                                DropPoisonGeneratingInsts)))
+  if (!isSimilar(C, *Basis, K))
     return false;
 
   assert(DT->dominates(Basis->Ins, C.Ins));
@@ -705,10 +704,9 @@ bool StraightLineStrengthReduce::candidatePredicate(Candidate *Basis,
       !C.isProfitableRewrite(*Delta, Candidate::IndexDelta))
     return false;
 
-  // If there is a Delta that we can reuse Basis to rewrite C,
-  // clean up DropPoisonGeneratingInsts returned by successful
-  // SE->canReuseInstruction()
-  for (Instruction *I : DropPoisonGeneratingInsts)
+  // If there is a Delta that we can reuse Basis to rewrite C, clean up
+  // previously collected poison generating instructions.
+  for (Instruction *I : Basis->DropList)
     I->dropPoisonGeneratingAnnotations();
 
   // Record delta if none has been found yet, or the new delta is
@@ -981,7 +979,16 @@ void StraightLineStrengthReduce::allocateCandidatesAndFindBasis(
   LLVM_DEBUG(dbgs() << "Allocated Candidate: " << C << "\n");
   Candidates.push_back(C);
   RewriteCandidates[C.Ins].push_back(&Candidates.back());
-  CandidateDict.add(Candidates.back());
+  // Only add to the dict if this instruction is safe to reuse as a basis. By
+  // doing this early we avoid calling canReuseInstruction repeatedly for the
+  // same instruction. The DropList is stored on the Candidate so
+  // candidatePredicate can drop the flags when a rewrite is being done.
+  if (!EnablePoisonReuseGuard) {
+    CandidateDict.add(Candidates.back());
+  } else if (SE->canReuseInstruction(SE->getSCEV(I), I,
+                                     Candidates.back().DropList)) {
+    CandidateDict.add(Candidates.back());
+  }
 }
 
 void StraightLineStrengthReduce::allocateCandidatesAndFindBasis(


### PR DESCRIPTION
`canReuseInstruction` only depends on `Basis`, but runs for each `(Basis, C)` pair. This patch moves the check earlier in the pass to remove the repeated call.

Assisted-by: Codex + Claude Sonnet 4.6