### PR TITLE
[DebugInfo] Pack DILocation hash inputs

### DIFF
--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -339,6 +339,8 @@ template <> struct MDNodeKeyImpl<DILocation> {
   }
 
   unsigned getHashValue() const {
+    uint64_t LineColumnAndImplicitCode =
+        (uint64_t(Line) << 17) | (uint64_t(Column) << 1) | ImplicitCode;
     // Hashing AtomGroup and AtomRank substantially impacts performance whether
     // Key Instructions is enabled or not. We can't detect whether it's enabled
     // here cheaply; avoiding hashing zero values is a good approximation. This
@@ -347,9 +349,9 @@ template <> struct MDNodeKeyImpl<DILocation> {
     // outweighed by the overall compile time savings by performing this check.
     // * (hash_combine(x) != hash_combine(x, 0))
     if (AtomGroup || AtomRank)
-      return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode,
-                          AtomGroup, (uint8_t)AtomRank);
-    return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode);
+      return hash_combine(LineColumnAndImplicitCode, Scope, InlinedAt,
+                          (AtomGroup << 3) | AtomRank);
+    return hash_combine(LineColumnAndImplicitCode, Scope, InlinedAt);
   }
 };
 

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -340,7 +340,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
 
   unsigned getHashValue() const {
     uint64_t LineColumnAndImplicitCode =
-        (uint64_t(Line) << 17) | (uint64_t(Column) << 1) | ImplicitCode;
+        Line | (uint64_t(Column) << 32) | (uint64_t(ImplicitCode) << 48);
     // Hashing AtomGroup and AtomRank substantially impacts performance whether
     // Key Instructions is enabled or not. We can't detect whether it's enabled
     // here cheaply; avoiding hashing zero values is a good approximation. This
@@ -350,7 +350,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
     // * (hash_combine(x) != hash_combine(x, 0))
     if (AtomGroup || AtomRank)
       return hash_combine(LineColumnAndImplicitCode, Scope, InlinedAt,
-                          (AtomGroup << 3) | AtomRank);
+                          AtomGroup | (uint64_t(AtomRank) << 61));
     return hash_combine(LineColumnAndImplicitCode, Scope, InlinedAt);
   }
 };


### PR DESCRIPTION
Pack DILocation fields before hashing. Now that column is 16-bits
Line/Column/ImplicitCode fit in one 64-bit value (32 + 16 + 1 = 49 bits)
and AtomGroup and AtomRank also fit cleanly in one 64-bit value (61 + 3
= 64 bits).

Fewer hash_combine inputs on the hot DILocation path is a small
compile-time improvement.

CTMark geomean:
- stage1-ReleaseLTO-g: -0.10%
- stage1-O0-g: -0.23%
- stage1-aarch64-O0-g: -0.19%
- stage2-O0-g: -0.07%

https://llvm-compile-time-tracker.com/compare.php?from=71fef6d5a306d1adf8bf7d30d2fe9e286380fecf&to=1d80b5f5aa98561d2ba09adc3f20c3eacd24cb88&stat=instructions%3Au

Assisted-by: codex