### PR TITLE
[clang][deps] Move `ScanningOutputFormat` out of the library

### DIFF
--- a/clang-tools-extra/clangd/ProjectModules.cpp
+++ b/clang-tools-extra/clangd/ProjectModules.cpp
@@ -155,7 +155,8 @@ public:
           dependencies::DependencyScanningServiceOptions Opts;
           Opts.MakeVFS = [&] { return TFS.view(std::nullopt); };
           Opts.Mode = dependencies::ScanningMode::CanonicalPreprocessing;
-          Opts.Format = dependencies::ScanningOutputFormat::P1689;
+          Opts.EmitWarnings = false;
+          Opts.ReportAbsolutePaths = false;
           return Opts;
         }()) {}
 

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -29,22 +29,6 @@ enum class ScanningMode {
   DependencyDirectivesScan,
 };
 
-/// The format that is output by the dependency scanner.
-enum class ScanningOutputFormat {
-  /// This is the Makefile compatible dep format. This will include all of the
-  /// deps necessary for an implicit modules build, but won't include any
-  /// intermodule dependency information.
-  Make,
-
-  /// This outputs the full clang module dependency graph suitable for use for
-  /// explicitly building modules.
-  Full,
-
-  /// This outputs the dependency graph for standard c++ modules in P1689R5
-  /// format.
-  P1689,
-};
-
 #define DSS_LAST_BITMASK_ENUM(Id)                                              \
   LLVM_MARK_AS_BITMASK_ENUM(Id), All = llvm::NextPowerOf2(Id) - 1
 
@@ -87,10 +71,10 @@ struct DependencyScanningServiceOptions {
       MakeVFS; // = [] { return llvm::vfs::createPhysicalFileSystem(); }
   /// Whether to use optimized dependency directive scan or full preprocessing.
   ScanningMode Mode = ScanningMode::DependencyDirectivesScan;
-  /// What output format are we expected to produce.
-  ScanningOutputFormat Format = ScanningOutputFormat::Full;
   /// How to optimize resulting explicit module command lines.
   ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default;
+  /// Whether the scanner should emit warnings.
+  bool EmitWarnings = true;
   /// Whether to make reported file paths absolute.
   bool ReportAbsolutePaths = true;
   /// Whether to report modules visible from modules that are imported directly.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -396,7 +396,7 @@ void dependencies::initializeScanCompilerInstance(
   ScanInstance.setBuildingModule(false);
   ScanInstance.createVirtualFileSystem(FS, DiagConsumer);
   ScanInstance.createDiagnostics(DiagConsumer, /*ShouldOwnClient=*/false);
-  if (Service.getOpts().Format == ScanningOutputFormat::P1689)
+  if (!Service.getOpts().EmitWarnings)
     ScanInstance.getDiagnostics().setIgnoreAllWarnings(true);
   ScanInstance.createFileManager();
   ScanInstance.createSourceManager();

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -81,6 +81,22 @@ enum ResourceDirRecipeKind {
   RDRK_InvokeCompiler,
 };
 
+/// The format that is output by the dependency scanner.
+enum class ScanningOutputFormat {
+  /// This is the Makefile compatible dep format. This will include all of the
+  /// deps necessary for an implicit modules build, but won't include any
+  /// intermodule dependency information.
+  Make,
+
+  /// This outputs the full clang module dependency graph suitable for use for
+  /// explicitly building modules.
+  Full,
+
+  /// This outputs the dependency graph for standard c++ modules in P1689R5
+  /// format.
+  P1689,
+};
+
 static std::string OutputFileName = "-";
 static ScanningMode ScanMode = ScanningMode::DependencyDirectivesScan;
 static ScanningOutputFormat Format = ScanningOutputFormat::Make;
@@ -1155,8 +1171,11 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
   DependencyScanningServiceOptions Opts;
   Opts.Mode = ScanMode;
-  Opts.Format = Format;
   Opts.OptimizeArgs = OptimizeArgs;
+  // The scanner currently ignores `#pragma clang diagnostic ...` and emits
+  // unexpected diagnostics. Work around this for now by disabling warnings
+  // entirely, at least for P1689 where people hit this most often.
+  Opts.EmitWarnings = Format != ScanningOutputFormat::P1689;
   // Within P1689 format, we don't want all the paths to be absolute path
   // since it may violate the traditional make style dependencies info.
   Opts.ReportAbsolutePaths = Format != ScanningOutputFormat::P1689;

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -230,7 +230,6 @@ TEST(DependencyScanner, ScanDepsWithFS) {
 
   DependencyScanningServiceOptions Opts;
   Opts.MakeVFS = [&] { return VFS; };
-  Opts.Format = ScanningOutputFormat::Make;
   DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service);
 
@@ -290,7 +289,6 @@ TEST(DependencyScanner, ScanDepsWithModuleLookup) {
 
   DependencyScanningServiceOptions Opts;
   Opts.MakeVFS = [&] { return InterceptFS; };
-  Opts.Format = ScanningOutputFormat::Make;
   DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service);
 


### PR DESCRIPTION
Basing behavior of the dependency scanner on the final output format is a leaky abstraction. Instead, we should aim to introduce proper feature flags.