### PR TITLE
[lldb] Assert that CommandObject::DoExecute sets a return status

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -189,7 +189,7 @@ private:
   std::vector<DiagnosticDetail> m_diagnostics;
   std::optional<uint16_t> m_diagnostic_indent;
 
-  lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
+  lldb::ReturnStatus m_status = lldb::eReturnStatusInvalid;
 
   /// An optionally empty list of values produced by this command.
   ValueObjectList m_value_objects;

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -189,6 +189,9 @@ private:
   std::vector<DiagnosticDetail> m_diagnostics;
   std::optional<uint16_t> m_diagnostic_indent;
 
+  /// The command's return status indicating success or failure. The default
+  /// value indicate no status has been set, which is enforced by an assert in
+  /// the CommandInterpreter.
   lldb::ReturnStatus m_status = lldb::eReturnStatusInvalid;
 
   /// An optionally empty list of values produced by this command.

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -927,7 +927,9 @@ protected:
                   error);
     if (error.Fail() || process_sp == nullptr) {
       result.AppendError(error.AsCString("Error connecting to the process"));
+      return;
     }
+    result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectProtocolServer.cpp
+++ b/lldb/source/Commands/CommandObjectProtocolServer.cpp
@@ -92,8 +92,8 @@ protected:
       result.AppendMessageWithFormatv(
           "{0} server started with connection listeners: {1}", protocol,
           address);
-      result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
+    result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 };
 
@@ -128,6 +128,7 @@ protected:
       result.AppendErrorWithFormatv("{0}", llvm::fmt_consume(std::move(error)));
       return;
     }
+    result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 };
 

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -37,6 +37,26 @@
 using namespace lldb;
 using namespace lldb_private;
 
+namespace {
+/// RAII scope that resets the result's status to eReturnStatusInvalid on entry
+/// and asserts on exit that DoExecute changed it (directly via SetStatus, or
+/// indirectly via AppendError/SetError, which call SetStatus internally).
+class DoExecuteStatusCheck {
+public:
+  explicit DoExecuteStatusCheck(CommandReturnObject &result)
+      : m_result(result) {
+    m_result.SetStatus(eReturnStatusInvalid);
+  }
+  ~DoExecuteStatusCheck() {
+    assert(m_result.GetStatus() != eReturnStatusInvalid &&
+           "DoExecute did not set a status on the CommandReturnObject");
+  }
+
+private:
+  CommandReturnObject &m_result;
+};
+} // namespace
+
 // CommandObject
 
 CommandObject::CommandObject(CommandInterpreter &interpreter,
@@ -825,6 +845,7 @@ void CommandObjectParsed::Execute(const char *args_string,
           return;
         }
         m_interpreter.IncreaseCommandUsage(*this);
+        DoExecuteStatusCheck check(result);
         DoExecute(cmd_args, result);
       }
     }
@@ -845,8 +866,10 @@ void CommandObjectRaw::Execute(const char *args_string,
     handled = InvokeOverrideCallback(argv, result);
   }
   if (!handled) {
-    if (CheckRequirements(result))
+    if (CheckRequirements(result)) {
+      DoExecuteStatusCheck check(result);
       DoExecute(args_string, result);
+    }
 
     Cleanup();
   }

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -181,7 +181,7 @@ void CommandReturnObject::Clear() {
   if (stream_sp)
     static_cast<StreamString *>(stream_sp.get())->Clear();
   m_diagnostics.clear();
-  m_status = eReturnStatusStarted;
+  m_status = eReturnStatusInvalid;
   m_did_change_process_state = false;
   m_suppress_immediate_output = false;
   m_interactive = true;

--- a/lldb/test/API/commands/command/script/TestCommandScript.py
+++ b/lldb/test/API/commands/command/script/TestCommandScript.py
@@ -214,8 +214,8 @@ class CmdPythonTestCase(TestBase):
         # valid.
         self.expect("script str(persistence.debugger_copy)", substrs=[str(self.dbg)])
         # The result object will be replaced by an empty result object (in the
-        # "Started" state).
-        self.expect("script str(persistence.result_copy)", substrs=["Started"])
+        # default "Invalid" state).
+        self.expect("script str(persistence.result_copy)", substrs=["Invalid"])
 
     def test_interactive(self):
         """

--- a/lldb/unittests/Interpreter/CMakeLists.txt
+++ b/lldb/unittests/Interpreter/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_unittest(InterpreterTests
   TestCommandPaths.cpp
+  TestCommandReturnObject.cpp
   TestCompletion.cpp
   TestOptionArgParser.cpp
   TestOptions.cpp

--- a/lldb/unittests/Interpreter/TestCommandReturnObject.cpp
+++ b/lldb/unittests/Interpreter/TestCommandReturnObject.cpp
@@ -1,0 +1,38 @@
+//===-- TestCommandReturnObject.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Interpreter/CommandReturnObject.h"
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+TEST(CommandReturnObjectTest, DefaultStatusIsInvalid) {
+  CommandReturnObject result(/*colors=*/false);
+  EXPECT_EQ(result.GetStatus(), eReturnStatusInvalid);
+}
+
+TEST(CommandReturnObjectTest, SetStatusUpdatesStatus) {
+  CommandReturnObject result(false);
+  result.SetStatus(eReturnStatusSuccessFinishResult);
+  EXPECT_EQ(result.GetStatus(), eReturnStatusSuccessFinishResult);
+}
+
+TEST(CommandReturnObjectTest, AppendErrorSetsFailed) {
+  CommandReturnObject result(false);
+  result.AppendError("boom");
+  EXPECT_EQ(result.GetStatus(), eReturnStatusFailed);
+}
+
+TEST(CommandReturnObjectTest, ClearResetsToInvalid) {
+  CommandReturnObject result(false);
+  result.SetStatus(eReturnStatusSuccessFinishResult);
+  ASSERT_EQ(result.GetStatus(), eReturnStatusSuccessFinishResult);
+  result.Clear();
+  EXPECT_EQ(result.GetStatus(), eReturnStatusInvalid);
+}


### PR DESCRIPTION
Change the default value of CommandReturnObject::m_status from eReturnStatusStarted to eReturnStatusInvalid, and add a debug-only RAII check in CommandObjectParsed::Execute and CommandObjectRaw::Execute that asserts the status is no longer Invalid after DoExecute returns. 

This catches commands that forget to call SetStatus on a success or failure path. Succeeded() still returns true when the status is Invalid (0 sorts below eReturnStatusSuccessContinuingResult), so helpers that read result.Succeeded() as a precondition before any explicit SetStatus (e.g. StopProcessIfNecessary) continue to work.

rdar://176506732