### PR TITLE
[VPlan] Fix cyclic phi type inference in early outer loop plans.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -72,10 +72,17 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPInstruction *R) {
     return SetResultTyFromOp();
 
   switch (Opcode) {
+  case Instruction::PHI:
+    for (VPValue *Op : R->operands()) {
+      if (auto *VIR = dyn_cast<VPIRValue>(Op))
+        return VIR->getType();
+      if (auto *Ty = CachedTypes.lookup(Op))
+        return Ty;
+    }
+  LLVM_FALLTHROUGH;
   case Instruction::ExtractElement:
   case Instruction::InsertElement:
   case Instruction::Freeze:
-  case Instruction::PHI:
   case VPInstruction::Broadcast:
   case VPInstruction::ComputeReductionResult:
   case VPInstruction::ExitingIVValue:


### PR DESCRIPTION
For phis check if any of the operands are VPIRValues or we already have cached types. If so, return them.

This fixes a verification stack overflow in the VPlan outer loop path after https://github.com/llvm/llvm-project/pull/192868.