### PR TITLE
Convert to exec-charset inside getPredefinedStringLiteralFromCache

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -326,6 +326,8 @@ public:
 
   llvm::TextEncodingConverter *FormatStrConverter;
 
+  llvm::TextEncodingConverter *ExecStrConverter;
+
   /// Retrieve the target options.
   TargetOptions &getTargetOpts() const {
     assert(TargetOpts && "Missing target options");

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -332,6 +332,8 @@ public:
 
   std::unique_ptr<llvm::TextEncodingConverter> FromSystemEncodingConverter;
 
+  llvm::TextEncodingConverter *ExecStrConverter;
+
   /// Retrieve the target options.
   TargetOptions &getTargetOpts() const {
     assert(TargetOpts && "Missing target options");

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13804,6 +13804,16 @@ ASTContext::getPredefinedStringLiteralFromCache(StringRef Key) const {
         *this, Key, StringLiteralKind::Ordinary,
         /*Pascal*/ false, getStringLiteralArrayType(CharTy, Key.size()),
         SourceLocation());
+
+  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
+  if (Converter) {
+    SmallString<128> Converted;
+    Converter->convert(Result->getString(), Converted);
+    Result = StringLiteral::Create(
+        *this, Converted, StringLiteralKind::Ordinary, /*Pascal*/ false,
+        getStringLiteralArrayType(CharTy, Converted.size()), SourceLocation());
+  }
+
   return Result;
 }
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13798,21 +13798,21 @@ QualType ASTContext::getStringLiteralArrayType(QualType EltTy,
 
 StringLiteral *
 ASTContext::getPredefinedStringLiteralFromCache(StringRef Key) const {
+  // Apply encoding conversion to the key before cache lookup to ensure
+  // proper deduplication when the same source location is used multiple times
+  SmallString<128> ConvertedKey;
+  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
+  if (Converter) {
+    Converter->convert(Key, ConvertedKey);
+    Key = ConvertedKey;
+  }
+
   StringLiteral *&Result = StringLiteralCache[Key];
   if (!Result)
     Result = StringLiteral::Create(
         *this, Key, StringLiteralKind::Ordinary,
         /*Pascal*/ false, getStringLiteralArrayType(CharTy, Key.size()),
         SourceLocation());
-
-  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
-  if (Converter) {
-    SmallString<128> Converted;
-    Converter->convert(Result->getString(), Converted);
-    Result = StringLiteral::Create(
-        *this, Converted, StringLiteralKind::Ordinary, /*Pascal*/ false,
-        getStringLiteralArrayType(CharTy, Converted.size()), SourceLocation());
-  }
 
   return Result;
 }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13891,21 +13891,21 @@ QualType ASTContext::getStringLiteralArrayType(QualType EltTy,
 
 StringLiteral *
 ASTContext::getPredefinedStringLiteralFromCache(StringRef Key) const {
+  // Apply encoding conversion to the key before cache lookup to ensure
+  // proper deduplication when the same source location is used multiple times
+  SmallString<128> ConvertedKey;
+  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
+  if (Converter) {
+    Converter->convert(Key, ConvertedKey);
+    Key = ConvertedKey;
+  }
+
   StringLiteral *&Result = StringLiteralCache[Key];
   if (!Result)
     Result = StringLiteral::Create(
         *this, Key, StringLiteralKind::Ordinary,
         /*Pascal*/ false, getStringLiteralArrayType(CharTy, Key.size()),
         SourceLocation());
-
-  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
-  if (Converter) {
-    SmallString<128> Converted;
-    Converter->convert(Result->getString(), Converted);
-    Result = StringLiteral::Create(
-        *this, Converted, StringLiteralKind::Ordinary, /*Pascal*/ false,
-        getStringLiteralArrayType(CharTy, Converted.size()), SourceLocation());
-  }
 
   return Result;
 }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13897,6 +13897,16 @@ ASTContext::getPredefinedStringLiteralFromCache(StringRef Key) const {
         *this, Key, StringLiteralKind::Ordinary,
         /*Pascal*/ false, getStringLiteralArrayType(CharTy, Key.size()),
         SourceLocation());
+
+  llvm::TextEncodingConverter *Converter = getTargetInfo().ExecStrConverter;
+  if (Converter) {
+    SmallString<128> Converted;
+    Converter->convert(Result->getString(), Converted);
+    Result = StringLiteral::Create(
+        *this, Converted, StringLiteralKind::Ordinary, /*Pascal*/ false,
+        getStringLiteralArrayType(CharTy, Converted.size()), SourceLocation());
+  }
+
   return Result;
 }
 

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -197,6 +197,9 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
 
   FormatStrConverter = new llvm::TextEncodingConverter(
       std::move(*llvm::TextEncodingConverter::createNoopConverter()));
+
+  ExecStrConverter = new llvm::TextEncodingConverter(
+      std::move(*llvm::TextEncodingConverter::createNoopConverter()));
 }
 
 // Out of line virtual dtor for TargetInfo.

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -201,6 +201,9 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
 
   FromSystemEncodingConverter = std::make_unique<llvm::TextEncodingConverter>(
       std::move(*llvm::TextEncodingConverter::createNoopConverter()));
+
+  ExecStrConverter = new llvm::TextEncodingConverter(
+      std::move(*llvm::TextEncodingConverter::createNoopConverter()));
 }
 
 // Out of line virtual dtor for TargetInfo.

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -55,7 +55,7 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
   if (ErrorOrConverter)
     TE.ToSystemEncodingConverter =
         std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
