### PR TITLE
[lld][WebAssembly] Remove the experimental warning for PIC/dynamic linking

### DIFF
--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -120,7 +120,6 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
   std::vector<const char *> LinkerArgs = {"wasm-ld",
                                           "-shared",
                                           "--import-memory",
-                                          "--experimental-pic",
                                           "--stack-first",
                                           "--allow-undefined",
                                           ObjectFileName.c_str(),

--- a/lld/docs/WebAssembly.rst
+++ b/lld/docs/WebAssembly.rst
@@ -108,9 +108,7 @@ WebAssembly-specific options:
      this means inputs should be compiled with `-fPIC` (i.e. `pic` or
      `dynamic-no-pic` relocation models).  This options is useful for linking
      binaries that are themselves static (non-relocatable) but whose undefined
-     symbols are resolved by a dynamic linker.  Since the dynamic linking API is
-     experimental, this option currently requires `--experimental-pic` to also
-     be specified.
+     symbols are resolved by a dynamic linker.
 
 .. option:: --import-memory
 

--- a/lld/test/wasm/bad-data-relocs.s
+++ b/lld/test/wasm/bad-data-relocs.s
@@ -2,7 +2,7 @@
 ## generated in `-shared/`-pie` binaries.
 
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: not wasm-ld -pie --experimental-pic %t.o -o %t.wasm 2>&1 | FileCheck %s
+# RUN: not wasm-ld -pie %t.o -o %t.wasm 2>&1 | FileCheck %s
 
 # CHECK: wasm-ld: error: invalid runtime relocation type in data section: R_WASM_FUNCTION_INDEX_I32
 

--- a/lld/test/wasm/bsymbolic.s
+++ b/lld/test/wasm/bsymbolic.s
@@ -2,10 +2,10 @@
 // RUN: wasm-ld --no-entry -Bsymbolic %t.o -o %t.wasm 2>&1 | FileCheck -check-prefix=WARNING %s
 // WARNING: warning: -Bsymbolic is only meaningful when combined with -shared
 
-// RUN: wasm-ld --experimental-pic -shared %t.o -o %t0.so
+// RUN: wasm-ld -shared %t.o -o %t0.so
 // RUN: obj2yaml %t0.so | FileCheck -check-prefix=NOOPTION %s
 
-// RUN: wasm-ld --experimental-pic -shared -Bsymbolic %t.o -o %t1.so
+// RUN: wasm-ld -shared -Bsymbolic %t.o -o %t1.so
 // RUN: obj2yaml %t1.so | FileCheck -check-prefix=SYMBOLIC %s
 
 // NOOPTION:       - Type:            IMPORT

--- a/lld/test/wasm/compact-imports.s
+++ b/lld/test/wasm/compact-imports.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --experimental-pic --unresolved-symbols=import-dynamic %t.o -o %t.wasm
+# RUN: wasm-ld --unresolved-symbols=import-dynamic %t.o -o %t.wasm
 
 .functype foo () -> ()
 .functype bar () -> ()

--- a/lld/test/wasm/data-segments.ll
+++ b/lld/test/wasm/data-segments.ll
@@ -18,7 +18,7 @@
 ; RUN: obj2yaml %t.bulk-mem64.wasm | FileCheck %s --check-prefixes ACTIVE,ACTIVE64
 
 ;; In -pie mode segments are combined into one active segment.
-; RUN: wasm-ld --experimental-pic --import-memory -pie -no-gc-sections --no-entry %t.atomics.bulk-mem.pic.o -o %t.pic.wasm
+; RUN: wasm-ld --import-memory -pie -no-gc-sections --no-entry %t.atomics.bulk-mem.pic.o -o %t.pic.wasm
 ; RUN: obj2yaml %t.pic.wasm | FileCheck %s --check-prefixes ACTIVE-PIC
 ; RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_init_memory --no-show-raw-insn --no-leading-addr %t.pic.wasm | FileCheck %s --check-prefixes PIC-NON-SHARED-DIS
 
@@ -33,12 +33,12 @@
 ; RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_init_memory --no-show-raw-insn --no-leading-addr %t.atomics.bulk-mem64.wasm | FileCheck %s --check-prefixes DIS,NOPIC-DIS -DPTR=i64
 
 ;; Also test in combination with PIC/pie
-; RUN: wasm-ld --experimental-pic -pie -no-gc-sections --no-entry --shared-memory --max-memory=131072 %t.atomics.bulk-mem.pic.o -o %t.shared.pic.wasm
+; RUN: wasm-ld -pie -no-gc-sections --no-entry --shared-memory --max-memory=131072 %t.atomics.bulk-mem.pic.o -o %t.shared.pic.wasm
 ; RUN: obj2yaml %t.shared.pic.wasm | FileCheck %s --check-prefixes PASSIVE-PIC,PASSIVE32-PIC
 ; RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_init_memory --no-show-raw-insn --no-leading-addr %t.shared.pic.wasm | FileCheck %s --check-prefixes DIS,PIC-DIS -DPTR=i32
 
 ;; Also test in combination with PIC/pie + wasm64
-; RUN: wasm-ld -mwasm64 --experimental-pic -pie -no-gc-sections --no-entry --shared-memory --max-memory=131072 %t.atomics.bulk-mem.pic-mem64.o -o %t.pic-mem64.wasm
+; RUN: wasm-ld -mwasm64 -pie -no-gc-sections --no-entry --shared-memory --max-memory=131072 %t.atomics.bulk-mem.pic-mem64.o -o %t.pic-mem64.wasm
 ; RUN: obj2yaml %t.pic-mem64.wasm | FileCheck %s --check-prefixes PASSIVE-PIC,PASSIVE64-PIC
 ; RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_init_memory --no-show-raw-insn --no-leading-addr %t.pic-mem64.wasm | FileCheck %s --check-prefixes DIS,PIC-DIS -DPTR=i64
 

--- a/lld/test/wasm/dylink-non-pie.s
+++ b/lld/test/wasm/dylink-non-pie.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.lib.o %p/Inputs/ret32.s
-# RUN: wasm-ld -m wasm32 --experimental-pic -shared --no-entry %t.lib.o -o %t.lib.so
+# RUN: wasm-ld -m wasm32 -shared --no-entry %t.lib.o -o %t.lib.so
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: wasm-ld -m wasm32 -Bdynamic %t.o %t.lib.so -o %t.wasm
 # RUN: obj2yaml %t.wasm | FileCheck %s

--- a/lld/test/wasm/dylink.s
+++ b/lld/test/wasm/dylink.s
@@ -1,9 +1,9 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten -mattr=+exception-handling -o %t.o %s
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten %p/Inputs/ret32.s -o %t.ret32.o
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten %p/Inputs/libsearch-dyn.s -o %t.dyn.o
-# RUN: wasm-ld --experimental-pic -shared %t.ret32.o %t.dyn.o -o %t.lib.so
-# RUN: not wasm-ld --experimental-pic -pie -o %t.wasm %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
-# RUN: wasm-ld --experimental-pic -pie -o %t.wasm %t.o %t.lib.so
+# RUN: wasm-ld -shared %t.ret32.o %t.dyn.o -o %t.lib.so
+# RUN: not wasm-ld -pie -o %t.wasm %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
+# RUN: wasm-ld -pie -o %t.wasm %t.o %t.lib.so
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
 # Same again for wasm64
@@ -11,9 +11,9 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten -mattr=+exception-handling -o %t.o %s
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten %p/Inputs/ret32.s -o %t.ret32.o
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten %p/Inputs/libsearch-dyn.s -o %t.dyn.o
-# RUN: wasm-ld --experimental-pic -mwasm64 -shared %t.ret32.o %t.dyn.o -o %t.lib.so
-# RUN: not wasm-ld --experimental-pic -mwasm64 -pie -o %t.wasm %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
-# RUN: wasm-ld --experimental-pic -mwasm64 -pie -o %t.wasm %t.o %t.lib.so
+# RUN: wasm-ld -mwasm64 -shared %t.ret32.o %t.dyn.o -o %t.lib.so
+# RUN: not wasm-ld -mwasm64 -pie -o %t.wasm %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
+# RUN: wasm-ld -mwasm64 -pie -o %t.wasm %t.o %t.lib.so
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
 # ERROR: error: {{.*}}: undefined symbol: ret32

--- a/lld/test/wasm/global-base.test
+++ b/lld/test/wasm/global-base.test
@@ -1,8 +1,8 @@
 RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/start.s -o %t.o
 
 # Check for error on `--global-base` with `-shared` and `-pie`
-RUN: not wasm-ld --global-base=2048 --experimental-pic -shared -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED-ERROR
-RUN: not wasm-ld --global-base=2048 --experimental-pic -pie -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED-ERROR
+RUN: not wasm-ld --global-base=2048 -shared -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED-ERROR
+RUN: not wasm-ld --global-base=2048 -pie -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED-ERROR
 SHARED-ERROR: error: --global-base may not be used with -shared/-pie
 
 # Check for error on `--global-base` which is lower than that end of the stack

--- a/lld/test/wasm/libsearch.s
+++ b/lld/test/wasm/libsearch.s
@@ -8,7 +8,7 @@
 // RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown \
 // RUN:   %p/Inputs/use-bar.s -o %tbar.o
 // RUN: mkdir -p %t.dir
-// RUN: wasm-ld -shared --experimental-pic %tdyn.o -o %t.dir/libls.so
+// RUN: wasm-ld -shared %tdyn.o -o %t.dir/libls.so
 // RUN: cp -f %t.dir/libls.so %t.dir/libls2.so
 // RUN: rm -f %t.dir/libls.a
 // RUN: llvm-ar rcs %t.dir/libls.a %tst.o
@@ -38,7 +38,7 @@
 // STATIC: Name: _static
 
 // Should use explicitly specified dynamic library
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -l:libls.so
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -l:libls.so
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
 // DYNAMIC: Symbols [
 // DYNAMIC-NOT: Name: _static
@@ -48,13 +48,13 @@
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
 
 // Should prefer dynamic when linking PIE.
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
 
 // Check for library search order
 // RUN: mkdir -p %t.dir2
 // RUN: cp %t.dir/libls.a %t.dir2
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir2 -L%t.dir -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir2 -L%t.dir -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
 
 // -L can be placed after -l
@@ -65,32 +65,32 @@
 // RUN: wasm-ld --emit-relocs --no-gc-sections -o %t3 %t.o --library-path %t.dir --library ls
 
 // Should not search for dynamic libraries if -Bstatic is specified
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
-// RUN: not wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o /dev/null %t.o -L%t.dir -Bstatic -lls2 2>&1 \
+// RUN: not wasm-ld -pie --emit-relocs --no-gc-sections -o /dev/null %t.o -L%t.dir -Bstatic -lls2 2>&1 \
 // RUN:   | FileCheck --check-prefix=NOLIB2 %s
 // NOLIB2: unable to find library -lls2
 
 // -Bdynamic should restore default behaviour
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -Bdynamic -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -Bdynamic -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
 
 // -Bstatic and -Bdynamic should affect only libraries which follow them
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -lls -Bstatic -Bdynamic
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -lls -Bstatic -Bdynamic
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -lls -Bdynamic
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -lls -Bdynamic
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
 
 // Check aliases as well
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -dn -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -dn -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -non_shared -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -non_shared -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -static -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -static -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=STATIC %s
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -dy -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -dy -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
-// RUN: wasm-ld -pie --experimental-pic --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -call_shared -lls
+// RUN: wasm-ld -pie --emit-relocs --no-gc-sections -o %t3 %t.o -L%t.dir -Bstatic -call_shared -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
 
 /// -r implies -Bstatic and has precedence over -Bdynamic.

--- a/lld/test/wasm/lto/pic-empty.s
+++ b/lld/test/wasm/lto/pic-empty.s
@@ -6,7 +6,7 @@
 ; See https://github.com/llvm/llvm-project/issues/51681.
 
 ; RUN: llvm-as %s -o %t.o
-; RUN: wasm-ld --lto-O2 --experimental-pic -shared --no-gc-sections --export=tls_int %t.o -o %t.so
+; RUN: wasm-ld --lto-O2 -shared --no-gc-sections --export=tls_int %t.o -o %t.so
 ; RUN: obj2yaml %t.so  | FileCheck %s
 
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-f128:64-n32:64-S128-ni:1:10:20"

--- a/lld/test/wasm/lto/relocation-model.ll
+++ b/lld/test/wasm/lto/relocation-model.ll
@@ -10,7 +10,7 @@
 
 ;; Linking with --unresolved-symbols=import-dynamic should also generate PIC
 ;; code for external references.
-; RUN: wasm-ld %t.o -o %t_import.wasm -save-temps --experimental-pic --unresolved-symbols=import-dynamic
+; RUN: wasm-ld %t.o -o %t_import.wasm -save-temps --unresolved-symbols=import-dynamic
 ; RUN: llvm-readobj -r %t_import.wasm.lto.o | FileCheck %s --check-prefix=PIC
 
 ; PIC: R_WASM_GLOBAL_INDEX_LEB foo

--- a/lld/test/wasm/no-shlib-sigcheck.s
+++ b/lld/test/wasm/no-shlib-sigcheck.s
@@ -1,17 +1,17 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten -o %t.o %s
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten %p/Inputs/ret32.s -o %t.ret32.o
-# RUN: wasm-ld --experimental-pic -shared %t.ret32.o -o %t.lib.so
+# RUN: wasm-ld -shared %t.ret32.o -o %t.lib.so
 
 ## Fails with signature mismatch by default
-# RUN: not wasm-ld --experimental-pic -pie -o %t.wasm %t.o %t.lib.so 2>&1 | FileCheck --check-prefix=ERROR %s
+# RUN: not wasm-ld -pie -o %t.wasm %t.o %t.lib.so 2>&1 | FileCheck --check-prefix=ERROR %s
 ## Same again with shared library first.
-# RUN: not wasm-ld --experimental-pic -pie -o %t.wasm %t.lib.so %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
+# RUN: not wasm-ld -pie -o %t.wasm %t.lib.so %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
 
 ## Succeeds with --no-shlib-sigcheck added
-# RUN: wasm-ld --experimental-pic -pie -o %t.wasm %t.o %t.lib.so --no-shlib-sigcheck
+# RUN: wasm-ld -pie -o %t.wasm %t.o %t.lib.so --no-shlib-sigcheck
 # RUN: obj2yaml %t.wasm | FileCheck %s
 ## Same again with shared library first.
-# RUN: wasm-ld --experimental-pic -pie -o %t.wasm %t.lib.so %t.o --no-shlib-sigcheck
+# RUN: wasm-ld -pie -o %t.wasm %t.lib.so %t.o --no-shlib-sigcheck
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
 .functype ret32 (f32) -> (i64)

--- a/lld/test/wasm/pie.s
+++ b/lld/test/wasm/pie.s
@@ -1,6 +1,6 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten -o %t.o %s
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten %S/Inputs/internal_func.s -o %t.internal_func.o
-# RUN: wasm-ld --no-gc-sections --experimental-pic -pie --unresolved-symbols=import-dynamic -o %t.wasm %t.o %t.internal_func.o
+# RUN: wasm-ld --no-gc-sections -pie --unresolved-symbols=import-dynamic -o %t.wasm %t.o %t.internal_func.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_apply_data_relocs --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DISASSEM
 
@@ -150,7 +150,7 @@ _start:
 # instruction in the InitExpr.  We also, therefore, do not need these globals
 # to be mutable.
 
-# RUN: wasm-ld --no-gc-sections --experimental-pic -pie --unresolved-symbols=import-dynamic --extra-features=extended-const -o %t.extended.wasm %t.o %t.internal_func.o
+# RUN: wasm-ld --no-gc-sections -pie --unresolved-symbols=import-dynamic --extra-features=extended-const -o %t.extended.wasm %t.o %t.internal_func.o
 # RUN: obj2yaml %t.extended.wasm | FileCheck %s --check-prefix=EXTENDED-CONST
 
 # EXTENDED-CONST-NOT: __wasm_apply_global_relocs
@@ -207,7 +207,7 @@ _start:
 # to be generated along with __wasm_start as the start
 # function.
 
-# RUN: wasm-ld --no-gc-sections --shared-memory --experimental-pic -pie --unresolved-symbols=import-dynamic -o %t.shmem.wasm %t.o %t.internal_func.o
+# RUN: wasm-ld --no-gc-sections --shared-memory -pie --unresolved-symbols=import-dynamic -o %t.shmem.wasm %t.o %t.internal_func.o
 # RUN: obj2yaml %t.shmem.wasm | FileCheck %s --check-prefix=SHMEM
 # RUN: llvm-objdump --disassemble-symbols=__wasm_start --no-show-raw-insn --no-leading-addr %t.shmem.wasm | FileCheck %s --check-prefix DISASSEM-SHMEM
 

--- a/lld/test/wasm/rpath.s
+++ b/lld/test/wasm/rpath.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld -shared -o %t1.wasm %t.o -rpath /a/b/c -rpath /x/y/z --experimental-pic
+# RUN: wasm-ld -shared -o %t1.wasm %t.o -rpath /a/b/c -rpath /x/y/z
 # RUN: obj2yaml %t1.wasm | FileCheck %s
 
 # CHECK:  - Type:            CUSTOM

--- a/lld/test/wasm/runtime-relocations-himem.s
+++ b/lld/test/wasm/runtime-relocations-himem.s
@@ -3,7 +3,7 @@
 ## instruction leading to invalid binaries.
 
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --global-base=2147483648 --experimental-pic --unresolved-symbols=import-dynamic -no-gc-sections --shared-memory --no-entry -o %t.wasm %t.o
+# RUN: wasm-ld --global-base=2147483648 --unresolved-symbols=import-dynamic -no-gc-sections --shared-memory --no-entry -o %t.wasm %t.o
 # XUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --
 

--- a/lld/test/wasm/shared-export-dynamic.s
+++ b/lld/test/wasm/shared-export-dynamic.s
@@ -1,12 +1,12 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 
 # By default all `default` symbols should be exported
-# RUN: wasm-ld -shared --experimental-pic -o %t.wasm %t.o
+# RUN: wasm-ld -shared -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s -check-prefix=DEFAULT
 # DEFAULT: foo
 
 # Verify that `--no-export-dynamic` works with `-shared`
-# RUN: wasm-ld -shared --experimental-pic --no-export-dynamic -o %t2.wasm %t.o
+# RUN: wasm-ld -shared --no-export-dynamic -o %t2.wasm %t.o
 # RUN: obj2yaml %t2.wasm | FileCheck %s -check-prefix=NO-EXPORT
 # NO-EXPORT-NOT: foo
 

--- a/lld/test/wasm/shared-lazy.s
+++ b/lld/test/wasm/shared-lazy.s
@@ -2,14 +2,14 @@
 
 # RUN: rm -rf %t && split-file %s %t && cd %t
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten a.s -o a.o
-# RUN: wasm-ld a.o --experimental-pic -shared -o a.so
+# RUN: wasm-ld a.o -shared -o a.so
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten b.s -o b.o
-# RUN: wasm-ld b.o --experimental-pic -shared -o b.so
+# RUN: wasm-ld b.o -shared -o b.so
 # RUN: llvm-ar rc a.a a.o
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-emscripten ref.s -o ref.o
-# RUN: wasm-ld a.a b.so ref.o --experimental-pic -shared -o 1.so
+# RUN: wasm-ld a.a b.so ref.o -shared -o 1.so
 # RUN: obj2yaml 1.so | FileCheck %s
-# RUN: wasm-ld a.so a.a ref.o --experimental-pic -shared -o 1.so
+# RUN: wasm-ld a.so a.a ref.o -shared -o 1.so
 # RUN: obj2yaml 1.so | FileCheck %s
 
 ## The definitions from a.so are used and we don't extract a member from the
@@ -28,9 +28,9 @@
 # CHECK-NEXT:         GlobalMutable:   true
 
 ## The extracted x1 is defined as STB_GLOBAL.
-# RUN: wasm-ld ref.o a.a b.so -o 2.so --experimental-pic -shared
+# RUN: wasm-ld ref.o a.a b.so -o 2.so -shared
 # RUN: obj2yaml 2.so | FileCheck %s --check-prefix=CHECK2
-# RUN: wasm-ld a.a ref.o b.so -o 2.so --experimental-pic -shared
+# RUN: wasm-ld a.a ref.o b.so -o 2.so -shared
 # RUN: obj2yaml 2.so | FileCheck %s --check-prefix=CHECK2
 
 # CHECK2:       - Type:            EXPORT

--- a/lld/test/wasm/shared-memory-bss.s
+++ b/lld/test/wasm/shared-memory-bss.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --experimental-pic -shared --shared-memory -o %t.so %t.o
+# RUN: wasm-ld -shared --shared-memory -o %t.so %t.o
 # RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.so | FileCheck %s
 # RUN: obj2yaml %t.so | FileCheck %s --check-prefix=YAML
 

--- a/lld/test/wasm/shared-needed.s
+++ b/lld/test/wasm/shared-needed.s
@@ -1,16 +1,16 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/ret32.s -o %t.ret32.o
 
-# RUN: wasm-ld -shared --experimental-pic -o %t.ret32.so %t.ret32.o
+# RUN: wasm-ld -shared -o %t.ret32.so %t.ret32.o
 # RUN: obj2yaml %t.ret32.so | FileCheck %s -check-prefix=SO1
 
 # Without linking against the ret32.so shared object we expect an undefined
 # symbol error
 
-# RUN: not wasm-ld -shared --experimental-pic -o %t.so %t.o 2>&1 | FileCheck %s --check-prefix=ERROR
+# RUN: not wasm-ld -shared -o %t.so %t.o 2>&1 | FileCheck %s --check-prefix=ERROR
 # ERROR: undefined symbol: ret32
 
-# RUN: wasm-ld -shared --experimental-pic -o %t.so %t.o %t.ret32.so
+# RUN: wasm-ld -shared -o %t.so %t.o %t.ret32.so
 # RUN: obj2yaml %t.so | FileCheck %s -check-prefix=SO2
 
 

--- a/lld/test/wasm/shared-weak-symbols.s
+++ b/lld/test/wasm/shared-weak-symbols.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --experimental-pic -shared -o %t.wasm %t.o
+# RUN: wasm-ld -shared -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d %t.wasm | FileCheck %s -check-prefix=ASM
 

--- a/lld/test/wasm/shared-weak-undefined.s
+++ b/lld/test/wasm/shared-weak-undefined.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --experimental-pic -shared -o %t.wasm %t.o
+# RUN: wasm-ld -shared -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d %t.wasm | FileCheck %s -check-prefix=ASM
 
@@ -11,7 +11,7 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.ret32.o %p/Inputs/ret32.s
 # RUN: rm -f %t.dir/libret32.a
 # RUN: llvm-ar cru %t.dir/libret32.a %t.ret32.o
-# RUN: wasm-ld --experimental-pic -shared -o %t.ret32.wasm %t.o %t.dir/libret32.a
+# RUN: wasm-ld -shared -o %t.ret32.wasm %t.o %t.dir/libret32.a
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d %t.wasm | FileCheck %s -check-prefix=ASM
 

--- a/lld/test/wasm/shared.s
+++ b/lld/test/wasm/shared.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld --experimental-pic --unresolved-symbols=import-dynamic -shared -o %t.wasm %t.o
+# RUN: wasm-ld --unresolved-symbols=import-dynamic -shared -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_apply_data_relocs --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 

--- a/lld/test/wasm/shared64.s
+++ b/lld/test/wasm/shared64.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-unknown -o %t.o %s
-# RUN: wasm-ld -mwasm64 --experimental-pic --unresolved-symbols=import-dynamic -shared -o %t.wasm %t.o
+# RUN: wasm-ld -mwasm64 --unresolved-symbols=import-dynamic -shared -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump --disassemble-symbols=__wasm_call_ctors,__wasm_apply_data_relocs --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 

--- a/lld/test/wasm/static-error.s
+++ b/lld/test/wasm/static-error.s
@@ -1,7 +1,7 @@
 // RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t.o
-// RUN: wasm-ld --experimental-pic -shared -o %t.so %t.o
+// RUN: wasm-ld -shared -o %t.so %t.o
 
-// RUN: wasm-ld --experimental-pic -pie -o /dev/null %t.o %t.so
+// RUN: wasm-ld -pie -o /dev/null %t.o %t.so
 // RUN: not wasm-ld -o /dev/null -static %t.o %t.so 2>&1 | FileCheck %s
 
 // CHECK: attempted static link of dynamic object

--- a/lld/test/wasm/tag-section.ll
+++ b/lld/test/wasm/tag-section.ll
@@ -13,7 +13,7 @@
 ; RUN: llc -filetype=obj -wasm-enable-eh -exception-model=wasm -mattr=+exception-handling -relocation-model=pic %p/Inputs/tag-section1.ll -o %t1.o
 ; RUN: llc -filetype=obj -wasm-enable-eh -exception-model=wasm -mattr=+exception-handling -relocation-model=pic %p/Inputs/tag-section2.ll -o %t2.o
 ; RUN: llc -filetype=obj -wasm-enable-eh -exception-model=wasm -mattr=+exception-handling -relocation-model=pic %s -o %t.o
-; RUN: wasm-ld --import-undefined --experimental-pic --unresolved-symbols=import-dynamic -pie -o %t_pic.wasm %t.o %t1.o %t2.o
+; RUN: wasm-ld --import-undefined --unresolved-symbols=import-dynamic -pie -o %t_pic.wasm %t.o %t1.o %t2.o
 ; RUN: obj2yaml %t_pic.wasm | FileCheck %s --check-prefix=PIC
 
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"

--- a/lld/test/wasm/tls-export.s
+++ b/lld/test/wasm/tls-export.s
@@ -1,6 +1,6 @@
 # RUN: split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t/define-tls.o %t/define-tls.s
-# RUN: wasm-ld -shared --experimental-pic -o %t/define-tls.so %t/define-tls.o
+# RUN: wasm-ld -shared -o %t/define-tls.so %t/define-tls.o
 # RUN: obj2yaml %t/define-tls.so | FileCheck %s
 
 #--- define-tls.s

--- a/lld/test/wasm/tls-non-shared-memory-basic.s
+++ b/lld/test/wasm/tls-non-shared-memory-basic.s
@@ -22,7 +22,7 @@ tls1:
 # RUN: wasm-ld --no-gc-sections --no-entry -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
-# RUN: wasm-ld --experimental-pic -shared -o %t.so %t.o
+# RUN: wasm-ld -shared -o %t.so %t.o
 # RUN: obj2yaml %t.so | FileCheck %s --check-prefix=PIC
 
 #      CHECK:  - Type:            DATA

--- a/lld/test/wasm/tls-non-shared-memory.s
+++ b/lld/test/wasm/tls-non-shared-memory.s
@@ -46,13 +46,13 @@ tls1:
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump --disassemble-symbols=get_tls1 --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck %s --check-prefixes DIS
 
-# RUN: wasm-ld --experimental-pic -shared -o %t.so %t.o
+# RUN: wasm-ld -shared -o %t.so %t.o
 # RUN: obj2yaml %t.so | FileCheck %s --check-prefixes=SHARED,PIC
 
-# RUN: wasm-ld --experimental-pic --no-gc-sections --no-entry -pie -o %t-pie.wasm %t.o
+# RUN: wasm-ld --no-gc-sections --no-entry -pie -o %t-pie.wasm %t.o
 # RUN: obj2yaml %t-pie.wasm | FileCheck %s --check-prefixes=PIE,PIC
 
-# RUN: wasm-ld --experimental-pic --features=atomics,bulk-memory,extended-const --no-gc-sections --no-entry -pie -o %t-extended-const.wasm %t.o
+# RUN: wasm-ld --features=atomics,bulk-memory,extended-const --no-gc-sections --no-entry -pie -o %t-extended-const.wasm %t.o
 # RUN: obj2yaml %t-extended-const.wasm | FileCheck %s --check-prefixes=EXT-CONST
 
 #      CHECK:   - Type:            GLOBAL

--- a/lld/test/wasm/tls-relocations.s
+++ b/lld/test/wasm/tls-relocations.s
@@ -26,7 +26,7 @@ tls_sym:
   .int8 11
   .ascii  "bulk-memory"
 
-# RUN: wasm-ld --experimental-pic -pie -no-gc-sections --shared-memory --no-entry -o %t.wasm %t.o
+# RUN: wasm-ld -pie -no-gc-sections --shared-memory --no-entry -o %t.wasm %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d --no-show-raw-insn --no-leading-addr %t.wasm | FileCheck --check-prefix=ASM %s --
 

--- a/lld/test/wasm/undef-shared.s
+++ b/lld/test/wasm/undef-shared.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t.o
-# RUN: not wasm-ld --experimental-pic %t.o -o /dev/null -shared 2>&1 | FileCheck %s
+# RUN: not wasm-ld %t.o -o /dev/null -shared 2>&1 | FileCheck %s
 
 # CHECK: error: {{.*}}: undefined symbol: hidden
 .global hidden

--- a/lld/test/wasm/undefined-data.s
+++ b/lld/test/wasm/undefined-data.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 # RUN: not wasm-ld -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=UNDEF
 # RUN: wasm-ld --allow-undefined -o %t.wasm %t.o
-# RUN: not wasm-ld --experimental-pic -shared --unresolved-symbols=import-dynamic -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED
+# RUN: not wasm-ld -shared --unresolved-symbols=import-dynamic -o %t.wasm %t.o 2>&1 | FileCheck %s -check-prefix=SHARED
 
 .globl  _start
 _start:

--- a/lld/test/wasm/unresolved-symbols-dynamic.s
+++ b/lld/test/wasm/unresolved-symbols-dynamic.s
@@ -1,8 +1,7 @@
 # Unresolve data symbols are allowing under import-dynamic when GOT
 # relocations are used
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t-dynamic.o
-# RUN: wasm-ld %t-dynamic.o -o %t.wasm --unresolved-symbols=import-dynamic 2>&1 | FileCheck -check-prefix=WARN %s
-# WARN: wasm-ld: warning: dynamic imports are not yet stable (--unresolved-symbols=import-dynamic)
+# RUN: wasm-ld %t-dynamic.o -o %t.wasm --unresolved-symbols=import-dynamic
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
 .functype undef () -> ()

--- a/lld/test/wasm/unresolved-symbols.s
+++ b/lld/test/wasm/unresolved-symbols.s
@@ -85,7 +85,7 @@
 # RUN: llvm-readobj %t4.wasm > /dev/null 2>&1
 
 ## import-dynamic should fail due to incompatible relocations.
-# RUN: not wasm-ld %t/main.o -o %t5.wasm --experimental-pic --unresolved-symbols=import-dynamic 2>&1 | FileCheck -check-prefix=ERRNOPIC %s
+# RUN: not wasm-ld %t/main.o -o %t5.wasm --unresolved-symbols=import-dynamic 2>&1 | FileCheck -check-prefix=ERRNOPIC %s
 # ERRNOPIC: relocation R_WASM_MEMORY_ADDR_SLEB cannot be used against symbol `undef_data`; recompile with -fPIC
 # ERRNOPIC: relocation R_WASM_TABLE_INDEX_SLEB cannot be used against symbol `undef_func`; recompile with -fPIC
 

--- a/lld/test/wasm/unsupported-pic-relocations.s
+++ b/lld/test/wasm/unsupported-pic-relocations.s
@@ -1,23 +1,23 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
 
-# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null 2>&1 | \
+# RUN: not wasm-ld -shared %t.o -o /dev/null 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
+# RUN: not wasm-ld -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
+# RUN: not wasm-ld -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
+# RUN: not wasm-ld -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
+# RUN: not wasm-ld -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
 ## These errors should not be reported under -r/--relocation (i.e. when
 ## generating an object file)
-# RUN: wasm-ld --experimental-pic -r %t.o -o /dev/null
+# RUN: wasm-ld -r %t.o -o /dev/null
 
 .functype external_func () -> ()
 

--- a/lld/test/wasm/unsupported-pic-relocations64.s
+++ b/lld/test/wasm/unsupported-pic-relocations64.s
@@ -1,23 +1,23 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-unknown -o %t.o %s
 
-# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null 2>&1 | \
+# RUN: not wasm-ld -mwasm64 -shared %t.o -o /dev/null 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
+# RUN: not wasm-ld -mwasm64 -shared %t.o -o /dev/null  --unresolved-symbols=report-all 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
+# RUN: not wasm-ld -mwasm64 -shared %t.o -o /dev/null  --warn-unresolved-symbols 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
+# RUN: not wasm-ld -mwasm64 -shared %t.o -o /dev/null  --unresolved-symbols=ignore-all 2>&1 | \
 # RUN:   FileCheck %s
 
-# RUN: not wasm-ld -mwasm64 --experimental-pic -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
+# RUN: not wasm-ld -mwasm64 -shared %t.o -o /dev/null  --unresolved-symbols=import-dynamic 2>&1 | \
 # RUN:   FileCheck %s
 
 ## These errors should not be reported under -r/--relocation (i.e. when
 ## generating an object file)
-# RUN: wasm-ld -mwasm64 --experimental-pic -r %t.o -o /dev/null
+# RUN: wasm-ld -mwasm64 -r %t.o -o /dev/null
 
 .functype external_func () -> ()
 

--- a/lld/test/wasm/weak-undefined-pic.s
+++ b/lld/test/wasm/weak-undefined-pic.s
@@ -74,7 +74,7 @@ _start:
 # With `-pie` or `-shared` the resolution should be deferred to the dynamic
 # linker and the function address should be imported as GOT.func.foo.
 #
-# RUN: wasm-ld --experimental-pic -pie %t.o -o %t3.wasm
+# RUN: wasm-ld -pie %t.o -o %t3.wasm
 # RUN: obj2yaml %t3.wasm | FileCheck %s --check-prefix=IMPORT
 
 #      IMPORT:  - Type:            IMPORT

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -56,7 +56,6 @@ struct Config {
   bool compressRelocations;
   bool demangle;
   bool disableVerify;
-  bool experimentalPic;
   bool emitRelocs;
   bool exportAll;
   bool exportDynamic;
@@ -82,8 +81,9 @@ struct Config {
   bool stripAll;
   bool stripDebug;
   bool stackFirst;
-  // Because dyamanic linking under Wasm is still experimental we default to
-  // static linking
+  // Static linking is currently the default under WebAssembly.  This may
+  // change as some point in the future if dynamic linking becomes more widely
+  // used.
   bool isStatic = true;
   bool thinLTOEmitImportsFiles;
   bool thinLTOEmitIndexFiles;

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -535,7 +535,6 @@ static void readConfigs(opt::InputArgList &args) {
   ctx.arg.demangle = args.hasFlag(OPT_demangle, OPT_no_demangle, true);
   ctx.arg.disableVerify = args.hasArg(OPT_disable_verify);
   ctx.arg.emitRelocs = args.hasArg(OPT_emit_relocs);
-  ctx.arg.experimentalPic = args.hasArg(OPT_experimental_pic);
   ctx.arg.entry = getEntry(args);
   ctx.arg.exportAll = args.hasArg(OPT_export_all);
   ctx.arg.exportTable = args.hasArg(OPT_export_table);
@@ -793,28 +792,6 @@ static void checkOptions(opt::InputArgList &args) {
       error("-r and --shared-memory may not be used together");
     if (ctx.arg.globalBase)
       error("-r and --global-base may not by used together");
-  }
-
-  // To begin to prepare for Module Linking-style shared libraries, start
-  // warning about uses of `-shared` and related flags outside of Experimental
-  // mode, to give anyone using them a heads-up that they will be changing.
-  //
-  // Also, warn about flags which request explicit exports.
-  if (!ctx.arg.experimentalPic) {
-    // -shared will change meaning when Module Linking is implemented.
-    if (ctx.arg.shared) {
-      warn("creating shared libraries, with -shared, is not yet stable");
-    }
-
-    // -pie will change meaning when Module Linking is implemented.
-    if (ctx.arg.pie) {
-      warn("creating PIEs, with -pie, is not yet stable");
-    }
-
-    if (ctx.arg.unresolvedSymbols == UnresolvedPolicy::ImportDynamic) {
-      warn("dynamic imports are not yet stable "
-           "(--unresolved-symbols=import-dynamic)");
-    }
   }
 
   if (ctx.arg.bsymbolic && !ctx.arg.shared) {

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -320,6 +320,6 @@ def thinlto_prefix_replace_eq: JJ<"thinlto-prefix-replace=">;
 def lto_debug_pass_manager: FF<"lto-debug-pass-manager">,
   HelpText<"Debug new pass manager">;
 
-// Experimental PIC mode.
+// Legacy experimental PIC flag. Remove this at some point in the future.
 def experimental_pic: FF<"experimental-pic">,
-  HelpText<"Enable Experimental PIC">;
+  HelpText<"Legacy enable Experimental PIC flag; ignored">;


### PR DESCRIPTION
The current dynamic linking support has been used for several years not both in emscripten and in wasi-sdk and is documented https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md.   We did/do have have plans to develop another version of the dynamic linking ABI that doesn't use a global symbol namespace, and that can still happen, but the current API is clearly production worthy regardless of future plans.

This change removes the linker warning and the corresponding `--experimental-pic` flag.

If we do want to still make breaking changes to the dylink format we can rename the `dylink.1` section (which already contains a version number).

This change is leads the way for enabling shared libraries by default in emscripten.