### PR TITLE
[AMDGPU] Add missing CMake link component

### DIFF
--- a/llvm/unittests/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/unittests/Target/AMDGPU/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LLVM_LINK_COMPONENTS
   GlobalISel
   MC
   MIRParser
+  Passes
   Support
   TargetParser
   )


### PR DESCRIPTION
The issue was triggered by #196547.