### PR TITLE
[AMDGPU] Fix inconsistencies in RP tracking advance/reset behavior

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
@@ -2452,7 +2452,7 @@ void printNextUseDistancesAsJson(json::OStream &J, const MachineFunction &MF,
     for (const MachineInstr &MI : MBB) {
       // Update register pressure tracker
       if (!PrevMI || PrevMI->getOpcode() == AMDGPU::PHI)
-        RPTracker.reset(MI);
+        RPTracker.reset(MI, MBB.end());
       RPTracker.advance();
 
       UseDistancePair Furthest;

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -621,13 +621,14 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
 // GCNDownwardRPTracker
 
 bool GCNDownwardRPTracker::reset(const MachineInstr &MI,
-                                 const LiveRegSet *LiveRegsCopy) {
+                                 MachineBasicBlock::const_iterator End,
+                                 const LiveRegSet *LiveRegsCopy) {                                 
   MRI = &MI.getMF()->getRegInfo();
   LastTrackedMI = nullptr;
   MBBEnd = MI.getParent()->end();
   NextMI = &MI;
-  NextMI = skipDebugInstructionsForward(NextMI, MBBEnd);
-  if (NextMI == MBBEnd)
+  NextMI = skipDebugInstructionsForward(NextMI, End);
+  if (NextMI == End)
     return false;
   GCNRPTracker::reset(*NextMI, LiveRegsCopy, false);
   return true;
@@ -746,7 +747,8 @@ bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator End) {
 bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator Begin,
                                    MachineBasicBlock::const_iterator End,
                                    const LiveRegSet *LiveRegsCopy) {
-  reset(*Begin, LiveRegsCopy);
+  if (!reset(*Begin, End, LiveRegsCopy))
+    return false;
   return advance(End);
 }
 

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -14,6 +14,7 @@
 #include "GCNRegPressure.h"
 #include "AMDGPU.h"
 #include "SIMachineFunctionInfo.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/CodeGen/RegisterPressure.h"
 
@@ -520,28 +521,54 @@ GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
   return LiveRegs;
 }
 
-void GCNRPTracker::reset(const MachineInstr &MI,
-                         const LiveRegSet *LiveRegsCopy,
-                         bool After) {
-  const MachineFunction &MF = *MI.getMF();
-  MRI = &MF.getRegInfo();
-  if (LiveRegsCopy) {
-    if (&LiveRegs != LiveRegsCopy)
-      LiveRegs = *LiveRegsCopy;
-  } else {
-    LiveRegs = After ? getLiveRegsAfter(MI, LIS)
-                     : getLiveRegsBefore(MI, LIS);
+void GCNRPTracker::reset(const MachineInstr &MI, bool After) {
+  const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
+  if (!MI.isDebugInstr()) {
+    SlotIndex SI = LIS.getInstructionIndex(MI);
+    if (After)
+      SI = SI.getDeadSlot();
+    reset(MRI, SI);
+    return;
   }
 
-  MaxPressure = CurPressure = getRegPressure(*MRI, LiveRegs);
+  // Look for the first valid index after the provided debug MI.
+  MachineBasicBlock::const_iterator It = MI.getIterator(),
+                                    MBBEnd = MI.getParent()->end();
+  MachineBasicBlock::const_iterator NonDbgMI =
+      skipDebugInstructionsForward(It, MBBEnd);
+  if (NonDbgMI == MBBEnd) {
+    // There are no non-debug instruction between MI and the end of the
+    // block, so we reset the tracker at the end of the block.
+    reset(*MI.getParent(), /*End=*/true);
+    return;
+  }
+  // MI is a debug instruction so register pressure before or after it is
+  // identical. Since we moved forward to finding a non-debug instruction
+  // in the block, we reset the tracker before that instruction i.e., at its
+  // base index.
+  reset(MRI, LIS.getInstructionIndex(*NonDbgMI));
 }
 
-void GCNRPTracker::reset(const MachineRegisterInfo &MRI_,
-                         const LiveRegSet &LiveRegs_) {
-  MRI = &MRI_;
-  LiveRegs = LiveRegs_;
+void GCNRPTracker::reset(const MachineBasicBlock &MBB, bool End) {
+  SlotIndex SI = End ? LIS.getSlotIndexes()->getMBBLastIdx(&MBB)
+                     : LIS.getMBBStartIdx(&MBB);
+  reset(MBB.getParent()->getRegInfo(), SI);
+}
+
+void GCNRPTracker::reset(const MachineRegisterInfo &MRI, SlotIndex SI) {
+  this->MRI = &MRI;
   LastTrackedMI = nullptr;
-  MaxPressure = CurPressure = getRegPressure(MRI_, LiveRegs_);
+  LiveRegs = llvm::getLiveRegs(SI, LIS, MRI);
+  MaxPressure = CurPressure = getRegPressure(MRI, LiveRegs);
+}
+
+void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
+                         const LiveRegSet &LiveRegs) {
+  this->MRI = &MRI;
+  LastTrackedMI = nullptr;
+  if (&this->LiveRegs != &LiveRegs)
+    this->LiveRegs = LiveRegs;
+  MaxPressure = CurPressure = getRegPressure(MRI, LiveRegs);
 }
 
 /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
@@ -623,15 +650,23 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
 bool GCNDownwardRPTracker::reset(const MachineInstr &MI,
                                  MachineBasicBlock::const_iterator End,
                                  const LiveRegSet *LiveRegsCopy) {
-  MRI = &MI.getMF()->getRegInfo();
-  LastTrackedMI = nullptr;
   MBBEnd = MI.getParent()->end();
+  assert(End == MBBEnd ||
+         End->getParent()->end() == MBBEnd && "end unrelated to MI block");
   NextMI = &MI;
   NextMI = skipDebugInstructionsForward(NextMI, End);
-  if (NextMI == End)
-    return false;
-  GCNRPTracker::reset(*NextMI, LiveRegsCopy, false);
-  return true;
+
+  // Do not use the MI to compute live registers when a set is provided.
+  // Otherwise the first non-debug instruction after the provided one (or the
+  // end of the block, if no such instruction exists) serves as the basis to
+  // compute a live register set.
+  if (LiveRegsCopy)
+    GCNRPTracker::reset(MI.getMF()->getRegInfo(), *LiveRegsCopy);
+  else if (NextMI != MBBEnd)
+    GCNRPTracker::reset(*NextMI, /*After=*/false);
+  else
+    GCNRPTracker::reset(*MI.getParent(), /*End=*/true);
+  return NextMI != End;
 }
 
 bool GCNDownwardRPTracker::advanceBeforeNext(MachineInstr *MI,
@@ -739,9 +774,10 @@ bool GCNDownwardRPTracker::advance(MachineInstr *MI, bool UseInternalIterator) {
 }
 
 bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator End) {
-  while (NextMI != End)
-    if (!advance()) return false;
-  return true;
+  bool AnyAdvance = false;
+  while (NextMI != End && advance())
+    AnyAdvance = true;
+  return AnyAdvance;
 }
 
 bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator Begin,
@@ -964,7 +1000,7 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
         RPAtMBBEnd = getRegPressure(MRI, LiveIn);
       } else {
         GCNDownwardRPTracker RPT(LIS);
-        RPT.reset(MBB.front());
+        RPT.reset(MBB.front(), MBB.end());
 
         LiveIn = RPT.getLiveRegs();
 

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -622,7 +622,7 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
 
 bool GCNDownwardRPTracker::reset(const MachineInstr &MI,
                                  MachineBasicBlock::const_iterator End,
-                                 const LiveRegSet *LiveRegsCopy) {                                 
+                                 const LiveRegSet *LiveRegsCopy) {
   MRI = &MI.getMF()->getRegInfo();
   LastTrackedMI = nullptr;
   MBBEnd = MI.getParent()->end();

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -428,10 +428,20 @@ public:
     return Res;
   }
 
-  /// Reset tracker to the point before the \p MI
-  /// filling \p LiveRegs upon this point using LIS.
-  /// \p returns false if block is empty except debug values.
-  bool reset(const MachineInstr &MI, const LiveRegSet *LiveRegs = nullptr);
+  /// Reset tracker to the point before the \p MI filling \p LiveRegs upon this
+  /// point using LIS. \p End must be between the MI and the end of its parent
+  /// block (inclusive). \p returns false if the range [MI, End) is empty except
+  /// debug values, in which case the current/maximum pressure are not changed.
+  bool reset(const MachineInstr &MI, MachineBasicBlock::const_iterator End,
+             const LiveRegSet *LiveRegs = nullptr);
+
+  /// Reset tracker to the point before the \p MI filling \p LiveRegs upon this
+  /// point using LIS. \p returns false if there are only debug values between
+  /// \p MI (inclusive) and end of its parent block, in which case the
+  /// current/maximum pressure are not changed.
+  bool reset(const MachineInstr &MI, const LiveRegSet *LiveRegs = nullptr) {
+    return reset(MI, MI.getParent()->end(), LiveRegs);
+  }
 
   /// Move to the state right before the next MI or after the end of MBB.
   /// \p returns false if reached end of the block.
@@ -462,10 +472,16 @@ public:
   /// \p MI and use LIS for RP calculations.
   bool advance(MachineInstr *MI = nullptr, bool UseInternalIterator = true);
 
-  /// Advance instructions until before \p End.
+  /// Advance instructions until before \p End using internal iterators to
+  /// process instructions in program order. Returns whether iterators actually
+  /// had to advance to reach \p End.
   bool advance(MachineBasicBlock::const_iterator End);
 
-  /// Reset to \p Begin and advance to \p End.
+  /// Reset tracker to \p Begin (filling \p LiveRegs upon this point using LIS)
+  /// and advance to \p End, which must be between \p Begin and the end of its
+  /// parent block (inclusive). \p returns false if the range [Begin, End) is
+  /// empty except debug values, in which case the current/maximum pressure are
+  /// not changed.
   bool advance(MachineBasicBlock::const_iterator Begin,
                MachineBasicBlock::const_iterator End,
                const LiveRegSet *LiveRegsCopy = nullptr);

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -331,8 +331,15 @@ protected:
 
   GCNRPTracker(const LiveIntervals &LIS_) : LIS(LIS_) {}
 
-  void reset(const MachineInstr &MI, const LiveRegSet *LiveRegsCopy,
-             bool After);
+  /// Resets tracker before or \p After the provided \p MI, which can be a debug
+  /// instruction.
+  void reset(const MachineInstr &MI, bool After);
+
+  /// Resets tracker at the start or \p End of the \p MBB.
+  void reset(const MachineBasicBlock &MBB, bool End);
+
+  /// Resets tracker at the specified slot index \p SI.
+  void reset(const MachineRegisterInfo &MRI, SlotIndex SI);
 
   /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
   void bumpDeadDefs(ArrayRef<VRegMaskOrUnit> DeadDefs);
@@ -340,8 +347,9 @@ protected:
   LaneBitmask getLastUsedLanes(Register Reg, SlotIndex Pos) const;
 
 public:
-  // reset tracker and set live register set to the specified value.
-  void reset(const MachineRegisterInfo &MRI_, const LiveRegSet &LiveRegs_);
+  /// Resets tracker with the provided \p LiveRegs.
+  void reset(const MachineRegisterInfo &MRI, const LiveRegSet &LiveRegs);
+
   // live regs for the current state
   const decltype(LiveRegs) &getLiveRegs() const { return LiveRegs; }
   const MachineInstr *getLastTrackedMI() const { return LastTrackedMI; }
@@ -369,21 +377,9 @@ public:
 
   using GCNRPTracker::reset;
 
-  /// reset tracker at the specified slot index \p SI.
-  void reset(const MachineRegisterInfo &MRI, SlotIndex SI) {
-    GCNRPTracker::reset(MRI, llvm::getLiveRegs(SI, LIS, MRI));
-  }
-
-  /// reset tracker to the end of the \p MBB.
-  void reset(const MachineBasicBlock &MBB) {
-    SlotIndex MBBLastSlot = LIS.getSlotIndexes()->getMBBLastIdx(&MBB);
-    reset(MBB.getParent()->getRegInfo(), MBBLastSlot);
-  }
-
-  /// reset tracker to the point just after \p MI (in program order).
-  void reset(const MachineInstr &MI) {
-    reset(MI.getMF()->getRegInfo(), LIS.getInstructionIndex(MI).getDeadSlot());
-  }
+  /// Resets tracker to the point just after \p MI (in program order), which can
+  /// be a debug instruction.
+  void reset(const MachineInstr &MI) { reset(MI, /*After=*/true); }
 
   /// Move to the state of RP just before the \p MI . If \p UseInternalIterator
   /// is set, also update the internal iterators. Setting \p UseInternalIterator
@@ -431,17 +427,9 @@ public:
   /// Reset tracker to the point before the \p MI filling \p LiveRegs upon this
   /// point using LIS. \p End must be between the MI and the end of its parent
   /// block (inclusive). \p returns false if the range [MI, End) is empty except
-  /// debug values, in which case the current/maximum pressure are not changed.
+  /// debug values.
   bool reset(const MachineInstr &MI, MachineBasicBlock::const_iterator End,
              const LiveRegSet *LiveRegs = nullptr);
-
-  /// Reset tracker to the point before the \p MI filling \p LiveRegs upon this
-  /// point using LIS. \p returns false if there are only debug values between
-  /// \p MI (inclusive) and end of its parent block, in which case the
-  /// current/maximum pressure are not changed.
-  bool reset(const MachineInstr &MI, const LiveRegSet *LiveRegs = nullptr) {
-    return reset(MI, MI.getParent()->end(), LiveRegs);
-  }
 
   /// Move to the state right before the next MI or after the end of MBB.
   /// \p returns false if reached end of the block.
@@ -480,8 +468,7 @@ public:
   /// Reset tracker to \p Begin (filling \p LiveRegs upon this point using LIS)
   /// and advance to \p End, which must be between \p Begin and the end of its
   /// parent block (inclusive). \p returns false if the range [Begin, End) is
-  /// empty except debug values, in which case the current/maximum pressure are
-  /// not changed.
+  /// empty except debug values.
   bool advance(MachineBasicBlock::const_iterator Begin,
                MachineBasicBlock::const_iterator End,
                const LiveRegSet *LiveRegsCopy = nullptr);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1029,8 +1029,13 @@ GCNScheduleDAGMILive::getRealRegPressure(unsigned RegionIdx) const {
   if (Regions[RegionIdx].first == Regions[RegionIdx].second)
     return llvm::getRegPressure(MRI, LiveIns[RegionIdx]);
   GCNDownwardRPTracker RPTracker(*LIS);
-  RPTracker.advance(Regions[RegionIdx].first, Regions[RegionIdx].second,
-                    &LiveIns[RegionIdx]);
+  if (!RPTracker.advance(Regions[RegionIdx].first, Regions[RegionIdx].second,
+                         &LiveIns[RegionIdx])) {
+    // Advance can produce false on a non-empty region if all MIs in the region
+    // are debug values; in such cases the maintained max pressure is invalid
+    // and the only source of pressure are the region's live-ins.
+    return llvm::getRegPressure(MRI, LiveIns[RegionIdx]);
+  }
   return RPTracker.moveMaxPressure();
 }
 
@@ -2025,8 +2030,7 @@ GCNSchedStage::getScheduleMetrics(const std::vector<SUnit> &InputSchedule) {
 #ifndef NDEBUG
   LLVM_DEBUG(
       printScheduleModel(ReadyCyclesSorted);
-      dbgs() << "\n\t"
-             << "Metric: "
+      dbgs() << "\n\t" << "Metric: "
              << (SumBubbles
                      ? (SumBubbles * ScheduleMetrics::ScaleFactor) / CurrCycle
                      : 1)

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1029,13 +1029,8 @@ GCNScheduleDAGMILive::getRealRegPressure(unsigned RegionIdx) const {
   if (Regions[RegionIdx].first == Regions[RegionIdx].second)
     return llvm::getRegPressure(MRI, LiveIns[RegionIdx]);
   GCNDownwardRPTracker RPTracker(*LIS);
-  if (!RPTracker.advance(Regions[RegionIdx].first, Regions[RegionIdx].second,
-                         &LiveIns[RegionIdx])) {
-    // Advance can produce false on a non-empty region if all MIs in the region
-    // are debug values; in such cases the maintained max pressure is invalid
-    // and the only source of pressure are the region's live-ins.
-    return llvm::getRegPressure(MRI, LiveIns[RegionIdx]);
-  }
+  RPTracker.advance(Regions[RegionIdx].first, Regions[RegionIdx].second,
+                    &LiveIns[RegionIdx]);
   return RPTracker.moveMaxPressure();
 }
 
@@ -1080,7 +1075,7 @@ void GCNScheduleDAGMILive::computeBlockPressure(unsigned RegionIdx,
   auto *NonDbgMI = &*skipDebugInstructionsForward(Rgn.first, Rgn.second);
   if (LiveInIt != MBBLiveIns.end()) {
     auto LiveIn = std::move(LiveInIt->second);
-    RPTracker.reset(*MBB->begin(), &LiveIn);
+    RPTracker.reset(*MBB->begin(), MBB->end(), &LiveIn);
     MBBLiveIns.erase(LiveInIt);
   } else {
     I = Rgn.first;
@@ -1088,7 +1083,7 @@ void GCNScheduleDAGMILive::computeBlockPressure(unsigned RegionIdx,
 #ifdef EXPENSIVE_CHECKS
     assert(isEqual(getLiveRegsBefore(*NonDbgMI, *LIS), LRS));
 #endif
-    RPTracker.reset(*I, &LRS);
+    RPTracker.reset(*I, I->getParent()->end(), &LRS);
   }
 
   for (;;) {
@@ -1212,16 +1207,10 @@ void GCNScheduleDAGMILive::runSchedStages() {
       }
 
       if (S.useGCNTrackers()) {
-        GCNDownwardRPTracker *DownwardTracker = S.getDownwardTracker();
-        GCNUpwardRPTracker *UpwardTracker = S.getUpwardTracker();
-        GCNRPTracker::LiveRegSet *RegionLiveIns =
-            &LiveIns[Stage->getRegionIdx()];
-
-        reinterpret_cast<GCNRPTracker *>(DownwardTracker)
-            ->reset(MRI, *RegionLiveIns);
-        reinterpret_cast<GCNRPTracker *>(UpwardTracker)
-            ->reset(MRI, RegionLiveOuts.getLiveRegsForRegionIdx(
-                             Stage->getRegionIdx()));
+        const unsigned RegionIdx = Stage->getRegionIdx();
+        S.getDownwardTracker()->reset(MRI, LiveIns[RegionIdx]);
+        S.getUpwardTracker()->reset(
+            MRI, RegionLiveOuts.getLiveRegsForRegionIdx(RegionIdx));
       }
 
       ScheduleDAGMILive::schedule();

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2030,7 +2030,8 @@ GCNSchedStage::getScheduleMetrics(const std::vector<SUnit> &InputSchedule) {
 #ifndef NDEBUG
   LLVM_DEBUG(
       printScheduleModel(ReadyCyclesSorted);
-      dbgs() << "\n\t" << "Metric: "
+      dbgs() << "\n\t"
+             << "Metric: "
              << (SumBubbles
                      ? (SumBubbles * ScheduleMetrics::ScaleFactor) / CurrCycle
                      : 1)

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -290,7 +290,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
         continue;
 
       if (!RPT.getNext().isValid())
-        RPT.reset(MI);
+        RPT.reset(MI, MBB.end());
       else { // Advance the state to the current MI.
         RPT.advance(MachineBasicBlock::const_iterator(MI));
         RPT.advanceBeforeNext();
@@ -299,7 +299,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
       const GCNRPTracker::LiveRegSet LiveRegsCopy(RPT.getLiveRegs());
       RegUse Defs, Uses;
       if (!processRegUses(MI, Defs, Uses, RPT)) {
-        RPT.reset(MI, &LiveRegsCopy);
+        RPT.reset(MI, MBB.end(), &LiveRegsCopy);
         continue;
       }
 
@@ -323,7 +323,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
         ++Length;
       }
       if (Length < 2) {
-        RPT.reset(MI, &LiveRegsCopy);
+        RPT.reset(MI, MBB.end(), &LiveRegsCopy);
         continue;
       }
 
@@ -391,7 +391,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
       }
 
       // Restore the state after processing the end of the bundle.
-      RPT.reset(MI, &LiveRegsCopy);
+      RPT.reset(MI, MBB.end(), &LiveRegsCopy);
 
       if (!Kill)
         continue;

--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -82,25 +82,15 @@ body:             |
     // which would return false in this case.
     //
     // There aren't any non-debug instruction between the beginning of bb1 and
-    // Dbg1 (exclusive). However, the call to reset takes the end of the MBB as
-    // the limit, so it pushes the beginning of the block up to %2's def and
-    // considers the reset successful.
-    EXPECT_TRUE(RPTracker.reset(*MBB1.begin(), &MBB1LiveIns));
-    EXPECT_TRUE(RPTrackerNoLiveIns.reset(*MBB1.begin(), nullptr));
-    // advance then unnecessarily processes instructions in order until the end
-    // of the block, even though it is already past Dbg1. It still returns false
-    // because it is stopped by the end of block delimiter, not the end
-    // iterator.
-    EXPECT_FALSE(RPTracker.advance(Dbg1));
-    EXPECT_FALSE(RPTrackerNoLiveIns.advance(Dbg1));
+    // Dbg1 (exclusive), the reset is therefore unsuccessful. The advance caller
+    // returns early on a failure to reset.
+    EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), Dbg1, &MBB1LiveIns));
+    EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), Dbg1, nullptr));
 
-    // In that case, the maximum pressure is also the pressure induced by the
-    // block's live-ins plus %2's def i.e., 3 VGPRs. This is confusing because
-    // %2's def is outside the [Begin,End) range we passed to advance, and there
-    // is no indication that a false return value should make the tracked
-    // pressure invalid.
-    EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 3U);
-    EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 3U);
+    // In that case, the maximum pressure is unchanged from the beginning since
+    // reset was unsuccessful.
+    EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 0U);
+    EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 0U);
   }
 }
 
