### PR TITLE
[clang][X86] Always emit trap for noreturn functions with -fms-kernel

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -529,6 +529,9 @@ ENUM_CODEGENOPT(WinControlFlowGuardMechanism, ControlFlowGuardMechanism,
 /// Adds attributes that prevent outlining (`-mno-outline`)
 CODEGENOPT(DisableOutlining, 1, 0, Benign)
 
+/// Forces backend to emit trap instruction for LLVM IR unreachable
+CODEGENOPT(ForceTrapUnreachable, 1, 0, Benign)
+
 /// FIXME: Make DebugOptions its own top-level .def file.
 #include "DebugOptions.def"
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4804,6 +4804,11 @@ defm virtual_function_elimination : BoolFOption<"virtual-function-elimination",
           "Enables dead virtual function elimination optimization. Requires -flto=full">,
   NegFlag<SetFalse>, BothFlags<[], [ClangOption, CLOption]>>;
 
+def ftrap_unreachable : Flag<["-"], "ftrap-unreachable">,
+  Group<f_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Force emission of a trap instruction at the end of noreturn functions">,
+  MarshallingInfoFlag<CodeGenOpts<"ForceTrapUnreachable">>;
 def fwrapv : Flag<["-"], "fwrapv">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Treat signed integer overflow as two's complement">;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -477,6 +477,9 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.VecLib =
       convertDriverVectorLibraryToVectorLibrary(CodeGenOpts.getVecLib());
 
+  if (LangOpts.Kernel)
+    Options.TrapUnreachable = true;
+
   switch (CodeGenOpts.getSwiftAsyncFramePointer()) {
   case CodeGenOptions::SwiftAsyncFramePointerKind::Auto:
     Options.SwiftAsyncFramePointer =

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -477,7 +477,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.VecLib =
       convertDriverVectorLibraryToVectorLibrary(CodeGenOpts.getVecLib());
 
-  if (LangOpts.Kernel)
+  if (CodeGenOpts.ForceTrapUnreachable)
     Options.TrapUnreachable = true;
 
   switch (CodeGenOpts.getSwiftAsyncFramePointer()) {

--- a/clang/test/CodeGen/MSKernel/noreturn.c
+++ b/clang/test/CodeGen/MSKernel/noreturn.c
@@ -1,0 +1,13 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-windows-msvc -O2 -S %s -o - | FileCheck %s
+
+// CHECK-LABEL: my_noreturn_func:
+// CHECK:       movl $0, (%rax)
+// CHECK-NEXT:  ud2
+
+extern long volatile *gtrap;
+
+__declspec(noreturn) void my_noreturn_func(void) {
+    *gtrap = 0;
+}
+

--- a/clang/test/CodeGen/trap-unreachable.c
+++ b/clang/test/CodeGen/trap-unreachable.c
@@ -1,5 +1,5 @@
 // REQUIRES: x86-registered-target
-// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-windows-msvc -O2 -S %s -o - | FileCheck %s
+// RUN: %clang_cc1 -ftrap-unreachable -fms-extensions -triple x86_64-windows-msvc -O2 -S %s -o - | FileCheck %s
 
 // CHECK-LABEL: my_noreturn_func:
 // CHECK:       movl $0, (%rax)


### PR DESCRIPTION
Patch lowers unreachable to the trap (ud2) when `-fms-kernel` is provided to ensure kernel trap handler is invoked in case something goes wrong, instead of falling through.