-    TInfo.ExecStrConverter = TEC.ToLiteralEncodingConverter.get();
+    TInfo.ExecStrConverter = TE.ToLiteralEncodingConverter.get();
   } else
     return ErrorOrConverter.getError();
 

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -55,7 +55,8 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
   if (ErrorOrConverter)
     TE.ToSystemEncodingConverter =
         std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
-  else
+    TInfo.ExecStrConverter = TEC.ToLiteralEncodingConverter.get();
+  } else
     return ErrorOrConverter.getError();
 
   ErrorOrConverter = llvm::TextEncodingConverter::create(

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -44,6 +44,8 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
       return ErrorOrLiteralConverter.getError();
   }
 
+  TInfo.ExecStrConverter = TE.ToLiteralEncodingConverter.get();
+
   if (TInfo.getDefaultOrdinaryLiteralEncoding() == UTF8)
     return std::error_code();
 
@@ -55,8 +57,7 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
   if (ErrorOrConverter)
     TE.ToSystemEncodingConverter =
         std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
-    TInfo.ExecStrConverter = TEC.ToLiteralEncodingConverter.get();
-  } else
+  else
     return ErrorOrConverter.getError();
 
   ErrorOrConverter = llvm::TextEncodingConverter::create(

--- a/clang/lib/Lex/TextEncodingConfig.cpp
+++ b/clang/lib/Lex/TextEncodingConfig.cpp
@@ -37,10 +37,11 @@ TextEncodingConfig::setConvertersFromOptions(TextEncodingConfig &TEC,
     return std::error_code();
   ErrorOr<TextEncodingConverter> ErrorOrConverter =
       llvm::TextEncodingConverter::create(UTF8, TEC.ExecEncoding);
-  if (ErrorOrConverter)
+  if (ErrorOrConverter) {
     TEC.ToExecEncodingConverter =
         new TextEncodingConverter(std::move(*ErrorOrConverter));
-  else
+    TInfo.ExecStrConverter = TEC.ToExecEncodingConverter;
+  } else
     return ErrorOrConverter.getError();
 
   ErrorOrConverter = llvm::TextEncodingConverter::create(

--- a/clang/test/CodeGen/systemz-charset.cpp
+++ b/clang/test/CodeGen/systemz-charset.cpp
@@ -71,3 +71,7 @@ const char16_t *UnicodeUCNString16 = u"\u00E2\u00AC\U000000DF";
 const char32_t *UnicodeUCNString32 = U"\u00E2\u00AC\U000000DF";
 //CHECK: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
 //CHECK=UTF8: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
+
+const char *file = __builtin_FILE();
+//CHECK: {{.*}}\A2\A8\A2\A3\85\94\A9`\83\88\81\99\A2\85\A3K\83\97\97\00"
+//CHECK-UTF8: {{.*}}systemz-charset.cpp\00"

--- a/clang/test/CodeGen/systemz-charset.cpp
+++ b/clang/test/CodeGen/systemz-charset.cpp
@@ -73,7 +73,6 @@ const char32_t *UnicodeUCNString32 = U"\u00E2\u00AC\U000000DF";
 //CHECK: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
 //CHECK-UTF8: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
 
-
 struct string_view {
     int S;
     const char* D;
@@ -96,3 +95,7 @@ void function()
 }
 // CHECK: asm{{.*}}|\86\96\96
 // CHECK-UTF8: asm{{.*}}|foo
+
+const char *file = __builtin_FILE();
+//CHECK: {{.*}}\A2\A8\A2\A3\85\94\A9`\83\88\81\99\A2\85\A3K\83\97\97\00"
+//CHECK-UTF8: {{.*}}systemz-charset.cpp\00"


### PR DESCRIPTION
Convert literals like __builtin_FILE() to the execution encoding