### PR TITLE
[lldb] Remove `__iter/len__` from `SBTypeEnumMember`

### DIFF
--- a/lldb/bindings/interface/SBTypeEnumMemberExtensions.i
+++ b/lldb/bindings/interface/SBTypeEnumMemberExtensions.i
@@ -2,14 +2,6 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTypeEnumMember, lldb::eDescriptionLevelBrief)
 %extend lldb::SBTypeEnumMember {
 #ifdef SWIGPYTHON
     %pythoncode %{
-        def __iter__(self):
-            '''Iterate over all members in a lldb.SBTypeEnumMemberList object.'''
-            return lldb_iter(self, 'GetSize', 'GetTypeEnumMemberAtIndex')
-
-        def __len__(self):
-            '''Return the number of members in a lldb.SBTypeEnumMemberList object.'''
-            return self.GetSize()
-
         name = property(GetName, None, doc='''A read only property that returns the name for this enum member as a string.''')
         type = property(GetType, None, doc='''A read only property that returns an lldb object that represents the type (lldb.SBType) for this enum member.''')
         signed = property(GetValueAsSigned, None, doc='''A read only property that returns the value of this enum member as a signed integer.''')


### PR DESCRIPTION
`SBTypeEnumMember` doesn't have a `GetSize` and `GetTypeEnumMemberAtIndex`, so having `__iter__` and `__len__` doesn't make sense. These are on `SBTypeEnumMemberList`. From the docstrings, it looks like the extensions were copied from said type.