### PR TITLE
Correction: NOP should be mov r0, r0 on all not V6K, including regular V6

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -2354,6 +2354,7 @@ def HINT : AI<(outs), (ins imm0_239:$imm), MiscFrm, NoItinerary,
   let DecoderMethod = "DecodeHINTInstruction";
 }
 
+// Architectural ARM-mode NOP is a HINT from ARMv6K; plain ARMv6 uses MOV (see MOV nop alias).
 def : InstAlias<"nop$p", (HINT 0, pred:$p)>, Requires<[IsARM, HasV6K]>;
 def : InstAlias<"yield$p", (HINT 1, pred:$p)>, Requires<[IsARM, HasV6K]>;
 def : InstAlias<"wfe$p", (HINT 2, pred:$p)>, Requires<[IsARM, HasV6K]>;
@@ -6580,9 +6581,9 @@ def RORr : ARMAsmPseudo<"ror${s}${p} $Rd, $Rn, $Rm",
 def : ARMInstAlias<"neg${s}${p} $Rd, $Rm",
                    (RSBri GPR:$Rd, GPR:$Rm, 0, pred:$p, cc_out:$s)>;
 
-// Pre-v6, 'mov r0, r0' was used as a NOP encoding.
+// Pre-ARMv6K (including ARMv6), 'mov r0, r0' is the NOP encoding in ARM state.
 def : InstAlias<"nop${p}", (MOVr R0, R0, pred:$p, (cc_out zero_reg)), 0>,
-         Requires<[IsARM, NoV6]>;
+         Requires<[IsARM, NoV6K]>;
 
 // MUL/UMLAL/SMLAL/UMULL/SMULL are available on all arches, but
 // the instruction definitions need difference constraints pre-v6.


### PR DESCRIPTION
Otherwise, nop on armv6 but not v6k targets may not work.