### PR TITLE
[mlir][core] Restore dropped printIR behavior.

### DIFF
--- a/mlir/lib/Pass/IRPrinting.cpp
+++ b/mlir/lib/Pass/IRPrinting.cpp
@@ -48,6 +48,11 @@ private:
 
 static void printIR(Operation *op, bool printModuleScope, raw_ostream &out,
                     OpPrintingFlags flags) {
+  // Check to see if we are not printing at module scope.
+  if (!printModuleScope)
+    return op->print(out, op->getBlock() ? flags.useLocalScope() : flags);
+
+  // Otherwise, we are printing at module scope.
   // Find the top-level operation.
   auto *topLevelOp = op;
   while (auto *parentOp = topLevelOp->getParentOp())


### PR DESCRIPTION
Restore checking for module scope which is dropped in #195198