@@ -140,17 +130,12 @@ body:             |
   // which would return true in this case.
   //
   // There aren't any non-debug instruction in bb.2, the reset is therefore
-  // unsuccessful. However the advance caller discards that return value and
-  // proceeds to calling its override.
-  EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), &MBB1LiveIns));
-  EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), nullptr));
-  // advance then produces true even though no advancement actually happened.
-  EXPECT_TRUE(RPTracker.advance(MBB1.end()));
-  EXPECT_TRUE(RPTrackerNoLiveIns.advance(MBB1.end()));
+  // unsuccessful. The advance caller returns early on a failure to reset.
+  EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), MBB1.end(), &MBB1LiveIns));
+  EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), MBB1.end(), nullptr));
 
   // In that case, the maximum pressure is unchanged from the beginning since
-  // reset was unsuccessful. This is confusing because the top-level advance
-  // call produced true, yet the block's live-in pressure was not considered.
+  // reset was unsuccessful.
   EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 0U);
   EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 0U);
 }

--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -86,6 +86,8 @@ body:             |
     // returns early on a failure to reset.
     EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), Dbg1, &MBB1LiveIns));
     EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), Dbg1, nullptr));
+    EXPECT_FALSE(RPTracker.advance(Dbg1));
+    EXPECT_FALSE(RPTrackerNoLiveIns.advance(Dbg1));
 
     // In that case, the maximum pressure is unchanged from the beginning since
     // reset was unsuccessful.

