### PR TITLE
[offload] update README for Tablegen

### DIFF
--- a/offload/liboffload/API/README.md
+++ b/offload/liboffload/API/README.md
@@ -27,13 +27,13 @@ be added to `liboffload/src/OffloadImpl.cpp`
 
 In short, the steps to add a new function are:
 * Add the new function definition to the `.td` files.
-* Build the `LLVMOffload` target. The relevant files will be regenerated, but
+* Build the `offload` target. The relevant files will be regenerated, but
   the library will fail to link because it is missing the implementation
   function.
 * Add the new implementation function to `liboffload/src/OffloadImpl.cpp`. You
   can copy the new function declaration from the generated
-  `OffloadImplFuncDecls.inc` file.
-* Rebuild `LLVMOffload`
+  `<build-directory>/runtimes/runtimes-bins/offload/liboffload/API/OffloadImplFuncDecls.inc` file.
+* Rebuild `offload`
 
 ## API Objects
 


### PR DESCRIPTION
This patch changes the non-existent target `LLVMOffload` to the correct target `offload` and adds a more detailed path to
`OffloadImplFuncDecls.inc`.