### PR TITLE
[AMDGPU] Avoid invalid bitcasts for odd-width vector types

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULateCodeGenPrepare.cpp
@@ -250,6 +250,8 @@ Type *LiveRegOptimizer::calculateConvertType(Type *OriginalType) {
 Value *LiveRegOptimizer::convertToOptType(Instruction *V,
                                           BasicBlock::iterator &InsertPt) {
   FixedVectorType *VTy = cast<FixedVectorType>(V->getType());
+  if (VTy->getScalarSizeInBits() % 8 != 0)
+    return nullptr;
   Type *NewTy = calculateConvertType(V->getType());
 
   TypeSize OriginalSize = DL.getTypeSizeInBits(VTy);
@@ -382,7 +384,8 @@ bool LiveRegOptimizer::optimizeLiveType(
     if (!ValMap.contains(D)) {
       BasicBlock::iterator InsertPt = std::next(D->getIterator());
       Value *ConvertVal = convertToOptType(D, InsertPt);
-      assert(ConvertVal);
+      if (!ConvertVal)
+        return false;
       ValMap[D] = ConvertVal;
     }
   }

--- a/llvm/test/CodeGen/AMDGPU/odd-vector-bitcast-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/odd-vector-bitcast-crash.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1100 -O2 %s -o /dev/null
+
+target triple = "amdgcn-amd-amdhsa"
+
+define void @repro(ptr %p, <3 x i1> %mask) {
+  %x = call <3 x i31> @llvm.masked.load.v3i31.p0(
+    ptr %p, <3 x i1> %mask, <3 x i31> zeroinitializer)
+
+  call void @llvm.masked.store.v3i31.p0(
+    <3 x i31> %x, ptr null, <3 x i1> %mask)
+
+  ret void
+}
+
+declare <3 x i31> @llvm.masked.load.v3i31.p0(
+  ptr, <3 x i1>, <3 x i31>)
+
+declare void @llvm.masked.store.v3i31.p0(
+  <3 x i31>, ptr, <3 x i1>)


### PR DESCRIPTION
Fix an assertion failure in AMDGPULateCodeGenPrepare triggered by
invalid bitcasts on vectors with odd-width integer element types
such as `<3 x i31>`.

The live register optimization tries to repack these vectors using
bitcasts, but the transformation is not valid for non-byte-aligned
element widths.

Skip the optimization for these vector types and add a regression
test for the crash.


Reproducer:

```llvm
define void @repro(ptr %p, <3 x i1> %mask) {
  %x = call <3 x i31> @llvm.masked.load.v3i31.p0(
    ptr %p, <3 x i1> %mask, <3 x i31> zeroinitializer)

  call void @llvm.masked.store.v3i31.p0(
    <3 x i31> %x, ptr null, <3 x i1> %mask)

  ret void
}
```
Fixes #196582 
