### PR TITLE
[clang] Suppress -Wunneeded-internal-declaration for referenced constexpr functions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -455,6 +455,10 @@ Improvements to Clang's diagnostics
 - Clang now emits ``-Wsizeof-pointer-memaccess`` when snprintf/vsnprintf use the sizeof
   the destination buffer(dynamically allocated) in the len parameter(#GH162366)
 
+- Fixed a false positive ``-Wunneeded-internal-declaration`` warning for
+  referenced ``constexpr`` functions used during constant evaluation.
+  (#GH196564)
+
 - Added ``-Wmodule-map-path-outside-directory`` (off by default) to warn on
   header and umbrella directory paths that use ``..`` to refer outside the module
   directory in module maps found via implicit search

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -891,6 +891,11 @@ static bool ShouldRemoveFromUnused(Sema *SemaRef, const DeclaratorDecl *D) {
     return true;
 
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+    // If a constexpr function is referenced for constant evaluation,
+    // don't warn even if it is not odr-used.
+    if (FD->isReferenced() && FD->isConstexpr())
+      return true;
+
     // If this is a function template and none of its specializations is used,
     // we should warn.
     if (FunctionTemplateDecl *Template = FD->getDescribedFunctionTemplate())

--- a/clang/test/SemaCXX/warn-unused-constexpr-function.cpp
+++ b/clang/test/SemaCXX/warn-unused-constexpr-function.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++14 -Wunused-function -fsyntax-only %s
+
+static constexpr bool returnInt(int) { return true; }
+
+template <bool B>
+struct select;
+
+template <>
+struct select<true> {
+  using type = int;
+};
+
+template <>
+struct select<false> {
+  using type = float;
+};
+
+template <typename T>
+typename select<returnInt(T{})>::type make() {
+  return T{};
+}
+
+int makeInt() { return make<int>(); }
+float makeFloat() { return make<float>(); }


### PR DESCRIPTION
This patch suppresses `-Wunneeded-internal-declaration` for referenced `constexpr` functions used during constant evaluation.

`constexpr` variables already receive similar handling in `ShouldRemoveFromUnused()` because they may participate in constant expression evaluation without being odr-used. Referenced `constexpr` functions currently lack equivalent handling, which can produce false positives in cases such as dependent return type evaluation.

Add analogous handling for referenced `constexpr` functions and include a regression test.

Fixes #196564 