--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -83,16 +83,17 @@ body:             |
     //
     // There aren't any non-debug instruction between the beginning of bb1 and
     // Dbg1 (exclusive), the reset is therefore unsuccessful. The advance caller
-    // returns early on a failure to reset.
+    // returns early on a failure to reset. Calling advance after this does
+    // nothing and produces false because the internal iterator already points
+    // to the second debug instruction.
     EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), Dbg1, &MBB1LiveIns));
     EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), Dbg1, nullptr));
     EXPECT_FALSE(RPTracker.advance(Dbg1));
     EXPECT_FALSE(RPTrackerNoLiveIns.advance(Dbg1));
 
-    // In that case, the maximum pressure is unchanged from the beginning since
-    // reset was unsuccessful.
-    EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 0U);
-    EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 0U);
+    // Register pressure should be the one at the block's live-ins.
+    EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 2U);
+    EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 2U);
   }
 }
 
@@ -129,15 +130,18 @@ body:             |
 
   // The following unpacks a call to
   // advance(MBB1.begin(), MBB1.end(), [MBB1LiveIns|nullptr])
-  // which would return true in this case.
+  // which would return false in this case.
   //
   // There aren't any non-debug instruction in bb.2, the reset is therefore
   // unsuccessful. The advance caller returns early on a failure to reset.
