### PR TITLE
[libc] Fix Annex K include order

### DIFF
--- a/libc/include/llvm-libc-macros/annex-k-macros.h
+++ b/libc/include/llvm-libc-macros/annex-k-macros.h
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H
-#define LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H
-
 #if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) ||              \
     (defined(__cplusplus) && __cplusplus >= 201703L)
 
@@ -16,12 +13,13 @@
 // TODO(bassiounix): uncomment/move when Annex K is fully implemented.
 // #define __STDC_LIB_EXT1__ 201112L
 
-#if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
+#if !defined(LIBC_HAS_ANNEX_K) && defined(__STDC_WANT_LIB_EXT1__) &&           \
+    __STDC_WANT_LIB_EXT1__ == 1
 
 #define LIBC_HAS_ANNEX_K
 
-#endif // defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
+#endif // !defined(LIBC_HAS_ANNEX_K) && defined(__STDC_WANT_LIB_EXT1__) &&
+       // __STDC_WANT_LIB_EXT1__ == 1
 
 #endif // (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) ||
        // (defined(__cplusplus) && __cplusplus >= 201703L)
-#endif // LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -99,6 +99,24 @@ add_libc_test(
 )
 
 add_libc_test(
+  annex_k_include_order_test
+  C_TEST
+  UNIT_TEST_ONLY
+  SUITE
+    libc_include_tests
+  SRCS
+    annex_k_include_order_test.c
+  COMPILE_OPTIONS
+    -std=c11
+    -Werror=implicit-function-declaration
+    -Wno-unknown-attributes
+  DEPENDS
+    libc.include.llvm-libc-types.locale_t
+    libc.include.stdio
+    libc.include.string
+)
+
+add_libc_test(
   issubnormal_test
   SUITE
     libc_include_tests

--- a/libc/test/include/annex_k_include_order_test.c
+++ b/libc/test/include/annex_k_include_order_test.c
@@ -1,0 +1,16 @@
+//===-- Include order test for Annex K macros -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdio.h>
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
+
+_Static_assert(sizeof(strnlen_s("", 0)) == sizeof(size_t),
+               "strnlen_s should be declared when Annex K is requested");
+
+int main(void) { return 0; }


### PR DESCRIPTION
stdio.h was including the annex k macro header before __STDC_WANT_LIB_EXT1__ was defined, so the include guard stopped it from being checked again later when string.h was included. 

Fixes #195276. 
