### PR TITLE
[libc++] Require the exact assignment expression to be trivial in __uninitialized_allocator_copy_impl

### DIFF
--- a/libcxx/include/__cxx03/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__cxx03/__memory/uninitialized_algorithms.h
@@ -223,7 +223,7 @@ template <class _Alloc,
           class _Out,
           __enable_if_t<
               // using _RawTypeIn because of the allocator<T const> extension
-              is_trivially_copy_constructible<_RawTypeIn>::value && is_trivially_copy_assignable<_RawTypeIn>::value &&
+              is_trivially_copy_constructible<_RawTypeIn>::value && is_trivially_assignable<_Out&, _In&>::value &&
                   is_same<__remove_const_t<_In>, __remove_const_t<_Out> >::value &&
                   __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>::value,
               int> = 0>

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -486,7 +486,7 @@ inline const bool __allocator_has_trivial_copy_construct_v<allocator<_Type>, _Ty
 template <class _Alloc,
           class _In,
           class _Out,
-          __enable_if_t<is_trivially_copy_constructible<_In>::value && is_trivially_copy_assignable<_In>::value &&
+          __enable_if_t<is_trivially_copy_constructible<_In>::value && is_trivially_assignable<_Out&, _In&>::value &&
                             is_same<__remove_const_t<_In>, __remove_const_t<_Out> >::value &&
                             __allocator_has_trivial_copy_construct_v<_Alloc, _In>,
                         int> = 0>

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/copy.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/copy.pass.cpp
@@ -10,13 +10,83 @@
 
 // vector(const vector& v);
 
-#include <vector>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+#include <vector>
 
 #include "test_macros.h"
 #include "test_allocator.h"
 #include "min_allocator.h"
 #include "asan_testing.h"
+
+#if TEST_STD_VER >= 11
+namespace gh196645 {
+
+class Optional {
+public:
+  Optional()                           = default;
+  Optional(const Optional&)            = default;
+  Optional& operator=(const Optional&) = default;
+  Optional(Optional&&) {}
+
+  template <class Arg>
+  Optional& operator=(Arg&& rhs) {
+    assert(value_ != Poison);
+    value_ = rhs.value_;
+    return *this;
+  }
+
+  TEST_CONSTEXPR_CXX20 bool hasValue() const { return value_ == HasValue; }
+
+private:
+  static constexpr std::uint32_t Poison   = 0xBEBEBEBE;
+  static constexpr std::uint32_t NoValue  = 0;
+  static constexpr std::uint32_t HasValue = 1;
+
+  std::uint32_t value_ = NoValue;
+};
+
+static_assert(std::is_trivially_copy_constructible<Optional>::value, "");
+static_assert(std::is_trivially_copy_assignable<Optional>::value, "");
+static_assert(!std::is_trivially_assignable<Optional&, Optional&>::value, "");
+
+template <class T>
+struct PoisoningAllocator {
+  using value_type = T;
+
+  TEST_CONSTEXPR_CXX20 PoisoningAllocator() = default;
+
+  template <class U>
+  TEST_CONSTEXPR_CXX20 PoisoningAllocator(const PoisoningAllocator<U>&) noexcept {}
+
+  TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
+    T* p = alloc_.allocate(n);
+    if (!TEST_IS_CONSTANT_EVALUATED)
+      std::memset(static_cast<void*>(p), 0xBE, n * sizeof(T));
+    return p;
+  }
+
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) noexcept { alloc_.deallocate(p, n); }
+
+  template <class U>
+  friend bool operator==(const PoisoningAllocator&, const PoisoningAllocator<U>&) noexcept {
+    return true;
+  }
+
+  template <class U>
+  friend bool operator!=(const PoisoningAllocator&, const PoisoningAllocator<U>&) noexcept {
+    return false;
+  }
+
+  std::allocator<T> alloc_;
+};
+
+} // namespace gh196645
+#endif // TEST_STD_VER >= 11
 
 template <class C>
 TEST_CONSTEXPR_CXX20 void test(const C& x) {
@@ -92,6 +162,11 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     assert(v2.get_allocator() == v.get_allocator());
     assert(is_contiguous_container_asan_correct(v));
     assert(is_contiguous_container_asan_correct(v2));
+  }
+  {
+    std::vector<gh196645::Optional, gh196645::PoisoningAllocator<gh196645::Optional> > v(1);
+    std::vector<gh196645::Optional, gh196645::PoisoningAllocator<gh196645::Optional> > v2 = v;
+    assert(!v2[0].hasValue());
   }
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/196645

`__uninitialized_allocator_copy_impl` has an optimization that replaces `allocator_traits::construct` with `std::copy` for raw pointer ranges when the element type is trivially copy constructible and trivially copy assignable.

The copy-assignment trait only checks whether assignment from `const T&` is trivial. That is weaker than the expression used by `std::copy`, which evaluates `*out = *in`. If overload resolution selects a different non-trivial assignment operator for that expression, `std::copy` can call that operator on uninitialized storage.

Check `is_trivially_assignable<_Out&, _In&>` instead. This matches the assignment expression used by `std::copy`, preserves the optimized path when that assignment is actually trivial, and avoids making non-const raw pointer callers select the generic `allocator_traits::construct` overload due to a qualification conversion.

Add a vector copy-constructor regression test with a type whose defaulted copy assignment is trivial but whose templated assignment operator is selected for non-const lvalue sources.
