### PR TITLE
[FileCheck] Handle directives at EOF without a trailing newline

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1903,17 +1903,17 @@ bool FileCheck::readCheckFile(
     assert(UsedPrefix.data() == Buffer.data() &&
            "Failed to move Buffer's start forward, or pointed prefix outside "
            "of the buffer!");
+
+    const char *BufferEnd = Buffer.data() + Buffer.size();
     assert(AfterSuffix.data() >= Buffer.data() &&
-           AfterSuffix.data() < Buffer.data() + Buffer.size() &&
+           AfterSuffix.data() <= BufferEnd &&
            "Parsing after suffix doesn't start inside of buffer!");
+
+    // Skip the buffer to the end of the parsed directive suffix.
+    Buffer = AfterSuffix;
 
     // Location to use for error messages.
     const char *UsedPrefixStart = UsedPrefix.data();
-
-    // Skip the buffer to the end of parsed suffix (or just prefix, if no good
-    // suffix was processed).
-    Buffer = AfterSuffix.empty() ? Buffer.drop_front(UsedPrefix.size())
-                                 : AfterSuffix;
 
     // Complain about misspelled directives.
     if (CheckTy == Check::CheckMisspelled) {

--- a/llvm/test/FileCheck/check-empty-tag.txt
+++ b/llvm/test/FileCheck/check-empty-tag.txt
@@ -41,7 +41,7 @@ CHECK4C: found 'CHECK-EMPTY' without previous 'CHECK: line
 ; CHECK-EMPTY at EOF without trailing newline still works after a prior check.
 ; RUN: printf "foo\n\n" > %t.no-newline-success.in
 ; RUN: printf "CHECK: foo\nCHECK-EMPTY:" > %t.no-newline-success.chk
-; RUN: FileCheck --allow-empty --input-file=%t.no-newline-success.in %t.no-newline-success.chk
+; RUN: FileCheck --input-file=%t.no-newline-success.in %t.no-newline-success.chk
 
 ; CHECK-EMPTY-NOT and CHECK-NOT-EMPTY rejected
 ; RUN: %ProtectFileCheckOutput \

--- a/llvm/test/FileCheck/check-empty-tag.txt
+++ b/llvm/test/FileCheck/check-empty-tag.txt
@@ -31,6 +31,18 @@ CHECK3B: found non-empty check string for empty check with prefix 'CHECK3A:'
 CHECK4A-EMPTY:
 CHECK4B: found 'CHECK4A-EMPTY' without previous 'CHECK4A: line
 
+; CHECK-EMPTY at EOF without trailing newline cannot be the first check.
+; RUN: printf "# CHECK-EMPTY:" > %t.no-newline
+; RUN: %ProtectFileCheckOutput \
+; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-newline 2>&1 \
+; RUN: | FileCheck %s --check-prefix=CHECK4C
+CHECK4C: found 'CHECK-EMPTY' without previous 'CHECK: line
+
+; CHECK-EMPTY at EOF without trailing newline still works after a prior check.
+; RUN: printf "foo\n\n" > %t.input
+; RUN: printf "CHECK: foo\nCHECK-EMPTY:" > %t.success
+; RUN: FileCheck --allow-empty --input-file=%t.input %t.success
+
 ; CHECK-EMPTY-NOT and CHECK-NOT-EMPTY rejected
 ; RUN: %ProtectFileCheckOutput \
 ; RUN: not FileCheck %s --input-file %s --check-prefixes=CHECK5A 2>&1 \

--- a/llvm/test/FileCheck/check-empty-tag.txt
+++ b/llvm/test/FileCheck/check-empty-tag.txt
@@ -32,16 +32,16 @@ CHECK4A-EMPTY:
 CHECK4B: found 'CHECK4A-EMPTY' without previous 'CHECK4A: line
 
 ; CHECK-EMPTY at EOF without trailing newline cannot be the first check.
-; RUN: printf "# CHECK-EMPTY:" > %t.no-newline
+; RUN: printf "# CHECK-EMPTY:" > %t.no-newline-fail.chk
 ; RUN: %ProtectFileCheckOutput \
-; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-newline 2>&1 \
+; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-newline-fail.chk 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK4C
 CHECK4C: found 'CHECK-EMPTY' without previous 'CHECK: line
 
 ; CHECK-EMPTY at EOF without trailing newline still works after a prior check.
-; RUN: printf "foo\n\n" > %t.input
-; RUN: printf "CHECK: foo\nCHECK-EMPTY:" > %t.success
-; RUN: FileCheck --allow-empty --input-file=%t.input %t.success
+; RUN: printf "foo\n\n" > %t.no-newline-success.in
+; RUN: printf "CHECK: foo\nCHECK-EMPTY:" > %t.no-newline-success.chk
+; RUN: FileCheck --allow-empty --input-file=%t.no-newline-success.in %t.no-newline-success.chk
 
 ; CHECK-EMPTY-NOT and CHECK-NOT-EMPTY rejected
 ; RUN: %ProtectFileCheckOutput \

--- a/llvm/test/FileCheck/check-eof-no-pattern.txt
+++ b/llvm/test/FileCheck/check-eof-no-pattern.txt
@@ -1,7 +1,7 @@
 ; CHECK requires a pattern, so the no-newline EOF case must fail here.
-; RUN: printf "CHECK:" > %t.no-newline
+; RUN: printf "CHECK:" > %t.no-pattern.chk
 ; RUN: %ProtectFileCheckOutput \
-; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-newline 2>&1 \
+; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-pattern.chk 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=ERR-EMPTY-CHECK
 
 ERR-EMPTY-CHECK: error: found empty check string

--- a/llvm/test/FileCheck/check-eof-no-pattern.txt
+++ b/llvm/test/FileCheck/check-eof-no-pattern.txt
@@ -1,0 +1,7 @@
+; CHECK requires a pattern, so the no-newline EOF case must fail here.
+; RUN: printf "CHECK:" > %t.no-newline
+; RUN: %ProtectFileCheckOutput \
+; RUN: not FileCheck --allow-empty --input-file=/dev/null %t.no-newline 2>&1 \
+; RUN: | FileCheck %s --check-prefix=ERR-EMPTY-CHECK
+
+ERR-EMPTY-CHECK: error: found empty check string


### PR DESCRIPTION
FileCheck could assert when a check directive ended at EOF without a trailing newline. After parsing the directive suffix, EOF can be a valid continuation point, so parsing now continues directly from `AfterSuffix`.

Fixes #101582