### PR TITLE
[FuncSpec] Relax restrictions on code size growth

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -63,9 +63,9 @@ static cl::opt<unsigned> MinFunctionSize(
     cl::desc("Don't specialize functions that have less than this number of "
              "instructions"));
 
-static cl::opt<unsigned> MaxCodeSizeGrowth(
-    "funcspec-max-codesize-growth", cl::init(3), cl::Hidden, cl::desc(
-    "Maximum codesize growth allowed per function"));
+static cl::opt<unsigned>
+    MaxCodeSizeGrowth("funcspec-max-codesize-growth", cl::init(4), cl::Hidden,
+                      cl::desc("Maximum codesize growth allowed per function"));
 
 static cl::opt<unsigned> MinCodeSizeSavings(
     "funcspec-min-codesize-savings", cl::init(20), cl::Hidden,

--- a/llvm/test/Transforms/FunctionSpecialization/recursive-penalty.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/recursive-penalty.ll
@@ -6,7 +6,7 @@
 ; Make sure the number of specializations created are not
 ; linear to the number of iterations (funcspec-max-iters).
 
-; CHECK: FnSpecialization: Created 4 specializations in module
+; CHECK: FnSpecialization: Created 6 specializations in module
 
 @Global = internal constant i32 1, align 4
 


### PR DESCRIPTION
This patch is a preparation for a follow-up patch which disables loop unroll in LTO pre-link pipeline, which affects code size and thus causes more functions to be rejected by the current code size growth restriction in function specialization.