+  // Calling advance after this does nothing and produces false because the
+  // internal iterator is already at the block's end.
   EXPECT_FALSE(RPTracker.reset(*MBB1.begin(), MBB1.end(), &MBB1LiveIns));
   EXPECT_FALSE(RPTrackerNoLiveIns.reset(*MBB1.begin(), MBB1.end(), nullptr));
+  EXPECT_FALSE(RPTracker.advance(MBB1.end()));
+  EXPECT_FALSE(RPTrackerNoLiveIns.advance(MBB1.end()));
 
-  // In that case, the maximum pressure is unchanged from the beginning since
-  // reset was unsuccessful.
-  EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 0U);
-  EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 0U);
+  // Register pressure should be the one at the block's live-ins.
+  EXPECT_EQ(RPTracker.moveMaxPressure().getVGPRNum(false), 1U);
+  EXPECT_EQ(RPTrackerNoLiveIns.moveMaxPressure().getVGPRNum(false), 1U);
 }


### PR DESCRIPTION
Some of the variants of `advance` and `reset` in the `GCNRPTracker` and
`GCNDownwardRPTracker` had unclear/inconsistent semantics on their
return value. This aims to clarify that through improved documentation
and light functional changes.

These inconsistencies ultimately triggered an assert in
`GCNRPTaget::saveRP` on a complex kernel during scheduling.
`GCNScheduleDAGMILive::getRealRegPressure` would incorrectly return a
null pressure for a non-empty region which only had debug values. Such
regions can arise if the `PreRARematStage` rematerializes all non-debug
instructions out of their original region, leaving only debug values.
Attempting to rematerialize registers across that same region afterwards
would trigger the assert.