### PR TITLE
[libc] Skip targets with unavailable __ONLY flags

### DIFF
--- a/libc/cmake/modules/LLVMLibCFlagRules.cmake
+++ b/libc/cmake/modules/LLVMLibCFlagRules.cmake
@@ -241,6 +241,22 @@ function(add_target_with_flags target_name)
     list(APPEND ADD_TO_EXPAND_FLAGS ${ADD_TO_EXPAND_ADD_FLAGS})
   endif()
   list(APPEND ADD_TO_EXPAND_FLAGS ${deps_flag_list})
+
+  # If any flag with the __ONLY modifier is unavailable (i.e. its
+  # SKIP_FLAG_EXPANSION is set), skip this target entirely.  The __ONLY
+  # modifier means the target must only be built with that flag active;
+  # building without it would produce incorrect results.
+  foreach(flag_with_modifier IN LISTS ADD_TO_EXPAND_FLAGS)
+    extract_flag_modifier(${flag_with_modifier} flag modifier)
+    if("${modifier}" STREQUAL "ONLY" AND SKIP_FLAG_EXPANSION_${flag})
+      if(SHOW_INTERMEDIATE_OBJECTS)
+        message(STATUS "Not generating ${fq_target_name} since "
+                       "${flag} is not available on the host.")
+      endif()
+      return()
+    endif()
+  endforeach()
+
   remove_duplicated_flags("${ADD_TO_EXPAND_FLAGS}" flags)
   list(SORT flags)
 


### PR DESCRIPTION
When SKIP_FLAG_EXPANSION strips a flag that has the __ONLY modifier, remove_duplicated_flags drops the flag from the list. This leaves expand_flags_for_target with an empty flag list, causing it to create a plain (non-flag) target. The __ONLY semantics, "only build this target with the flag active", are silently violated.

On x86-64 CI runners without FMA, this results in cosf_float_test and sinf_float_test being built and linked without FMA. The sincosf algorithm was tuned assuming fused multiply-add precision, so the unfused x*y+z fallback exceeds the 3.5 ULP tolerance (57 ULP for cosf, 12 ULP for sinf).

Added an early return in add_target_with_flags: if any flag with the __ONLY modifier would be skipped, the target is not generated.

Assisted-by: Automated tooling, human reviewed.