### PR TITLE
[libc] Fix op_tests Memcmp guard to require SSE4.1

### DIFF
--- a/libc/test/src/string/memory_utils/op_tests.cpp
+++ b/libc/test/src/string/memory_utils/op_tests.cpp
@@ -299,7 +299,7 @@ TYPED_TEST(LlvmLibcOpTest, Bcmp, BcmpImplementations) {
 
 using MemcmpImplementations = testing::TypeList<
 #if defined(LIBC_TARGET_ARCH_IS_X86_64) && !defined(LIBC_TARGET_OS_IS_WINDOWS)
-#ifdef __SSE2__
+#ifdef __SSE4_1__
     generic::Memcmp<__m128i>, //
 #endif
 #ifdef __AVX2__


### PR DESCRIPTION
The is_vector<__m128i> specialisation in op_x86.h is gated on __SSE4_1__, but op_tests.cpp included generic::Memcmp<__m128i> under the weaker __SSE2__ guard. On baseline x86-64 (where __SSE2__ is always defined but __SSE4_1__ may not be), this caused a static_assert failure in is_element_type_v.

Changed the guard from __SSE2__ to __SSE4_1__ to match the specialisation requirement, consistent with how BcmpImplementations already guards its __m128i entry.

Assisted-by: Automated tooling, human reviewed.