### PR TITLE
[Clang][Modules] Fix -Wunused-variable

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -6327,7 +6327,8 @@ Module *ASTReader::getSubmodule(uint32_t GlobalID) {
   assert(It != GlobalSubmoduleMap.end());
   ModuleFile &F = *It->second;
   unsigned Index = GlobalID - F.BaseSubmoduleID - NUM_PREDEF_SUBMODULE_IDS;
-  unsigned LocalID = Index + F.LocalBaseSubmoduleID + NUM_PREDEF_SUBMODULE_IDS;
+  [[maybe_unused]] unsigned LocalID =
+      Index + F.LocalBaseSubmoduleID + NUM_PREDEF_SUBMODULE_IDS;
 
   BitstreamCursor &Cursor = F.SubmodulesCursor;
   SavedStreamPosition SavedPosition(Cursor);
@@ -6397,10 +6398,9 @@ Module *ASTReader::getSubmodule(uint32_t GlobalID) {
 
       StringRef Name = Blob;
       unsigned Idx = 0;
-      unsigned ReadLocalID = Record[Idx++];
+      [[maybe_unused]] unsigned ReadLocalID = Record[Idx++];
       assert(LocalID == ReadLocalID);
-      SubmoduleID ReadGlobalID = getGlobalSubmoduleID(F, ReadLocalID);
-      assert(GlobalID == ReadGlobalID);
+      assert(GlobalID == getGlobalSubmoduleID(F, ReadLocalID));
       SubmoduleID Parent = getGlobalSubmoduleID(F, Record[Idx++]);
       Module::ModuleKind Kind = (Module::ModuleKind)Record[Idx++];
       SourceLocation DefinitionLoc = ReadSourceLocation(F, Record[Idx++]);


### PR DESCRIPTION
Mark some variables [[maybe_unused]] and inline others that do not have
side effects to avoid -Wunused-variable in non-assert builds.