### PR TITLE
[libc++][mdspan] Add missing `std::move` in `std::extents`

### DIFF
--- a/libcxx/include/__mdspan/extents.h
+++ b/libcxx/include/__mdspan/extents.h
@@ -348,7 +348,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit extents(_OtherIndexTypes... __dynvals) noexcept
       // Not catching this could lead to out of bounds errors later
       // e.g. mdspan m(ptr, dextents<char, 1>(200u)); leads to an extent of -56 on m
-      : __vals_(__representability_checked_cast(__dynvals...)) {}
+      : __vals_(__representability_checked_cast(std::move(__dynvals)...)) {}
 
   template <class _OtherIndexType, size_t _Size>
     requires(is_convertible_v<const _OtherIndexType&, index_type> &&

--- a/libcxx/test/std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp
@@ -38,6 +38,12 @@
 #include "CtorTestCombinations.h"
 #include "test_macros.h"
 
+struct RValueInt {
+  int val;
+  constexpr RValueInt(int v) : val(v) {}
+  constexpr operator int() && noexcept { return val; }
+};
+
 struct IntegralCtorTest {
   template <class E, class AllExtents, class Extents, size_t... Indices>
   static constexpr void test_construction(AllExtents all_ext, Extents ext, std::index_sequence<Indices...>) {
@@ -56,11 +62,20 @@ constexpr bool test_ctor_from_bool() {
   return true;
 }
 
+constexpr bool test_ctor_from_rvalue_convertible() {
+  constexpr size_t D = std::dynamic_extent;
+  std::extents<int, D> e(RValueInt{1});
+  assert(e.extent(0) == 1);
+  return true;
+}
+
 int main(int, char**) {
   test_index_type_combo<IntegralCtorTest>();
   static_assert(test_index_type_combo<IntegralCtorTest>());
   test_ctor_from_bool();
   static_assert(test_ctor_from_bool());
+  test_ctor_from_rvalue_convertible();
+  static_assert(test_ctor_from_rvalue_convertible());
 
   constexpr size_t D = std::dynamic_extent;
   using E            = std::extents<int, 1, D, 3, D>;


### PR DESCRIPTION
Without this fix, libc++ rejects this example:

```cpp
#include <mdspan>

struct RValueInt {
  constexpr operator int() && noexcept { return 0; }
};

int main() {
  std::extents<int, std::dynamic_extent> e(RValueInt{});
}
```