### PR TITLE
[HLSL] Add Offload distribution

### DIFF
--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -16,7 +16,7 @@ if (HLSL_ENABLE_DISTRIBUTION)
 endif()
 
 # Enable the offload test suite distribution. Produces a portable install
-# prefix containing the binaries and test data needed to run the HLSL
+# prefix containing the binaries, headers, and libs needed to run the HLSL
 # offload test suite on another machine. See the offload-test-suite repo
 # (docs/offload-distribution.md) for setup, prerequisites, and run
 # instructions.

--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -15,26 +15,18 @@ if (HLSL_ENABLE_DISTRIBUTION)
       CACHE STRING "")
 endif()
 
-# Enable the offload test suite distribution. This produces a portable
-# install prefix containing all binaries and test files needed to run the
-# HLSL offload test suite on another machine.
-#
-# Install with:
-#   cmake --build build --target install-distribution
-#   cmake --build build --target install-offload-tools
-#   cmake --build build --target install-offload-test-suite
-#
-# Prerequisites on the target machine:
-#   - Python 3.6+
-#   - pip install lit pyyaml
-#   - GPU drivers (D3D12, Vulkan, or Metal depending on test suite)
-#   - For non-clang test suites: a DXC executable (clang-dxc is included)
-#
-# After installing, configure and run tests:
-#   cd <prefix>/share/hlsl-test-suite
-#   ./configure-test-suite.py --suite clang-d3d12
-#   lit run/test/clang-d3d12
+# Enable the offload test suite distribution. Produces a portable install
+# prefix containing the binaries and test data needed to run the HLSL
+# offload test suite on another machine. See the offload-test-suite repo
+# (docs/offload-distribution.md) for setup, prerequisites, and run
+# instructions.
 if (HLSL_ENABLE_OFFLOAD_DISTRIBUTION)
+  if (NOT "OffloadTest" IN_LIST LLVM_EXTERNAL_PROJECTS)
+    message(FATAL_ERROR
+      "HLSL_ENABLE_OFFLOAD_DISTRIBUTION requires OffloadTest to be enabled "
+      "as an external project. Pass -DLLVM_EXTERNAL_PROJECTS=OffloadTest "
+      "and -DLLVM_EXTERNAL_OFFLOADTEST_SOURCE_DIR=<path-to-offload-test-suite>.")
+  endif()
   # Lit utilities (FileCheck, split-file, etc.) require LLVM_INSTALL_UTILS.
   set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
   set(LLVM_DISTRIBUTION_COMPONENTS

--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -14,3 +14,30 @@ if (HLSL_ENABLE_DISTRIBUTION)
       "clang;hlsl-resource-headers;clangd"
       CACHE STRING "")
 endif()
+
+# Enable the offload test suite distribution. This produces a portable
+# install prefix containing all binaries and test files needed to run the
+# HLSL offload test suite on another machine.
+#
+# Install with:
+#   cmake --build build --target install-distribution
+#   cmake --build build --target install-offload-tools
+#   cmake --build build --target install-offload-test-suite
+#
+# Prerequisites on the target machine:
+#   - Python 3.6+
+#   - pip install lit pyyaml
+#   - GPU drivers (D3D12, Vulkan, or Metal depending on test suite)
+#   - For non-clang test suites: a DXC executable (clang-dxc is included)
+#
+# After installing, configure and run tests:
+#   cd <prefix>/share/hlsl-test-suite
+#   ./configure-test-suite.py --suite clang-d3d12
+#   lit run/test/clang-d3d12
+if (HLSL_ENABLE_OFFLOAD_DISTRIBUTION)
+  # Lit utilities (FileCheck, split-file, etc.) require LLVM_INSTALL_UTILS.
+  set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
+  set(LLVM_DISTRIBUTION_COMPONENTS
+      "clang;hlsl-resource-headers;FileCheck;split-file;obj2yaml;not"
+      CACHE STRING "")
+endif()


### PR DESCRIPTION
This PR adds a new distribution to the HLSL cmake file.
The purpose is so that we can portably distribute binaries to other machines so that offload testing can be optimized.
Assisted by: Github Copilot
This PR was inspired by @Icohedron 's comment here: https://github.com/llvm/offload-test-suite/pull/1149#issuecomment-4409079785
This addresses https://github.com/llvm/offload-test-suite/issues/1150
