### PR TITLE
[CodeGen] Use unique_ptr for FunctionInfo to prevent memory leaks

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -843,7 +843,7 @@ void CodeGenModule::computeABIInfoUsingLib(CGFunctionInfo &FI) {
   if (Required.allowsOptionalArgs())
     NumRequired = Required.getNumRequiredArgs();
 
-  llvm::abi::FunctionInfo *AbiFI = llvm::abi::FunctionInfo::create(
+  auto AbiFI = llvm::abi::FunctionInfo::create(
       FI.getCallingConvention(), AbiMapper->convertType(FI.getReturnType()),
       MappedArgTypes, NumRequired);
 

--- a/llvm/include/llvm/ABI/FunctionInfo.h
+++ b/llvm/include/llvm/ABI/FunctionInfo.h
@@ -234,7 +234,7 @@ public:
 
   unsigned arg_size() const { return NumArgs; }
 
-  static FunctionInfo *
+  static std::unique_ptr<FunctionInfo>
   create(CallingConv::ID CC, const Type *ReturnType,
          ArrayRef<const Type *> ArgTypes,
          std::optional<unsigned> NumRequired = std::nullopt);

--- a/llvm/lib/ABI/FunctionInfo.cpp
+++ b/llvm/lib/ABI/FunctionInfo.cpp
@@ -12,16 +12,17 @@
 using namespace llvm;
 using namespace llvm::abi;
 
-FunctionInfo *FunctionInfo::create(CallingConv::ID CC, const Type *ReturnType,
-                                   ArrayRef<const Type *> ArgTypes,
-                                   std::optional<unsigned> NumRequired) {
+std::unique_ptr<FunctionInfo>
+FunctionInfo::create(CallingConv::ID CC, const Type *ReturnType,
+                     ArrayRef<const Type *> ArgTypes,
+                     std::optional<unsigned> NumRequired) {
 
   assert(!NumRequired || *NumRequired <= ArgTypes.size());
 
   void *Buffer = operator new(totalSizeToAlloc<ArgEntry>(ArgTypes.size()));
 
-  FunctionInfo *FI =
-      new (Buffer) FunctionInfo(CC, ReturnType, ArgTypes.size(), NumRequired);
+  std::unique_ptr<FunctionInfo> FI(
+      new (Buffer) FunctionInfo(CC, ReturnType, ArgTypes.size(), NumRequired));
 
   ArgEntry *Args = FI->getTrailingObjects();
   for (unsigned I = 0; I < ArgTypes.size(); ++I)


### PR DESCRIPTION
Raw pointer return from `FunctionInfo::create` caused leaks in callers
like `computeABIInfoUsingLib`, breaking BPF tests on ASan bots.
Using `std::unique_ptr` enforces automatic cleanup.

Fixes leak from 07b5dfe9473c.
Buildbot: https://lab.llvm.org/buildbot/#/builders/52/builds/17090
