### PR TITLE
[CodeGen][AMDGPU] Move boilerplate unit test code to base class (NFC)

### DIFF
--- a/llvm/unittests/CodeGen/CodeGenTestBase.h
+++ b/llvm/unittests/CodeGen/CodeGenTestBase.h
@@ -1,0 +1,91 @@
+//===--- CodeGenTestBase.h - Utilities for codegen unit tests ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_UNITTESTS_CODEGEN_CODEGENTESTBASE_H
+#define LLVM_UNITTESTS_CODEGEN_CODEGENTESTBASE_H
+
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/MachineFunctionAnalysis.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+namespace llvm {
+
+/// Boilerplate set-up for codegen tests. Sets up all analyses managers for a
+/// given target and creates a module from an MIR string.
+class CodeGenTestBase : public testing::Test {
+public:
+  LLVMContext Context;
+  std::unique_ptr<TargetMachine> TM;
+  std::unique_ptr<MachineModuleInfo> MMI;
+  std::unique_ptr<MIRParser> MIR;
+  std::unique_ptr<Module> Mod;
+
+  LoopAnalysisManager LAM;
+  MachineFunctionAnalysisManager MFAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+
+  MachineFunction &getMF(StringRef FuncName) {
+    return FAM.getResult<MachineFunctionAnalysis>(*Mod->getFunction(FuncName))
+        .getMF();
+  }
+
+protected:
+  /// Sets up the target machine and analyses managers.
+  void setUpImpl(StringRef Triple, StringRef CPU, StringRef FS) {
+    llvm::Triple TT(Triple);
+    std::string Error;
+    const Target *T = TargetRegistry::lookupTarget("", TT, Error);
+    if (!T)
+      GTEST_SKIP();
+    TargetOptions Options;
+    TM.reset(T->createTargetMachine(TT, CPU, FS, Options, std::nullopt));
+    if (!TM)
+      GTEST_SKIP();
+    MMI = std::make_unique<MachineModuleInfo>(TM.get());
+
+    PassBuilder PB(TM.get());
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.registerMachineFunctionAnalyses(MFAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
+    MAM.registerPass([&] { return MachineModuleAnalysis(*MMI); });
+  }
+
+  /// Parses \p MIRCode into a module. Returns whether parsing was successful.
+  bool parseMIR(StringRef MIRCode) {
+    SMDiagnostic Diagnostic;
+    std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
+    MIR = createMIRParser(std::move(MBuffer), Context);
+    if (!MIR)
+      return false;
+
+    Mod = MIR->parseIRModule();
+    Mod->setDataLayout(TM->createDataLayout());
+    if (MIR->parseMachineFunctions(*Mod, MAM)) {
+      Mod.reset();
+      return false;
+    }
+    return true;
+  }
+};
+
+} // namespace llvm
+
+#endif // LLVM_UNITTESTS_CODEGEN_CODEGENTESTBASE_H

--- a/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
+++ b/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
@@ -7,88 +7,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CodeGen/MachineDomTreeUpdater.h"
-#include "llvm/Analysis/CGSCCPassManager.h"
-#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "CodeGenTestBase.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
-#include "llvm/CodeGen/MachineFunctionAnalysis.h"
-#include "llvm/CodeGen/MachineModuleInfo.h"
-#include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
-#include "llvm/CodeGen/SelectionDAG.h"
-#include "llvm/CodeGen/TargetLowering.h"
-#include "llvm/IR/Module.h"
-#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
-#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Target/TargetMachine.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
 
-class MachineDomTreeUpdaterTest : public testing::Test {
+class MachineDomTreeUpdaterTest : public CodeGenTestBase {
 public:
-  LLVMContext Context;
-  std::unique_ptr<TargetMachine> TM;
-  std::unique_ptr<Module> M;
-  std::unique_ptr<MachineModuleInfo> MMI;
-  std::unique_ptr<MIRParser> MIR;
-
-  LoopAnalysisManager LAM;
-  MachineFunctionAnalysisManager MFAM;
-  FunctionAnalysisManager FAM;
-  CGSCCAnalysisManager CGAM;
-  ModuleAnalysisManager MAM;
-
-  ModulePassManager MPM;
-  FunctionPassManager FPM;
-  MachineFunctionPassManager MFPM;
-
   static void SetUpTestCase() {
     InitializeAllTargets();
     InitializeAllTargetMCs();
   }
 
-  void SetUp() override {
-    Triple TargetTriple("x86_64-unknown-linux-gnu");
-    std::string Error;
-    const Target *T = TargetRegistry::lookupTarget("", TargetTriple, Error);
-    if (!T)
-      GTEST_SKIP();
-    TargetOptions Options;
-    TM = std::unique_ptr<TargetMachine>(
-        T->createTargetMachine(TargetTriple, "", "", Options, std::nullopt));
-    if (!TM)
-      GTEST_SKIP();
-    MMI = std::make_unique<MachineModuleInfo>(TM.get());
-
-    PassBuilder PB(TM.get());
-    PB.registerModuleAnalyses(MAM);
-    PB.registerCGSCCAnalyses(CGAM);
-    PB.registerFunctionAnalyses(FAM);
-    PB.registerLoopAnalyses(LAM);
-    PB.registerMachineFunctionAnalyses(MFAM);
-    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
-    MAM.registerPass([&] { return MachineModuleAnalysis(*MMI); });
-  }
-
-  bool parseMIR(StringRef MIRCode) {
-    SMDiagnostic Diagnostic;
-    std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
-    MIR = createMIRParser(std::move(MBuffer), Context);
-    if (!MIR)
-      return false;
-
-    M = MIR->parseIRModule();
-    M->setDataLayout(TM->createDataLayout());
-
-    if (MIR->parseMachineFunctions(*M, MAM)) {
-      M.reset();
-      return false;
-    }
-
-    return true;
-  }
+  void SetUp() override { setUpImpl("x86_64-unknown-linux-gnu", "", ""); }
 };
 
 TEST_F(MachineDomTreeUpdaterTest, EagerUpdateBasicOperations) {
@@ -150,8 +85,7 @@ body:             |
 
   ASSERT_TRUE(parseMIR(MIRString));
 
-  auto &MF =
-      FAM.getResult<MachineFunctionAnalysis>(*M->getFunction("f0")).getMF();
+  MachineFunction &MF = getMF("f0");
 
   MachineDominatorTree DT(MF);
   MachinePostDominatorTree PDT(MF);
@@ -240,8 +174,7 @@ body:             |
 
   ASSERT_TRUE(parseMIR(MIRString));
 
-  auto &MF =
-      FAM.getResult<MachineFunctionAnalysis>(*M->getFunction("f0")).getMF();
+  MachineFunction &MF = getMF("f0");
 
   MachineDominatorTree DT(MF);
   MachinePostDominatorTree PDT(MF);

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -18,7 +18,7 @@ class RematerializerTest : public CodeGenTestBase {
 public:
   std::unique_ptr<SmallVector<Rematerializer::RegionBoundaries>> Regions;
   std::unique_ptr<Rematerializer> Remater;
-  MachineFunction* MF;
+  MachineFunction *MF;
 
   static void SetUpTestCase() {
     InitializeAllTargets();

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -7,96 +7,31 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CodeGen/Rematerializer.h"
-#include "llvm/Analysis/CGSCCPassManager.h"
-#include "llvm/Analysis/LoopAnalysisManager.h"
-#include "llvm/CodeGen/MIRParser/MIRParser.h"
-#include "llvm/CodeGen/MachineDomTreeUpdater.h"
-#include "llvm/CodeGen/MachineFunctionAnalysis.h"
-#include "llvm/CodeGen/MachineModuleInfo.h"
-#include "llvm/CodeGen/MachinePassManager.h"
-#include "llvm/CodeGen/MachinePostDominators.h"
-#include "llvm/CodeGen/MachineScheduler.h"
-#include "llvm/CodeGen/SelectionDAG.h"
-#include "llvm/CodeGen/TargetLowering.h"
-#include "llvm/IR/Module.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Passes/PassBuilder.h"
-#include "llvm/Support/SourceMgr.h"
+#include "CodeGenTestBase.h"
+#include "llvm/CodeGen/LiveIntervals.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Target/TargetMachine.h"
-#include "gtest/gtest.h"
-#include <memory>
 
 using namespace llvm;
 using RegisterIdx = Rematerializer::RegisterIdx;
 
-class RematerializerTest : public testing::Test {
+class RematerializerTest : public CodeGenTestBase {
 public:
-  LLVMContext Context;
-  std::unique_ptr<TargetMachine> TM;
-  std::unique_ptr<Module> M;
-  std::unique_ptr<MachineModuleInfo> MMI;
-
-  std::unique_ptr<MIRParser> MIR;
   std::unique_ptr<SmallVector<Rematerializer::RegionBoundaries>> Regions;
   std::unique_ptr<Rematerializer> Remater;
-  MachineFunction *MF;
-
-  LoopAnalysisManager LAM;
-  MachineFunctionAnalysisManager MFAM;
-  FunctionAnalysisManager FAM;
-  CGSCCAnalysisManager CGAM;
-
-  ModulePassManager MPM;
-  FunctionPassManager FPM;
-  MachineFunctionPassManager MFPM;
-  ModuleAnalysisManager MAM;
+  MachineFunction* MF;
 
   static void SetUpTestCase() {
     InitializeAllTargets();
     InitializeAllTargetMCs();
   }
 
-  void SetUp() override {
-    Triple TargetTriple("amdgcn--");
-    std::string Error;
-    const Target *T = TargetRegistry::lookupTarget("", TargetTriple, Error);
-    if (!T)
-      GTEST_SKIP();
-    TargetOptions Options;
-    TM = std::unique_ptr<TargetMachine>(T->createTargetMachine(
-        TargetTriple, "gfx950", "", Options, std::nullopt));
-    if (!TM)
-      GTEST_SKIP();
-    MMI = std::make_unique<MachineModuleInfo>(TM.get());
-
-    PassBuilder PB(TM.get());
-    PB.registerModuleAnalyses(MAM);
-    PB.registerCGSCCAnalyses(CGAM);
-    PB.registerFunctionAnalyses(FAM);
-    PB.registerLoopAnalyses(LAM);
-    PB.registerMachineFunctionAnalyses(MFAM);
-    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
-    MAM.registerPass([&] { return MachineModuleAnalysis(*MMI); });
-  }
+  void SetUp() override { setUpImpl("amdgcn--", "gfx950", ""); }
 
   bool parseMIRAndInit(StringRef MIRCode, StringRef FunName) {
-    SMDiagnostic Diagnostic;
-    std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
-    MIR = createMIRParser(std::move(MBuffer), Context);
-    if (!MIR)
+    if (!parseMIR(MIRCode))
       return false;
 
-    M = MIR->parseIRModule();
-    M->setDataLayout(TM->createDataLayout());
-
-    if (MIR->parseMachineFunctions(*M, MAM)) {
-      M.reset();
-      return false;
-    }
-
-    MF = &FAM.getResult<MachineFunctionAnalysis>(*M->getFunction(FunName))
-              .getMF();
+    MF = &CodeGenTestBase::getMF(FunName);
     LiveIntervals &LIS = MFAM.getResult<LiveIntervalsAnalysis>(*MF);
 
     // Create regions for the rematerializer. Both MBBs and terminator MIs

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/CodeGen/Rematerializer.h"
 #include "CodeGenTestBase.h"
 #include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/RegisterPressure.h"
 #include "llvm/Support/TargetSelect.h"
 
 using namespace llvm;

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
@@ -17,11 +17,15 @@
 
 using namespace llvm;
 
-void initializeAMDGPUTarget() {
+static void initializeAMDGPUTarget() {
   LLVMInitializeAMDGPUTargetInfo();
   LLVMInitializeAMDGPUTarget();
   LLVMInitializeAMDGPUTargetMC();
 }
+
+void AMDGPUTestBase::SetUpTestSuite() { initializeAMDGPUTarget(); }
+
+void AMDGPUCodeGenTestBase::SetUpTestSuite() { initializeAMDGPUTarget(); }
 
 std::unique_ptr<GCNTargetMachine>
 createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
@@ -81,10 +85,11 @@ static bool checkMinMax(std::stringstream &OS, unsigned Occ, unsigned MinOcc,
   return MinValid && MaxValid && RangeValid;
 }
 
-static const std::pair<StringRef, StringRef>
-  EmptyFS = {"", ""},
-  W32FS = {"+wavefrontsize32", "w32"},
-  W64FS = {"+wavefrontsize64", "w64"};
+static const std::pair<StringRef, StringRef> EmptyFS = {"", ""},
+                                             W32FS = {"+wavefrontsize32",
+                                                      "w32"},
+                                             W64FS = {"+wavefrontsize64",
+                                                      "w64"};
 
 using TestFuncTy = function_ref<bool(std::stringstream &, unsigned,
                                      const GCNSubtarget &, bool)>;

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPUUnitTests.h"
+#include "AMDGPUGenSubtargetInfo.inc"
 #include "AMDGPUTargetMachine.h"
 #include "GCNSubtarget.h"
 #include "llvm/MC/TargetRegistry.h"
@@ -14,24 +15,16 @@
 #include "llvm/TargetParser/TargetParser.h"
 #include "gtest/gtest.h"
 
-#include "AMDGPUGenSubtargetInfo.inc"
-
 using namespace llvm;
 
-std::once_flag flag;
-
-void InitializeAMDGPUTarget() {
-  std::call_once(flag, []() {
-    LLVMInitializeAMDGPUTargetInfo();
-    LLVMInitializeAMDGPUTarget();
-    LLVMInitializeAMDGPUTargetMC();
-  });
+void initializeAMDGPUTarget() {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTarget();
+  LLVMInitializeAMDGPUTargetMC();
 }
 
-std::unique_ptr<const GCNTargetMachine>
-llvm::createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
-  InitializeAMDGPUTarget();
-
+std::unique_ptr<GCNTargetMachine>
+createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
   Triple TT(TStr);
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
@@ -180,7 +173,7 @@ static void testDynamicVGPRLimits(StringRef CPUName, StringRef FS,
   testWithBlockSize(32);
 }
 
-TEST(AMDGPU, TestVGPRLimitsPerOccupancy) {
+TEST_F(AMDGPUTestBase, TestVGPRLimitsPerOccupancy) {
   auto test = [](std::stringstream &OS, unsigned Occ, const GCNSubtarget &ST,
                  unsigned DynamicVGPRBlockSize) {
     unsigned MaxVGPRNum = ST.getAddressableNumVGPRs(DynamicVGPRBlockSize);
@@ -240,7 +233,7 @@ static void testAbsoluteLimits(StringRef CPUName, StringRef FS,
   EXPECT_EQ(12u, Range.second) << CPUName << ' ' << FS;
 }
 
-TEST(AMDGPU, TestOccupancyAbsoluteLimits) {
+TEST_F(AMDGPUTestBase, TestOccupancyAbsoluteLimits) {
   // CPUName, Features, DynamicVGPRBlockSize; Expected MinOcc, MaxOcc, MaxVGPRs
   testAbsoluteLimits("gfx1200", "+wavefrontsize32", 0, 1, 16, 256);
   testAbsoluteLimits("gfx1200", "+wavefrontsize32", 16, 1, 16, 128);
@@ -251,7 +244,7 @@ static const char *printSubReg(const TargetRegisterInfo &TRI, unsigned SubReg) {
   return SubReg ? TRI.getSubRegIndexName(SubReg) : "<none>";
 }
 
-TEST(AMDGPU, TestReverseComposeSubRegIndices) {
+TEST_F(AMDGPUTestBase, TestReverseComposeSubRegIndices) {
   auto TM = createAMDGPUTargetMachine("amdgcn-amd-", "gfx900", "");
   if (!TM)
     return;
@@ -327,7 +320,7 @@ TEST(AMDGPU, TestReverseComposeSubRegIndices) {
   }
 }
 
-TEST(AMDGPU, TestGetNamedOperandIdx) {
+TEST_F(AMDGPUTestBase, TestGetNamedOperandIdx) {
   std::unique_ptr<const GCNTargetMachine> TM =
       createAMDGPUTargetMachine("amdgcn-amd-", "gfx900", "");
   if (!TM)

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
@@ -9,17 +9,32 @@
 #ifndef LLVM_UNITTESTS_TARGET_AMDGPU_AMDGPUUNITTESTS_H
 #define LLVM_UNITTESTS_TARGET_AMDGPU_AMDGPUUNITTESTS_H
 
+#include "AMDGPUGenSubtargetInfo.inc"
+#include "AMDGPUTargetMachine.h"
+#include "CodeGenTestBase.h"
+#include "GCNSubtarget.h"
 #include <memory>
 #include <string>
 
 namespace llvm {
-
 class GCNTargetMachine;
 class StringRef;
-
-std::unique_ptr<const GCNTargetMachine>
-createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS);
-
 } // end namespace llvm
+
+void initializeAMDGPUTarget();
+
+std::unique_ptr<llvm::GCNTargetMachine>
+createAMDGPUTargetMachine(std::string TStr, llvm::StringRef CPU,
+                          llvm::StringRef FS);
+
+class AMDGPUTestBase : public testing::Test {
+public:
+  static void SetUpTestSuite() { initializeAMDGPUTarget(); }
+};
+
+class AMDGPUCodeGenTestBase : public llvm::CodeGenTestBase {
+public:
+  static void SetUpTestSuite() { initializeAMDGPUTarget(); }
+};
 
 #endif // LLVM_UNITTESTS_TARGET_AMDGPU_AMDGPUUNITTESTS_H

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.h
@@ -21,20 +21,18 @@ class GCNTargetMachine;
 class StringRef;
 } // end namespace llvm
 
-void initializeAMDGPUTarget();
-
 std::unique_ptr<llvm::GCNTargetMachine>
 createAMDGPUTargetMachine(std::string TStr, llvm::StringRef CPU,
                           llvm::StringRef FS);
 
 class AMDGPUTestBase : public testing::Test {
 public:
-  static void SetUpTestSuite() { initializeAMDGPUTarget(); }
+  static void SetUpTestSuite();
 };
 
 class AMDGPUCodeGenTestBase : public llvm::CodeGenTestBase {
 public:
-  static void SetUpTestSuite() { initializeAMDGPUTarget(); }
+  static void SetUpTestSuite();
 };
 
 #endif // LLVM_UNITTESTS_TARGET_AMDGPU_AMDGPUUNITTESTS_H

--- a/llvm/unittests/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/unittests/Target/AMDGPU/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(
   ${PROJECT_SOURCE_DIR}/lib/Target/AMDGPU
   ${PROJECT_BINARY_DIR}/lib/Target/AMDGPU
+  ${PROJECT_SOURCE_DIR}/unittests/CodeGen
   )
 
 set(LLVM_LINK_COMPONENTS

--- a/llvm/unittests/Target/AMDGPU/CSETest.cpp
+++ b/llvm/unittests/Target/AMDGPU/CSETest.cpp
@@ -15,7 +15,7 @@
 
 using namespace llvm;
 
-TEST(AMDGPU, TestCSEForRegisterClassOrBankAndLLT) {
+TEST_F(AMDGPUTestBase, TestCSEForRegisterClassOrBankAndLLT) {
   auto TM = createAMDGPUTargetMachine("amdgcn-amd-", "gfx1100", "");
   if (!TM)
     GTEST_SKIP();

--- a/llvm/unittests/Target/AMDGPU/DwarfRegMappings.cpp
+++ b/llvm/unittests/Target/AMDGPU/DwarfRegMappings.cpp
@@ -12,7 +12,7 @@
 
 using namespace llvm;
 
-TEST(AMDGPU, TestWave64DwarfRegMapping) {
+TEST_F(AMDGPUTestBase, TestWave64DwarfRegMapping) {
   for (auto Triple :
        {"amdgcn-amd-", "amdgcn-amd-amdhsa", "amdgcn-amd-amdpal"}) {
     auto TM = createAMDGPUTargetMachine(Triple, "gfx1010", "+wavefrontsize64");
@@ -52,7 +52,7 @@ TEST(AMDGPU, TestWave64DwarfRegMapping) {
   }
 }
 
-TEST(AMDGPU, TestWave32DwarfRegMapping) {
+TEST_F(AMDGPUTestBase, TestWave32DwarfRegMapping) {
   for (auto Triple :
        {"amdgcn-amd-", "amdgcn-amd-amdhsa", "amdgcn-amd-amdpal"}) {
     auto TM = createAMDGPUTargetMachine(Triple, "gfx1010", "+wavefrontsize32");

--- a/llvm/unittests/Target/AMDGPU/ExecMayBeModifiedBeforeAnyUse.cpp
+++ b/llvm/unittests/Target/AMDGPU/ExecMayBeModifiedBeforeAnyUse.cpp
@@ -13,7 +13,7 @@
 
 using namespace llvm;
 
-TEST(AMDGPU, ExecMayBeModifiedBeforeAnyUse) {
+TEST_F(AMDGPUTestBase, ExecMayBeModifiedBeforeAnyUse) {
   auto TM = createAMDGPUTargetMachine("amdgcn-amd-", "gfx906", "");
   if (!TM)
     GTEST_SKIP();

--- a/llvm/unittests/Target/AMDGPU/LiveRegUnits.cpp
+++ b/llvm/unittests/Target/AMDGPU/LiveRegUnits.cpp
@@ -6,52 +6,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "AMDGPUTargetMachine.h"
 #include "AMDGPUUnitTests.h"
 #include "GCNSubtarget.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/TargetParser/TargetParser.h"
 #include "gtest/gtest.h"
 
 #include "AMDGPUGenSubtargetInfo.inc"
 
 using namespace llvm;
 
-// FIXME: Consolidate parseMIR and other common helpers (this one is copied from
-// unittests/MIR/MachineMetadata.cpp).
-std::unique_ptr<Module> parseMIR(LLVMContext &Context, const TargetMachine &TM,
-                                 StringRef MIRCode, const char *FnName,
-                                 MachineModuleInfo &MMI) {
-  SMDiagnostic Diagnostic;
-  std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
-  auto MIR = createMIRParser(std::move(MBuffer), Context);
-  if (!MIR)
-    return nullptr;
+class LiveRegUnitsTest : public AMDGPUCodeGenTestBase {
+public:
+  void SetUp() override { setUpImpl("amdgcn-amd-", "gfx1200", ""); }
+};
 
-  std::unique_ptr<Module> Mod = MIR->parseIRModule();
-  if (!Mod)
-    return nullptr;
-
-  Mod->setDataLayout(TM.createDataLayout());
-
-  if (MIR->parseMachineFunctions(*Mod, MMI)) {
-    return nullptr;
-  }
-
-  return Mod;
-}
-
-TEST(AMDGPULiveRegUnits, TestVGPRBlockLoadStore) {
-  auto TM = createAMDGPUTargetMachine("amdgcn-amd-", "gfx1200", "");
-  ASSERT_TRUE(TM) << "No target machine";
-
-  GCNSubtarget ST(TM->getTargetTriple(), std::string(TM->getTargetCPU()),
-                  std::string(TM->getTargetFeatureString()), *TM);
-
+TEST_F(LiveRegUnitsTest, TestVGPRBlockLoadStore) {
   // Add a very simple MIR snippet that saves and restores a block of VGPRs. The
   // body of the function, represented by a S_NOP, clobbers one CSR (v42) and
   // one caller-saved register (v49), and reads one CSR (v61) and one
@@ -76,17 +46,13 @@ body:             |
 ...
 )MIR";
 
-  LLVMContext Context;
-  MachineModuleInfo MMI(TM.get());
-  auto M = parseMIR(Context, *TM, MIRString, "vgpr-block-insts", MMI);
-
-  auto *MF = MMI.getMachineFunction(*M->getFunction("vgpr-block-insts"));
-  auto *MBB = MF->getBlockNumbered(0);
-
+  ASSERT_TRUE(parseMIR(MIRString));
+  MachineFunction &MF = getMF("vgpr-block-insts");
+  auto *MBB = MF.getBlockNumbered(0);
   auto MIt = --MBB->instr_end();
 
   LiveRegUnits LiveUnits;
-  LiveUnits.init(*ST.getRegisterInfo());
+  LiveUnits.init(*MF.getSubtarget<GCNSubtarget>().getRegisterInfo());
 
   LiveUnits.addLiveOuts(*MBB);
   LiveUnits.stepBackward(*MIt);

--- a/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
+++ b/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPUTargetMachine.h"
+#include "AMDGPUUnitTests.h"
 #include "GCNSubtarget.h"
 #include "SIProgramInfo.h"
 #include "Utils/AMDGPUPALMetadata.h"
@@ -17,13 +18,12 @@
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
 
-class PALMetadata : public testing::Test {
+class PALMetadata : public AMDGPUTestBase {
 protected:
   std::unique_ptr<GCNTargetMachine> TM;
   std::unique_ptr<LLVMContext> Ctx;
@@ -33,23 +33,8 @@ protected:
   std::unique_ptr<Module> M;
   AMDGPUPALMetadata MD;
 
-  static void SetUpTestSuite() {
-    LLVMInitializeAMDGPUTargetInfo();
-    LLVMInitializeAMDGPUTarget();
-    LLVMInitializeAMDGPUTargetMC();
-  }
-
   PALMetadata() {
-    Triple TT("amdgcn--amdpal");
-    StringRef CPU = "gfx1010";
-    StringRef FS = "";
-
-    std::string Error;
-    const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
-    TargetOptions Options;
-
-    TM.reset(static_cast<GCNTargetMachine *>(TheTarget->createTargetMachine(
-        TT, CPU, FS, Options, std::nullopt, std::nullopt)));
+    TM = createAMDGPUTargetMachine("amdgcn--amdpal", "gfx1010", "");
 
     Ctx = std::make_unique<LLVMContext>();
     M = std::make_unique<Module>("Module", *Ctx);

--- a/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/UniformityAnalysisTest.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Analysis/UniformityAnalysis.h"
+#include "AMDGPUUnitTests.h"
 #include "llvm/ADT/GenericUniformityImpl.h"
 #include "llvm/Analysis/CycleAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -19,25 +20,11 @@
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
-#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
-#include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
-
-static std::unique_ptr<TargetMachine>
-createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
-  Triple TT(TStr);
-  std::string Error;
-  const Target *T = TargetRegistry::lookupTarget(TT, Error);
-  if (!T)
-    return nullptr;
-  return std::unique_ptr<TargetMachine>(
-      T->createTargetMachine(TT, CPU, FS, {}, std::nullopt));
-}
 
 static UniformityInfo computeUniformity(const TargetTransformInfo *TTI,
                                         Function *F) {
@@ -50,10 +37,7 @@ static UniformityInfo computeUniformity(const TargetTransformInfo *TTI,
   return UI;
 }
 
-TEST(UniformityAnalysis, NewValueIsConservativelyDivergent) {
-  LLVMInitializeAMDGPUTargetInfo();
-  LLVMInitializeAMDGPUTarget();
-  LLVMInitializeAMDGPUTargetMC();
+TEST_F(AMDGPUTestBase, NewValueIsConservativelyDivergent) {
 
   StringRef ModuleString = R"(
   target triple = "amdgcn-unknown-amdhsa"


### PR DESCRIPTION
This adds the `CodeGenTestBase` class to handle boilerplate code for codegen unit tests and makes use of it wherever possible, in particular in AMDGPU unit tests.

Furthermore, this makes all AMDGPU unit tests rely on GoogleTest's API for "run once per test-suite" code, instead of re-implementing that behavior using a `std::once` flag. As a consequence all TEST(...) become TEST_F().