### PR TITLE
Open the JSON files as text

### DIFF
--- a/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/JSONFormatTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Serialization/JSONFormatTest/JSONFormatTest.cpp
@@ -123,7 +123,7 @@ bool JSONFormatTest::permissionsAreEnforced() const {
                  // silently suppressing the test.
   }
 
-  auto Buffer = llvm::MemoryBuffer::getFile(ProbePath);
+  auto Buffer = llvm::MemoryBuffer::getFile(ProbePath, /*IsText=*/true);
   bool Enforced = !Buffer; // If open failed, permissions are enforced.
 
   // Restore permissions so TearDown can clean up the temp directory.
@@ -137,7 +137,7 @@ llvm::Expected<llvm::json::Value>
 JSONFormatTest::readJSONFromFile(llvm::StringRef FileName) const {
   PathString FilePath = makePath(FileName);
 
-  auto BufferOrError = llvm::MemoryBuffer::getFile(FilePath);
+  auto BufferOrError = llvm::MemoryBuffer::getFile(FilePath, /*IsText=*/true);
   if (!BufferOrError) {
     return llvm::createStringError(BufferOrError.getError(),
                                    "Failed to read file: %s", FilePath.c_str());


### PR DESCRIPTION
Open the JSON files as text so z/OS gets the correct encoding for the file.