### PR TITLE
[lldb] Fix CommandObjects that don't set a return status

### DIFF
--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -75,7 +75,13 @@ protected:
     SBCommandReturnObject sb_return(result);
     SBCommandInterpreter sb_interpreter(&m_interpreter);
     SBDebugger debugger_sb(m_interpreter.GetDebugger().shared_from_this());
-    m_backend->DoExecute(debugger_sb, command.GetArgumentVector(), sb_return);
+    bool success = m_backend->DoExecute(debugger_sb,
+                                        command.GetArgumentVector(), sb_return);
+    // If the plugin command did not set its own status, infer it from the
+    // boolean return value so that callers always see a defined status.
+    if (result.GetStatus() == eReturnStatusInvalid)
+      result.SetStatus(success ? eReturnStatusSuccessFinishResult
+                               : eReturnStatusFailed);
   }
   lldb::SBCommandPluginInterface *m_backend;
   std::optional<std::string> m_auto_repeat_command;

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -2959,6 +2959,7 @@ protected:
                                        m_bp_opts.GetBreakpointOptions(),
                                        m_access_options.GetPermissions());
     }
+    result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 
 private:

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -868,6 +868,7 @@ protected:
 
       if (error.Success()) {
         AddRegexCommandToInterpreter();
+        result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
     if (error.Fail()) {
@@ -2498,6 +2499,8 @@ protected:
     if (m_options.m_class_name.empty() && m_options.m_funct_name.empty()) {
       m_interpreter.GetPythonCommandsFromIOHandler("     ", // Prompt
                                                    *this);  // IOHandlerDelegate
+      // Still gathering input; the IOHandler will set the final status.
+      result.SetStatus(eReturnStatusStarted);
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -593,6 +593,8 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
 
   if (command.empty()) {
     GetMultilineExpression();
+    // Still gathering input; the IOHandler will set the final status.
+    result.SetStatus(eReturnStatusStarted);
     return;
   }
 
@@ -660,6 +662,8 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
     // No expression following options
     else if (expr.empty()) {
       GetMultilineExpression();
+      // Still gathering input; the IOHandler will set the final status.
+      result.SetStatus(eReturnStatusStarted);
       return;
     }
   }

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -176,6 +176,8 @@ protected:
     ValueObjectPrinter printer(*valobj_sp, &result.GetOutputStream(), options);
     if (llvm::Error error = printer.PrintValueObject())
       result.AppendError(toString(std::move(error)));
+    else
+      result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectHelp.cpp
+++ b/lldb/source/Commands/CommandObjectHelp.cpp
@@ -168,6 +168,7 @@ void CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
       for (size_t i = 0; i < match_count; i++) {
         output_strm.Printf("\t%s\n", matches.GetStringAtIndex(i));
       }
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       // Maybe the user is asking for help about a command argument rather than
       // a command.

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -273,7 +273,8 @@ protected:
       if (Log::DisableLogChannel(channel, args.GetArgumentArrayRef(),
                                  error_stream))
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      result.GetErrorStream() << error;
+      else
+        result.AppendError(error);
     }
   }
 };

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -769,6 +769,7 @@ protected:
             result.GetOutputStream().Printf(
                 "%zi bytes %s to '%s'\n", bytes_written,
                 append ? "appended" : "written", path.c_str());
+            result.SetStatus(eReturnStatusSuccessFinishResult);
             return;
           } else {
             result.AppendErrorWithFormat("Failed to write %" PRIu64
@@ -820,6 +821,7 @@ protected:
           return;
         }
       }
+      result.SetStatus(eReturnStatusSuccessFinishResult);
       return;
     }
 
@@ -1510,6 +1512,7 @@ protected:
         return;
       }
     }
+    result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 
   OptionGroupOptions m_option_group;

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1300,6 +1300,7 @@ protected:
                 ostrm, platform_sp->GetUserIDResolver(), m_options.show_args,
                 m_options.verbose);
           }
+          result.SetStatus(eReturnStatusSuccessFinishResult);
         }
       }
     } else {

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -220,6 +220,8 @@ protected:
         }
       }
     }
+    if (result.GetStatus() != eReturnStatusFailed)
+      result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   class CommandOptions : public OptionGroup {

--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -229,6 +229,8 @@ protected:
 
     if (!num_listed_interface)
       s << " None\n";
+
+    result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
 private:

--- a/lldb/source/Commands/CommandObjectSession.cpp
+++ b/lldb/source/Commands/CommandObjectSession.cpp
@@ -179,6 +179,7 @@ protected:
         }
         history.Dump(result.GetOutputStream(), start_idx.second,
                      stop_idx.second);
+        result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
       }
     }
   }

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -393,6 +393,7 @@ protected:
     if (args.empty()) {
       GetDebugger().DumpAllPropertyValues(&clean_ctx, out_file,
                                           OptionValue::eDumpGroupExport);
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
       return;
     }
 
@@ -403,6 +404,8 @@ protected:
         result.AppendError(error.AsCString());
       }
     }
+    if (result.GetStatus() != eReturnStatusFailed)
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 
 private:

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -1199,6 +1199,8 @@ protected:
         }
       }
     }
+    if (result.GetStatus() != eReturnStatusFailed)
+      result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   const SymbolContextList *GetBreakpointLocations() {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -305,6 +305,8 @@ protected:
       if (!label.empty()) {
         if (auto E = target_sp->SetLabel(label))
           result.SetError(std::move(E));
+        else
+          result.SetStatus(eReturnStatusSuccessFinishNoResult);
         return;
       }
 
@@ -989,6 +991,8 @@ protected:
 
     m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
                                            m_cmd_name);
+    if (result.GetStatus() != eReturnStatusFailed)
+      result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   OptionGroupOptions m_option_group;
@@ -3104,6 +3108,8 @@ protected:
       result.AppendError("either the \"--file <module>\" or the \"--uuid "
                          "<uuid>\" option must be specified.\n");
     }
+    if (result.GetStatus() != eReturnStatusFailed)
+      result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   OptionGroupOptions m_option_group;
@@ -3772,6 +3778,7 @@ protected:
 
       result.GetOutputStream().Printf("\n");
     }
+    result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -782,6 +782,7 @@ protected:
 
       if (!error.Success()) {
         result.AppendMessage(error.AsCString());
+        result.SetStatus(eReturnStatusFailed);
         return;
       }
 

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -1559,10 +1559,12 @@ void CommandObjectTypeSummaryAdd::DoExecute(Args &command,
 #else
     result.AppendError("python is disabled");
 #endif
-    return;
+  } else {
+    Execute_StringSummary(command, result);
   }
 
-  Execute_StringSummary(command, result);
+  if (result.GetStatus() != eReturnStatusFailed)
+    result.SetStatus(eReturnStatusSuccessFinishResult);
 }
 
 static bool FixArrayTypeNameWithRegex(ConstString &type_name) {


### PR DESCRIPTION
Several CommandObject subclasses had DoExecute paths that returned without ever calling SetStatus on the CommandReturnObject. The status was silently left at its initial eReturnStatusStarted value, which made Succeeded() report false for what were really successful commands and left CommandReturnObject in an undefined state.