### PR TITLE
[mlir][spirv] Remove stale NV CooperativeMatrix attributes

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
@@ -79,24 +79,6 @@ def SPIRV_CooperativeMatrixPropertiesKHRArrayAttr :
     TypedArrayAttrBase<SPIRV_CooperativeMatrixPropertiesKHRAttr,
                        "CooperativeMatrixPropertiesKHR array attribute">;
 
-// Description of cooperative matrix operations supported on the
-// target. Represents `VkCooperativeMatrixPropertiesNV`. See
-// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCooperativeMatrixPropertiesNV.html
-def SPIRV_CooperativeMatrixPropertiesNVAttr :
-    SPIRV_Attr<"CooperativeMatrixPropertiesNV", "coop_matrix_props_nv"> {
-  let parameters = (ins
-    "int":$m_size,
-    "int":$n_size,
-    "int":$k_size,
-    "mlir::Type":$a_type,
-    "mlir::Type":$b_type,
-    "mlir::Type":$c_type,
-    "mlir::Type":$result_type,
-    "mlir::spirv::ScopeAttr":$scope
-  );
-  let assemblyFormat = "`<` struct(params) `>`";
-}
-
 def SPIRV_CacheControlLoadINTELAttr :
     SPIRV_Attr<"CacheControlLoadINTEL", "cache_control_load_intel"> {
   let parameters = (ins "unsigned":$cache_level,
@@ -110,10 +92,6 @@ def SPIRV_CacheControlStoreINTELAttr :
                         "mlir::spirv::StoreCacheControl":$store_cache_control);
   let assemblyFormat = "`<` struct(params) `>`";
 }
-
-def SPIRV_CooperativeMatrixPropertiesNVArrayAttr :
-    TypedArrayAttrBase<SPIRV_CooperativeMatrixPropertiesNVAttr,
-                       "CooperativeMatrixPropertiesNV array attribute">;
 
 // This attribute specifies the limits for various resources on the target
 // architecture.

--- a/mlir/test/Dialect/SPIRV/IR/target-and-abi.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/target-and-abi.mlir
@@ -257,45 +257,6 @@ func.func @target_env_cooperative_matrix_khr() attributes{
 
 // -----
 
-func.func @target_env_cooperative_matrix_nv() attributes{
-  // CHECK:      spirv.target_env = #spirv.target_env<
-  // CHECK-SAME:   SPV_NV_cooperative_matrix
-  // CHECK-SAME: #spirv.coop_matrix_props_nv<
-  // CHECK-SAME:   m_size = 8, n_size = 8, k_size = 32,
-  // CHECK-SAME:   a_type = i8, b_type = i8, c_type = i32,
-  // CHECK-SAME:   result_type = i32, scope = <Subgroup>>
-  // CHECK-SAME: #spirv.coop_matrix_props_nv<
-  // CHECK-SAME:   m_size = 8, n_size = 8, k_size = 16,
-  // CHECK-SAME:   a_type = f16, b_type = f16, c_type = f16,
-  // CHECK-SAME:   result_type = f16, scope = <Subgroup>>
-  spirv.target_env = #spirv.target_env<
-  #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class,
-                            SPV_NV_cooperative_matrix]>,
-  #spirv.resource_limits<
-    cooperative_matrix_properties_nv = [#spirv.coop_matrix_props_nv<
-      m_size = 8,
-      n_size = 8,
-      k_size = 32,
-      a_type = i8,
-      b_type = i8,
-      c_type = i32,
-      result_type = i32,
-      scope = #spirv.scope<Subgroup>
-    >, #spirv.coop_matrix_props_nv<
-      m_size = 8,
-      n_size = 8,
-      k_size = 16,
-      a_type = f16,
-      b_type = f16,
-      c_type = f16,
-      result_type = f16,
-      scope = #spirv.scope<Subgroup>
-    >]
-  >>
-} { return }
-
-// -----
-
 //===----------------------------------------------------------------------===//
 // spirv.vce
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Since the support for NV CooperativeMatrix has been removed a while back, those attributes can be probably safely removed.