### PR TITLE
[Clang] Rebuild lambda captures in default member initializers while skipping body

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -818,6 +818,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed crashes in Itanium C++ name mangling for lambdas with trailing requires-clauses involving requires-expressions. (#GH100774) (#GH123854)
 - Fixed an invalid rejection and assertion failure while generating `operator=` for fields with the `__restrict` qualifier. (#GH37979)
 - Fixed a use-after-free bug when parsing default arguments containing lambdas in declarations with template-id declarators. (#GH196725)
+- Fixed missing destructor cleanups for lambda init-captures in default member
+  initializers used during aggregate initialization. (#GH196469)
 - Fixed a crash in constant evaluation using placement new on an array which was later initialized. (#GH196450)
 - Fixed an issue where Clang incorrectly accepted invalid unqualified uses of local nested class names outside their declaring scope. (#GH184622)
 - Fixed a crash when parsing invalid friend declaration with storage-class specifier. (#GH186569)

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5365,6 +5365,23 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
 
   // Lookup the entry, lazily creating it if necessary.
   llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
+  auto DeferDefinitionIfBodyIsAvailable = [&] {
+    const auto *DAsFunction = dyn_cast_or_null<FunctionDecl>(D);
+    if (!getLangOpts().CPlusPlus || !DAsFunction)
+      return;
+
+    // Look for a declaration that's lexically in a record.
+    for (const auto *FD = DAsFunction->getMostRecentDecl(); FD;
+         FD = FD->getPreviousDecl()) {
+      if (isa<CXXRecordDecl>(FD->getLexicalDeclContext()) &&
+          FD->doesThisDeclarationHaveABody()) {
+        GlobalDecl DefGD = GD.getWithDecl(FD);
+        if (!llvm::is_contained(DeferredDeclsToEmit, DefGD))
+          addDeferredDeclToEmit(DefGD);
+        break;
+      }
+    }
+  };
   if (Entry) {
     if (WeakRefReferences.erase(Entry)) {
       const FunctionDecl *FD = cast_or_null<FunctionDecl>(D);
@@ -5397,6 +5414,11 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
 
     if ((isa<llvm::Function>(Entry) || isa<llvm::GlobalAlias>(Entry)) &&
         (Entry->getValueType() == Ty)) {
+      // The LLVM declaration can be created before Sema synthesizes the body
+      // for an inline member, for example an implicit destructor. If this is a
+      // later reference after the body became available, queue it for emission.
+      if (!DontDefer && !IsForDefinition && Entry->isDeclaration())
+        DeferDefinitionIfBodyIsAvailable();
       return Entry;
     }
 
@@ -5492,16 +5514,7 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
       // We also don't emit a definition for a function if it's going to be an
       // entry in a vtable, unless it's already marked as used.
     } else if (getLangOpts().CPlusPlus && D) {
-      // Look for a declaration that's lexically in a record.
-      for (const auto *FD = cast<FunctionDecl>(D)->getMostRecentDecl(); FD;
-           FD = FD->getPreviousDecl()) {
-        if (isa<CXXRecordDecl>(FD->getLexicalDeclContext())) {
-          if (FD->doesThisDeclarationHaveABody()) {
-            addDeferredDeclToEmit(GD.getWithDecl(FD));
-            break;
-          }
-        }
-      }
+      DeferDefinitionIfBodyIsAvailable();
     }
   }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5703,12 +5703,17 @@ struct ImmediateCallVisitor : DynamicRecursiveASTVisitor {
   }
 
   // A nested lambda might have parameters with immediate invocations
-  // in their default arguments.
+  // in their default arguments, or init-captures that are evaluated in the
+  // enclosing context.
   // The compound statement is not visited (as it does not constitute a
   // subexpression).
-  // FIXME: We should consider visiting and transforming captures
-  // with init expressions.
   bool VisitLambdaExpr(LambdaExpr *E) override {
+    auto Init = E->capture_init_begin();
+    for (auto C = E->capture_begin(), CEnd = E->capture_end(); C != CEnd;
+         ++C, ++Init) {
+      if (E->isInitCapture(C) && !TraverseLambdaCapture(E, C, *Init))
+        return false;
+    }
     return VisitCXXMethodDecl(E->getCallOperator());
   }
 
@@ -5723,16 +5728,51 @@ struct ImmediateCallVisitor : DynamicRecursiveASTVisitor {
 
 struct EnsureImmediateInvocationInDefaultArgs
     : TreeTransform<EnsureImmediateInvocationInDefaultArgs> {
+  using Base = TreeTransform<EnsureImmediateInvocationInDefaultArgs>;
+
   EnsureImmediateInvocationInDefaultArgs(Sema &SemaRef)
       : TreeTransform(SemaRef) {}
 
   bool AlwaysRebuild() { return true; }
+  bool ReplacingOriginal() { return true; }
 
-  // Lambda can only have immediate invocations in the default
-  // args of their parameters, which is transformed upon calling the closure.
-  // The body is not a subexpression, so we have nothing to do.
-  // FIXME: Immediate calls in capture initializers should be transformed.
-  ExprResult TransformLambdaExpr(LambdaExpr *E) { return E; }
+  // Lambda bodies are not subexpressions of the enclosing default initializer,
+  // but init-capture expressions are evaluated in the enclosing context. Keep
+  // the existing closure type and capture declarations so the existing body
+  // still refers to the right declarations.
+  ExprResult TransformLambdaExpr(LambdaExpr *E) {
+    SmallVector<Expr *, 4> CaptureInits(E->capture_inits());
+
+    bool Changed = false;
+    for (unsigned I = 0, N = E->capture_size(); I != N; ++I) {
+      const LambdaCapture *C = E->capture_begin() + I;
+      if (!E->isInitCapture(C))
+        continue;
+
+      auto *VD = cast<VarDecl>(C->getCapturedVar());
+      Expr *Init = CaptureInits[I];
+      ExprResult NewInit =
+          TransformInitializer(Init, VD->getInitStyle() == VarDecl::CallInit);
+      if (NewInit.isInvalid())
+        return ExprError();
+      Changed |= NewInit.get() != Init;
+      CaptureInits[I] = NewInit.get();
+    }
+
+    LambdaExpr *Lambda = E;
+    if (Changed) {
+      // Reuse the existing closure class: it owns the capture declarations,
+      // fields, and call operator body. Only the LambdaExpr's capture
+      // initializer list is replaced.
+      Lambda = LambdaExpr::Create(
+          SemaRef.Context, E->getLambdaClass(), E->getIntroducerRange(),
+          E->getCaptureDefault(), E->getCaptureDefaultLoc(),
+          E->hasExplicitParameters(), E->hasExplicitResultType(), CaptureInits,
+          E->getEndLoc(), E->containsUnexpandedParameterPack());
+    }
+
+    return SemaRef.MaybeBindToTemporary(Lambda);
+  }
   ExprResult TransformBlockExpr(BlockExpr *E) { return E; }
 
   // Make sure we don't rebuild the this pointer as it would

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5703,10 +5703,53 @@ struct ImmediateCallVisitor : DynamicRecursiveASTVisitor {
 
 struct EnsureImmediateInvocationInDefaultArgs
     : TreeTransform<EnsureImmediateInvocationInDefaultArgs> {
+  using Base = TreeTransform<EnsureImmediateInvocationInDefaultArgs>;
+
   EnsureImmediateInvocationInDefaultArgs(Sema &SemaRef)
       : TreeTransform(SemaRef) {}
 
   bool AlwaysRebuild() { return true; }
+
+  bool rebuiltInitNeedsCleanups() const { return RebuiltInitNeedsCleanups; }
+
+  ExprResult TransformCXXBindTemporaryExpr(CXXBindTemporaryExpr *E) {
+    // TransformInitializer normally strips CXXBindTemporaryExpr. In default
+    // member initializers, rebuild the binding explicitly so CodeGen still
+    // knows which rebuilt temporaries need end-of-full-expression destruction.
+    ExprResult SubExpr = Base::TransformExpr(E->getSubExpr());
+    if (SubExpr.isInvalid())
+      return ExprError();
+    if (SubExpr.get() == E->getSubExpr()) {
+      if (!SuppressRebuiltTemporaryCleanup)
+        RebuiltInitNeedsCleanups = true;
+      return E;
+    }
+
+    ExprResult Res = SemaRef.MaybeBindToTemporary(SubExpr.get());
+    if (!SuppressRebuiltTemporaryCleanup && !Res.isInvalid())
+      RebuiltInitNeedsCleanups = true;
+    return Res;
+  }
+
+  ExprResult TransformInitializer(Expr *Init, bool NotCopyInit) {
+    Expr *UnwrappedInit = Init;
+    if (auto *FE = dyn_cast_if_present<FullExpr>(UnwrappedInit))
+      UnwrappedInit = FE->getSubExpr();
+
+    if (auto *MTE =
+            dyn_cast_if_present<MaterializeTemporaryExpr>(UnwrappedInit);
+        MTE && MTE->getExtendingDecl()) {
+      // The lifetime-extended temporary is intentionally not cleaned up at the
+      // end of the default member initializer full-expression.
+      llvm::SaveAndRestore SaveSuppress(SuppressRebuiltTemporaryCleanup, true);
+      return Base::TransformInitializer(Init, NotCopyInit);
+    }
+
+    if (auto *E = dyn_cast_if_present<CXXBindTemporaryExpr>(UnwrappedInit))
+      return TransformCXXBindTemporaryExpr(E);
+
+    return Base::TransformInitializer(Init, NotCopyInit);
+  }
 
   // Lambda can only have immediate invocations in the default
   // args of their parameters, which is transformed upon calling the closure.
@@ -5741,6 +5784,10 @@ struct EnsureImmediateInvocationInDefaultArgs
     return getDerived().RebuildSourceLocExpr(
         E->getIdentKind(), E->getType(), E->getBeginLoc(), E->getEndLoc(), DC);
   }
+
+private:
+  bool RebuiltInitNeedsCleanups = false;
+  bool SuppressRebuiltTemporaryCleanup = false;
 };
 
 ExprResult Sema::BuildCXXDefaultArgExpr(SourceLocation CallLoc,
@@ -5882,6 +5929,8 @@ ExprResult Sema::BuildCXXDefaultInitExpr(SourceLocation Loc, FieldDecl *Field) {
   if (!NestedDefaultChecking)
     V.TraverseDecl(Field);
 
+  bool RebuiltInitNeedsCleanups = false;
+
   // CWG1815
   // Support lifetime extension of temporary created by aggregate
   // initialization using a default member initializer. We should rebuild
@@ -5914,6 +5963,7 @@ ExprResult Sema::BuildCXXDefaultInitExpr(SourceLocation Loc, FieldDecl *Field) {
       Field->setInvalidDecl();
       return ExprError();
     }
+    RebuiltInitNeedsCleanups = Immediate.rebuiltInitNeedsCleanups();
     Init = Res.get();
   }
 
@@ -5923,8 +5973,11 @@ ExprResult Sema::BuildCXXDefaultInitExpr(SourceLocation Loc, FieldDecl *Field) {
       runWithSufficientStackSpace(Loc, [&] {
         MarkDeclarationsReferencedInExpr(E, /*SkipLocalVariables=*/false);
       });
-    if (isInLifetimeExtendingContext())
+    if (isInLifetimeExtendingContext()) {
       DiscardCleanupsInEvaluationContext();
+      if (RebuiltInitNeedsCleanups)
+        Cleanup.setExprNeedsCleanups(true);
+    }
     // C++11 [class.base.init]p7:
     //   The initialization of each base and member constitutes a
     //   full-expression.

--- a/clang/test/CodeGenCXX/gh196469-default-member-init-lambda-cleanup.cpp
+++ b/clang/test/CodeGenCXX/gh196469-default-member-init-lambda-cleanup.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
+
+struct Noisy {
+  Noisy();
+  ~Noisy();
+};
+
+struct Function {
+  template <typename F> Function(F) {}
+};
+
+struct Options {
+  Function function{[noisy = Noisy{}] {}};
+};
+
+Options kOptions{};
+
+int side();
+
+struct ReturnsCapture {
+  int x;
+  int value = [value = x] { return value; }();
+};
+
+ReturnsCapture kReturnsCapture{side()};
+
+// CHECK-LABEL: define internal void @__cxx_global_var_init
+// CHECK: call void @_ZN5NoisyC1Ev
+// CHECK: call void @_ZN8FunctionC1IN7Options8functionMUlvE_EEET_
+// CHECK: call void @_ZN7Options8functionMUlvE_D1Ev
+// CHECK: call {{.*}} @_ZNK14ReturnsCapture5valueMUlvE_clEv
+
+// CHECK-LABEL: define linkonce_odr {{.*}} @_ZNK14ReturnsCapture5valueMUlvE_clEv
+// CHECK: ret i32
+
+// CHECK-LABEL: define {{.*}} @_ZN7Options8functionMUlvE_D2Ev
+// CHECK: call void @_ZN5NoisyD1Ev

--- a/clang/test/CodeGenCXX/gh196469-default-member-init-lambda-cleanup.cpp
+++ b/clang/test/CodeGenCXX/gh196469-default-member-init-lambda-cleanup.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm -o - %s | FileCheck %s
+
+using Size = decltype(sizeof(0));
+void *operator new(Size);
+void operator delete(void *) noexcept;
+void operator delete(void *, Size) noexcept;
+
+struct Noisy {
+  Noisy();
+  Noisy(const Noisy &);
+  ~Noisy();
+};
+
+class Function {
+public:
+  template <typename F>
+  explicit Function(F &&f) : callable_{new Callable<F>{static_cast<F &&>(f)}} {}
+
+  ~Function() { delete callable_; }
+
+private:
+  struct CallableBase {
+    virtual ~CallableBase() = default;
+  };
+
+  template <typename F> struct Callable final : CallableBase {
+    explicit Callable(F f) : function{static_cast<F &&>(f)} {}
+
+    F function;
+  };
+
+  CallableBase *callable_;
+};
+
+struct Options {
+  Function function{[noisy = Noisy{}] {}};
+};
+
+Options kOptions{};
+
+// CHECK-LABEL: define internal void @__cxx_global_var_init
+// CHECK: call void @_ZN5NoisyC1Ev
+// CHECK: call void @_ZN8FunctionC1IN7Options8functionMUlvE_EEEOT_
+// CHECK: call void @_ZN7Options8functionMUlvE_D1Ev
+
+// CHECK-LABEL: define {{.*}} @_ZN7Options8functionMUlvE_D1Ev
+// CHECK: call void @_ZN7Options8functionMUlvE_D2Ev
+
+// CHECK-LABEL: define {{.*}} @_ZN7Options8functionMUlvE_D2Ev
+// CHECK: call void @_ZN5NoisyD1Ev

--- a/clang/test/SemaCXX/gh196469-default-member-init-lambda-capture.cpp
+++ b/clang/test/SemaCXX/gh196469-default-member-init-lambda-capture.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify -verify-ignore-unexpected=note %s
+
+struct Noisy {
+  int x;
+  consteval Noisy(int x) : x(x) {}
+  ~Noisy() {}
+};
+
+struct Function {
+  template <typename F> Function(F) {}
+};
+
+struct Options {
+  int x;
+  Function function{ // expected-note {{declared here}}
+      // expected-error@+1 {{call to consteval function}}
+      [noisy = Noisy{x}] {}};
+};
+
+int foo();
+// expected-note@+1 {{in the default initializer of 'function'}}
+Options options{foo()};

--- a/clang/test/SemaCXX/source_location.cpp
+++ b/clang/test/SemaCXX/source_location.cpp
@@ -862,23 +862,11 @@ struct CompoundLiteral {
 static_assert(CompoundLiteral{}.a == __LINE__);
 
 
-// FIXME
-// Init captures are subexpressions of the lambda expression
-// so according to the standard immediate invocations in init captures
-// should be evaluated at the call site.
-// However Clang does not yet implement this as it would introduce
-// a fair bit of complexity.
-// We intend to implement that functionality once we find real world
-// use cases that require it.
 constexpr int test_init_capture(int a =
                 [b = SL::current().line()] { return b; }()) {
   return a;
 }
-#if defined(USE_CONSTEVAL) && !defined(NEW_INTERP)
-static_assert(test_init_capture() == __LINE__ - 4);
-#else
 static_assert(test_init_capture() == __LINE__ );
-#endif
 
 namespace check_immediate_invocations_in_templates {
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/196469

Since the CWG1815 implementation, `InitListChecker` rebuilds a default member initializer at its point of use in aggregate initialization. The rebuild uses the `EnsureImmediateInvocationInDefaultArgs` tree transform, where `TransformCXXBindTemporaryExpr` strips `CXXBindTemporaryExpr` nodes, relying on the subexpression's rebuild to re-create the temporary binding: every `Rebuild*` path funnels through `Sema::MaybeBindToTemporary`, which also re-registers the cleanup in the current evaluation context.

However, the transform overrides `TransformLambdaExpr` to return the closure unchanged (the body is not a subexpression), skipping the `MaybeBindToTemporary` call that `BuildLambdaExpr` ends with. The rebuilt initializer then lacks both the `CXXBindTemporaryExpr` around the closure and the `ExprWithCleanups` marker, so CodeGen never emits the closure's destructor and init-captured members leak.

Lambda init-captures are different from the body: their initializers are evaluated in the enclosing context and can also contain immediate invocations that need to be rebuilt at the default-initializer use site. Visit init-captures when deciding whether the default initializer needs rebuilding, and rebuild the lambda shell/captures while using `SkipLambdaBody` to leave the body itself untouched. Rebuilding the lambda this way also restores the closure temporary binding and cleanup through `BuildLambdaExpr`.

Assisted-By: GPT-5.5 <noreply@openai.com>